### PR TITLE
fix(video): 修正可灵有声档位分类、Vidu 参考生视频时长档位与超长提示词静默截断

### DIFF
--- a/frontend/src/types/custom-provider.ts
+++ b/frontend/src/types/custom-provider.ts
@@ -59,7 +59,7 @@ export interface CustomProviderModelInfo {
 export type ReferenceAudioMode = "none" | "direct";
 
 /** 后端 VideoCapabilities 中界面用得到的子集（后端另有 reference_audio_per_image、
- *  max_reference_audio_total_seconds 等纯执行期维度，不在此声明）。
+ *  max_reference_audio_total_seconds、max_prompt_chars 等纯执行期维度，不在此声明）。
  *  参考图路径以 max_reference_images > 0 表达，
  *  不另设布尔位——两份声明会漂移出「称支持但上限为 0」这类自相矛盾的状态。 */
 export interface VideoCapabilityFlags {

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -921,6 +921,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control"],
                 default=True,
                 supported_durations=list(range(1, 17)),
+                # 参考生视频端点的时长下限是 3 秒（文/图生视频仍为 1 起），不收窄会让 r2v 项目的
+                # 时长下拉出现 1s / 2s 幽灵档位——选中后被 backend 静默取到 3 秒并按 3 秒计费。
+                reference_image_durations=list(range(3, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 max_reference_images=7,
                 pricing=ViduDelegate(),
@@ -931,7 +934,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control"],
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
-                max_reference_images=7,
+                # 官方三次上线记录均未把 viduq3-pro 纳入 reference2video 端点，参考图路径不可用，
+                # 与 backend 的 r2v 白名单同口径声明为 0。
+                max_reference_images=0,
                 pricing=ViduDelegate(),
             ),
             "viduq3": ModelInfo(
@@ -939,6 +944,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="video",
                 capabilities=["image_to_video", "generate_audio", "seed_control"],
                 supported_durations=list(range(3, 17)),
+                reference_image_durations=list(range(3, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 max_reference_images=7,
                 pricing=ViduDelegate(),

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -304,7 +304,7 @@ def _minimax_video_pricing(model_id: str, buckets: dict[tuple[str, int], float])
 
 # 可灵 Kling 视频「质量档 × 是否有声」¥/s 矩阵（官方一手核实，CNY，1 积分 = ¥1）。
 # 全部 video 模型共享同一档位矩阵（官方按维度组合定价、不分模型）：4K 档仅 v3/v3-omni 可达、
-# 有声仅 v2-6（pro）；turbo 仅触达 std/pro 无声/有声档。
+# 有声档仅 v2-6 / v3 / v3-omni 可达；turbo 与 video-o1 仅触达 std/pro 无声档。
 _KLING_VIDEO_TIERED_RATES: dict[tuple[str, bool], float] = {
     ("std", False): 0.6,
     ("std", True): 0.8,
@@ -934,7 +934,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control"],
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
-                # 官方三次上线记录均未把 viduq3-pro 纳入 reference2video 端点，参考图路径不可用，
+                # 官方 /reference2video 的模型清单不含 viduq3-pro，参考图路径不可用，
                 # 与 backend 的 r2v 白名单同口径声明为 0。
                 max_reference_images=0,
                 pricing=ViduDelegate(),
@@ -1214,8 +1214,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         # api_key 单键 / access_key+secret_key 双键二选一（官方 API Key 鉴权全模型可用，AK/SK JWT
         # 仅 3.0 及更早模型）；同时填写时 backend_assembly 按 api_key 优先分派。
         credential_groups=[["api_key"], ["access_key", "secret_key"]],
-        # JWT 直连：视频默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 多图主体）、
-        # v2-6（pro 人声）、video-o1（多图主体 R2V）；图像 kling-image-o1（默认）+ v3-omni（两栖）。
+        # JWT 直连：视频默认 kling-v2-5-turbo（性价比走量）+ v3/v3-omni（旗舰 4K + 人声 + 多图主体）、
+        # v2-6（人声，官方限 1080P）、video-o1（多图主体 R2V）；图像 kling-image-o1（默认）+ v3-omni（两栖）。
         models={
             "kling-v2-5-turbo": ModelInfo(
                 display_name="可灵 2.5 Turbo",
@@ -1249,7 +1249,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3": ModelInfo(
                 display_name="可灵 v3",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video", "image_to_video", "generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 pricing=_kling_video_pricing("kling-v3"),
@@ -1257,7 +1257,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3-omni": ModelInfo(
                 display_name="可灵 v3 Omni",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video", "image_to_video", "generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -313,6 +313,7 @@ MESSAGES = {
     "video_reference_audio_slots_insufficient": "Model {model} attaches each reference audio clip to a reference asset, but only {slots} reference assets are available for {count} clips; add reference images for those characters, or reduce the number of characters with reference audio",
     "video_reference_audio_unreadable": "Model {model} has reference audio that is missing or unreadable; generation aborted: {names}; check the reference audio paths",
     "video_reference_audio_format_unsupported": "Reference audio {name} has an unsupported format (only {supported}); use a different audio file",
+    "video_prompt_too_long": "{provider}/{model} accepts prompts of at most {limit} characters but received {count}; the provider would silently truncate the excess, so generation was aborted. Shorten the prompt",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -315,6 +315,7 @@ MESSAGES = {
     "video_reference_audio_slots_insufficient": "Mô hình {model} gắn mỗi đoạn âm thanh tham chiếu vào một tư liệu tham chiếu, nhưng chỉ có {slots} tư liệu cho {count} đoạn; hãy bổ sung ảnh tham chiếu cho các nhân vật đó, hoặc giảm số nhân vật có âm thanh tham chiếu",
     "video_reference_audio_unreadable": "Mô hình {model} có âm thanh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn âm thanh tham chiếu",
     "video_reference_audio_format_unsupported": "Âm thanh tham chiếu {name} có định dạng không được hỗ trợ (chỉ {supported}); hãy dùng tệp âm thanh khác",
+    "video_prompt_too_long": "{provider}/{model} chỉ chấp nhận câu lệnh tối đa {limit} ký tự nhưng nhận được {count}; phần vượt quá sẽ bị nhà cung cấp cắt bỏ âm thầm nên đã hủy tạo. Hãy rút ngắn câu lệnh",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -278,6 +278,7 @@ MESSAGES = {
     "video_reference_audio_slots_insufficient": "模型 {model} 的参考音频需逐段挂在参考素材上，当前只有 {slots} 个参考素材却收到 {count} 段音频；请为这些角色补齐参考图，或减少带参考音频的角色数量",
     "video_reference_audio_unreadable": "模型 {model} 有参考音频缺失或无法读取，已中止生成：{names}；请检查参考音频路径",
     "video_reference_audio_format_unsupported": "参考音频 {name} 的格式不受支持（仅支持 {supported}）；请更换音频文件",
+    "video_prompt_too_long": "{provider}/{model} 的提示词最多 {limit} 个字符，当前 {count} 个；超出部分会被供应商静默截断，已中止生成。请缩短提示词",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -610,22 +610,17 @@ class MediaGenerator:
         # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；两者均无副作用，前置最干净。
         from lib.video_frame_slots import gate_video_request, plan_frame_slots, resolve_video_capabilities
 
-        # 能力查询保持惰性：三条可选路径都不走的请求不触发校验，无谓查询只会给最常见的
-        # 纯首帧路径新增一层后端属性依赖；未查询即传 None，不伪造一份占位能力声明。
-        needs_caps = end_image is not None or bool(reference_images) or bool(reference_audio_files)
-        video_caps = (
-            resolve_video_capabilities(
-                self._video_backend,
-                service_tier=version_metadata.get("service_tier", "default"),
-                resolution=resolution,
-            )
-            if needs_caps
-            else None
+        # prompt 长度校验对每个请求都适用（不像尾帧/参考图/参考音频那样可选），故能力查询不再
+        # 按可选路径惰性触发。查询是纯读后端声明的同步调用，没有 I/O 开销。
+        video_caps = resolve_video_capabilities(
+            self._video_backend,
+            service_tier=version_metadata.get("service_tier", "default"),
+            resolution=resolution,
         )
         # 总时长校验需要读音频元数据，只能在这层（拿得到文件路径）探测好再传给纯函数的
         # gate_video_request；探测失败（ffprobe 不可用等）按 None 传入，由其按既有降级口径跳过
-        # 该项校验，不阻断请求。仅当 caps 声明了总时长约束才探测——同一份「能力查询保持惰性」
-        # 原则，未声明该约束的后端（如 wan2.7）不必为每个请求多付一轮 ffprobe 子进程开销。
+        # 该项校验，不阻断请求。仅当 caps 声明了总时长约束才探测——未声明该约束的后端
+        # （如 wan2.7）不必为每个请求多付一轮 ffprobe 子进程开销。
         reference_audio_total_seconds = (
             await probe_reference_audio_total_seconds(reference_audio_files)
             if reference_audio_files
@@ -637,6 +632,7 @@ class MediaGenerator:
             caps=video_caps,
             provider=self._video_backend.name,
             model=model_name,
+            prompt=prompt,
             end_image=end_image,
             reference_images=reference_images,
             reference_audio_files=reference_audio_files,

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -39,6 +39,7 @@ CAPABILITY_FAILURE_CODES: frozenset[str] = frozenset(
         "video_end_image_unreadable",
         "video_last_frame_requires_pro",
         "video_last_frame_unsupported",
+        "video_prompt_too_long",
         "video_reference_images_duration_unsupported",
         "video_reference_images_exceeded",
         "video_reference_images_required",

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -416,6 +416,13 @@ class VideoCapabilities:
     聚合约束，仅按 ``max_reference_audio_count`` 卡段数）。段数上限推不出总时长——两段各处于
     单段合法区间的音频，合计仍可能超出供应商总时长上限，故需独立声明。判定需要读音频元数据，
     调用方在 :func:`lib.video_frame_slots.gate_video_request` 前置探测好总时长再传入。
+
+    ``max_prompt_chars``：提示词字符数上限（None = 该后端未声明约束）。声明的是**该 model 无论
+    走哪条端点都成立**的上限——部分供应商按端点各设更窄的值（如 Vidu 的参考生视频端点），那层
+    收窄留在 backend 组装期按实际端点 fail-loud，不塞进这个无端点上下文的静态声明里。计量口径
+    为字符数（中英文同权），与各家文档一致。超限的典型失败模式是静默截断而非报错：供应商照常
+    扣费、成片与意图不符、用户无从知情，正是 :func:`lib.video_frame_slots.gate_video_request`
+    要在付费前堵住的降级。
     """
 
     first_frame: bool = True
@@ -425,6 +432,7 @@ class VideoCapabilities:
     max_reference_audio_count: int = 0
     max_reference_audio_total_seconds: float | None = None
     reference_audio_per_image: bool = False
+    max_prompt_chars: int | None = None
 
 
 @dataclass

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -97,14 +97,18 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 # （官方：参考图像 + 参考视频 ≤ 5）。
 _WAN27_R2V_MAX_REFERENCE = 5
 
+# wan2.7 全家族 prompt 上限 5000 字符（官方参数表原文「超过部分会自动截断」，错误码表无对应
+# 条目——超限不报错、直接静默截断并照常计费，故由 gate_video_request 在付费前拒绝）。
+_WAN27_MAX_PROMPT_CHARS = 5000
+
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
 _MODEL_PROFILES: dict[str, VideoCapabilities] = {
     "happyhorse-1.0-t2v": VideoCapabilities(first_frame=False),
     "happyhorse-1.0-i2v": VideoCapabilities(first_frame=True),
     "happyhorse-1.0-r2v": VideoCapabilities(first_frame=False, max_reference_images=9),
-    "wan2.7-t2v": VideoCapabilities(first_frame=False),
-    "wan2.7-i2v": VideoCapabilities(first_frame=True),
+    "wan2.7-t2v": VideoCapabilities(first_frame=False, max_prompt_chars=_WAN27_MAX_PROMPT_CHARS),
+    "wan2.7-i2v": VideoCapabilities(first_frame=True, max_prompt_chars=_WAN27_MAX_PROMPT_CHARS),
     # 带首帧的参考生视频是 wan2.7-r2v 的官方形态（_build_media 同请求组装
     # first_frame + reference_image）。
     "wan2.7-r2v": VideoCapabilities(
@@ -115,6 +119,7 @@ _MODEL_PROFILES: dict[str, VideoCapabilities] = {
         # 音色挂在具体参考素材项上（_attach_reference_voices），不是独立的音色输入通道，
         # 编排层必须显式给出「谁的声音配哪张图」的映射，不能假设与 reference_audio_files 同序。
         reference_audio_per_image=True,
+        max_prompt_chars=_WAN27_MAX_PROMPT_CHARS,
     ),
 }
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -12,9 +12,9 @@
 
 各视频模型能力按 ``_KLING_VIDEO_CAPS`` 表驱动（官方一手核实）：
 - ``kling-v2-5-turbo``：文/图生视频含首尾帧，无音频/参考（默认 model）。
-- ``kling-v3`` / ``kling-v3-omni``：旗舰，首尾帧 + 4K（``mode="4k"``）；v3-omni 多图主体 R2V。
-- ``kling-v2-6``：pro 档支持视频内人声（``enable_audio``）。
-- ``kling-video-o1``：图生 + 多图主体 R2V。
+- ``kling-v3`` / ``kling-v3-omni``：旗舰，首尾帧 + 4K（``mode="4k"``）+ 音画同出；v3-omni 多图主体 R2V。
+- ``kling-v2-6``：支持视频内人声，官方限 1080P。
+- ``kling-video-o1``：图生 + 多图主体 R2V；只能保留参考视频原声、不生成原生人声。
 未登记 model（bearer 透传原生 model_name）回落保守默认能力。
 """
 
@@ -75,8 +75,12 @@ class _KlingVideoModelCaps:
     last_frame_requires_pro: bool
     reference_images: bool
     max_reference_images: int
-    generate_audio: bool  # 能产出视频内人声；官方仅 v2-6（pro 档）标 ✅
-    audio_param: bool  # 请求体是否带 enable_audio：v3 代默认有声需显式压制，旧档无此字段
+    # 能产出视频内人声（官方能力地图的「音画同出」列）：v2-6 / v3 / v3-omni ✅。该位同时决定请求体
+    # 是否携带音频开关 sound——官方各档默认 off，无此能力的 model 不发该字段而非发 "off" 压制。
+    generate_audio: bool
+    # 有声仅在 1080P 下可用（官方 v2-6 明文「生成有声视频时，仅支持生成 1080P」）。约束绑分辨率、
+    # 不绑 std/pro 质量档；v3 系官方未声明任何分辨率或档位限制，故为 False。
+    audio_requires_1080p: bool
 
 
 # turbo / 未登记 model（bearer 透传原生 model_name）兜底：文/图生视频、首尾帧，无音频/参考。
@@ -88,7 +92,7 @@ _DEFAULT_VIDEO_CAPS = _KlingVideoModelCaps(
     reference_images=False,
     max_reference_images=0,
     generate_audio=False,
-    audio_param=False,
+    audio_requires_1080p=False,
 )
 
 _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
@@ -100,8 +104,8 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         last_frame_requires_pro=False,
         reference_images=False,
         max_reference_images=0,
-        generate_audio=False,
-        audio_param=True,
+        generate_audio=True,
+        audio_requires_1080p=False,
     ),
     "kling-v3-omni": _KlingVideoModelCaps(
         text_to_video=True,
@@ -110,8 +114,8 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         last_frame_requires_pro=False,
         reference_images=True,
         max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
-        generate_audio=False,
-        audio_param=True,
+        generate_audio=True,
+        audio_requires_1080p=False,
     ),
     "kling-v2-6": _KlingVideoModelCaps(
         text_to_video=True,
@@ -121,7 +125,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         reference_images=False,
         max_reference_images=0,
         generate_audio=True,
-        audio_param=True,
+        audio_requires_1080p=True,
     ),
     "kling-video-o1": _KlingVideoModelCaps(
         text_to_video=False,
@@ -131,7 +135,7 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
         reference_images=True,
         max_reference_images=_R2V_MAX_REFERENCE_IMAGES,
         generate_audio=False,
-        audio_param=False,
+        audio_requires_1080p=False,
     ),
 }
 
@@ -240,10 +244,12 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def effective_generate_audio_for_model(model: str) -> bool:
         """无逐请求档位上下文时，返回默认执行档真正生效的音频计价参数。
 
-        可灵默认档为 std，而官方仅 kling-v2-6 pro 能产出人声，因此这条供预估使用的
-        无上下文接口对所有 model 都返回 False；执行期仍由 ``_effective_audio`` 按请求档决定。
+        有声受分辨率约束的 model（v2-6 官方限 1080P）无从得知调用方将选哪档分辨率，保守返回
+        False；无约束的有声 model（v3 / v3-omni）只要请求要人声就产出，返回 True。执行期仍由
+        ``_effective_audio`` 按请求实际分辨率决定。
         """
-        return False
+        caps = _lookup_video_caps(model)
+        return caps.generate_audio and not caps.audio_requires_1080p
 
     @property
     def video_capabilities(self) -> VideoCapabilities:
@@ -288,11 +294,17 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         return self._resolve_mode_from(request.resolution, request.service_tier)
 
     def _effective_audio(self, request: VideoGenerationRequest) -> bool:
-        """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + pro 档（官方仅 v2-6 pro ✅）。
+        """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + 满足该 model 的分辨率约束。
 
         无能力的 model 恒 False——不被错配有声价（下游 pricing 取 ``result.generate_audio``）。
+        受约束的 model 按官方原文绑分辨率（v2-6「生成有声视频时，仅支持生成 1080P」）而非绑 mode：
+        mode 是 std/pro/4k 质量档，与官方声明音频约束时用的维度无关。
         """
-        return bool(request.generate_audio and self._caps.generate_audio and self._resolve_mode(request) == "pro")
+        if not (request.generate_audio and self._caps.generate_audio):
+            return False
+        if self._caps.audio_requires_1080p:
+            return (request.resolution or "").lower() == "1080p"
+        return True
 
     @staticmethod
     def _valid_frames(images: list[Path] | None) -> list[Path]:
@@ -349,10 +361,11 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
                 payload["image_tail"] = self._encode_frame(Path(end_image))
             subpath = _IMAGE2VIDEO
 
-        # enable_audio 仅 text2video / image2video 子路径携带（multi-image2video 原生 schema 不含）；
-        # v3 代默认有声，无能力 model 在此显式压制为 False，有能力的 v2-6（pro）按需开启。
-        if self._caps.audio_param:
-            payload["enable_audio"] = self._effective_audio(request)
+        # 音频开关 sound（官方参数，取 "on"/"off"，各档默认 off）仅 text2video / image2video 子路径
+        # 携带（multi-image2video 原生 schema 不含）；无音频能力的 model 不发该字段，避免向不支持的
+        # 端点递未知参数。
+        if self._caps.generate_audio:
+            payload["sound"] = "on" if self._effective_audio(request) else "off"
         return subpath, payload
 
     def _encode_frame(self, path: Path) -> str:
@@ -378,7 +391,8 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
             "mode": payload.get("mode"),
             "duration": payload.get("duration"),
             "aspect_ratio": payload.get("aspect_ratio"),
-            "enable_audio": bool(payload.get("enable_audio")),
+            # 空串 = 该档不携带音频开关，与显式 "off" 区分开
+            "sound": payload.get("sound", ""),
             "has_image": "image" in payload,
             "has_image_tail": "image_tail" in payload,
             "reference_count": len(image_list) if isinstance(image_list, list) else 0,

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -295,18 +295,21 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def _resolve_mode(self, request: VideoGenerationRequest) -> str:
         return self._resolve_mode_from(request.resolution, request.service_tier)
 
-    def _effective_audio(self, request: VideoGenerationRequest) -> bool:
+    def _effective_audio(self, request: VideoGenerationRequest, *, subpath: str) -> bool:
         """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + 走得到音频开关的子路径
         + 满足该 model 的分辨率约束。
 
         无能力的 model 恒 False——不被错配有声价（下游 pricing 取 ``result.generate_audio``）。
+
+        ``subpath`` 必传而非由 ``request.reference_images`` 推断：resume 请求重建时不带图字段
+        （见 ``media_generator.resume_video_async``），按参考图推断会把旧格式 job_id 的多图主体
+        任务判成有声。generate 侧由 ``_build_payload`` 给出，resume 侧由 job_id 解码得出。
         """
         if not (request.generate_audio and self._caps.generate_audio):
             return False
-        # 有参考图 = multi-image2video 子路径，其原生 schema 不含音频开关，``_build_payload`` 不会
-        # 携带 sound（判据与那里的子路径优先级同源）。此处必须一并返回 False：否则 v3-omni 的多图
-        # 主体请求会拿到必然无声的成片，却因该标志进 ledger 而按有声价出账。
-        if self._valid_frames(request.reference_images):
+        # multi-image2video 原生 schema 不含音频开关，``_build_payload`` 不会携带 sound，成片必然
+        # 无声。此处必须一并返回 False：否则该请求会因标志进 ledger 而按有声价出账。
+        if subpath == _MULTI_IMAGE2VIDEO:
             return False
         if self._caps.audio_requires_1080p:
             # 官方约束的维度是分辨率（v2-6「生成有声视频时，仅支持生成 1080P」），但可灵请求体没有
@@ -375,7 +378,7 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         # 携带（multi-image2video 原生 schema 不含）；无音频能力的 model 不发该字段，避免向不支持的
         # 端点递未知参数。
         if self._caps.generate_audio:
-            payload["sound"] = "on" if self._effective_audio(request) else "off"
+            payload["sound"] = "on" if self._effective_audio(request, subpath=subpath) else "off"
         return subpath, payload
 
     def _encode_frame(self, path: Path) -> str:
@@ -413,7 +416,7 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
 
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         subpath, payload = self._build_payload(request)
-        generate_audio = self._effective_audio(request)
+        generate_audio = self._effective_audio(request, subpath=subpath)
         logger.info("调用 Kling 视频 API payload=%s", self._safe_log_view(subpath, payload))
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._submit_task(client, f"videos/{subpath}", payload)
@@ -434,10 +437,13 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
 
         有声标志同样优先取持久化值（submit 时算定）：直连有声/无声计费，避免按 resume 时
-        可能已漂移的 config 默认/请求重算。旧 job_id 未持久化时（None）回落重算。
+        可能已漂移的 config 默认/请求重算。旧 job_id 未持久化时（None）按解码出的子路径重算——
+        resume 请求不带图字段，子路径是此处唯一能判出多图主体（必然无声）的依据。
         """
         subpath, task_id, persisted_audio = _decode_job_id(job_id)
-        generate_audio = persisted_audio if persisted_audio is not None else self._effective_audio(request)
+        generate_audio = (
+            persisted_audio if persisted_audio is not None else self._effective_audio(request, subpath=subpath)
+        )
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -78,8 +78,9 @@ class _KlingVideoModelCaps:
     # 能产出视频内人声（官方能力地图的「音画同出」列）：v2-6 / v3 / v3-omni ✅。该位同时决定请求体
     # 是否携带音频开关 sound——官方各档默认 off，无此能力的 model 不发该字段而非发 "off" 压制。
     generate_audio: bool
-    # 有声仅在 1080P 下可用（官方 v2-6 明文「生成有声视频时，仅支持生成 1080P」）。约束绑分辨率、
-    # 不绑 std/pro 质量档；v3 系官方未声明任何分辨率或档位限制，故为 False。
+    # 有声仅在 1080P 下可用（官方 v2-6 明文「生成有声视频时，仅支持生成 1080P」）。可灵请求体没有
+    # 分辨率字段——输出档位只由 mode 决定，故执行期判据落在 mode 上（见 `_effective_audio`）。
+    # v3 系官方未声明任何分辨率或档位限制，故为 False。
     audio_requires_1080p: bool
 
 
@@ -244,9 +245,9 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def effective_generate_audio_for_model(model: str) -> bool:
         """无逐请求档位上下文时，返回默认执行档真正生效的音频计价参数。
 
-        有声受分辨率约束的 model（v2-6 官方限 1080P）无从得知调用方将选哪档分辨率，保守返回
+        有声受 1080P 约束的 model（v2-6）无从得知调用方将选哪档质量档，保守返回
         False；无约束的有声 model（v3 / v3-omni）只要请求要人声就产出，返回 True。执行期仍由
-        ``_effective_audio`` 按请求实际分辨率与子路径决定——v3-omni 走多图主体子路径时实际无声，
+        ``_effective_audio`` 按请求实际质量档与子路径决定——v3-omni 走多图主体子路径时实际无声，
         本接口无从得知是否带参考图而返回 True，方向是高估成本（预估偏保守），不会低报。
         """
         caps = _lookup_video_caps(model)
@@ -299,8 +300,6 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         + 满足该 model 的分辨率约束。
 
         无能力的 model 恒 False——不被错配有声价（下游 pricing 取 ``result.generate_audio``）。
-        受约束的 model 按官方原文绑分辨率（v2-6「生成有声视频时，仅支持生成 1080P」）而非绑 mode：
-        mode 是 std/pro/4k 质量档，与官方声明音频约束时用的维度无关。
         """
         if not (request.generate_audio and self._caps.generate_audio):
             return False
@@ -310,7 +309,11 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         if self._valid_frames(request.reference_images):
             return False
         if self._caps.audio_requires_1080p:
-            return (request.resolution or "").lower() == "1080p"
+            # 官方约束的维度是分辨率（v2-6「生成有声视频时，仅支持生成 1080P」），但可灵请求体没有
+            # 分辨率字段：输出档位只由 mode 决定（std 720P / pro 1080P / 4k），``request.resolution``
+            # 除识别 4k 档外不进入 payload。判据因此落在实际发出的 mode 上——std 档拿不到 1080P，
+            # 据 resolution="1080p" 发 sound="on" 会拿到无声片却按有声价出账。
+            return self._resolve_mode(request) != "std"
         return True
 
     @staticmethod

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -313,10 +313,11 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
             return False
         if self._caps.audio_requires_1080p:
             # 官方约束的维度是分辨率（v2-6「生成有声视频时，仅支持生成 1080P」），但可灵请求体没有
-            # 分辨率字段：输出档位只由 mode 决定（std 720P / pro 1080P / 4k），``request.resolution``
-            # 除识别 4k 档外不进入 payload。判据因此落在实际发出的 mode 上——std 档拿不到 1080P，
-            # 据 resolution="1080p" 发 sound="on" 会拿到无声片却按有声价出账。
-            return self._resolve_mode(request) != "std"
+            # 分辨率字段：输出档位只由 mode 决定，``request.resolution`` 除识别 4k 档外不进入 payload。
+            # 判据因此落在实际发出的 mode 上。声明该位的 model（v2-6）只有 std / pro 两档，pro 即
+            # 1080P；4k 档是 v3 系专有，对这些 model 是非法请求，不当作满足 1080P 放行——否则会发
+            # sound="on" 并按有声价出账，换回一个必然失败或无声的任务。
+            return self._resolve_mode(request) == "pro"
         return True
 
     @staticmethod
@@ -437,13 +438,12 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
 
         有声标志同样优先取持久化值（submit 时算定）：直连有声/无声计费，避免按 resume 时
-        可能已漂移的 config 默认/请求重算。旧 job_id 未持久化时（None）按解码出的子路径重算——
-        resume 请求不带图字段，子路径是此处唯一能判出多图主体（必然无声）的依据。
+        可能已漂移的 config 默认/请求重算。未持久化该标志的 2 段旧 job_id 一律判无声——产出这类
+        job_id 的实现尚不具备任何音频能力（结果恒 ``generate_audio=False``），成片必然无声；按
+        当前能力图重算会让这些旧任务按有声价出账（v3 系有声档在其之后才登记）。
         """
         subpath, task_id, persisted_audio = _decode_job_id(job_id)
-        generate_audio = (
-            persisted_audio if persisted_audio is not None else self._effective_audio(request, subpath=subpath)
-        )
+        generate_audio = persisted_audio if persisted_audio is not None else False
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             return await self._poll_and_build(client, subpath, task_id, request, generate_audio=generate_audio)
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -246,7 +246,8 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
 
         有声受分辨率约束的 model（v2-6 官方限 1080P）无从得知调用方将选哪档分辨率，保守返回
         False；无约束的有声 model（v3 / v3-omni）只要请求要人声就产出，返回 True。执行期仍由
-        ``_effective_audio`` 按请求实际分辨率决定。
+        ``_effective_audio`` 按请求实际分辨率与子路径决定——v3-omni 走多图主体子路径时实际无声，
+        本接口无从得知是否带参考图而返回 True，方向是高估成本（预估偏保守），不会低报。
         """
         caps = _lookup_video_caps(model)
         return caps.generate_audio and not caps.audio_requires_1080p
@@ -294,13 +295,19 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         return self._resolve_mode_from(request.resolution, request.service_tier)
 
     def _effective_audio(self, request: VideoGenerationRequest) -> bool:
-        """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + 满足该 model 的分辨率约束。
+        """实际是否产出视频内人声：请求要 + model 有 generate_audio 能力 + 走得到音频开关的子路径
+        + 满足该 model 的分辨率约束。
 
         无能力的 model 恒 False——不被错配有声价（下游 pricing 取 ``result.generate_audio``）。
         受约束的 model 按官方原文绑分辨率（v2-6「生成有声视频时，仅支持生成 1080P」）而非绑 mode：
         mode 是 std/pro/4k 质量档，与官方声明音频约束时用的维度无关。
         """
         if not (request.generate_audio and self._caps.generate_audio):
+            return False
+        # 有参考图 = multi-image2video 子路径，其原生 schema 不含音频开关，``_build_payload`` 不会
+        # 携带 sound（判据与那里的子路径优先级同源）。此处必须一并返回 False：否则 v3-omni 的多图
+        # 主体请求会拿到必然无声的成片，却因该标志进 ledger 而按有声价出账。
+        if self._valid_frames(request.reference_images):
             return False
         if self._caps.audio_requires_1080p:
             return (request.resolution or "").lower() == "1080p"

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -174,9 +174,9 @@ def _encode_job_id(subpath: str, task_id: str, *, generate_audio: bool) -> str:
 def _decode_job_id(job_id: str) -> tuple[str, str, bool | None]:
     """从持久化 job_id 复原 ``(子路径, task_id, 有声标志)``。
 
-    新格式 ``subpath:task_id:audio``（3 段，audio 为 0/1）；旧格式 ``subpath:task_id``
-    （2 段，有声标志未持久化，返回 None 由 caller 重算）；无已知前缀（异常/更旧数据）
-    回落 text2video、整串作 task_id。
+    ``subpath:task_id:audio``（3 段，audio 为 0/1）带有声标志；``subpath:task_id``
+    （2 段）不带，返回 None——caller 据此按无声处理；无已知前缀回落 text2video、
+    整串作 task_id。
     """
     parts = job_id.split(":")
     if len(parts) == 3 and parts[0] in _RESUMABLE_SUBPATHS and parts[2] in ("0", "1"):
@@ -438,9 +438,8 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
         而 resume 请求已无 ``start_image`` 可推断，故不能再从 request 取（见 _encode_job_id）。
 
         有声标志同样优先取持久化值（submit 时算定）：直连有声/无声计费，避免按 resume 时
-        可能已漂移的 config 默认/请求重算。未持久化该标志的 2 段旧 job_id 一律判无声——产出这类
-        job_id 的实现尚不具备任何音频能力（结果恒 ``generate_audio=False``），成片必然无声；按
-        当前能力图重算会让这些旧任务按有声价出账（v3 系有声档在其之后才登记）。
+        可能已漂移的 config 默认/请求重算。不含该标志的 2 段 job_id 一律判无声：这类 job_id 只
+        由不具备音频能力的实现产出，成片必然无声，按当前能力表重算会让它们按有声价出账。
         """
         subpath, task_id, persisted_audio = _decode_job_id(job_id)
         generate_audio = persisted_audio if persisted_audio is not None else False

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -217,7 +217,7 @@ class ViduVideoBackend:
         return self.video_capabilities_for_model(self._model)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # Vidu 不支持 resume：poll 完全内联在 generate，接续需先把它抽成独立的轮询入口。
+        # Vidu 不支持 resume：poll 完全内联在 generate，没有可供接续的独立轮询入口。
         # orphan handler 据 NotImplementedError 标 [resume_unsupported]
         raise NotImplementedError("ViduVideoBackend 暂不支持 resume_video")
 

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -149,6 +149,17 @@ _RESOLUTION_WHITELIST: dict[str, list[str]] = {
 _DEFAULT_RESOLUTION = "720p"
 
 
+def _serves_only_reference2video(model: str) -> bool:
+    """该 model 除 /reference2video 外不派发到任何端点。
+
+    是无请求上下文时能否按 r2v 的窄 prompt 上限静态声明的判据：多端点 model 走 r2v 时的
+    窄值改由 ``_build_request`` 按实际端点兜底。
+    """
+    return model in _ENDPOINT_MODELS["/reference2video"] and not any(
+        model in _ENDPOINT_MODELS[endpoint] for endpoint in ("/text2video", "/img2video", "/start-end2video")
+    )
+
+
 class ViduVideoBackend:
     """Vidu 视频生成后端，按 request 字段分派到不同端点。"""
 
@@ -193,15 +204,11 @@ class ViduVideoBackend:
             # start_image 不进请求体（首帧被丢弃）。
             #
             # prompt 上限按端点分档（/reference2video 更窄），而本函数无端点上下文，只能声明
-            # 「该 model 无论走哪条端点都成立」的值：只跑 /reference2video 的 model（如 viduq3）
-            # 取窄值，能跑其他端点的 model 取宽值——多端点 model 走 /reference2video 时的窄值由
-            # _build_request 按实际端点 fail-loud 兜底，不在此处按最窄值误拒其合法的 t2v/i2v 请求。
-            # 未登记 model（中转自定义命名）不在任何白名单内，取宽值：静态声明只该拒绝必然违约的
-            # 请求，对能力不明的 model 误拒是更糟的降级。
+            # 「该 model 无论走哪条端点都成立」的值，不在此处按最窄值误拒多端点 model 合法的
+            # t2v/i2v 请求。未登记 model（中转自定义命名）不在任何白名单内，取宽值：静态声明只该
+            # 拒绝必然违约的请求，对能力不明的 model 误拒是更糟的降级。
             max_prompt_chars=(
-                _PROMPT_MAX_REFERENCE2VIDEO
-                if reference_images and not (first_frame or last_frame or model in _ENDPOINT_MODELS["/text2video"])
-                else _PROMPT_MAX_TEXT2VIDEO
+                _PROMPT_MAX_REFERENCE2VIDEO if _serves_only_reference2video(model) else _PROMPT_MAX_TEXT2VIDEO
             ),
         )
 

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -17,6 +17,7 @@ from lib.providers import PROVIDER_VIDU
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     VideoCapabilities,
+    VideoCapabilityError,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
@@ -68,9 +69,10 @@ _DURATION_RULES: dict[tuple[str, str], list[int]] = {
     ("viduq3-pro", "/img2video"): list(range(1, 17)),
     ("viduq3-turbo", "/img2video"): list(range(1, 17)),
     ("viduq3-pro-fast", "/img2video"): list(range(1, 17)),
-    ("viduq2-pro-fast", "/img2video"): list(range(1, 9)),
-    ("viduq2-pro", "/img2video"): list(range(1, 9)),
-    ("viduq2-turbo", "/img2video"): list(range(1, 9)),
+    # q2 系在 /img2video 为 1–10；1–8 是 /start-end2video（首尾帧）端点的值，两端点不同。
+    ("viduq2-pro-fast", "/img2video"): list(range(1, 11)),
+    ("viduq2-pro", "/img2video"): list(range(1, 11)),
+    ("viduq2-turbo", "/img2video"): list(range(1, 11)),
     ("viduq1", "/img2video"): [5],
     ("viduq1-classic", "/img2video"): [5],
     ("vidu2.0", "/img2video"): [4, 8],
@@ -181,12 +183,26 @@ class ViduVideoBackend:
         `/video-capabilities`）。
         """
         reference_images = model in _ENDPOINT_MODELS["/reference2video"]
+        first_frame = model in _ENDPOINT_MODELS["/img2video"]
+        last_frame = model in _ENDPOINT_MODELS["/start-end2video"]
         return VideoCapabilities(
-            first_frame=model in _ENDPOINT_MODELS["/img2video"],
-            last_frame=model in _ENDPOINT_MODELS["/start-end2video"],
+            first_frame=first_frame,
+            last_frame=last_frame,
             max_reference_images=_MAX_REFERENCE_IMAGES if reference_images else 0,
             # 参考图与首帧在 Vidu 上是互斥模式：_select_endpoint 见参考图即切 /reference2video，
             # start_image 不进请求体（首帧被丢弃）。
+            #
+            # prompt 上限按端点分档（/reference2video 更窄），而本函数无端点上下文，只能声明
+            # 「该 model 无论走哪条端点都成立」的值：只跑 /reference2video 的 model（如 viduq3）
+            # 取窄值，能跑其他端点的 model 取宽值——多端点 model 走 /reference2video 时的窄值由
+            # _build_request 按实际端点 fail-loud 兜底，不在此处按最窄值误拒其合法的 t2v/i2v 请求。
+            # 未登记 model（中转自定义命名）不在任何白名单内，取宽值：静态声明只该拒绝必然违约的
+            # 请求，对能力不明的 model 误拒是更糟的降级。
+            max_prompt_chars=(
+                _PROMPT_MAX_REFERENCE2VIDEO
+                if reference_images and not (first_frame or last_frame or model in _ENDPOINT_MODELS["/text2video"])
+                else _PROMPT_MAX_TEXT2VIDEO
+            ),
         )
 
     @property
@@ -260,12 +276,21 @@ class ViduVideoBackend:
         # 2) duration 在合法集合内取最近值
         duration = _coerce_duration(self._model, endpoint, request.duration_seconds)
 
-        # 3) prompt 截断（reference2video 上限 2000，其他 5000）
+        # 3) prompt 长度（reference2video 上限 2000，其他 5000）
+        # 超限一律拒绝，不再客户端截断：截断会产出与意图不符的成片却照常计费、用户无从知情，
+        # 与 gate_video_request 「同一种违约只有硬失败、没有静默降级」的口径一致。model 级上限
+        # （video_capabilities_for_model 声明的那个）已由 gate 在付费前拦下；此处是端点级更窄
+        # 上限的执行期防御——多端点 model 走 /reference2video 时 gate 的静态声明覆盖不到。
         prompt = request.prompt or ""
         prompt_max = _PROMPT_MAX_REFERENCE2VIDEO if endpoint == "/reference2video" else _PROMPT_MAX_TEXT2VIDEO
         if len(prompt) > prompt_max:
-            logger.warning("Vidu prompt 长度 %d 超限 %d，截断", len(prompt), prompt_max)
-            prompt = prompt[:prompt_max]
+            raise VideoCapabilityError(
+                "video_prompt_too_long",
+                provider=self.name,
+                model=self._model,
+                limit=prompt_max,
+                count=len(prompt),
+            )
 
         body: dict = {
             "model": self._model,

--- a/lib/video_backends/vidu.py
+++ b/lib/video_backends/vidu.py
@@ -156,7 +156,7 @@ def _serves_only_reference2video(model: str) -> bool:
     窄值改由 ``_build_request`` 按实际端点兜底。
     """
     return model in _ENDPOINT_MODELS["/reference2video"] and not any(
-        model in _ENDPOINT_MODELS[endpoint] for endpoint in ("/text2video", "/img2video", "/start-end2video")
+        model in models for endpoint, models in _ENDPOINT_MODELS.items() if endpoint != "/reference2video"
     )
 
 
@@ -217,7 +217,7 @@ class ViduVideoBackend:
         return self.video_capabilities_for_model(self._model)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
-        # 本 PR 暂不实现 Vidu resume（poll 完全内联在 generate，需要先抽 _poll_until_done）；
+        # Vidu 不支持 resume：poll 完全内联在 generate，接续需先把它抽成独立的轮询入口。
         # orphan handler 据 NotImplementedError 标 [resume_unsupported]
         raise NotImplementedError("ViduVideoBackend 暂不支持 resume_video")
 

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -79,6 +79,7 @@ def gate_video_request(
     caps: VideoCapabilities | None,
     provider: str,
     model: str,
+    prompt: str | None = None,
     end_image: Path | None = None,
     reference_images: "list[Path] | None" = None,
     reference_audio_files: "list[Path] | None" = None,
@@ -101,9 +102,24 @@ def gate_video_request(
     未知（探测失败/环境不支持），此时跳过总时长校验而不是当作超限拒绝——与本仓库 ffprobe
     不可用时降级放行的既有口径一致。
 
+    ``prompt`` 与三条可选路径不同：它在每个请求上都存在，故 ``caps`` 未声明
+    ``max_prompt_chars`` 时（含 ``caps`` 为 None）跳过该项——未声明约束不等于上限为 0。
+
     与 :func:`plan_frame_slots` 分离是有意的：校验会抛、组装是纯函数，两者调用时机不同——
     校验须先于记账括号（硬失败要不扣费、不留 failed ApiCall 行），组装则可在其后按需进行。
     """
+    prompt_limit = None if caps is None else caps.max_prompt_chars
+    if prompt_limit is not None and prompt is not None and len(prompt) > prompt_limit:
+        # 供应商对超长 prompt 普遍是静默截断而非报错（如 wan2.7 文档原文「超过部分会自动截断」，
+        # 错误码表无对应条目），照常扣费却产出与意图不符的成片——付费前拒绝，不放行。
+        raise VideoCapabilityError(
+            "video_prompt_too_long",
+            provider=provider,
+            model=model,
+            limit=prompt_limit,
+            count=len(prompt),
+        )
+
     if end_image is not None and (caps is None or not caps.last_frame):
         raise VideoCapabilityError("video_last_frame_unsupported", provider=provider, model=model)
 

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -142,6 +142,7 @@ class TestModelListExposesCapabilities:
             "max_reference_audio_count": 0,
             "max_reference_audio_total_seconds": None,
             "reference_audio_per_image": False,
+            "max_prompt_chars": None,
         }
         assert models[0]["capability_overrides"] is None
 
@@ -160,6 +161,7 @@ class TestModelListExposesCapabilities:
             "max_reference_audio_count": expected.max_reference_audio_count,
             "max_reference_audio_total_seconds": expected.max_reference_audio_total_seconds,
             "reference_audio_per_image": expected.reference_audio_per_image,
+            "max_prompt_chars": expected.max_prompt_chars,
         }
 
     @pytest.mark.integration

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -268,6 +268,22 @@ class TestModelHasAudioTrack:
         assert "generate_audio" in model.capabilities
         assert model_has_audio_track("openai", model) is True
 
+    def test_kling_audio_capable_models_declare_token(self):
+        """可灵支持音画同出的三档均声明 token；能力地图的「声音控制（人声）」列是指定音色通道，
+        不是音频能力本身，不据此判定音轨。"""
+        for model_id in ("kling-v2-6", "kling-v3", "kling-v3-omni"):
+            model = self._model("kling", model_id)
+            assert "generate_audio" in model.capabilities
+            assert model_has_audio_track("kling", model) is True
+
+    def test_kling_silent_models_omit_token(self):
+        """kling-v2-5-turbo 无音频开关、kling-video-o1 只能保留参考视频原声（ArcReel 不下发参考
+        视频）——两档均不声明 token。"""
+        for model_id in ("kling-v2-5-turbo", "kling-video-o1"):
+            model = self._model("kling", model_id)
+            assert "generate_audio" not in model.capabilities
+            assert model_has_audio_track("kling", model) is False
+
     def test_minimax_true_silent(self):
         """MiniMax 未声明 token 且不在恒有声例外表内——真无声模型。"""
         model = self._model("minimax", "MiniMax-Hailuo-2.3")

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -939,14 +939,16 @@ class TestVoiceConsistency:
         caps = await self._caps({"video_backend": "openai/sora-2"})
         assert caps["voice_consistency"] == "soft"
 
-    async def test_kling_v3_soft_after_token_correction(self):
-        """可灵 v3 系目录补 generate_audio 后派生 soft（不再因缺 token 误判 none、不注入 Voice_Profiles）。"""
+    @pytest.mark.unit
+    async def test_kling_v3_audio_models_are_soft(self):
+        """可灵 v3 系声明音频能力 → soft（注入 Voice_Profiles）。"""
         for model_id in ("kling-v3", "kling-v3-omni"):
             caps = await self._caps({"video_backend": f"kling/{model_id}"})
             assert caps["voice_consistency"] == "soft"
 
+    @pytest.mark.unit
     async def test_kling_turbo_true_silent_is_none(self):
-        """可灵 v2-5-turbo 无音频开关 → none（token 修正不外溢到真无声档）。"""
+        """可灵 v2-5-turbo 无音频开关 → none。"""
         caps = await self._caps({"video_backend": "kling/kling-v2-5-turbo"})
         assert caps["voice_consistency"] == "none"
 

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -939,6 +939,17 @@ class TestVoiceConsistency:
         caps = await self._caps({"video_backend": "openai/sora-2"})
         assert caps["voice_consistency"] == "soft"
 
+    async def test_kling_v3_soft_after_token_correction(self):
+        """可灵 v3 系目录补 generate_audio 后派生 soft（不再因缺 token 误判 none、不注入 Voice_Profiles）。"""
+        for model_id in ("kling-v3", "kling-v3-omni"):
+            caps = await self._caps({"video_backend": f"kling/{model_id}"})
+            assert caps["voice_consistency"] == "soft"
+
+    async def test_kling_turbo_true_silent_is_none(self):
+        """可灵 v2-5-turbo 无音频开关 → none（token 修正不外溢到真无声档）。"""
+        caps = await self._caps({"video_backend": "kling/kling-v2-5-turbo"})
+        assert caps["voice_consistency"] == "none"
+
     async def test_minimax_true_silent_is_none(self):
         """MiniMax 真无声模型 → none。"""
         caps = await self._caps({"video_backend": "minimax/MiniMax-Hailuo-2.3"})

--- a/tests/test_config_resolver_resolution.py
+++ b/tests/test_config_resolver_resolution.py
@@ -239,6 +239,18 @@ def test_constrain_durations_by_reference_images():
 
 
 @pytest.mark.unit
+def test_constrain_durations_drops_vidu_r2v_ghost_tiers():
+    """Vidu 参考生视频端点时长下限为 3 秒：走参考图路径时 1s / 2s 幽灵档位被剔除。
+
+    不剔除的后果是用户在 r2v 项目选中 1s，提交后被 backend 静默取到 3 秒并按 3 秒计费。
+    """
+    full = list(range(1, 17))
+    assert constrain_durations("vidu", "viduq3-turbo", full, uses_reference_images=True) == list(range(3, 17))
+    # 非参考图路径（文/图生视频）不受影响，1s / 2s 在那里合法
+    assert constrain_durations("vidu", "viduq3-turbo", full, uses_reference_images=False) == full
+
+
+@pytest.mark.unit
 def test_constrain_durations_both_dimensions_intersect():
     """两条约束同时生效时取交集。"""
     assert constrain_durations(*_HAILUO, [6, 10], resolution="1080p", uses_reference_images=True) == [6]

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -29,12 +29,14 @@ class TestOverrideFieldSchema:
             "max_reference_audio_count",
             "max_reference_audio_total_seconds",
             "reference_audio_per_image",
+            "max_prompt_chars",
         }
         assert CAPABILITY_OVERRIDE_FIELDS["last_frame"] is bool
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_images"] is int
         assert CAPABILITY_OVERRIDE_FIELDS["reference_audio_mode"] is ReferenceAudioMode
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_audio_count"] is int
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_audio_total_seconds"] == (float | None)
+        assert CAPABILITY_OVERRIDE_FIELDS["max_prompt_chars"] == (int | None)
         assert CAPABILITY_OVERRIDE_FIELDS["reference_audio_per_image"] is bool
 
 

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -145,6 +145,20 @@ class TestCapabilities:
         b = DashScopeVideoBackend(api_key="sk", model="happyhorse")
         assert b.video_capabilities.max_reference_images == 0
 
+    def test_wan27_declares_prompt_char_limit(self):
+        """wan2.7 全家族 prompt ≤ 5000 字符；超限官方静默截断并照常计费，故须付费前拦。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        for model in ("wan2.7-t2v", "wan2.7-i2v", "wan2.7-r2v"):
+            assert DashScopeVideoBackend.video_capabilities_for_model(model).max_prompt_chars == 5000
+
+    def test_models_without_verified_limit_declare_none(self):
+        """未取证到上限的 model 不声明——未声明 ≠ 上限 0，凭空声明会误拒合法请求。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        for model in ("happyhorse-1.0-t2v", "happyhorse-1.0-i2v", "happyhorse-1.0-r2v", "happyhorse"):
+            assert DashScopeVideoBackend.video_capabilities_for_model(model).max_prompt_chars is None
+
 
 class TestReferenceToVideo:
     async def test_r2v_happy_path(self, tmp_path: Path):

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -145,6 +145,7 @@ class TestCapabilities:
         b = DashScopeVideoBackend(api_key="sk", model="happyhorse")
         assert b.video_capabilities.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_wan27_declares_prompt_char_limit(self):
         """wan2.7 全家族 prompt ≤ 5000 字符；超限官方静默截断并照常计费，故须付费前拦。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend
@@ -152,6 +153,7 @@ class TestCapabilities:
         for model in ("wan2.7-t2v", "wan2.7-i2v", "wan2.7-r2v"):
             assert DashScopeVideoBackend.video_capabilities_for_model(model).max_prompt_chars == 5000
 
+    @pytest.mark.unit
     def test_models_without_verified_limit_declare_none(self):
         """未取证到上限的 model 不声明——未声明 ≠ 上限 0，凭空声明会误拒合法请求。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -277,8 +277,14 @@ class TestMultiImageSubpath:
         _, payload = _jwt_backend("kling-v3-omni")._build_payload(
             _request(tmp_path, reference_images=refs, resolution="1080p", generate_audio=True)
         )
-        # multi-image2video 原生 schema 不含音频开关
+        # multi-image2video 原生 schema 不含音频开关；有声决策同步归 False，避免按有声价出账
         assert "sound" not in payload
+        assert (
+            _jwt_backend("kling-v3-omni")._effective_audio(
+                _request(tmp_path, reference_images=refs, resolution="1080p", generate_audio=True)
+            )
+            is False
+        )
 
     def test_reference_images_take_precedence_over_start_image(self, tmp_path):
         refs = self._refs(tmp_path, 1)
@@ -663,6 +669,25 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
             result = await _jwt_backend().generate(_request(tmp_path, resolution="1080p", generate_audio=True))
+        assert result.generate_audio is False
+
+    async def test_v3_omni_multi_image_audio_result_false(self, tmp_path):
+        # multi-image2video 子路径不携带 sound（原生 schema 无此字段），成片必然无声：
+        # result.generate_audio 必须同步为 False，否则按有声价出账却拿到无声片
+        ref = tmp_path / "ref0.png"
+        ref.write_bytes(b"\x89PNG\r\n")
+        post = AsyncMock(return_value=_resp(_submit("task-b3")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v3-omni").generate(
+                _request(tmp_path, reference_images=[ref], resolution="1080p", generate_audio=True)
+            )
+        assert post.await_args.args[0].endswith("/videos/multi-image2video")
         assert result.generate_audio is False
 
     async def test_v2_6_persists_audio_bit_in_job_id(self, tmp_path):

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -224,6 +224,7 @@ class TestAudioGating:
         )
         assert payload["sound"] == "off"
 
+    @pytest.mark.unit
     def test_v2_6_audio_gate_ignores_request_resolution(self, tmp_path):
         # request.resolution 不进 payload（4k 档除外），不能作为成片是否 1080P 的判据：
         # pro 档即 1080P，resolution 写 720p 也照常有声
@@ -232,6 +233,15 @@ class TestAudioGating:
         )
         assert payload["sound"] == "on"
 
+    @pytest.mark.unit
+    def test_v2_6_4k_audio_forced_off(self, tmp_path):
+        # 4k 档是 v3 系专有，对 v2-6 是非法请求：不当作满足 1080P 放行，避免按有声价出账
+        _, payload = _jwt_backend("kling-v2-6")._build_payload(
+            _request(tmp_path, resolution="4k", service_tier="pro", generate_audio=True)
+        )
+        assert payload["sound"] == "off"
+
+    @pytest.mark.unit
     def test_v3_audio_enabled_without_tier_constraint(self, tmp_path):
         # v3 系官方未声明分辨率/档位约束：请求要人声即开启，不按未记载的限制降级
         for model in ("kling-v3", "kling-v3-omni"):
@@ -240,11 +250,13 @@ class TestAudioGating:
             )
             assert payload["sound"] == "on"
 
+    @pytest.mark.unit
     def test_audio_capable_model_sends_off_when_not_requested(self, tmp_path):
         # 有能力但请求不要人声：显式发 "off"，与官方默认值一致
         _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, generate_audio=False))
         assert payload["sound"] == "off"
 
+    @pytest.mark.unit
     def test_no_audio_model_omits_sound_field(self, tmp_path):
         # 无音频能力的档：不携带 sound，避免向不支持的端点发未知参数
         img = tmp_path / "start.png"
@@ -274,6 +286,7 @@ class TestMultiImageSubpath:
         assert not payload["image_list"][0]["image"].startswith("data:")
         assert "image" not in payload and "image_tail" not in payload
 
+    @pytest.mark.unit
     def test_multi_image2video_omits_sound(self, tmp_path):
         refs = self._refs(tmp_path, 1)
         _, payload = _jwt_backend("kling-v3-omni")._build_payload(
@@ -648,6 +661,7 @@ class TestAudioGatingResult:
         assert result.generate_audio is True
         assert post.await_args.args[0].endswith("/videos/text2video")
 
+    @pytest.mark.unit
     async def test_v2_6_std_audio_result_false(self, tmp_path):
         # std 档拿不到 1080P：即使 request.resolution 写 1080p，结果也必须记为无声，
         # 否则拿到无声片却按有声价（¥1.0/s vs ¥0.8/s）出账
@@ -664,6 +678,7 @@ class TestAudioGatingResult:
             )
         assert result.generate_audio is False
 
+    @pytest.mark.unit
     async def test_v3_audio_result_true(self, tmp_path):
         # v3 支持音画同出且无分辨率约束：请求有声 → result.generate_audio=True
         post = AsyncMock(return_value=_resp(_submit("task-b")))
@@ -677,6 +692,7 @@ class TestAudioGatingResult:
             result = await _jwt_backend("kling-v3").generate(_request(tmp_path, generate_audio=True))
         assert result.generate_audio is True
 
+    @pytest.mark.unit
     async def test_turbo_audio_gated_result_false(self, tmp_path):
         # turbo 无音频能力：即使请求有声，result.generate_audio=False（计费取无声价）
         post = AsyncMock(return_value=_resp(_submit("task-b2")))
@@ -690,6 +706,7 @@ class TestAudioGatingResult:
             result = await _jwt_backend().generate(_request(tmp_path, resolution="1080p", generate_audio=True))
         assert result.generate_audio is False
 
+    @pytest.mark.unit
     async def test_v3_omni_multi_image_audio_result_false(self, tmp_path):
         # multi-image2video 子路径不携带 sound（原生 schema 无此字段），成片必然无声：
         # result.generate_audio 必须同步为 False，否则按有声价出账却拿到无声片
@@ -709,6 +726,7 @@ class TestAudioGatingResult:
         assert post.await_args.args[0].endswith("/videos/multi-image2video")
         assert result.generate_audio is False
 
+    @pytest.mark.unit
     async def test_v2_6_persists_audio_bit_in_job_id(self, tmp_path):
         # submit 时算定的有声决策编入 job_id（v2-6 pro 有声 → 末段 :1），resume 据此直连计费
         post = AsyncMock(return_value=_resp(_submit("task-c")))
@@ -746,8 +764,8 @@ class TestAudioGatingResult:
         assert result.task_id == "task-c"
         assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
-    async def test_resume_legacy_job_id_recomputes_audio(self, tmp_path):
-        # 旧 job_id（2 段，未持久化有声标志）回落按请求重算
+    async def test_resume_legacy_job_id_stays_silent(self, tmp_path):
+        # 2 段旧 job_id 出自尚无音频能力的实现，成片必然无声：不得按当前能力图重算为有声
         post = AsyncMock()
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
         client = _client(post=post, get=get)
@@ -760,11 +778,12 @@ class TestAudioGatingResult:
                 "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
             )
         post.assert_not_called()
-        assert result.generate_audio is True
+        assert result.generate_audio is False
         # 2 段旧 job_id 同样须正确复原子路径/任务号（不误把整串当 task_id）
         assert result.task_id == "task-c"
         assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
+    @pytest.mark.unit
     async def test_resume_legacy_multi_image_job_id_stays_silent(self, tmp_path):
         # 旧格式多图主体 job_id 回落重算时，resume 请求已不带参考图字段，只能按解码出的
         # 子路径判定：multi-image2video 成片必然无声，不得按有声价出账

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -210,27 +210,29 @@ class TestModeAndResolution:
 
 
 class TestAudioGating:
-    def test_v2_6_1080p_audio_enabled(self, tmp_path):
+    def test_v2_6_pro_audio_enabled(self, tmp_path):
         _, payload = _jwt_backend("kling-v2-6")._build_payload(
-            _request(tmp_path, resolution="1080p", generate_audio=True)
+            _request(tmp_path, resolution="1080p", service_tier="pro", generate_audio=True)
         )
         assert payload["sound"] == "on"
 
-    def test_v2_6_720p_audio_forced_off(self, tmp_path):
-        # v2-6 有声官方限 1080P：其余分辨率即使请求有声也压制为无声
-        _, payload = _jwt_backend("kling-v2-6")._build_payload(
-            _request(tmp_path, resolution="720p", service_tier="pro", generate_audio=True)
-        )
-        assert payload["sound"] == "off"
-
-    def test_v2_6_audio_gate_ignores_service_tier(self, tmp_path):
-        # 官方约束绑分辨率不绑质量档：1080p + std 同样有声
+    def test_v2_6_std_audio_forced_off(self, tmp_path):
+        # v2-6 有声官方限 1080P，而可灵只能经 mode 请求该档位：std 档拿不到 1080P，
+        # 即使 request.resolution 写 1080p 也压制为无声——否则拿到无声片却按有声价出账
         _, payload = _jwt_backend("kling-v2-6")._build_payload(
             _request(tmp_path, resolution="1080p", service_tier="std", generate_audio=True)
         )
+        assert payload["sound"] == "off"
+
+    def test_v2_6_audio_gate_ignores_request_resolution(self, tmp_path):
+        # request.resolution 不进 payload（4k 档除外），不能作为成片是否 1080P 的判据：
+        # pro 档即 1080P，resolution 写 720p 也照常有声
+        _, payload = _jwt_backend("kling-v2-6")._build_payload(
+            _request(tmp_path, resolution="720p", service_tier="pro", generate_audio=True)
+        )
         assert payload["sound"] == "on"
 
-    def test_v3_audio_enabled_without_resolution_constraint(self, tmp_path):
+    def test_v3_audio_enabled_without_tier_constraint(self, tmp_path):
         # v3 系官方未声明分辨率/档位约束：请求要人声即开启，不按未记载的限制降级
         for model in ("kling-v3", "kling-v3-omni"):
             _, payload = _jwt_backend(model)._build_payload(
@@ -629,8 +631,8 @@ class TestResume:
 
 
 class TestAudioGatingResult:
-    async def test_v2_6_1080p_audio_result_true(self, tmp_path):
-        # v2-6 1080p + 请求有声 → result.generate_audio=True（下游计费取有声价）
+    async def test_v2_6_pro_audio_result_true(self, tmp_path):
+        # v2-6 pro（即 1080P 档）+ 请求有声 → result.generate_audio=True（下游计费取有声价）
         post = AsyncMock(return_value=_resp(_submit("task-a")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
         client = _client(post=post, get=get)
@@ -640,10 +642,26 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
             result = await _jwt_backend("kling-v2-6").generate(
-                _request(tmp_path, resolution="1080p", generate_audio=True)
+                _request(tmp_path, resolution="1080p", service_tier="pro", generate_audio=True)
             )
         assert result.generate_audio is True
         assert post.await_args.args[0].endswith("/videos/text2video")
+
+    async def test_v2_6_std_audio_result_false(self, tmp_path):
+        # std 档拿不到 1080P：即使 request.resolution 写 1080p，结果也必须记为无声，
+        # 否则拿到无声片却按有声价（¥1.0/s vs ¥0.8/s）出账
+        post = AsyncMock(return_value=_resp(_submit("task-a2")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v2-6").generate(
+                _request(tmp_path, resolution="1080p", service_tier="std", generate_audio=True)
+            )
+        assert result.generate_audio is False
 
     async def test_v3_audio_result_true(self, tmp_path):
         # v3 支持音画同出且无分辨率约束：请求有声 → result.generate_audio=True
@@ -691,7 +709,7 @@ class TestAudioGatingResult:
         assert result.generate_audio is False
 
     async def test_v2_6_persists_audio_bit_in_job_id(self, tmp_path):
-        # submit 时算定的有声决策编入 job_id（v2-6 1080p 有声 → 末段 :1），resume 据此直连计费
+        # submit 时算定的有声决策编入 job_id（v2-6 pro 有声 → 末段 :1），resume 据此直连计费
         post = AsyncMock(return_value=_resp(_submit("task-c")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
         client = _client(post=post, get=get)
@@ -702,7 +720,7 @@ class TestAudioGatingResult:
             patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _jwt_backend("kling-v2-6").generate(
-                _request(tmp_path, task_id="local-a", resolution="1080p", generate_audio=True)
+                _request(tmp_path, task_id="local-a", service_tier="pro", generate_audio=True)
             )
         assert persist.await_args is not None
         assert persist.await_args.args[1] == "text2video:task-c:1"
@@ -738,7 +756,7 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
             result = await _jwt_backend("kling-v2-6").resume_video(
-                "text2video:task-c", _request(tmp_path, resolution="1080p", generate_audio=True)
+                "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
             )
         post.assert_not_called()
         assert result.generate_audio is True

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -210,30 +210,46 @@ class TestModeAndResolution:
 
 
 class TestAudioGating:
-    def test_v2_6_pro_audio_enabled(self, tmp_path):
+    def test_v2_6_1080p_audio_enabled(self, tmp_path):
         _, payload = _jwt_backend("kling-v2-6")._build_payload(
-            _request(tmp_path, service_tier="pro", generate_audio=True)
+            _request(tmp_path, resolution="1080p", generate_audio=True)
         )
-        assert payload["enable_audio"] is True
+        assert payload["sound"] == "on"
 
-    def test_v2_6_std_audio_forced_off(self, tmp_path):
-        # 人声仅 pro 档：std 即使请求有声也压制为无声
+    def test_v2_6_720p_audio_forced_off(self, tmp_path):
+        # v2-6 有声官方限 1080P：其余分辨率即使请求有声也压制为无声
         _, payload = _jwt_backend("kling-v2-6")._build_payload(
-            _request(tmp_path, service_tier="std", generate_audio=True)
+            _request(tmp_path, resolution="720p", service_tier="pro", generate_audio=True)
         )
-        assert payload["enable_audio"] is False
+        assert payload["sound"] == "off"
 
-    def test_v3_audio_capability_absent_forced_off(self, tmp_path):
-        # 无 generate_audio 能力的 model：即使请求有声，enable_audio 强制 False（压制 v3 默认有声）
-        _, payload = _jwt_backend("kling-v3")._build_payload(
-            _request(tmp_path, service_tier="pro", generate_audio=True)
+    def test_v2_6_audio_gate_ignores_service_tier(self, tmp_path):
+        # 官方约束绑分辨率不绑质量档：1080p + std 同样有声
+        _, payload = _jwt_backend("kling-v2-6")._build_payload(
+            _request(tmp_path, resolution="1080p", service_tier="std", generate_audio=True)
         )
-        assert payload["enable_audio"] is False
+        assert payload["sound"] == "on"
 
-    def test_turbo_omits_enable_audio_field(self, tmp_path):
-        # 旧档无 enable_audio 字段：不携带，避免向不支持的端点发未知参数
-        _, payload = _jwt_backend()._build_payload(_request(tmp_path, generate_audio=True))
-        assert "enable_audio" not in payload
+    def test_v3_audio_enabled_without_resolution_constraint(self, tmp_path):
+        # v3 系官方未声明分辨率/档位约束：请求要人声即开启，不按未记载的限制降级
+        for model in ("kling-v3", "kling-v3-omni"):
+            _, payload = _jwt_backend(model)._build_payload(
+                _request(tmp_path, resolution="720p", service_tier="std", generate_audio=True)
+            )
+            assert payload["sound"] == "on"
+
+    def test_audio_capable_model_sends_off_when_not_requested(self, tmp_path):
+        # 有能力但请求不要人声：显式发 "off"，与官方默认值一致
+        _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, generate_audio=False))
+        assert payload["sound"] == "off"
+
+    def test_no_audio_model_omits_sound_field(self, tmp_path):
+        # 无音频能力的档：不携带 sound，避免向不支持的端点发未知参数
+        img = tmp_path / "start.png"
+        img.write_bytes(b"\x89PNG\r\n")
+        for backend in (_jwt_backend(), _jwt_backend("kling-video-o1")):
+            _, payload = backend._build_payload(_request(tmp_path, start_image=img, generate_audio=True))
+            assert "sound" not in payload
 
 
 class TestMultiImageSubpath:
@@ -256,13 +272,13 @@ class TestMultiImageSubpath:
         assert not payload["image_list"][0]["image"].startswith("data:")
         assert "image" not in payload and "image_tail" not in payload
 
-    def test_multi_image2video_omits_enable_audio(self, tmp_path):
+    def test_multi_image2video_omits_sound(self, tmp_path):
         refs = self._refs(tmp_path, 1)
         _, payload = _jwt_backend("kling-v3-omni")._build_payload(
-            _request(tmp_path, reference_images=refs, service_tier="pro", generate_audio=True)
+            _request(tmp_path, reference_images=refs, resolution="1080p", generate_audio=True)
         )
-        # multi-image2video 原生 schema 不含 enable_audio
-        assert "enable_audio" not in payload
+        # multi-image2video 原生 schema 不含音频开关
+        assert "sound" not in payload
 
     def test_reference_images_take_precedence_over_start_image(self, tmp_path):
         refs = self._refs(tmp_path, 1)
@@ -607,8 +623,8 @@ class TestResume:
 
 
 class TestAudioGatingResult:
-    async def test_v2_6_pro_audio_result_true(self, tmp_path):
-        # v2-6 pro + 请求有声 → result.generate_audio=True（下游计费取有声价 ¥1/s）
+    async def test_v2_6_1080p_audio_result_true(self, tmp_path):
+        # v2-6 1080p + 请求有声 → result.generate_audio=True（下游计费取有声价）
         post = AsyncMock(return_value=_resp(_submit("task-a")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
         client = _client(post=post, get=get)
@@ -618,13 +634,13 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
             result = await _jwt_backend("kling-v2-6").generate(
-                _request(tmp_path, service_tier="pro", generate_audio=True)
+                _request(tmp_path, resolution="1080p", generate_audio=True)
             )
         assert result.generate_audio is True
         assert post.await_args.args[0].endswith("/videos/text2video")
 
-    async def test_v3_audio_gated_result_false(self, tmp_path):
-        # v3 无音频能力：即使请求有声，result.generate_audio=False（计费取无声价）
+    async def test_v3_audio_result_true(self, tmp_path):
+        # v3 支持音画同出且无分辨率约束：请求有声 → result.generate_audio=True
         post = AsyncMock(return_value=_resp(_submit("task-b")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
         client = _client(post=post, get=get)
@@ -633,13 +649,24 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
-            result = await _jwt_backend("kling-v3").generate(
-                _request(tmp_path, service_tier="pro", generate_audio=True)
-            )
+            result = await _jwt_backend("kling-v3").generate(_request(tmp_path, generate_audio=True))
+        assert result.generate_audio is True
+
+    async def test_turbo_audio_gated_result_false(self, tmp_path):
+        # turbo 无音频能力：即使请求有声，result.generate_audio=False（计费取无声价）
+        post = AsyncMock(return_value=_resp(_submit("task-b2")))
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend().generate(_request(tmp_path, resolution="1080p", generate_audio=True))
         assert result.generate_audio is False
 
-    async def test_v2_6_pro_persists_audio_bit_in_job_id(self, tmp_path):
-        # submit 时算定的有声决策编入 job_id（v2-6 pro 有声 → 末段 :1），resume 据此直连计费
+    async def test_v2_6_persists_audio_bit_in_job_id(self, tmp_path):
+        # submit 时算定的有声决策编入 job_id（v2-6 1080p 有声 → 末段 :1），resume 据此直连计费
         post = AsyncMock(return_value=_resp(_submit("task-c")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
         client = _client(post=post, get=get)
@@ -650,7 +677,7 @@ class TestAudioGatingResult:
             patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
         ):
             await _jwt_backend("kling-v2-6").generate(
-                _request(tmp_path, task_id="local-a", service_tier="pro", generate_audio=True)
+                _request(tmp_path, task_id="local-a", resolution="1080p", generate_audio=True)
             )
         assert persist.await_args is not None
         assert persist.await_args.args[1] == "text2video:task-c:1"
@@ -686,7 +713,7 @@ class TestAudioGatingResult:
             patch("lib.video_backends.kling.download_video", new=AsyncMock()),
         ):
             result = await _jwt_backend("kling-v2-6").resume_video(
-                "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
+                "text2video:task-c", _request(tmp_path, resolution="1080p", generate_audio=True)
             )
         post.assert_not_called()
         assert result.generate_audio is True

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -165,7 +165,7 @@ class TestPerModelCapabilities:
         request = _request(tmp_path, generate_audio=True)
 
         assert effective_generate_audio_for_model("kling", "kling-video-o1") is False
-        assert backend._effective_audio(request) is False
+        assert backend._effective_audio(request, subpath="text2video") is False
 
     def test_unknown_model_falls_back_to_default_caps(self):
         # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、尾帧仅 pro 档，声明按 std 档保守
@@ -283,7 +283,8 @@ class TestMultiImageSubpath:
         assert "sound" not in payload
         assert (
             _jwt_backend("kling-v3-omni")._effective_audio(
-                _request(tmp_path, reference_images=refs, resolution="1080p", generate_audio=True)
+                _request(tmp_path, reference_images=refs, resolution="1080p", generate_audio=True),
+                subpath="multi-image2video",
             )
             is False
         )
@@ -763,3 +764,21 @@ class TestAudioGatingResult:
         # 2 段旧 job_id 同样须正确复原子路径/任务号（不误把整串当 task_id）
         assert result.task_id == "task-c"
         assert get.await_args.args[0].endswith("/videos/text2video/task-c")
+
+    async def test_resume_legacy_multi_image_job_id_stays_silent(self, tmp_path):
+        # 旧格式多图主体 job_id 回落重算时，resume 请求已不带参考图字段，只能按解码出的
+        # 子路径判定：multi-image2video 成片必然无声，不得按有声价出账
+        post = AsyncMock()
+        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
+        ):
+            result = await _jwt_backend("kling-v3-omni").resume_video(
+                "multi-image2video:task-d", _request(tmp_path, generate_audio=True)
+            )
+        post.assert_not_called()
+        assert result.generate_audio is False
+        assert get.await_args.args[0].endswith("/videos/multi-image2video/task-d")

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -765,7 +765,7 @@ class TestAudioGatingResult:
         assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
     async def test_resume_legacy_job_id_stays_silent(self, tmp_path):
-        # 2 段旧 job_id 出自尚无音频能力的实现，成片必然无声：不得按当前能力图重算为有声
+        # 不含有声标志的 2 段 job_id 一律判无声：这类任务的成片必然无声，不得按当前能力表重算为有声
         post = AsyncMock()
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
         client = _client(post=post, get=get)
@@ -785,8 +785,7 @@ class TestAudioGatingResult:
 
     @pytest.mark.unit
     async def test_resume_legacy_multi_image_job_id_stays_silent(self, tmp_path):
-        # 旧格式多图主体 job_id 回落重算时，resume 请求已不带参考图字段，只能按解码出的
-        # 子路径判定：multi-image2video 成片必然无声，不得按有声价出账
+        # 多图主体子路径的成片必然无声：接续请求不带参考图字段，判据只能取自解码出的子路径
         post = AsyncMock()
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
         client = _client(post=post, get=get)

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -892,3 +892,55 @@ class TestReferenceCompressionSeam:
         )
 
         assert probe_calls == []
+
+    @pytest.mark.unit
+    async def test_prompt_over_limit_raises_before_backend_call(self, tmp_path):
+        """超长 prompt 在调 backend.generate（即付费请求）之前被拦截，不留记账行。"""
+        from lib.video_backends.base import VideoCapabilities, VideoCapabilityError
+
+        gen = _build_generator(tmp_path)
+
+        class _PromptLimitedVideoBackend:
+            name = "fake-video"
+            model = "video-model"
+            video_capabilities = VideoCapabilities(max_prompt_chars=10)
+
+            def __init__(self):
+                self.called = False
+
+            async def generate(self, request):
+                self.called = True
+                raise AssertionError("超限请求不应到达 backend.generate")
+
+        backend = _PromptLimitedVideoBackend()
+        gen._video_backend = backend
+
+        with pytest.raises(VideoCapabilityError) as exc:
+            await gen.generate_video_async(prompt="x" * 11, resource_type="videos", resource_id="E1S01")
+
+        assert exc.value.code == "video_prompt_too_long"
+        assert backend.called is False
+        assert gen.ledger.outcomes == []
+
+    @pytest.mark.unit
+    async def test_prompt_gating_applies_without_optional_paths(self, tmp_path):
+        """prompt 长度对每个请求都适用：纯文生/首帧路径（无尾帧、参考图、参考音频）同样查能力。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        gen = _build_generator(tmp_path)
+
+        class _PromptLimitedVideoBackend:
+            name = "fake-video"
+            model = "video-model"
+            video_capabilities = VideoCapabilities(max_prompt_chars=10)
+
+            async def generate(self, request):
+                request.output_path.parent.mkdir(parents=True, exist_ok=True)
+                request.output_path.write_bytes(b"v")
+                return _FakeVideoResult()
+
+        gen._video_backend = _PromptLimitedVideoBackend()
+
+        await gen.generate_video_async(prompt="x" * 10, resource_type="videos", resource_id="E1S01")
+
+        assert gen.ledger.outcomes

--- a/tests/test_model_candidates_api.py
+++ b/tests/test_model_candidates_api.py
@@ -272,11 +272,13 @@ class TestBucketJudgement:
         assert builtin_model_buckets(provider_id, model_id, model_info) == frozenset()
 
     def test_builtin_video_r2v_reads_backend_not_registry(self):
-        """registry 的 max_reference_images 与 backend 声明并存时，判定以 backend 为准。"""
+        """registry 的 max_reference_images 与 backend 声明冲突时，判定以 backend 为准。
+
+        viduq3-pro 不在 Vidu 的 /reference2video 端点白名单内，backend 据此声明
+        max_reference_images=0。此处人为把 registry 侧的并行声明改成非 0，断言桶判定不受其影响。
+        """
         meta = PROVIDER_REGISTRY["vidu"]
-        # viduq3-pro 的 backend 声明 max_reference_images=0，registry 侧则非 0
-        model_info = meta.models["viduq3-pro"]
-        assert model_info.max_reference_images > 0
+        model_info = replace(meta.models["viduq3-pro"], max_reference_images=7)
         assert "r2v" not in builtin_model_buckets("vidu", "viduq3-pro", model_info)
 
     @pytest.mark.parametrize(

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -25,6 +25,7 @@ CAPS_WITH_AUDIO_DURATION_LIMIT = VideoCapabilities(
     max_reference_audio_count=3,
     max_reference_audio_total_seconds=15.0,
 )
+CAPS_WITH_PROMPT_LIMIT = VideoCapabilities(first_frame=True, max_prompt_chars=100)
 
 
 def _gate(caps: VideoCapabilities | None, **kwargs):
@@ -258,6 +259,40 @@ class TestReferenceAudioDurationGating:
             reference_audio_files=[Path("a.mp3"), Path("b.wav")],
             reference_audio_total_seconds=1000.0,
         )
+
+
+class TestPromptLengthGating:
+    def test_prompt_within_limit_passes(self):
+        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 99)
+
+    def test_prompt_at_limit_passes(self):
+        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 100)
+
+    def test_prompt_beyond_limit_raises(self):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 101)
+
+        assert exc.value.code == "video_prompt_too_long"
+        assert exc.value.params == {"provider": "acme", "model": "acme-v1", "limit": 100, "count": 101}
+
+    def test_limit_counts_characters_not_bytes(self):
+        """计量口径是字符数，中英文同权——按字节算会把中文 prompt 误拒。"""
+        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="中" * 100)
+
+    def test_no_declared_limit_skips_check(self):
+        """caps 未声明上限：任意长度都放行，未声明不等于上限为 0。"""
+        _gate(CAPS_WITH_LAST_FRAME, prompt="x" * 100_000)
+
+    def test_none_caps_skips_check(self):
+        """能力未查询（caps=None）时不拦 prompt——无从得知上限，拒绝反成误伤。"""
+        _gate(None, prompt="x" * 100_000)
+
+    def test_prompt_checked_before_optional_paths(self):
+        """prompt 违约先于尾帧等可选路径报出，用户一次只看到最先命中的那条。"""
+        with pytest.raises(VideoCapabilityError) as exc:
+            _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 101, end_image=Path("end.png"))
+
+        assert exc.value.code == "video_prompt_too_long"
 
 
 class TestGateAndAssemblySeparation:

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -9,6 +9,7 @@ import pytest
 
 from lib.providers import PROVIDER_VIDU
 from lib.video_backends.base import (
+    VideoCapabilityError,
     VideoGenerationRequest,
 )
 from lib.video_backends.vidu import (
@@ -266,11 +267,75 @@ class TestBuildRequest:
             backend._build_request(req)
 
 
+class TestPromptLength:
+    """prompt 超限一律拒绝，不再客户端静默截断。"""
+
+    def test_reference_only_model_declares_narrow_limit(self):
+        """viduq3 只跑 /reference2video，静态声明取该端点的窄值。"""
+        assert ViduVideoBackend.video_capabilities_for_model("viduq3").max_prompt_chars == 2000
+
+    def test_multi_endpoint_model_declares_wide_limit(self):
+        """viduq3-turbo 还能跑 t2v/i2v，静态声明取宽值——否则会误拒其合法的长 prompt。"""
+        assert ViduVideoBackend.video_capabilities_for_model("viduq3-turbo").max_prompt_chars == 5000
+
+    def test_unknown_model_declares_wide_limit(self):
+        """未登记 model（中转自定义命名）取宽值：能力不明时误拒是更糟的降级。"""
+        assert ViduVideoBackend.video_capabilities_for_model("proxy-x").max_prompt_chars == 5000
+
+    def test_reference2video_over_limit_raises(self, output_path: Path):
+        backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
+        req = VideoGenerationRequest(
+            prompt="字" * 2001,
+            output_path=output_path,
+            duration_seconds=8,
+            reference_images=[Path("a.png")],
+        )
+        with pytest.raises(VideoCapabilityError) as exc:
+            backend._build_request(req)
+
+        assert exc.value.code == "video_prompt_too_long"
+        assert exc.value.params == {
+            "provider": PROVIDER_VIDU,
+            "model": "viduq3-turbo",
+            "limit": 2000,
+            "count": 2001,
+        }
+
+    @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    def test_reference2video_at_limit_passes_untruncated(self, _mock_data_uri, output_path: Path):
+        backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
+        prompt = "字" * 2000
+        req = VideoGenerationRequest(
+            prompt=prompt,
+            output_path=output_path,
+            duration_seconds=8,
+            reference_images=[Path("a.png")],
+        )
+        _endpoint, body = backend._build_request(req)
+
+        assert body["prompt"] == prompt
+
+    def test_text2video_allows_longer_than_reference_limit(self, output_path: Path):
+        """端点上限按端点各算：t2v 的 5000 不受 /reference2video 的 2000 牵连。"""
+        backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
+        req = VideoGenerationRequest(prompt="字" * 3000, output_path=output_path, duration_seconds=8)
+        _endpoint, body = backend._build_request(req)
+
+        assert len(body["prompt"]) == 3000
+
+
 class TestDurationRulesSpec:
     """直接钉死 _DURATION_RULES 关键条目，避免误改。"""
 
     def test_q1_text2video_only_5(self):
         assert _DURATION_RULES[("viduq1", "/text2video")] == [5]
+
+    def test_q2_img2video_up_to_10(self):
+        """/img2video 官方为 1–10；1–8 是 /start-end2video 的值，两端点不同。"""
+        assert _DURATION_RULES[("viduq2-pro", "/img2video")] == list(range(1, 11))
+        assert _DURATION_RULES[("viduq2-turbo", "/img2video")] == list(range(1, 11))
+        assert _DURATION_RULES[("viduq2-pro-fast", "/img2video")] == list(range(1, 11))
+        assert _DURATION_RULES[("viduq2-pro", "/start-end2video")] == list(range(1, 9))
 
     def test_vidu2_0_img2video_only_4_8(self):
         assert _DURATION_RULES[("vidu2.0", "/img2video")] == [4, 8]

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -267,21 +267,26 @@ class TestBuildRequest:
             backend._build_request(req)
 
 
+@pytest.mark.unit
 class TestPromptLength:
     """prompt 超限一律拒绝，不再客户端静默截断。"""
 
+    @pytest.mark.unit
     def test_reference_only_model_declares_narrow_limit(self):
         """viduq3 只跑 /reference2video，静态声明取该端点的窄值。"""
         assert ViduVideoBackend.video_capabilities_for_model("viduq3").max_prompt_chars == 2000
 
+    @pytest.mark.unit
     def test_multi_endpoint_model_declares_wide_limit(self):
         """viduq3-turbo 还能跑 t2v/i2v，静态声明取宽值——否则会误拒其合法的长 prompt。"""
         assert ViduVideoBackend.video_capabilities_for_model("viduq3-turbo").max_prompt_chars == 5000
 
+    @pytest.mark.unit
     def test_unknown_model_declares_wide_limit(self):
         """未登记 model（中转自定义命名）取宽值：能力不明时误拒是更糟的降级。"""
         assert ViduVideoBackend.video_capabilities_for_model("proxy-x").max_prompt_chars == 5000
 
+    @pytest.mark.unit
     def test_reference2video_over_limit_raises(self, output_path: Path):
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
         req = VideoGenerationRequest(
@@ -302,6 +307,7 @@ class TestPromptLength:
         }
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
+    @pytest.mark.unit
     def test_reference2video_at_limit_passes_untruncated(self, _mock_data_uri, output_path: Path):
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
         prompt = "字" * 2000
@@ -315,6 +321,7 @@ class TestPromptLength:
 
         assert body["prompt"] == prompt
 
+    @pytest.mark.unit
     def test_text2video_allows_longer_than_reference_limit(self, output_path: Path):
         """端点上限按端点各算：t2v 的 5000 不受 /reference2video 的 2000 牵连。"""
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
@@ -330,6 +337,7 @@ class TestDurationRulesSpec:
     def test_q1_text2video_only_5(self):
         assert _DURATION_RULES[("viduq1", "/text2video")] == [5]
 
+    @pytest.mark.unit
     def test_q2_img2video_up_to_10(self):
         """/img2video 官方为 1–10；1–8 是 /start-end2video 的值，两端点不同。"""
         assert _DURATION_RULES[("viduq2-pro", "/img2video")] == list(range(1, 11))


### PR DESCRIPTION
Closes #1576

供应商能力数据的三条修正，覆盖票面验收标准 1、2、3 全量。

## 1. 可灵 v3 / v3-omni 有声分类修正（验收标准 1）

原分类把官方能力地图的「声音控制（指定音色）」一列误读为音频能力本身，导致 `kling-v3` / `kling-v3-omni` 被当作真无声档：能力查询不报有声、`derive_voice_consistency` 派生为 `none` 而不注入 Voice_Profiles。

- registry 与 backend `_KLING_VIDEO_CAPS` 给这两档补上音频能力；`kling-v2-5-turbo` / `kling-video-o1` 维持无声不变
- 请求体的音频开关改用官方参数 `sound`（`"on"` / `"off"`），取代原先并不存在于官方参数表的 `enable_audio`；无音频能力的档不再携带该字段
- v2-6 的有声约束按官方原文是绑分辨率（「生成有声视频时，仅支持生成 1080P」）。可灵请求体没有分辨率字段——输出档位只由质量档决定（标准档 720P、高质量档 1080P、4K 档），项目里选的分辨率除识别 4K 档外不会发给供应商，因此执行期判据落在实际发出的质量档上。v3 系官方未声明任何分辨率或档位限制，故不加
- 多图主体（参考图）路径的请求体不携带音频开关（该端点原生 schema 无此字段），成片必然无声——有声标志在该路径下同步判定为无声，避免按有声价出账却拿到无声片

### 未实测说明（重要）

票面原文要求「改前先实测」一次真实调用确认服务端接受哪个音频参数名。**项目所有者已明确免除该前置**（无可用 kling 凭据），指示依官方文档调研结论实现、待真实用户反馈异常再修。因此本 PR 的可灵音频改动**未经真实调用验证**，以下三点均为依官方文档推断、非已验证事实：

1. 服务端是否确实接受 `sound` 而非 `enable_audio`（官方两份独立取证的参数表均只列 `sound`，但两者都未经真实响应确认）
2. v3 系有声是否真的不受 1080P 约束（官方未声明，本次取宽）
3. 可灵各质量档与输出分辨率的对应关系（标准档 720P、高质量档 1080P）取自官方模型清单与定价口径，未经一次真实调用回读成片分辨率确认

任一处若与服务端实际行为不符，症状是「请求了人声但成片无声、仍按有声价出账」——与修正前的失败模式同类，范围不扩大。

官方新版参数 `settings.audio`（`native` / `original` / `off`）未接入，本次沿用票面「改法」指定的旧版 `sound`。

## 2. Vidu 参考生视频幽灵时长档位（验收标准 2）

`viduq3-turbo` / `viduq3` 声明的时长档位含 1s / 2s，但参考生视频端点官方下限是 3 秒——用户在参考生视频项目里选中 1s / 2s 提交后被后端静默取到 3 秒并按 3 秒计费。改用 registry 既有的「参考图↔时长」约束机制收窄，其触发条件与后端端点选择同源，参考生视频项目里无引用的退化镜头走文生视频路径（1–16 合法）不受误伤。

顺带清理：`viduq3-pro` 的参考图上限 7 → 0（官方参考生视频端点的模型清单不含它，后端白名单本就正确，此处是并行声明的过时副本）；`viduq2` 系在图生视频端点的时长范围 1–8 → 1–10（1–8 是首尾帧端点的值，仅影响自定义供应商透传）。

## 3. 超长提示词付费前拦截（验收标准 3）

阿里百炼对超出上限的提示词是**静默截断**而非报错（官方原文「超过部分会自动截断」，错误码表无对应条目）：照常扣费 + 成片与意图不符 + 用户无从知情。Vidu 后端则自己做客户端静默截断，与统一闸口「同一种违约不该有的硬失败、有的静默截断」的口径相左。

- `VideoCapabilities` 新增提示词字符数上限维度，付费前闸口按字符数硬拒，新增结构化错误码 + 中/英/越三语文案
- Vidu 的客户端静默截断收编到同一闸口；端点级更窄的上限（参考生视频端点）留在后端组装期硬失败兜底
- 未登记型号取宽值或不声明：静态声明只该拒绝必然违约的请求，对能力不明的型号误拒是更糟的降级

票面提到的 wan2.6（1500）/ wan2.2、wanx2.1（800）未声明——这些型号在 registry 与后端型号表里都不存在，只可能经中转自定义命名到达，凭空加条目属新增投机面。

## 验证

- 后端全量 pytest 通过；`ruff check` / `ruff format --check` 通过；`basedpyright` 0 error；`lint-imports` 分层契约 KEPT
- 前端 `pnpm lint` / `pnpm check` 通过（前端仅涉及自定义供应商能力字段的类型定义）
- 未经真实供应商调用验证的部分见上方「未实测说明」

## 附注：提交历史与实际范围

commit `6abb8c48` 的 message 只描述了 Vidu 侧改动，实际还包含本 PR 的可灵改动——成因是可灵部分当时正写在同一工作树里被一并提交。该 commit 已推送，未改写历史。squash 合并下 changelog 取 PR 标题，此偏差不外溢到发布记录。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持按视频模型和端点限制校验提示词长度，超限时提供明确的多语言错误提示。
  * 更新 Kling 音频生成能力，可根据模型、分辨率和请求类型选择音轨。
  * 补充 Vidu、Wan 2.7 等模型的视频时长、参考图及提示词限制说明。

* **问题修复**
  * 优化视频时长、音频和参考图能力判断。
  * 修正 Vidu 模型的视频时长范围及参考图能力判定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
