### PR TITLE
test(end-frames): 尾帧设置与清除的并发用例改为确定性断言,消除 CI 偶发失败

### DIFF
--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -349,15 +349,20 @@ def _interleave_across_critical_section(
     monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _gated_persist)
 
     results: dict[str, httpx.Response] = {}
+    errors: dict[str, BaseException] = {}
 
     def _run(key: str, call: Callable[[], httpx.Response]) -> threading.Thread:
         def _target() -> None:
-            results[key] = call()
+            try:
+                results[key] = call()
+            except BaseException as exc:  # noqa: BLE001 — 主线程复述，不能只打印到 stderr
+                errors[key] = exc
 
         thread = threading.Thread(target=_target)
         thread.start()
         return thread
 
+    t_second: threading.Thread | None = None
     t_first = _run("first", first)
     try:
         assert entered_section.wait(timeout=10), "先到的请求没能进入剧本锁临界区"
@@ -369,9 +374,11 @@ def _interleave_across_critical_section(
     finally:
         resume.set()
     t_first.join(timeout=10)
-    t_second.join(timeout=10)
+    if t_second is not None:
+        t_second.join(timeout=10)
     assert not t_first.is_alive(), "先到的请求未在超时内结束"
-    assert not t_second.is_alive(), "后到的请求未在超时内结束"
+    assert t_second is not None and not t_second.is_alive(), "后到的请求未在超时内结束"
+    assert not errors, f"请求线程内抛出异常：{errors}"
     return _InterleavedResponses(first=results["first"], second=results["second"])
 
 

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -362,7 +362,6 @@ def _interleave_across_critical_section(
         thread.start()
         return thread
 
-    t_second: threading.Thread | None = None
     t_first = _run("first", first)
     try:
         assert entered_section.wait(timeout=10), "先到的请求没能进入剧本锁临界区"
@@ -374,10 +373,9 @@ def _interleave_across_critical_section(
     finally:
         resume.set()
     t_first.join(timeout=10)
-    if t_second is not None:
-        t_second.join(timeout=10)
+    t_second.join(timeout=10)
     assert not t_first.is_alive(), "先到的请求未在超时内结束"
-    assert t_second is not None and not t_second.is_alive(), "后到的请求未在超时内结束"
+    assert not t_second.is_alive(), "后到的请求未在超时内结束"
     assert not errors, f"请求线程内抛出异常：{errors}"
     return _InterleavedResponses(first=results["first"], second=results["second"])
 

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -6,8 +6,10 @@
 
 import asyncio
 import threading
+from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -303,47 +305,102 @@ class TestSnapshotDecoupling:
         assert (pm.get_project_path("demo") / "end_frames/scene_E1S02.png").exists()
 
 
+def _interleave_across_critical_section(
+    monkeypatch, first: Callable[[], Any], second: Callable[[], Any]
+) -> dict[str, Any]:
+    """让 `first` 停在剧本锁临界区内，确认 `second` 被锁挡在外面后再放行，返回两者的返回值。
+
+    交错点由钩子对齐而非靠线程调度碰运气：钩子挂在锁内的剧本持久化上（`locked_script`
+    退出前的最后一步），此时先到的一方已经做完自己的文件副作用、字段写回尚未落盘——正是
+    「一方写完文件、对方抢在字段写回前动手」这一悬空引用场景的临界点。后到的一方在此期间
+    必须仍被剧本锁挡住：它若能完成，就说明两段操作没有真正互斥。
+
+    两个请求错开发出还有一层必要性：TestClient 每个请求起独立线程与事件循环，而 FastAPI 对
+    `include_router` 的路由展开是首次匹配时惰性构建、且不加锁；同时发出的两个首请求会撞上
+    半构建的路由表，随机得到路由级 404。此处第二个请求在第一个请求完成路由之后才发出。
+
+    返回 dict 含 `first` / `second` 两个键，值为各自请求的响应。
+    """
+    original = ProjectManager._write_script_unlocked
+    entered_section = threading.Event()
+    resume = threading.Event()
+    gate_lock = threading.Lock()
+    gate_open = True
+
+    def _gated_persist(self, *args, **kwargs):
+        nonlocal gate_open
+        with gate_lock:
+            take_gate, gate_open = gate_open, False
+        if take_gate:
+            entered_section.set()
+            assert resume.wait(timeout=10), "主线程未放行临界区"
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _gated_persist)
+
+    results: dict[str, Any] = {}
+
+    def _run(key: str, call: Callable[[], Any]) -> threading.Thread:
+        def _target() -> None:
+            results[key] = call()
+
+        thread = threading.Thread(target=_target)
+        thread.start()
+        return thread
+
+    t_first = _run("first", first)
+    try:
+        assert entered_section.wait(timeout=10), "先到的请求没能进入剧本锁临界区"
+
+        t_second = _run("second", second)
+        # 先到的一方还停在临界区内，后到的一方不该有任何完成的可能
+        t_second.join(timeout=0.3)
+        assert "second" not in results, f"后到的请求插进了对方的临界区：{results.get('second')}"
+    finally:
+        resume.set()
+    t_first.join(timeout=10)
+    t_second.join(timeout=10)
+    assert not t_first.is_alive() and not t_second.is_alive(), "并发请求未在超时内结束"
+    return results
+
+
 class TestConcurrentSetClear:
     """设置与清除并发交错时，字段与快照文件必须同进同退，不留悬空引用。"""
 
-    def test_interleaved_set_and_clear_never_dangles(self, client):
+    def test_clear_blocked_until_set_leaves_critical_section(self, client, monkeypatch):
+        """设置先进临界区：清除被挡到设置整段完成之后，最终状态是「清除赢」且无残留引用。"""
         c, pm = client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
-        for _ in range(20):
-            barrier = threading.Barrier(2)
-            results: dict[str, object] = {}
+        results = _interleave_across_critical_section(
+            monkeypatch,
+            first=lambda: _upload(c, _img_bytes("PNG")),
+            second=lambda: _delete(c),
+        )
 
-            def _do_set():
-                barrier.wait()
-                try:
-                    results["set"] = _upload(c, _img_bytes("PNG")).status_code
-                except Exception as exc:  # noqa: BLE001 - 捕获后由主线程断言失败
-                    results["set"] = exc
+        assert results["first"].status_code == 200, results["first"].text
+        assert results["second"].status_code == 200, results["second"].text
+        # 清除后到、整段落在设置之后：字段置空，快照文件随之删除
+        assert _segment(pm).get("end_frame_image") is None
+        assert not snapshot.exists()
 
-            def _do_clear():
-                barrier.wait()
-                try:
-                    results["clear"] = _delete(c).status_code
-                except Exception as exc:  # noqa: BLE001
-                    results["clear"] = exc
+    def test_set_blocked_until_clear_leaves_critical_section(self, client, monkeypatch):
+        """清除先进临界区：设置被挡到清除整段完成之后，最终字段非空且快照文件在位。"""
+        c, pm = client
+        snapshot = pm.get_project_path("demo") / END_FRAME_REL
+        assert _upload(c, _img_bytes("PNG")).status_code == 200
 
-            t_set = threading.Thread(target=_do_set)
-            t_clear = threading.Thread(target=_do_clear)
-            t_set.start()
-            t_clear.start()
-            t_set.join()
-            t_clear.join()
+        results = _interleave_across_critical_section(
+            monkeypatch,
+            first=lambda: _delete(c),
+            second=lambda: _upload(c, _img_bytes("PNG")),
+        )
 
-            assert results["set"] == 200, results["set"]
-            assert results["clear"] == 200, results["clear"]
-
-            end_frame_image = _segment(pm).get("end_frame_image")
-            # 设置赢：字段非空则快照文件必须存在——不允许指向缺失文件的引用
-            if end_frame_image is not None:
-                assert end_frame_image == END_FRAME_REL
-                assert snapshot.exists()
-            # 清除赢：字段置空，文件可能已删或残留孤儿（无害），但不检验其存在性
+        assert results["first"].status_code == 200, results["first"].text
+        assert results["second"].status_code == 200, results["second"].text
+        # 设置后到、整段落在清除之后：字段非空则快照文件必须存在——不允许指向缺失文件的引用
+        assert _segment(pm)["end_frame_image"] == END_FRAME_REL
+        assert snapshot.exists()
 
 
 def _fail_first_persist(monkeypatch):

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -9,8 +9,9 @@ import threading
 from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import NamedTuple
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -305,10 +306,17 @@ class TestSnapshotDecoupling:
         assert (pm.get_project_path("demo") / "end_frames/scene_E1S02.png").exists()
 
 
+class _InterleavedResponses(NamedTuple):
+    """`_interleave_across_critical_section` 的两个请求各自的响应。"""
+
+    first: httpx.Response
+    second: httpx.Response
+
+
 def _interleave_across_critical_section(
-    monkeypatch, first: Callable[[], Any], second: Callable[[], Any]
-) -> dict[str, Any]:
-    """让 `first` 停在剧本锁临界区内，确认 `second` 被锁挡在外面后再放行，返回两者的返回值。
+    monkeypatch, first: Callable[[], httpx.Response], second: Callable[[], httpx.Response]
+) -> _InterleavedResponses:
+    """让 `first` 停在剧本锁临界区内，确认 `second` 被锁挡在外面后再放行，返回两者的响应。
 
     交错点由钩子对齐而非靠线程调度碰运气：钩子挂在锁内的剧本持久化上（`locked_script`
     退出前的最后一步），此时先到的一方已经做完自己的文件副作用、字段写回尚未落盘——正是
@@ -319,7 +327,9 @@ def _interleave_across_critical_section(
     `include_router` 的路由展开是首次匹配时惰性构建、且不加锁；同时发出的两个首请求会撞上
     半构建的路由表，随机得到路由级 404。此处第二个请求在第一个请求完成路由之后才发出。
 
-    返回 dict 含 `first` / `second` 两个键，值为各自请求的响应。
+    「后到的一方没能完成」这一断言以固定等待窗口否证，是单向的：互斥若被破坏，慢机上后到
+    的一方也可能因窗口内尚未跑完而漏报；但绝不会反过来把守规矩的实现判成失败，故不引入
+    时序敏感性。不带锁的整条 set/clear 是毫秒级，窗口取值远宽于此。
     """
     original = ProjectManager._write_script_unlocked
     entered_section = threading.Event()
@@ -338,9 +348,9 @@ def _interleave_across_critical_section(
 
     monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _gated_persist)
 
-    results: dict[str, Any] = {}
+    results: dict[str, httpx.Response] = {}
 
-    def _run(key: str, call: Callable[[], Any]) -> threading.Thread:
+    def _run(key: str, call: Callable[[], httpx.Response]) -> threading.Thread:
         def _target() -> None:
             results[key] = call()
 
@@ -360,8 +370,9 @@ def _interleave_across_critical_section(
         resume.set()
     t_first.join(timeout=10)
     t_second.join(timeout=10)
-    assert not t_first.is_alive() and not t_second.is_alive(), "并发请求未在超时内结束"
-    return results
+    assert not t_first.is_alive(), "先到的请求未在超时内结束"
+    assert not t_second.is_alive(), "后到的请求未在超时内结束"
+    return _InterleavedResponses(first=results["first"], second=results["second"])
 
 
 class TestConcurrentSetClear:
@@ -378,8 +389,8 @@ class TestConcurrentSetClear:
             second=lambda: _delete(c),
         )
 
-        assert results["first"].status_code == 200, results["first"].text
-        assert results["second"].status_code == 200, results["second"].text
+        assert results.first.status_code == 200, results.first.text
+        assert results.second.status_code == 200, results.second.text
         # 清除后到、整段落在设置之后：字段置空，快照文件随之删除
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
@@ -396,8 +407,8 @@ class TestConcurrentSetClear:
             second=lambda: _upload(c, _img_bytes("PNG")),
         )
 
-        assert results["first"].status_code == 200, results["first"].text
-        assert results["second"].status_code == 200, results["second"].text
+        assert results.first.status_code == 200, results.first.text
+        assert results.second.status_code == 200, results.second.text
         # 设置后到、整段落在清除之后：字段非空则快照文件必须存在——不允许指向缺失文件的引用
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
         assert snapshot.exists()
@@ -547,7 +558,7 @@ class TestPersistFailureRestoresSnapshot:
         assert not snapshot.exists()
 
     def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, client, monkeypatch):
-        """Codex 指出的别名归一问题：本次失败操作用 `scripts/episode_1.json` 这个别名，
+        """别名归一：失败的这次操作用 `scripts/episode_1.json` 这个别名，
         代次键若不归一化会与并发接管（用 `episode_1.json` 归一后的键）各自生成一把代次，
         互相看不见——回滚会误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。"""
         c, pm = client

--- a/tests/test_end_frames_router.py
+++ b/tests/test_end_frames_router.py
@@ -355,7 +355,7 @@ def _interleave_across_critical_section(
         def _target() -> None:
             try:
                 results[key] = call()
-            except BaseException as exc:  # noqa: BLE001 — 主线程复述，不能只打印到 stderr
+            except Exception as exc:  # 主线程复述，不能只打印到 stderr
                 errors[key] = exc
 
         thread = threading.Thread(target=_target)


### PR DESCRIPTION
Closes #1580

## 问题

`TestConcurrentSetClear::test_interleaved_set_and_clear_never_dangles` 靠 `threading.Barrier` 抢跑 20 轮碰运气触发交错,在 CI 全量 + 覆盖率运行下偶发 404,本地单跑常绿——任何 PR 都可能被随机染红,每次撞上都是一轮「是否我改坏了」的排查加 rerun。

根因不在被测代码,也不是票面猜测的共享 fixture 状态 / 事件循环调度 / 清理竞态:404 响应体是 Starlette 的路由级 `{"detail":"Not Found"}`,业务代码根本没被进入。fastapi 0.139.0 把 `include_router` 的路由展开推迟到首次匹配时惰性构建(`_IncludedRouter.effective_candidates()` 先清空候选列表、逐条填充、最后才盖版本号),全程无锁;TestClient 每个请求起独立线程,两个**首**请求同时打到刚建好的 app,输的一方读到半构建的候选列表。生产不受影响——uvicorn 单事件循环内路由匹配不并行。

## 改法

不 retry、不 skip、不加 sleep。把「靠线程调度碰运气抢交错」换成「由钩子对齐交错点」:先到的请求停在剧本锁临界区内(自己的文件副作用已落、字段写回未落,正是悬空引用场景的临界点),此时才发出第二个请求并确认它被锁挡在外面,再放行、检查最终态。原 1 个概率性用例拆成 2 个确定性用例,清除后到与设置后到各一。

## 断言语义

原意图(交错 set/clear 后不留悬空尾帧引用)完整保留,并从「设置赢时才检查」变成两个方向都检查到确定的最终态;另新增原用例没有的断言——两段操作真正互斥。

## 验证

- **变异测试**:临时去掉 `_script_lock` 里的 `file_lock`,两个新用例 100% 失败;同一变异下原用例 3 次里 2 次仍全绿。检测力是加强,用例非空转。
- **重复运行**:整文件重复 100 次,0 失败(`46 passed` × 100)。Linux/amd64 容器(原复现环境,带 `--cov`)重复 40 次 0 失败;作为对照,同环境下改写前的复现脚本 15–65 秒内必挂。
- **质量门**:`pytest -m "not e2e" --cov` → 7622 passed,覆盖率 92.12%;`ruff check` / `ruff format --check` 全绿;`basedpyright` 0 errors;`lint-imports` KEPT。

## 已知边界

「后到方未完成」以固定等待窗口否证,是单向的:极慢的机器上互斥即使被破坏也可能因窗口内尚未跑完而漏报,但绝不会把守规矩的实现判红,不引入新的时序敏感性(已写进 docstring)。选图通道与清除的交错未单列用例——两条设置通道汇合在同一个 `_write_snapshot_and_field`,临界区是同一段代码。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 强化并发请求场景下设置与清除操作的测试覆盖。
  * 验证后续请求会在前一请求完成前正确等待，确保最终状态保持一致。
  * 更新别名归一化相关测试说明，并移除不稳定的旧并发测试方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->