### PR TITLE
fix(reference-video): 网页与智能体同时编辑参考单元时不再互相覆盖，冲突改为提示合并

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -518,6 +518,7 @@ describe("API", () => {
       // 三个封装都用含空格项目名，断言 encodeURIComponent 在各自路径上生效（编码丢失即失败）。
       await API.getScriptReview("a b", 1);
       await API.saveScriptReviewContent("a b", 2, content);
+      await API.saveScriptReviewContent("a b", 2, content, "fp 1");
       await API.confirmScriptReview("a b", 3);
 
       expect(requestSpy).toHaveBeenCalledWith("/projects/a%20b/episodes/1/script-review", {
@@ -527,6 +528,14 @@ describe("API", () => {
         method: "PUT",
         body: JSON.stringify(content),
       });
+      // 基线指纹经 query 传递（编码后），供服务端做并发编辑冲突比对
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/projects/a%20b/episodes/2/script-review/content?base_fingerprint=fp%201",
+        {
+          method: "PUT",
+          body: JSON.stringify(content),
+        },
+      );
       expect(requestSpy).toHaveBeenCalledWith("/projects/a%20b/episodes/3/script-review/confirm", {
         method: "POST",
       });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -878,14 +878,21 @@ class API {
     );
   }
 
-  /** 保存手动 / agent 编辑后的结构化中间态，返回最新状态（重新待审）。 */
+  /** 保存手动 / agent 编辑后的结构化中间态，返回最新状态（重新待审）。
+   *
+   * `baseFingerprint` 传 GET 时拿到的内容指纹：编辑期间 step1 被另一写入方（如 agent 晋升）
+   * 改过时服务端 409 冲突、不落盘，避免静默覆盖对方的修改；不传则不比对。 */
   static async saveScriptReviewContent(
     projectName: string,
     episode: number,
-    content: DramaNormalizedScript | NarrationStep1Draft | ReferenceStep1Draft
+    content: DramaNormalizedScript | NarrationStep1Draft | ReferenceStep1Draft,
+    baseFingerprint?: string | null
   ): Promise<ScriptReviewState> {
+    const query = baseFingerprint
+      ? `?base_fingerprint=${encodeURIComponent(baseFingerprint)}`
+      : "";
     return this.request(
-      `/projects/${encodeURIComponent(projectName)}/episodes/${episode}/script-review/content`,
+      `/projects/${encodeURIComponent(projectName)}/episodes/${episode}/script-review/content${query}`,
       {
         method: "PUT",
         body: JSON.stringify(content),

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
@@ -212,6 +212,33 @@ describe("ReferenceStep1PreviewPanel", () => {
     });
   });
 
+  it("saves with the fingerprint of the content the draft was based on, not the refreshed one", async () => {
+    const agentEdited = pendingState({ fingerprint: "fp2" });
+    (agentEdited.content as ReferenceStep1Draft).units[0].shots[0].text = "@[阿离] agent 改写的镜头";
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(pendingState())
+      .mockResolvedValueOnce(agentEdited);
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(pendingState());
+
+    render(<ReferenceStep1PreviewPanel projectName="p" episode={1} lookup={LOOKUP} />);
+    await waitFor(() => expect(screen.getByText("E1U01")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "编辑文稿" }));
+    const textarea = await screen.findByDisplayValue("@[阿离] 撑伞走过 @[长街]");
+    fireEvent.change(textarea, { target: { value: "@[阿离] 我的本地编辑" } });
+    await screen.findByText("保存");
+
+    // agent 改了 step1 → 外部刷新把 state 换成新版，但用户草稿仍基于旧版
+    useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText("保存"));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    // 提交草稿所基于的 fp1，服务端才能判出冲突；提交刷新后的 fp2 会让 OCC 放行、静默覆盖 agent 的修改
+    expect(save.mock.calls[0][3]).toBe("fp1");
+  });
+
   it("renders shot / spoken-line counts in the unit header", async () => {
     vi.spyOn(API, "getScriptReview").mockResolvedValue(quarantinedState());
     render(<ReferenceStep1PreviewPanel projectName="p" episode={1} lookup={LOOKUP} />);

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
@@ -476,20 +476,20 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
     if (!draft) return;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft));
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
     } finally {
       setSaving(false);
     }
-  }, [draft, projectName, episode, adopt, pushToast, t]);
+  }, [draft, state, projectName, episode, adopt, pushToast, t]);
 
   const handleConfirm = useCallback(async () => {
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft));
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
       }
       adopt(await API.confirmScriptReview(projectName, episode));
       // 两次 await 期间用户可能已切走项目（本组件所在的 tab 可能因此被卸载）：只在项目本身
@@ -506,7 +506,7 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
     } finally {
       setConfirming(false);
     }
-  }, [dirty, draft, projectName, episode, adopt, pushToast, t]);
+  }, [dirty, draft, state, projectName, episode, adopt, pushToast, t]);
 
   const handleRequestFix = useCallback(() => {
     const violations = state?.quarantine?.violations ?? [];

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
@@ -389,6 +389,10 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
 
   const [state, setState] = useState<ScriptReviewState | null>(null);
   const [draft, setDraft] = useState<ReferenceStep1Draft | null>(null);
+  // 保存时提交的基线指纹：绑定在**当前草稿所基于的那份服务端内容**上，只在草稿采用服务端内容时推进。
+  // 不能改用 state.fingerprint——有未保存编辑时的外部刷新会更新 state 却保留旧草稿，届时提交
+  // state.fingerprint 等于拿别人新写的内容当基线，OCC 会放行并静默覆盖对方的修改。
+  const [baseFingerprint, setBaseFingerprint] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<{ message: string } | null>(null);
   const [reloadNonce, setReloadNonce] = useState(0);
@@ -410,6 +414,7 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
     setState(next);
     const content = next.content != null && "units" in next.content ? (next.content) : null;
     setDraft(content ? (JSON.parse(JSON.stringify(content)) as ReferenceStep1Draft) : null);
+    setBaseFingerprint(next.fingerprint);
   }, []);
 
   const handleRetry = useCallback(() => {
@@ -434,6 +439,7 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
         if (!dirtyRef.current) {
           const content = next.content != null && "units" in next.content ? (next.content) : null;
           setDraft(content ? (JSON.parse(JSON.stringify(content)) as ReferenceStep1Draft) : null);
+          setBaseFingerprint(next.fingerprint);
         }
       })
       .catch((err) => {
@@ -476,20 +482,20 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
     if (!draft) return;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
     } finally {
       setSaving(false);
     }
-  }, [draft, state, projectName, episode, adopt, pushToast, t]);
+  }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const handleConfirm = useCallback(async () => {
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       }
       adopt(await API.confirmScriptReview(projectName, episode));
       // 两次 await 期间用户可能已切走项目（本组件所在的 tab 可能因此被卸载）：只在项目本身
@@ -506,7 +512,7 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
     } finally {
       setConfirming(false);
     }
-  }, [dirty, draft, state, projectName, episode, adopt, pushToast, t]);
+  }, [dirty, draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const handleRequestFix = useCallback(() => {
     const violations = state?.quarantine?.violations ?? [];

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
@@ -172,6 +172,34 @@ describe("ScriptReviewGate", () => {
     expect(screen.queryByDisplayValue("服务端覆盖文案")).not.toBeInTheDocument();
   });
 
+  it("saves with the fingerprint of the content the draft was based on, not the refreshed one", async () => {
+    const serverEdited = dramaState({ fingerprint: "fp2" });
+    (serverEdited.content as { scenes: { utterances: { text: string }[] }[] }).scenes[0].utterances[1].text =
+      "agent 改写的文案";
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(dramaState())
+      .mockResolvedValueOnce(serverEdited);
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(dramaState());
+
+    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
+    await waitFor(() => expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByDisplayValue("你终于回来了。"), { target: { value: "我的本地编辑" } });
+    await screen.findByText("保存");
+
+    // agent 改了 step1 → 外部刷新把 state 换成新版，但用户草稿仍基于旧版
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText("保存"));
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    // 提交草稿所基于的 fp1，服务端才能判出冲突；提交刷新后的 fp2 会让 OCC 放行、静默覆盖 agent 的修改
+    expect(save.mock.calls[0][3]).toBe("fp1");
+  });
+
   it("shows an empty state when there is no step1 content", async () => {
     vi.spyOn(API, "getScriptReview").mockResolvedValue(
       dramaState({ status: "no_step1", content: null, fingerprint: null }),

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
@@ -109,10 +109,12 @@ describe("ScriptReviewGate", () => {
     fireEvent.click(saveBtn);
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
-    const [, , savedContent] = save.mock.calls[0];
+    const [, , savedContent, baseFingerprint] = save.mock.calls[0];
     expect(savedContent).toMatchObject({
       scenes: [{ utterances: [{ text: "三年后。" }, { text: "你怎么才回来。" }] }],
     });
+    // 保存携带 GET 时拿到的内容指纹，供服务端做并发编辑冲突比对
+    expect(baseFingerprint).toBe("fp1");
   });
 
   it("renders narration novel_text as editable", async () => {

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
@@ -175,6 +175,10 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
 
   const [state, setState] = useState<ScriptReviewState | null>(null);
   const [draft, setDraft] = useState<ReviewDraft | null>(null);
+  // 保存时提交的基线指纹：绑定在**当前草稿所基于的那份服务端内容**上，只在草稿采用服务端内容时推进。
+  // 不能改用 state.fingerprint——有未保存编辑时的外部刷新会更新 state 却保留旧草稿，届时提交
+  // state.fingerprint 等于拿别人新写的内容当基线，OCC 会放行并静默覆盖对方的修改。
+  const [baseFingerprint, setBaseFingerprint] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<{ message: string } | null>(null);
   const [reloadNonce, setReloadNonce] = useState(0);
@@ -198,6 +202,7 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     setDraft(
       next.content ? (JSON.parse(JSON.stringify(next.content)) as ReviewDraft) : null,
     );
+    setBaseFingerprint(next.fingerprint);
   }, []);
 
   const handleRetry = useCallback(() => {
@@ -227,6 +232,7 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
               ? (JSON.parse(JSON.stringify(next.content)) as ReviewDraft)
               : null,
           );
+          setBaseFingerprint(next.fingerprint);
         }
       })
       .catch((err) => {
@@ -248,20 +254,20 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     if (!draft) return;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
     } finally {
       setSaving(false);
     }
-  }, [draft, state, projectName, episode, adopt, pushToast, t]);
+  }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const handleConfirm = useCallback(async () => {
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       }
       adopt(await API.confirmScriptReview(projectName, episode));
       pushToast(t("dashboard:review_confirmed"), "success");
@@ -270,7 +276,7 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     } finally {
       setConfirming(false);
     }
-  }, [dirty, draft, state, projectName, episode, adopt, pushToast, t]);
+  }, [dirty, draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const updateDramaScene = (index: number, patch: Partial<DramaSceneContent>) => {
     setDraft((prev) => {

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
@@ -248,20 +248,20 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     if (!draft) return;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft));
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
     } finally {
       setSaving(false);
     }
-  }, [draft, projectName, episode, adopt, pushToast, t]);
+  }, [draft, state, projectName, episode, adopt, pushToast, t]);
 
   const handleConfirm = useCallback(async () => {
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft));
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, state?.fingerprint));
       }
       adopt(await API.confirmScriptReview(projectName, episode));
       pushToast(t("dashboard:review_confirmed"), "success");
@@ -270,7 +270,7 @@ export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptRe
     } finally {
       setConfirming(false);
     }
-  }, [dirty, draft, projectName, episode, adopt, pushToast, t]);
+  }, [dirty, draft, state, projectName, episode, adopt, pushToast, t]);
 
   const updateDramaScene = (index: number, patch: Partial<DramaSceneContent>) => {
     setDraft((prev) => {

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -102,6 +102,10 @@ MESSAGES = {
     "script_review_quarantined": (
         "This episode has a rejected Step 1 draft awaiting repair; let the agent fix and promote it before confirming"
     ),
+    "script_review_conflict": (
+        "The Step 1 draft was modified by another editor while you were editing; your save was not applied. "
+        "Refresh to see the latest content, merge your changes, then save again"
+    ),
     "script_review_invalid_content": "Step 1 draft structure validation failed: {details}",
     "script_review_quarantine_unreadable": (
         "The quarantined draft file is corrupted or malformed and can't be read; ask the agent to re-split this episode"

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -102,6 +102,10 @@ MESSAGES = {
     "script_review_quarantined": (
         "Tập này có bản nháp Step 1 vi phạm đang chờ xử lý; hãy để tác nhân sửa và thăng cấp trước khi xác nhận"
     ),
+    "script_review_conflict": (
+        "Bản nháp Step 1 đã bị người chỉnh sửa khác thay đổi trong lúc bạn đang chỉnh sửa; lần lưu này chưa được áp dụng. "
+        "Hãy tải lại để xem nội dung mới nhất, hợp nhất thay đổi của bạn rồi lưu lại"
+    ),
     "script_review_invalid_content": "Xác thực cấu trúc bản nháp Step 1 thất bại: {details}",
     "script_review_quarantine_unreadable": (
         "Tệp bản nháp bị cách ly đã hỏng hoặc sai định dạng, không thể đọc được; hãy để tác nhân chia lại tập này"

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -100,6 +100,7 @@ MESSAGES = {
     "script_review_not_applicable": "该集不适用 step1 审核确认（该模式无结构化 step1 中间态）",
     "script_review_no_step1": "尚无 step1 结构化中间态可确认，请先完成预处理",
     "script_review_quarantined": "本集 step1 有违约产物待处置，请让智能体修复并晋升后再确认",
+    "script_review_conflict": "step1 内容在编辑期间已被其他编辑方修改，本次保存未覆盖；请刷新查看最新内容，合并后再保存",
     "script_review_invalid_content": "step1 中间态结构校验失败：{details}",
     "script_review_quarantine_unreadable": "隔离草稿文件已损坏或格式不符，无法读取，请让智能体重新拆分该集",
     "draft_event_label": "第 {episode} 集{label_prefix}",

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -880,7 +880,7 @@ class ScriptGenerator:
             # 存量草稿的 per-shot 时长一次性收编到 unit 级并回写落盘（二次加载不再触发）。
             # 此处持有模型档位，收编结果直接取档，与下方的枚举校验对齐。
             migrated_project, migration_warnings = migrate_step1_draft_in_place(
-                step1_json,
+                self.project_path,
                 raw,
                 episode=episode,
                 update_project=lambda mutate: pm.update_project(self.project_path.name, mutate),

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -1,8 +1,10 @@
-"""step1→step2 审核 gate 的纯逻辑：适用性判定、step1 路径、内容指纹、审核状态派生。
+"""step1→step2 审核 gate 的核心逻辑：适用性判定、step1 路径、内容指纹、审核状态派生，
+以及参考生视频正式 step1 的单一写盘出口（``step1_write_lock`` / ``write_step1_locked``）。
 
 gate 横跨两处消费：SDK 工具（``generate_episode_script`` 的 step2 阻塞 enforcement）与 web
-router / service（结构化中间态审阅 / 编辑 / 确认）。本模块只做不依赖 ProjectManager 的纯计算
-（读 step1 文件 + project dict），令两处共用同一真相源。
+router / service（结构化中间态审阅 / 编辑 / 确认）。状态派生只依赖 step1 文件 + project dict
+的纯计算；写盘出口另持 ``ProjectManager.file_lock`` 的 per-path 锁，四条写路径（Web 端保存、
+重拆分、晋升、迁移回写）全部汇入，锁、乐观并发比对与 step2 隔离草稿清理只存在一处。
 
 真值只存「确认指纹」于 project.json ``episodes[i].step1_review``；pending / confirmed 由读时
 比对 live step1 内容指纹派生（沿 StatusCalculator「能算不存」哲学）。因此重跑 normalize、agent
@@ -18,10 +20,12 @@ router / service（结构化中间态审阅 / 编辑 / 确认）。本模块只�
 
 from __future__ import annotations
 
+import enum
 import hashlib
 import json
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
 
@@ -31,10 +35,15 @@ from lib.episode_paths import (
     episode_drafts_dir,
     episode_script_relpath,
 )
-from lib.json_io import atomic_write_json
-from lib.project_manager import find_episode, is_reference_video_project
+from lib.json_io import atomic_write_json, load_json_or_none
+from lib.project_manager import ProjectManager, find_episode, is_reference_video_project
 from lib.reference_video.duration_migration import migrate_unit_durations
-from lib.reference_video.quarantine import QUARANTINE_KIND_STEP1, quarantine_path
+from lib.reference_video.quarantine import (
+    QUARANTINE_KIND_STEP1,
+    QUARANTINE_KIND_STEP2,
+    clear_quarantine,
+    quarantine_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +143,96 @@ def content_fingerprint(path: Path) -> str | None:
     return content_fingerprint_of_data(parsed)
 
 
+class _UncheckedFingerprint(enum.Enum):
+    """``write_step1_locked`` 的 ``expected_fingerprint`` 哨兵类型：区分「不做基线比对」与
+    「基线是 None（写入方取基线时正式文件不存在）」——两者都要能表达，``None`` 只够表达后者。"""
+
+    TOKEN = 0
+
+
+#: 「不做基线比对」哨兵：写入方没有基线可言（重拆分整份覆盖、同临界区读改写）时传它。
+UNCHECKED_FINGERPRINT = _UncheckedFingerprint.TOKEN
+
+
+class Step1WriteConflict(Exception):
+    """正式 step1 的乐观并发冲突：写入方的基线指纹与盘上现值不一致。
+
+    携带盘上现值（``current_content``，非法 JSON 时 None）与两侧指纹，供编辑方渲染冲突报告、
+    对照最新内容合并——单一写盘出口在锁内比对后抛出，后写方收到本异常而非静默覆盖先写方。
+    """
+
+    def __init__(self, *, expected: str | None, actual: str | None, current_content: dict[str, Any] | None):
+        super().__init__(f"step1 并发冲突：基线指纹 {expected}，盘上现值指纹 {actual}")
+        self.expected = expected
+        self.actual = actual
+        self.current_content = current_content
+
+
+def official_reference_step1_path(project_path: Path, episode: int) -> Path:
+    """该集参考生视频正式 step1 的路径（``drafts/episode_N/step1_reference_units.json``）。
+
+    与 ``step1_path`` 的区别：后者按项目变体判定文件名、不适用时 None；本函数是 rv 写盘出口
+    的路径真相源，不依赖 project dict。"""
+    return episode_drafts_dir(project_path, episode) / REFERENCE_VIDEO_STEP1_FILENAME
+
+
+@contextmanager
+def step1_write_lock(project_path: Path, episode: int) -> Iterator[Path]:
+    """参考生视频正式 step1 的写临界区：建目录 + per-path 排他锁，yield 正式文件路径。
+
+    与迁移读改写、Web 端保存、重拆分 / 晋升共用同一把 ``ProjectManager.file_lock``（per-path，
+    进程间排他、不可重入）。凡要「读正式文件后据此写盘或写隔离草稿」的操作都应整段包在本
+    临界区内——读与写拆开在锁外各做一次，就是并发覆盖窗口。
+    """
+    drafts_dir = episode_drafts_dir(project_path, episode)
+    drafts_dir.mkdir(parents=True, exist_ok=True)
+    path = official_reference_step1_path(project_path, episode)
+    pm = ProjectManager(str(project_path.parent))
+    with pm.file_lock(path):
+        yield path
+
+
+def write_step1_locked(
+    project_path: Path,
+    episode: int,
+    content: dict[str, Any],
+    *,
+    expected_fingerprint: str | None | _UncheckedFingerprint = UNCHECKED_FINGERPRINT,
+    clear_step2_quarantine: bool = True,
+) -> bool:
+    """参考生视频正式 step1 的**单一写盘出口**：基线比对（OCC）→ 原子写 → 内容变化时清 step2
+    隔离草稿。返回内容是否发生变化。
+
+    调用方须已持有该文件的排他锁（``step1_write_lock``，或同一路径的 ``ProjectManager.file_lock``
+    ——锁不可重入，已在临界区内的调用方不能再套 ``step1_write_lock``）。四条写路径（Web 端
+    保存、重拆分、晋升、迁移回写）全部汇入本函数，写盘语义只存在这一处。
+
+    ``expected_fingerprint`` 是写入方取基线时的正式文件指纹（``None`` 表示彼时文件不存在）；
+    与盘上现值不一致时抛 ``Step1WriteConflict``、不落盘——后写方拿冲突报告去合并，先写方的
+    内容不被静默覆盖。传 ``UNCHECKED_FINGERPRINT`` 跳过比对：重拆分是刻意的整份重建，
+    同临界区读改写（迁移、确认）则读写之间本就无并发窗口。
+
+    step2 隔离草稿的保结构 diff 以旧 step1 为基底，step1 真的变了才作废它；迁移回写是机械
+    格式收编、不是内容编辑，调用方传 ``clear_step2_quarantine=False`` 保留 step2 草稿。
+    """
+    path = official_reference_step1_path(project_path, episode)
+    if not isinstance(expected_fingerprint, _UncheckedFingerprint):
+        actual = content_fingerprint(path)
+        if expected_fingerprint != actual:
+            current = load_json_or_none(path)
+            raise Step1WriteConflict(
+                expected=expected_fingerprint,
+                actual=actual,
+                current_content=current if isinstance(current, dict) else None,
+            )
+    previous = load_json_or_none(path)
+    changed = previous != content
+    atomic_write_json(path, content)
+    if changed and clear_step2_quarantine:
+        clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP2)
+    return changed
+
+
 def stored_review(project: dict[str, Any], episode: int) -> dict[str, Any]:
     """该集已存的确认记录（``episodes[i].step1_review``），缺失或形状坏时返回空 dict。"""
     ep = find_episode(project, episode)
@@ -227,7 +326,7 @@ def carry_confirmation_through_migration(project: dict[str, Any], episode: int, 
 
 
 def migrate_step1_draft_in_place(
-    path: Path,
+    project_path: Path,
     content: object,
     *,
     episode: int,
@@ -236,8 +335,10 @@ def migrate_step1_draft_in_place(
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """对已读入内存的 step1 草稿就地做一次性时长收编迁移并回写；返回 ``(最新 project, warnings)``。
 
-    调用方须已持有该文件的排他锁（``ProjectManager.file_lock``）——迁移回写与 Web 端保存 /
-    重拆分写盘共享同一把 per-path 锁。未发生迁移时不回写，返回 ``(None, [])``。
+    调用方须已持有该文件的排他锁（``step1_write_lock`` / 同路径 ``ProjectManager.file_lock``）
+    ——回写经单一写盘出口 ``write_step1_locked``，与 Web 端保存 / 重拆分写盘同一把 per-path
+    锁。迁移是机械格式收编、不是内容编辑，不作废 step2 隔离草稿；同临界区读改写也无并发
+    窗口，不做基线比对。未发生迁移时不回写，返回 ``(None, [])``。
 
     迁移多数情况下是机械格式收编，回写会让内容指纹漂移：经 ``update_project`` 在锁内把该集
     确认指纹平移到迁移后的值（``carry_confirmation_through_migration``），避免已确认分集仅因
@@ -262,7 +363,7 @@ def migrate_step1_draft_in_place(
     before = content_fingerprint_of_data(content)
     changed, warnings = migrate_unit_durations(content.get("units"), supported_durations=supported_durations)
     for message in warnings:
-        logger.warning("step1 草稿 %s 时长收编迁移: %s", path.name, message)
+        logger.warning("step1 草稿 %s 时长收编迁移: %s", REFERENCE_VIDEO_STEP1_FILENAME, message)
     if not changed:
         return None, []
 
@@ -284,5 +385,5 @@ def migrate_step1_draft_in_place(
 
         updated = update_project(_carry)
 
-    atomic_write_json(path, content)
+    write_step1_locked(project_path, episode, content, clear_step2_quarantine=False)
     return updated, warnings

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -168,6 +168,27 @@ class Step1WriteConflict(Exception):
         self.current_content = current_content
 
 
+def assert_base_fingerprint(path: Path, expected: str | None | _UncheckedFingerprint) -> None:
+    """乐观并发比对：``expected`` 与 ``path`` 盘上现值不一致时抛 ``Step1WriteConflict``、不落盘。
+
+    ``expected`` 是写入方取基线时的文件指纹（``None`` 表示彼时文件不存在），
+    ``UNCHECKED_FINGERPRINT`` 跳过比对。三个 step1 变体共用本函数，比对语义只存在这一处。
+
+    调用方须已持该路径的排他锁：比对与随后的写盘不在同一临界区内，比对就只是一次过期读。
+    """
+    if isinstance(expected, _UncheckedFingerprint):
+        return
+    actual = content_fingerprint(path)
+    if expected == actual:
+        return
+    current = load_json_or_none(path)
+    raise Step1WriteConflict(
+        expected=expected,
+        actual=actual,
+        current_content=current if isinstance(current, dict) else None,
+    )
+
+
 def official_reference_step1_path(project_path: Path, episode: int) -> Path:
     """该集参考生视频正式 step1 的路径（``drafts/episode_N/step1_reference_units.json``）。
 
@@ -216,15 +237,7 @@ def write_step1_locked(
     格式收编、不是内容编辑，调用方传 ``clear_step2_quarantine=False`` 保留 step2 草稿。
     """
     path = official_reference_step1_path(project_path, episode)
-    if not isinstance(expected_fingerprint, _UncheckedFingerprint):
-        actual = content_fingerprint(path)
-        if expected_fingerprint != actual:
-            current = load_json_or_none(path)
-            raise Step1WriteConflict(
-                expected=expected_fingerprint,
-                actual=actual,
-                current_content=current if isinstance(current, dict) else None,
-            )
+    assert_base_fingerprint(path, expected_fingerprint)
     previous = load_json_or_none(path)
     changed = previous != content
     atomic_write_json(path, content)

--- a/server/agent_runtime/agent_access_policy.py
+++ b/server/agent_runtime/agent_access_policy.py
@@ -42,7 +42,7 @@ class ProtectedWriteRule:
     故谓词与投影是两列独立声明，不从彼此推导。
     """
 
-    #: 规则名（诊断用）。
+    #: 规则名：表内每行的可读标识，无运行期消费者（谓词与投影都不按名字查找）。
     name: str
     #: hook 层谓词：``(target, bases) -> 是否命中``。target 由 caller 分别以「逻辑目标」与
     #: 「resolve 后目标」各调一次，bases 为 raw + resolved 两种形式的 project_cwd。

--- a/server/agent_runtime/agent_access_policy.py
+++ b/server/agent_runtime/agent_access_policy.py
@@ -13,6 +13,7 @@ import re
 import shlex
 import tempfile
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -26,6 +27,30 @@ logger = logging.getLogger(__name__)
 def _default_claude_projects_dir() -> Path:
     """SDK 存放 per-project 会话数据的基准目录。"""
     return Path.home() / ".claude" / "projects"
+
+
+@dataclass(frozen=True)
+class ProtectedWriteRule:
+    """一类受保护写路径的完整声明：hook 谓词、拒绝文案与 sandbox denyWrite 投影同处一行。
+
+    ``AgentAccessPolicy.PROTECTED_WRITE_RULES`` 是这类规则的单一真相源：应用层 hook
+    （``_check_write_access``，管内置 Write/Edit）与内核 sandbox denyWrite（管 Bash 子进程，
+    见 ``_build_protected_write_abs_paths``）都从这张表投影，新增一类受保护路径只需加一行，
+    两层同步生效——分散声明时漏掉任一处都会留出单层旁路（ADR 0026 的双层前提被破坏）。
+
+    两层的覆盖面允许刻意不对称（如 hook 只拒 ``drafts/`` 下的正式 step1、sandbox 整目录拒），
+    故谓词与投影是两列独立声明，不从彼此推导。
+    """
+
+    #: 规则名（诊断用）。
+    name: str
+    #: hook 层谓词：``(target, bases) -> 是否命中``。target 由 caller 分别以「逻辑目标」与
+    #: 「resolve 后目标」各调一次，bases 为 raw + resolved 两种形式的 project_cwd。
+    matches: Callable[[Path, list[Path]], bool]
+    #: hook 层拒绝文案（须指明改用哪条合法通道）。
+    deny_message: str
+    #: sandbox denyWrite 投影：相对 project_cwd base 的子路径（目录即整子树 deny）。
+    sandbox_subpaths: tuple[str, ...]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -140,6 +165,9 @@ class AgentAccessPolicy:
         "Grep": "path",
     }
     _WRITE_TOOLS: ClassVar[set[str]] = {"Write", "Edit"}
+    #: 受保护写路径规则表——hook 拒绝与 sandbox denyWrite 的单一真相源。谓词引用本类的
+    #: classmethod，故在类体之后赋值（见模块尾部）；新增受保护类别只在该表加一行。
+    PROTECTED_WRITE_RULES: ClassVar[tuple[ProtectedWriteRule, ...]]
     _CODE_EXTENSIONS_FORBIDDEN: ClassVar[set[str]] = {
         ".py",
         ".js",
@@ -283,18 +311,13 @@ class AgentAccessPolicy:
 
     @classmethod
     def _build_protected_write_abs_paths(cls, project_cwd: Path) -> list[str]:
-        """Bash 子进程写禁清单（绝对路径）：``scripts/`` 目录子树 + ``project.json`` + ``drafts/`` 目录子树。
+        """Bash 子进程写禁清单（绝对路径）：``PROTECTED_WRITE_RULES`` 各规则 ``sandbox_subpaths``
+        的投影（目录即整子树 deny）。
 
         与 ``_check_write_access`` 的内置 Write/Edit 拒绝构成双层（ADR 0026）：sandbox denyWrite
         管 Bash 子进程（内核级），``_check_write_access`` hook 管内置 Write/Edit（权限系统，全平台）
-        ——内置文件工具在主进程内执行、不经 Bash，内核沙箱覆盖不到，反之亦然。
-
-        ``drafts/`` 按整目录 deny 而非枚举 ``drafts/episode_*/step1_reference_units.json``：
-        清单在会话装配期一次性构造，而集是运行时增删的——「同一会话内先拆分出第 N 集、再改它」
-        恰是主流程，逐文件枚举在这条路上必然落空。两层因此在 ``drafts/`` 上刻意不对称：Bash
-        整目录拒（本就没有合法的 Bash 写入者——中间文件由 in-process MCP 工具写、由内置 Edit
-        改），hook 层只拒参考生视频正式 step1（见 ``_is_protected_reference_step1``；隔离草稿
-        正是留给内置 Edit 的编辑工位，不能拒）。
+        ——内置文件工具在主进程内执行、不经 Bash，内核沙箱覆盖不到，反之亦然。两层从同一张
+        规则表投影，新增受保护路径类别只改表一处即两层同步生效。
 
         base 经 ``_enumerate_cwd_bases`` 同时枚举 raw + resolved 两种形式（与
         ``_check_write_access`` 同口径）：sandbox 实现若按字符串路径比对而非 inode，
@@ -303,10 +326,11 @@ class AgentAccessPolicy:
         """
         paths: list[str] = []
         for base in cls._enumerate_cwd_bases(project_cwd):
-            for target in (base / "scripts", base / "project.json", base / "drafts"):
-                target_s = str(target)
-                if target_s not in paths:
-                    paths.append(target_s)
+            for rule in cls.PROTECTED_WRITE_RULES:
+                for subpath in rule.sandbox_subpaths:
+                    target_s = str(base / subpath)
+                    if target_s not in paths:
+                        paths.append(target_s)
         return paths
 
     def _build_sensitive_abs_paths(self) -> list[str]:
@@ -541,10 +565,9 @@ class AgentAccessPolicy:
         return False, (f"访问被拒绝：路径在项目根外 ({resolved})")
 
     def _check_write_access(self, resolved: Path, project_cwd: Path, *, logical_norm: Path) -> tuple[bool, str | None]:
-        """Write/Edit 的写入约束：cwd 外一律拒，cwd 内代码扩展名拒（agent 不写代码），
-        且 ``scripts/*.json``、``project.json`` 与参考生视频正式 step1 一律拒——只能走收归后的
-        MCP 工具。前两类是「写入口收归」，step1 是「写入口持锁」：它另有三条持同一把 per-path
-        锁的写入路径，沙箱内的 Write/Edit 取不到锁，直改即丢失更新窗口。
+        """Write/Edit 的写入约束：cwd 外一律拒，cwd 内先过 ``PROTECTED_WRITE_RULES`` 规则表
+        （``scripts/*.json`` / ``project.json`` / 参考生视频正式 step1——只能走收归后的 MCP
+        工具），再拒代码扩展名（agent 不写代码）。
 
         所有 cwd-relative 判定（cwd 内外、protected 区命中）都按 **base 同时枚举 raw + resolved**
         两种形式与 target 比对：caller 传入的 ``resolved`` 已展开 symlink，但 ``project_cwd`` 可能
@@ -553,28 +576,15 @@ class AgentAccessPolicy:
         """
         # raw + resolved 两种形式的 base 由 _enumerate_cwd_bases 一次性枚举，避免 symlinked
         # project_cwd 下 is_relative_to / 受保护谓词因 base↔target 形式不一致漏判。bases 复用
-        # 给下游 `_is_protected_project_json`,后者直接消费列表不再做第二次 resolve（消除冗余 lstat）。
+        # 给规则表各谓词,后者直接消费列表不再做第二次 resolve（消除冗余 lstat）。
         bases = self._enumerate_cwd_bases(project_cwd)
 
         if not any(resolved.is_relative_to(base) for base in bases):
             return False, (f"访问被拒绝：不允许写入当前项目目录之外的路径 ({resolved})")
 
-        if any(self._is_protected_project_json(target, bases) for target in (resolved, logical_norm)):
-            return False, (
-                "访问被拒绝：scripts/*.json 与 project.json 不可用 Write/Edit 直改，"
-                "请改用 MCP 工具——剧本编辑走 mcp__arcreel__patch_episode_script / "
-                "mcp__arcreel__insert_segment / mcp__arcreel__remove_segment / mcp__arcreel__split_segment，"
-                "角色/场景/道具走 mcp__arcreel__patch_project。"
-            )
-
-        if any(self._is_protected_reference_step1(target, bases) for target in (resolved, logical_norm)):
-            return False, (
-                f"访问被拒绝：参考生视频的 {REFERENCE_VIDEO_STEP1_FILENAME} 不可用 Write/Edit 直改。"
-                "该文件与 Web 端保存、迁移读改写、重拆分共享一把文件锁，而 Write/Edit 取不到这把锁，"
-                "直改会与并发的保存互相丢失更新。"
-                f'请改用 MCP 工具——mcp__arcreel__{STEP1_EDIT_TOOL_NAME}({{"episode": N}}) 取回可编辑草稿，'
-                f"改草稿的 content.units[i]，再用 mcp__arcreel__{PROMOTE_TOOL_NAME} 校验并晋升回正式文件。"
-            )
+        for rule in self.PROTECTED_WRITE_RULES:
+            if any(rule.matches(target, bases) for target in (resolved, logical_norm)):
+                return False, rule.deny_message
 
         ext = resolved.suffix.lower()
         if ext in self._CODE_EXTENSIONS_FORBIDDEN:
@@ -693,3 +703,41 @@ class AgentAccessPolicy:
             if len(parts) == 2 and parts[0].startswith("episode_") and parts[1] == filename:
                 return True
         return False
+
+
+#: 受保护写路径的单一真相源：每行声明 hook 谓词、拒绝文案与 sandbox denyWrite 投影，
+#: ``_check_write_access``（内置 Write/Edit）与 ``_build_protected_write_abs_paths``
+#: （Bash 子进程内核级）同表投影。谓词引用类的 classmethod，故在类体之后赋值。
+#:
+#: - ``project_json``：「写入口收归」——``scripts/*.json`` 与 ``project.json`` 只能走 MCP
+#:   工具；两层投影同覆盖面（``scripts/`` 整子树 + ``project.json``）。
+#: - ``reference_step1``：「写入口持锁」——正式 step1 另有三条持同一把 per-path 锁的写入
+#:   路径，Write/Edit 取不到锁，直改即丢失更新窗口。两层刻意不对称：sandbox 按 ``drafts/``
+#:   整目录 deny（清单在会话装配期一次性构造，集是运行时增删的，逐文件枚举必然落空；Bash
+#:   本就没有合法写入者），hook 只拒正式 step1——同目录的 ``.invalid.json`` 隔离草稿正是
+#:   留给内置 Edit 的编辑工位，不能拒。
+AgentAccessPolicy.PROTECTED_WRITE_RULES = (
+    ProtectedWriteRule(
+        name="project_json",
+        matches=AgentAccessPolicy._is_protected_project_json,
+        deny_message=(
+            "访问被拒绝：scripts/*.json 与 project.json 不可用 Write/Edit 直改，"
+            "请改用 MCP 工具——剧本编辑走 mcp__arcreel__patch_episode_script / "
+            "mcp__arcreel__insert_segment / mcp__arcreel__remove_segment / mcp__arcreel__split_segment，"
+            "角色/场景/道具走 mcp__arcreel__patch_project。"
+        ),
+        sandbox_subpaths=("scripts", "project.json"),
+    ),
+    ProtectedWriteRule(
+        name="reference_step1",
+        matches=AgentAccessPolicy._is_protected_reference_step1,
+        deny_message=(
+            f"访问被拒绝：参考生视频的 {REFERENCE_VIDEO_STEP1_FILENAME} 不可用 Write/Edit 直改。"
+            "该文件与 Web 端保存、迁移读改写、重拆分共享一把文件锁，而 Write/Edit 取不到这把锁，"
+            "直改会与并发的保存互相丢失更新。"
+            f'请改用 MCP 工具——mcp__arcreel__{STEP1_EDIT_TOOL_NAME}({{"episode": N}}) 取回可编辑草稿，'
+            f"改草稿的 content.units[i]，再用 mcp__arcreel__{PROMOTE_TOOL_NAME} 校验并晋升回正式文件。"
+        ),
+        sandbox_subpaths=("drafts",),
+    ),
+)

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -965,13 +965,16 @@ def _render_step1_conflict_report(
         latest_block = f"当前正式 step1 的最新内容（扁平书写层，与草稿 content 同形）：\n{latest}"
     else:
         latest_block = "当前正式文件不存在或不是合法的 step1 JSON，无法附上最新内容；请自行读取该文件确认。"
+    # 指纹按 JSON 字面量给：正式文件已被删除时现值是 null，写成 "None" 会让 agent 把这串字符
+    # 当基线填回 meta，之后每次重晋升都比对不上、拿到同一份报告，冲突再也解不掉。
+    actual_literal = json.dumps(conflict.actual)
     return (
         "❌ 晋升中止（并发冲突）：正式 step1 在本草稿产出后已被其他写入方（如 Web 端保存）修改，"
         "直接晋升会覆盖对方的修改，本次未写盘、草稿仍在场。\n"
-        f"草稿基线指纹: {conflict.expected}；盘上现值指纹: {conflict.actual}\n\n"
+        f"草稿基线指纹: {json.dumps(conflict.expected)}；盘上现值指纹: {actual_literal}\n\n"
         f"{latest_block}\n\n"
         f"处置：对照上方最新内容与草稿 {draft.path} 的 content.units，把对方的修改合并进草稿；"
-        f'合并完成后把草稿 meta.base_fingerprint 更新为 "{conflict.actual}"，'
+        f"合并完成后把草稿 meta.base_fingerprint 更新为 {actual_literal}，"
         f'再调用 {PROMOTE_TOOL_NAME}({{"episode": {episode}}}) 重新晋升。'
     )
 

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -34,7 +34,7 @@ from lib.episode_paths import (
 from lib.i18n import _ as translate
 from lib.json_io import atomic_write_json, load_json_or_none
 from lib.path_safety import PathTraversalError, safe_join
-from lib.project_manager import DEFAULT_SOURCE_KIND, ProjectManager, is_reference_video_project
+from lib.project_manager import DEFAULT_SOURCE_KIND, is_reference_video_project
 from lib.prompt_builders_reference import build_reference_units_split_prompt
 from lib.prompt_builders_script import build_narration_split_prompt, build_normalize_prompt
 from lib.reference_video.draft_validation import (
@@ -925,39 +925,55 @@ async def _promote_reference_step1(ctx: ToolContext, episode: int, draft: Quaran
         return {"content": [{"type": "text", "text": report}], "is_error": True}
 
     units = _build_reference_units_from_flat(flat_units, project, episode=episode, max_refs=split_caps.max_refs)
-    step1_path = _write_reference_step1(project_path, episode, units)
-    # 落盘成功后才清草稿：写盘失败时草稿还在，重试晋升即可，不会两头皆空。
-    clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP1)
+    # 写盘经单一出口（lib.script_review.write_step1_locked）：锁、基线比对、step2 隔离草稿清理
+    # 只存在那一处。基线指纹取自取回 / 隔离时记进 meta 的 base_fingerprint——正式文件在草稿
+    # 产出后被其他写入方（Web 端保存、另一次拆分）改过时晋升中止、返回冲突报告让 agent 合并，
+    # 不静默覆盖对方的修改。引入基线前产出的存量草稿缺该键，按无基线晋升。
+    expected = (
+        draft.meta["base_fingerprint"] if "base_fingerprint" in draft.meta else script_review.UNCHECKED_FINGERPRINT
+    )
+    try:
+        with script_review.step1_write_lock(project_path, episode) as step1_path:
+            script_review.write_step1_locked(project_path, episode, {"units": units}, expected_fingerprint=expected)
+            # 落盘成功后才清草稿：写盘失败（含冲突）时草稿还在，改完重试晋升即可，不会两头皆空。
+            # 清理与写盘同一临界区：并发的取回请求不会在两步之间看到「正式文件已是新内容、
+            # 草稿却还在场」的中间态。
+            clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP1)
+    except script_review.Step1WriteConflict as conflict:
+        return {
+            "content": [{"type": "text", "text": _render_step1_conflict_report(episode, draft, conflict)}],
+            "is_error": True,
+        }
     warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.raw)
     return {
         "content": [{"type": "text", "text": _reference_result_text(step1_path, units, warning_lines, action="晋升")}]
     }
 
 
-def _write_reference_step1(project_path: Path, episode: int, units: list[dict]) -> Path:
-    """把结构化 step1 原子写入正式文件（拆分与晋升共用的唯一写盘出口）。
+def _render_step1_conflict_report(
+    episode: int, draft: QuarantinedDraft, conflict: script_review.Step1WriteConflict
+) -> str:
+    """渲染晋升遇乐观并发冲突时回给 agent 的结构化报告：最新内容 + 合并指引。
 
-    与 ScriptGenerator._load_reference_step1 / ScriptReviewService 共享同一把 per-path 锁：
-    重新拆分的整份覆盖式重写与迁移、Web 端编辑相互串行化。agent 对已有拆分的修改也汇入这里
-    ——它经 ``open_reference_step1_for_edit`` 取回草稿、改完走晋升，写盘只发生在本函数，
-    沙箱内取不到锁的 Write/Edit 直改由 ``AgentAccessPolicy`` 拒绝。
-
-    step1 真的变了，在场的 step2 隔离草稿才作废：它的保结构 diff 以旧 step1 为基底，留着既
-    永远晋升不了（unit 数与台词都对不上新基底），又会让生成侧一直阻塞在这份没有出路的草稿
-    上。取回编辑后中途放弃、原样晋升（``units`` 与盘上原值逐字相同）时内容并未变化，此时
-    不清——agent 放弃 step1 修改不该连带销毁一份内容仍对得上基底的 step2 修复草稿。
+    报告要让编辑方能就地合并：附上盘上现值的扁平书写层（与草稿 ``content`` 同形，可逐 unit
+    对照），并指明确认合并后把 ``meta.base_fingerprint`` 更新为现值指纹——这一步是显式确认
+    「我已看过并合并了对方的修改」，之后重新晋升才会放行；不更新就重试只会拿到同一份报告。
     """
-    drafts_dir = episode_drafts_dir(project_path, episode)
-    drafts_dir.mkdir(parents=True, exist_ok=True)
-    step1_path = drafts_dir / REFERENCE_VIDEO_STEP1_FILENAME
-    pm = ProjectManager(str(project_path.parent))
-    with pm.file_lock(step1_path):
-        previous = load_json_or_none(step1_path)
-        changed = not (isinstance(previous, dict) and previous.get("units") == units)
-        atomic_write_json(step1_path, {"units": units})
-    if changed:
-        clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP2)
-    return step1_path
+    current_units = (conflict.current_content or {}).get("units")
+    if isinstance(current_units, list) and current_units:
+        latest = json.dumps({"units": _flatten_reference_step1_units(current_units)}, ensure_ascii=False, indent=2)
+        latest_block = f"当前正式 step1 的最新内容（扁平书写层，与草稿 content 同形）：\n{latest}"
+    else:
+        latest_block = "当前正式文件不存在或不是合法的 step1 JSON，无法附上最新内容；请自行读取该文件确认。"
+    return (
+        "❌ 晋升中止（并发冲突）：正式 step1 在本草稿产出后已被其他写入方（如 Web 端保存）修改，"
+        "直接晋升会覆盖对方的修改，本次未写盘、草稿仍在场。\n"
+        f"草稿基线指纹: {conflict.expected}；盘上现值指纹: {conflict.actual}\n\n"
+        f"{latest_block}\n\n"
+        f"处置：对照上方最新内容与草稿 {draft.path} 的 content.units，把对方的修改合并进草稿；"
+        f'合并完成后把草稿 meta.base_fingerprint 更新为 "{conflict.actual}"，'
+        f'再调用 {PROMOTE_TOOL_NAME}({{"episode": {episode}}}) 重新晋升。'
+    )
 
 
 def _flatten_reference_step1_units(units: list[Any]) -> list[dict[str, Any]]:
@@ -1051,13 +1067,11 @@ def open_reference_step1_for_edit_tool(ctx: ToolContext):
                 except ValueError as exc:
                     return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
-            step1_path = episode_drafts_dir(project_path, episode) / REFERENCE_VIDEO_STEP1_FILENAME
-            pm = ProjectManager(str(project_path.parent))
             # 草稿有无的检查、正式文件的读取、草稿的写入须在同一把锁的临界区内完成：拆开在锁外
             # 各做一次的话，同一集的两个并发取回请求可能都先看到「无草稿」，再都各自写入草稿，
-            # 后写者悄悄覆盖前者的 content 与 meta.source。锁与 Web 端保存、迁移同一把，读也持锁
-            # 避免取回一份写到一半的 step1。
-            with pm.file_lock(step1_path):
+            # 后写者悄悄覆盖前者的 content 与 meta.source。写临界区与 Web 端保存、迁移同一把锁，
+            # 读也持锁避免取回一份写到一半的 step1。
+            with script_review.step1_write_lock(project_path, episode) as step1_path:
                 # 已有草稿在场时不覆盖：那份草稿要么是违约产物、要么是上一轮取回后 agent 已改了
                 # 一半，拿正式文件盖过去等于抹掉它手上的修改。两种情况的出路相同——继续改那份
                 # 草稿再晋升。
@@ -1107,8 +1121,13 @@ def open_reference_step1_for_edit_tool(ctx: ToolContext):
                     # 晋升时照常全量重判。
                     violations=[],
                     # source 键一律写出（未指定时为 null），与拆分侧同口径：晋升侧据此区分「本就按
-                    # 整个 source/ 判锚」与「meta 被改坏」。
-                    meta={"source": source or None},
+                    # 整个 source/ 判锚」与「meta 被改坏」。base_fingerprint 记下此刻正式文件的
+                    # 指纹（与本临界区读到的 data 同一份内容）：晋升前按它做基线比对，取回与晋升
+                    # 之间正式文件被 Web 端保存等并发写入改过时中止晋升、报冲突让 agent 合并。
+                    meta={
+                        "source": source or None,
+                        "base_fingerprint": script_review.content_fingerprint_of_data(data),
+                    },
                 )
             return {
                 "content": [
@@ -1241,25 +1260,35 @@ def split_reference_video_units_tool(ctx: ToolContext):
                 # 违约不丢弃、也不写正式文件：产物连同报告落隔离草稿，由 agent 修复后经
                 # 晋升工具重判。源文路径进 meta——重判时按整个 source/ 重解析会让原文锚的
                 # 子串判定比产出时更松，一份改写过的锚可能在别集原文里恰好命中。
-                report = quarantine_and_report(
-                    project_path,
-                    episode,
-                    QUARANTINE_KIND_STEP1,
-                    content={"units": flat_units},
-                    violations=violations,
-                    # source 键一律写出（未指定源文时为 null）：晋升侧据此区分「原本就按整个
-                    # source/ 产出」与「meta 被改坏」，缺键时不能默默退回更松的全目录解析。
-                    meta={"source": source or None},
-                )
+                # 基线读取与草稿写入在同一写临界区内完成：锁外各做一次的话，记下的基线可能
+                # 描述的是另一份并发写入前的内容。
+                with script_review.step1_write_lock(project_path, episode) as step1_path:
+                    report = quarantine_and_report(
+                        project_path,
+                        episode,
+                        QUARANTINE_KIND_STEP1,
+                        content={"units": flat_units},
+                        violations=violations,
+                        # source 键一律写出（未指定源文时为 null）：晋升侧据此区分「原本就按整个
+                        # source/ 产出」与「meta 被改坏」，缺键时不能默默退回更松的全目录解析。
+                        # base_fingerprint 记下此刻正式文件的指纹（不存在时为 null）：这份草稿
+                        # 修好晋升时若正式文件已被别的写入方改过，按基线比对中止并报冲突。
+                        meta={
+                            "source": source or None,
+                            "base_fingerprint": script_review.content_fingerprint(step1_path),
+                        },
+                    )
                 return {"content": [{"type": "text", "text": report}], "is_error": True}
 
             raw_units = _build_reference_units_from_flat(
                 flat_units, project, episode=episode, max_refs=split_caps.max_refs
             )
-            step1_path = _write_reference_step1(project_path, episode, raw_units)
-            # 重拆分成功即清掉上一轮的隔离草稿：正式文件已是这一份产物，旧草稿留着只会让
-            # gate 与生成侧继续阻塞在一份已被取代的违约产物上。
-            clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP1)
+            # 重拆分是刻意的整份重建，无基线可比对；写盘经单一出口。上一轮隔离草稿的清除与
+            # 写盘同一临界区：正式文件已是这一份产物，旧草稿留着只会让 gate 与生成侧继续阻塞
+            # 在一份已被取代的违约产物上。
+            with script_review.step1_write_lock(project_path, episode) as step1_path:
+                script_review.write_step1_locked(project_path, episode, {"units": raw_units})
+                clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP1)
             warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.raw)
             return {
                 "content": [

--- a/server/routers/_script_review_errors.py
+++ b/server/routers/_script_review_errors.py
@@ -1,0 +1,40 @@
+"""gate 领域错误 → HTTP 响应的共享映射。
+
+审核 gate 的领域错误从两个 router 冒出来：``script_review``（审阅门自身的读写端点）与
+``files``（通用草稿端点对参考生视频 step1 改道 ``ScriptReviewService``）。映射放在两者之外的
+共享模块，两个 router 各自从这里取，同一个错误码在不同端点上不会给出不同的状态码或文案。
+"""
+
+from fastapi import HTTPException
+
+from lib.i18n import Translator
+from server.services.script_review import ScriptReviewError
+
+# gate 领域错误码 → HTTP 状态。invalid_content / episode_not_found 带参数另行注入。
+_ERROR_STATUS: dict[str, int] = {
+    "not_applicable": 409,
+    "no_step1": 409,
+    "invalid_content": 422,
+    "episode_not_found": 404,
+    "quarantined": 409,
+    "conflict": 409,
+}
+# 仅无参错误码走本映射；invalid_content / episode_not_found 需注参，在 raise_review_error 单独处理。
+_ERROR_I18N: dict[str, str] = {
+    "not_applicable": "script_review_not_applicable",
+    "no_step1": "script_review_no_step1",
+    "quarantined": "script_review_quarantined",
+    "conflict": "script_review_conflict",
+}
+
+
+def raise_review_error(exc: ScriptReviewError, episode: int, _t: Translator) -> None:
+    """把 ``ScriptReviewError`` 抛成对应的 ``HTTPException``；未登记的错误码落 400。"""
+    status = _ERROR_STATUS.get(exc.code, 400)
+    if exc.code == "invalid_content":
+        detail = _t("script_review_invalid_content", details=exc.message)
+    elif exc.code == "episode_not_found":
+        detail = _t("episode_not_found", episode=episode)
+    else:
+        detail = _t(_ERROR_I18N.get(exc.code, "internal_server_error"))
+    raise HTTPException(status_code=status, detail=detail)

--- a/server/routers/_script_review_errors.py
+++ b/server/routers/_script_review_errors.py
@@ -5,6 +5,8 @@
 共享模块，两个 router 各自从这里取，同一个错误码在不同端点上不会给出不同的状态码或文案。
 """
 
+from typing import NoReturn
+
 from fastapi import HTTPException
 
 from lib.i18n import Translator
@@ -28,7 +30,7 @@ _ERROR_I18N: dict[str, str] = {
 }
 
 
-def raise_review_error(exc: ScriptReviewError, episode: int, _t: Translator) -> None:
+def raise_review_error(exc: ScriptReviewError, episode: int, _t: Translator) -> NoReturn:
     """把 ``ScriptReviewError`` 抛成对应的 ``HTTPException``；未登记的错误码落 400。"""
     status = _ERROR_STATUS.get(exc.code, 400)
     if exc.code == "invalid_content":

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -53,6 +53,8 @@ from lib.source_loader import (
     SourceLoader,
     UnsupportedFormatError,
 )
+from server.routers.script_review import _raise_review_error
+from server.services.script_review import ScriptReviewError, ScriptReviewService
 
 router = APIRouter()
 
@@ -818,7 +820,7 @@ async def update_draft_content(
     """更新草稿内容"""
     try:
 
-        def _sync():
+        def _resolve_target() -> tuple[Path, str, Path]:
             project_dir = get_project_manager().get_project_path(project_name)
             content_mode, generation_mode = _load_project_modes(project_name)
             step_files = _get_step_files(content_mode, generation_mode)
@@ -826,68 +828,89 @@ async def update_draft_content(
             if step_num not in step_files:
                 raise HTTPException(status_code=400, detail=_t("invalid_step_num", step_num=step_num))
 
-            drafts_dir = episode_drafts_dir(project_dir, episode)
-            drafts_dir.mkdir(parents=True, exist_ok=True)
-
             # 写入始终落到当前模式的目标文件；fallback 仅用于读取/删除（兼容跨模式切换的旧 step1）。
             # 若写入 fallback 到老文件，切模式后后续 subagent 读 step_files[step_num] 仍为空，
             # 导致"前端保存成功但生成报缺少 step1"。
-            draft_path = drafts_dir / step_files[step_num]
+            return project_dir, content_mode, episode_drafts_dir(project_dir, episode) / step_files[step_num]
 
-            # drama step1 落结构化 .json：写入前与 _load_drama_step1_content 的读取契约同口径校验
-            # ——合法 JSON、顶层对象、scenes 为非空且每项为带非空 scene_id 的对象，避免任意文本 / 空剧本 /
-            # 非对象场景项 / 缺失或空 scene_id 写进结构化草稿、拖到生成阶段才解析失败（前端保存成功但生成必然
-            # 失败）。按目标文件名而非 content_mode 触发：_get_step_files 对未知模式回落到 drama 的
-            # 结构化文件名，仅凭 content_mode 判定会让脏值绕过校验把任意文本写成 drama JSON。narration /
-            # reference 的 step1 落各自文件名，不匹配此校验。
-            if draft_path.name == STEP1_FILENAMES["drama"]:
-                try:
-                    parsed = json.loads(content)
-                except json.JSONDecodeError:
-                    raise HTTPException(status_code=400, detail=_t("draft_invalid_json"))
-                scenes = parsed.get("scenes") if isinstance(parsed, dict) else None
-                if (
-                    not isinstance(parsed, dict)
-                    or not isinstance(scenes, list)
-                    or not scenes
-                    or any(not isinstance(scene, dict) for scene in scenes)
-                    or any(not isinstance(scene.get("scene_id"), str) or not scene.get("scene_id") for scene in scenes)
-                ):
-                    raise HTTPException(status_code=400, detail=_t("draft_invalid_json"))
+        project_dir, content_mode, draft_path = await asyncio.to_thread(_resolve_target)
 
-            # 与 ScriptGenerator / ScriptReviewService 共享同一把 per-path 锁：
-            # 草稿文件的迁移读改写与 Web 端保存相互串行化。
-            pm = get_project_manager()
-            with pm.file_lock(draft_path):
-                is_new = not draft_path.exists()
-                draft_path.write_text(content, encoding="utf-8")
-
-            # 发射 draft 事件通知前端
-            action = "created" if is_new else "updated"
-            label_prefix = _t("segment_splitting") if content_mode == "narration" else _t("normalized_script")
-            change = {
-                "entity_type": "draft",
-                "action": action,
-                "entity_id": f"episode_{episode}_step{step_num}",
-                "label": _t("draft_event_label", episode=episode, label_prefix=label_prefix),
-                "episode": episode,
-                "focus": {
-                    "pane": "episode",
-                    "episode": episode,
-                },
-                "important": is_new,
-            }
+        if draft_path.name == REFERENCE_VIDEO_STEP1_FILENAME:
+            # 参考生视频正式 step1 不走本端点的裸文本直写：它的写盘统一收敛在
+            # ScriptReviewService.save_content 的单一出口（结构校验、references 重派生、
+            # per-path 锁与 step2 隔离草稿清理），裸写会成为一条未经校验、绕开写盘语义的旁路。
+            # 本端点无基线指纹可传，不做并发基线比对（同其余无基线的直连调用）。
             try:
-                emit_project_change_batch(project_name, [change], source="worker")
-            except Exception:
-                logger.warning("发送 draft 事件失败 project=%s episode=%s", project_name, episode, exc_info=True)
+                parsed = json.loads(content)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=400, detail=_t("script_review_invalid_content", details=str(exc)))
+            is_new = not draft_path.exists()
+            try:
+                await ScriptReviewService(get_project_manager()).save_content(project_name, episode, parsed)
+            except ScriptReviewError as exc:
+                _raise_review_error(exc, episode, _t)
+        else:
+            is_new = await asyncio.to_thread(_write_plain_draft, draft_path, content, _t)
 
-            return {"success": True, "path": draft_path.relative_to(project_dir).as_posix()}
+        # 发射 draft 事件通知前端
+        action = "created" if is_new else "updated"
+        label_prefix = _t("segment_splitting") if content_mode == "narration" else _t("normalized_script")
+        change = {
+            "entity_type": "draft",
+            "action": action,
+            "entity_id": f"episode_{episode}_step{step_num}",
+            "label": _t("draft_event_label", episode=episode, label_prefix=label_prefix),
+            "episode": episode,
+            "focus": {
+                "pane": "episode",
+                "episode": episode,
+            },
+            "important": is_new,
+        }
+        try:
+            emit_project_change_batch(project_name, [change], source="worker")
+        except Exception:
+            logger.warning("发送 draft 事件失败 project=%s episode=%s", project_name, episode, exc_info=True)
 
-        return await asyncio.to_thread(_sync)
+        return {"success": True, "path": draft_path.relative_to(project_dir).as_posix()}
 
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=project_name) from exc
+
+
+def _write_plain_draft(draft_path: Path, content: str, _t: Translator) -> bool:
+    """非参考生视频 step1 的草稿落盘（同步主体），返回是否为新建文件。
+
+    drama step1 落结构化 .json：写入前与 _load_drama_step1_content 的读取契约同口径校验
+    ——合法 JSON、顶层对象、scenes 为非空且每项为带非空 scene_id 的对象，避免任意文本 / 空剧本 /
+    非对象场景项 / 缺失或空 scene_id 写进结构化草稿、拖到生成阶段才解析失败（前端保存成功但生成必然
+    失败）。按目标文件名而非 content_mode 触发：_get_step_files 对未知模式回落到 drama 的
+    结构化文件名，仅凭 content_mode 判定会让脏值绕过校验把任意文本写成 drama JSON。narration
+    的 step1 落自己的文件名，不匹配此校验。
+    """
+    draft_path.parent.mkdir(parents=True, exist_ok=True)
+    if draft_path.name == STEP1_FILENAMES["drama"]:
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail=_t("draft_invalid_json"))
+        scenes = parsed.get("scenes") if isinstance(parsed, dict) else None
+        if (
+            not isinstance(parsed, dict)
+            or not isinstance(scenes, list)
+            or not scenes
+            or any(not isinstance(scene, dict) for scene in scenes)
+            or any(not isinstance(scene.get("scene_id"), str) or not scene.get("scene_id") for scene in scenes)
+        ):
+            raise HTTPException(status_code=400, detail=_t("draft_invalid_json"))
+
+    # 与 ScriptGenerator / ScriptReviewService 共享同一把 per-path 锁：
+    # 草稿文件的迁移读改写与 Web 端保存相互串行化。
+    pm = get_project_manager()
+    with pm.file_lock(draft_path):
+        is_new = not draft_path.exists()
+        draft_path.write_text(content, encoding="utf-8")
+    return is_new
 
 
 @router.delete("/projects/{project_name}/drafts/{episode}/step{step_num}")

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -53,7 +53,7 @@ from lib.source_loader import (
     SourceLoader,
     UnsupportedFormatError,
 )
-from server.routers.script_review import _raise_review_error
+from server.routers._script_review_errors import raise_review_error
 from server.services.script_review import ScriptReviewError, ScriptReviewService
 
 router = APIRouter()
@@ -844,11 +844,13 @@ async def update_draft_content(
                 parsed = json.loads(content)
             except json.JSONDecodeError as exc:
                 raise HTTPException(status_code=400, detail=_t("script_review_invalid_content", details=str(exc)))
-            is_new = not draft_path.exists()
+            # 存在性探测同其余同步文件 I/O 卸到线程：本函数由请求协程直接 await，
+            # 裸 exists() 会跑在事件循环上阻塞并发请求。
+            is_new = not await asyncio.to_thread(draft_path.exists)
             try:
                 await ScriptReviewService(get_project_manager()).save_content(project_name, episode, parsed)
             except ScriptReviewError as exc:
-                _raise_review_error(exc, episode, _t)
+                raise_review_error(exc, episode, _t)
         else:
             is_new = await asyncio.to_thread(_write_plain_draft, draft_path, content, _t)
 

--- a/server/routers/script_review.py
+++ b/server/routers/script_review.py
@@ -7,44 +7,17 @@ drama（utterances + source_text）与 narration（结构化 novel_text）共用
 
 import logging
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body
 
 from lib.api_errors import NotFoundError
 from lib.i18n import Translator
 from lib.project_manager import get_project_manager
+from server.routers._script_review_errors import raise_review_error
 from server.services.script_review import ScriptReviewError, ScriptReviewService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# gate 领域错误码 → (HTTP 状态, i18n key)。invalid_content / episode_not_found 带参数另行注入。
-_ERROR_STATUS: dict[str, int] = {
-    "not_applicable": 409,
-    "no_step1": 409,
-    "invalid_content": 422,
-    "episode_not_found": 404,
-    "quarantined": 409,
-    "conflict": 409,
-}
-# 仅无参错误码走本映射；invalid_content / episode_not_found 需注参，在 _raise_review_error 单独处理。
-_ERROR_I18N: dict[str, str] = {
-    "not_applicable": "script_review_not_applicable",
-    "no_step1": "script_review_no_step1",
-    "quarantined": "script_review_quarantined",
-    "conflict": "script_review_conflict",
-}
-
-
-def _raise_review_error(exc: ScriptReviewError, episode: int, _t: Translator) -> None:
-    status = _ERROR_STATUS.get(exc.code, 400)
-    if exc.code == "invalid_content":
-        detail = _t("script_review_invalid_content", details=exc.message)
-    elif exc.code == "episode_not_found":
-        detail = _t("episode_not_found", episode=episode)
-    else:
-        detail = _t(_ERROR_I18N.get(exc.code, "internal_server_error"))
-    raise HTTPException(status_code=status, detail=detail)
 
 
 async def _attach_duration_tiers(service: ScriptReviewService, project_name: str, episode: int, state: dict) -> dict:
@@ -95,7 +68,7 @@ async def get_script_review(project_name: str, episode: int, _t: Translator):
         state["quarantine"] = _localize_quarantine_violations(quarantine, _t)
         return state
     except ScriptReviewError as exc:
-        _raise_review_error(exc, episode, _t)
+        raise_review_error(exc, episode, _t)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=project_name) from exc
 
@@ -131,7 +104,7 @@ async def update_script_review_content(
         state["quarantine"] = _localize_quarantine_violations(quarantine, _t)
         return state
     except ScriptReviewError as exc:
-        _raise_review_error(exc, episode, _t)
+        raise_review_error(exc, episode, _t)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=project_name) from exc
 
@@ -153,6 +126,6 @@ async def confirm_script_review(project_name: str, episode: int, _t: Translator)
         )
         return state
     except ScriptReviewError as exc:
-        _raise_review_error(exc, episode, _t)
+        raise_review_error(exc, episode, _t)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=project_name) from exc

--- a/server/routers/script_review.py
+++ b/server/routers/script_review.py
@@ -25,12 +25,14 @@ _ERROR_STATUS: dict[str, int] = {
     "invalid_content": 422,
     "episode_not_found": 404,
     "quarantined": 409,
+    "conflict": 409,
 }
 # 仅无参错误码走本映射；invalid_content / episode_not_found 需注参，在 _raise_review_error 单独处理。
 _ERROR_I18N: dict[str, str] = {
     "not_applicable": "script_review_not_applicable",
     "no_step1": "script_review_no_step1",
     "quarantined": "script_review_quarantined",
+    "conflict": "script_review_conflict",
 }
 
 
@@ -104,8 +106,12 @@ async def update_script_review_content(
     episode: int,
     _t: Translator,
     content: dict = Body(...),
+    base_fingerprint: str | None = None,
 ):
     """保存手动 / agent 编辑后的结构化中间态，并使该集重新进入待审。
+
+    ``base_fingerprint``（query）是编辑方 GET 时拿到的内容指纹：给定时服务端在锁内比对，
+    编辑期间 step1 被另一写入方改过则 409 冲突、不落盘；缺省不比对（无基线的直连调用）。
 
     ``quarantine`` 同 GET 一并合并：保存作用于正式草稿，与隔离草稿是两份独立文件，保存在途时
     agent 可能已经另外产出一份新的隔离草稿——响应缺这个字段的话 ``adopt()`` 会把它当作
@@ -119,7 +125,7 @@ async def update_script_review_content(
     """
     try:
         service = ScriptReviewService(get_project_manager())
-        state = await service.save_content(project_name, episode, content)
+        state = await service.save_content(project_name, episode, content, base_fingerprint)
         quarantine = await service.get_quarantine_info(project_name, episode)
         await _attach_duration_tiers(service, project_name, episode, state)
         state["quarantine"] = _localize_quarantine_violations(quarantine, _t)

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -372,24 +372,26 @@ class ScriptReviewService:
             validated = model.model_validate(content).model_dump()
         except ValidationError as exc:
             raise ScriptReviewError("invalid_content", str(exc)) from exc
-        if kind == "reference_video":
-            # references 是从 shot 文本机械派生的字段：编辑正文后随之重派生，避免正文与 references
-            # 漂移（step2 会用陈旧 [图N] 映射生成）。机械变换、不校验能力上限（同 drama / narration 只结构校验）。
-            rederive_unit_references(validated["units"], project)
-            # 写盘经单一出口：锁、基线比对、step2 隔离草稿清理都在 write_step1_locked 一处。
-            expected = base_fingerprint if base_fingerprint is not None else script_review.UNCHECKED_FINGERPRINT
-            try:
+        # 入参的 None 表示「调用方无基线、不比对」；比对语义里的 None 另有含义（取基线时文件不存在），
+        # 两者在此一次性转换，三个变体共用同一个 expected。
+        expected = base_fingerprint if base_fingerprint is not None else script_review.UNCHECKED_FINGERPRINT
+        try:
+            if kind == "reference_video":
+                # references 是从 shot 文本机械派生的字段：编辑正文后随之重派生，避免正文与 references
+                # 漂移（step2 会用陈旧 [图N] 映射生成）。机械变换、不校验能力上限（同 drama / narration 只结构校验）。
+                rederive_unit_references(validated["units"], project)
+                # 写盘经单一出口：锁、基线比对、step2 隔离草稿清理都在 write_step1_locked 一处。
                 with script_review.step1_write_lock(project_path, episode):
                     script_review.write_step1_locked(project_path, episode, validated, expected_fingerprint=expected)
-            except script_review.Step1WriteConflict as exc:
-                raise ScriptReviewError("conflict", str(exc)) from exc
-            return
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # 与 _read_step1_migrated 共享同一把 per-path 锁：保存与迁移的读改写相互互斥。
-        with self.pm.file_lock(path):
-            if base_fingerprint is not None and base_fingerprint != script_review.content_fingerprint(path):
-                raise ScriptReviewError("conflict", f"step1 内容在编辑期间已被修改（基线 {base_fingerprint}）")
-            atomic_write_json(path, validated)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                # 与 _read_step1_migrated 共享同一把 per-path 锁：保存与迁移的读改写相互互斥。
+                # 基线比对同 rv 走 assert_base_fingerprint，两者的冲突判据不分叉。
+                with self.pm.file_lock(path):
+                    script_review.assert_base_fingerprint(path, expected)
+                    atomic_write_json(path, validated)
+        except script_review.Step1WriteConflict as exc:
+            raise ScriptReviewError("conflict", str(exc)) from exc
 
     async def confirm(self, project_name: str, episode: int) -> dict[str, Any]:
         """把该集审核状态翻到 confirmed（记录当前 step1 内容指纹），放行 step2。

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -145,6 +145,7 @@ class ScriptReviewService:
         project: dict[str, Any],
         episode: int,
         path: Path,
+        project_path: Path,
         supported_durations: list[int] | None,
     ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
         """读结构化 step1，并对参考生视频草稿做一次性时长收编迁移；返回 ``(内容, 最新 project)``。
@@ -168,7 +169,7 @@ class ScriptReviewService:
             return content, project
 
         updated, _warnings = script_review.migrate_step1_draft_in_place(
-            path,
+            project_path,
             content,
             episode=episode,
             update_project=lambda mutate: self.pm.update_project(project_name, mutate),
@@ -218,7 +219,9 @@ class ScriptReviewService:
             # 迁移可能回写 step1 与确认记录；指纹与状态在同一把锁内、迁移之后取，三者才据
             # 同一份落盘内容派生——锁外取则并发 save_content 会让指纹描述另一份内容。
             with self.pm.file_lock(path):
-                content, project = self._read_step1_migrated(project_name, project, episode, path, supported_durations)
+                content, project = self._read_step1_migrated(
+                    project_name, project, episode, path, project_path, supported_durations
+                )
                 fingerprint = script_review.content_fingerprint(path)
                 status = script_review.review_status(project_path, project, episode)
         else:
@@ -337,19 +340,27 @@ class ScriptReviewService:
         with_refs, without_refs = reference_unit_duration_tiers(project, caps, raw)
         return {"with_references": sorted(set(with_refs)), "without_references": sorted(set(without_refs))}
 
-    async def save_content(self, project_name: str, episode: int, content: object) -> dict[str, Any]:
+    async def save_content(
+        self, project_name: str, episode: int, content: object, base_fingerprint: str | None = None
+    ) -> dict[str, Any]:
         """校验并落盘编辑后的结构化中间态（手动或 agent 编辑后回写），返回最新状态（重新待审）。
 
         内容变更使指纹漂移，``get_state`` 据此自动回到 pending_review——保存即重新需要确认。
 
+        ``base_fingerprint`` 是编辑方读取内容（``get_state``）时拿到的指纹：给定时在锁内与盘上
+        现值比对，不一致（编辑期间另一写入方已改过 step1）抛 ``conflict``、不落盘——后写方拿
+        409 冲突提示去刷新合并，先写方的内容不被静默覆盖。``None`` 不比对（无基线的直连调用）。
+
         落盘本身全同步（不做时长收编，无需档位表），整段卸到线程；随后的 ``get_state`` 自行
         解析档位表，保存的响应与 GET 首次加载因此同源。
         """
-        await asyncio.to_thread(self._save_content_sync, project_name, episode, content)
+        await asyncio.to_thread(self._save_content_sync, project_name, episode, content, base_fingerprint)
         return await self.get_state(project_name, episode)
 
-    def _save_content_sync(self, project_name: str, episode: int, content: object) -> None:
-        """``save_content`` 的同步主体：结构校验、references 重派生、落盘。"""
+    def _save_content_sync(
+        self, project_name: str, episode: int, content: object, base_fingerprint: str | None
+    ) -> None:
+        """``save_content`` 的同步主体：结构校验、references 重派生、基线比对、落盘。"""
         project = self.pm.load_project(project_name)
         project_path = self.pm.get_project_path(project_name)
         path = script_review.step1_path(project_path, project, episode)
@@ -365,9 +376,19 @@ class ScriptReviewService:
             # references 是从 shot 文本机械派生的字段：编辑正文后随之重派生，避免正文与 references
             # 漂移（step2 会用陈旧 [图N] 映射生成）。机械变换、不校验能力上限（同 drama / narration 只结构校验）。
             rederive_unit_references(validated["units"], project)
+            # 写盘经单一出口：锁、基线比对、step2 隔离草稿清理都在 write_step1_locked 一处。
+            expected = base_fingerprint if base_fingerprint is not None else script_review.UNCHECKED_FINGERPRINT
+            try:
+                with script_review.step1_write_lock(project_path, episode):
+                    script_review.write_step1_locked(project_path, episode, validated, expected_fingerprint=expected)
+            except script_review.Step1WriteConflict as exc:
+                raise ScriptReviewError("conflict", str(exc)) from exc
+            return
         path.parent.mkdir(parents=True, exist_ok=True)
         # 与 _read_step1_migrated 共享同一把 per-path 锁：保存与迁移的读改写相互互斥。
         with self.pm.file_lock(path):
+            if base_fingerprint is not None and base_fingerprint != script_review.content_fingerprint(path):
+                raise ScriptReviewError("conflict", f"step1 内容在编辑期间已被修改（基线 {base_fingerprint}）")
             atomic_write_json(path, validated)
 
     async def confirm(self, project_name: str, episode: int) -> dict[str, Any]:
@@ -407,7 +428,9 @@ class ScriptReviewService:
         # per-path 锁覆盖读改写全程（含下方 reference_video 分支自己的落盘），避免中途被
         # save_content 或迁移的写入插队——_read_step1_migrated 要求调用方已持锁。
         with self.pm.file_lock(path):
-            content, project = self._read_step1_migrated(project_name, project, episode, path, supported_durations)
+            content, project = self._read_step1_migrated(
+                project_name, project, episode, path, project_path, supported_durations
+            )
             if content is None and not path.exists():
                 raise ScriptReviewError("no_step1")
             # 确认前按 step1 变体模型校验 step1 结构：content 为 None（非法 JSON / 非对象）同样会
@@ -424,7 +447,10 @@ class ScriptReviewService:
                 # 这份对象直接算，确认记录与实际写入内容一致。
                 dumped = validated.model_dump()
                 rederive_unit_references(dumped["units"], project)
-                atomic_write_json(path, dumped)
+                # 单一写盘出口（已持同一把 per-path 锁，不再套 step1_write_lock）；同临界区
+                # 读改写无并发窗口，不做基线比对。重派生真的改了内容时，step2 隔离草稿的基底
+                # 随之失效，由出口按变更清理。
+                script_review.write_step1_locked(project_path, episode, dumped)
                 fingerprint = script_review.content_fingerprint_of_data(dumped)
             else:
                 # 指纹从校验通过的 content 派生，不二次读盘：确认记录须对应这里校验过的内容。

--- a/tests/agent_runtime/test_agent_access_policy.py
+++ b/tests/agent_runtime/test_agent_access_policy.py
@@ -644,3 +644,42 @@ def test_logs_dir_outside_repo_is_sensitive(tmp_path: Path) -> None:
     assert policy.is_sensitive_path(external_logs.resolve())
     # repo/logs 在此场景下不应被默认 deny（避免误覆盖）
     assert not policy.is_sensitive_path((repo / "logs" / "anything.txt").resolve())
+
+
+# ============================================================
+# 受保护写路径规则表：hook 与 sandbox denyWrite 同表投影
+# ============================================================
+
+
+def test_protected_write_rules_project_new_rule_in_both_layers(
+    policy: AgentAccessPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """新增一类受保护路径只需在 PROTECTED_WRITE_RULES 加一行：hook 拒绝与 sandbox denyWrite
+    都从同一张表投影、随之同步生效——分散声明时漏掉任一处都会留出单层旁路。"""
+    from server.agent_runtime.agent_access_policy import ProtectedWriteRule
+
+    def _matches_meta_lock(target: Path, bases: list[Path]) -> bool:
+        return any(str(target) == str(base / "meta.lock") for base in bases)
+
+    synthetic = ProtectedWriteRule(
+        name="meta_lock",
+        matches=_matches_meta_lock,
+        deny_message="访问被拒绝：meta.lock 不可直改（合成规则）",
+        sandbox_subpaths=("meta.lock",),
+    )
+    monkeypatch.setattr(
+        AgentAccessPolicy, "PROTECTED_WRITE_RULES", (*AgentAccessPolicy.PROTECTED_WRITE_RULES, synthetic)
+    )
+
+    cwd = _cwd(policy)
+    # hook 层：新规则立即生效
+    allowed, reason = policy.check_path_access(str(cwd / "meta.lock"), "Write", cwd)
+    assert not allowed
+    assert reason == synthetic.deny_message
+    # sandbox 层：denyWrite 投影同表同步
+    deny_write = policy.build_sandbox_settings(cwd)["filesystem"]["denyWrite"]
+    assert str(cwd / "meta.lock") in deny_write
+    # 既有规则不受影响
+    assert str(cwd / "project.json") in deny_write
+    assert str(cwd / "scripts") in deny_write
+    assert str(cwd / "drafts") in deny_write

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 
+from lib import script_review
 from lib.reference_video.draft_validation import DraftViolation
 from lib.reference_video.quarantine import (
     QUARANTINE_KIND_STEP1,
@@ -3915,6 +3916,95 @@ async def test_open_reference_step1_for_edit_rejects_non_reference_episode(fake_
 
     assert out.get("is_error") is True
     assert not _rv_quarantine_path(fake_ctx).exists()
+
+
+# ---------------------------------------------------------------------------
+# step1 乐观并发控制（取回时记基线指纹，晋升前锁内比对）
+# ---------------------------------------------------------------------------
+
+
+async def test_open_reference_step1_for_edit_records_base_fingerprint(fake_ctx: ToolContext) -> None:
+    """取回时把正式文件此刻的内容指纹记进 meta.base_fingerprint，供晋升前基线比对。"""
+    _rv_source(fake_ctx)
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 起身"])])
+
+    out = await _open_for_edit(fake_ctx)
+
+    assert out.get("is_error") is not True, out
+    meta = _read_rv_quarantine(fake_ctx)["meta"]
+    assert meta["base_fingerprint"] == script_review.content_fingerprint(_rv_step1_path(fake_ctx))
+
+
+async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: ToolContext, monkeypatch) -> None:
+    """「用户在审阅门编辑 + agent 改隔离草稿并晋升」的双端并发：取回后正式文件被另一写入方
+    改过时，晋升中止并返回冲突报告（含最新内容与合并指引），不静默覆盖对方的修改；草稿
+    留在原地。按报告把 meta.base_fingerprint 更新为现值（显式确认已合并）后方可重新晋升。"""
+    _rv_source(fake_ctx)
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 起身"])])
+    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
+
+    # 模拟取回之后 Web 端保存改写了正式文件
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 在 @[村口] 等候"])])
+    web_version = _rv_step1_path(fake_ctx).read_text(encoding="utf-8")
+
+    out = await _promote(fake_ctx, monkeypatch)
+
+    assert out.get("is_error") is True
+    report = out["content"][0]["text"]
+    assert "并发冲突" in report
+    assert "base_fingerprint" in report
+    # 冲突报告附上盘上现值的扁平书写层，供 agent 对照合并
+    assert "在 @[村口] 等候" in report
+    # 正式文件未被覆盖，草稿仍在场
+    assert _rv_step1_path(fake_ctx).read_text(encoding="utf-8") == web_version
+    assert _rv_quarantine_path(fake_ctx).exists()
+
+    # 按报告指引更新基线指纹（显式确认已合并对方修改）后重新晋升即放行
+    envelope = _read_rv_quarantine(fake_ctx)
+    envelope["meta"]["base_fingerprint"] = script_review.content_fingerprint(_rv_step1_path(fake_ctx))
+    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    out = await _promote(fake_ctx, monkeypatch)
+    assert out.get("is_error") is not True, out
+    assert not _rv_quarantine_path(fake_ctx).exists()
+
+
+async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext, monkeypatch) -> None:
+    """基线机制引入前产出的存量草稿缺 meta.base_fingerprint 键：按无基线晋升，不被新校验卡死。"""
+    _rv_source(fake_ctx)
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 起身"])])
+    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = _read_rv_quarantine(fake_ctx)
+    del envelope["meta"]["base_fingerprint"]
+    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    # 取回后正式文件又被改过——存量草稿无基线可比，照旧覆盖（维持引入前语义）
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 在 @[村口] 等候"])])
+
+    out = await _promote(fake_ctx, monkeypatch)
+
+    assert out.get("is_error") is not True, out
+    assert not _rv_quarantine_path(fake_ctx).exists()
+
+
+async def test_split_violation_quarantine_records_base_fingerprint(fake_ctx: ToolContext, monkeypatch) -> None:
+    """拆分违约落隔离草稿时同样记基线：修好晋升前正式文件被并发改写的话按基线中止。
+    首拆时正式文件不存在，基线为 null——晋升时若正式文件已被另一次拆分写出，同样判冲突。"""
+    _rv_source(fake_ctx)
+    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("镜头1：@[不存在的人] 出场")])
+
+    meta = _read_rv_quarantine(fake_ctx)["meta"]
+    assert "base_fingerprint" in meta
+    assert meta["base_fingerprint"] is None
+
+    # 草稿在场期间正式文件被写出（另一路径），修好草稿后晋升应报冲突而非覆盖
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 起身"])])
+    envelope = _read_rv_quarantine(fake_ctx)
+    envelope["content"]["units"][0]["text"] = "镜头1：@[张三] 出场"
+    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+
+    out = await _promote(fake_ctx, monkeypatch)
+
+    assert out.get("is_error") is True
+    assert "并发冲突" in out["content"][0]["text"]
 
 
 @pytest.mark.parametrize(

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -3968,6 +3968,31 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """取回后正式文件被删除：现值指纹是 null，报告须按 JSON 字面量给出而非字符串 "None"。
+    照报告把 meta.base_fingerprint 设为 null 后重晋升即放行——写成字符串则永远比对不上、冲突解不掉。"""
+    _rv_source(fake_ctx)
+    _write_rv_step1(fake_ctx, [_rv_saved_unit(["@[张三] 起身"])])
+    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
+    _rv_step1_path(fake_ctx).unlink()
+
+    out = await _promote(fake_ctx, monkeypatch)
+
+    assert out.get("is_error") is True
+    report = out["content"][0]["text"]
+    assert "null" in report
+    assert "None" not in report
+
+    envelope = _read_rv_quarantine(fake_ctx)
+    envelope["meta"]["base_fingerprint"] = None
+    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    out = await _promote(fake_ctx, monkeypatch)
+    assert out.get("is_error") is not True, out
+    assert not _rv_quarantine_path(fake_ctx).exists()
+
+
 async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext, monkeypatch) -> None:
     """基线机制引入前产出的存量草稿缺 meta.base_fingerprint 键：按无基线晋升，不被新校验卡死。"""
     _rv_source(fake_ctx)

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -943,7 +943,7 @@ class TestFilesRouter:
 
     def test_draft_content_reference_video_mode(self, tmp_path, monkeypatch):
         """参考生视频模式下读/写 step1_reference_units.json，避免被按 content_mode 错误路由；
-        旧 .md 仅存量兼读，写入落结构化 .json"""
+        旧 .md 仅存量兼读，写入经 ScriptReviewService 单一出口做结构校验后落结构化 .json"""
         client, pm = _client(monkeypatch, tmp_path)
         project_dir = pm.get_project_path("demo")
 
@@ -952,6 +952,9 @@ class TestFilesRouter:
         payload = json.loads(project_json.read_text(encoding="utf-8"))
         payload["generation_mode"] = "reference_video"
         project_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        # 分集须可登记（save_content 的写入前置）：派生源文在场即可经孤儿分集自愈补建条目
+        (project_dir / "source").mkdir(parents=True, exist_ok=True)
+        (project_dir / "source" / "episode_1.txt").write_text("原文", encoding="utf-8")
 
         drafts_dir = project_dir / "drafts" / "episode_1"
         drafts_dir.mkdir(parents=True, exist_ok=True)
@@ -963,19 +966,35 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert resp.text == "E1U1 stub"
 
-            # 写入时按 generation_mode 路由到结构化 step1_reference_units.json
+            # 裸文本 / 非法结构不再直写正式 step1（旁路已收敛到单一写盘出口）
+            bad = client.put(
+                "/api/v1/projects/demo/drafts/1/step1",
+                content="raw text",
+                headers={"content-type": "text/plain"},
+            )
+            assert bad.status_code == 400
+            invalid = client.put(
+                "/api/v1/projects/demo/drafts/1/step1",
+                content='{"units": [{"bogus": 1}]}',
+                headers={"content-type": "text/plain"},
+            )
+            assert invalid.status_code == 422
+
+            # 合法结构化内容按 generation_mode 路由到 step1_reference_units.json
+            unit = {"unit_id": "E1U01", "shots": [{"text": "镜头描述"}], "duration_seconds": 8}
             update = client.put(
                 "/api/v1/projects/demo/drafts/1/step1",
-                content='{"units": []}',
+                content=json.dumps({"units": [unit]}, ensure_ascii=False),
                 headers={"content-type": "text/plain"},
             )
             assert update.status_code == 200
             assert update.json()["path"] == "drafts/episode_1/step1_reference_units.json"
 
-            # 结构化 .json 存在后优先于旧 .md
+            # 结构化 .json 存在后优先于旧 .md；落盘的是校验后的结构化内容
             resp = client.get("/api/v1/projects/demo/drafts/1/step1")
             assert resp.status_code == 200
-            assert resp.text == '{"units": []}'
+            saved = json.loads(resp.text)
+            assert saved["units"][0]["unit_id"] == "E1U01"
 
     def test_draft_content_fallback_when_mode_mismatches_file(self, tmp_path, monkeypatch):
         """content_mode=narration 但磁盘上只有 reference_units 文件（集级模式切换/历史项目）也能读到"""
@@ -1003,11 +1022,14 @@ class TestFilesRouter:
 
         drafts_dir = project_dir / "drafts" / "episode_2"
         drafts_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "source").mkdir(parents=True, exist_ok=True)
+        (project_dir / "source" / "episode_2.txt").write_text("原文", encoding="utf-8")
 
         with client:
+            unit = {"unit_id": "E2U01", "shots": [{"text": "镜头描述"}], "duration_seconds": 8}
             update = client.put(
                 "/api/v1/projects/demo/drafts/2/step1",
-                content="ep2 reference units",
+                content=json.dumps({"units": [unit]}, ensure_ascii=False),
                 headers={"content-type": "text/plain"},
             )
             assert update.status_code == 200

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -15,7 +15,13 @@ from lib import script_review
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
 from lib.reference_video.draft_validation import DraftViolation
-from lib.reference_video.quarantine import QUARANTINE_KIND_STEP1, clear_quarantine, write_quarantine
+from lib.reference_video.quarantine import (
+    QUARANTINE_KIND_STEP1,
+    QUARANTINE_KIND_STEP2,
+    clear_quarantine,
+    quarantine_path,
+    write_quarantine,
+)
 from server.services.script_review import ScriptReviewError, ScriptReviewService
 
 
@@ -902,6 +908,151 @@ class TestErrors:
         assert exc.value.code == "episode_not_found"
         orphan = pm.get_project_path("demo") / "drafts" / "episode_99" / "step1_normalized_script.json"
         assert not orphan.exists()
+
+    async def test_save_with_stale_fingerprint_conflicts_reference_video(self, tmp_path):
+        """rv 并发编辑：保存携带的基线指纹与盘上现值不一致（编辑期间另一方已保存）→ conflict、
+        不落盘不覆盖；拿最新指纹（等价于刷新合并后）重试放行。"""
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        svc = ScriptReviewService(pm)
+        path = _write_rv_step1(pm, _rv_step1())
+        stale = (await svc.get_state("demo", 1))["fingerprint"]
+
+        # 另一编辑方先保存（内容变化 → 指纹漂移）
+        other = _rv_step1()
+        other["units"][0]["shots"][0]["text"] = "@[阿离] 转身离开。"
+        await svc.save_content("demo", 1, other)
+        before = path.read_text(encoding="utf-8")
+
+        mine = _rv_step1()
+        mine["units"][0]["shots"][1]["text"] = "@[裴与] 下马。"
+        with pytest.raises(ScriptReviewError) as exc:
+            await svc.save_content("demo", 1, mine, stale)
+        assert exc.value.code == "conflict"
+        assert path.read_text(encoding="utf-8") == before
+
+        fresh = (await svc.get_state("demo", 1))["fingerprint"]
+        state = await svc.save_content("demo", 1, mine, fresh)
+        assert state["status"] == "pending_review"
+        assert json.loads(path.read_text(encoding="utf-8"))["units"][0]["shots"][1]["text"] == "@[裴与] 下马。"
+
+    async def test_save_with_stale_fingerprint_conflicts_drama(self, tmp_path):
+        """drama/narration 的 web 保存同样受基线比对保护：同一个 conflict 错误码。"""
+        pm = _make_project(tmp_path, "drama")
+        svc = ScriptReviewService(pm)
+        path = _write_step1(pm, "drama", _drama_step1())
+        stale = (await svc.get_state("demo", 1))["fingerprint"]
+
+        other = _drama_step1()
+        other["title"] = "另一方改的标题"
+        await svc.save_content("demo", 1, other)
+        before = path.read_text(encoding="utf-8")
+
+        with pytest.raises(ScriptReviewError) as exc:
+            await svc.save_content("demo", 1, _drama_step1(), stale)
+        assert exc.value.code == "conflict"
+        assert path.read_text(encoding="utf-8") == before
+
+    async def test_save_without_fingerprint_skips_baseline_check(self, tmp_path):
+        """不带基线指纹的直连调用维持原语义：不比对、直接落盘。"""
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        svc = ScriptReviewService(pm)
+        _write_rv_step1(pm, _rv_step1())
+        other = _rv_step1()
+        other["units"][0]["shots"][0]["text"] = "@[阿离] 转身离开。"
+        await svc.save_content("demo", 1, other)
+
+        state = await svc.save_content("demo", 1, _rv_step1())
+        assert state["status"] == "pending_review"
+
+    async def test_rv_save_clears_stale_step2_quarantine_on_change(self, tmp_path):
+        """web 保存改了 step1 内容 → 在场的 step2 隔离草稿作废（其保结构 diff 以旧 step1 为
+        基底）；内容未变的保存不清。与 agent 侧写盘同一出口、同一语义。"""
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        svc = ScriptReviewService(pm)
+        project_path = pm.get_project_path("demo")
+        _write_rv_step1(pm, _rv_step1())
+        # 先经一次保存把归一化形状（含模型默认字段）落盘，"内容未变"的比较才有同一基准
+        await svc.save_content("demo", 1, _rv_step1())
+        step2_q = quarantine_path(project_path, 1, QUARANTINE_KIND_STEP2)
+
+        write_quarantine(project_path, 1, QUARANTINE_KIND_STEP2, content={"units": [{"text": "旧基底"}]}, violations=[])
+        await svc.save_content("demo", 1, _rv_step1())  # 内容未变（校验/重派生结果与盘上一致）
+        assert step2_q.exists()
+
+        edited = _rv_step1()
+        edited["units"][0]["shots"][0]["text"] = "@[阿离] 转身离开。"
+        await svc.save_content("demo", 1, edited)
+        assert not step2_q.exists()
+
+
+# ---------------------------------------------------------------------------
+# 单一写盘出口（lib.script_review.write_step1_locked）
+# ---------------------------------------------------------------------------
+
+
+class TestStep1WriteStore:
+    def _project_path(self, tmp_path: Path) -> Path:
+        pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
+        return pm.get_project_path("demo")
+
+    def test_conflict_on_stale_baseline_keeps_file(self, tmp_path: Path):
+        project_path = self._project_path(tmp_path)
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 1}]})
+        stale = "0" * 64
+
+        with pytest.raises(script_review.Step1WriteConflict) as exc:
+            with script_review.step1_write_lock(project_path, 1):
+                script_review.write_step1_locked(project_path, 1, {"units": [{"v": 2}]}, expected_fingerprint=stale)
+
+        assert exc.value.expected == stale
+        assert exc.value.actual == script_review.content_fingerprint_of_data({"units": [{"v": 1}]})
+        assert exc.value.current_content == {"units": [{"v": 1}]}
+        path = script_review.official_reference_step1_path(project_path, 1)
+        assert json.loads(path.read_text(encoding="utf-8")) == {"units": [{"v": 1}]}
+
+    def test_matching_baseline_and_none_baseline_write(self, tmp_path: Path):
+        """基线一致放行；``None`` 基线表示「取基线时文件不存在」，首写同样放行。"""
+        project_path = self._project_path(tmp_path)
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 1}]}, expected_fingerprint=None)
+        current = script_review.content_fingerprint(script_review.official_reference_step1_path(project_path, 1))
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 2}]}, expected_fingerprint=current)
+        path = script_review.official_reference_step1_path(project_path, 1)
+        assert json.loads(path.read_text(encoding="utf-8")) == {"units": [{"v": 2}]}
+
+    def test_none_baseline_conflicts_when_file_appeared(self, tmp_path: Path):
+        """基线 None（取基线时无正式文件）而写盘前文件已被另一方写出 → 冲突，不覆盖。"""
+        project_path = self._project_path(tmp_path)
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 1}]})
+        with pytest.raises(script_review.Step1WriteConflict):
+            with script_review.step1_write_lock(project_path, 1):
+                script_review.write_step1_locked(project_path, 1, {"units": [{"v": 2}]}, expected_fingerprint=None)
+
+    def test_step2_quarantine_cleared_only_on_change(self, tmp_path: Path):
+        project_path = self._project_path(tmp_path)
+        step2_q = quarantine_path(project_path, 1, QUARANTINE_KIND_STEP2)
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 1}]})
+
+        # 内容未变 → 不清
+        write_quarantine(project_path, 1, QUARANTINE_KIND_STEP2, content={"units": [{"text": "基底"}]}, violations=[])
+        with script_review.step1_write_lock(project_path, 1):
+            assert script_review.write_step1_locked(project_path, 1, {"units": [{"v": 1}]}) is False
+        assert step2_q.exists()
+
+        # 内容变了 → 清
+        with script_review.step1_write_lock(project_path, 1):
+            assert script_review.write_step1_locked(project_path, 1, {"units": [{"v": 2}]}) is True
+        assert not step2_q.exists()
+
+        # 迁移回写按机械收编处理：内容变了也不清
+        write_quarantine(project_path, 1, QUARANTINE_KIND_STEP2, content={"units": [{"text": "基底"}]}, violations=[])
+        with script_review.step1_write_lock(project_path, 1):
+            script_review.write_step1_locked(project_path, 1, {"units": [{"v": 3}]}, clear_step2_quarantine=False)
+        assert step2_q.exists()
 
     async def test_confirm_corrupt_step1_rejected(self, tmp_path):
         """step1 文件损坏（非法 JSON，但 content_fingerprint 仍产哈希）→ 确认被结构校验拒绝。"""

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -984,6 +984,16 @@ class TestErrors:
         await svc.save_content("demo", 1, edited)
         assert not step2_q.exists()
 
+    async def test_confirm_corrupt_step1_rejected(self, tmp_path):
+        """step1 文件损坏（非法 JSON，但 content_fingerprint 仍产哈希）→ 确认被结构校验拒绝。"""
+        pm = _make_project(tmp_path, "drama")
+        svc = ScriptReviewService(pm)
+        path = _write_step1(pm, "drama", _drama_step1())
+        path.write_bytes(b"\x00\x01 not json at all {")
+        with pytest.raises(ScriptReviewError) as exc:
+            await svc.confirm("demo", 1)
+        assert exc.value.code == "invalid_content"
+
 
 # ---------------------------------------------------------------------------
 # 单一写盘出口（lib.script_review.write_step1_locked）
@@ -1053,16 +1063,6 @@ class TestStep1WriteStore:
         with script_review.step1_write_lock(project_path, 1):
             script_review.write_step1_locked(project_path, 1, {"units": [{"v": 3}]}, clear_step2_quarantine=False)
         assert step2_q.exists()
-
-    async def test_confirm_corrupt_step1_rejected(self, tmp_path):
-        """step1 文件损坏（非法 JSON，但 content_fingerprint 仍产哈希）→ 确认被结构校验拒绝。"""
-        pm = _make_project(tmp_path, "drama")
-        svc = ScriptReviewService(pm)
-        path = _write_step1(pm, "drama", _drama_step1())
-        path.write_bytes(b"\x00\x01 not json at all {")
-        with pytest.raises(ScriptReviewError) as exc:
-            await svc.confirm("demo", 1)
-        assert exc.value.code == "invalid_content"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -524,3 +524,28 @@ class TestReferenceVideoRouter:
             # meta 缺失时降级出的 quarantine_unreadable 兜底条目。
             codes = [v["code"] for v in put_body["quarantine"]["violations"]]
             assert codes and "quarantine_unreadable" not in codes
+
+    def test_put_with_stale_base_fingerprint_conflicts_409(self, tmp_path, monkeypatch):
+        """PUT 携带的 ``base_fingerprint`` 与盘上现值不一致（编辑期间另一方已保存）→ 409、
+        不落盘；拿最新指纹重试放行。缺省不带指纹的调用维持原语义（不比对）。"""
+        client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
+        _write_rv_step1(pm, _rv_step1())
+
+        with client:
+            base = "/api/v1/projects/demo/episodes/1/script-review"
+            stale = client.get(base).json()["fingerprint"]
+
+            other = _rv_step1()
+            other["units"][0]["shots"][0]["text"] = "@[阿离] 转身离开。"
+            assert client.put(f"{base}/content", json=other).status_code == 200
+
+            mine = _rv_step1()
+            resp = client.put(f"{base}/content", params={"base_fingerprint": stale}, json=mine)
+            assert resp.status_code == 409
+            # 冲突未覆盖：盘上仍是另一方保存的内容
+            assert client.get(base).json()["content"]["units"][0]["shots"][0]["text"] == "@[阿离] 转身离开。"
+
+            fresh = client.get(base).json()["fingerprint"]
+            resp = client.put(f"{base}/content", params={"base_fingerprint": fresh}, json=mine)
+            assert resp.status_code == 200
+            assert resp.json()["content"]["units"][0]["shots"][0]["text"] == "@[阿离] 立于屋檐下。"


### PR DESCRIPTION
Closes #1577

## 变更

1. **写路径收敛**：参考生视频正式 step1（`step1_reference_units.json`）的四条写路径——网页保存、重拆分、晋升、迁移回写——全部汇入 `lib/script_review.py::write_step1_locked`，锁、基线比对、step2 隔离草稿清理只存在这一处；`_write_reference_step1` 删除。
2. **受保护路径规则表**：`AgentAccessPolicy.PROTECTED_WRITE_RULES` 成为单一真相源，应用层 hook 谓词与内核 sandbox `denyWrite` 从同一张表投影，新增一类只加一行、两层同步生效。
3. **乐观并发控制**：取回 / 打开编辑时把正式文件指纹记入草稿 `meta.base_fingerprint`，晋升 / 保存前在锁内比对。不一致时——网页侧返回 409 与三语提示，智能体侧返回带最新内容与合并指引的结构化冲突报告，两侧均不落盘、不静默覆盖先写方。

顺带收敛（超出参考生视频字面范围）：drama / narration 的网页保存走同一套基线比对与冲突错误码，前端得以统一处理 409；通用草稿端点 `PUT /drafts/{ep}/step1` 对参考生视频 step1 由裸文本直写改道结构化保存（非 JSON → 400，结构非法 → 422），并同步清理 step2 隔离草稿。

## 验证

- `uv run python -m pytest`：7790 passed
- `uv run ruff check . && uv run ruff format --check .`：全绿
- `uv run basedpyright`：0 error
- `uv run lint-imports`：契约 KEPT
- `pnpm lint` / `pnpm check`：1633 passed

并发冲突在网页与智能体两侧各有回归测试（`tests/test_script_review.py`、`tests/test_script_review_router.py`、`tests/server/agent_runtime/test_sdk_tools.py`）；规则表双层同步用合成规则测试覆盖（`tests/agent_runtime/test_agent_access_policy.py`）。

## 已知边界

- 智能体侧冲突处置协议要求它显式把 `meta.base_fingerprint` 更新为盘上现值后重新晋升；该字段本就在智能体可编辑的隔离草稿内，因此这是「显式确认已合并」的握手，而非对抗性防护。引入基线前产出的存量草稿缺该键，按无基线晋升（grandfather）。
- `PUT /drafts/{ep}/step1` 的线上契约不带指纹字段，该端点写参考生视频 step1 仍不做基线比对（无前端调用方）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 脚本审核保存支持并发冲突检测，避免覆盖他人较新的修改。
  * 保存冲突时返回最新内容和明确提示，便于刷新、合并后重试。
  * 参考视频 Step 1 的保存、确认、重拆分与草稿晋升流程更加一致，并减少中间状态。
* **错误修复**
  * 优化非法脚本内容校验及错误提示。
  * 改善草稿迁移、隔离草稿清理和文件写入的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->