### PR TITLE
fix(reference-video): 广告参考图跨编码形式不再漏挂或重复占位

### DIFF
--- a/lib/reference_video/ad_units.py
+++ b/lib/reference_video/ad_units.py
@@ -30,7 +30,13 @@ _REFERENCE_FIELDS: tuple[tuple[str, str], ...] = (
 
 
 def _unit_references(shots: list[dict]) -> list[dict]:
-    """unit 参考集：成员镜头参考的并集，产品在前，类型内按首次出现顺序去重。"""
+    """unit 参考集：成员镜头参考的并集，产品在前，类型内按首次出现顺序去重。
+
+    去重按归一名（:func:`lib.asset_types.normalize_asset_name`）而非裸字符串：同一资产在不同
+    镜头里可能以 NFC/NFD 两种等价编码写入，裸比对判不相等会让它派生出两条 reference——画布
+    上重复显示同一资产，并各占一个参考图槽位挤掉真正不同的参考。条目本身保留镜头里的原始
+    形式，判等交给读取侧的归一（与 ``_resolve_unit_references`` 的去重同构）。
+    """
     references: list[dict] = []
     for field, ref_type in _REFERENCE_FIELDS:
         seen: set[str] = set()
@@ -39,9 +45,12 @@ def _unit_references(shots: list[dict]) -> list[dict]:
             if not isinstance(names, list):
                 continue
             for name in names:
-                if not isinstance(name, str) or not name or name in seen:
+                if not isinstance(name, str) or not name:
                     continue
-                seen.add(name)
+                canonical = normalize_asset_name(name)
+                if canonical in seen:
+                    continue
+                seen.add(canonical)
                 references.append({"type": ref_type, "name": name})
     return references
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -401,7 +401,7 @@ def _resolve_ad_unit_reference_entries(
     """
     warnings: list[dict] = []
     product_names: list[str] = []
-    asset_refs: list[tuple[str, str]] = []
+    asset_refs: list[tuple[str, str, str]] = []
     seen_products: set[str] = set()
     seen_assets: set[tuple[str, str]] = set()
     for ref in references:
@@ -422,7 +422,7 @@ def _resolve_ad_unit_reference_entries(
             key = (str(rtype), canonical)
             if key not in seen_assets:
                 seen_assets.add(key)
-                asset_refs.append((str(rtype), rname))
+                asset_refs.append((str(rtype), rname, canonical))
 
     entries = collect_product_references_for_names(project, project_path, product_names)
     # entries 的 "name" 字段已被 collect_product_references_for_names 归一为 canonical，
@@ -432,16 +432,21 @@ def _resolve_ad_unit_reference_entries(
         if normalize_asset_name(name) not in injected_products:
             warnings.append({"key": "ref_ad_reference_skipped", "params": {"type": "product", "name": name}})
 
-    for rtype, rname in asset_refs:
+    # 条目的名字写归一形式，与产品条目同口径（``collect_product_references_for_names``
+    # 产出的 "name" 已归一），让 entries 内部不因来源不同而混用两种编码形式。
+    # 这是加固而非替换：按名字判等的消费点（``prompt_render`` 的第一段主体绑定与参考音频
+    # 图号对齐）在读取处各自归一，那道归一仍是它们正确性的依据，不因这里归一而可省。
+    # warning 的 params 仍回显用户输入的原始形式。
+    for rtype, rname, canonical in asset_refs:
         bucket = normalize_asset_bucket(project.get(BUCKET_KEY[rtype]))
-        item = bucket.get(normalize_asset_name(rname))
+        item = bucket.get(canonical)
         sheet_rel = item.get(SHEET_KEY[rtype]) if isinstance(item, dict) else None
         if sheet_rel and safe_exists(project_path, sheet_rel):
             entries.append(
                 {
                     "image": project_path / sheet_rel,
-                    "label": f"{ASSET_SPECS[rtype].label_zh}「{rname}」设计图",
-                    "name": rname,
+                    "label": f"{ASSET_SPECS[rtype].label_zh}「{canonical}」设计图",
+                    "name": canonical,
                     "kind": "asset",
                     "asset_type": rtype,
                 }

--- a/tests/lib/test_ad_reference_units.py
+++ b/tests/lib/test_ad_reference_units.py
@@ -128,6 +128,27 @@ class TestReferenceInheritance:
             {"type": "character", "name": "小明"},
         ]
 
+    def test_references_deduplicated_across_encoding_forms(self):
+        # 同一资产在两个镜头里以 NFC / NFD 两种等价编码写入：派生参考集须按归一名判同，
+        # 否则画布上重复显示同一资产、并各占一个参考图槽位
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+        assert name_nfc != name_nfd
+
+        shots = [
+            _shot("E1S1", characters_in_shot=[name_nfc], products_in_shot=[name_nfc]),
+            _shot("E1S2", characters_in_shot=[name_nfd], products_in_shot=[name_nfd]),
+        ]
+
+        units = derive_ad_reference_units(shots, episode=1)
+
+        assert units[0]["references"] == [
+            {"type": "product", "name": name_nfc},
+            {"type": "character", "name": name_nfc},
+        ]
+
     def test_atmosphere_only_unit_has_zero_product_references(self):
         shots = [_shot("E1S1", scenes=["海边"]), _shot("E1S2", scenes=["海边"])]
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -249,6 +249,29 @@ def test_resolve_ad_unit_reference_entries_dedupes_nfc_nfd_pair(tmp_path: Path):
 
 
 @pytest.mark.integration
+def test_resolve_ad_unit_reference_entries_nfd_reference_hits_nfc_registered_asset(tmp_path: Path):
+    """镜头以 NFD 形式引用、资产表按 NFC 登记：解析须命中该资产的 sheet 而非软跳过，且条目的
+    name/label 写归一形式——下游按名字判等（第一段主体绑定、参考音频图号对齐）才落在同一坐标系。"""
+    import unicodedata
+
+    proj_dir = _write_project(tmp_path)
+    project, _ = _load_project_and_unit(proj_dir, "E1U1")
+    name_nfc = unicodedata.normalize("NFC", "Hiếu")
+    name_nfd = unicodedata.normalize("NFD", "Hiếu")
+    assert name_nfc != name_nfd
+    project["characters"][name_nfc] = {"description": "x", "character_sheet": "characters/hieu.png"}
+    (proj_dir / "characters" / "hieu.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    refs = [{"type": "character", "name": name_nfd}]
+    entries, warnings = _resolve_ad_unit_reference_entries(project, proj_dir, refs)
+
+    assert warnings == []
+    assert [e["image"].name for e in entries] == ["hieu.png"]
+    assert entries[0]["name"] == name_nfc
+    assert name_nfc in entries[0]["label"] and name_nfd not in entries[0]["label"]
+
+
+@pytest.mark.integration
 def test_resolve_ad_unit_reference_entries_no_false_positive_warning_for_nfd_product(tmp_path: Path):
     """产品参考在 unit.references 中以 NFD 编码出现且 sheet 存在：collect_product_references_for_names
     返回的 entries["name"] 已归一为 NFC，membership 检查须同样归一后再比较产品名是否成功注入，


### PR DESCRIPTION
Closes #1608

## 改了什么

广告（ad）派生路径的参考资产名比对收敛到 NFC 归一口径，与 narration/drama 路径一致：

- `_resolve_ad_unit_reference_entries`：解析出的条目 `name` / `label` 写归一形式，与产品条目（`collect_product_references_for_names` 已归一）同口径，entries 内部不再混用两种编码形式。warning 的 `params.name` 仍回显用户输入的原始形式，用户能在项目里搜到自己写的那个字符串。
- `_unit_references`：成员镜头参考的去重按归一名判同，同一资产以 NFC / NFD 两种等价编码写在不同镜头时不再派生出两条 reference（画布重复显示、各占一个参考图槽位）。条目本身保留镜头里的原始形式，不重写落盘数据。

## 与 issue 正文的范围差异

issue 缺陷 1 有两半，其中「`bucket.get(rname)` 用原始编码查资产表」这一半在起草之后已由 #1595 修复，本 PR 前即不成立；验收标准 1（NFD 引用命中 NFC 登记的 sheet、不落 `ref_ad_reference_skipped`）因此在改动前已通过。本 PR 关闭的是残留的两条：条目名仍写原始形式、派生侧裸字符串去重。asset 侧此前只被去重测试间接覆盖，本 PR 补了直接的回归测试并钉住条目名的归一形式，避免已修好的口径无声退化。

## 验证

- 新增回归测试两条：NFD 镜头引用命中 NFC 登记的资产 sheet 且条目 name/label 为归一形式；NFC/NFD 同名参考在 `_unit_references` 产出中只出现一条
- `uv run python -m pytest` 全量 7793 passed
- `ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `lint-imports` 均通过
- 未触碰 narration/drama 路径；消费侧 `prompt_render` 读取处的归一保持原样——本次归一是加固，不替换那道


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进广告参考资产名称的规范化处理，兼容不同 Unicode 编码形式。
  * 避免同一资产因名称编码差异被重复识别。
  * 统一解析结果中的资产名称与标签，并保留用户输入名称用于缺失提示。
* **Tests**
  * 新增测试，覆盖 Unicode 名称去重及跨编码格式的资产解析场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->