### PR TITLE
fix(video): 修正 vidu2.0 的时长与分辨率联动约束，消除无效组合

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -31,8 +31,8 @@ class ModelInfo:
     supported_durations: list[int] = field(default_factory=list)
     duration_resolution_constraints: dict[str, list[int]] = field(default_factory=dict)
     # 使用参考图（参考生视频）时允许的时长；空 = 该模型的参考图路径不额外约束时长。
-    # 与 duration_resolution_constraints 同构的最窄表达：目前只有 Veo 一家把「带参考图」
-    # 单独收窄到 8 秒，故按条件各立一字段，不引入通用「条件→约束」语言。
+    # 与 duration_resolution_constraints 同构的最窄表达：需要表达的条件只有「高分辨率」
+    # 与「带参考图」两种，故按条件各立一字段，不引入通用「条件→约束」语言。
     reference_image_durations: list[int] = field(default_factory=list)
     resolutions: list[str] = field(default_factory=list)
     # 参考生视频单镜头参考图上限；0 = 不适用（图像/文本模型，或视频模型未声明）。
@@ -954,8 +954,8 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="video",
                 capabilities=["image_to_video", "seed_control"],
                 supported_durations=[4, 8],
-                # 图生/首尾帧端点 8 秒档只出 720p，1080p 仅 4 秒档可选。
-                duration_resolution_constraints={"1080p": [4]},
+                # 图生/首尾帧端点 8 秒档只出 720p，360p 与 1080p 均仅 4 秒档可选。
+                duration_resolution_constraints={"360p": [4], "1080p": [4]},
                 # 参考生视频端点时长仅认 4 秒；不收窄会让 r2v 项目的时长下拉出现
                 # 8 秒幽灵档位——选中后被 backend 静默取到 4 秒。
                 reference_image_durations=[4],

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -954,6 +954,11 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 media_type="video",
                 capabilities=["image_to_video", "seed_control"],
                 supported_durations=[4, 8],
+                # 图生/首尾帧端点 8 秒档只出 720p，1080p 仅 4 秒档可选。
+                duration_resolution_constraints={"1080p": [4]},
+                # 参考生视频端点时长仅认 4 秒；不收窄会让 r2v 项目的时长下拉出现
+                # 8 秒幽灵档位——选中后被 backend 静默取到 4 秒。
+                reference_image_durations=[4],
                 resolutions=["360p", "720p", "1080p"],
                 max_reference_images=7,
                 pricing=ViduDelegate(),

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -31,7 +31,7 @@ class ModelInfo:
     supported_durations: list[int] = field(default_factory=list)
     duration_resolution_constraints: dict[str, list[int]] = field(default_factory=dict)
     # 使用参考图（参考生视频）时允许的时长；空 = 该模型的参考图路径不额外约束时长。
-    # 与 duration_resolution_constraints 同构的最窄表达：需要表达的条件只有「高分辨率」
+    # 与 duration_resolution_constraints 同构的最窄表达：需要表达的条件只有「指定分辨率」
     # 与「带参考图」两种，故按条件各立一字段，不引入通用「条件→约束」语言。
     reference_image_durations: list[int] = field(default_factory=list)
     resolutions: list[str] = field(default_factory=list)

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -355,6 +355,33 @@ class TestDurationRulesSpec:
         assert _DURATION_RULES[("viduq3-turbo", "/text2video")] == list(range(1, 17))
 
 
+class TestRegistryBackendConsistency:
+    """registry 的 vidu2.0 声明与 backend 执行期白名单须无分歧（两侧同一份官方文档核实）。"""
+
+    def _vidu2_model_info(self):
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        return PROVIDER_REGISTRY["vidu"].models["vidu2.0"]
+
+    def test_reference_image_durations_matches_reference2video_rule(self):
+        model_info = self._vidu2_model_info()
+        assert model_info.reference_image_durations == _DURATION_RULES[("vidu2.0", "/reference2video")]
+
+    def test_supported_durations_covers_img2video_and_start_end2video(self):
+        model_info = self._vidu2_model_info()
+        assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/img2video")])
+        assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/start-end2video")])
+
+    def test_duration_resolution_constraints_forbids_8s_1080p(self):
+        """8 秒档只出 720p——1080p 须声明仅 4 秒可选，UI 才不会给出 8s+1080p 的无效组合。"""
+        model_info = self._vidu2_model_info()
+        assert model_info.duration_resolution_constraints.get("1080p") == [4]
+
+    def test_resolutions_is_superset_of_backend_whitelist(self):
+        model_info = self._vidu2_model_info()
+        assert set(model_info.resolutions) == set(_RESOLUTION_WHITELIST["vidu2.0"])
+
+
 class TestCreateTask413:
     """413 规整：_create_task 透出保留状态码的 httpx.HTTPStatusError（咽喉层据此降档）。"""
 

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from lib.config.registry import PROVIDER_REGISTRY
 from lib.providers import PROVIDER_VIDU
 from lib.video_backends.base import (
     VideoCapabilityError,
@@ -359,8 +360,6 @@ class TestRegistryBackendConsistency:
     """registry 的 vidu2.0 声明与 backend 执行期白名单须无分歧（两侧同一份官方文档核实）。"""
 
     def _vidu2_model_info(self):
-        from lib.config.registry import PROVIDER_REGISTRY
-
         return PROVIDER_REGISTRY["vidu"].models["vidu2.0"]
 
     def test_reference_image_durations_matches_reference2video_rule(self):
@@ -372,12 +371,12 @@ class TestRegistryBackendConsistency:
         assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/img2video")])
         assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/start-end2video")])
 
-    def test_duration_resolution_constraints_forbids_8s_1080p(self):
-        """8 秒档只出 720p——1080p 须声明仅 4 秒可选，UI 才不会给出 8s+1080p 的无效组合。"""
+    def test_duration_resolution_constraints_confines_non_720p_to_4s(self):
+        """8 秒档只出 720p——360p / 1080p 须声明仅 4 秒可选，UI 才不会给出无效的时长×分辨率组合。"""
         model_info = self._vidu2_model_info()
-        assert model_info.duration_resolution_constraints.get("1080p") == [4]
+        assert model_info.duration_resolution_constraints == {"360p": [4], "1080p": [4]}
 
-    def test_resolutions_is_superset_of_backend_whitelist(self):
+    def test_resolutions_matches_backend_whitelist(self):
         model_info = self._vidu2_model_info()
         assert set(model_info.resolutions) == set(_RESOLUTION_WHITELIST["vidu2.0"])
 

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -368,8 +368,10 @@ class TestRegistryBackendConsistency:
 
     def test_supported_durations_covers_img2video_and_start_end2video(self):
         model_info = self._vidu2_model_info()
-        assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/img2video")])
-        assert set(model_info.supported_durations) == set(_DURATION_RULES[("vidu2.0", "/start-end2video")])
+        expected_durations = set(_DURATION_RULES[("vidu2.0", "/img2video")]) | set(
+            _DURATION_RULES[("vidu2.0", "/start-end2video")]
+        )
+        assert set(model_info.supported_durations) == expected_durations
 
     def test_duration_resolution_constraints_confines_non_720p_to_4s(self):
         """8 秒档只出 720p——360p / 1080p 须声明仅 4 秒可选，UI 才不会给出无效的时长×分辨率组合。"""


### PR DESCRIPTION
Closes #1607

## 背景

`lib/config/registry.py` 的 `vidu2.0` 缺时长联动约束声明，UI 可选出 backend 不认的组合。

按 issue 订正后的口径：`supported_durations=[4, 8]` 与 `resolutions` 作为跨端点并集与 backend 白名单一致，是既有设计，**不收窄**；缺口在两项联动约束缺失。

## 改动

`lib/config/registry.py` 的 `vidu2.0` 补两项声明：

1. `reference_image_durations=[4]` —— 参考生视频端点时长仅认 4 秒（官方 `参考生视频.md`「vidu2.0：默认4秒，可选：4」，与 backend `_DURATION_RULES[("vidu2.0", "/reference2video")]` 一致）
2. `duration_resolution_constraints={"360p": [4], "1080p": [4]}` —— 图生视频/首尾帧端点 8 秒档只出 720p（官方「vidu2.0 8秒：默认 720p，可选：720p」），故 360p 与 1080p 同为 4 秒专属。360p 还是 4 秒档的默认分辨率，用户从默认切到 8 秒正好落在无效组合上，且 backend 的 `_RESOLUTION_WHITELIST` 是型号级、不区分时长，不会拦截该组合。

`tests/test_vidu_video_backend.py` 新增 `TestRegistryBackendConsistency`，把 registry 声明与 backend `_DURATION_RULES` / `_RESOLUTION_WHITELIST` 对 vidu2.0 的一致性锚定为测试。

## 验证

- `uv run python -m pytest -m "not e2e" -q` → 7795 passed
- `uv run ruff check` / `ruff format --check` 改动文件全绿
- `uv run basedpyright` 改动文件 0 errors
- `uv run lint-imports` → Contracts: 1 kept, 0 broken

## 已知边界（不在本 PR 范围）

参考生视频端点实际只支持 360p/720p（无 1080p），但 `ModelInfo` 目前没有「参考图路径专属分辨率」字段（`reference_image_durations` 只管时长），故 `resolutions` 对 r2v 场景仍偏宽——这与 backend `_RESOLUTION_WHITELIST` 本身「型号级、按端点取并集」的既有设计一致，非本次引入。若要收紧需先引入新的通用字段。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能调整**
  * 更新 Vidu 2.0 视频生成的分辨率与时长限制。
  * 360p 和 1080p 分辨率现仅支持 4 秒视频。
  * 使用参考视频生成时，时长限制为 4 秒。

* **测试**
  * 增加配置与实际生成能力的一致性校验，确保可选分辨率及各类生成模式的时长规则准确生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->