### PR TITLE
docs: 清理生成路线口径残留注释

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ pnpm build       # 生产构建，含 typecheck
 
 - **content_mode** — `drama`（剧集，内容驱动）/`narration`（说书，旁白驱动） / `ad`（广告/短片）。决定剧本结构与 agent profile 加载哪个 `CLAUDE.*.md` 变体
 - **generation_mode** — 项目级**生成路线**，二值必填：`storyboard`（分镜路线，分镜图驱动，走 i2v）/ `reference_video`（参考路线，无需分镜图步骤，直接使用资产图作为参考图生成视频，见 `lib/reference_video/`）。创建时二选一、创建后不可更改；宫格不是路线，由独立的项目级布尔 `grid_storyboard` 表达（见 `docs/adr/0055`）
-- 两字段对 LLM 隐藏（`SkipJsonSchema`），由编排层自动注入
+- 两字段均对 LLM 隐藏：`content_mode` 是剧本模型上的 `SkipJsonSchema` 字段、由编排层写入；`generation_mode` 只存 project.json，剧本不携带该字段
 
 ## Agent 沙箱
 

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -278,9 +278,11 @@ class NarrationEpisodeScript(BaseModel):
     由 `ScriptGenerator._add_metadata` 写入。不让 AI 生成该字段，避免幻觉写错集号
     进而污染 project.json（曾导致 episode_10.json 内部 episode=1 覆盖第 1 集条目）。
 
-    顶层**不**走 ``extra="forbid"``:``episode`` / ``metadata`` / ``generation_mode`` 等
-    字段由运行时注入(``_add_metadata`` / ``_write_script_unlocked``)而非 schema 内字段,
-    顶层 forbid 会让现有写盘流程崩。typo 防护靠子模型(VideoPrompt / ImagePrompt /
+    顶层**不**走 ``extra="forbid"``:``episode`` / ``metadata`` 等字段由运行时注入
+    (``_add_metadata`` / ``_write_script_unlocked``)而非 schema 内字段,顶层 forbid
+    会让现有写盘流程崩;``generation_mode`` 不在其列——写盘统一入口会剥离剧本级
+    ``generation_mode`` 戳(路线的真相源是 project.json,见 ``ScriptGenerator``),存量
+    在制品中的残留字段按未知字段忽略。typo 防护靠子模型(VideoPrompt / ImagePrompt /
     NarrationSegment 等)的 ``extra="forbid"`` 在嵌套字段路径上挡。
     """
 

--- a/lib/script_models.py
+++ b/lib/script_models.py
@@ -280,9 +280,9 @@ class NarrationEpisodeScript(BaseModel):
 
     顶层**不**走 ``extra="forbid"``:``episode`` / ``metadata`` 等字段由运行时注入
     (``_add_metadata`` / ``_write_script_unlocked``)而非 schema 内字段,顶层 forbid
-    会让现有写盘流程崩;``generation_mode`` 不在其列——写盘统一入口会剥离剧本级
-    ``generation_mode`` 戳(路线的真相源是 project.json,见 ``ScriptGenerator``),存量
-    在制品中的残留字段按未知字段忽略。typo 防护靠子模型(VideoPrompt / ImagePrompt /
+    会让现有写盘流程崩;``generation_mode`` 不在其列——路线的真相源是 project.json,剧本
+    不留戳,生成写盘前由 ``ScriptGenerator._add_metadata`` 剥离,存量在制品里的残留字段按
+    未知字段忽略。typo 防护靠子模型(VideoPrompt / ImagePrompt /
     NarrationSegment 等)的 ``extra="forbid"`` 在嵌套字段路径上挡。
     """
 

--- a/server/agent_runtime/sdk_tools/patch_episode_meta.py
+++ b/server/agent_runtime/sdk_tools/patch_episode_meta.py
@@ -5,8 +5,8 @@
 写上下文里直接写剧本顶层白名单字段，退出时经写盘统一入口 ``_write_script_unlocked``
 （``sync_project=True`` 默认）自动把集元数据镜像到 project.json 的 ``episodes[].title``。
 
-剧本顶层刻意无 ``extra='forbid'``（要容纳运行时注入的 ``episode``/``metadata``/
-``generation_mode``，见 ``lib/script_models.py``），故必须靠显式白名单兜底，防 agent 写任意键。
+剧本顶层刻意无 ``extra='forbid'``（要容纳运行时注入的 ``episode``/``metadata`` 等字段，
+见 ``lib/script_models.py``），故必须靠显式白名单兜底，防 agent 写任意键。
 
 工具返回文本是 agent-facing（免 i18n）；显示名在 ``ARCREEL_MCP_TOOL_IDS`` 注册、补三语。
 """

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -743,7 +743,7 @@ _STEP1_FAMILY: dict[str, list[str]] = {
 }
 _STEP1_FAMILY[REFERENCE_VIDEO_STEP1_FILENAME] = [REFERENCE_VIDEO_STEP1_FILENAME, REFERENCE_VIDEO_STEP1_LEGACY_FILENAME]
 
-# step1 实际文件候选 —— 主文件不存在时用于 fallback 探测，兼容 episode 级 generation_mode 覆盖。
+# step1 实际文件候选 —— 主文件不存在时用于 fallback 探测。
 # 结构化 .json 与旧 .md 候选均由单一真相源派生；各自保留旧 .md 以便存量在制品仍可浏览。
 # 跨模式遗留回落的探测优先级固定为 reference_video → narration → drama（保持历史 tie-break，
 # 避免收敛后跨模式选到的遗留文件与旧实现不一致）；未登记于此序列的未来 content_mode 附加在后。

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -41,9 +41,9 @@ ActualBySegment = dict[str, dict[str, CostBreakdown]]
 ACTUAL_COST_TYPES = ("image", "video", "audio")
 
 
-#: 读侧定桶要枚举的全部视频能力桶。两个桶都预解析：同一项目里逐集的生效路径可以不同
-#: （集级 generation_mode 覆盖、或剧本自带 r2v 戳），而解析需要 resolver session，不能推迟到
-#: 已关闭 session 的估算循环里逐集去做。桶只有两个，代价有界。
+#: 读侧定桶要枚举的全部视频能力桶。项目生成路线（generation_mode）唯一决定生效桶、整个
+#: 项目逐集不变；两个桶仍都在这里预解析，省去按路线分支判断该解析哪个桶的复杂度——桶只有
+#: 两个，代价有界。
 _VIDEO_BUCKETS: tuple[VideoCapability, ...] = ("i2v", "r2v")
 
 
@@ -176,8 +176,8 @@ class CostEstimationService:
                 image_provider, image_model = "unknown", "unknown"
 
             # 视频按能力桶解析（``docs/adr/0054``），与执行扣费同一个模型：参考生视频路径算 r2v
-            # 桶的价、图生视频 / 宫格算 i2v 桶的价。逐集选桶，故两个桶都在这里解析出来（见
-            # ``_VIDEO_BUCKETS``），分辨率与 generate_audio 随各自的模型身份求值。
+            # 桶的价、图生视频 / 宫格算 i2v 桶的价，整个项目逐集同一个桶。两个桶仍都在这里解析
+            # 出来（见 ``_VIDEO_BUCKETS``），分辨率与 generate_audio 随各自的模型身份求值。
             video_identity: dict[VideoCapability, tuple[str, str, str | None, bool]] = {}
             for capability in _VIDEO_BUCKETS:
                 try:

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -236,7 +236,7 @@ class CostEstimationService:
             ) in video_identity.items()
         }
         # 项目层展示的视频模型按项目 generation_mode 定桶：``models`` 回答的是「当前项目配置」；
-        # 逐集算价另按该集实际入队路径的桶取（见循环内 ``episode_video``）。
+        # 逐集算价由入队路径按同一条项目路线取到同一个桶（见循环内 ``episode_video``）。
         project_video = video_pricing[video_bucket_for_generation_mode(project_data.get("generation_mode"))]
 
         grid_enabled = grid_storyboard_enabled(project_data)


### PR DESCRIPTION
Closes #1612

## 改了什么

四处注释/docstring 仍按已废除的口径描述现状（集级 `generation_mode` 覆盖、剧本顶层运行时注入 `generation_mode`、逐集选能力桶），按现状改写：

- `server/routers/files.py` — step1 候选注释去掉「兼容 episode 级 generation_mode 覆盖」
- `server/agent_runtime/sdk_tools/patch_episode_meta.py` — 模块 docstring 不再称剧本顶层要容纳注入的 `generation_mode`
- `lib/script_models.py` — 说明剧本不留路线戳、剥离发生在 `ScriptGenerator._add_metadata`，存量残留字段按未知字段忽略
- `server/services/cost_estimation.py` — 能力桶由项目路线唯一决定、全项目逐集不变（`estimate_by_unit = is_reference_video`），三处相关注释统一口径
- `AGENTS.md` — `generation_mode` 已不是剧本模型字段，去掉「由编排层注入剧本」的表述

## 验证

- diff 全为注释/docstring 行，无任何可执行行改动
- `ruff check` / `ruff format --check` 通过
- `basedpyright` 0 error
- `lint-imports` 契约 KEPT
- `pytest tests/test_i18n_consistency.py tests/test_cost_estimation_service.py tests/test_cost_estimation_router.py tests/test_data_validator.py tests/test_script_models.py` 333 passed
- 全仓 grep 复核：代码内已无「集级覆盖 / 运行时注入 generation_mode」残留；`docs/superpowers/` 下的历史 spec/plan 与 `lib/project_migrations/v4_to_v5_generation_route.py` 的迁移说明属历史记述，保留

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 生成模式统一按项目级设置保存，不再随单集剧本传递。
  - 项目内各集使用一致的视频能力与计价路线。
  - 视频模型、分辨率及音频生成选项的解析与单集估价保持一致。
  - 继续支持单集运行时信息注入，并减少无效字段对剧本数据的影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->