### PR TITLE
refactor(剧本审核): 两条审核路线共用同一套草稿状态机

### DIFF
--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
@@ -206,37 +206,12 @@ describe("ReferenceStep1PreviewPanel", () => {
     fireEvent.click(saveBtn);
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
-    const [, , savedContent] = save.mock.calls[0];
+    const [, , savedContent, baseFingerprint] = save.mock.calls[0];
     expect(savedContent).toMatchObject({
       units: [{ unit_id: "E1U01", shots: [{ text: "@[阿离] 缓步走过 @[长街]" }] }],
     });
-  });
-
-  it("saves with the fingerprint of the content the draft was based on, not the refreshed one", async () => {
-    const agentEdited = pendingState({ fingerprint: "fp2" });
-    (agentEdited.content as ReferenceStep1Draft).units[0].shots[0].text = "@[阿离] agent 改写的镜头";
-    const get = vi
-      .spyOn(API, "getScriptReview")
-      .mockResolvedValueOnce(pendingState())
-      .mockResolvedValueOnce(agentEdited);
-    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(pendingState());
-
-    render(<ReferenceStep1PreviewPanel projectName="p" episode={1} lookup={LOOKUP} />);
-    await waitFor(() => expect(screen.getByText("E1U01")).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole("button", { name: "编辑文稿" }));
-    const textarea = await screen.findByDisplayValue("@[阿离] 撑伞走过 @[长街]");
-    fireEvent.change(textarea, { target: { value: "@[阿离] 我的本地编辑" } });
-    await screen.findByText("保存");
-
-    // agent 改了 step1 → 外部刷新把 state 换成新版，但用户草稿仍基于旧版
-    useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
-    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
-
-    fireEvent.click(screen.getByText("保存"));
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
-    // 提交草稿所基于的 fp1，服务端才能判出冲突；提交刷新后的 fp2 会让 OCC 放行、静默覆盖 agent 的修改
-    expect(save.mock.calls[0][3]).toBe("fp1");
+    // 保存携带 GET 时拿到的内容指纹，供服务端做并发编辑冲突比对
+    expect(baseFingerprint).toBe("fp1");
   });
 
   it("renders shot / spoken-line counts in the unit header", async () => {

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, CheckCircle2, ChevronDown, Clock, Lock, OctagonAlert, Pencil, RotateCcw, Save } from "lucide-react";
-import { API } from "@/api";
 import type {
   ReferenceResource,
   ReferenceStep1Draft,
@@ -14,6 +13,7 @@ import type {
 import { useAppStore } from "@/stores/app-store";
 import { useAssistantStore } from "@/stores/assistant-store";
 import { useProjectsStore } from "@/stores/projects-store";
+import { useScriptReviewDraft } from "@/hooks/useScriptReviewDraft";
 import { voidPromise } from "@/utils/async";
 import { AutoTextarea } from "@/components/ui/AutoTextarea";
 import { ACCENT_BTN_CLS, ACCENT_BUTTON_STYLE, CARD_STYLE, GHOST_BTN_CLS, GHOST_BTN_LG_CLS } from "@/components/ui/darkroom-tokens";
@@ -364,14 +364,9 @@ function UnitCard({
   );
 }
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : "";
-}
-
-/** 内容是否有未保存编辑：以序列化比对，draft 由 server content 克隆而来，键序稳定。 */
-function isDirty(draft: unknown, serverContent: unknown): boolean {
-  if (draft == null) return false;
-  return JSON.stringify(draft) !== JSON.stringify(serverContent);
+/** 本面板只编辑 reference_video 变体的 units 内容；其余变体的内容不属于这里。 */
+function selectUnitsContent(state: ScriptReviewState): ReferenceStep1Draft | null {
+  return state.content != null && "units" in state.content ? state.content : null;
 }
 
 /**
@@ -385,78 +380,43 @@ function isDirty(draft: unknown, serverContent: unknown): boolean {
 export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: ReferenceStep1PreviewPanelProps) {
   const { t } = useTranslation("dashboard");
   const pushToast = useAppStore((s) => s.pushToast);
-  const draftRevision = useAppStore((s) => s.getEntityRevision(`draft:episode_${episode}_step1`));
 
-  const [state, setState] = useState<ScriptReviewState | null>(null);
-  const [draft, setDraft] = useState<ReferenceStep1Draft | null>(null);
-  // 保存时提交的基线指纹：绑定在**当前草稿所基于的那份服务端内容**上，只在草稿采用服务端内容时推进。
-  // 不能改用 state.fingerprint——有未保存编辑时的外部刷新会更新 state 却保留旧草稿，届时提交
-  // state.fingerprint 等于拿别人新写的内容当基线，OCC 会放行并静默覆盖对方的修改。
-  const [baseFingerprint, setBaseFingerprint] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<{ message: string } | null>(null);
-  const [reloadNonce, setReloadNonce] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [confirming, setConfirming] = useState(false);
   const [editingUnitKey, setEditingUnitKey] = useState<string | null>(null);
 
-  const serverContent = state?.content != null && "units" in state.content ? (state.content) : null;
-  const dirty = useMemo(() => isDirty(draft, serverContent), [draft, serverContent]);
-  const busy = saving || confirming;
+  const handleConfirmed = useCallback(() => {
+    // 保存 / 确认两次 await 期间用户可能已切走项目（本组件所在的 tab 可能因此被卸载）：只在项目
+    // 本身变了才抑制全局副作用，否则会把续写消息写进用户切换到的别的项目/会话。同项目内切
+    // tab（如切到「视频单元」，本面板同样会被卸载）不属于这种情况——预填文案本身带着具体
+    // 集号，写进全局 assistant 输入框依然准确，不该被同一份卸载信号误伤。
+    if (useProjectsStore.getState().currentProjectName !== projectName) return;
+    pushToast(t("dashboard:review_confirmed"), "success");
+    // 确认放行 + 预填继续消息到会话输入框——只填不发送，用户自行核对后发送。
+    useAssistantStore.getState().setInput(t("reference_step1_confirm_continue_prefill", { episode }));
+    useAppStore.getState().setAssistantPanelOpen(true);
+  }, [projectName, episode, pushToast, t]);
 
-  const dirtyRef = useRef(false);
-  useEffect(() => {
-    dirtyRef.current = dirty;
-  }, [dirty]);
+  const {
+    state,
+    draft,
+    setDraft,
+    dirty,
+    loading,
+    loadError,
+    saving,
+    busy,
+    retry: handleRetry,
+    save: handleSave,
+    confirm: handleConfirm,
+    confirming,
+  } = useScriptReviewDraft<ReferenceStep1Draft>({
+    projectName,
+    episode,
+    selectContent: selectUnitsContent,
+    onConfirmed: handleConfirmed,
+  });
 
-
-  const adopt = useCallback((next: ScriptReviewState) => {
-    setState(next);
-    const content = next.content != null && "units" in next.content ? (next.content) : null;
-    setDraft(content ? (JSON.parse(JSON.stringify(content)) as ReferenceStep1Draft) : null);
-    setBaseFingerprint(next.fingerprint);
-  }, []);
-
-  const handleRetry = useCallback(() => {
-    setLoadError(null);
-    setLoading(true);
-    setReloadNonce((n) => n + 1);
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
-    const hadResponse = state != null;
-    const hasContent = draft != null;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!hadResponse) setLoading(true);
-    API.getScriptReview(projectName, episode, { signal })
-      .then((next) => {
-        // 响应已 resolve 之后才 abort 的窗口：写 state 前复核，避免离场的这轮回写。
-        if (signal.aborted) return;
-        setLoadError(null);
-        setState(next);
-        if (!dirtyRef.current) {
-          const content = next.content != null && "units" in next.content ? (next.content) : null;
-          setDraft(content ? (JSON.parse(JSON.stringify(content)) as ReferenceStep1Draft) : null);
-          setBaseFingerprint(next.fingerprint);
-        }
-      })
-      .catch((err) => {
-        if (signal.aborted) return;
-        if (!hasContent) setLoadError({ message: errorMessage(err) });
-      })
-      .finally(() => {
-        // 收尾让位给接管方：已作废就不碰 loading，否则会打断新一轮加载态。
-        if (!signal.aborted) setLoading(false);
-      });
-    return () => {
-      controller.abort();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- state/draft 仅用于决定加载态与错误态分支，加入 deps 会在每次刷新后重新拉取造成循环
-  }, [projectName, episode, draftRevision, reloadNonce]);
-
-  const updateShotText = useCallback((unitIndex: number, shotIndex: number, text: string) => {
+  const updateShotText = useCallback(
+    (unitIndex: number, shotIndex: number, text: string) => {
     setDraft((prev) => {
       if (!prev) return prev;
       return {
@@ -466,53 +426,22 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
         ),
       };
     });
-  }, []);
+    },
+    [setDraft],
+  );
 
-  const updateDuration = useCallback((unitIndex: number, seconds: number) => {
-    setDraft((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        units: prev.units.map((u, i) => (i === unitIndex ? { ...u, duration_seconds: seconds } : u)),
-      };
-    });
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    if (!draft) return;
-    setSaving(true);
-    try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
-      pushToast(t("dashboard:review_saved"), "success");
-    } catch (err) {
-      pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
-    } finally {
-      setSaving(false);
-    }
-  }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
-
-  const handleConfirm = useCallback(async () => {
-    setConfirming(true);
-    try {
-      if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
-      }
-      adopt(await API.confirmScriptReview(projectName, episode));
-      // 两次 await 期间用户可能已切走项目（本组件所在的 tab 可能因此被卸载）：只在项目本身
-      // 变了才抑制全局副作用，否则会把续写消息写进用户切换到的别的项目/会话。同项目内切
-      // tab（如切到「视频单元」，本面板同样会被卸载）不属于这种情况——预填文案本身带着具体
-      // 集号，写进全局 assistant 输入框依然准确，不该被同一份卸载信号误伤。
-      if (useProjectsStore.getState().currentProjectName !== projectName) return;
-      pushToast(t("dashboard:review_confirmed"), "success");
-      // 确认放行 + 预填继续消息到会话输入框——只填不发送，用户自行核对后发送。
-      useAssistantStore.getState().setInput(t("reference_step1_confirm_continue_prefill", { episode }));
-      useAppStore.getState().setAssistantPanelOpen(true);
-    } catch (err) {
-      pushToast(errorMessage(err) || t("dashboard:review_confirm_failed"), "error");
-    } finally {
-      setConfirming(false);
-    }
-  }, [dirty, draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
+  const updateDuration = useCallback(
+    (unitIndex: number, seconds: number) => {
+      setDraft((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          units: prev.units.map((u, i) => (i === unitIndex ? { ...u, duration_seconds: seconds } : u)),
+        };
+      });
+    },
+    [setDraft],
+  );
 
   const handleRequestFix = useCallback(() => {
     const violations = state?.quarantine?.violations ?? [];

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
@@ -417,15 +417,15 @@ export function ReferenceStep1PreviewPanel({ projectName, episode, lookup }: Ref
 
   const updateShotText = useCallback(
     (unitIndex: number, shotIndex: number, text: string) => {
-    setDraft((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        units: prev.units.map((u, i) =>
-          i === unitIndex ? { ...u, shots: u.shots.map((s, j) => (j === shotIndex ? { ...s, text } : s)) } : u,
-        ),
-      };
-    });
+      setDraft((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          units: prev.units.map((u, i) =>
+            i === unitIndex ? { ...u, shots: u.shots.map((s, j) => (j === shotIndex ? { ...s, text } : s)) } : u,
+          ),
+        };
+      });
     },
     [setDraft],
   );

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.test.tsx
@@ -172,34 +172,6 @@ describe("ScriptReviewGate", () => {
     expect(screen.queryByDisplayValue("服务端覆盖文案")).not.toBeInTheDocument();
   });
 
-  it("saves with the fingerprint of the content the draft was based on, not the refreshed one", async () => {
-    const serverEdited = dramaState({ fingerprint: "fp2" });
-    (serverEdited.content as { scenes: { utterances: { text: string }[] }[] }).scenes[0].utterances[1].text =
-      "agent 改写的文案";
-    const get = vi
-      .spyOn(API, "getScriptReview")
-      .mockResolvedValueOnce(dramaState())
-      .mockResolvedValueOnce(serverEdited);
-    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(dramaState());
-
-    render(<ScriptReviewGate projectName="p" episode={1} contentMode="drama" />);
-    await waitFor(() => expect(screen.getByDisplayValue("你终于回来了。")).toBeInTheDocument());
-
-    fireEvent.change(screen.getByDisplayValue("你终于回来了。"), { target: { value: "我的本地编辑" } });
-    await screen.findByText("保存");
-
-    // agent 改了 step1 → 外部刷新把 state 换成新版，但用户草稿仍基于旧版
-    act(() => {
-      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
-    });
-    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
-
-    fireEvent.click(screen.getByText("保存"));
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
-    // 提交草稿所基于的 fp1，服务端才能判出冲突；提交刷新后的 fp2 会让 OCC 放行、静默覆盖 agent 的修改
-    expect(save.mock.calls[0][3]).toBe("fp1");
-  });
-
   it("shows an empty state when there is no step1 content", async () => {
     vi.spyOn(API, "getScriptReview").mockResolvedValue(
       dramaState({ status: "no_step1", content: null, fingerprint: null }),

--- a/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
+++ b/frontend/src/components/canvas/timeline/ScriptReviewGate.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, CheckCircle2, Clock, Lock, RotateCcw, Save } from "lucide-react";
-import { API } from "@/api";
 import type {
   DramaNormalizedScript,
   DramaSceneContent,
@@ -11,6 +10,7 @@ import type {
   Utterance,
 } from "@/types";
 import { useAppStore } from "@/stores/app-store";
+import { useScriptReviewDraft } from "@/hooks/useScriptReviewDraft";
 import { voidPromise } from "@/utils/async";
 import { AutoTextarea } from "@/components/ui/AutoTextarea";
 import {
@@ -37,8 +37,9 @@ const SECTION_LABEL_STYLE: React.CSSProperties = {
 /** 两条 step1 变体（drama / narration）的可编辑草稿联合。 */
 type ReviewDraft = DramaNormalizedScript | NarrationStep1Draft;
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : "";
+/** 本面板承接 drama / narration 两个变体的内容，reference_video 变体不会路由到这里。 */
+function selectReviewContent(state: ScriptReviewState): ReviewDraft | null {
+  return (state.content ?? null) as ReviewDraft | null;
 }
 
 /** Read-only 资产引用 pills（出场角色 / 场景 / 道具），由 step1 登记、gate 不改。 */
@@ -157,12 +158,6 @@ function NarrationSegmentCard({
   );
 }
 
-/** 内容是否有未保存编辑：以序列化比对，draft 由 server content 克隆而来，键序稳定。 */
-function isDirty(draft: unknown, serverContent: unknown): boolean {
-  if (draft == null) return false;
-  return JSON.stringify(draft) !== JSON.stringify(serverContent);
-}
-
 /**
  * step1→step2 web 审核 gate 面板：把 step1 结构化中间态在网页结构化呈现、可手动 / agent 编辑，
  * 用户显式确认后才放行 step2 视觉生成。drama（utterances + source_text）与 narration
@@ -171,112 +166,30 @@ function isDirty(draft: unknown, serverContent: unknown): boolean {
 export function ScriptReviewGate({ projectName, episode, contentMode }: ScriptReviewGateProps) {
   const { t } = useTranslation("dashboard");
   const pushToast = useAppStore((s) => s.pushToast);
-  const draftRevision = useAppStore((s) => s.getEntityRevision(`draft:episode_${episode}_step1`));
 
-  const [state, setState] = useState<ScriptReviewState | null>(null);
-  const [draft, setDraft] = useState<ReviewDraft | null>(null);
-  // 保存时提交的基线指纹：绑定在**当前草稿所基于的那份服务端内容**上，只在草稿采用服务端内容时推进。
-  // 不能改用 state.fingerprint——有未保存编辑时的外部刷新会更新 state 却保留旧草稿，届时提交
-  // state.fingerprint 等于拿别人新写的内容当基线，OCC 会放行并静默覆盖对方的修改。
-  const [baseFingerprint, setBaseFingerprint] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<{ message: string } | null>(null);
-  const [reloadNonce, setReloadNonce] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [confirming, setConfirming] = useState(false);
+  const handleConfirmed = useCallback(() => {
+    pushToast(t("dashboard:review_confirmed"), "success");
+  }, [pushToast, t]);
 
-  const serverContent = state?.content ?? null;
-  const dirty = useMemo(() => isDirty(draft, serverContent), [draft, serverContent]);
-  const busy = saving || confirming;
-
-  // 把 dirty 镜像进 ref，供下方拉取 effect 读取最新值，而无需把 dirty 列入 deps（否则每次编辑都会重新拉取）。
-  const dirtyRef = useRef(false);
-  useEffect(() => {
-    dirtyRef.current = dirty;
-  }, [dirty]);
-
-  // 采用服务端内容为新草稿（深克隆，避免与服务端态共享引用）。用户主动动作（保存 / 确认）后调用，
-  // 总是覆盖本地草稿；setDraft 传值而非更新器，保持纯净、不在更新器内读写 ref。
-  const adopt = useCallback((next: ScriptReviewState) => {
-    setState(next);
-    setDraft(
-      next.content ? (JSON.parse(JSON.stringify(next.content)) as ReviewDraft) : null,
-    );
-    setBaseFingerprint(next.fingerprint);
-  }, []);
-
-  const handleRetry = useCallback(() => {
-    setLoadError(null);
-    setLoading(true);
-    setReloadNonce((n) => n + 1);
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    // 已拿到过任一响应（空态或内容态）后，revision 触发的重新拉取静默刷新、不闪加载态；
-    const hadResponse = state != null;
-    // 屏上有真实内容可保留时，刷新失败静默保留、不破坏用户视图；无内容（首屏，或空态）时失败才进错误态。
-    const hasContent = draft != null;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!hadResponse) setLoading(true);
-    API.getScriptReview(projectName, episode)
-      .then((next) => {
-        if (cancelled) return;
-        setLoadError(null);
-        setState(next);
-        // 外部刷新（挂载 / agent 改 step1 触发的 revision）：用户无未保存编辑时采用服务端内容，
-        // 有编辑则仅更新服务端态、保留用户草稿。dirtyRef 读取在 effect 内安全（非 render 期）。
-        if (!dirtyRef.current) {
-          setDraft(
-            next.content
-              ? (JSON.parse(JSON.stringify(next.content)) as ReviewDraft)
-              : null,
-          );
-          setBaseFingerprint(next.fingerprint);
-        }
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        // 屏上无真实内容（首屏失败，或空态后 revision 刷新失败）→ 错误态（区别于空态）+ 重试；
-        // 已有内容的静默刷新失败则保留现有内容，不破坏用户视图。
-        if (!hasContent) setLoadError({ message: errorMessage(err) });
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- state/draft 仅用于决定加载态与错误态分支，加入 deps 会在每次刷新后重新拉取造成循环
-  }, [projectName, episode, draftRevision, reloadNonce]);
-
-  const handleSave = useCallback(async () => {
-    if (!draft) return;
-    setSaving(true);
-    try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
-      pushToast(t("dashboard:review_saved"), "success");
-    } catch (err) {
-      pushToast(errorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
-    } finally {
-      setSaving(false);
-    }
-  }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
-
-  const handleConfirm = useCallback(async () => {
-    setConfirming(true);
-    try {
-      if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
-      }
-      adopt(await API.confirmScriptReview(projectName, episode));
-      pushToast(t("dashboard:review_confirmed"), "success");
-    } catch (err) {
-      pushToast(errorMessage(err) || t("dashboard:review_confirm_failed"), "error");
-    } finally {
-      setConfirming(false);
-    }
-  }, [dirty, draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
+  const {
+    state,
+    draft,
+    setDraft,
+    dirty,
+    loading,
+    loadError,
+    saving,
+    busy,
+    retry: handleRetry,
+    save: handleSave,
+    confirm: handleConfirm,
+    confirming,
+  } = useScriptReviewDraft<ReviewDraft>({
+    projectName,
+    episode,
+    selectContent: selectReviewContent,
+    onConfirmed: handleConfirmed,
+  });
 
   const updateDramaScene = (index: number, patch: Partial<DramaSceneContent>) => {
     setDraft((prev) => {

--- a/frontend/src/hooks/useScriptReviewDraft.test.tsx
+++ b/frontend/src/hooks/useScriptReviewDraft.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useScriptReviewDraft } from "@/hooks/useScriptReviewDraft";
+import { useAppStore } from "@/stores/app-store";
+import type { DramaNormalizedScript, ScriptReviewState } from "@/types";
+
+function reviewState(overrides: Partial<ScriptReviewState> = {}): ScriptReviewState {
+  return {
+    episode: 1,
+    content_mode: "drama",
+    status: "pending_review",
+    fingerprint: "fp1",
+    confirmed_at: null,
+    quarantine: null,
+    supported_durations: null,
+    duration_tiers: null,
+    content: {
+      title: "第一集",
+      scenes: [
+        {
+          scene_id: "E1S01",
+          duration_seconds: 8,
+          segment_break: false,
+          characters_in_scene: ["阿离"],
+          scenes: [],
+          props: [],
+          scene_description: "雨夜，阿离立于屋檐下",
+          utterances: [{ kind: "dialogue", speaker: "阿离", text: "你终于回来了。" }],
+          source_text: "阿离：你终于回来了。",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function selectContent(state: ScriptReviewState): DramaNormalizedScript | null {
+  return (state.content ?? null) as DramaNormalizedScript | null;
+}
+
+const noop = () => {};
+
+function renderDraft() {
+  return renderHook(() =>
+    useScriptReviewDraft<DramaNormalizedScript>({
+      projectName: "p",
+      episode: 1,
+      selectContent,
+      onConfirmed: noop,
+    }),
+  );
+}
+
+function editFirstUtterance(draft: DramaNormalizedScript, text: string): DramaNormalizedScript {
+  return {
+    ...draft,
+    scenes: draft.scenes.map((s, i) =>
+      i === 0 ? { ...s, utterances: s.utterances.map((u, j) => (j === 0 ? { ...u, text } : u)) } : s,
+    ),
+  };
+}
+
+describe("useScriptReviewDraft", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("saves with the fingerprint of the content the draft was based on, not the refreshed one", async () => {
+    const agentEdited = reviewState({ fingerprint: "fp2" });
+    (agentEdited.content as DramaNormalizedScript).scenes[0].utterances[0].text = "agent 改写的台词";
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(reviewState())
+      .mockResolvedValueOnce(agentEdited);
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(reviewState());
+
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft).not.toBeNull());
+
+    act(() => {
+      result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "我的本地编辑") : prev));
+    });
+    expect(result.current.dirty).toBe(true);
+
+    // agent 改了 step1 → 外部刷新把服务端态换成新版，但用户草稿仍基于旧版
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    // 未保存编辑在外部刷新后保留，不被服务端内容覆盖
+    expect(result.current.draft?.scenes[0].utterances[0].text).toBe("我的本地编辑");
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    // 提交草稿所基于的 fp1，服务端才能判出冲突；提交刷新后的 fp2 会让 OCC 放行、静默覆盖 agent 的修改
+    expect(save.mock.calls[0][3]).toBe("fp1");
+  });
+
+  it("adopts the saved content as the new baseline, so a follow-up save carries the new fingerprint", async () => {
+    vi.spyOn(API, "getScriptReview").mockResolvedValue(reviewState());
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(reviewState({ fingerprint: "fp2" }));
+
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft).not.toBeNull());
+
+    act(() => {
+      result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "第一次编辑") : prev));
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+    // 采纳保存回显后草稿与服务端一致，脏标记复位
+    expect(result.current.dirty).toBe(false);
+
+    act(() => {
+      result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "第二次编辑") : prev));
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save.mock.calls[1][3]).toBe("fp2");
+  });
+});

--- a/frontend/src/hooks/useScriptReviewDraft.test.tsx
+++ b/frontend/src/hooks/useScriptReviewDraft.test.tsx
@@ -41,6 +41,30 @@ function selectContent(state: ScriptReviewState): DramaNormalizedScript | null {
 
 const noop = () => {};
 
+/**
+ * 一次挂起的 `getScriptReview`：像真实 fetch 一样在 abort 时 reject，并留出 signal 供断言。
+ * 只用 resolve 的 mock 无法覆盖取消时序——请求被误取消时它仍会成功返回。
+ */
+function deferredGet() {
+  let captured: AbortSignal | null = null;
+  let settle: (state: ScriptReviewState) => void = noop;
+  const impl = (_projectName: string, _episode: number, options?: { signal?: AbortSignal }) => {
+    captured = options?.signal ?? null;
+    return new Promise<ScriptReviewState>((resolve, reject) => {
+      settle = resolve;
+      options?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+    });
+  };
+  return {
+    impl,
+    /** 让这次拉取返回内容；已被 abort 时 promise 已 reject，此处即无效果。 */
+    respond: (state: ScriptReviewState) => settle(state),
+    get signal() {
+      return captured;
+    },
+  };
+}
+
 function renderDraft() {
   return renderHook(() =>
     useScriptReviewDraft<DramaNormalizedScript>({
@@ -125,23 +149,21 @@ describe("useScriptReviewDraft", () => {
     expect(save.mock.calls[1][3]).toBe("fp2");
   });
 
-  it("keeps the adopted content when a pull issued before the save resolves afterwards", async () => {
-    let resolvePending: (state: ScriptReviewState) => void = noop;
-    const pending = new Promise<ScriptReviewState>((resolve) => {
-      resolvePending = resolve;
-    });
+  it("cancels the pull that was in flight when the save is adopted, so it cannot roll the draft back", async () => {
+    const pull = deferredGet();
+    const saved = reviewState({ fingerprint: "fp2" });
+    (saved.content as DramaNormalizedScript).scenes[0].utterances[0].text = "我的本地编辑";
     const get = vi
       .spyOn(API, "getScriptReview")
       .mockResolvedValueOnce(reviewState())
-      .mockReturnValueOnce(pending);
-    const saved = reviewState({ fingerprint: "fp2" });
-    (saved.content as DramaNormalizedScript).scenes[0].utterances[0].text = "我的本地编辑";
+      .mockImplementationOnce(pull.impl)
+      .mockResolvedValue(saved);
     const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(saved);
 
     const { result } = renderDraft();
     await waitFor(() => expect(result.current.draft).not.toBeNull());
 
-    // 外部刷新发出 GET，但它在用户保存完成前都不 resolve
+    // 外部刷新发出 GET，它在用户保存完成前都不 resolve——读到的是保存前的旧内容
     act(() => {
       useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
     });
@@ -154,31 +176,29 @@ describe("useScriptReviewDraft", () => {
       await result.current.save();
     });
 
-    // 保存前发出的 GET 此刻才回来，携带保存前的旧内容与旧指纹
+    // 采纳保存回显时该 GET 被作废；此刻服务端才回旧内容，作废后它不再回写：
+    // 否则草稿回退、基线指纹退回 fp1，下次保存撞 OCC
+    expect(pull.signal?.aborted).toBe(true);
     await act(async () => {
-      resolvePending(reviewState());
-      await pending;
+      pull.respond(reviewState());
+      await Promise.resolve();
     });
-
-    // 旧响应不得回写：草稿保持刚采纳的内容，基线指纹保持 fp2（否则下次保存拿 fp1 撞 OCC）
-    expect(result.current.draft?.scenes[0].utterances[0].text).toBe("我的本地编辑");
+    await waitFor(() => expect(result.current.draft?.scenes[0].utterances[0].text).toBe("我的本地编辑"));
     await act(async () => {
       await result.current.save();
     });
     expect(save.mock.calls[1][3]).toBe("fp2");
   });
 
-  it("keeps a refresh that started after the save was issued", async () => {
+  it("re-pulls after adopting, so an external refresh cancelled by the save is not lost", async () => {
     const agentEdited = reviewState({ fingerprint: "fp3" });
     (agentEdited.content as DramaNormalizedScript).scenes[0].utterances[0].text = "agent 改写的台词";
-    let resolveRefresh: (state: ScriptReviewState) => void = noop;
-    const refresh = new Promise<ScriptReviewState>((resolve) => {
-      resolveRefresh = resolve;
-    });
+    const refresh = deferredGet();
     const get = vi
       .spyOn(API, "getScriptReview")
       .mockResolvedValueOnce(reviewState())
-      .mockReturnValueOnce(refresh);
+      .mockImplementationOnce(refresh.impl)
+      .mockResolvedValue(agentEdited);
     let resolveSave: (state: ScriptReviewState) => void = noop;
     const savePromise = new Promise<ScriptReviewState>((resolve) => {
       resolveSave = resolve;
@@ -191,7 +211,7 @@ describe("useScriptReviewDraft", () => {
     act(() => {
       result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "我的本地编辑") : prev));
     });
-    // 保存发出后仍在途时，agent 改了 step1 触发外部刷新——这个 GET 晚于保存，携带更新的服务端态
+    // 保存在途时 agent 改了 step1，外部刷新发出 GET；它与保存的先后无法在客户端判定，一律作废
     let saving: Promise<void>;
     act(() => {
       saving = result.current.save();
@@ -205,13 +225,16 @@ describe("useScriptReviewDraft", () => {
       resolveSave(reviewState({ fingerprint: "fp2" }));
       await saving;
     });
-    await act(async () => {
-      resolveRefresh(agentEdited);
-      await refresh;
-    });
 
-    // 晚于保存发出的刷新不得被误杀：触发它的 revision 已被消费，作废后不会再有请求补上
-    expect(result.current.draft?.scenes[0].utterances[0].text).toBe("agent 改写的台词");
+    // 该刷新读库早于保存落库，此刻返回的是保存前的旧内容——作废后不得回写
+    expect(refresh.signal?.aborted).toBe(true);
+    await act(async () => {
+      refresh.respond(reviewState());
+      await Promise.resolve();
+    });
+    // 作废的那次刷新由采纳后补发的一轮拉取补回，agent 的修改不丢
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(result.current.draft?.scenes[0].utterances[0].text).toBe("agent 改写的台词"));
     save.mockResolvedValue(agentEdited);
     await act(async () => {
       await result.current.save();

--- a/frontend/src/hooks/useScriptReviewDraft.test.tsx
+++ b/frontend/src/hooks/useScriptReviewDraft.test.tsx
@@ -124,4 +124,47 @@ describe("useScriptReviewDraft", () => {
     expect(save).toHaveBeenCalledTimes(2);
     expect(save.mock.calls[1][3]).toBe("fp2");
   });
+
+  it("keeps the adopted content when a pull issued before the save resolves afterwards", async () => {
+    let resolvePending: (state: ScriptReviewState) => void = noop;
+    const pending = new Promise<ScriptReviewState>((resolve) => {
+      resolvePending = resolve;
+    });
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(reviewState())
+      .mockReturnValueOnce(pending);
+    const saved = reviewState({ fingerprint: "fp2" });
+    (saved.content as DramaNormalizedScript).scenes[0].utterances[0].text = "我的本地编辑";
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockResolvedValue(saved);
+
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft).not.toBeNull());
+
+    // 外部刷新发出 GET，但它在用户保存完成前都不 resolve
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "我的本地编辑") : prev));
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+
+    // 保存前发出的 GET 此刻才回来，携带保存前的旧内容与旧指纹
+    await act(async () => {
+      resolvePending(reviewState());
+      await pending;
+    });
+
+    // 旧响应不得回写：草稿保持刚采纳的内容，基线指纹保持 fp2（否则下次保存拿 fp1 撞 OCC）
+    expect(result.current.draft?.scenes[0].utterances[0].text).toBe("我的本地编辑");
+    await act(async () => {
+      await result.current.save();
+    });
+    expect(save.mock.calls[1][3]).toBe("fp2");
+  });
 });

--- a/frontend/src/hooks/useScriptReviewDraft.test.tsx
+++ b/frontend/src/hooks/useScriptReviewDraft.test.tsx
@@ -167,4 +167,55 @@ describe("useScriptReviewDraft", () => {
     });
     expect(save.mock.calls[1][3]).toBe("fp2");
   });
+
+  it("keeps a refresh that started after the save was issued", async () => {
+    const agentEdited = reviewState({ fingerprint: "fp3" });
+    (agentEdited.content as DramaNormalizedScript).scenes[0].utterances[0].text = "agent 改写的台词";
+    let resolveRefresh: (state: ScriptReviewState) => void = noop;
+    const refresh = new Promise<ScriptReviewState>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const get = vi
+      .spyOn(API, "getScriptReview")
+      .mockResolvedValueOnce(reviewState())
+      .mockReturnValueOnce(refresh);
+    let resolveSave: (state: ScriptReviewState) => void = noop;
+    const savePromise = new Promise<ScriptReviewState>((resolve) => {
+      resolveSave = resolve;
+    });
+    const save = vi.spyOn(API, "saveScriptReviewContent").mockReturnValueOnce(savePromise);
+
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft).not.toBeNull());
+
+    act(() => {
+      result.current.setDraft((prev) => (prev ? editFirstUtterance(prev, "我的本地编辑") : prev));
+    });
+    // 保存发出后仍在途时，agent 改了 step1 触发外部刷新——这个 GET 晚于保存，携带更新的服务端态
+    let saving: Promise<void>;
+    act(() => {
+      saving = result.current.save();
+    });
+    act(() => {
+      useAppStore.getState().invalidateEntities(["draft:episode_1_step1"]);
+    });
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveSave(reviewState({ fingerprint: "fp2" }));
+      await saving;
+    });
+    await act(async () => {
+      resolveRefresh(agentEdited);
+      await refresh;
+    });
+
+    // 晚于保存发出的刷新不得被误杀：触发它的 revision 已被消费，作废后不会再有请求补上
+    expect(result.current.draft?.scenes[0].utterances[0].text).toBe("agent 改写的台词");
+    save.mockResolvedValue(agentEdited);
+    await act(async () => {
+      await result.current.save();
+    });
+    expect(save.mock.calls[1][3]).toBe("fp3");
+  });
 });

--- a/frontend/src/hooks/useScriptReviewDraft.ts
+++ b/frontend/src/hooks/useScriptReviewDraft.ts
@@ -7,7 +7,7 @@ import { useAppStore } from "@/stores/app-store";
 /** 面板可编辑的草稿：`ScriptReviewState.content` 的某个变体。 */
 type ScriptReviewContent = NonNullable<ScriptReviewState["content"]>;
 
-export function scriptReviewErrorMessage(err: unknown): string {
+function scriptReviewErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : "";
 }
 

--- a/frontend/src/hooks/useScriptReviewDraft.ts
+++ b/frontend/src/hooks/useScriptReviewDraft.ts
@@ -88,21 +88,26 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
     dirtyRef.current = dirty;
   }, [dirty]);
 
-  // 在途拉取的 controller，供保存 / 确认发起时捕获。
+  // 在途拉取的 controller 与在途标记，供 adopt 作废与补拉判定。
   const loadControllerRef = useRef<AbortController | null>(null);
+  const loadInFlightRef = useRef(false);
 
   // 采用服务端内容为新草稿（深克隆，避免与服务端态共享引用）。用户主动动作（保存 / 确认）后调用，
   // 总是覆盖本地草稿；setDraft 传值而非更新器，保持纯净、不在更新器内读写 ref。
-  // `staleLoad` 是该动作发起**时刻**就已在途的拉取，须一并作废：它早于本次变更发出，回来时 dirtyRef
-  // 已因采纳而为 false，会按变更前的旧内容回写 draft 与 baseFingerprint——草稿回退，且下次保存拿旧
-  // 指纹撞 OCC。动作发起之后才起的拉取（外部事件触发）携带的是更新的服务端态，不能顺带误杀——
-  // 触发它的那次 revision 已被消费，作废后不会再有请求补上。
+  //
+  // 采纳前发出的拉取一律作废：它读到的服务端态未必包含本次写入，回来时 dirtyRef 已因采纳而为
+  // false，会按旧内容回写 draft 与 baseFingerprint——草稿回退，且下次保存拿旧指纹撞 OCC。
+  // 但作废掉的若是外部事件（agent 改 step1 的 revision）触发的那次拉取，该 revision 已被消费、
+  // 不会再有请求补上，外部更新就此丢失；故确有在途拉取被作废时补发一轮，把它重新拉回来。
   const adopt = useCallback(
-    (next: ScriptReviewState, staleLoad: AbortController | null) => {
-      staleLoad?.abort();
+    (next: ScriptReviewState) => {
+      const abandonedLoad = loadInFlightRef.current;
+      loadControllerRef.current?.abort();
+      loadInFlightRef.current = false;
       setState(next);
       setDraft(clone(selectContent(next)));
       setBaseFingerprint(next.fingerprint);
+      if (abandonedLoad) setReloadNonce((n) => n + 1);
     },
     [selectContent],
   );
@@ -117,6 +122,7 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
     const controller = new AbortController();
     const { signal } = controller;
     loadControllerRef.current = controller;
+    loadInFlightRef.current = true;
     // 已拿到过任一响应（空态或内容态）后，revision 触发的重新拉取静默刷新、不闪加载态；
     const hadResponse = state != null;
     // 屏上有真实内容可保留时，刷新失败静默保留、不破坏用户视图；无内容（首屏，或空态）时失败才进错误态。
@@ -143,8 +149,11 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
         if (!hasContent) setLoadError({ message: scriptReviewErrorMessage(err) });
       })
       .finally(() => {
-        // 收尾让位给接管方：已作废就不碰 loading，否则会打断新一轮加载态。
-        if (!signal.aborted) setLoading(false);
+        // 收尾让位给接管方：已作废就不碰在途标记与 loading，否则会打断新一轮加载态。
+        if (!signal.aborted) {
+          loadInFlightRef.current = false;
+          setLoading(false);
+        }
       });
     return () => {
       controller.abort();
@@ -154,10 +163,9 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
 
   const save = useCallback(async () => {
     if (!draft) return;
-    const staleLoad = loadControllerRef.current;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint), staleLoad);
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(scriptReviewErrorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
@@ -167,13 +175,12 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
   }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const confirm = useCallback(async () => {
-    const staleLoad = loadControllerRef.current;
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint), staleLoad);
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
       }
-      adopt(await API.confirmScriptReview(projectName, episode), staleLoad);
+      adopt(await API.confirmScriptReview(projectName, episode));
       onConfirmed();
     } catch (err) {
       pushToast(scriptReviewErrorMessage(err) || t("dashboard:review_confirm_failed"), "error");

--- a/frontend/src/hooks/useScriptReviewDraft.ts
+++ b/frontend/src/hooks/useScriptReviewDraft.ts
@@ -88,16 +88,18 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
     dirtyRef.current = dirty;
   }, [dirty]);
 
-  // 在途拉取的 controller，供 adopt 接管时作废。
+  // 在途拉取的 controller，供保存 / 确认发起时捕获。
   const loadControllerRef = useRef<AbortController | null>(null);
 
   // 采用服务端内容为新草稿（深克隆，避免与服务端态共享引用）。用户主动动作（保存 / 确认）后调用，
   // 总是覆盖本地草稿；setDraft 传值而非更新器，保持纯净、不在更新器内读写 ref。
+  // `staleLoad` 是该动作发起**时刻**就已在途的拉取，须一并作废：它早于本次变更发出，回来时 dirtyRef
+  // 已因采纳而为 false，会按变更前的旧内容回写 draft 与 baseFingerprint——草稿回退，且下次保存拿旧
+  // 指纹撞 OCC。动作发起之后才起的拉取（外部事件触发）携带的是更新的服务端态，不能顺带误杀——
+  // 触发它的那次 revision 已被消费，作废后不会再有请求补上。
   const adopt = useCallback(
-    (next: ScriptReviewState) => {
-      // 先作废在途拉取：它可能早于本次保存 / 确认发出，回来时 dirtyRef 已因采纳而为 false，
-      // 会按保存前的旧内容回写 draft 与 baseFingerprint——草稿回退，且下次保存拿旧指纹撞 OCC。
-      loadControllerRef.current?.abort();
+    (next: ScriptReviewState, staleLoad: AbortController | null) => {
+      staleLoad?.abort();
       setState(next);
       setDraft(clone(selectContent(next)));
       setBaseFingerprint(next.fingerprint);
@@ -152,9 +154,10 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
 
   const save = useCallback(async () => {
     if (!draft) return;
+    const staleLoad = loadControllerRef.current;
     setSaving(true);
     try {
-      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint), staleLoad);
       pushToast(t("dashboard:review_saved"), "success");
     } catch (err) {
       pushToast(scriptReviewErrorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
@@ -164,12 +167,13 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
   }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
 
   const confirm = useCallback(async () => {
+    const staleLoad = loadControllerRef.current;
     setConfirming(true);
     try {
       if (dirty && draft) {
-        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint), staleLoad);
       }
-      adopt(await API.confirmScriptReview(projectName, episode));
+      adopt(await API.confirmScriptReview(projectName, episode), staleLoad);
       onConfirmed();
     } catch (err) {
       pushToast(scriptReviewErrorMessage(err) || t("dashboard:review_confirm_failed"), "error");

--- a/frontend/src/hooks/useScriptReviewDraft.ts
+++ b/frontend/src/hooks/useScriptReviewDraft.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { API } from "@/api";
+import type { ScriptReviewState } from "@/types";
+import { useAppStore } from "@/stores/app-store";
+
+/** 面板可编辑的草稿：`ScriptReviewState.content` 的某个变体。 */
+type ScriptReviewContent = NonNullable<ScriptReviewState["content"]>;
+
+export function scriptReviewErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "";
+}
+
+/** 内容是否有未保存编辑：以序列化比对，draft 由 server content 克隆而来，键序稳定。 */
+function isDirty(draft: unknown, serverContent: unknown): boolean {
+  if (draft == null) return false;
+  return JSON.stringify(draft) !== JSON.stringify(serverContent);
+}
+
+function clone<TDraft>(content: TDraft | null): TDraft | null {
+  return content ? (JSON.parse(JSON.stringify(content)) as TDraft) : null;
+}
+
+interface ScriptReviewDraftOptions<TDraft extends ScriptReviewContent> {
+  projectName: string;
+  episode: number;
+  /**
+   * 从服务端审核态取出本面板可编辑的那份内容；形状不属于本面板的变体时返回 null。
+   * 须是稳定引用（模块级函数或 `useCallback`）——它参与拉取 effect 的依赖。
+   */
+  selectContent: (state: ScriptReviewState) => TDraft | null;
+  /** 确认成功后的面板专属处理（含成功提示）；失败提示由本 hook 统一给出。 */
+  onConfirmed: () => void;
+}
+
+interface ScriptReviewDraftHandle<TDraft extends ScriptReviewContent> {
+  /** 最近一次拉取到的服务端审核态；尚未拿到任何响应时为 null。 */
+  state: ScriptReviewState | null;
+  draft: TDraft | null;
+  setDraft: React.Dispatch<React.SetStateAction<TDraft | null>>;
+  /** 草稿与其所基于的服务端内容不一致，即有未保存编辑。 */
+  dirty: boolean;
+  loading: boolean;
+  loadError: { message: string } | null;
+  saving: boolean;
+  confirming: boolean;
+  /** 保存 / 确认请求在途：调用方据此锁住编辑控件，避免回显覆盖请求发出后的新编辑。 */
+  busy: boolean;
+  retry: () => void;
+  save: () => Promise<void>;
+  confirm: () => Promise<void>;
+}
+
+/**
+ * step1→step2 审核 gate 面板的草稿状态机：拉取 / 外部刷新 / 脏标记 / 采纳 / 保存 / 确认。
+ * `ScriptReviewGate`（drama、narration）与 `ReferenceStep1PreviewPanel`（reference_video）
+ * 共用，面板只保留各自的呈现与专属交互。
+ */
+export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
+  projectName,
+  episode,
+  selectContent,
+  onConfirmed,
+}: ScriptReviewDraftOptions<TDraft>): ScriptReviewDraftHandle<TDraft> {
+  const { t } = useTranslation("dashboard");
+  const pushToast = useAppStore((s) => s.pushToast);
+  const draftRevision = useAppStore((s) => s.getEntityRevision(`draft:episode_${episode}_step1`));
+
+  const [state, setState] = useState<ScriptReviewState | null>(null);
+  const [draft, setDraft] = useState<TDraft | null>(null);
+  // 保存时提交的基线指纹：绑定在**当前草稿所基于的那份服务端内容**上，只在草稿采用服务端内容时推进。
+  // 不能改用 state.fingerprint——有未保存编辑时的外部刷新会更新 state 却保留旧草稿，届时提交
+  // state.fingerprint 等于拿别人新写的内容当基线，OCC 会放行并静默覆盖对方的修改。
+  const [baseFingerprint, setBaseFingerprint] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<{ message: string } | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+
+  const serverContent = state ? selectContent(state) : null;
+  const dirty = useMemo(() => isDirty(draft, serverContent), [draft, serverContent]);
+  const busy = saving || confirming;
+
+  // 把 dirty 镜像进 ref，供下方拉取 effect 读取最新值，而无需把 dirty 列入 deps（否则每次编辑都会重新拉取）。
+  const dirtyRef = useRef(false);
+  useEffect(() => {
+    dirtyRef.current = dirty;
+  }, [dirty]);
+
+  // 采用服务端内容为新草稿（深克隆，避免与服务端态共享引用）。用户主动动作（保存 / 确认）后调用，
+  // 总是覆盖本地草稿；setDraft 传值而非更新器，保持纯净、不在更新器内读写 ref。
+  const adopt = useCallback(
+    (next: ScriptReviewState) => {
+      setState(next);
+      setDraft(clone(selectContent(next)));
+      setBaseFingerprint(next.fingerprint);
+    },
+    [selectContent],
+  );
+
+  const retry = useCallback(() => {
+    setLoadError(null);
+    setLoading(true);
+    setReloadNonce((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    // 已拿到过任一响应（空态或内容态）后，revision 触发的重新拉取静默刷新、不闪加载态；
+    const hadResponse = state != null;
+    // 屏上有真实内容可保留时，刷新失败静默保留、不破坏用户视图；无内容（首屏，或空态）时失败才进错误态。
+    const hasContent = draft != null;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (!hadResponse) setLoading(true);
+    API.getScriptReview(projectName, episode, { signal })
+      .then((next) => {
+        // 响应已 resolve 之后才 abort 的窗口：写 state 前复核，避免离场的这轮回写。
+        if (signal.aborted) return;
+        setLoadError(null);
+        setState(next);
+        // 外部刷新（挂载 / agent 改 step1 触发的 revision）：用户无未保存编辑时采用服务端内容，
+        // 有编辑则仅更新服务端态、保留用户草稿。dirtyRef 读取在 effect 内安全（非 render 期）。
+        if (!dirtyRef.current) {
+          setDraft(clone(selectContent(next)));
+          setBaseFingerprint(next.fingerprint);
+        }
+      })
+      .catch((err: unknown) => {
+        if (signal.aborted) return;
+        // 屏上无真实内容（首屏失败，或空态后 revision 刷新失败）→ 错误态（区别于空态）+ 重试；
+        // 已有内容的静默刷新失败则保留现有内容，不破坏用户视图。
+        if (!hasContent) setLoadError({ message: scriptReviewErrorMessage(err) });
+      })
+      .finally(() => {
+        // 收尾让位给接管方：已作废就不碰 loading，否则会打断新一轮加载态。
+        if (!signal.aborted) setLoading(false);
+      });
+    return () => {
+      controller.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- state/draft 仅用于决定加载态与错误态分支，加入 deps 会在每次刷新后重新拉取造成循环
+  }, [projectName, episode, draftRevision, reloadNonce, selectContent]);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    setSaving(true);
+    try {
+      adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
+      pushToast(t("dashboard:review_saved"), "success");
+    } catch (err) {
+      pushToast(scriptReviewErrorMessage(err) || t("dashboard:save_failed", { message: "" }), "error");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, baseFingerprint, projectName, episode, adopt, pushToast, t]);
+
+  const confirm = useCallback(async () => {
+    setConfirming(true);
+    try {
+      if (dirty && draft) {
+        adopt(await API.saveScriptReviewContent(projectName, episode, draft, baseFingerprint));
+      }
+      adopt(await API.confirmScriptReview(projectName, episode));
+      onConfirmed();
+    } catch (err) {
+      pushToast(scriptReviewErrorMessage(err) || t("dashboard:review_confirm_failed"), "error");
+    } finally {
+      setConfirming(false);
+    }
+  }, [dirty, draft, baseFingerprint, projectName, episode, adopt, onConfirmed, pushToast, t]);
+
+  return {
+    state,
+    draft,
+    setDraft,
+    dirty,
+    loading,
+    loadError,
+    saving,
+    confirming,
+    busy,
+    retry,
+    save,
+    confirm,
+  };
+}

--- a/frontend/src/hooks/useScriptReviewDraft.ts
+++ b/frontend/src/hooks/useScriptReviewDraft.ts
@@ -88,10 +88,16 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
     dirtyRef.current = dirty;
   }, [dirty]);
 
+  // 在途拉取的 controller，供 adopt 接管时作废。
+  const loadControllerRef = useRef<AbortController | null>(null);
+
   // 采用服务端内容为新草稿（深克隆，避免与服务端态共享引用）。用户主动动作（保存 / 确认）后调用，
   // 总是覆盖本地草稿；setDraft 传值而非更新器，保持纯净、不在更新器内读写 ref。
   const adopt = useCallback(
     (next: ScriptReviewState) => {
+      // 先作废在途拉取：它可能早于本次保存 / 确认发出，回来时 dirtyRef 已因采纳而为 false，
+      // 会按保存前的旧内容回写 draft 与 baseFingerprint——草稿回退，且下次保存拿旧指纹撞 OCC。
+      loadControllerRef.current?.abort();
       setState(next);
       setDraft(clone(selectContent(next)));
       setBaseFingerprint(next.fingerprint);
@@ -108,6 +114,7 @@ export function useScriptReviewDraft<TDraft extends ScriptReviewContent>({
   useEffect(() => {
     const controller = new AbortController();
     const { signal } = controller;
+    loadControllerRef.current = controller;
     // 已拿到过任一响应（空态或内容态）后，revision 触发的重新拉取静默刷新、不闪加载态；
     const hadResponse = state != null;
     // 屏上有真实内容可保留时，刷新失败静默保留、不破坏用户视图；无内容（首屏，或空态）时失败才进错误态。


### PR DESCRIPTION
两条审核路线（分镜路线的 `ScriptReviewGate` 与参考路线的 `ReferenceStep1PreviewPanel`）此前各自维护一套完全同构的草稿交互逻辑，基线指纹缺陷曾在两处各修一遍。本次把这套状态机——拉取、外部刷新、脏标记、采纳、保存、确认——收敛为共享 hook `useScriptReviewDraft`，两面板消费，各自只保留呈现与专属交互（参考路线的隔离草稿、时长档位、编辑态 unit）。

两面板用户可见行为不变。附带把分镜路线面板的加载取消从闭包标志迁到 AbortSignal，与参考路线口径一致。

## 差异参数化

- `selectContent`：两条路线从服务端审核态取内容的方式不同（分镜路线直取，参考路线按 `units` 收窄），由调用方传入稳定引用
- `onConfirmed`：确认成功后的副作用不同（参考路线有「切走项目则抑制全局副作用」的守卫），成功提示交回调用方；失败提示统一在 hook 内

## 验证

- `pnpm lint` / `pnpm typecheck` / `vitest run`：141 文件 1635 例全绿
- 两条重复的「基线指纹不随外部刷新推进」回归测试合一为 hook 层测试，另补一条「保存回显推进基线」；两面板各自的保存动作测试保留且仍断言基线指纹
- 纯前端改动，未涉及后端与数据库

Closes #1617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 统一优化剧本审核草稿的加载、编辑、保存、确认与重试体验。
  - 服务端内容刷新时保留未保存的本地编辑，减少内容丢失。
  - 保存成功后同步最新服务端内容，降低并发编辑造成覆盖的风险。
  - 确认审核内容后，继续操作及助手面板可保持顺畅衔接。

- **测试**
  - 完善草稿刷新、本地编辑保留、保存结果同步及并发场景的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->