### PR TITLE
fix(资产): 资产名读写统一按 NFC 归一，同一名字不再产生重复资产与配音映射错位

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,6 +224,10 @@ _Avoid_: 与既有 `Dialogue` 条目混为一谈——前者声明音色、每 s
 AI 生成的角色/场景/道具定型图（`character_sheet` / `scene_sheet` / `prop_sheet`），是资产生成阶段的**产出**，随后作为 reference image 输入下游分镜/宫格/参考生视频以锚定一致性。
 _Avoid_: 与「参考图（reference image，生成的条件输入）」混为一谈——方向相反：sheet 是产出后再被引用，参考图是输入；也不要与 character 的用户上传 `reference_image` 字段混淆（那是用户上传的参考文件，非 AI 定型图）。
 
+**资产名坐标系（asset name normalization）**：
+资产名的比对总是「文本里的名字 × 资产表的 key」，两侧须在同一坐标系（Unicode NFC）里才判得准，函数集中在 `lib/asset_types`。登记闸口 `validate_asset_name`（strip + NFC）覆盖全部新写入路径，NFD 输入（macOS 输入法与文件名拖放天然产生）因此不再落成视觉同名的第二条资产；存量 key 保持原形态、**不迁移**，由读取侧承担：整桶比对用 `normalize_asset_bucket`，按 key 就地更新/删除/判冲突用 `resolve_asset_key` 解析出真实落盘 key 再操作。同名多形态的存量 key 之间一律**后写入胜出**，后端两函数与前端 `sheetOf` / `VoiceLegacyBanner` 同向。展示值（`Voice_Profiles` 的 Speaker、参考图 label）保留原文，只有索引与去重走归一。
+_Avoid_: 拿归一后的名字直接下标存量桶——会对同一个视觉名字新建第二条资产或漏判冲突；在比对点逐处补归一而不走上述函数；把全局资产库 DB 侧的按名唯一性算进来——`assets` 表仍是字节精确比对，不在这个坐标系内。
+
 **全局资产库（global asset library）**：
 跨项目复用 character/scene/prop 三类资产的全局单一仓库（DB 持久化 + `_global_assets/` 图片目录），与项目以**快照复制**而非引用关联。
 _Avoid_: 把它与项目当「引用耦合」——入库 / 应用到项目都物理复制图片，改一边不影响另一边；以为改名/删除库内资产会传导到已用项目；把 product 放进来——多图列表型资产不兼容库的单图列模型，spec 以 `in_global_library=False` 豁免。

--- a/frontend/src/components/canvas/reference/ReferencePanel.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferencePanel.test.tsx
@@ -81,7 +81,7 @@ describe("ReferencePanel", () => {
   });
 
   it("resolves the chip thumbnail from the last matching bucket key when NFC and NFD duplicates exist", () => {
-    // 存量桶可能同时含同一名字的 NFC/NFD 两条 key（写入侧收敛前的遗留），
+    // 存量桶可能同时含同一名字的 NFC/NFD 两条 key（登记闸口只约束新写入，存量不迁移），
     // 后写入的胜出——与后端 normalize_asset_bucket / VoiceLegacyBanner 的合并方向一致。
     const nameNfc = "Hiếu".normalize("NFC");
     const nameNfd = "Hiếu".normalize("NFD");

--- a/frontend/src/components/canvas/reference/ReferencePanel.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferencePanel.test.tsx
@@ -80,6 +80,35 @@ describe("ReferencePanel", () => {
     expect(screen.getAllByRole("button", { name: /Remove reference|移除引用/ })).toHaveLength(2);
   });
 
+  it("resolves the chip thumbnail from the last matching bucket key when NFC and NFD duplicates exist", () => {
+    // 存量桶可能同时含同一名字的 NFC/NFD 两条 key（写入侧收敛前的遗留），
+    // 后写入的胜出——与后端 normalize_asset_bucket / VoiceLegacyBanner 的合并方向一致。
+    const nameNfc = "Hiếu".normalize("NFC");
+    const nameNfd = "Hiếu".normalize("NFD");
+    useProjectsStore.setState({
+      currentProjectName: "proj",
+      currentProjectData: {
+        ...PROJECT,
+        characters: {
+          [nameNfc]: { description: "", character_sheet: "characters/first.png" },
+          [nameNfd]: { description: "", character_sheet: "characters/last.png" },
+        },
+      },
+    });
+    const { container } = render(
+      <ReferencePanel
+        references={[{ type: "character", name: nameNfc }]}
+        projectName="proj"
+        onReorder={vi.fn()}
+        onRemove={vi.fn()}
+        onAdd={vi.fn()}
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toContain("last.png");
+  });
+
   it("calls onRemove when the ✕ button is clicked", () => {
     const onRemove = vi.fn();
     render(

--- a/frontend/src/components/canvas/reference/ReferencePanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferencePanel.tsx
@@ -33,7 +33,8 @@ const refId = (r: ReferenceResource): string => `${r.type}:${normalizeAssetName(
 type BucketEntry = Partial<Record<"character_sheet" | "scene_sheet" | "prop_sheet", string>>;
 // bucket key 与 name 可能是 NFC/NFD 中的任一方（bucket 来自落盘的 project.json 原始 key，
 // name 可能来自已归一的 references 或选择器候选），两侧归一后再比对，见
-// `utils/reference-mentions.ts` 顶部注释的坐标系约定。
+// `utils/reference-mentions.ts` 顶部注释的坐标系约定。存量桶里视觉同名的多形式 key
+// 之间后写入的胜出，与后端 normalize_asset_bucket / VoiceLegacyBanner 的合并方向一致。
 const sheetOf = (
   bucket: Record<string, unknown> | undefined,
   kind: AssetKind,
@@ -41,12 +42,13 @@ const sheetOf = (
 ): string | null => {
   if (!bucket) return null;
   const target = normalizeAssetName(name);
+  let sheet: string | null = null;
   for (const key of Object.keys(bucket)) {
     if (normalizeAssetName(key) === target) {
-      return (bucket[key] as BucketEntry | undefined)?.[SHEET_FIELD[kind]] ?? null;
+      sheet = (bucket[key] as BucketEntry | undefined)?.[SHEET_FIELD[kind]] ?? null;
     }
   }
-  return null;
+  return sheet;
 };
 
 export interface ReferencePanelProps {

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.test.tsx
@@ -295,6 +295,42 @@ describe("ReferenceVideoCanvas", () => {
     });
   });
 
+  it("removes both NFC and NFD forms of the same asset when its chip is removed", async () => {
+    // 存量 references 可能同时含同一资产的 NFC/NFD 两条等价记录；删除按归一后比对，
+    // 一次移除即清干净，不留一条肉眼相同、按字节不同的残余 chip。
+    const nameNfc = "Hiếu".normalize("NFC");
+    const nameNfd = "Hiếu".normalize("NFD");
+    expect(nameNfc).not.toBe(nameNfd);
+    useProjectsStore.setState({
+      currentProjectName: "proj",
+      currentProjectData: {
+        ...STUB_PROJECT,
+        characters: { [nameNfd]: { description: "" } },
+      } as ProjectData,
+    });
+    const unit: ReferenceVideoUnit = {
+      ...mkUnit("E1U1", "推门。"),
+      references: [
+        { type: "character", name: nameNfc },
+        { type: "character", name: nameNfd },
+      ],
+    };
+    vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [unit] });
+    const patchSpy = vi
+      .spyOn(API, "patchReferenceVideoUnit")
+      .mockResolvedValue({ unit: { ...unit, references: [] } });
+
+    render(<ReferenceVideoCanvas projectName="proj" episode={1} />);
+    const removeButtons = await screen.findAllByRole("button", {
+      name: /Remove reference|移除引用/,
+    });
+    expect(removeButtons).toHaveLength(2);
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => expect(patchSpy).toHaveBeenCalled());
+    expect(patchSpy).toHaveBeenCalledWith("proj", 1, "E1U1", { references: [] });
+  });
+
   // 时长是 unit 级单一真相：下拉档位来自模型能力声明，选中即单独 PATCH（不牵连正文草稿）
   it("renders the unit duration dropdown from the model's declared slots and patches on change", async () => {
     vi.spyOn(API, "listReferenceVideoUnits").mockResolvedValue({ units: [mkUnit("E1U1")] });

--- a/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceVideoCanvas.tsx
@@ -547,8 +547,11 @@ export function ReferenceVideoCanvas({
   const handleRemoveRef = useCallback(
     (ref: ReferenceResource) => {
       if (!selected) return;
+      // 存量 references 的 name 可能是 NFD（外部编辑/旧数据落盘），归一后比对，
+      // 否则视觉同名的条目删不掉
+      const target = normalizeAssetName(ref.name);
       const next = selected.references.filter(
-        (r) => !(r.name === ref.name && r.type === ref.type),
+        (r) => !(normalizeAssetName(r.name) === target && r.type === ref.type),
       );
       patchReferencesAtomic(selected.unit_id, next);
     },

--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -163,8 +163,32 @@ def normalize_asset_bucket(bucket: object) -> dict[str, Any]:
     return {normalize_asset_name(str(name)): item for name, item in bucket.items()}  # pyright: ignore[reportUnknownVariableType]
 
 
+def resolve_asset_key(bucket: object, name: str) -> str | None:
+    """在资产桶中按比对坐标系（NFC）解析 *name* 对应的真实落盘 key；未命中返回 None。
+
+    写入侧已统一落 NFC（:func:`validate_asset_name`），但存量数据的 key 可能是任一
+    编码形式且无需迁移：按 key 就地更新/删除/冲突判定时不能拿归一后的名字直接下标，
+    须先解析出真实 key 再操作，否则会对同一个视觉名字新建第二条资产或漏判冲突。
+
+    同名多形式的存量 key 之间后写入的胜出，与 :func:`normalize_asset_bucket` 的合并
+    方向一致。非 dict 的畸形桶按空桶处理。
+    """
+    if not isinstance(bucket, dict):
+        return None
+    target = normalize_asset_name(name)
+    found: str | None = None
+    for key in bucket:
+        if isinstance(key, str) and normalize_asset_name(key) == target:
+            found = key
+    return found
+
+
 def validate_asset_name(name: object) -> str:
-    """校验并规范化（strip）资产名，非法时抛 ValueError，合法时返回 strip 后的名字。
+    """校验并规范化（strip + NFC）资产名，非法时抛 ValueError，合法时返回规范化后的名字。
+
+    这是登记路径的规范化闸口：所有新登记/新写入的资产名经此落到 NFC 坐标系
+    （见 :func:`normalize_asset_name`），NFD 输入不再以另一种编码形式落盘产生
+    视觉同名的重复资产。
 
     资产名全链路被当作单段路径组件使用：文件名（``characters/{name}.png``、
     ``versions/{type}/{name}_v{n}_{ts}.png``）与 REST 路由的单段路径参数。含路径
@@ -175,7 +199,7 @@ def validate_asset_name(name: object) -> str:
     """
     if not isinstance(name, str):
         raise ValueError(f"资产名称必须是字符串，当前为 {type(name).__name__}")
-    cleaned = name.strip()
+    cleaned = normalize_asset_name(name.strip())
     if not cleaned:
         raise ValueError("资产名称不能为空或仅含空白字符")
     if (

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -497,26 +497,20 @@ class DataValidator:
         *,
         field_label: str,
         kind_label: str,
-        normalize: bool = False,
     ) -> None:
-        """``normalize=True`` 时按 NFC 归一比对：ad + reference_video 的镜头参考集直接驱动
-        reference_video 的 unit 派生（见 ``lib.reference_video.ad_units``），project.json
-        资产 key 与镜头引用编码形式不一致时不能误判未登记。narration/drama 的 segments/scenes
-        校验路径、以及 ad 的 storyboard 生成路径均保持原始比对（``normalize`` 默认 False）——
-        storyboard 路径的图片收集（``server.services.generation_tasks._collect_sheet_references``）
-        仍按原始字符串查找，校验层先归一会让此处判「已登记」放行而收集层实际查不到，
-        生成时静默漏收对应 sheet。"""
+        """按 ``lib.asset_types`` 的比对坐标系（NFC）判断镜头引用是否已登记。
+
+        剧本里的名字与 project.json 的资产 key 可以是 NFC/NFD 中的任一形态（登记闸口落
+        NFC，存量剧本与桶均不迁移），两侧归一后才判得准；下游各收集器同样归一后索引，
+        校验层与收集层因此对同一份数据给出一致结论。"""
         if refs is None:
             warnings.append(f"{prefix}: 缺少 {field_label}，将使用默认空数组")
             return
         if not isinstance(refs, list):
             errors.append(f"{prefix}: {field_label} 必须是数组")
             return
-        if normalize:
-            normalized_valid = {normalize_asset_name(v) for v in valid_set}
-            invalid = [r for r in refs if not isinstance(r, str) or normalize_asset_name(r) not in normalized_valid]
-        else:
-            invalid = [r for r in refs if not isinstance(r, str) or r not in valid_set]
+        normalized_valid = {normalize_asset_name(v) for v in valid_set}
+        invalid = [r for r in refs if not isinstance(r, str) or normalize_asset_name(r) not in normalized_valid]
         if invalid:
             errors.append(f"{prefix}: {field_label} 引用了不存在于 project.json 的{kind_label}: {invalid}")
 
@@ -912,12 +906,8 @@ class DataValidator:
         （supported_durations 枚举，校验器拿不到供应商能力、只把关正整数）；
         ``reference_mode=True`` 时按 1-15 自由整数区间校验（与参考视频 Shot 同口径）。
 
-        资产引用的归一比对按各自收集器的实际行为对齐：characters_in_shot/scenes/props
-        三个字段的 storyboard 收集器（``_collect_sheet_references``）始终原始比对，校验层
-        随 ``reference_mode`` 切换（见 ``_validate_segment_refs`` 文档）；products_in_shot
-        的收集器（``collect_product_references_for_names``）不区分生成路径、始终归一，
-        校验层因此始终 ``normalize=True``——否则 storyboard 路径下合法的 NFC/NFD 产品名
-        会被校验层拒绝，而收集层其实能正常解析。
+        资产引用一律按 NFC 归一比对（见 ``_validate_segment_refs``），与两条生成路径的
+        各收集器同口径。
         """
         if not isinstance(shots, list) or not shots:
             errors.append("ad 剧本缺少 shots 数组或为空")
@@ -964,7 +954,6 @@ class DataValidator:
                 warnings,
                 field_label="characters_in_shot",
                 kind_label="角色",
-                normalize=reference_mode,
             )
             self._validate_segment_refs(
                 prefix,
@@ -974,7 +963,6 @@ class DataValidator:
                 warnings,
                 field_label="scenes",
                 kind_label="场景",
-                normalize=reference_mode,
             )
             self._validate_segment_refs(
                 prefix,
@@ -984,7 +972,6 @@ class DataValidator:
                 warnings,
                 field_label="props",
                 kind_label="道具",
-                normalize=reference_mode,
             )
             self._validate_segment_refs(
                 prefix,
@@ -994,7 +981,6 @@ class DataValidator:
                 warnings,
                 field_label="products_in_shot",
                 kind_label="产品",
-                normalize=True,
             )
 
             if not shot.get("image_prompt"):

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -487,6 +487,16 @@ class DataValidator:
                             f"{kind_label} '{name}'.{field_name}[{idx}] 必须是字符串，当前为 {type(item).__name__}"
                         )
 
+    def _unregistered_refs(self, refs: list[Any], valid_set: set[str]) -> list[Any]:
+        """按 ``lib.asset_types`` 的比对坐标系（NFC）挑出未登记的资产引用。
+
+        剧本里的名字与 project.json 的资产 key 可以是 NFC/NFD 中的任一形态（登记闸口落
+        NFC，存量剧本与桶均不迁移），两侧归一后才判得准；下游各收集器同样归一后索引，
+        校验层与收集层因此对同一份数据给出一致结论。资产引用的判等一律经此，不在各字段
+        处按裸字符串做集合差。"""
+        normalized_valid = {normalize_asset_name(v) for v in valid_set}
+        return [r for r in refs if not isinstance(r, str) or normalize_asset_name(r) not in normalized_valid]
+
     def _validate_segment_refs(
         self,
         prefix: str,
@@ -498,19 +508,14 @@ class DataValidator:
         field_label: str,
         kind_label: str,
     ) -> None:
-        """按 ``lib.asset_types`` 的比对坐标系（NFC）判断镜头引用是否已登记。
-
-        剧本里的名字与 project.json 的资产 key 可以是 NFC/NFD 中的任一形态（登记闸口落
-        NFC，存量剧本与桶均不迁移），两侧归一后才判得准；下游各收集器同样归一后索引，
-        校验层与收集层因此对同一份数据给出一致结论。"""
+        """校验可缺省的镜头资产引用字段：缺失给 warning，非数组或引用未登记给 error。"""
         if refs is None:
             warnings.append(f"{prefix}: 缺少 {field_label}，将使用默认空数组")
             return
         if not isinstance(refs, list):
             errors.append(f"{prefix}: {field_label} 必须是数组")
             return
-        normalized_valid = {normalize_asset_name(v) for v in valid_set}
-        invalid = [r for r in refs if not isinstance(r, str) or normalize_asset_name(r) not in normalized_valid]
+        invalid = self._unregistered_refs(refs, valid_set)
         if invalid:
             errors.append(f"{prefix}: {field_label} 引用了不存在于 project.json 的{kind_label}: {invalid}")
 
@@ -676,7 +681,7 @@ class DataValidator:
             elif not isinstance(chars_in_segment, list):
                 errors.append(f"{prefix}: characters_in_segment 必须是数组")
             else:
-                invalid = set(chars_in_segment) - project_characters
+                invalid = self._unregistered_refs(chars_in_segment, project_characters)
                 if invalid:
                     errors.append(f"{prefix}: characters_in_segment 引用了不存在于 project.json 的角色: {invalid}")
 
@@ -760,29 +765,28 @@ class DataValidator:
             elif not isinstance(chars_in_scene, list):
                 errors.append(f"{prefix}: characters_in_scene 必须是数组")
             else:
-                invalid = set(chars_in_scene) - project_characters
+                invalid = self._unregistered_refs(chars_in_scene, project_characters)
                 if invalid:
                     errors.append(f"{prefix}: characters_in_scene 引用了不存在于 project.json 的角色: {invalid}")
 
-            scenes_in_scene = scene.get("scenes")
-            if scenes_in_scene is None:
-                warnings.append(f"{prefix}: 缺少 scenes，将使用默认空数组")
-            elif not isinstance(scenes_in_scene, list):
-                errors.append(f"{prefix}: scenes 必须是数组")
-            else:
-                invalid = set(scenes_in_scene) - project_scenes
-                if invalid:
-                    errors.append(f"{prefix}: scenes 引用了不存在于 project.json 的场景: {invalid}")
-
-            props_in_scene = scene.get("props")
-            if props_in_scene is None:
-                warnings.append(f"{prefix}: 缺少 props，将使用默认空数组")
-            elif not isinstance(props_in_scene, list):
-                errors.append(f"{prefix}: props 必须是数组")
-            else:
-                invalid = set(props_in_scene) - project_props
-                if invalid:
-                    errors.append(f"{prefix}: props 引用了不存在于 project.json 的道具: {invalid}")
+            self._validate_segment_refs(
+                prefix,
+                scene.get("scenes"),
+                project_scenes,
+                errors,
+                warnings,
+                field_label="scenes",
+                kind_label="场景",
+            )
+            self._validate_segment_refs(
+                prefix,
+                scene.get("props"),
+                project_props,
+                errors,
+                warnings,
+                field_label="props",
+                kind_label="道具",
+            )
 
             # utterances：场景级有序发声序列（取代旧 video_prompt.dialogue + voiceover）。
             # 缺失放行（存量 drama 走读时迁移，旧双字段不在此层校验）；出现则校验结构与

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, Field
 
 from lib.agent_profile import agent_profile_dir
 from lib.app_data_dir import app_data_dir
-from lib.asset_types import ASSET_SPECS, validate_asset_name
+from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
 from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
 from lib.episode_paths import episode_script_relpath
 from lib.json_io import atomic_write_json, load_json, load_json_or_none
@@ -949,10 +949,11 @@ class ProjectManager:
         """更新角色设计图路径"""
         # 资产回写热路径：只动运行时字段，结构不可能因此变坏，豁免结构校验。
         with self.locked_script(project_name, script_filename, validate=False) as script:
-            if name not in script["characters"]:
+            key = resolve_asset_key(script.get("characters"), name)
+            if key is None:
                 # 在锁内抛出，locked_script 跳过写回
                 raise KeyError(f"角色 '{name}' 不存在")
-            script["characters"][name]["character_sheet"] = sheet_path
+            script["characters"][key]["character_sheet"] = sheet_path
         return script
 
     # ==================== 数据结构标准化 ====================
@@ -1719,7 +1720,8 @@ class ProjectManager:
         def _mutate(project):
             nonlocal added
             bucket = project.setdefault(spec.bucket_key, {})
-            if name in bucket:
+            # 存量 key 可能是 NFD，按坐标系解析后判冲突，避免视觉同名的第二条资产
+            if resolve_asset_key(bucket, name) is not None:
                 logger.debug("%s '%s' 已存在于 project.json，跳过", spec.label_zh, name)
                 return
             bucket[name] = entry
@@ -1737,8 +1739,9 @@ class ProjectManager:
         的 lost-update 竞态。
         """
         spec = ASSET_SPECS[asset_type]
-        # 与 upsert_assets 同口径：strip 后等价的 key（{"李白", "  李白  "}）不允许静默
-        # 互相覆盖，整批 fail-loud 不落盘，让调用方感知 collision 并去重。
+        # 与 upsert_assets 同口径：规范化（strip + NFC）后等价的 key（{"李白", "  李白  "}
+        # 或 NFC/NFD 双形态）不允许静默互相覆盖，整批 fail-loud 不落盘，让调用方感知
+        # collision 并去重。
         normalized_entries: dict[str, dict] = {}
         raw_keys_by_normalized: dict[str, str] = {}
         for raw_name, entry in entries.items():
@@ -1746,7 +1749,7 @@ class ProjectManager:
             if name in normalized_entries:
                 raise ValueError(
                     f"{spec.bucket_key} 的 entries 含规范化后冲突的 name {name!r}："
-                    f"原始键 {raw_keys_by_normalized[name]!r} 与 {raw_name!r} 在 strip 后等价"
+                    f"原始键 {raw_keys_by_normalized[name]!r} 与 {raw_name!r} 在规范化（strip + NFC）后等价"
                 )
             normalized_entries[name] = entry
             raw_keys_by_normalized[name] = raw_name
@@ -1757,7 +1760,7 @@ class ProjectManager:
             nonlocal added
             bucket = project.setdefault(spec.bucket_key, {})
             for name, entry in entries.items():
-                if name in bucket:
+                if resolve_asset_key(bucket, name) is not None:
                     logger.debug("%s '%s' 已存在，跳过", spec.label_zh, name)
                     continue
                 bucket[name] = entry
@@ -1796,11 +1799,11 @@ class ProjectManager:
             raise ValueError(f"entries 必须是对象（dict），当前为 {type(entries).__name__}")
         if not entries:
             raise ValueError("entries 不能为空（至少需要一个 name → attrs 条目）")
-        # 规范化 name：strip 空白后非空，且须是路径安全的单段组件（validate_asset_name，
+        # 规范化 name：strip + NFC 后非空，且须是路径安全的单段组件（validate_asset_name，
         # 名称会被拼进文件路径与单段路由参数）。agent 误传 "  李白  " 这种带空格的 name 会让
         # 后续按 name 索引查找（角色生成等）因空格差异 mismatch。非法 name fail-loud。
-        # 同时检测 strip 后冲突：{"李白": {...}, "  李白  ": {...}} 规范化后 key 相同 →
-        # 后者会 silent overwrite 前者；fail-loud 让 agent 明确感知 collision 并去重。
+        # 同时检测规范化后冲突：{"李白": {...}, "  李白  ": {...}} 或 NFC/NFD 双形态规范化后
+        # key 相同 → 后者会 silent overwrite 前者；fail-loud 让 agent 明确感知 collision 并去重。
         normalized_entries: dict[str, dict] = {}
         raw_keys_by_normalized: dict[str, str] = {}
         for raw_name, attrs in entries.items():
@@ -1813,7 +1816,7 @@ class ProjectManager:
             if name in normalized_entries:
                 raise ValueError(
                     f"{table} 的 entries 含规范化后冲突的 name {name!r}："
-                    f"原始键 {raw_keys_by_normalized[name]!r} 与 {raw_name!r} 在 strip 后等价"
+                    f"原始键 {raw_keys_by_normalized[name]!r} 与 {raw_name!r} 在规范化（strip + NFC）后等价"
                 )
             normalized_entries[name] = attrs
             raw_keys_by_normalized[name] = raw_name
@@ -1868,7 +1871,9 @@ class ProjectManager:
                 # 给出意外类型与 offending key（mutation 物理上无法对非 dict 施加，与「不更坏」无关）。
                 raise ValueError(f"project[{spec.bucket_key!r}] 必须是对象，当前为 {type(bucket).__name__}")
             for name, attrs in cleaned.items():
-                existing = isinstance(bucket.get(name), dict)
+                # 存量 entry 的 key 可能是 NFD：解析真实 key 就地更新，而非按 NFC 名新建第二条
+                key = resolve_asset_key(bucket, name) or name
+                existing = isinstance(bucket.get(key), dict)
                 # 仅对已存在 entry 检测 no-op:全字段被白名单/legacy strip 丢空时 update({})
                 # 实际不变,归到 noop 而非 merged 避免「合并 1 个」误报。新 entry 即使
                 # cleaned 空也仍走 _build_asset_entry,让 description 缺失的 validator 拒写
@@ -1877,10 +1882,10 @@ class ProjectManager:
                     noop.append(name)
                     continue
                 if existing:
-                    bucket[name].update(attrs)  # 改：合并字段，保留 sheet 路径等既有字段
+                    bucket[key].update(attrs)  # 改：合并字段，保留 sheet 路径等既有字段
                     merged.append(name)
                 else:
-                    bucket[name] = self._build_asset_entry(asset_type, attrs.get("description", ""), attrs)
+                    bucket[key] = self._build_asset_entry(asset_type, attrs.get("description", ""), attrs)
                     added.append(name)
             after_errors = set(validator.validate_project_payload(project).errors)
             # 「不更坏」按 error set diff 判定：after 不应比 before 多任何 errors。
@@ -1922,9 +1927,10 @@ class ProjectManager:
 
         def _mutate(project):
             bucket = project.get(spec.bucket_key)
-            if bucket is None or name not in bucket:
+            key = resolve_asset_key(bucket, name)
+            if not isinstance(bucket, dict) or key is None:
                 raise KeyError(f"{spec.label_zh} '{name}' 不存在")
-            bucket[name][spec.sheet_field] = sheet_path
+            bucket[key][spec.sheet_field] = sheet_path
 
         return self.update_project(project_name, _mutate)
 
@@ -1933,9 +1939,10 @@ class ProjectManager:
         spec = ASSET_SPECS[asset_type]
         project = self.load_project(project_name)
         bucket = project.get(spec.bucket_key)
-        if bucket is None or name not in bucket:
+        key = resolve_asset_key(bucket, name)
+        if not isinstance(bucket, dict) or key is None:
             raise KeyError(f"{spec.label_zh} '{name}' 不存在")
-        return bucket[name]
+        return bucket[key]
 
     def _get_pending_assets(self, asset_type: str, project_name: str) -> list[dict]:
         """无 sheet 字段或 sheet 文件不存在的资产列表。"""
@@ -1980,7 +1987,10 @@ class ProjectManager:
         name = validate_asset_name(name)
 
         def _mutate(project: dict) -> None:
-            project["characters"][name] = {
+            bucket = project["characters"]
+            # 覆盖写也要落在存量真实 key 上（可能是 NFD），否则会残留视觉同名的旧条目
+            key = resolve_asset_key(bucket, name) or name
+            bucket[key] = {
                 "description": description,
                 "voice_style": voice_style or "",
                 "character_sheet": character_sheet or "",
@@ -2006,9 +2016,10 @@ class ProjectManager:
         """
 
         def _mutate(project: dict) -> None:
-            if "characters" not in project or char_name not in project["characters"]:
+            key = resolve_asset_key(project.get("characters"), char_name)
+            if key is None:
                 raise KeyError(f"角色 '{char_name}' 不存在")
-            project["characters"][char_name]["reference_image"] = ref_path
+            project["characters"][key]["reference_image"] = ref_path
 
         return self.update_project(project_name, _mutate)
 
@@ -2034,10 +2045,11 @@ class ProjectManager:
         """
 
         def _mutate(project: dict) -> None:
-            if "characters" not in project or char_name not in project["characters"]:
+            key = resolve_asset_key(project.get("characters"), char_name)
+            if key is None:
                 raise KeyError(f"角色 '{char_name}' 不存在")
-            project["characters"][char_name]["reference_audio"] = ref_path
-            project["characters"][char_name]["voice_updated_at"] = datetime.now(UTC).isoformat()
+            project["characters"][key]["reference_audio"] = ref_path
+            project["characters"][key]["voice_updated_at"] = datetime.now(UTC).isoformat()
 
         return self.update_project(project_name, _mutate)
 
@@ -2111,9 +2123,10 @@ class ProjectManager:
 
         def _mutate(project: dict) -> None:
             bucket = project.get("products")
-            if bucket is None or product_name not in bucket:
+            key = resolve_asset_key(bucket, product_name)
+            if not isinstance(bucket, dict) or key is None:
                 raise KeyError(f"产品 '{product_name}' 不存在")
-            refs = bucket[product_name].setdefault("reference_images", [])
+            refs = bucket[key].setdefault("reference_images", [])
             if not isinstance(refs, list):
                 raise ValueError(
                     f"products['{product_name}'].reference_images 必须是列表，当前为 {type(refs).__name__}"

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -26,7 +26,13 @@ from pydantic import BaseModel, Field
 
 from lib.agent_profile import agent_profile_dir
 from lib.app_data_dir import app_data_dir
-from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
+from lib.asset_types import (
+    ASSET_SPECS,
+    normalize_asset_bucket,
+    normalize_asset_name,
+    resolve_asset_key,
+    validate_asset_name,
+)
 from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
 from lib.episode_paths import episode_script_relpath
 from lib.json_io import atomic_write_json, load_json, load_json_or_none
@@ -2215,14 +2221,20 @@ class ProjectManager:
 
         Returns:
             参考图路径列表
+
+        剧本里的资产名与资产桶 key 可能是 NFC/NFD 中的任一形态（登记闸口落 NFC，存量剧本
+        与桶均无需迁移），索引前按 ``lib.asset_types`` 的比对坐标系归一。
         """
         project = self.load_project(project_name)
         project_dir = self.get_project_path(project_name)
         refs = []
 
+        characters = normalize_asset_bucket(project.get("characters"))
+        props = normalize_asset_bucket(project.get("props"))
+
         # 角色参考图
         for char in scene.get("characters_in_scene", []):
-            char_data = project["characters"].get(char, {})
+            char_data = characters.get(normalize_asset_name(char), {})
             sheet = char_data.get("character_sheet")
             if sheet:
                 sheet_path = project_dir / sheet
@@ -2231,7 +2243,7 @@ class ProjectManager:
 
         # 道具参考图
         for prop in scene.get("props_in_scene", []):
-            prop_data = project.get("props", {}).get(prop, {})
+            prop_data = props.get(normalize_asset_name(prop), {})
             sheet = prop_data.get("prop_sheet")
             if sheet:
                 sheet_path = project_dir / sheet

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -10,6 +10,7 @@ from typing import Any, get_args
 
 import yaml
 
+from lib.asset_types import normalize_asset_bucket, normalize_asset_name
 from lib.script_models import CameraMotion, ShotType
 
 logger = logging.getLogger(__name__)
@@ -170,19 +171,24 @@ def _build_voice_profiles(dialogue: list[dict[str, str]], characters: dict[str, 
     出现的顺序去重）；speaker 未命中角色资产或资产 ``voice_style`` 为空，静默跳过
     （不建面向用户的提示通道，调用方按需记 logger）。
 
+    speaker 与角色表 key 可能是 NFC/NFD 中的任一形态（存量剧本/桶无需迁移），按
+    ``lib.asset_types`` 的比对坐标系归一后索引与去重，``Speaker`` 展示值保留 dialogue 原文。
+
     ``characters`` 来自明文 project.json，用户手编或外部脚本可能写成非 dict，逐层做类型
     收窄而非直接下标（同 ``lib.config.resolver._safe_dict`` 的取向）。
     """
-    if not isinstance(characters, dict):
-        return []
+    characters = normalize_asset_bucket(characters)
     seen: set[str] = set()
     profiles: list[dict[str, str]] = []
     for entry in dialogue:
         speaker = entry.get("speaker") if isinstance(entry, dict) else None
-        if not isinstance(speaker, str) or not speaker or speaker in seen:
+        if not isinstance(speaker, str) or not speaker:
             continue
-        seen.add(speaker)
-        character = characters.get(speaker)
+        speaker_key = normalize_asset_name(speaker)
+        if speaker_key in seen:
+            continue
+        seen.add(speaker_key)
+        character = characters.get(speaker_key)
         if not isinstance(character, dict):
             logger.debug("Voice_Profiles 跳过：speaker %r 未命中角色资产", speaker)
             continue

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from claude_agent_sdk import tool
 
-from lib.asset_types import ASSET_SPECS, AssetSpec
+from lib.asset_types import ASSET_SPECS, AssetSpec, resolve_asset_key
 from lib.generation_queue_client import (
     TaskSpec,
     batch_enqueue_and_wait,
@@ -47,16 +47,18 @@ def _build_specs(
     if names:
         resolved: list[str] = []
         for name in names:
-            if name not in assets_dict:
+            # 调用方给的名字与桶 key 可能是 NFC/NFD 中的任一形态，按坐标系解析真实落盘 key
+            key = resolve_asset_key(assets_dict, name)
+            if key is None:
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 不存在于 project.json 中，跳过")
                 continue
             # 仅当 description 是非空字符串才入队；空白 / 非字符串（dict、数字等）
             # 都告警跳过，避免漏到 from_request 抛错或 .strip() 抛 AttributeError 而中断整批。
-            desc = assets_dict[name].get("description")
+            desc = assets_dict[key].get("description")
             if not (isinstance(desc, str) and desc.strip()):
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 缺少描述，跳过")
                 continue
-            resolved.append(name)
+            resolved.append(key)
     else:
         pending = _get_pending(pm, project_name, asset_type)
         resolved = []

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -46,12 +46,18 @@ def _build_specs(
 
     if names:
         resolved: list[str] = []
+        # 调用方侧的保序去重只按原始字符串，同一资产的 NFC/NFD 两种拼写会各留一份；
+        # 解析到同一个真实 key 后在此二次去重，避免同一资产入两次队、重复产出版本。
+        seen_keys: set[str] = set()
         for name in names:
             # 调用方给的名字与桶 key 可能是 NFC/NFD 中的任一形态，按坐标系解析真实落盘 key
             key = resolve_asset_key(assets_dict, name)
             if key is None:
                 warnings.append(f"⚠️  {spec.label_zh} '{name}' 不存在于 project.json 中，跳过")
                 continue
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
             # 仅当 description 是非空字符串才入队；空白 / 非字符串（dict、数字等）
             # 都告警跳过，避免漏到 from_request 抛错或 .strip() 抛 AttributeError 而中断整批。
             desc = assets_dict[key].get("description")

--- a/server/routers/_asset_router_factory.py
+++ b/server/routers/_asset_router_factory.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
 
 from lib.api_errors import NotFoundError
-from lib.asset_types import ASSET_SPECS, validate_asset_name
+from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
 from lib.i18n import Translator
 from lib.project_change_hints import project_change_source
 from lib.project_manager import ProjectManager
@@ -191,9 +191,10 @@ def build_asset_router(
 
                 def _mutate(project):
                     bucket = project.get(spec.bucket_key) or {}
-                    if entry_name not in bucket:
+                    key = resolve_asset_key(bucket, entry_name)
+                    if key is None:
                         raise KeyError(entry_name)
-                    entry = bucket[entry_name]
+                    entry = bucket[key]
                     for field in (*update_fields, *update_list_fields):
                         if req.get(field) is not None:
                             # voice_notice_dismissed_at 语义是「已确认到的声音版本」，必须原样
@@ -240,9 +241,10 @@ def build_asset_router(
 
                 def _mutate(project):
                     bucket = project.get(spec.bucket_key) or {}
-                    if entry_name not in bucket:
+                    key = resolve_asset_key(bucket, entry_name)
+                    if key is None:
                         raise KeyError(entry_name)
-                    del bucket[entry_name]
+                    del bucket[key]
 
                 with project_change_source("webui"):
                     manager.update_project(project_name, _mutate)

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -15,7 +15,15 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
 from lib.api_errors import NotFoundError
-from lib.asset_types import BUCKET_KEY, GLOBAL_LIBRARY_ASSET_TYPES, SHEET_KEY, localize_asset_type, validate_asset_name
+from lib.asset_types import (
+    BUCKET_KEY,
+    GLOBAL_LIBRARY_ASSET_TYPES,
+    SHEET_KEY,
+    localize_asset_type,
+    normalize_asset_name,
+    resolve_asset_key,
+    validate_asset_name,
+)
 from lib.db import async_session_factory
 from lib.db.repositories.asset_repo import AssetRepository
 from lib.i18n import Translator
@@ -264,7 +272,9 @@ async def from_project(
     # 3) 从对应 bucket 中读取资源
     bucket_key = BUCKET_KEY[req.resource_type]
     bucket = project.get(bucket_key) or {}
-    resource = bucket.get(req.resource_id)
+    # 存量 key 与请求名可能是 NFC/NFD 中的任一形态，按坐标系解析
+    resource_key = resolve_asset_key(bucket, req.resource_id)
+    resource = bucket.get(resource_key) if resource_key is not None else None
     if resource is None:
         raise HTTPException(
             status_code=404,
@@ -455,8 +465,11 @@ async def apply_to_project(
     # 4) 先在内存里算好每条 asset 的目标名 + 是否需要拷贝文件，
     #    再一次性执行文件拷贝和 project.json 写回
     project_dir = project_manager.get_project_path(req.target_project)
-    # 按 bucket 维护一份"已占用的名字"集合，用于 rename 策略的累积冲突检查
-    bucket_names: dict[str, set[str]] = {bk: set((project.get(bk) or {}).keys()) for bk in BUCKET_KEY.values()}
+    # 按 bucket 维护一份"已占用的名字"集合（NFC 坐标系，存量 key 可能是 NFD），
+    # 用于冲突判定与 rename 策略的累积冲突检查
+    bucket_names: dict[str, set[str]] = {
+        bk: {normalize_asset_name(str(k)) for k in (project.get(bk) or {})} for bk in BUCKET_KEY.values()
+    }
     plans: list[dict] = []
     for asset_id in req.asset_ids:
         a = assets_by_id.get(asset_id)
@@ -478,10 +491,12 @@ async def apply_to_project(
                 skipped.append({"id": a.id, "name": a.name})
                 continue
             if req.conflict_policy == "rename":
+                # 基名用校验后的 desired_name（NFC），与 names 集合同坐标系，DB 原文可能是 NFD
+                base_name = desired_name
                 i = 2
-                while f"{a.name} ({i})" in names:
+                while f"{base_name} ({i})" in names:
                     i += 1
-                desired_name = f"{a.name} ({i})"
+                desired_name = f"{base_name} ({i})"
             # overwrite: 保留原名，后续覆盖
 
         # 规划图片拷贝
@@ -586,7 +601,9 @@ async def apply_to_project(
                 payload[sk] = ts
             if bk not in data or not isinstance(data.get(bk), dict):
                 data[bk] = {}
-            data[bk][name_] = payload
+            # overwrite 策略要落在存量真实 key 上（可能是 NFD），否则会并存两条视觉同名条目
+            key = resolve_asset_key(data[bk], name_) or name_
+            data[bk][key] = payload
 
     if plans:
         project_manager.update_project(req.target_project, _apply_all)

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, Body, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, PlainTextResponse
 
 from lib.api_errors import NotFoundError
-from lib.asset_types import ASSET_SPECS, GLOBAL_LIBRARY_ASSET_TYPES, validate_asset_name
+from lib.asset_types import ASSET_SPECS, GLOBAL_LIBRARY_ASSET_TYPES, resolve_asset_key, validate_asset_name
 from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
@@ -362,9 +362,9 @@ async def upload_file(
             stale_audio_path: Path | None = None
             if spec.tracks_stale_audio and name:
                 # 实际删除推迟到新文件与字段写入成功之后（见 discard_stale_reference_audio）。
-                old_audio = (manager.load_project(project_name).get("characters", {}).get(name, {})).get(
-                    "reference_audio"
-                )
+                characters = manager.load_project(project_name).get("characters", {})
+                char_key = resolve_asset_key(characters, name)
+                old_audio = (characters.get(char_key, {}) if char_key else {}).get("reference_audio")
                 stale_audio_path = resolve_stale_reference_audio(
                     project_dir, target_dir, old_audio, target_dir / filename
                 )
@@ -418,7 +418,9 @@ async def delete_character_reference_audio(project_name: str, name: str, _t: Tra
             manager = get_project_manager()
             project_dir = manager.get_project_path(project_name)
             project = manager.load_project(project_name)
-            character = (project.get("characters") or {}).get(name)
+            characters = project.get("characters") or {}
+            char_key = resolve_asset_key(characters, name)
+            character = characters.get(char_key) if char_key else None
             if character is None:
                 raise HTTPException(status_code=404, detail=_t("character_not_found", name=name))
 

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -322,7 +322,8 @@ async def upload_file(
 
             if spec.host_bucket is not None:
                 hosts = manager.load_project(project_name).get(spec.host_bucket) or {}
-                if not name or name not in hosts:
+                # name 已经过 validate_asset_name 落到 NFC，存量宿主 key 可能是 NFD，按坐标系解析存在性
+                if not name or resolve_asset_key(hosts, name) is None:
                     raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name or ""))
 
             target_dir = project_dir.joinpath(*spec.subdir)

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -631,19 +631,21 @@ async def _enqueue_asset_generation(
     spec = ASSET_SPECS[asset_type]
     keys = _ASSET_GENERATE_I18N[asset_type]
 
-    def _sync():
+    def _sync() -> str:
         project = get_project_manager().load_project(project_name)
-        # load_project 读时不校验 bucket 结构：project.json 存在显式 null 时
-        # get(key, {}) 仍返回 None，`not in None` 会抛 TypeError → 500，故用 `or {}` 兜底
-        if resource_name not in (project.get(spec.bucket_key) or {}):
+        # 存量 key 可能是 NFD，按坐标系解析存在性并取真实落盘 key；
+        # 非 dict / 显式 null 的畸形桶由 resolve_asset_key 按空桶处理
+        resolved = resolve_asset_key(project.get(spec.bucket_key), resource_name)
+        if resolved is None:
             raise NotFoundError(keys["not_found"], name=resource_name)
+        return resolved
 
-    await asyncio.to_thread(_sync)
+    resource_key = await asyncio.to_thread(_sync)
 
     task_spec = TaskSpec.from_request(
         task_type=asset_type,
         media_type="image",
-        resource_id=resource_name,
+        resource_id=resource_key,
         prompt=prompt,
     )
 

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from lib.api_errors import BadRequestError, ConflictError, NotFoundError
-from lib.asset_types import ASSET_SPECS, validate_asset_name
+from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
 from lib.audio_utils import discard_stale_reference_audio, resolve_stale_reference_audio
 from lib.config.resolver import ConfigResolver, video_bucket_for_generation_mode
 from lib.generation_queue import get_generation_queue
@@ -466,7 +466,8 @@ async def generate_character_voice_sample(
             char_name = validate_asset_name(name)
         except ValueError:
             raise BadRequestError("asset_invalid_name", name=name)
-        if char_name not in (project.get("characters") or {}):
+        # 存量角色 key 可能是 NFD，按坐标系解析存在性
+        if resolve_asset_key(project.get("characters"), char_name) is None:
             raise NotFoundError("character_not_found", name=char_name)
         return project, char_name
 
@@ -538,7 +539,8 @@ async def confirm_character_voice_sample(
     def _sync() -> dict:
         pm_local = get_project_manager()
         project = pm_local.load_project(project_name)
-        if char_name not in (project.get("characters") or {}):
+        char_key = resolve_asset_key(project.get("characters"), char_name)
+        if char_key is None:
             raise NotFoundError("character_not_found", name=char_name)
 
         project_dir = pm_local.get_project_path(project_name)
@@ -552,7 +554,7 @@ async def confirm_character_voice_sample(
         filename = f"{char_name}.wav"
         target_path = refs_audio_dir / filename
 
-        old_audio = ((project.get("characters") or {}).get(char_name) or {}).get("reference_audio")
+        old_audio = ((project.get("characters") or {}).get(char_key) or {}).get("reference_audio")
         stale_audio_path = resolve_stale_reference_audio(project_dir, refs_audio_dir, old_audio, target_path)
 
         target_path.write_bytes(content)

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -266,7 +266,9 @@ async def add_unit(
     req: AddUnitRequest,
     _t: Translator,
 ) -> dict[str, Any]:
-    refs = [r.model_dump() for r in req.references]
+    # 落盘值统一 NFC：请求可能携带 NFD 形态的资产名（macOS 输入法/拖放），持久化前归一，
+    # 与镜头正文（parse_prompt 内 NFC）及前端 mergeReferences 的写回口径一致
+    refs = [{**r.model_dump(), "name": normalize_asset_name(r.name)} for r in req.references]
 
     # 时长是 unit 级单一真相：请求未给出时按项目能力解析默认档位（异步 IO 不进项目锁临界区）
     duration_seconds = req.duration_seconds
@@ -332,8 +334,12 @@ async def patch_unit(
     req: PatchUnitRequest,
     _t: Translator,
 ) -> dict[str, Any]:
-    # references 存在性校验在解析器内、项目锁内进行，失败 raise 400
-    refs: list[dict] | None = [r.model_dump() for r in req.references] if req.references is not None else None
+    # references 存在性校验在解析器内、项目锁内进行，失败 raise 400；落盘值统一 NFC（同 add_unit）
+    refs: list[dict] | None = (
+        [{**r.model_dump(), "name": normalize_asset_name(r.name)} for r in req.references]
+        if req.references is not None
+        else None
+    )
 
     with _locked_episode_script(
         project_name, _episode_script_resolver(episode, _t, refs, require_ad=False), _t

--- a/server/routers/reference_videos.py
+++ b/server/routers/reference_videos.py
@@ -259,6 +259,15 @@ async def derive_units(
     return {"units": units}
 
 
+def _normalized_refs(references: list[Any]) -> list[dict]:
+    """把请求里的 reference 条目转成落盘 dict，资产名统一归一到 NFC。
+
+    请求可能携带 NFD 形态的资产名（macOS 输入法/拖放），持久化前归一，与镜头正文
+    （parse_prompt 内 NFC）及前端 mergeReferences 的写回口径一致。
+    """
+    return [{**r.model_dump(), "name": normalize_asset_name(r.name)} for r in references]
+
+
 @router.post("/episodes/{episode}/units", status_code=status.HTTP_201_CREATED)
 async def add_unit(
     project_name: str,
@@ -266,9 +275,7 @@ async def add_unit(
     req: AddUnitRequest,
     _t: Translator,
 ) -> dict[str, Any]:
-    # 落盘值统一 NFC：请求可能携带 NFD 形态的资产名（macOS 输入法/拖放），持久化前归一，
-    # 与镜头正文（parse_prompt 内 NFC）及前端 mergeReferences 的写回口径一致
-    refs = [{**r.model_dump(), "name": normalize_asset_name(r.name)} for r in req.references]
+    refs = _normalized_refs(req.references)
 
     # 时长是 unit 级单一真相：请求未给出时按项目能力解析默认档位（异步 IO 不进项目锁临界区）
     duration_seconds = req.duration_seconds
@@ -334,12 +341,8 @@ async def patch_unit(
     req: PatchUnitRequest,
     _t: Translator,
 ) -> dict[str, Any]:
-    # references 存在性校验在解析器内、项目锁内进行，失败 raise 400；落盘值统一 NFC（同 add_unit）
-    refs: list[dict] | None = (
-        [{**r.model_dump(), "name": normalize_asset_name(r.name)} for r in req.references]
-        if req.references is not None
-        else None
-    )
+    # references 存在性校验在解析器内、项目锁内进行，失败 raise 400
+    refs: list[dict] | None = _normalized_refs(req.references) if req.references is not None else None
 
     with _locked_episode_script(
         project_name, _episode_script_resolver(episode, _t, refs, require_ad=False), _t

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -218,8 +218,11 @@ def _collect_sheet_references(
     Returns (list of ``{"image": Path, "label": 资产名}`` dicts, set of relative
     sheet strings for dedup). If *max_count* > 0 collection stops after that many images.
 
-    label 取 project.json 中的资产名，与 prompt 里的专名严格一致——供支持内联标签的
+    label 取剧本条目里的资产名，与 prompt 里的专名严格一致——供支持内联标签的
     后端（如 Gemini）把参考图与 prompt 专名显式绑定，不再依赖文件名推断。
+
+    剧本里的资产名与资产桶 key 可能是 NFC/NFD 中的任一形态（登记闸口落 NFC，存量剧本
+    与桶均无需迁移），索引前按 ``lib.asset_types`` 的比对坐标系归一，label 保留剧本原文。
 
     ``char_field`` 为 ``None`` 表示该骨架无逐条角色名单字段（video_units：角色以
     references 条目形态存在），``item.get(None) or []`` 天然跳过角色 sheet 收集。
@@ -227,18 +230,15 @@ def _collect_sheet_references(
     seen: set[str] = set()
     refs: list[dict] = []
 
-    characters = project.get("characters")
-    characters = characters if isinstance(characters, dict) else {}
-    project_scenes = project.get("scenes")
-    project_scenes = project_scenes if isinstance(project_scenes, dict) else {}
-    project_props = project.get("props")
-    project_props = project_props if isinstance(project_props, dict) else {}
+    characters = normalize_asset_bucket(project.get("characters"))
+    project_scenes = normalize_asset_bucket(project.get("scenes"))
+    project_props = normalize_asset_bucket(project.get("props"))
 
     for item in items:
         for char_name in item.get(char_field) or []:
             if not isinstance(char_name, str):
                 continue
-            char_data = characters.get(char_name)
+            char_data = characters.get(normalize_asset_name(char_name))
             sheet = char_data.get("character_sheet") if isinstance(char_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 path = project_path / sheet
@@ -248,7 +248,7 @@ def _collect_sheet_references(
         for scene_name in item.get(scene_field) or []:
             if not isinstance(scene_name, str):
                 continue
-            scene_data = project_scenes.get(scene_name)
+            scene_data = project_scenes.get(normalize_asset_name(scene_name))
             sheet = scene_data.get("scene_sheet") if isinstance(scene_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 path = project_path / sheet
@@ -258,7 +258,7 @@ def _collect_sheet_references(
         for prop_name in item.get(prop_field) or []:
             if not isinstance(prop_name, str):
                 continue
-            prop_data = project_props.get(prop_name)
+            prop_data = project_props.get(normalize_asset_name(prop_name))
             sheet = prop_data.get("prop_sheet") if isinstance(prop_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 path = project_path / sheet
@@ -1375,12 +1375,9 @@ def _collect_grid_reference_images(
     scene_id_set = set(scene_ids)
     matched_items = [item for item in items if str(item.get(id_field, "")) in scene_id_set]
 
-    characters = project.get("characters")
-    characters = characters if isinstance(characters, dict) else {}
-    project_scenes = project.get("scenes")
-    project_scenes = project_scenes if isinstance(project_scenes, dict) else {}
-    project_props = project.get("props")
-    project_props = project_props if isinstance(project_props, dict) else {}
+    characters = normalize_asset_bucket(project.get("characters"))
+    project_scenes = normalize_asset_bucket(project.get("scenes"))
+    project_props = normalize_asset_bucket(project.get("props"))
 
     seen: set[str] = set()
     paths: list[Path] = []
@@ -1391,7 +1388,7 @@ def _collect_grid_reference_images(
         for char_name in item.get(char_field) or []:
             if not isinstance(char_name, str):
                 continue
-            char_data = characters.get(char_name)
+            char_data = characters.get(normalize_asset_name(char_name))
             sheet = char_data.get("character_sheet") if isinstance(char_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 p = project_path / sheet
@@ -1402,7 +1399,7 @@ def _collect_grid_reference_images(
         for scene_name in item.get(scene_field) or []:
             if not isinstance(scene_name, str):
                 continue
-            scene_data = project_scenes.get(scene_name)
+            scene_data = project_scenes.get(normalize_asset_name(scene_name))
             sheet = scene_data.get("scene_sheet") if isinstance(scene_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 p = project_path / sheet
@@ -1413,7 +1410,7 @@ def _collect_grid_reference_images(
         for prop_name in item.get(prop_field) or []:
             if not isinstance(prop_name, str):
                 continue
-            prop_data = project_props.get(prop_name)
+            prop_data = project_props.get(normalize_asset_name(prop_name))
             sheet = prop_data.get("prop_sheet") if isinstance(prop_data, dict) else None
             if isinstance(sheet, str) and sheet and sheet not in seen:
                 p = project_path / sheet

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -10,7 +10,13 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-from lib.asset_types import ASSET_SPECS, normalize_asset_bucket, normalize_asset_name, validate_asset_name
+from lib.asset_types import (
+    ASSET_SPECS,
+    normalize_asset_bucket,
+    normalize_asset_name,
+    resolve_asset_key,
+    validate_asset_name,
+)
 from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
@@ -831,7 +837,7 @@ async def execute_character_voice_sample_task(
         raise ValueError("voice sample 任务需要 task_id")
 
     project = await asyncio.to_thread(get_project_manager().load_project, project_name)
-    if character_name not in project.get("characters", {}):
+    if resolve_asset_key(project.get("characters"), character_name) is None:
         # 与 execute_character_task 等其它执行器同口径：入队后、worker 取到任务前角色可能
         # 已被删除，执行前重新核实存在，避免花钱合成一段没有归属的孤儿预览。
         raise ValueError(f"character not found: {character_name}")
@@ -1131,9 +1137,10 @@ async def execute_character_task(
     def _prepare_char():
         _project = get_project_manager().load_project(project_name)
         _project_path = get_project_manager().get_project_path(project_name)
-        if resource_id not in _project.get("characters", {}):
+        _char_key = resolve_asset_key(_project.get("characters"), resource_id)
+        if _char_key is None:
             raise ValueError(f"character not found: {resource_id}")
-        _char_data = _project["characters"][resource_id]
+        _char_data = _project["characters"][_char_key]
         _style = _project.get("style", "")
         _style_desc = _project.get("style_description", "")
         _full_prompt = build_character_prompt(resource_id, prompt, _style, _style_desc)
@@ -1172,7 +1179,10 @@ async def execute_character_task(
 
     def _finalize_char():
         def _set_character_sheet(p: dict) -> None:
-            p["characters"][resource_id]["character_sheet"] = sheet_path
+            key = resolve_asset_key(p.get("characters"), resource_id)
+            if key is None:
+                raise KeyError(f"角色 '{resource_id}' 不存在")
+            p["characters"][key]["character_sheet"] = sheet_path
 
         get_project_manager().update_project(project_name, _set_character_sheet)
         return generator.versions.get_versions("characters", resource_id)["versions"][-1]["created_at"]

--- a/server/services/image_edit_tasks.py
+++ b/server/services/image_edit_tasks.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from lib.asset_types import ASSET_SPECS
+from lib.asset_types import ASSET_SPECS, resolve_asset_key
 from lib.db.base import DEFAULT_USER_ID
 from lib.path_safety import safe_exists
 from lib.resource_paths import resource_relative_path
@@ -67,7 +67,9 @@ def resolve_current_image_rel(
 
     spec = ASSET_SPECS[resource_type]
     bucket = project.get(spec.bucket_key)
-    entry = bucket.get(resource_id) if isinstance(bucket, dict) else None
+    # 请求里的资产名与桶 key 可能是 NFC/NFD 中的任一形态，按坐标系解析真实落盘 key
+    key = resolve_asset_key(bucket, resource_id)
+    entry = bucket.get(key) if isinstance(bucket, dict) and key is not None else None
     if not isinstance(entry, dict):
         raise KeyError(f"{resource_type} not found: {resource_id}")
     sheet = entry.get(spec.sheet_field)
@@ -111,12 +113,17 @@ async def execute_image_edit_task(
         _project = pm.load_project(project_name)
         _project_path = pm.get_project_path(project_name)
         _script = pm.load_script(project_name, str(script_file)) if resource_type == "storyboard" else None
-        _current_rel = resolve_current_image_rel(_project, resource_type, resource_id, _script)
+        # 资产名可能以 NFC/NFD 任一形态传入：先解析出真实落盘 key，之后的版本登记与
+        # canonical 图路径统一按它写，避免同一资产落出两种编码形式的文件与版本记录。
+        _key = resource_id
+        if resource_type != "storyboard":
+            _key = resolve_asset_key(_project.get(ASSET_SPECS[resource_type].bucket_key), resource_id) or resource_id
+        _current_rel = resolve_current_image_rel(_project, resource_type, _key, _script)
         if not (_current_rel and safe_exists(_project_path, _current_rel)):
             raise ValueError(f"no current image to edit: {resource_type}/{resource_id}")
-        return _project, _project_path / _current_rel
+        return _project, _project_path / _current_rel, _key
 
-    project, current_image = await asyncio.to_thread(_prepare)
+    project, current_image, resource_key = await asyncio.to_thread(_prepare)
 
     # 编辑必然 i2i：单次解析拿到 generator 与 image lane 产物（provider / backend / resolution）。
     ctx = await resolve_generation_context(
@@ -134,7 +141,7 @@ async def execute_image_edit_task(
     await asyncio.to_thread(
         generator.versions.ensure_current_tracked,
         version_resource_type,
-        resource_id,
+        resource_key,
         current_image,
         "",
     )
@@ -147,14 +154,14 @@ async def execute_image_edit_task(
     _, version = await generator.generate_image_async(
         prompt=instruction,
         resource_type=version_resource_type,
-        resource_id=resource_id,
+        resource_id=resource_key,
         reference_images=[current_image],
         aspect_ratio=aspect_ratio,
         image_size=image_size,
         source=IMAGE_EDIT_VERSION_SOURCE,
     )
 
-    canonical_rel = resource_relative_path(version_resource_type, resource_id)
+    canonical_rel = resource_relative_path(version_resource_type, resource_key)
 
     def _finalize():
         pm = get_project_manager()
@@ -162,13 +169,13 @@ async def execute_image_edit_task(
             pm.update_scene_asset(
                 project_name=project_name,
                 script_filename=str(script_file),
-                scene_id=resource_id,
+                scene_id=resource_key,
                 asset_type="storyboard_image",
                 asset_path=canonical_rel,
             )
         else:
-            pm._update_asset_sheet(resource_type, project_name, resource_id, canonical_rel)
-        return generator.versions.get_versions(version_resource_type, resource_id)["versions"][-1]["created_at"]
+            pm._update_asset_sheet(resource_type, project_name, resource_key, canonical_rel)
+        return generator.versions.get_versions(version_resource_type, resource_key)["versions"][-1]["created_at"]
 
     created_at = await asyncio.to_thread(_finalize)
 
@@ -177,5 +184,5 @@ async def execute_image_edit_task(
         "file_path": canonical_rel,
         "created_at": created_at,
         "resource_type": version_resource_type,
-        "resource_id": resource_id,
+        "resource_id": resource_key,
     }

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -36,6 +36,22 @@ ARCHIVE_SCRIPT_SCHEMA_VERSION = 2
 DEFAULT_IMPORT_FILENAME = "imported-project.zip"
 
 
+def _resolve_existing_asset(name: str, candidates: set[str]) -> str:
+    """把剧本里的资产名解析为 *candidates* 中等价的真实名字；未命中原样返回。
+
+    导入的剧本与 project.json 可以各自是 NFC/NFD 中的任一形态（登记闸口落 NFC，
+    存量归档不迁移），按 ``lib.asset_types`` 的比对坐标系解析后才判得准成员关系：
+    否则修复期会给已登记的资产补一条视觉同名的占位定义，或对其报 blocking 缺失。
+    """
+    if name in candidates:
+        return name
+    canonical = normalize_asset_name(name)
+    for candidate in candidates:
+        if normalize_asset_name(candidate) == canonical:
+            return candidate
+    return name
+
+
 @dataclass(frozen=True)
 class ArchiveMember:
     info: zipfile.ZipInfo
@@ -841,7 +857,9 @@ class ProjectArchiveService:
                 refs = item.get(asset_field)
                 if not isinstance(refs, list):
                     continue
-                missing = sorted({name for name in refs if isinstance(name, str) and name not in pool})
+                missing = sorted(
+                    {name for name in refs if isinstance(name, str) and _resolve_existing_asset(name, pool) not in pool}
+                )
                 if missing:
                     diagnostics.add(
                         "blocking",
@@ -975,8 +993,12 @@ class ProjectArchiveService:
         character_name: str,
         diagnostics: ArchiveDiagnostics,
     ) -> bool:
-        """为缺失的角色引用补占位定义，返回是否改动 project_payload。"""
-        if character_name in project_characters:
+        """为缺失的角色引用补占位定义，返回是否改动 project_payload。
+
+        成员判定经 :func:`_resolve_existing_asset`：已登记角色的另一种编码形式不再被
+        当作缺失补进第二条占位定义（后写入胜出会盖掉真实的 sheet / 配音元数据）。
+        """
+        if _resolve_existing_asset(character_name, project_characters) in project_characters:
             return False
         project_payload.setdefault("characters", {})
         if not isinstance(project_payload.get("characters"), dict):
@@ -1120,23 +1142,12 @@ class ProjectArchiveService:
         与 narration/drama 的 characters/scenes/props 处理对齐——只是引用结构是
         list[{type, name}]。返回是否补过占位角色（即 project_payload 是否改动）。
 
-        引用名（``ref_name``）在别处已归一到 NFC（见 ``lib.asset_types.normalize_asset_name``），
-        registered 集合的 key 仍是落盘原始形式（可能是 NFD）；比对前把 ``ref_name`` 解析回
-        registered 集合里字节形式一致的那个 key，否则会把已登记的资产误判缺失，插入一份
-        重复的占位定义（角色）或产出假阳性阻断诊断（场景/道具）。
+        引用名与 registered 集合的 key 可以是 NFC/NFD 中的任一形态，成员判定一律经
+        :func:`_resolve_existing_asset`，与 narration/drama 分支同口径。
         """
         references = unit.get("references")
         if not isinstance(references, list):
             return False
-
-        def resolve_existing(name: str, candidates: set[str]) -> str:
-            if name in candidates:
-                return name
-            canonical = normalize_asset_name(name)
-            for candidate in candidates:
-                if normalize_asset_name(candidate) == canonical:
-                    return candidate
-            return name
 
         project_changed = False
         missing_scenes: set[str] = set()
@@ -1149,12 +1160,11 @@ class ProjectArchiveService:
                 continue
             ref_type = ref.get("type")
             if ref_type == "character":
-                resolved_name = resolve_existing(ref_name, project_characters)
-                if self._add_placeholder_character(project_payload, project_characters, resolved_name, diagnostics):
+                if self._add_placeholder_character(project_payload, project_characters, ref_name, diagnostics):
                     project_changed = True
-            elif ref_type == "scene" and resolve_existing(ref_name, project_scenes) not in project_scenes:
+            elif ref_type == "scene" and _resolve_existing_asset(ref_name, project_scenes) not in project_scenes:
                 missing_scenes.add(ref_name)
-            elif ref_type == "prop" and resolve_existing(ref_name, project_props) not in project_props:
+            elif ref_type == "prop" and _resolve_existing_asset(ref_name, project_props) not in project_props:
                 missing_props.add(ref_name)
 
         for missing, asset_type, label in (

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1682,6 +1682,27 @@ def test_build_asset_specs_skips_invalid_description(monkeypatch) -> None:
     assert any("Carol" in w for w in warnings)
 
 
+def test_build_asset_specs_resolves_nfd_registered_key() -> None:
+    """智能体给的名字与桶 key 形态可以不同：按坐标系解析后入队，resource_id 用真实落盘 key。"""
+    import unicodedata
+
+    from lib.asset_types import ASSET_SPECS
+    from server.agent_runtime.sdk_tools.enqueue_assets import _build_specs
+
+    name_nfc = unicodedata.normalize("NFC", "Hiếu")
+    name_nfd = unicodedata.normalize("NFD", "Hiếu")
+    bucket = ASSET_SPECS["character"].bucket_key
+
+    class _PM:
+        def load_project(self, _name):
+            return {bucket: {name_nfd: {"description": "存量 NFD 角色"}}}
+
+    warnings: list[str] = []
+    specs = _build_specs(_PM(), "demo", "character", [name_nfc], warnings)  # type: ignore[arg-type]
+    assert [s.resource_id for s in specs] == [name_nfd]
+    assert warnings == []
+
+
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
     """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1702,6 +1702,12 @@ def test_build_asset_specs_resolves_nfd_registered_key() -> None:
     assert [s.resource_id for s in specs] == [name_nfd]
     assert warnings == []
 
+    # 同一资产的两种拼写解析到同一个 key，只入一次队（调用方侧的去重只按原始字符串）
+    warnings = []
+    specs = _build_specs(_PM(), "demo", "character", [name_nfc, name_nfd], warnings)  # type: ignore[arg-type]
+    assert [s.resource_id for s in specs] == [name_nfd]
+    assert warnings == []
+
 
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
     """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import unicodedata
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -217,8 +218,6 @@ def test_patch_unit_rejects_unknown_reference(client: TestClient):
 def test_patch_unit_accepts_nfc_reference_for_nfd_registered_name(client: TestClient):
     """资产以 NFD 形式登记、PATCH 请求携带解析器已归一的 NFC 名字：_validate_references_exist
     须按归一形式比对判「已登记」放行，不能因编码形式不同误判未登记。"""
-    import unicodedata
-
     from server.routers import reference_videos as router_mod
 
     name_nfd = unicodedata.normalize("NFD", "Hiếu")
@@ -241,8 +240,6 @@ def test_patch_unit_accepts_nfc_reference_for_nfd_registered_name(client: TestCl
 def test_unit_references_persisted_as_nfc(client: TestClient):
     """add/patch 落盘的 reference name 统一 NFC：NFD 请求名（macOS 输入法/拖放形态）
     不得以原始编码持久化，否则同一资产在 references 里会出现视觉同名的两种形态。"""
-    import unicodedata
-
     from server.routers import reference_videos as router_mod
 
     name_nfd = unicodedata.normalize("NFD", "Hiếu")

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -237,6 +237,44 @@ def test_patch_unit_accepts_nfc_reference_for_nfd_registered_name(client: TestCl
     assert resp.status_code == 200, resp.text
 
 
+@pytest.mark.integration
+def test_unit_references_persisted_as_nfc(client: TestClient):
+    """add/patch 落盘的 reference name 统一 NFC：NFD 请求名（macOS 输入法/拖放形态）
+    不得以原始编码持久化，否则同一资产在 references 里会出现视觉同名的两种形态。"""
+    import unicodedata
+
+    from server.routers import reference_videos as router_mod
+
+    name_nfd = unicodedata.normalize("NFD", "Hiếu")
+    name_nfc = unicodedata.normalize("NFC", "Hiếu")
+    pm = router_mod.get_project_manager()
+    project = pm.load_project("demo")
+    project["characters"][name_nfd] = {"description": "x"}
+    pm.save_project("demo", project)
+
+    resp = client.post(
+        "/api/v1/projects/demo/reference-videos/episodes/1/units",
+        json={
+            "prompt": "镜头1：推门",
+            "duration_seconds": 3,
+            "references": [{"type": "character", "name": name_nfd}],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    unit = resp.json()["unit"]
+    assert unit["references"] == [{"type": "character", "name": name_nfc}]
+
+    resp = client.patch(
+        f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit['unit_id']}",
+        json={"references": [{"type": "character", "name": name_nfd}, {"type": "character", "name": "张三"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["unit"]["references"] == [
+        {"type": "character", "name": name_nfc},
+        {"type": "character", "name": "张三"},
+    ]
+
+
 def test_patch_unknown_unit_404(client: TestClient):
     resp = client.patch(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9",

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -206,3 +206,19 @@ class TestNfcConvergence:
         chars = pm.load_project("demo")["characters"]
         assert list(chars) == [_NAME_NFD]
         assert chars[_NAME_NFD]["reference_audio"] == "characters/refs_audio/x.wav"
+
+    def test_collect_reference_images_matches_across_forms(self, pm):
+        """剧本里的名字与桶 key 形态可以不同（登记闸口落 NFC，剧本原文未归一）。"""
+        pm.add_character("demo", _NAME_NFD, "desc")
+        sheet = "characters/sheet.png"
+        sheet_path = pm.get_project_path("demo") / sheet
+        sheet_path.parent.mkdir(parents=True, exist_ok=True)
+        sheet_path.write_bytes(b"png")
+
+        def _mutate(project: dict) -> None:
+            project["characters"][_NAME_NFC]["character_sheet"] = sheet
+
+        pm.update_project("demo", _mutate)
+
+        refs = pm.collect_reference_images("demo", {"characters_in_scene": [_NAME_NFD]})
+        assert refs == [sheet_path]

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -7,10 +7,15 @@ versions/{type}/{name}_v{n}_{ts}.png）与 REST 路由的单段路径参数
 无法匹配的 URL（uvicorn 把 %2F 解码回 / 后单段参数 404），因此须在所有创建入口拒绝。
 """
 
+import unicodedata
+
 import pytest
 
-from lib.asset_types import validate_asset_name
+from lib.asset_types import resolve_asset_key, validate_asset_name
 from lib.project_manager import ProjectManager
+
+_NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
+_NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
 
 
 class TestValidateAssetName:
@@ -18,6 +23,32 @@ class TestValidateAssetName:
         assert validate_asset_name("李白") == "李白"
         assert validate_asset_name("  李白  ") == "李白"
         assert validate_asset_name("Mr. Smith-2") == "Mr. Smith-2"
+
+    def test_nfd_input_normalized_to_nfc(self):
+        """登记闸口统一落 NFC：NFD 输入不得以另一种编码形式落盘产生视觉同名的重复资产。"""
+        assert _NAME_NFD != _NAME_NFC
+        assert validate_asset_name(_NAME_NFD) == _NAME_NFC
+        assert validate_asset_name(_NAME_NFC) == _NAME_NFC
+        assert validate_asset_name(f"  {_NAME_NFD}  ") == _NAME_NFC
+
+
+class TestResolveAssetKey:
+    def test_resolves_nfd_registered_key_by_nfc_name(self):
+        bucket = {_NAME_NFD: {"description": "d"}}
+        assert resolve_asset_key(bucket, _NAME_NFC) == _NAME_NFD
+        assert resolve_asset_key(bucket, _NAME_NFD) == _NAME_NFD
+
+    def test_missing_name_returns_none(self):
+        assert resolve_asset_key({"李白": {}}, "杜甫") is None
+
+    def test_malformed_bucket_returns_none(self):
+        assert resolve_asset_key(None, "李白") is None
+        assert resolve_asset_key("not-a-dict", "李白") is None
+
+    def test_duplicate_forms_last_wins(self):
+        # 与 normalize_asset_bucket 的合并方向一致：后写入的胜出
+        bucket = {_NAME_NFC: {"description": "first"}, _NAME_NFD: {"description": "last"}}
+        assert resolve_asset_key(bucket, _NAME_NFC) == _NAME_NFD
 
     @pytest.mark.parametrize(
         "bad",
@@ -125,3 +156,53 @@ class TestProjectManagerCreationEntryPoints:
         result = pm.upsert_assets("demo", "scenes", {"庙宇": {"description": "d"}})
         assert "庙宇" in result["added"]
         assert pm.add_props_batch("demo", {"玉佩": {"description": "d"}}) == 1
+
+
+def _seed_nfd_character(pm: ProjectManager) -> None:
+    """绕过登记闸口直写 NFD key，模拟存量数据（存量无需迁移，读写按坐标系解析）。"""
+
+    def _mutate(project: dict) -> None:
+        project.setdefault("characters", {})[_NAME_NFD] = {"description": "legacy", "voice_style": ""}
+
+    pm.update_project("demo", _mutate)
+
+
+class TestNfcConvergence:
+    def test_add_character_nfd_input_lands_nfc(self, pm):
+        assert pm.add_character("demo", _NAME_NFD, "desc") is True
+        chars = pm.load_project("demo")["characters"]
+        assert _NAME_NFC in chars
+        assert _NAME_NFD not in chars
+
+    def test_add_character_nfc_input_skips_nfd_registered(self, pm):
+        _seed_nfd_character(pm)
+        assert pm.add_character("demo", _NAME_NFC, "desc") is False
+        chars = pm.load_project("demo")["characters"]
+        assert list(chars) == [_NAME_NFD]
+
+    def test_add_batch_rejects_nfc_nfd_collision(self, pm):
+        with pytest.raises(ValueError, match="冲突"):
+            pm.add_scenes_batch("demo", {_NAME_NFC: {"description": "a"}, _NAME_NFD: {"description": "b"}})
+        assert pm.load_project("demo").get("scenes", {}) == {}
+
+    def test_add_batch_nfc_input_skips_nfd_registered(self, pm):
+        _seed_nfd_character(pm)
+        assert pm.add_characters_batch("demo", {_NAME_NFC: {"description": "new"}}) == 0
+        chars = pm.load_project("demo")["characters"]
+        assert list(chars) == [_NAME_NFD]
+        assert chars[_NAME_NFD]["description"] == "legacy"
+
+    def test_upsert_nfc_updates_nfd_registered_entry_in_place(self, pm):
+        _seed_nfd_character(pm)
+        result = pm.upsert_assets("demo", "characters", {_NAME_NFC: {"description": "updated"}})
+        assert result["merged"] == [_NAME_NFC]
+        chars = pm.load_project("demo")["characters"]
+        assert list(chars) == [_NAME_NFD]
+        assert chars[_NAME_NFD]["description"] == "updated"
+
+    def test_update_reference_audio_resolves_nfd_registered_key(self, pm):
+        _seed_nfd_character(pm)
+        pm.update_character_reference_audio("demo", _NAME_NFC, "characters/refs_audio/x.wav")
+        chars = pm.load_project("demo")["characters"]
+        assert list(chars) == [_NAME_NFD]
+        assert chars[_NAME_NFD]["reference_audio"] == "characters/refs_audio/x.wav"

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -50,6 +50,19 @@ class TestResolveAssetKey:
         bucket = {_NAME_NFC: {"description": "first"}, _NAME_NFD: {"description": "last"}}
         assert resolve_asset_key(bucket, _NAME_NFC) == _NAME_NFD
 
+    def test_duplicate_forms_last_wins_after_json_roundtrip(self, tmp_path):
+        """胜出结果由写入顺序决定，落盘再读回后仍一致——JSON 序列化不重排键顺序。"""
+        import json
+
+        bucket = {_NAME_NFC: {"description": "first"}, _NAME_NFD: {"description": "last"}}
+        path = tmp_path / "project.json"
+        path.write_text(json.dumps({"characters": bucket}, ensure_ascii=False), encoding="utf-8")
+
+        reloaded = json.loads(path.read_text(encoding="utf-8"))["characters"]
+        key = resolve_asset_key(reloaded, _NAME_NFC)
+        assert key == _NAME_NFD
+        assert reloaded[key]["description"] == "last"
+
     @pytest.mark.parametrize(
         "bad",
         [

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -4,6 +4,8 @@ scenes/props 的 CRUD 行为由 test_scenes_router / test_props_router 覆盖；
 factory 引入的新能力（character extras + extra='allow' 创建语义）。
 """
 
+import unicodedata
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -17,6 +19,9 @@ from tests.conftest import make_translator
 # 兜底 500 的默认 locale 文案：测试未覆盖 get_translator，端点回落到 DEFAULT_LOCALE("zh")，
 # 与 make_translator() 默认 locale 一致。
 _INTERNAL_ERROR_DETAIL = make_translator()("internal_server_error")
+
+_NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
+_NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
 
 
 class _FakePM:
@@ -326,3 +331,27 @@ class TestAssetRouterNoLeak:
             assert resp.status_code == 500
             assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_delete" not in resp.text
+
+
+class TestNfcConvergence:
+    """PATCH/DELETE 的路径参数与桶 key 形态可以不同：登记闸口落 NFC，存量 key 未迁移。"""
+
+    def test_patch_resolves_across_normalization_forms(self, monkeypatch):
+        client, fake_pm = _client(monkeypatch)
+        fake_pm.projects["demo"]["characters"][_NAME_NFD] = {"name": _NAME_NFD, "description": "legacy"}
+
+        resp = client.patch(f"/api/v1/projects/demo/characters/{_NAME_NFC}", json={"description": "new"})
+
+        assert resp.status_code == 200
+        chars = fake_pm.projects["demo"]["characters"]
+        assert list(chars) == [_NAME_NFD]
+        assert chars[_NAME_NFD]["description"] == "new"
+
+    def test_delete_resolves_across_normalization_forms(self, monkeypatch):
+        client, fake_pm = _client(monkeypatch)
+        fake_pm.projects["demo"]["characters"][_NAME_NFC] = {"name": _NAME_NFC, "description": "d"}
+
+        resp = client.delete(f"/api/v1/projects/demo/characters/{_NAME_NFD}")
+
+        assert resp.status_code == 200
+        assert fake_pm.projects["demo"]["characters"] == {}

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -308,6 +308,83 @@ class TestDataValidator:
         assert any("不存在于 project.json 的场景" in error for error in result.errors)
         assert any("不存在于 project.json 的道具" in error for error in result.errors)
 
+    def test_validate_episode_accepts_nfc_nfd_mismatch_on_narration_segment_refs(self, tmp_path):
+        """segment 的角色/场景/道具引用一律按 NFC 归一比对：登记闸口落 NFC 后，
+        保留原 NFD 拼写的存量剧本仍须放行，否则合法剧本会被判为引用了未登记资产。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+        assert name_nfc != name_nfd
+
+        project = _project_payload("narration")
+        project["characters"] = {name_nfc: {"description": "女主"}}
+        project["scenes"] = {name_nfc: {"description": "场景"}}
+        project["props"] = {name_nfc: {"description": "道具"}}
+
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", project)
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "content_mode": "narration",
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "duration_seconds": 4,
+                        "novel_text": "原文",
+                        "characters_in_segment": [name_nfd],
+                        "scenes": [name_nfd],
+                        "props": [name_nfd],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                    }
+                ],
+            },
+        )
+
+        result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
+        assert result.valid, result.errors
+
+    def test_validate_episode_accepts_nfc_nfd_mismatch_on_drama_scene_refs(self, tmp_path):
+        """drama 场景的三类引用与 narration segment 同口径归一。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+
+        project = _project_payload("drama")
+        project["characters"] = {name_nfc: {"description": "女主"}}
+        project["scenes"] = {name_nfc: {"description": "场景"}}
+        project["props"] = {name_nfc: {"description": "道具"}}
+
+        project_dir = tmp_path / "projects" / "demo"
+        _write_json(project_dir / "project.json", project)
+        _write_json(
+            project_dir / "scripts" / "episode_2.json",
+            {
+                "episode": 2,
+                "title": "第二集",
+                "content_mode": "drama",
+                "scenes": [
+                    {
+                        "scene_id": "E2S01",
+                        "duration_seconds": 8,
+                        "characters_in_scene": [name_nfd],
+                        "scenes": [name_nfd],
+                        "props": [name_nfd],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                    }
+                ],
+            },
+        )
+
+        result = validate_episode("demo", "episode_2.json", projects_root=str(tmp_path / "projects"))
+        assert result.valid, result.errors
+
     @pytest.mark.parametrize("bad_duration", [0, -1, "5", 4.5, True])
     def test_validate_episode_rejects_non_positive_integer_duration(self, tmp_path, bad_duration):
         """非正整数的 duration_seconds 仍应报错（0 / 负数 / 字符串 / 浮点 / bool）。"""

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1169,10 +1169,9 @@ class TestAdEpisodeValidation:
 
     @pytest.mark.integration
     def test_shot_product_reference_accepts_nfc_nfd_mismatch_on_storyboard_path(self, tmp_path):
-        """products_in_shot 的归一比对不随 generation_mode 切换，始终与其收集器
-        （collect_product_references_for_names，无条件归一）同口径——即使在 storyboard
-        路径（默认 generation_mode）下，NFC/NFD 不一致的合法产品名也必须放行，否则
-        校验层会比实际生成时的收集层更严格，挡下收集层其实能解析的产品。"""
+        """products_in_shot 与其收集器（collect_product_references_for_names）同口径归一：
+        NFC/NFD 不一致的合法产品名必须放行，否则校验层比实际生成时的收集层更严格，
+        挡下收集层其实能解析的产品。"""
         import unicodedata
 
         name_nfc = unicodedata.normalize("NFC", "Hiếu")
@@ -1184,11 +1183,10 @@ class TestAdEpisodeValidation:
         assert result.valid, result.errors
 
     @pytest.mark.integration
-    def test_shot_reference_storyboard_path_keeps_raw_comparison(self, tmp_path):
-        """storyboard 路径（默认 generation_mode）保持原始字符串比对：该路径的图片收集
-        （server.services.generation_tasks._collect_sheet_references）仍按原始名称查找，
-        校验层若归一放行、收集层实际查不到，会生成时静默漏收对应 sheet——不能让校验层
-        比收集层更宽松。"""
+    def test_shot_reference_accepts_nfc_nfd_mismatch_on_storyboard_path(self, tmp_path):
+        """storyboard 路径的资产引用同样按 NFC 归一比对：该路径的图片收集
+        （server.services.generation_tasks._collect_sheet_references）归一后索引，校验层
+        若在此原样比对会拒掉收集层其实能解析的合法名字。"""
         import unicodedata
 
         name_nfc = unicodedata.normalize("NFC", "Hiếu")
@@ -1197,8 +1195,7 @@ class TestAdEpisodeValidation:
 
         project = _ad_project_payload(characters={name_nfd: {"description": "出镜模特"}})
         result = self._validate(tmp_path, [self._ad_shot(characters_in_shot=[name_nfc])], project=project)
-        assert not result.valid
-        assert any("characters_in_shot" in e for e in result.errors)
+        assert result.valid, result.errors
 
     def test_missing_duration_warns_with_default(self, tmp_path):
         shot = self._ad_shot()

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -524,6 +524,31 @@ class TestFilesRouter:
             for p in paths:
                 assert (project_dir / p).exists()
 
+    def test_product_ref_upload_resolves_nfd_registered_host(self, tmp_path, monkeypatch):
+        """宿主资产的存量 key 可能是 NFD：上传入口按坐标系解析存在性，
+        否则闸口把 name 归一到 NFC 后会先返回 404，写回侧的解析根本走不到。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+
+        client, pm = _client(monkeypatch, tmp_path)
+
+        def _mutate(project: dict) -> None:
+            project.setdefault("products", {})[name_nfd] = {"description": "存量 NFD 产品"}
+
+        pm.update_project("demo", _mutate)
+
+        with client:
+            resp = client.post(
+                f"/api/v1/projects/demo/upload/product_ref?name={name_nfc}",
+                files={"file": ("x.jpg", _img_bytes("JPEG"), "image/jpeg")},
+            )
+            assert resp.status_code == 200, resp.text
+            products = pm.load_project("demo")["products"]
+            assert name_nfc not in products  # 不因上传新造一条 NFC 产品
+            assert products[name_nfd]["reference_images"] == [resp.json()["path"]]
+
     def test_product_ref_unknown_product_404(self, tmp_path, monkeypatch):
         """原图列表是文件的唯一指针：产品不存在时拒收，避免落下孤儿文件。"""
         client, pm = _client(monkeypatch, tmp_path)

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -440,6 +440,28 @@ class TestGenerateRouter:
             assert call["media_type"] == "image"
             assert call["resource_id"] == "Alice"
 
+    def test_character_enqueue_resolves_nfd_registered_key(self, tmp_path, monkeypatch):
+        """路径参数与桶 key 形态可以不同：登记闸口落 NFC 后，仍须能按 NFD 原文发起生成，
+        且入队的 resource_id 用真实落盘 key，不新造一种编码形式。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"] = {name_nfd: {"description": "存量 NFD 角色"}}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            resp = client.post(
+                f"/api/v1/projects/demo/generate/character/{name_nfc}",
+                json={"prompt": "女主，冷静"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert fake_queue.calls[0]["resource_id"] == name_nfd
+
     def test_scene_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/test_image_edit_executor.py
+++ b/tests/test_image_edit_executor.py
@@ -134,6 +134,18 @@ class TestResolveCurrentImageRel:
         with pytest.raises(KeyError):
             resolve_current_image_rel(project, "character", "不存在")
 
+    def test_asset_sheet_matches_across_nfc_nfd_forms(self):
+        """请求里的资产名与桶 key 形态可以不同（登记闸口落 NFC，存量 key 可能是 NFD）。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+        assert name_nfc != name_nfd
+
+        project = {"characters": {name_nfd: {"character_sheet": "characters/legacy.png"}}}
+        assert resolve_current_image_rel(project, "character", name_nfc) == "characters/legacy.png"
+        assert resolve_current_image_rel(project, "character", name_nfd) == "characters/legacy.png"
+
     def test_storyboard_pointer_and_canonical_fallback(self):
         script = {
             "content_mode": "narration",

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -899,6 +899,57 @@ class TestProjectArchiveService:
         assert any("不存在于 project.json 的场景" in error for error in exc_info.value.errors)
         assert exc_info.value.extra["diagnostics"]["blocking"]
 
+    def test_import_resolves_nfd_script_refs_against_nfc_registered_assets(self, tmp_path):
+        """剧本与 project.json 可以各自是 NFC/NFD：修复期的成员判定按坐标系解析，
+        否则已登记的角色会被补出一份重复占位定义（后写入胜出会盖掉真实元数据），
+        已登记的场景/道具会被误报 blocking 缺失。"""
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        service = ProjectArchiveService(pm)
+
+        project = pm.load_project("demo")
+        project["characters"][name_nfc] = {"description": "已登记角色"}
+        project["scenes"] = {name_nfc: {"description": "已登记场景"}}
+        project["props"][name_nfc] = {"description": "已登记道具"}
+        pm.save_project("demo", project)
+
+        _write_json(
+            project_dir / "scripts" / "episode_1.json",
+            {
+                "episode": 1,
+                "title": "第一集",
+                "content_mode": "narration",
+                "novel": {"title": "Demo", "chapter": "第一章"},
+                "segments": [
+                    {
+                        "segment_id": "E1S01",
+                        "duration_seconds": 4,
+                        "novel_text": "原文",
+                        "characters_in_segment": [name_nfd],
+                        "scenes": [name_nfd],
+                        "props": [name_nfd],
+                        "image_prompt": "img",
+                        "video_prompt": "vid",
+                    }
+                ],
+            },
+        )
+
+        archive_path = tmp_path / "nfc-nfd.zip"
+        _make_manual_zip(project_dir, archive_path)
+        shutil.rmtree(project_dir)
+
+        result = service.import_project_archive(archive_path, uploaded_filename="nfc-nfd.zip")
+
+        imported = pm.load_project(result.project_name)
+        assert name_nfd not in imported["characters"]  # 不补重复占位角色
+        assert not any(item["code"] == "placeholder_character_added" for item in result.diagnostics["auto_fixed"])
+
     def test_import_blocks_missing_prop_definition(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -132,6 +132,28 @@ class TestBuildDramaVideoPrompt:
         prompt = build_drama_video_prompt(carried, [_utterance("王", "嗯")], characters={"王": {"voice_style": "低沉"}})
         assert prompt["voice_profiles"] == [{"Speaker": "王", "Voice_Style": "低沉"}]
 
+    def test_nfd_speaker_hits_nfc_registered_character(self):
+        # speaker 与角色表 key 可能各是 NFC/NFD 中的任一形态（存量数据无需迁移），
+        # 归一后索引须双向命中；Speaker 展示值保留 dialogue 原文
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+        for speaker, registered in ((name_nfd, name_nfc), (name_nfc, name_nfd)):
+            prompt = build_drama_video_prompt(
+                _BASE_PROMPT, [_utterance(speaker, "xin chào")], characters={registered: {"voice_style": "trầm"}}
+            )
+            assert prompt["voice_profiles"] == [{"Speaker": speaker, "Voice_Style": "trầm"}]
+
+    def test_nfc_nfd_same_speaker_deduped_to_one_profile(self):
+        import unicodedata
+
+        name_nfc = unicodedata.normalize("NFC", "Hiếu")
+        name_nfd = unicodedata.normalize("NFD", "Hiếu")
+        utterances = [_utterance(name_nfc, "một"), _utterance(name_nfd, "hai")]
+        prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters={name_nfc: {"voice_style": "trầm"}})
+        assert prompt["voice_profiles"] == [{"Speaker": name_nfc, "Voice_Style": "trầm"}]
+
     def test_speaker_without_matching_character_skipped_silently(self):
         prompt = build_drama_video_prompt(_BASE_PROMPT, [_utterance("路人甲", "喂")], characters={})
         assert "voice_profiles" not in prompt

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 import yaml
 
 from lib.prompt_utils import (
@@ -103,6 +105,9 @@ def _utterance(speaker: str | None, text: str) -> dict[str, object]:
 
 _BASE_PROMPT = {"action": "抬头观察", "camera_motion": "Static", "ambiance_audio": "雨声"}
 
+_NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
+_NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
+
 
 class TestBuildDramaVideoPrompt:
     """两注入点共用的 drama dialogue + Voice_Profiles 出口。"""
@@ -135,24 +140,16 @@ class TestBuildDramaVideoPrompt:
     def test_nfd_speaker_hits_nfc_registered_character(self):
         # speaker 与角色表 key 可能各是 NFC/NFD 中的任一形态（存量数据无需迁移），
         # 归一后索引须双向命中；Speaker 展示值保留 dialogue 原文
-        import unicodedata
-
-        name_nfc = unicodedata.normalize("NFC", "Hiếu")
-        name_nfd = unicodedata.normalize("NFD", "Hiếu")
-        for speaker, registered in ((name_nfd, name_nfc), (name_nfc, name_nfd)):
+        for speaker, registered in ((_NAME_NFD, _NAME_NFC), (_NAME_NFC, _NAME_NFD)):
             prompt = build_drama_video_prompt(
                 _BASE_PROMPT, [_utterance(speaker, "xin chào")], characters={registered: {"voice_style": "trầm"}}
             )
             assert prompt["voice_profiles"] == [{"Speaker": speaker, "Voice_Style": "trầm"}]
 
     def test_nfc_nfd_same_speaker_deduped_to_one_profile(self):
-        import unicodedata
-
-        name_nfc = unicodedata.normalize("NFC", "Hiếu")
-        name_nfd = unicodedata.normalize("NFD", "Hiếu")
-        utterances = [_utterance(name_nfc, "một"), _utterance(name_nfd, "hai")]
-        prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters={name_nfc: {"voice_style": "trầm"}})
-        assert prompt["voice_profiles"] == [{"Speaker": name_nfc, "Voice_Style": "trầm"}]
+        utterances = [_utterance(_NAME_NFC, "một"), _utterance(_NAME_NFD, "hai")]
+        prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters={_NAME_NFC: {"voice_style": "trầm"}})
+        assert prompt["voice_profiles"] == [{"Speaker": _NAME_NFC, "Voice_Style": "trầm"}]
 
     def test_speaker_without_matching_character_skipped_silently(self):
         prompt = build_drama_video_prompt(_BASE_PROMPT, [_utterance("路人甲", "喂")], characters={})


### PR DESCRIPTION
Closes #1616

视觉上同一个资产名可以有两种 Unicode 编码形式（macOS 输入法与文件名拖放天然产生 NFD），此前写入侧不做归一，同一个名字可以各建一条资产；读取侧另有零星比对点未过归一，表现为 drama 配音映射错位。

## 改动

- **写入侧收口**：资产登记闸口 `validate_asset_name` 统一 strip + NFC，覆盖全部登记路径；参考生视频 unit 的 `references` 持久化前同样归一。存量数据的名字保持原样、不迁移。
- **读取侧按归一名解析**：新增 `resolve_asset_key`，把「按名字就地更新/删除/判冲突」的调用点改为先解析出真实落盘 key 再操作，存量资产因此照常匹配、无需迁移。同名多形态的存量条目一律后写入胜出，前后端同向。
- **drama 配音映射**：说话人索引角色表改为归一后比对，另一种编码形式的说话人名不再漏配音；`Voice_Profiles` 的展示值保留台词原文。
- **分镜路线参考图收集**：角色/场景/道具设定图的收集改为按归一名索引，参考图标签保留剧本原文。
- **剧本校验**：资产引用统一按归一名判断是否已登记，不再对分镜路线单独放宽。
- **前端**：参考面板缩略图解析与删除过滤按归一名比对，同名多形态时的取值方向与后端对齐。
- CONTEXT.md 补「资产名坐标系」词条，记录闸口位置、存量不迁移、后写入胜出三条约束。

## 验证

- `uv run python -m pytest` 全量 7820 passed
- `uv run ruff check .`、`uv run basedpyright`（0 error）、`uv run lint-imports` 均通过
- `pnpm lint`、`pnpm check` 通过
- 新增回归测试覆盖：NFD 输入落 NFC、存量另一形态资产的改名/删除/更新命中、drama 配音双向命中与去重、分镜路线参考图跨形态命中、参考生视频 references 落盘形态；这些测试经验证在修复前均失败

## 已知边界

- 全局资产库 DB（`assets` 表）的按名唯一性仍是精确比对，存量行不在本次收敛范围内


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **改进**
  * 统一资产名称的 Unicode 规范化处理，确保不同编码形式的相同名称可被正确识别。
  * 优化资产的新增、更新、删除、引用、生成及文件操作，避免产生重复条目。
  * 保留资产原始展示名称，同时提升特殊字符名称的兼容性。

* **测试**
  * 新增资产名称规范化、冲突处理及跨模块兼容性测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->