### PR TITLE
fix(配置解析): 项目里只填供应商名时不再静默换用其他供应商

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -296,6 +296,21 @@ _TEXT_TIER_SETTING_KEYS: dict[TextTaskTier, str] = {
 }
 
 
+# 文本档位（docs/adr/0051）键位。档位即桶，项目级与全局同名同构，故桶层两侧同键；默认层
+# 两侧同用 default_text_backend。
+_TEXT_LAYERED_KEYS: dict[TextTaskTier, _LayeredBackendKeys] = {
+    tier: _LayeredBackendKeys(
+        media_type="text",
+        parse_fallback=_DEFAULT_TEXT_BACKEND,
+        project_bucket_key=tier_key,
+        project_default_key="default_text_backend",
+        global_bucket_key=tier_key,
+        global_default_key="default_text_backend",
+    )
+    for tier, tier_key in _TEXT_TIER_SETTING_KEYS.items()
+}
+
+
 # 当 resolve_resolution 返回 None 时下游的保底分辨率。Grok 即便 registry 声明 1080p
 # 也可能被 xai_sdk 拒收，故按 provider 区分。
 PROVIDER_FALLBACK_RESOLUTION: dict[str, str] = {
@@ -1476,30 +1491,9 @@ class ConfigResolver:
         task_type: TextTaskType,
         project_name: str | None,
     ) -> tuple[str, str]:
-        tier_key = _TEXT_TIER_SETTING_KEYS[TEXT_TASK_TIERS[task_type]]
-        resolved: tuple[str, str] | None = None
-
-        # 1/2. 项目档位 > 项目默认模型（「项目默认」读作「本项目整体用它」，遮蔽全局配置）
-        if project_name:
-            project = get_project_manager().load_project(project_name)
-            for key in (tier_key, "default_text_backend"):
-                project_val = project.get(key)
-                if project_val and "/" in str(project_val):
-                    resolved = ConfigService._parse_backend(str(project_val), _DEFAULT_TEXT_BACKEND)
-                    break
-
-        # 3/4. 全局档位 > 全局默认模型
-        if resolved is None:
-            for key in (tier_key, "default_text_backend"):
-                global_val = await svc.get_setting(key, "")
-                if global_val and "/" in global_val:
-                    resolved = ConfigService._parse_backend(global_val, _DEFAULT_TEXT_BACKEND)
-                    break
-
-        # 5. 自动推断
-        if resolved is None:
-            resolved = await self._auto_resolve_backend(svc, session, "text")
-
+        project = get_project_manager().load_project(project_name) if project_name else None
+        keys = _TEXT_LAYERED_KEYS[TEXT_TASK_TIERS[task_type]]
+        resolved = await self._resolve_layered_backend(svc, session, project, keys)
         if task_type in VISION_REQUIRED_TASKS:
             _ensure_text_model_vision_capable(task_type, *resolved)
         return resolved

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -197,6 +197,16 @@ _VIDEO_LAYERED_KEYS: dict[str, _LayeredBackendKeys] = {
     for cap in ("i2v", "r2v")
 }
 
+
+# 音频键位。音频无能力桶，桶层留空（None）由骨架直接跳过：项目默认层用 project.json 的
+# audio_backend 字段，全局默认层用 default_audio_backend 设置键。
+_AUDIO_LAYERED_KEYS = _LayeredBackendKeys(
+    media_type="audio",
+    parse_fallback=_DEFAULT_AUDIO_BACKEND,
+    project_default_key="audio_backend",
+    global_default_key="default_audio_backend",
+)
+
 #: 视频能力桶：i2v（图生视频 / 宫格，由首帧驱动）、r2v（参考生视频，含无参考图退化镜头）。
 #: t2v 不设桶（docs/adr/0054）。
 VideoCapability = Literal["i2v", "r2v"]
@@ -1185,22 +1195,11 @@ class ConfigResolver:
         return ProviderModel(selected.provider_id, default_model.model_id)
 
     async def _resolve_default_audio_backend(self, svc: ConfigService, session: AsyncSession) -> tuple[str, str]:
-        raw = await svc.get_setting("default_audio_backend", "")
-        if raw and "/" in raw:
-            return ConfigService._parse_backend(raw, _DEFAULT_AUDIO_BACKEND)
-        return await self._auto_resolve_backend(svc, session, "audio")
+        """仅全局层解析音频默认 backend：全局默认键 > 自动推断。
 
-    async def _resolve_audio_backend_from_project(
-        self,
-        svc: ConfigService,
-        session: AsyncSession,
-        project: dict | None,
-    ) -> tuple[str, str]:
-        if project is not None:
-            parsed = _parse_project_provider(project.get("audio_backend"), "audio")
-            if parsed is not None:
-                return parsed
-        return await self._resolve_default_audio_backend(svc, session)
+        走四级骨架但不带项目（project=None 跳过项目层）。
+        """
+        return await self._resolve_layered_backend(svc, session, None, _AUDIO_LAYERED_KEYS)
 
     async def _resolve_audio_provider_model(
         self,
@@ -1220,7 +1219,7 @@ class ConfigResolver:
                 model = _payload_model_or_default(payload.get("audio_model"), provider_id, "audio")
                 if model is not None:
                     return ProviderModel(provider_id, model)
-        provider_id, model_id = await self._resolve_audio_backend_from_project(svc, session, project)
+        provider_id, model_id = await self._resolve_layered_backend(svc, session, project, _AUDIO_LAYERED_KEYS)
         return ProviderModel(provider_id, model_id)
 
     async def _resolve_video_capabilities(

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1817,6 +1817,20 @@ class TestTextBackendTierResolution:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, None)
         assert result == ("g-def", "m")
 
+    async def test_project_bare_provider_pins_its_default_model(self):
+        """项目档位写裸 provider（写边界放行的合法值）→ pin 住该 provider 补默认 model，
+        不静默回退到全局默认的另一供应商。与图片 / 视频的项目层同构。"""
+        from unittest.mock import MagicMock
+
+        from lib.text_backends.base import TextTaskType
+
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(settings={"default_text_backend": "g-def/m"})
+        with patch("lib.config.resolver.get_project_manager") as mock_pm:
+            mock_pm.return_value.load_project.return_value = {"text_backend_complex": "openai"}
+            result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, "demo")
+        assert result == ("openai", "gpt-5.4-mini")
+
 
 class TestStyleAnalysisVisionGuard:
     """简单档模型不支持图像输入时，风格分析解析直接报错，不静默换模型。"""

--- a/tests/test_tts_resolver.py
+++ b/tests/test_tts_resolver.py
@@ -31,6 +31,9 @@ class _FakeSvc:
     async def get_setting(self, key: str, default: str = "") -> str:
         return self._settings.get(key, default)
 
+    async def get_all_settings(self) -> dict[str, str]:
+        return dict(self._settings)
+
     async def get_all_providers_status(self) -> list[ProviderStatus]:
         if self._ready is not None:
             return self._ready


### PR DESCRIPTION
Closes #1571

文本与音频的后端解析收编到既有的四级分层骨架（`_resolve_layered_backend` + `_LayeredBackendKeys`，此前已服务图片与视频），删除两处手写的相似解析代码。解析顺序不变：项目桶 > 项目默认 > 全局桶 > 全局默认 > 自动推断。

## 行为变更（显式声明，非隐性夹带）

主体是重构，但文本**项目层**的取值口径从「只认 `provider/model` 完整形态」改为与图片 / 视频同构的 `_parse_project_provider`，随之有四处可感知的差异。影响面仅限 `project.json` 的 `text_backend_simple` / `text_backend_complex` / `default_text_backend` 存了非完整形态值的情形，音频侧无行为变更。

1. **裸供应商名**（如 `"openai"`，写边界本就放行）：原先被跳过、静默回退到全局默认的**另一**供应商；现在 pin 住该供应商并补它的默认文本模型。该供应商没有默认文本模型时仍落到全局层，与原先一致。
2. `"openai/"`（有尾斜杠、缺模型）：原先解析出空模型带进执行层；现在补该供应商的默认模型。
3. `"/model"`（缺供应商）：原先解析出空供应商带进执行层；现在落到全局层。
4. 非字符串值（写进 dict / list / 数字等）：原先经 `str()` 后若碰巧含 `/` 会解析出垃圾值对；现在直接跳过、落到下一层。

连带效应：第 1 条 pin 住供应商后，若其默认文本模型不支持图像输入，风格分析这类要求视觉能力的任务会直接报错，而不是静默回退到全局的其他模型——与仓库既有的 fail loud 口径一致。

## 其余分支的等价性

- **音频**：项目层原本就走 `_parse_project_provider`；`if project is not None` 与骨架的 `if project:` 在空 dict 上同解；全局层 `get_setting(k, "") + raw and "/" in raw` 与骨架的 `settings.get(k, "") + "/" in raw` 同解。逐分支等价。
- **文本**：五级顺序、全局层脏值（不含 `/`）落穿、视觉能力后置校验均保持不变。
- **全局层由逐键查询改为一次性读取**：`SystemSettingRepository.get` 与 `get_all` 同源直读 `system_setting` 表，`value` 列 NOT NULL，缺键两侧都取默认空串——语义等价，顺带把逐键查询收敛为单次查询。

## 验证

- `uv run python -m pytest`：7804 passed（基于本分支 HEAD 的现场）
- `uv run basedpyright`：0 errors
- `uv run ruff check` + `ruff format --check`（改动文件）：通过
- `uv run lint-imports`：契约 KEPT

## 后续候选（未纳入本 PR）

视频的非分桶路径（`_resolve_video_backend_from_project` + `_resolve_default_video_backend`）仍是手写的相似解析代码，与 `_VIDEO_LAYERED_KEYS` 并存。其项目层已用 `_parse_project_provider`、无本 PR 的裸供应商分歧，可无损收编为不带桶层的骨架委托。本 issue 范围限文本 / 音频，未动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 音频与文本后端现支持统一的四级配置解析，按项目设置、全局设置及默认值智能确定档位。
  * 支持仅指定供应商时自动采用该供应商的默认模型。

* **问题修复**
  * 修正项目级供应商配置被错误回退至全局默认供应商的问题。
  * 优化音频和文本配置的默认值继承与自动推断行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->