### PR TITLE
test: pytest 分类 marker 改为收集期强制校验

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ cd frontend && pnpm lint:fix      # 自动修可修的部分
 
 ### Pytest markers 纪律
 
-新增测试必须按类型打标，默认 CI 跑 `-m "not e2e"`：
+每个测试用例必须恰好带一个类型标记，默认 CI 跑 `-m "not e2e"`：
 
 | Marker | 含义 | 禁止 |
 |--------|------|------|
@@ -104,7 +104,14 @@ cd frontend && pnpm lint:fix      # 自动修可修的部分
 | `integration` | 跨模块协作，使用真实依赖（in-memory DB、tmp 文件系统等） | **禁止 mock 被测 module 的公共入口**（例如测 `MediaGenerator` 的集成测试不能 mock `MediaGenerator.generate`，否则是在测 mock 本身） |
 | `e2e` | 端到端，依赖真实外部资源（远程 API、大模型调用、真实 ffmpeg 重活） | CI 默认跳过，本地按需运行 |
 
-现存测试不强制回溯打标；只对新增测试落实。
+标记可打在用例、类或模块（`pytestmark`）任一层，三层叠加后仍须恰好命中一个分类。
+
+打标由 pytest 收集期强制，不依赖人工 review：
+
+- 漏标或多标的用例让收集直接失败（`tests/conftest.py::_enforce_classification_markers`），报错列出具体 nodeid
+- `--strict-markers` 使未在 `pyproject.toml` 注册的 marker 同样在收集期失败
+
+`unit`/`integration` 的现存分类由批量默认档得出（真实 ffmpeg、`uses_db` 命中的归 `integration`，其余归 `unit`），不保证逐条语义精确；新增测试按上表语义自行选择。
 
 ## 工作流程
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ cd frontend && pnpm lint:fix      # 自动修可修的部分
 - 漏标或多标的用例让收集直接失败（`tests/conftest.py::_enforce_classification_markers`），报错列出具体 nodeid
 - `--strict-markers` 使未在 `pyproject.toml` 注册的 marker 同样在收集期失败
 
-`unit`/`integration` 的现存分类由批量默认档得出（真实 ffmpeg、`uses_db` 命中的归 `integration`，其余归 `unit`），不保证逐条语义精确；新增测试按上表语义自行选择。
+`unit`/`integration` 的现存分类由批量默认档得出（真实调用 ffmpeg 生成测试用音视频资源、`uses_db` 命中的归 `integration`，其余归 `unit`），不保证逐条语义精确；新增测试按上表语义自行选择——用真实 ffmpeg 生成用例夹具与 `e2e` 定义的"真实 ffmpeg 重活"不是同一回事：前者是调用 ffmpeg 产出测试输入，后者指端到端场景里的重量级 ffmpeg 处理链路。
 
 ## 工作流程
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ packages = ["lib", "server"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--strict-markers"
 asyncio_mode = "auto"
 markers = [
     "unit: 快速、隔离、不触达真实 I/O 或外部服务的测试",

--- a/tests/agent_runtime/test_agent_access_policy.py
+++ b/tests/agent_runtime/test_agent_access_policy.py
@@ -12,6 +12,8 @@ import pytest
 
 from server.agent_runtime.agent_access_policy import AgentAccessPolicy
 
+pytestmark = pytest.mark.unit
+
 
 def _make_policy(tmp_path: Path, **overrides: object) -> AgentAccessPolicy:
     """以 tmp 根路径纯构造 policy：repo 布局与旧 SessionManager fixture 一致。"""

--- a/tests/agent_runtime/test_agent_startup_error.py
+++ b/tests/agent_runtime/test_agent_startup_error.py
@@ -24,6 +24,8 @@ from server.agent_runtime.session_manager import (
 )
 from server.agent_runtime.session_store import SessionMetaStore
 
+pytestmark = pytest.mark.unit
+
 
 def test_agent_startup_error_str_includes_stderr() -> None:
     exc = AgentStartupError(

--- a/tests/agent_runtime/test_entry_pipeline.py
+++ b/tests/agent_runtime/test_entry_pipeline.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from server.agent_runtime.entry_pipeline import DraftAccumulator, SessionEntryPipeline
+
+pytestmark = pytest.mark.unit
 
 
 class _RecordingStore:

--- a/tests/agent_runtime/test_entry_stream.py
+++ b/tests/agent_runtime/test_entry_stream.py
@@ -22,6 +22,8 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.conftest import make_translator
 from tests.factories import make_session_meta
 
+pytestmark = pytest.mark.unit
+
 SESSION_ID = "entry-stream-s1"
 
 

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -19,6 +19,8 @@ from server.agent_runtime.event_log import (
     normalize_sdk_message_to_entries,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 async def log_store():

--- a/tests/agent_runtime/test_event_log_session_flow.py
+++ b/tests/agent_runtime/test_event_log_session_flow.py
@@ -15,6 +15,8 @@ from server.agent_runtime.session_manager import AgentStartupError, SessionManag
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.fakes import FakeSDKClient
 
+pytestmark = pytest.mark.unit
+
 SDK_ID = "sdk-e2e-1"
 
 

--- a/tests/agent_runtime/test_failure_observation.py
+++ b/tests/agent_runtime/test_failure_observation.py
@@ -1,9 +1,13 @@
 import json
 
+import pytest
+
 from server.agent_runtime.failure_observation import (
     build_startup_failure_observation,
     build_turn_failure_observation,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_startup_observation_uses_standard_exception_chain_without_serializing_attributes() -> None:

--- a/tests/agent_runtime/test_keyed_locks.py
+++ b/tests/agent_runtime/test_keyed_locks.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import asyncio
 import gc
 
+import pytest
+
 from server.agent_runtime.keyed_locks import KeyedLocks
+
+pytestmark = pytest.mark.unit
 
 
 class TestKeyedLocks:

--- a/tests/agent_runtime/test_options_assembler.py
+++ b/tests/agent_runtime/test_options_assembler.py
@@ -18,6 +18,8 @@ from server.agent_runtime.options_assembler import (
     load_provider_env_overrides,
 )
 
+pytestmark = pytest.mark.unit
+
 _ALLOWED_TOOLS = ["Skill", "Task", "Bash", "BashOutput", "KillBash", "Read", "Write", "Edit"]
 _SETTING_SOURCES = ["project"]
 

--- a/tests/agent_runtime/test_sdk_0_1_76_features.py
+++ b/tests/agent_runtime/test_sdk_0_1_76_features.py
@@ -15,6 +15,8 @@ import pytest
 
 from server.agent_runtime.service import AssistantService
 
+pytestmark = pytest.mark.unit
+
 
 class TestApiErrorStatusInStatusPayload:
     """0.1.76 新字段 api_error_status 透传到 SSE payload。"""

--- a/tests/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/agent_runtime/test_session_manager_sandbox.py
@@ -14,6 +14,8 @@ from server.agent_runtime.agent_access_policy import AgentAccessPolicy
 from server.agent_runtime.session_manager import SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def session_manager(tmp_path: Path) -> SessionManager:

--- a/tests/agent_runtime/test_session_manager_store_injection.py
+++ b/tests/agent_runtime/test_session_manager_store_injection.py
@@ -9,6 +9,8 @@ import pytest
 from lib.agent_session_store.store import DbSessionStore
 from server.agent_runtime.session_manager import SessionManager
 
+pytestmark = pytest.mark.unit
+
 
 async def _fake_provider_env():
     """Stub: 跳过 DB 访问，返回空 dict（不影响 session_store/flush 字段断言）。"""

--- a/tests/agent_runtime/test_session_store_e2e.py
+++ b/tests/agent_runtime/test_session_store_e2e.py
@@ -13,6 +13,8 @@ from claude_agent_sdk import (
 from lib.agent_session_store import make_project_key
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_append_then_list_then_load_via_sdk_helpers(session_factory, tmp_path: Path):

--- a/tests/agent_session_store/test_conformance.py
+++ b/tests/agent_session_store/test_conformance.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.agent_session_store.store import DbSessionStore
 from lib.db.base import Base
 
+pytestmark = pytest.mark.unit
+
 
 def _pg_url_from_env() -> str | None:
     url = os.environ.get("DATABASE_URL")

--- a/tests/agent_session_store/test_flush_mode.py
+++ b/tests/agent_session_store/test_flush_mode.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from lib.agent_session_store import session_store_flush_mode
+
+pytestmark = pytest.mark.unit
 
 
 def test_default_is_eager(monkeypatch):

--- a/tests/agent_session_store/test_import_local.py
+++ b/tests/agent_session_store/test_import_local.py
@@ -10,6 +10,8 @@ from claude_agent_sdk import project_key_for_directory
 
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 
 def _write_fake_local_transcript(project_cwd: Path, session_id: str, sdk_root: Path):
     """Mimic the SDK on-disk layout: <CLAUDE_CONFIG_DIR>/projects/<sanitized>/<session_id>.jsonl."""

--- a/tests/agent_session_store/test_make_project_key.py
+++ b/tests/agent_session_store/test_make_project_key.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from claude_agent_sdk import project_key_for_directory
 
 from lib.agent_session_store import make_project_key
+
+pytestmark = pytest.mark.unit
 
 
 def test_matches_sdk_helper(tmp_path: Path):

--- a/tests/agent_session_store/test_models.py
+++ b/tests/agent_session_store/test_models.py
@@ -8,6 +8,8 @@ from sqlalchemy.exc import IntegrityError
 
 from lib.agent_session_store.models import AgentSessionEntry, AgentSessionSummary
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_entry_can_round_trip(session_factory):

--- a/tests/agent_session_store/test_store_append.py
+++ b/tests/agent_session_store/test_store_append.py
@@ -8,6 +8,8 @@ from sqlalchemy import select
 from lib.agent_session_store import AgentSessionEntry
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 KEY = {"project_key": "proj", "session_id": "sess"}
 
 

--- a/tests/agent_session_store/test_store_concurrency.py
+++ b/tests/agent_session_store/test_store_concurrency.py
@@ -10,6 +10,8 @@ from sqlalchemy import select
 from lib.agent_session_store import AgentSessionEntry
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.sqlite_only
 @pytest.mark.asyncio

--- a/tests/agent_session_store/test_store_load.py
+++ b/tests/agent_session_store/test_store_load.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_load_returns_None_for_unknown_key(session_factory):

--- a/tests/agent_session_store/test_store_optional.py
+++ b/tests/agent_session_store/test_store_optional.py
@@ -8,6 +8,8 @@ from sqlalchemy import select
 from lib.agent_session_store import AgentSessionEntry, AgentSessionSummary
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_list_sessions_returns_unique_session_ids_with_mtime(session_factory):

--- a/tests/agent_session_store/test_store_summary.py
+++ b/tests/agent_session_store/test_store_summary.py
@@ -10,6 +10,8 @@ from sqlalchemy import select
 from lib.agent_session_store import AgentSessionSummary
 from lib.agent_session_store.store import DbSessionStore
 
+pytestmark = pytest.mark.integration
+
 KEY = {"project_key": "proj", "session_id": "sess"}
 
 

--- a/tests/backends/test_no_env_fallback.py
+++ b/tests/backends/test_no_env_fallback.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 def test_ark_shared_no_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ARK_API_KEY", raising=False)

--- a/tests/config/test_anthropic_env_dict.py
+++ b/tests/config/test_anthropic_env_dict.py
@@ -9,6 +9,8 @@ import pytest
 
 from lib.config.service import build_anthropic_env_dict
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.asyncio
 async def test_active_credential_returns_full_dict(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/config/test_env_keys.py
+++ b/tests/config/test_env_keys.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.config.env_keys import (
     ANTHROPIC_ENV_KEYS,
     OTHER_PROVIDER_ENV_KEYS,
     PROVIDER_SECRET_KEYS,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_provider_secret_keys_is_subset_of_all_provider_keys():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ async def session_manager(tmp_path: Path, meta_store: SessionMetaStore) -> Sessi
 # ---------------------------------------------------------------------------
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Auto-mark dialect-sensitive tests with `uses_db`.
 
     Mark a test only when it consumes a fixture defined in a canonical
@@ -223,7 +223,7 @@ def pytest_collection_modifyitems(config, items):
     _enforce_classification_markers(items)
 
 
-def _enforce_classification_markers(items) -> None:
+def _enforce_classification_markers(items: list[pytest.Item]) -> None:
     """收集期强制：每个用例恰好带一个 unit/integration/e2e 分类 marker。
 
     漏标不影响用例本身通过，只能靠人工 review 发现；这里把它变成收集期失败，

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,24 +224,36 @@ def pytest_collection_modifyitems(config, items):
 
 
 def _enforce_classification_markers(items) -> None:
-    """Every collected test must carry exactly one of unit/integration/e2e.
+    """收集期强制：每个用例恰好带一个 unit/integration/e2e 分类 marker。
 
-    Unmarked tests only surface via external review (a whole batch once slipped
-    10+ unmarked cases through); this makes the omission a collection-time
-    failure instead, so it can't reach CI unnoticed.
+    漏标不影响用例本身通过，只能靠人工 review 发现；这里把它变成收集期失败，
+    使其无法进入 CI。多标同样拦截——三类语义互斥，同时命中会让 `-m` 选集失去意义
+    （marker 可来自用例、类、模块三层，叠加时容易出现自相矛盾的组合）。
     """
     classify_marks = {"unit", "integration", "e2e"}
-    offenders = []
+    missing = []
+    conflicting = []
     for item in items:
         marks = {m.name for m in item.iter_markers()} & classify_marks
         if not marks:
-            offenders.append(item.nodeid)
-    if offenders:
-        listing = "\n".join(f"  - {nodeid}" for nodeid in offenders)
-        raise pytest.UsageError(
-            f"{len(offenders)} 个测试用例缺少分类 marker（unit/integration/e2e 三选一）：\n{listing}\n"
+            missing.append(item.nodeid)
+        elif len(marks) > 1:
+            conflicting.append(f"{item.nodeid}（{'/'.join(sorted(marks))}）")
+    problems = []
+    if missing:
+        listing = "\n".join(f"  - {nodeid}" for nodeid in missing)
+        problems.append(
+            f"{len(missing)} 个测试用例缺少分类 marker（unit/integration/e2e 三选一）：\n{listing}\n"
             "在用例或所在模块补 @pytest.mark.unit / integration / e2e。"
         )
+    if conflicting:
+        listing = "\n".join(f"  - {entry}" for entry in conflicting)
+        problems.append(
+            f"{len(conflicting)} 个测试用例带多个分类 marker（三者互斥）：\n{listing}\n"
+            "去掉用例/类/模块三层中多余的那个分类 marker。"
+        )
+    if problems:
+        raise pytest.UsageError("\n".join(problems))
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,29 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(uses_db)
                 break
 
+    _enforce_classification_markers(items)
+
+
+def _enforce_classification_markers(items) -> None:
+    """Every collected test must carry exactly one of unit/integration/e2e.
+
+    Unmarked tests only surface via external review (a whole batch once slipped
+    10+ unmarked cases through); this makes the omission a collection-time
+    failure instead, so it can't reach CI unnoticed.
+    """
+    classify_marks = {"unit", "integration", "e2e"}
+    offenders = []
+    for item in items:
+        marks = {m.name for m in item.iter_markers()} & classify_marks
+        if not marks:
+            offenders.append(item.nodeid)
+    if offenders:
+        listing = "\n".join(f"  - {nodeid}" for nodeid in offenders)
+        raise pytest.UsageError(
+            f"{len(offenders)} 个测试用例缺少分类 marker（unit/integration/e2e 三选一）：\n{listing}\n"
+            "在用例或所在模块补 @pytest.mark.unit / integration / e2e。"
+        )
+
 
 @pytest.fixture()
 async def async_session():

--- a/tests/integration/test_reference_video_e2e.py
+++ b/tests/integration/test_reference_video_e2e.py
@@ -23,6 +23,8 @@ from fastapi.testclient import TestClient
 from server.auth import CurrentUserInfo, get_current_user
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 _TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
     b"\x08\x02\x00\x00\x00&\x93\t)\x00\x00\x00\x13IDATx\x9cc<\x91b\xc4\x00"

--- a/tests/lib/test_ad_reference_units.py
+++ b/tests/lib/test_ad_reference_units.py
@@ -40,6 +40,7 @@ def _shot(shot_id: str, duration: int = 3, **overrides) -> dict:
 
 
 class TestDeriveGrouping:
+    @pytest.mark.unit
     def test_consecutive_shots_grouped_into_single_unit(self):
         shots = [_shot("E1S1"), _shot("E1S2"), _shot("E1S3")]
 
@@ -49,6 +50,7 @@ class TestDeriveGrouping:
         assert units[0]["unit_id"] == "E1U1"
         assert units[0]["shot_ids"] == ["E1S1", "E1S2", "E1S3"]
 
+    @pytest.mark.unit
     def test_unit_holds_at_most_four_shots(self):
         shots = [_shot(f"E1S{n}") for n in range(1, 7)]
 
@@ -60,6 +62,7 @@ class TestDeriveGrouping:
         ]
         assert [u["unit_id"] for u in units] == ["E1U1", "E1U2"]
 
+    @pytest.mark.unit
     def test_unit_total_duration_respects_provider_cap(self):
         shots = [
             _shot("E1S1", duration=5),
@@ -72,6 +75,7 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1", "E1S2"], ["E1S3", "E1S4"]]
 
+    @pytest.mark.unit
     def test_single_shot_exceeding_cap_forms_its_own_unit(self):
         # 单镜头无法再拆，超上限时独立成 unit，留给执行层 clamp + warning 软处理
         shots = [_shot("E1S1", duration=15), _shot("E1S2", duration=3)]
@@ -80,6 +84,7 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1"], ["E1S2"]]
 
+    @pytest.mark.unit
     def test_no_cap_groups_by_shot_count_only(self):
         shots = [_shot(f"E1S{n}", duration=15) for n in range(1, 5)]
 
@@ -87,6 +92,7 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1", "E1S2", "E1S3", "E1S4"]]
 
+    @pytest.mark.unit
     def test_short_two_to_three_second_shots_are_legal(self):
         # 2-3 秒短切镜头是该路径的合法常态（快节奏剪辑感）
         shots = [_shot("E1S1", duration=2), _shot("E1S2", duration=3), _shot("E1S3", duration=2)]
@@ -97,6 +103,7 @@ class TestDeriveGrouping:
 
 
 class TestReferenceInheritance:
+    @pytest.mark.unit
     def test_unit_inherits_member_shot_references_products_first(self):
         # 产品镜头沿用注入二元规则：产品参考全量进入参考集且排序绝对优先
         shots = [
@@ -113,6 +120,7 @@ class TestReferenceInheritance:
             {"type": "prop", "name": "毛巾"},
         ]
 
+    @pytest.mark.unit
     def test_references_deduplicated_preserving_first_appearance(self):
         shots = [
             _shot("E1S1", products_in_shot=["按摩仪"], characters_in_shot=["小美", "小明"]),
@@ -128,6 +136,7 @@ class TestReferenceInheritance:
             {"type": "character", "name": "小明"},
         ]
 
+    @pytest.mark.unit
     def test_references_deduplicated_across_encoding_forms(self):
         # 同一资产在两个镜头里以 NFC / NFD 两种等价编码写入：派生参考集须按归一名判同，
         # 否则画布上重复显示同一资产、并各占一个参考图槽位
@@ -149,6 +158,7 @@ class TestReferenceInheritance:
             {"type": "character", "name": name_nfc},
         ]
 
+    @pytest.mark.unit
     def test_atmosphere_only_unit_has_zero_product_references(self):
         shots = [_shot("E1S1", scenes=["海边"]), _shot("E1S2", scenes=["海边"])]
 
@@ -158,6 +168,7 @@ class TestReferenceInheritance:
 
 
 class TestReproducibility:
+    @pytest.mark.unit
     def test_same_shots_and_cap_always_produce_identical_grouping(self):
         shots = [
             _shot("E1S1", duration=2, products_in_shot=["按摩仪"]),
@@ -172,6 +183,7 @@ class TestReproducibility:
 
         assert first == second
 
+    @pytest.mark.unit
     def test_index_only_references_shot_ids_without_copying_content(self):
         shots = [_shot("E1S1", products_in_shot=["按摩仪"])]
 
@@ -179,6 +191,7 @@ class TestReproducibility:
 
         assert set(units[0].keys()) == {"unit_id", "shot_ids", "references"}
 
+    @pytest.mark.unit
     def test_dirty_shots_skipped_deterministically(self):
         shots = [
             "not-a-dict",
@@ -194,6 +207,7 @@ class TestReproducibility:
 
 
 class TestSyncPersistence:
+    @pytest.mark.unit
     def test_sync_writes_index_into_script(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
 
@@ -203,6 +217,7 @@ class TestSyncPersistence:
         assert units[0]["shot_ids"] == ["E1S1", "E1S2"]
         assert units[0]["generated_assets"]["status"] == "pending"
 
+    @pytest.mark.unit
     def test_resync_with_unchanged_shots_preserves_generated_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
         sync_ad_reference_units(script, episode=1)
@@ -214,6 +229,7 @@ class TestSyncPersistence:
         assert units[0]["generated_assets"]["video_clip"] == "reference_videos/E1U1.mp4"
         assert units[0]["generated_assets"]["status"] == "completed"
 
+    @pytest.mark.unit
     def test_resync_after_shot_change_resets_changed_unit_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
         sync_ad_reference_units(script, episode=1)
@@ -226,6 +242,7 @@ class TestSyncPersistence:
         assert units[0]["shot_ids"] == ["E1S1", "E1S2", "E1S3"]
         assert units[0]["generated_assets"].get("video_clip") is None
 
+    @pytest.mark.unit
     def test_resync_after_reference_change_resets_unit_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1")]}
         sync_ad_reference_units(script, episode=1)
@@ -239,6 +256,7 @@ class TestSyncPersistence:
 
 
 class TestResolveUnitShots:
+    @pytest.mark.unit
     def test_hydrates_member_shots_from_script_in_index_order(self):
         script = {"shots": [_shot("E1S1"), _shot("E1S2"), _shot("E1S3")]}
         unit = {"unit_id": "E1U1", "shot_ids": ["E1S2", "E1S3"]}
@@ -247,6 +265,7 @@ class TestResolveUnitShots:
 
         assert [s["shot_id"] for s in shots] == ["E1S2", "E1S3"]
 
+    @pytest.mark.unit
     def test_dangling_shot_id_raises_stale_index_error(self):
         script = {"shots": [_shot("E1S1")]}
         unit = {"unit_id": "E1U1", "shot_ids": ["E1S1", "E1S9"]}
@@ -256,6 +275,7 @@ class TestResolveUnitShots:
 
 
 class TestRenderUnitPrompt:
+    @pytest.mark.unit
     def test_renders_shot_headers_with_durations_and_visual_content(self):
         shots = [
             _shot("E1S1", duration=3),
@@ -270,6 +290,7 @@ class TestRenderUnitPrompt:
         assert "E1S1 画面" in prompt
         assert "E1S1 动作" in prompt
 
+    @pytest.mark.unit
     def test_voiceover_text_excluded_from_video_prompt(self):
         # 口播是后期配音的输入，不进画面生成 prompt
         shots = [_shot("E1S1", voiceover_text="买它买它")]
@@ -278,6 +299,7 @@ class TestRenderUnitPrompt:
 
         assert "买它买它" not in prompt
 
+    @pytest.mark.unit
     def test_dialogue_and_camera_motion_included(self):
         shots = [
             _shot(
@@ -323,6 +345,7 @@ class TestRenderUnitPrompt:
         assert f"<{name_nfc}>说 {{太好用了}}" in prompt
         assert name_nfd not in prompt
 
+    @pytest.mark.unit
     def test_all_blank_shots_render_empty_for_enqueue_guard(self):
         # 空提示词必须渲染为空串，让 TaskSpec 入队守卫当场拒绝
         shots = [_shot("E1S1", image_prompt={"scene": "", "composition": {}}, video_prompt={"action": ""})]

--- a/tests/lib/test_ad_reference_units.py
+++ b/tests/lib/test_ad_reference_units.py
@@ -13,6 +13,8 @@ from lib.reference_video.ad_units import (
     sync_ad_reference_units,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _shot(shot_id: str, duration: int = 3, **overrides) -> dict:
     base = {
@@ -40,7 +42,6 @@ def _shot(shot_id: str, duration: int = 3, **overrides) -> dict:
 
 
 class TestDeriveGrouping:
-    @pytest.mark.unit
     def test_consecutive_shots_grouped_into_single_unit(self):
         shots = [_shot("E1S1"), _shot("E1S2"), _shot("E1S3")]
 
@@ -50,7 +51,6 @@ class TestDeriveGrouping:
         assert units[0]["unit_id"] == "E1U1"
         assert units[0]["shot_ids"] == ["E1S1", "E1S2", "E1S3"]
 
-    @pytest.mark.unit
     def test_unit_holds_at_most_four_shots(self):
         shots = [_shot(f"E1S{n}") for n in range(1, 7)]
 
@@ -62,7 +62,6 @@ class TestDeriveGrouping:
         ]
         assert [u["unit_id"] for u in units] == ["E1U1", "E1U2"]
 
-    @pytest.mark.unit
     def test_unit_total_duration_respects_provider_cap(self):
         shots = [
             _shot("E1S1", duration=5),
@@ -75,7 +74,6 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1", "E1S2"], ["E1S3", "E1S4"]]
 
-    @pytest.mark.unit
     def test_single_shot_exceeding_cap_forms_its_own_unit(self):
         # 单镜头无法再拆，超上限时独立成 unit，留给执行层 clamp + warning 软处理
         shots = [_shot("E1S1", duration=15), _shot("E1S2", duration=3)]
@@ -84,7 +82,6 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1"], ["E1S2"]]
 
-    @pytest.mark.unit
     def test_no_cap_groups_by_shot_count_only(self):
         shots = [_shot(f"E1S{n}", duration=15) for n in range(1, 5)]
 
@@ -92,7 +89,6 @@ class TestDeriveGrouping:
 
         assert [u["shot_ids"] for u in units] == [["E1S1", "E1S2", "E1S3", "E1S4"]]
 
-    @pytest.mark.unit
     def test_short_two_to_three_second_shots_are_legal(self):
         # 2-3 秒短切镜头是该路径的合法常态（快节奏剪辑感）
         shots = [_shot("E1S1", duration=2), _shot("E1S2", duration=3), _shot("E1S3", duration=2)]
@@ -103,7 +99,6 @@ class TestDeriveGrouping:
 
 
 class TestReferenceInheritance:
-    @pytest.mark.unit
     def test_unit_inherits_member_shot_references_products_first(self):
         # 产品镜头沿用注入二元规则：产品参考全量进入参考集且排序绝对优先
         shots = [
@@ -120,7 +115,6 @@ class TestReferenceInheritance:
             {"type": "prop", "name": "毛巾"},
         ]
 
-    @pytest.mark.unit
     def test_references_deduplicated_preserving_first_appearance(self):
         shots = [
             _shot("E1S1", products_in_shot=["按摩仪"], characters_in_shot=["小美", "小明"]),
@@ -136,7 +130,6 @@ class TestReferenceInheritance:
             {"type": "character", "name": "小明"},
         ]
 
-    @pytest.mark.unit
     def test_references_deduplicated_across_encoding_forms(self):
         # 同一资产在两个镜头里以 NFC / NFD 两种等价编码写入：派生参考集须按归一名判同，
         # 否则画布上重复显示同一资产、并各占一个参考图槽位
@@ -158,7 +151,6 @@ class TestReferenceInheritance:
             {"type": "character", "name": name_nfc},
         ]
 
-    @pytest.mark.unit
     def test_atmosphere_only_unit_has_zero_product_references(self):
         shots = [_shot("E1S1", scenes=["海边"]), _shot("E1S2", scenes=["海边"])]
 
@@ -168,7 +160,6 @@ class TestReferenceInheritance:
 
 
 class TestReproducibility:
-    @pytest.mark.unit
     def test_same_shots_and_cap_always_produce_identical_grouping(self):
         shots = [
             _shot("E1S1", duration=2, products_in_shot=["按摩仪"]),
@@ -183,7 +174,6 @@ class TestReproducibility:
 
         assert first == second
 
-    @pytest.mark.unit
     def test_index_only_references_shot_ids_without_copying_content(self):
         shots = [_shot("E1S1", products_in_shot=["按摩仪"])]
 
@@ -191,7 +181,6 @@ class TestReproducibility:
 
         assert set(units[0].keys()) == {"unit_id", "shot_ids", "references"}
 
-    @pytest.mark.unit
     def test_dirty_shots_skipped_deterministically(self):
         shots = [
             "not-a-dict",
@@ -207,7 +196,6 @@ class TestReproducibility:
 
 
 class TestSyncPersistence:
-    @pytest.mark.unit
     def test_sync_writes_index_into_script(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
 
@@ -217,7 +205,6 @@ class TestSyncPersistence:
         assert units[0]["shot_ids"] == ["E1S1", "E1S2"]
         assert units[0]["generated_assets"]["status"] == "pending"
 
-    @pytest.mark.unit
     def test_resync_with_unchanged_shots_preserves_generated_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
         sync_ad_reference_units(script, episode=1)
@@ -229,7 +216,6 @@ class TestSyncPersistence:
         assert units[0]["generated_assets"]["video_clip"] == "reference_videos/E1U1.mp4"
         assert units[0]["generated_assets"]["status"] == "completed"
 
-    @pytest.mark.unit
     def test_resync_after_shot_change_resets_changed_unit_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1"), _shot("E1S2")]}
         sync_ad_reference_units(script, episode=1)
@@ -242,7 +228,6 @@ class TestSyncPersistence:
         assert units[0]["shot_ids"] == ["E1S1", "E1S2", "E1S3"]
         assert units[0]["generated_assets"].get("video_clip") is None
 
-    @pytest.mark.unit
     def test_resync_after_reference_change_resets_unit_assets(self):
         script = {"episode": 1, "shots": [_shot("E1S1")]}
         sync_ad_reference_units(script, episode=1)
@@ -256,7 +241,6 @@ class TestSyncPersistence:
 
 
 class TestResolveUnitShots:
-    @pytest.mark.unit
     def test_hydrates_member_shots_from_script_in_index_order(self):
         script = {"shots": [_shot("E1S1"), _shot("E1S2"), _shot("E1S3")]}
         unit = {"unit_id": "E1U1", "shot_ids": ["E1S2", "E1S3"]}
@@ -265,7 +249,6 @@ class TestResolveUnitShots:
 
         assert [s["shot_id"] for s in shots] == ["E1S2", "E1S3"]
 
-    @pytest.mark.unit
     def test_dangling_shot_id_raises_stale_index_error(self):
         script = {"shots": [_shot("E1S1")]}
         unit = {"unit_id": "E1U1", "shot_ids": ["E1S1", "E1S9"]}
@@ -275,7 +258,6 @@ class TestResolveUnitShots:
 
 
 class TestRenderUnitPrompt:
-    @pytest.mark.unit
     def test_renders_shot_headers_with_durations_and_visual_content(self):
         shots = [
             _shot("E1S1", duration=3),
@@ -290,7 +272,6 @@ class TestRenderUnitPrompt:
         assert "E1S1 画面" in prompt
         assert "E1S1 动作" in prompt
 
-    @pytest.mark.unit
     def test_voiceover_text_excluded_from_video_prompt(self):
         # 口播是后期配音的输入，不进画面生成 prompt
         shots = [_shot("E1S1", voiceover_text="买它买它")]
@@ -299,7 +280,6 @@ class TestRenderUnitPrompt:
 
         assert "买它买它" not in prompt
 
-    @pytest.mark.unit
     def test_dialogue_and_camera_motion_included(self):
         shots = [
             _shot(
@@ -318,7 +298,6 @@ class TestRenderUnitPrompt:
         assert "Zoom In" in prompt
         assert "太好用了" in prompt
 
-    @pytest.mark.unit
     def test_dialogue_speaker_normalized_to_nfc(self):
         # derive_voice_bindings（script_preview 复用于 ad 路径）把说话人名归一到 NFC 再产出
         # 音色绑定声明；画面 prompt 的台词句式须用同一坐标系，否则两处 `<X>` 字节不同，
@@ -345,14 +324,12 @@ class TestRenderUnitPrompt:
         assert f"<{name_nfc}>说 {{太好用了}}" in prompt
         assert name_nfd not in prompt
 
-    @pytest.mark.unit
     def test_all_blank_shots_render_empty_for_enqueue_guard(self):
         # 空提示词必须渲染为空串，让 TaskSpec 入队守卫当场拒绝
         shots = [_shot("E1S1", image_prompt={"scene": "", "composition": {}}, video_prompt={"action": ""})]
 
         assert render_ad_unit_prompt(shots, style="水彩插画") == ""
 
-    @pytest.mark.unit
     def test_dialogue_without_speaker_renders_as_voiceover(self):
         shots = [
             _shot(

--- a/tests/lib/test_cost_calculator_reference_video.py
+++ b/tests/lib/test_cost_calculator_reference_video.py
@@ -5,6 +5,8 @@ import pytest
 from lib.cost_calculator import CostCalculator
 from lib.providers import PROVIDER_ARK, PROVIDER_GROK, PROVIDER_OPENAI
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def calc() -> CostCalculator:

--- a/tests/lib/test_data_validator_reference.py
+++ b/tests/lib/test_data_validator_reference.py
@@ -68,6 +68,7 @@ def _reference_project(*, with_assets: bool = True) -> dict:
     return project
 
 
+@pytest.mark.unit
 def test_validator_accepts_reference_video_generation_mode(tmp_path: Path):
     _write(tmp_path, "project.json", _reference_project())
     _write(tmp_path, "scripts/episode_1.json", _valid_reference_script())
@@ -99,6 +100,7 @@ def test_validator_accepts_nfc_reference_for_nfd_registered_character(tmp_path: 
     assert result.valid, result.errors
 
 
+@pytest.mark.unit
 def test_validator_rejects_unknown_mention(tmp_path: Path):
     _write(tmp_path, "project.json", _reference_project(with_assets=False))
     _write(tmp_path, "scripts/episode_1.json", _valid_reference_script())
@@ -110,6 +112,7 @@ def test_validator_rejects_unknown_mention(tmp_path: Path):
     assert any("酒馆" in e for e in result.errors)
 
 
+@pytest.mark.unit
 def test_validator_allows_reference_videos_dir(tmp_path: Path):
     project = _reference_project(with_assets=False)
     project["episodes"] = []
@@ -122,6 +125,7 @@ def test_validator_allows_reference_videos_dir(tmp_path: Path):
     assert result.valid, result.errors
 
 
+@pytest.mark.unit
 def test_validator_rejects_non_string_reference_name(tmp_path: Path):
     project = _reference_project(with_assets=False)
     script = _valid_reference_script()
@@ -135,6 +139,7 @@ def test_validator_rejects_non_string_reference_name(tmp_path: Path):
     assert any("reference.name 必须是非空字符串" in e for e in result.errors)
 
 
+@pytest.mark.unit
 def test_validator_rejects_invalid_unit_duration(tmp_path: Path):
     project = _reference_project()
     script = _valid_reference_script()
@@ -194,6 +199,7 @@ def test_validator_rejects_duplicate_ad_reference_unit_ids(tmp_path: Path):
     assert any("unit_id 重复 'E1U1'" in error for error in result.errors)
 
 
+@pytest.mark.unit
 def test_validator_rejects_reference_video_in_content_mode(tmp_path: Path):
     """content_mode 严格只允许 narration / drama；reference_video 属于 generation_mode
     维度。UI 不可达该值，无需兼容迁移，直接拒绝即可。

--- a/tests/lib/test_image_compression_batch.py
+++ b/tests/lib/test_image_compression_batch.py
@@ -7,6 +7,8 @@ from PIL import Image
 
 from lib.image_utils import compress_image_bytes
 
+pytestmark = pytest.mark.unit
+
 
 def _make_big_png(width: int = 4096, height: int = 3072) -> bytes:
     img = Image.new("RGB", (width, height), color=(240, 80, 40))

--- a/tests/lib/test_logging_utils.py
+++ b/tests/lib/test_logging_utils.py
@@ -1,8 +1,11 @@
 import json
 
+import pytest
 from pydantic import BaseModel
 
 from lib.logging_utils import format_kwargs_for_log, sanitize_diagnostic_payload
+
+pytestmark = pytest.mark.unit
 
 
 def test_diagnostic_payload_preserves_unknown_fields_without_truncation():

--- a/tests/lib/test_reference_video_errors.py
+++ b/tests/lib/test_reference_video_errors.py
@@ -5,6 +5,8 @@ from lib.reference_video.errors import (
     ProviderUnsupportedFeatureError,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_missing_reference_error_carries_details():
     err = MissingReferenceError(missing=[("character", "张三"), ("scene", "酒馆")])

--- a/tests/lib/test_script_generator_reference_branch.py
+++ b/tests/lib/test_script_generator_reference_branch.py
@@ -403,6 +403,7 @@ async def test_script_generator_rejects_step2_unregistered_mention(reference_pro
         await gen.generate(episode=1)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_script_generator_reference_branch_inherits_drama_content_mode(tmp_path: Path):
     """drama 项目下生成的参考视频集 content_mode 必须为 drama。
@@ -441,6 +442,7 @@ async def test_script_generator_reference_branch_inherits_drama_content_mode(tmp
     assert "generation_mode" not in data
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "caps, expected",
     [
@@ -475,6 +477,7 @@ def test_resolve_max_refs_from_caps(tmp_path: Path, caps, expected):
     assert gen._resolve_max_refs(caps) == expected
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "video_backend, expected",
     [
@@ -511,6 +514,7 @@ def test_resolve_max_refs_from_registry_fallback(tmp_path: Path, video_backend, 
     assert gen._resolve_max_refs(None) == expected
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_prompt_no_video_backend_raises_value_error(tmp_path: Path):
     """project.json 缺 video_backend 且 caps 不可解析时，build_prompt 应抛 ValueError。
@@ -553,6 +557,7 @@ async def test_build_prompt_no_video_backend_raises_value_error(tmp_path: Path):
             await gen.build_prompt(episode=1)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_fetch_video_capabilities_swallows_db_errors(reference_project: Path):
     """CI 回归：裸测试容器缺 migration 时 ConfigResolver 会抛 OperationalError；
@@ -567,6 +572,7 @@ async def test_fetch_video_capabilities_swallows_db_errors(reference_project: Pa
     assert caps is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_prompt_follows_project_reference_route(tmp_path: Path):
     """项目路线为 reference_video 时 build_prompt 必须走 reference 分支。
@@ -623,6 +629,7 @@ async def test_script_generator_reads_legacy_step1_draft_without_source_text(ref
     assert _json.loads(out.read_text(encoding="utf-8"))["video_units"][0]["unit_id"] == "E1U01"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reference_step1_legacy_md_prompts_resplit(reference_project: Path):
     """仅存在结构化前的旧 .md 拆分表时，给出明确的「重跑拆分」提示而非笼统缺文件错误。"""
@@ -635,6 +642,7 @@ async def test_reference_step1_legacy_md_prompts_resplit(reference_project: Path
         await gen.build_prompt(episode=1)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reference_step1_missing_raises(reference_project: Path):
     drafts = reference_project / "drafts" / "episode_1"
@@ -645,6 +653,7 @@ async def test_reference_step1_missing_raises(reference_project: Path):
         await gen.build_prompt(episode=1)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reference_step1_rejects_out_of_enum_duration(reference_project: Path):
     """读取侧复验 unit 时长 ∈ supported_durations，防手工编辑漂移出非法时长。"""
@@ -664,6 +673,7 @@ async def test_reference_step1_rejects_out_of_enum_duration(reference_project: P
             await gen.build_prompt(episode=1)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reference_step1_rejects_duplicate_unit_ids(reference_project: Path):
     drafts = reference_project / "drafts" / "episode_1"

--- a/tests/lib/test_script_models_ad_units.py
+++ b/tests/lib/test_script_models_ad_units.py
@@ -5,6 +5,8 @@ import pytest
 
 from lib.script_models import AdEpisodeScript
 
+pytestmark = pytest.mark.unit
+
 
 def _shot_dict(shot_id: str) -> dict:
     return {

--- a/tests/lib/test_script_models_reference.py
+++ b/tests/lib/test_script_models_reference.py
@@ -10,23 +10,27 @@ from lib.script_models import (
 )
 
 
+@pytest.mark.unit
 def test_shot_valid():
     s = Shot(text="中远景，主角推门进酒馆")
     assert "酒馆" in s.text
 
 
+@pytest.mark.unit
 def test_shot_rejects_duration_field():
     """时长收编到 unit 级：镜头不再承载时长，写入即被 strict 模型拒绝。"""
     with pytest.raises(ValidationError):
         Shot.model_validate({"duration": 5, "text": "x"})
 
 
+@pytest.mark.unit
 def test_reference_resource_valid_types():
     for t in ("character", "scene", "prop"):
         r = ReferenceResource(type=t, name="张三")
         assert r.type == t
 
 
+@pytest.mark.unit
 def test_reference_resource_rejects_clue():
     with pytest.raises(ValidationError):
         ReferenceResource(type="clue", name="张三")
@@ -43,6 +47,7 @@ def _make_unit(**overrides):
     return ReferenceVideoUnit(**defaults)
 
 
+@pytest.mark.unit
 def test_reference_video_unit_minimal():
     u = _make_unit()
     assert u.unit_id == "E1U1"
@@ -51,16 +56,19 @@ def test_reference_video_unit_minimal():
     assert u.transition_to_next == "cut"
 
 
+@pytest.mark.unit
 def test_reference_video_unit_requires_at_least_one_shot():
     with pytest.raises(ValidationError):
         _make_unit(shots=[])
 
 
+@pytest.mark.unit
 def test_reference_video_unit_transition_enum():
     with pytest.raises(ValidationError):
         _make_unit(transition_to_next="wipe")
 
 
+@pytest.mark.unit
 def test_reference_video_script_valid():
     script = ReferenceVideoScript(
         title="江湖夜话",
@@ -75,6 +83,7 @@ def test_reference_video_script_valid():
     assert len(script.video_units) == 1
 
 
+@pytest.mark.unit
 def test_reference_video_script_accepts_drama_content_mode():
     script = ReferenceVideoScript(
         title="剧集",
@@ -85,6 +94,7 @@ def test_reference_video_script_accepts_drama_content_mode():
     assert script.content_mode == "drama"
 
 
+@pytest.mark.unit
 def test_reference_video_script_rejects_legacy_reference_video_content_mode():
     """content_mode 不再允许 reference_video（它属于项目级 generation_mode 维度）。"""
     with pytest.raises(ValidationError):
@@ -96,17 +106,20 @@ def test_reference_video_script_rejects_legacy_reference_video_content_mode():
         )
 
 
+@pytest.mark.unit
 def test_reference_video_unit_rejects_more_than_four_shots():
     many_shots = [Shot(text=f"s{i}") for i in range(5)]
     with pytest.raises(ValidationError):
         _make_unit(shots=many_shots)
 
 
+@pytest.mark.unit
 def test_reference_video_unit_duration_is_independent_of_shots():
     """unit 时长是唯一真相：不再与镜头数 / 镜头内容挂钩，取值只受结构区间约束。"""
     assert _make_unit(duration_seconds=12).duration_seconds == 12
 
 
+@pytest.mark.unit
 def test_reference_video_unit_rejects_duration_out_of_structural_range():
     with pytest.raises(ValidationError):
         _make_unit(duration_seconds=0)

--- a/tests/lib/test_status_calculator_reference.py
+++ b/tests/lib/test_status_calculator_reference.py
@@ -12,6 +12,8 @@ import pytest
 from lib.project_manager import ProjectManager
 from lib.status_calculator import StatusCalculator
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def pm(tmp_path: Path) -> ProjectManager:

--- a/tests/prompt_rules/test_episode_pacing.py
+++ b/tests/prompt_rules/test_episode_pacing.py
@@ -6,6 +6,8 @@ from lib.prompt_rules.episode_pacing import (
     render_pacing_section,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_drama_rules_keywords() -> None:
     text = render_pacing_section("drama")

--- a/tests/prompt_rules/test_subagent_md_sync.py
+++ b/tests/prompt_rules/test_subagent_md_sync.py
@@ -5,10 +5,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from lib.prompt_rules.episode_pacing import (
     DRAMA_PACING_RULES,
     NARRATION_PACING_RULES,
 )
+
+pytestmark = pytest.mark.unit
 
 REPO = Path(__file__).resolve().parents[2]
 

--- a/tests/scripts/test_fixture_generator.py
+++ b/tests/scripts/test_fixture_generator.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from scripts.fixtures.reference_video.generate_fixtures import generate_color_refs
+
+pytestmark = pytest.mark.unit
 
 
 def test_generate_color_refs_creates_n_pngs(tmp_path: Path):

--- a/tests/scripts/test_project_status_sync.py
+++ b/tests/scripts/test_project_status_sync.py
@@ -2,6 +2,8 @@ import pytest
 
 from scripts.project_status_sync import derive_status
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     ("state", "labels", "has_assignee", "has_open_closing_pr", "expected"),

--- a/tests/scripts/test_verify_reference_video_sdks.py
+++ b/tests/scripts/test_verify_reference_video_sdks.py
@@ -11,6 +11,8 @@ from lib.video_backends.base import (
 )
 from scripts.verify_reference_video_sdks import Provider, RunResult, parse_args, render_report, run_once
 
+pytestmark = pytest.mark.unit
+
 
 def test_parse_args_provider_required():
     with pytest.raises(SystemExit):

--- a/tests/server/agent_runtime/test_patch_tools.py
+++ b/tests/server/agent_runtime/test_patch_tools.py
@@ -170,6 +170,7 @@ def _text(out: dict[str, Any]) -> str:
 
 
 class TestPatchEpisodeScript:
+    @pytest.mark.unit
     async def test_batch_multi_segment_multi_field(self, ctx: ToolContext) -> None:
         """一次调用改多分镜 × 多字段，全部落盘。"""
         out = await _call(
@@ -188,6 +189,7 @@ class TestPatchEpisodeScript:
         assert saved[0]["duration_seconds"] == 6
         assert saved[1]["video_prompt"]["action"] == "抬头"
 
+    @pytest.mark.unit
     async def test_single_edit_is_length_one_map(self, ctx: ToolContext) -> None:
         """单条编辑 = 长度 1 的 map（不再有 id/field/value 单条形态）。"""
         out = await _call(
@@ -197,6 +199,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert _load(ctx)["segments"][1]["image_prompt"]["scene"] == "新场景"
 
+    @pytest.mark.unit
     async def test_unknown_id_rolls_back_whole_batch(self, ctx: ToolContext) -> None:
         """一批里含未命中 id → 整批零落盘（同批的合法编辑也回滚），错误定位到该 id。"""
         out = await _call(
@@ -215,6 +218,7 @@ class TestPatchEpisodeScript:
         # 同批的合法编辑未落盘（all-or-nothing）
         assert _load(ctx)["segments"][0]["image_prompt"]["scene"] == "场景描述"
 
+    @pytest.mark.unit
     async def test_invalid_value_rolls_back_whole_batch(self, ctx: ToolContext) -> None:
         """某条把合法剧本改非法（duration 越界）→ 写盘统一入口挡下，整批不落盘。"""
         out = await _call(
@@ -232,6 +236,7 @@ class TestPatchEpisodeScript:
         assert saved[0]["duration_seconds"] == 4  # 未落盘
         assert saved[1]["image_prompt"]["scene"] == "场景描述"  # 同批回滚
 
+    @pytest.mark.unit
     async def test_error_localizes_scene_id_and_field(self, ctx: ToolContext) -> None:
         """字段路径不存在 → 错误精确指出触发的 scene_id + field。"""
         out = await _call(
@@ -243,11 +248,13 @@ class TestPatchEpisodeScript:
         assert "E1S01" in text
         assert "image_prompt.nope.deep" in text
 
+    @pytest.mark.unit
     async def test_empty_edits_rejected(self, ctx: ToolContext) -> None:
         """空 edits map 被拒（对齐 patch_project 的非空映射校验）。"""
         out = await _call(patch_episode_script_tool(ctx), {"script": "episode_1.json", "edits": {}})
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_empty_field_map_rejected(self, ctx: ToolContext) -> None:
         """某分镜的子映射为空 → 拒（禁止零信号成功）。"""
         out = await _call(
@@ -257,6 +264,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is True
         assert _load(ctx)["segments"][0]["image_prompt"]["scene"] == "场景描述"
 
+    @pytest.mark.unit
     async def test_reject_generated_assets(self, ctx: ToolContext) -> None:
         """禁改 generated_assets（逐字继承单编辑约束），整批不落盘。"""
         out = await _call(
@@ -265,6 +273,7 @@ class TestPatchEpisodeScript:
         )
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_reject_id_field(self, ctx: ToolContext) -> None:
         """禁改分镜 id 字段（逐字继承单编辑约束）。"""
         out = await _call(
@@ -274,6 +283,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is True
         assert [s["segment_id"] for s in _load(ctx)["segments"]] == ["E1S01", "E1S02"]
 
+    @pytest.mark.unit
     async def test_create_missing_optional_leaf(self, ctx: ToolContext) -> None:
         """叶子字段不存在可创建（补 LLM 漏写的 optional 字段 video_prompt.dialogue）。"""
         out = await _call(
@@ -286,6 +296,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert _load(ctx)["segments"][0]["video_prompt"]["dialogue"] == [{"speaker": "甲", "line": "台词"}]
 
+    @pytest.mark.unit
     async def test_rejects_path_in_script_arg(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_script_tool(ctx),
@@ -293,6 +304,7 @@ class TestPatchEpisodeScript:
         )
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_hallucinated_leaf_blocked_by_funnel(self, ctx: ToolContext) -> None:
         """中间路径存在、叶子被凭空创建的 hallucinated 字段（video_prompt.hallucinated_key）
         经写盘统一入口 extra='forbid' 结构校验拒写，不静默落盘。"""
@@ -303,6 +315,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is True
         assert "hallucinated_key" not in _load(ctx)["segments"][0]["video_prompt"]
 
+    @pytest.mark.unit
     async def test_middle_path_typo_fail_loud(self, ctx: ToolContext) -> None:
         """中间路径拼错（image_prompt.scen 应为 .scene）→ fail-loud，错误定位到 id/field。"""
         out = await _call(
@@ -313,6 +326,7 @@ class TestPatchEpisodeScript:
         text = _text(out)
         assert "E1S01" in text and "image_prompt.scen.x" in text
 
+    @pytest.mark.unit
     async def test_prompt_change_includes_regen_hint(self, ctx: ToolContext) -> None:
         """改了 image_prompt / video_prompt 后，返回文本聚合『须重新生成』提示。"""
         out = await _call(
@@ -322,6 +336,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert "重新生成" in _text(out)
 
+    @pytest.mark.unit
     async def test_non_prompt_change_omits_regen_hint(self, ctx: ToolContext) -> None:
         """只改非 prompt 字段（duration_seconds）时不追加重生提示。"""
         out = await _call(
@@ -331,6 +346,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert "重新生成" not in _text(out)
 
+    @pytest.mark.unit
     async def test_drama_mode_by_scene_id(self, drama_ctx: ToolContext) -> None:
         """drama 模式：按 scene_id 定位，批量改字段落盘。"""
         out = await _call(
@@ -340,6 +356,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert _load(drama_ctx)["scenes"][1]["image_prompt"]["scene"] == "剧集新场景"
 
+    @pytest.mark.unit
     async def test_reference_mode_by_unit_id(self, ref_ctx: ToolContext) -> None:
         """reference 模式：按 unit_id 定位，批量改字段落盘。"""
         out = await _call(
@@ -349,6 +366,7 @@ class TestPatchEpisodeScript:
         assert out.get("is_error") is not True
         assert _load(ref_ctx)["video_units"][0]["note"] == "单元备注"
 
+    @pytest.mark.unit
     async def test_ad_mode_by_shot_id(self, ad_ctx: ToolContext) -> None:
         """ad 模式：按 shot_id 定位，批量改字段落盘。"""
         out = await _call(
@@ -360,6 +378,7 @@ class TestPatchEpisodeScript:
 
 
 class TestInsertRemoveSplit:
+    @pytest.mark.unit
     async def test_insert_adds_at_position(self, ctx: ToolContext) -> None:
         out = await _call(
             insert_segment_tool(ctx),
@@ -369,11 +388,13 @@ class TestInsertRemoveSplit:
         ids = [s["segment_id"] for s in _load(ctx)["segments"]]
         assert ids == ["E1S01", "E1S01_1", "E1S02"]
 
+    @pytest.mark.unit
     async def test_remove_by_id(self, ctx: ToolContext) -> None:
         out = await _call(remove_segment_tool(ctx), {"script": "episode_1.json", "id": "E1S01"})
         assert out.get("is_error") is not True
         assert [s["segment_id"] for s in _load(ctx)["segments"]] == ["E1S02"]
 
+    @pytest.mark.unit
     async def test_split_keeps_first_id_clears_assets(self, ctx: ToolContext) -> None:
         # part 自带已生成资产，验证 split 改变分镜身份后会清空它（旧资产无合理归属）
         part_a = _segment("a")
@@ -389,6 +410,7 @@ class TestInsertRemoveSplit:
         assert not saved[0].get("generated_assets")
         assert not saved[1].get("generated_assets")
 
+    @pytest.mark.unit
     async def test_split_too_few_parts_errors(self, ctx: ToolContext) -> None:
         out = await _call(
             split_segment_tool(ctx),
@@ -400,6 +422,7 @@ class TestInsertRemoveSplit:
 class TestPatchEpisodeMeta:
     """patch_episode_meta：编辑剧本顶层 title，白名单兜底，写盘自动镜像到 project.json。"""
 
+    @pytest.mark.unit
     async def test_set_title(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_meta_tool(ctx),
@@ -412,6 +435,7 @@ class TestPatchEpisodeMeta:
         entry = next(e for e in episodes if e["episode"] == 1)
         assert entry["title"] == "新标题"
 
+    @pytest.mark.unit
     async def test_title_trimmed(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_meta_tool(ctx),
@@ -420,6 +444,7 @@ class TestPatchEpisodeMeta:
         assert out.get("is_error") is not True
         assert _load(ctx)["title"] == "去空白"
 
+    @pytest.mark.unit
     async def test_empty_title_rejected(self, ctx: ToolContext) -> None:
         for blank in ("", "   ", "\t\n"):
             out = await _call(
@@ -429,6 +454,7 @@ class TestPatchEpisodeMeta:
             assert out.get("is_error") is True
         assert _load(ctx)["title"] == "标题"  # 原值未改
 
+    @pytest.mark.unit
     async def test_non_whitelist_field_rejected(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_meta_tool(ctx),
@@ -437,6 +463,7 @@ class TestPatchEpisodeMeta:
         assert out.get("is_error") is True
         assert _load(ctx)["episode"] == 1  # 未被改写
 
+    @pytest.mark.unit
     async def test_non_string_value_rejected(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_meta_tool(ctx),
@@ -445,6 +472,7 @@ class TestPatchEpisodeMeta:
         assert out.get("is_error") is True
         assert _load(ctx)["title"] == "标题"
 
+    @pytest.mark.unit
     async def test_rejects_path_in_script_arg(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_episode_meta_tool(ctx),
@@ -454,6 +482,7 @@ class TestPatchEpisodeMeta:
 
 
 class TestPatchProject:
+    @pytest.mark.unit
     async def test_add_new_character(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -464,6 +493,7 @@ class TestPatchProject:
         assert chars["李白"]["description"] == "白衣剑客"
         assert chars["李白"]["voice_style"] == "豪放"
 
+    @pytest.mark.unit
     async def test_modify_existing_character_merges_fields(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"table": "characters", "entries": {"李白": {"description": "剑客"}}})
         out = await _call(
@@ -473,6 +503,7 @@ class TestPatchProject:
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["characters"]["李白"]["description"] == "改后描述"
 
+    @pytest.mark.unit
     async def test_invalid_entry_blocked_and_not_written(self, ctx: ToolContext) -> None:
         """缺 description 的资产结构非法 → 校验失败、不落盘。"""
         out = await _call(
@@ -482,10 +513,12 @@ class TestPatchProject:
         assert out.get("is_error") is True
         assert "空场景" not in ctx.pm.load_project("demo").get("scenes", {})
 
+    @pytest.mark.unit
     async def test_unknown_table_errors(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"table": "weapons", "entries": {"剑": {"description": "x"}}})
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_invalid_entry_rejected_even_when_project_already_invalid(self, ctx: ToolContext) -> None:
         """「不更坏」error set diff 语义：项目本就脏（无关字段非法）时，本次 upsert 引入的
         新错误（如新 entry 缺 description）仍应被拒——单纯 `before_valid AND after.valid` 判定
@@ -501,6 +534,7 @@ class TestPatchProject:
         # 不落盘：空场景没写入
         assert "空场景" not in ctx.pm.load_project("demo").get("scenes", {})
 
+    @pytest.mark.unit
     async def test_upsert_allowed_when_project_already_invalid(self, ctx: ToolContext) -> None:
         """「不更坏」：项目本就含与资产无关的历史非法（空 style）时，patch_project 仍应成功——
         否则带历史脏数据的项目会整条编辑路径不可用。"""
@@ -512,6 +546,7 @@ class TestPatchProject:
         assert out.get("is_error") is not True
         assert "李白" in ctx.pm.load_project("demo").get("characters", {})
 
+    @pytest.mark.unit
     async def test_entry_name_whitespace_normalized(self, ctx: ToolContext) -> None:
         """agent 传带前后空格的 name → strip 规范化后存储（避免按 name 查找因空格差异 mismatch）。"""
         out = await _call(
@@ -523,6 +558,7 @@ class TestPatchProject:
         assert "李白" in chars  # 规范化后存储
         assert "  李白  " not in chars
 
+    @pytest.mark.unit
     async def test_blank_entry_name_rejected(self, ctx: ToolContext) -> None:
         """全空白或空 name fail-loud：避免把 \"\" / \"   \" 写成合法 entry key。"""
         for blank_name in ("", "   ", "\t\n"):
@@ -532,6 +568,7 @@ class TestPatchProject:
             )
             assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_non_string_extra_field_rejected(self, ctx: ToolContext) -> None:
         """voice_style 等 extra_string_fields 须为字符串：agent 传 int / dict / list 会被守卫点拦下，
         否则下游把 reference_image 当路径拼接时会运行时崩。"""
@@ -542,6 +579,7 @@ class TestPatchProject:
         assert out.get("is_error") is True
         assert "李白" not in ctx.pm.load_project("demo").get("characters", {})
 
+    @pytest.mark.unit
     async def test_upsert_strips_sheet_and_unknown_fields(self, ctx: ToolContext) -> None:
         """least-privilege：agent 仅能改 description + spec.extra_string_fields。
         sheet 字段（系统生成的资产图路径）+ spec-undeclared key 均被静默丢弃，不让 agent
@@ -577,6 +615,7 @@ class TestPatchProject:
         assert char["character_sheet"] == "characters/li_bai.png"  # 系统字段未被 agent 覆写
         assert "random_extra_field" not in char  # spec 外字段不入库
 
+    @pytest.mark.unit
     async def test_upsert_strips_reference_audio(self, ctx: ToolContext) -> None:
         """reference_audio 与 reference_image 同性质（用户上传路径），不进
         agent_editable_extra_fields，agent 尝试写入应被静默丢弃。"""
@@ -609,6 +648,7 @@ class TestPatchProject:
         char = ctx.pm.load_project("demo")["characters"]["李白"]
         assert char["reference_audio"] == "characters/refs_audio/李白.wav"  # 未被 agent 覆写
 
+    @pytest.mark.unit
     async def test_non_string_description_rejected(self, ctx: ToolContext) -> None:
         """description 必须是非空字符串：agent 误传数字（如 LLM 把"1"输出成 int）
         会让原 truthy 校验放行、错误数据作为合法资产落盘——守卫点须 fail-loud。"""
@@ -619,6 +659,7 @@ class TestPatchProject:
         assert out.get("is_error") is True
         assert "阿青" not in ctx.pm.load_project("demo").get("characters", {})
 
+    @pytest.mark.unit
     async def test_upsert_fails_loud_when_bucket_not_dict(self, ctx: ToolContext) -> None:
         """bucket_key 已存在却非 dict（历史脏数据，如 list）→ fail-loud，
         而非在 bucket.get 处抛含糊的 AttributeError。"""
@@ -629,6 +670,7 @@ class TestPatchProject:
         )
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_normalized_name_collision_fails_loud(self, ctx: ToolContext) -> None:
         """两个 raw key strip 后等价（如 "李白" 与 "  李白  "）→ fail-loud，避免后者
         silent overwrite 前者的 attrs；agent 应明确感知 collision 并去重。"""
@@ -646,6 +688,7 @@ class TestPatchProject:
         # 任何一个版本都不应入库（mutation 在校验阶段就 raise，不落盘）
         assert "李白" not in ctx.pm.load_project("demo").get("characters", {})
 
+    @pytest.mark.unit
     async def test_upsert_strips_reference_image_field(self, ctx: ToolContext) -> None:
         """reference_image 是用户上传或系统生成的文件路径（与 sheet_field 同性质），
         agent_editable_extra_fields 不包含它——patch_project 应静默丢弃，不让 agent
@@ -681,6 +724,7 @@ class TestPatchProject:
         # 用户上传的 reference_image 不被 agent 覆写
         assert char["reference_image"] == "characters/refs/li_bai.jpg"
 
+    @pytest.mark.unit
     async def test_product_upsert_selling_points_editable(self, ctx: ToolContext) -> None:
         """products 表对 agent 开放；selling_points 在可编辑白名单内（agent 起草、用户可改），
         新 entry 的列表字段按 spec 初始化。"""
@@ -699,6 +743,7 @@ class TestPatchProject:
         assert product["product_sheet"] == ""
         assert product["brand"] == ""
 
+    @pytest.mark.unit
     async def test_product_upsert_strips_reference_images(self, ctx: ToolContext) -> None:
         """reference_images 是用户上传的原图路径列表（保真验收锚点），不在 agent 白名单——
         upsert 应静默丢弃且不覆写既有值，更新走专用上传 API。"""
@@ -727,6 +772,7 @@ class TestPatchProject:
         assert product["selling_points"] == ["双层真空"]
         assert product["reference_images"] == ["products/refs/保温杯_1.jpg"]
 
+    @pytest.mark.unit
     async def test_product_upsert_invalid_selling_points_blocked(self, ctx: ToolContext) -> None:
         """selling_points 须为字符串列表：非法类型被结构校验拦截，不落盘。"""
         out = await _call(
@@ -736,6 +782,7 @@ class TestPatchProject:
         assert out.get("is_error") is True
         assert "保温杯" not in ctx.pm.load_project("demo").get("products", {})
 
+    @pytest.mark.unit
     async def test_response_distinguishes_added_and_merged(self, ctx: ToolContext) -> None:
         """工具返回文本应区分『新增 N 个 / 合并改字段 N 个』,让 agent 验证是否符合预期策略
         (如 analyze-assets subagent 应预期合并数=0,出现合并数说明遗漏了已存在过滤)。"""
@@ -755,6 +802,7 @@ class TestPatchProject:
         assert "合并改字段" in text2 and "李白" in text2
         assert "新增" not in text2
 
+    @pytest.mark.unit
     async def test_response_lists_dropped_non_allowed_fields(self, ctx: ToolContext) -> None:
         """工具返回文本应显式列出被白名单丢弃的字段(reference_image / sheet_field 等),
         让 LLM 知道为何这些字段没生效,不再重复尝试。"""
@@ -776,6 +824,7 @@ class TestPatchProject:
         assert "character_sheet" in text
         assert "agent 可编辑范围" in text or "已忽略" in text
 
+    @pytest.mark.unit
     async def test_existing_entry_with_only_dropped_fields_reports_noop(self, ctx: ToolContext) -> None:
         """已存在的 entry,agent 提交的全部字段都被白名单/legacy strip 丢空时,
         cleaned[name]={} → bucket.update({}) 是 no-op。工具应明确报『无可写字段已跳过』,
@@ -801,6 +850,7 @@ class TestPatchProject:
         # 描述未被改写,仍为原值
         assert ctx.pm.load_project("demo")["characters"]["李白"]["description"] == "白衣剑客"
 
+    @pytest.mark.unit
     async def test_response_lists_dropped_legacy_fields(self, ctx: ToolContext) -> None:
         """工具返回文本应显式列出被剔除的历史字段(type / importance),让 agent 不再发它们。"""
         out = await _call(
@@ -825,12 +875,14 @@ class TestPatchProject:
 class TestPatchProjectSettings:
     """patch_project 顶层 settings 分支:首期支持 episode_target_units 写入/清除/校验."""
 
+    @pytest.mark.unit
     async def test_set_episode_target_units(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": 1000}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["episode_target_units"] == 1000
         assert "已更新" in _text(out)
 
+    @pytest.mark.unit
     async def test_clear_episode_target_units(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": 1000}})
         out = await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": None}})
@@ -838,12 +890,14 @@ class TestPatchProjectSettings:
         assert "episode_target_units" not in ctx.pm.load_project("demo")
         assert "已清除" in _text(out)
 
+    @pytest.mark.unit
     async def test_noop_when_same_value(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": 800}})
         out = await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": 800}})
         assert out.get("is_error") is not True
         assert "无变更" in _text(out)
 
+    @pytest.mark.unit
     async def test_non_whitelist_field_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"arbitrary_field": 1}})
         assert out.get("is_error") is True
@@ -858,6 +912,7 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is True
         assert ctx.pm.load_project("demo").get(field) == before
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("lang", ["zh", "en", "vi"])
     async def test_set_source_language_allowed_values(self, ctx: ToolContext, lang: str) -> None:
         """source_language 作为 user-confirmed 恢复通道(overview 失败/跳过时),enum 校验."""
@@ -865,24 +920,28 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["source_language"] == lang
 
+    @pytest.mark.unit
     async def test_clear_source_language(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"source_language": "en"}})
         out = await _call(patch_project_tool(ctx), {"settings": {"source_language": None}})
         assert out.get("is_error") is not True
         assert "source_language" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad", ["english", "ja", "ZH", "", 1, True, ["en"]])
     async def test_invalid_source_language_rejected(self, ctx: ToolContext, bad: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"source_language": bad}})
         assert out.get("is_error") is True
         assert "source_language" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad_value", [0, -5, 1.5, True, "10.5", "10.0", "abc", ""])
     async def test_invalid_value_rejected(self, ctx: ToolContext, bad_value: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"episode_target_units": bad_value}})
         assert out.get("is_error") is True
         assert "episode_target_units" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("key", ["episode_target_units", "planning_window_chars", "planning_max_episodes"])
     async def test_positive_int_setting_accepts_digit_string(self, ctx: ToolContext, key: str) -> None:
         """MCP object 入参无逐字段类型声明，模型常把数字加引号传入；数字字符串按落盘用 int 容忍。"""
@@ -890,6 +949,7 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")[key] == 10
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("key", ["planning_window_chars", "planning_max_episodes"])
     async def test_set_and_clear_planning_overrides(self, ctx: ToolContext, key: str) -> None:
         """分集规划的窗口字数 / 每批集数覆盖项：正整数写入，null 清除回内部默认。"""
@@ -900,6 +960,7 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is not True
         assert key not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("key", ["planning_window_chars", "planning_max_episodes"])
     @pytest.mark.parametrize("bad_value", [0, -1, 2.5, True, "10.5", "10.0", "abc", ""])
     async def test_invalid_planning_override_rejected(self, ctx: ToolContext, key: str, bad_value: Any) -> None:
@@ -907,6 +968,7 @@ class TestPatchProjectSettings:
         assert out.get("is_error") is True
         assert key not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     async def test_table_and_settings_together_rejected(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -914,14 +976,17 @@ class TestPatchProjectSettings:
         )
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_neither_table_nor_settings_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {})
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_empty_settings_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {}})
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_legacy_upsert_path_still_works(self, ctx: ToolContext) -> None:
         """老 schema 回归:只传 table/entries 仍走 upsert 分支(向后兼容 8 处既有调用)."""
         out = await _call(
@@ -935,18 +1000,21 @@ class TestPatchProjectSettings:
 class TestPatchProjectNarrationSettings:
     """narration_voice / narration_speed 经 settings 白名单写入/清除/校验（项目级旁白覆盖）。"""
 
+    @pytest.mark.unit
     async def test_set_narration_voice(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_voice": "Ethan"}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["narration_voice"] == "Ethan"
         assert "已更新" in _text(out)
 
+    @pytest.mark.unit
     async def test_modify_narration_voice(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"narration_voice": "Ethan"}})
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_voice": "Cherry"}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["narration_voice"] == "Cherry"
 
+    @pytest.mark.unit
     async def test_clear_narration_voice(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"narration_voice": "Ethan"}})
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_voice": None}})
@@ -954,24 +1022,28 @@ class TestPatchProjectNarrationSettings:
         assert "narration_voice" not in ctx.pm.load_project("demo")
         assert "已清除" in _text(out)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad", ["", "   ", "\t\n", 1, 1.5, True, ["Ethan"], {"id": "Ethan"}])
     async def test_invalid_narration_voice_rejected(self, ctx: ToolContext, bad: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_voice": bad}})
         assert out.get("is_error") is True
         assert "narration_voice" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("speed", [1.2, 0.5, 2, 1])
     async def test_set_narration_speed(self, ctx: ToolContext, speed: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": speed}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["narration_speed"] == speed
 
+    @pytest.mark.unit
     async def test_narration_speed_accepts_numeric_string(self, ctx: ToolContext) -> None:
         """MCP object 入参无逐字段类型声明，模型常把数字加引号传入；有限数值字符串按落盘用 float 容忍。"""
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": "1.5"}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["narration_speed"] == 1.5
 
+    @pytest.mark.unit
     async def test_clear_narration_speed(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"settings": {"narration_speed": 1.2}})
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": None}})
@@ -979,6 +1051,7 @@ class TestPatchProjectNarrationSettings:
         assert "narration_speed" not in ctx.pm.load_project("demo")
         assert "已清除" in _text(out)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad", [0, -1.5, float("inf"), float("nan"), True, False, "fast", "", [1.2], 10**400])
     async def test_invalid_narration_speed_rejected(self, ctx: ToolContext, bad: Any) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"narration_speed": bad}})
@@ -987,6 +1060,7 @@ class TestPatchProjectNarrationSettings:
         assert "narration_speed 必须是正的有限数值" in _text(out)
         assert "narration_speed" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     async def test_one_invalid_field_rejects_whole_batch(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -997,6 +1071,7 @@ class TestPatchProjectNarrationSettings:
         assert "narration_voice" not in project
         assert "narration_speed" not in project
 
+    @pytest.mark.unit
     async def test_resolver_uses_values_written_by_tool(self, ctx: ToolContext) -> None:
         """工具写入与生成端解析读的是同一份顶层字段:写入后 resolver 实际解析出覆盖值。"""
         from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -1025,6 +1100,7 @@ class TestPatchProjectNarrationSettings:
 class TestPatchProjectOverview:
     """patch_project overview 分支：四字段白名单 merge 编辑，概述不存在时创建，三选一互斥。"""
 
+    @pytest.mark.unit
     async def test_set_overview_fields(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -1038,6 +1114,7 @@ class TestPatchProjectOverview:
         assert ov["world_setting"] == "近未来"
         assert "已更新" in _text(out)
 
+    @pytest.mark.unit
     async def test_merge_preserves_untouched_fields(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"overview": {"synopsis": "原始梗概", "genre": "原题材"}})
         out = await _call(patch_project_tool(ctx), {"overview": {"genre": "悬疑"}})
@@ -1046,32 +1123,38 @@ class TestPatchProjectOverview:
         assert ov["genre"] == "悬疑"
         assert ov["synopsis"] == "原始梗概"  # 未传字段保留
 
+    @pytest.mark.unit
     async def test_creates_overview_when_absent(self, ctx: ToolContext) -> None:
         assert "overview" not in ctx.pm.load_project("demo")
         out = await _call(patch_project_tool(ctx), {"overview": {"synopsis": "新建概述"}})
         assert out.get("is_error") is not True
         assert ctx.pm.load_project("demo")["overview"]["synopsis"] == "新建概述"
 
+    @pytest.mark.unit
     async def test_non_whitelist_key_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"overview": {"title": "x"}})
         assert out.get("is_error") is True
         assert "title" not in ctx.pm.load_project("demo").get("overview", {})
 
+    @pytest.mark.unit
     async def test_non_string_value_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"overview": {"synopsis": 1}})
         assert out.get("is_error") is True
         assert "overview" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     async def test_empty_overview_rejected(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"overview": {}})
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_noop_when_same_value(self, ctx: ToolContext) -> None:
         await _call(patch_project_tool(ctx), {"overview": {"synopsis": "同值"}})
         out = await _call(patch_project_tool(ctx), {"overview": {"synopsis": "同值"}})
         assert out.get("is_error") is not True
         assert "无变更" in _text(out)
 
+    @pytest.mark.unit
     async def test_overview_with_settings_rejected(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -1079,6 +1162,7 @@ class TestPatchProjectOverview:
         )
         assert out.get("is_error") is True
 
+    @pytest.mark.unit
     async def test_overview_with_table_rejected(self, ctx: ToolContext) -> None:
         out = await _call(
             patch_project_tool(ctx),
@@ -1097,22 +1181,26 @@ class TestPatchProjectBriefSetting:
         pm.create_project_metadata("ad-demo", "Ad Demo", "Realistic", "ad", target_duration=60)
         return ToolContext(project_name="ad-demo", projects_root=tmp_path, pm=pm)
 
+    @pytest.mark.unit
     async def test_set_brief_on_ad_project(self, ad_ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ad_ctx), {"settings": {"brief": "突出 3 秒速干卖点"}})
         assert out.get("is_error") is not True
         assert ad_ctx.pm.load_project("ad-demo")["brief"] == "突出 3 秒速干卖点"
 
+    @pytest.mark.unit
     async def test_clear_brief_on_ad_project(self, ad_ctx: ToolContext) -> None:
         await _call(patch_project_tool(ad_ctx), {"settings": {"brief": "x"}})
         out = await _call(patch_project_tool(ad_ctx), {"settings": {"brief": None}})
         assert out.get("is_error") is not True
         assert "brief" not in ad_ctx.pm.load_project("ad-demo")
 
+    @pytest.mark.unit
     async def test_brief_rejected_on_non_ad_project(self, ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ctx), {"settings": {"brief": "x"}})
         assert out.get("is_error") is True
         assert "brief" not in ctx.pm.load_project("demo")
 
+    @pytest.mark.unit
     async def test_non_string_brief_rejected(self, ad_ctx: ToolContext) -> None:
         out = await _call(patch_project_tool(ad_ctx), {"settings": {"brief": 42}})
         assert out.get("is_error") is True

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -132,6 +132,7 @@ async def _call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_build_arcreel_mcp_server_contains_all_tools(tmp_path: Path) -> None:
     srv = build_arcreel_mcp_server(project_name="demo", projects_root=tmp_path)
     assert srv["name"] == "arcreel"
@@ -140,6 +141,7 @@ def test_build_arcreel_mcp_server_contains_all_tools(tmp_path: Path) -> None:
     assert "instance" in srv
 
 
+@pytest.mark.unit
 def test_generate_narration_audio_registered() -> None:
     """旁白配音工具必须同时进 MCP 工具 id 集（前端 chip 三语校验依赖它）。"""
     from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
@@ -152,6 +154,7 @@ def test_generate_narration_audio_registered() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "bad",
     [
@@ -171,12 +174,14 @@ def test_validate_script_filename_rejects_paths(bad: str) -> None:
         validate_script_filename(bad)
 
 
+@pytest.mark.unit
 def test_validate_script_filename_accepts_basename() -> None:
     from server.agent_runtime.sdk_tools._context import validate_script_filename
 
     assert validate_script_filename("episode_1.json") == "episode_1.json"
 
 
+@pytest.mark.unit
 async def test_generate_storyboards_rejects_path_in_script_arg(fake_ctx: ToolContext) -> None:
     """Agent 传带路径分隔符的 script 名必须被 handler 拒绝（共享 validate_script_filename 防御）。"""
     tool_obj = generate_storyboards_tool(fake_ctx)
@@ -190,6 +195,7 @@ async def test_generate_storyboards_rejects_path_in_script_arg(fake_ctx: ToolCon
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_list_pending_assets_happy(fake_ctx: ToolContext) -> None:
     tool_obj = list_pending_assets_tool(fake_ctx)
     out = await _call(tool_obj, {})
@@ -200,6 +206,7 @@ async def test_list_pending_assets_happy(fake_ctx: ToolContext) -> None:
     assert "保温杯" in text
 
 
+@pytest.mark.unit
 async def test_list_pending_assets_error(fake_ctx: ToolContext, monkeypatch) -> None:
     def boom(_name):
         raise RuntimeError("db down")
@@ -210,6 +217,7 @@ async def test_list_pending_assets_error(fake_ctx: ToolContext, monkeypatch) -> 
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_assets_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_assets as mod
 
@@ -236,6 +244,7 @@ async def test_generate_assets_happy(fake_ctx: ToolContext, monkeypatch) -> None
     assert "张三" in text
 
 
+@pytest.mark.unit
 async def test_generate_assets_names_without_type(fake_ctx: ToolContext) -> None:
     tool_obj = generate_assets_tool(fake_ctx)
     out = await _call(tool_obj, {"names": ["张三"]})
@@ -266,6 +275,7 @@ def _narration_audio_script() -> dict[str, Any]:
     }
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: ToolContext, monkeypatch) -> None:
     """不传 segment_ids → 只为缺 narration_audio 的段入队 tts 任务，prompt 为该段 novel_text。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -304,6 +314,7 @@ async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: Tool
     assert "audio/segment_E1S01.wav" in text
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_selects_item_with_corrupt_generated_assets(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -338,6 +349,7 @@ async def test_generate_narration_audio_selects_item_with_corrupt_generated_asse
     assert [s.resource_id for s in captured] == ["E1S01"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_explicit_ids_regenerate(fake_ctx: ToolContext, monkeypatch) -> None:
     """传 segment_ids → 即使该段已有 narration_audio 也重新入队（批量范围/单段重生语义）。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -361,6 +373,7 @@ async def test_generate_narration_audio_explicit_ids_regenerate(fake_ctx: ToolCo
     assert [s.resource_id for s in captured] == ["E1S02"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_blank_text_reported(fake_ctx: ToolContext, monkeypatch) -> None:
     """novel_text 空白的段不能静默丢弃：不入队、在输出中可见，显式点名时按错误上报。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -397,6 +410,7 @@ async def test_generate_narration_audio_blank_text_reported(fake_ctx: ToolContex
     assert "0 succeeded, 1 failed" in text
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_partial_unmatched_reported(fake_ctx: ToolContext, monkeypatch) -> None:
     """部分 id 不命中不能静默丢弃：命中的照常入队，未命中的按失败上报。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -423,6 +437,7 @@ async def test_generate_narration_audio_partial_unmatched_reported(fake_ctx: Too
     assert "E1S99" in text and "片段不存在" in text
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_rejects_drama_script(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
 
@@ -535,6 +550,7 @@ async def test_generate_narration_audio_rejects_mismatched_script(fake_ctx: Tool
     assert "骨架" in text and "重新拆分" in text
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_rejects_string_segment_ids(fake_ctx: ToolContext) -> None:
     """segment_ids 传裸字符串会被逐字符迭代成 {'E','1','S'...}，必须显式拒绝。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -546,6 +562,7 @@ async def test_generate_narration_audio_rejects_string_segment_ids(fake_ctx: Too
     assert "数组" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_skips_segment_without_id(fake_ctx: ToolContext, monkeypatch) -> None:
     """缺 segment_id 的片段不能让整批中断：跳过并告警，其余片段照常入队。"""
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
@@ -572,6 +589,7 @@ async def test_generate_narration_audio_skips_segment_without_id(fake_ctx: ToolC
     assert "跳过 1 个缺少 segment_id 的片段" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_no_match_error(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
 
@@ -582,6 +600,7 @@ async def test_generate_narration_audio_no_match_error(fake_ctx: ToolContext) ->
     assert "没有找到匹配的片段" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_all_done(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
 
@@ -594,6 +613,7 @@ async def test_generate_narration_audio_all_done(fake_ctx: ToolContext) -> None:
     assert "所有片段的旁白音频都已生成" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_task_failures_surface(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
 
@@ -617,6 +637,7 @@ async def test_generate_narration_audio_task_failures_surface(fake_ctx: ToolCont
     assert "provider down" in text
 
 
+@pytest.mark.unit
 async def test_generate_narration_audio_rejects_path_in_script_arg(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import enqueue_narration_audio as mod
 
@@ -631,6 +652,7 @@ async def test_generate_narration_audio_rejects_path_in_script_arg(fake_ctx: Too
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_generate_storyboards_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_storyboards as mod
 
@@ -656,6 +678,7 @@ async def test_generate_storyboards_happy(fake_ctx: ToolContext, monkeypatch) ->
     assert out.get("is_error") is not True
 
 
+@pytest.mark.unit
 async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -703,6 +726,7 @@ async def test_generate_storyboards_rejects_mismatched_unit_script(fake_ctx: Too
     assert "骨架" in text and "重新拆分" in text
 
 
+@pytest.mark.unit
 async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) -> None:
     def boom(*args, **kwargs):
         raise ValueError("bad script")
@@ -718,6 +742,7 @@ async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) ->
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_edit_images_registered() -> None:
     """edit_images 必须同时进 MCP 工具 id 集（前端 chip 三语校验依赖它）。"""
     from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
@@ -725,6 +750,7 @@ def test_edit_images_registered() -> None:
     assert "edit_images" in ARCREEL_MCP_TOOL_IDS
 
 
+@pytest.mark.unit
 async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
@@ -763,6 +789,7 @@ async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     assert "张三" in text
 
 
+@pytest.mark.unit
 async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext, monkeypatch) -> None:
     """i2i 不可用时直接报错，不创建任何任务（复用服务端 fail-fast 判断点）。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -779,6 +806,7 @@ async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext, monkeypatch) -
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
@@ -792,12 +820,14 @@ async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext
     assert "script_file" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_edit_images_rejects_unknown_resource_type(fake_ctx: ToolContext) -> None:
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "video", "edits": [{"id": "x", "instruction": "y"}]})
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext, monkeypatch) -> None:
     """资产没有可编辑的当前图（sheet 字段未设置）时跳过并告警，不入队。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -815,6 +845,7 @@ async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext, mo
     assert "没有可编辑的当前图" in text
 
 
+@pytest.mark.unit
 async def test_edit_images_rejects_empty_edits(fake_ctx: ToolContext) -> None:
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "character", "edits": []})
@@ -822,6 +853,7 @@ async def test_edit_images_rejects_empty_edits(fake_ctx: ToolContext) -> None:
     assert "edits 不能为空" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypatch) -> None:
     """_build_specs 的告警分支（非法条目/缺 id/重复 id/缺指令/资源不存在）逐一命中，合法条目仍正常入队。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -874,6 +906,7 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
     assert "1 succeeded" in text
 
 
+@pytest.mark.unit
 async def test_edit_images_storyboard_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     """storyboard 分支带合法 script_file 时应正常解析剧本并入队（覆盖 validate_script_filename + load_script 调用）。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -910,6 +943,7 @@ async def test_edit_images_storyboard_happy(fake_ctx: ToolContext, monkeypatch) 
     assert "1 succeeded" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) -> None:
     """批量入队返回失败项时，摘要与明细都要带上失败原因。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -941,6 +975,7 @@ async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) 
     assert "provider timeout" in text
 
 
+@pytest.mark.unit
 async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
     """未预期的异常（如 pm 读取项目失败）要落到统一的 tool_error 兜底，而非向上抛出。"""
 
@@ -954,6 +989,7 @@ async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
     assert "edit_images 失败" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_i2i_provider_available_true(monkeypatch) -> None:
     from lib.config.resolver import ConfigResolver
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -966,6 +1002,7 @@ async def test_i2i_provider_available_true(monkeypatch) -> None:
     assert await mod._i2i_provider_available({}) is True
 
 
+@pytest.mark.unit
 async def test_i2i_provider_available_false_on_value_error(monkeypatch) -> None:
     from lib.config.resolver import ConfigResolver
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
@@ -982,6 +1019,7 @@ async def test_i2i_provider_available_false_on_value_error(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_generate_grid_list_only(fake_ctx: ToolContext) -> None:
     fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
     fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
@@ -995,6 +1033,7 @@ async def test_generate_grid_list_only(fake_ctx: ToolContext) -> None:
     assert "分组" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_grid_wrong_mode(fake_ctx: ToolContext) -> None:
     # 项目未开启 grid_storyboard → error
     tool_obj = generate_grid_tool(fake_ctx)
@@ -1002,6 +1041,7 @@ async def test_generate_grid_wrong_mode(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_grid_rejected_on_reference_video_route(fake_ctx: ToolContext) -> None:
     # reference_video 路线无分镜图步骤：即使残留 grid_storyboard=true 也不适用宫格工具
     fake_ctx.pm.project_payload["generation_mode"] = "reference_video"  # type: ignore[attr-defined]
@@ -1016,6 +1056,7 @@ async def test_generate_grid_rejected_on_reference_video_route(fake_ctx: ToolCon
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_generate_video_episode_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
@@ -1072,6 +1113,7 @@ async def test_generate_video_episode_non_dict_generated_assets_does_not_abort_b
     assert enqueued == ["E1S02"]
 
 
+@pytest.mark.unit
 async def test_generate_video_episode_error(fake_ctx: ToolContext) -> None:
     fake_ctx.pm.script_payload = {"content_mode": "narration", "segments": [], "episode": 1}  # type: ignore[attr-defined]
     tool_obj = generate_video_episode_tool(fake_ctx)
@@ -1560,6 +1602,7 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
     assert [s.resource_id for s in enqueued] == ["E1U1"]
 
 
+@pytest.mark.unit
 async def test_generate_video_scene_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
@@ -1572,6 +1615,7 @@ async def test_generate_video_scene_happy(fake_ctx: ToolContext, monkeypatch) ->
     assert out.get("is_error") is not True
 
 
+@pytest.mark.unit
 async def test_generate_video_scene_missing(fake_ctx: ToolContext) -> None:
     tool_obj = generate_video_scene_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "NO_SUCH"})
@@ -1598,6 +1642,7 @@ async def test_generate_video_scene_rejects_invalid_storyboard_image(
     assert f"invalid storyboard image path: {storyboard_value!r}" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
@@ -1618,6 +1663,7 @@ async def test_generate_video_all_happy(fake_ctx: ToolContext, monkeypatch) -> N
     assert out.get("is_error") is not True
 
 
+@pytest.mark.unit
 async def test_generate_video_all_error(fake_ctx: ToolContext) -> None:
     def boom(*a, **kw):
         raise RuntimeError("broken")
@@ -1628,6 +1674,7 @@ async def test_generate_video_all_error(fake_ctx: ToolContext) -> None:
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_video_selected_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
@@ -1652,12 +1699,14 @@ async def test_generate_video_selected_happy(fake_ctx: ToolContext, monkeypatch)
     assert out.get("is_error") is not True
 
 
+@pytest.mark.unit
 async def test_generate_video_selected_no_match(fake_ctx: ToolContext) -> None:
     tool_obj = generate_video_selected_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["NO_SUCH"]})
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 def test_build_asset_specs_skips_invalid_description(monkeypatch) -> None:
     """空白 / 非字符串描述都被跳过并告警，不应抛错（.strip()）或漏到 from_request 而中断整批。"""
     from lib.asset_types import ASSET_SPECS
@@ -1682,6 +1731,7 @@ def test_build_asset_specs_skips_invalid_description(monkeypatch) -> None:
     assert any("Carol" in w for w in warnings)
 
 
+@pytest.mark.unit
 def test_build_asset_specs_resolves_nfd_registered_key() -> None:
     """智能体给的名字与桶 key 形态可以不同：按坐标系解析后入队，resource_id 用真实落盘 key。"""
     import unicodedata
@@ -1709,6 +1759,7 @@ def test_build_asset_specs_resolves_nfd_registered_key() -> None:
     assert warnings == []
 
 
+@pytest.mark.unit
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
     """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
@@ -1835,6 +1886,7 @@ async def test_generate_video_scene_generated_assets_non_dict_readable_rejection
     assert "没有分镜图" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     """drama：_get_video_prompt 从场景级 dialogue-kind utterances 派生 video YAML 台词，
     voiceover-kind 不进；narration / ad（无 utterances 字段）原样渲染既有 video_prompt.dialogue。"""
@@ -1866,6 +1918,7 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     assert parsed_narr["Dialogue"] == [{"Speaker": "Alice", "Line": "hello"}]
 
 
+@pytest.mark.unit
 def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None:
     """drama：传入带非空 voice_style 的角色资产时 YAML 顶部出现 Voice_Profiles；
     voice_characters 缺省（既有调用点行为）不注入。"""
@@ -1892,6 +1945,7 @@ def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None
     assert "Voice_Profiles" not in parsed_no_style
 
 
+@pytest.mark.unit
 def test_get_video_prompt_injects_voice_profiles_from_legacy_dialogue() -> None:
     """utterances 迁移前的存量 drama 剧本（无 utterances 字段，台词仍在
     video_prompt.dialogue）：改走 legacy 出口派生 Voice_Profiles，不因缺 utterances 静默丢失。"""
@@ -1915,6 +1969,7 @@ def test_get_video_prompt_injects_voice_profiles_from_legacy_dialogue() -> None:
     assert parsed["Dialogue"] == [{"Speaker": "王", "Line": "你来了。"}]
 
 
+@pytest.mark.unit
 def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() -> None:
     """narration/ad（item 无 utterances 字段）剧本 video_prompt 自带 voice_profiles 时一律剥离：
     该声明段唯一来源是 build_drama_video_prompt 的机械派生，剧本残留值不得越权、绕过 C 类
@@ -1936,6 +1991,7 @@ def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() 
     assert "Voice_Profiles" not in parsed
 
 
+@pytest.mark.unit
 async def test_resolve_voice_characters_skips_non_drama(fake_ctx: ToolContext) -> None:
     """narration/ad：不解析 voice_consistency，直接跳过（无 drama dialogue speaker 概念）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_characters
@@ -1943,6 +1999,7 @@ async def test_resolve_voice_characters_skips_non_drama(fake_ctx: ToolContext) -
     assert await _resolve_voice_characters(fake_ctx, "narration") is None
 
 
+@pytest.mark.unit
 async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -1963,6 +2020,7 @@ async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     assert await mod._resolve_voice_characters(fake_ctx, "drama") is None
 
 
+@pytest.mark.unit
 def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     """参考生视频入队经统一守卫点：prompt 由 shots 拼接后随 payload 入队（见 ADR-0001）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
@@ -1986,6 +2044,7 @@ def test_build_reference_specs_routes_through_guard(tmp_path) -> None:
     assert specs[0].payload["script_file"] == "episode_1.json"
 
 
+@pytest.mark.unit
 def test_build_reference_specs_skips_blank_prompt(tmp_path) -> None:
     """shots 存在但文本全空白的 unit 被跳过并告警，不漏到执行层（结构校验上移到守卫点）。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
@@ -2000,6 +2059,7 @@ def test_build_reference_specs_skips_blank_prompt(tmp_path) -> None:
     assert any("E1U1" in w for w in log)
 
 
+@pytest.mark.unit
 def test_build_reference_specs_skips_bad_unit_id_without_aborting_batch(tmp_path) -> None:
     """unit_id 为空或键缺失（Agent 裸写 JSON 可致）都跳过该 unit 而非中断整批：
     空串经 from_request 抛 ValueError 被捕获，缺键经 .get 归一化为空串后同样被拒。"""
@@ -2015,6 +2075,7 @@ def test_build_reference_specs_skips_bad_unit_id_without_aborting_batch(tmp_path
     assert [s.resource_id for s in specs] == ["E1U2"]
 
 
+@pytest.mark.unit
 def test_build_reference_specs_handles_malformed_shots(tmp_path) -> None:
     """畸形 shots（显式 null text / 非 dict 元素）不应崩溃整批，且不得把 'None' 注入 prompt。"""
     from server.agent_runtime.sdk_tools.enqueue_videos import _build_reference_specs
@@ -2035,6 +2096,7 @@ def test_build_reference_specs_handles_malformed_shots(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_get_video_capabilities_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2137,6 +2199,7 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
     assert seen == [fake_ctx.project_name]
 
 
+@pytest.mark.unit
 async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2149,6 +2212,7 @@ async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) 
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2172,12 +2236,14 @@ async def test_generate_episode_script_dry_run(fake_ctx: ToolContext, monkeypatc
     assert "fake prompt" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_missing_step1(fake_ctx: ToolContext) -> None:
     tool_obj = generate_episode_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 99})
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_writes_to_default_project_scripts(fake_ctx: ToolContext, monkeypatch) -> None:
     """output 参数已下线；写出路径必须由 ScriptGenerator 内部决定，handler 不应让 agent 控制。"""
     from lib import script_review
@@ -2221,6 +2287,7 @@ async def test_generate_episode_script_writes_to_default_project_scripts(fake_ct
     assert "output_path" not in captured["calls"]
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_ad_skips_step1(fake_ctx: ToolContext, monkeypatch) -> None:
     """ad 一键生成不依赖 step1 中间文件：缺 drafts/ 也不报 step1 错误。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -2244,6 +2311,7 @@ async def test_generate_episode_script_ad_skips_step1(fake_ctx: ToolContext, mon
     assert out.get("is_error") is not True
 
 
+@pytest.mark.unit
 def test_parse_normalized_content_uses_dynamic_duration_schema() -> None:
     """_parse_normalized_content 复用按 supported_durations 构造的动态 schema：合法 duration 经模型
     校验并补全默认字段；超出枚举的 duration 触发 fail-loud（抛 ValueError），而非被静态模型(ge=1,le=60)
@@ -2269,6 +2337,7 @@ def test_parse_normalized_content_uses_dynamic_duration_schema() -> None:
         _parse_normalized_content(json.dumps({"title": "t", "scenes": [bad]}), model)
 
 
+@pytest.mark.unit
 async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
     """resolver 失败时软回退须与自定义供应商写入层的保守默认（duration_presets.DEFAULT_FALLBACK）
     同一真相源——独立维护第二套回退集会让 LLM 拿到供应商未必支持的时长。"""
@@ -2350,6 +2419,7 @@ async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) ->
     assert durations == [8]
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -2368,6 +2438,7 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
     assert "DRY RUN" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContext, monkeypatch) -> None:
     """normalize 把项目 source_language 透传为 build_normalize_prompt 的 target_language——
     非中文项目的 step1 输出语言据此切换，而非恒退默认中文。"""
@@ -2390,6 +2461,7 @@ async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContex
     assert "English" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext, monkeypatch) -> None:
     """normalize 产出空 scenes → 工具报错，不把空 step1 当成功产物写盘（与 _load_drama_step1_content 同口径）。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -2422,6 +2494,7 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     assert not (project_path / "drafts" / "episode_1" / "step1_normalized_script.json").exists()
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: ToolContext, monkeypatch) -> None:
     """工具必须把 episode 注入 build_normalize_prompt，避免 LLM 写错 E\\d+ 前缀。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -2444,6 +2517,7 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
     assert "E1S01" not in prompt_text
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolContext, monkeypatch) -> None:
     """内容抽取前移后，分集大纲（故事节点 / 钩子）随 step1 注入 normalize prompt（见 ADR 0041）。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -2473,6 +2547,7 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
     assert "少年坠崖生死未卜" in prompt_text
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
     """工具必须把 ctx.project_name 传给 TextGenerator.create/generate，
     否则项目级文本档位覆盖被跳过，且 usage tracking 会丢 project_name。"""
@@ -2539,6 +2614,7 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
     )
 
 
+@pytest.mark.unit
 async def test_normalize_drama_script_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
@@ -2551,6 +2627,7 @@ async def test_normalize_drama_script_no_source(fake_ctx: ToolContext) -> None:
 
 
 class TestBuildPrompt:
+    @pytest.mark.unit
     def test_structured_no_duplicate_style(self) -> None:
         from server.agent_runtime.sdk_tools.enqueue_storyboards import _build_prompt
 
@@ -2571,6 +2648,7 @@ class TestBuildPrompt:
         # style_description 仍以 Visual style 前缀注入
         assert out.startswith("Visual style: Soft light")
 
+    @pytest.mark.unit
     def test_unstructured_keeps_style_prefix_normalized(self) -> None:
         from server.agent_runtime.sdk_tools.enqueue_storyboards import _build_prompt
 
@@ -2612,6 +2690,7 @@ def _fake_planner_cls(result: Any, captured: dict[str, Any] | None = None):
     return _FakePlanner
 
 
+@pytest.mark.unit
 async def test_plan_episodes_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_planner import EpisodePlanSummary, PlanResult
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -2639,6 +2718,7 @@ async def test_plan_episodes_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     assert captured["plan_instructions"] is None  # 不传时透传 None
 
 
+@pytest.mark.unit
 async def test_plan_episodes_forwards_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """用户分集偏好经 instructions 透传给 EpisodePlanner.plan（strip 后非空）。"""
     from lib.episode_planner import EpisodePlanSummary, PlanResult
@@ -2658,6 +2738,7 @@ async def test_plan_episodes_forwards_instructions(fake_ctx: ToolContext, monkey
     assert captured["plan_instructions"] == "按章节对齐切分"
 
 
+@pytest.mark.unit
 async def test_plan_episodes_blank_instructions_treated_as_none(fake_ctx: ToolContext, monkeypatch) -> None:
     """纯空白 instructions 视同未传：透传 None，与不传逐字一致。"""
     from lib.episode_planner import PlanResult
@@ -2673,6 +2754,7 @@ async def test_plan_episodes_blank_instructions_treated_as_none(fake_ctx: ToolCo
     assert captured["plan_instructions"] is None
 
 
+@pytest.mark.unit
 async def test_plan_episodes_rejects_non_string_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """instructions 传非字符串（如数组）按参数错误上报，不静默吞掉。"""
     from lib.episode_planner import PlanResult
@@ -2685,6 +2767,7 @@ async def test_plan_episodes_rejects_non_string_instructions(fake_ctx: ToolConte
     assert "instructions" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_plan_episodes_rejects_overlong_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """instructions 超长按参数错误提前拒绝，不注入 prompt。"""
     from lib.episode_planner import PlanResult
@@ -2697,6 +2780,7 @@ async def test_plan_episodes_rejects_overlong_instructions(fake_ctx: ToolContext
     assert "过长" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_plan_episodes_accepts_boundary_length_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """instructions 恰好等于上限长度应被接受（覆盖 > 比较的差一边界）。"""
     from lib.episode_planner import EpisodePlanSummary, PlanResult
@@ -2717,6 +2801,7 @@ async def test_plan_episodes_accepts_boundary_length_instructions(fake_ctx: Tool
     assert captured["plan_instructions"] == text
 
 
+@pytest.mark.unit
 async def test_plan_episodes_planner_value_error_not_mislabeled_as_param_error(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -2732,6 +2817,7 @@ async def test_plan_episodes_planner_value_error_not_mislabeled_as_param_error(
     assert "参数错误" not in text  # 供应商未配置不是入参问题
 
 
+@pytest.mark.unit
 async def test_plan_episodes_source_exhausted(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_planner import PlanResult
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -2744,6 +2830,7 @@ async def test_plan_episodes_source_exhausted(fake_ctx: ToolContext, monkeypatch
     assert "全部规划" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_plan_episodes_source_exhausted_includes_ledger_stats(fake_ctx: ToolContext, monkeypatch) -> None:
     """再次调用无新内容（早退路径）：附全局核对材料供主 agent 核对结构性偏好。"""
     from lib.episode_planner import LedgerStats, PlanResult
@@ -2764,6 +2851,7 @@ async def test_plan_episodes_source_exhausted_includes_ledger_stats(fake_ctx: To
     assert "有偏差须向用户明确说明" in text
 
 
+@pytest.mark.unit
 async def test_plan_episodes_normal_batch_reports_total_planned_line_only(fake_ctx: ToolContext, monkeypatch) -> None:
     """常规（非耗尽）批次没有 ledger_stats：只附「累计已规划 N 集」一行，不带全局核对材料。"""
     from lib.episode_planner import EpisodePlanSummary, PlanResult
@@ -2788,6 +2876,7 @@ async def test_plan_episodes_normal_batch_reports_total_planned_line_only(fake_c
     assert "体量最小的几集" not in text
 
 
+@pytest.mark.unit
 async def test_plan_episodes_error_envelope(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib.episode_planner import EpisodePlanningError
     from server.agent_runtime.sdk_tools import episode_planning as mod
@@ -3004,6 +3093,7 @@ def ad_reference_ctx(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> 
     return fake_ctx
 
 
+@pytest.mark.unit
 async def test_generate_video_episode_ad_reference_derives_and_enqueues(
     ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3044,6 +3134,7 @@ async def test_generate_video_episode_ad_reference_derives_and_enqueues(
     assert script["reference_units"][0]["references"][0] == {"type": "product", "name": "保温杯"}
 
 
+@pytest.mark.unit
 async def test_generate_video_episode_ad_reference_regenerates_reset_unit(
     ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3092,6 +3183,7 @@ async def test_generate_video_episode_ad_reference_regenerates_reset_unit(
     assert [s.resource_id for s in enqueued] == ["E1U1"]
 
 
+@pytest.mark.unit
 async def test_generate_video_episode_ad_reference_skips_unchanged_unit_with_output(
     ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3126,6 +3218,7 @@ async def test_generate_video_episode_ad_reference_skips_unchanged_unit_with_out
     assert enqueued == []
 
 
+@pytest.mark.unit
 async def test_generate_video_all_ad_reference_falls_through_to_episode(
     ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3176,6 +3269,7 @@ def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_durat
     return fake_caps
 
 
+@pytest.mark.unit
 async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeypatch) -> None:
     """unit 时长就是发给供应商的那个值，档位原样取自模型声明（不与任何静态区间求交）。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -3300,6 +3394,7 @@ async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_stat
     assert caps.tiers_for(has_references=False) == [4, 6, 8]
 
 
+@pytest.mark.unit
 async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
     """rv 路径的软回退与 _fetch_caps_with_fallback 同口径，取 duration_presets.DEFAULT_FALLBACK。"""
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
@@ -3424,6 +3519,7 @@ async def _run_rv_split(fake_ctx: ToolContext, monkeypatch, units: list[dict], *
     return await _call(split_reference_video_units_tool(fake_ctx), {"episode": 1})
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -3442,6 +3538,7 @@ async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext, monkey
     assert "镜头N：" in prompt_text
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_happy_derives_structure(fake_ctx: ToolContext, monkeypatch) -> None:
     """happy path：LLM 只写扁平正文，unit_id / shots / references 全部由工具机械派生后落盘。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -3469,6 +3566,7 @@ async def test_split_reference_video_units_happy_derives_structure(fake_ctx: Too
     assert captured["generate_project_name"] == "demo"
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_numbers_unit_ids_by_order(fake_ctx: ToolContext, monkeypatch) -> None:
     """unit_id 按数组序号机械编号：LLM 不写 id，也就不存在重复 / 错集号可写。"""
     _rv_source(fake_ctx)
@@ -3479,6 +3577,7 @@ async def test_split_reference_video_units_numbers_unit_ids_by_order(fake_ctx: T
     assert [u["unit_id"] for u in saved["units"]] == ["E1U01", "E1U02"]
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_derives_dialogue_without_reference_image(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -3491,6 +3590,7 @@ async def test_split_reference_video_units_derives_dialogue_without_reference_im
     assert saved["units"][0]["references"] == []
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_unregistered_asset(fake_ctx: ToolContext, monkeypatch) -> None:
     """正文引用未登记资产名 → fail-loud，不写盘（资产名引用完整性）。"""
     _rv_source(fake_ctx)
@@ -3500,6 +3600,7 @@ async def test_split_reference_video_units_rejects_unregistered_asset(fake_ctx: 
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_unregistered_speaker(fake_ctx: ToolContext, monkeypatch) -> None:
     """说话人位未登记同样阻断：说话人决定该句台词绑哪段参考音频。"""
     _rv_source(fake_ctx)
@@ -3509,6 +3610,7 @@ async def test_split_reference_video_units_rejects_unregistered_speaker(fake_ctx
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_over_max_refs(fake_ctx: ToolContext, monkeypatch) -> None:
     _rv_source(fake_ctx)
     out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("镜头1：@[张三] 与 @[李四] 在 @[村口]")], max_refs=2)
@@ -3558,6 +3660,7 @@ async def test_split_reference_video_units_accepts_wide_tier_without_references(
     assert saved["units"][0]["references"] == []
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_out_of_enum_duration(fake_ctx: ToolContext, monkeypatch) -> None:
     """本地校验复用动态 schema：超出 supported_durations 的 unit 时长被拦截，不落盘。"""
     _rv_source(fake_ctx)
@@ -3567,6 +3670,7 @@ async def test_split_reference_video_units_rejects_out_of_enum_duration(fake_ctx
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_empty_units(fake_ctx: ToolContext, monkeypatch) -> None:
     _rv_source(fake_ctx)
     out = await _run_rv_split(fake_ctx, monkeypatch, [])
@@ -3574,6 +3678,7 @@ async def test_split_reference_video_units_rejects_empty_units(fake_ctx: ToolCon
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_non_verbatim_source_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """source_text 非源文逐字子串 → 响亮失败（模型转述 / 杜撰原文）。"""
     _rv_source(fake_ctx)
@@ -3584,6 +3689,7 @@ async def test_split_reference_video_units_rejects_non_verbatim_source_text(fake
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_accepts_source_text_substring(fake_ctx: ToolContext, monkeypatch) -> None:
     """锚只需是源文子串：unit 是画面单元，不必覆盖整段原文。"""
     _rv_source(fake_ctx)
@@ -3592,6 +3698,7 @@ async def test_split_reference_video_units_accepts_source_text_substring(fake_ct
     assert out.get("is_error") is not True, out
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_dialogue_overload(fake_ctx: ToolContext, monkeypatch) -> None:
     """台词量按语速估算超过 unit 时长（宽容系数外）→ 阻断。"""
     _rv_source(fake_ctx)
@@ -3603,6 +3710,7 @@ async def test_split_reference_video_units_rejects_dialogue_overload(fake_ctx: T
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_braces_in_description(fake_ctx: ToolContext, monkeypatch) -> None:
     """描述行误用花括号保留语法 → 阻断（写在描述行里的台词不会被识别，须响亮失败）。"""
     _rv_source(fake_ctx)
@@ -3612,6 +3720,7 @@ async def test_split_reference_video_units_rejects_braces_in_description(fake_ct
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_rejects_too_many_shots(fake_ctx: ToolContext, monkeypatch) -> None:
     _rv_source(fake_ctx)
     text = "\n".join(f"镜头{i}：@[张三] 动作 {i}" for i in range(1, 6))
@@ -3621,6 +3730,7 @@ async def test_split_reference_video_units_rejects_too_many_shots(fake_ctx: Tool
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = split_reference_video_units_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
@@ -3667,6 +3777,7 @@ _RV_VIOLATION_CASES = [
 ]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(("code", "unit"), _RV_VIOLATION_CASES, ids=[c for c, _ in _RV_VIOLATION_CASES])
 async def test_split_reference_video_units_quarantines_each_violation_class(
     fake_ctx: ToolContext, monkeypatch, code: str, unit: dict
@@ -3693,6 +3804,7 @@ async def test_split_reference_video_units_quarantines_each_violation_class(
     assert "validate_and_promote_reference_draft" in report
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_reports_all_bad_units_in_one_round(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -3713,6 +3825,7 @@ async def test_split_reference_video_units_reports_all_bad_units_in_one_round(
     assert len(envelope["content"]["units"]) == 3
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_promotes_after_repair(fake_ctx: ToolContext, monkeypatch) -> None:
     """agent 修好隔离草稿后晋升：正式 step1 落盘、草稿清除、结构由正文机械派生。"""
     _rv_source(fake_ctx)
@@ -3734,6 +3847,7 @@ async def test_validate_and_promote_reference_draft_promotes_after_repair(fake_c
     ]
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_reports_again_without_round_limit(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -3785,6 +3899,7 @@ async def _open_for_edit(fake_ctx: ToolContext, **args) -> dict:
     return await _call(open_reference_step1_for_edit_tool(fake_ctx), {"episode": 1, **args})
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_returns_flat_writing_layer(fake_ctx: ToolContext) -> None:
     """取回的草稿装扁平书写层，不装派生物：agent 改的是正文 / 锚 / 时长，
     unit_id / shots / references 由晋升时按正文重新派生，放进草稿等于给漂移开口子。"""
@@ -3807,6 +3922,7 @@ async def test_open_reference_step1_for_edit_returns_flat_writing_layer(fake_ctx
     assert unit["text"] == "镜头1：@[张三] 起身\n镜头2：@[张三] 走向 @[村口]"
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_leaves_official_file_untouched(fake_ctx: ToolContext) -> None:
     """取回只是开编辑工位，正式文件一步不动——改动落回正式文件只发生在持锁的晋升侧。"""
     _rv_source(fake_ctx)
@@ -3818,6 +3934,7 @@ async def test_open_reference_step1_for_edit_leaves_official_file_untouched(fake
     assert _rv_step1_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_round_trips_through_promote(fake_ctx: ToolContext, monkeypatch) -> None:
     """情况 B 的完整闭环：取回 → 改草稿 → 晋升。改动经晋升侧的持锁写盘落回正式文件，
     结构字段按新正文重新派生（references 跟着正文里的 @ 引用走）。"""
@@ -3841,6 +3958,7 @@ async def test_open_reference_step1_for_edit_round_trips_through_promote(fake_ct
     ]
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_refuses_to_clobber_existing_draft(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -3858,6 +3976,7 @@ async def test_open_reference_step1_for_edit_refuses_to_clobber_existing_draft(
     assert "validate_and_promote_reference_draft" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_without_official_file(fake_ctx: ToolContext) -> None:
     """没有正式 step1 时指回首次拆分工具，而不是开一份空草稿让 agent 手写整集。"""
     _rv_source(fake_ctx)
@@ -3869,6 +3988,7 @@ async def test_open_reference_step1_for_edit_without_official_file(fake_ctx: Too
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_keeps_malformed_duration_verbatim(fake_ctx: ToolContext) -> None:
     """盘上 unit 的字段类型不符时原样带进草稿，不归一化成合法值：``8.0`` 被改写成 ``0``
     后，agent 从草稿里看到的是一个它没写过的时长，晋升报告说「时长不在档位内」也对不上
@@ -3884,6 +4004,7 @@ async def test_open_reference_step1_for_edit_keeps_malformed_duration_verbatim(f
     assert _read_rv_quarantine(fake_ctx)["content"]["units"][0]["duration_seconds"] == 8.0
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_keeps_malformed_non_dict_unit_slot(fake_ctx: ToolContext) -> None:
     """盘上 units 混入非 dict 元素时不能直接丢弃：跳过会让草稿数组比正式文件短一个，若剩余
     unit 都能过校验，晋升会悄悄覆盖正式文件、丢失这个 unit 而无人知晓。留空占位在原数组
@@ -3902,6 +4023,7 @@ async def test_open_reference_step1_for_edit_keeps_malformed_non_dict_unit_slot(
     assert units[1] == {"duration_seconds": None, "source_text": "", "text": ""}
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_blanks_shot_with_embedded_fake_header(fake_ctx: ToolContext) -> None:
     """盘上 shot 自身文本里恰好有一行形如「镜头N：」（旧数据经 Web 端保存，字段不禁止这种
     文本）时，render 后重新解析会把这一个 shot 误判成两个——原样晋升也会带着错位的分镜覆盖
@@ -3918,6 +4040,7 @@ async def test_open_reference_step1_for_edit_blanks_shot_with_embedded_fake_head
     assert _read_rv_quarantine(fake_ctx)["content"]["units"][0]["text"] == ""
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_rejects_missing_source_without_side_effect(
     fake_ctx: ToolContext,
 ) -> None:
@@ -3933,6 +4056,7 @@ async def test_open_reference_step1_for_edit_rejects_missing_source_without_side
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_rejects_non_reference_episode(fake_ctx: ToolContext) -> None:
     """切走参考路径的集不给编辑：盘上的 step1 与该集此刻的生成路径无关。与晋升工具同一判据。"""
     _rv_source(fake_ctx)
@@ -3950,6 +4074,7 @@ async def test_open_reference_step1_for_edit_rejects_non_reference_episode(fake_
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 async def test_open_reference_step1_for_edit_records_base_fingerprint(fake_ctx: ToolContext) -> None:
     """取回时把正式文件此刻的内容指纹记进 meta.base_fingerprint，供晋升前基线比对。"""
     _rv_source(fake_ctx)
@@ -3962,6 +4087,7 @@ async def test_open_reference_step1_for_edit_records_base_fingerprint(fake_ctx: 
     assert meta["base_fingerprint"] == script_review.content_fingerprint(_rv_step1_path(fake_ctx))
 
 
+@pytest.mark.unit
 async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: ToolContext, monkeypatch) -> None:
     """「用户在审阅门编辑 + agent 改隔离草稿并晋升」的双端并发：取回后正式文件被另一写入方
     改过时，晋升中止并返回冲突报告（含最新内容与合并指引），不静默覆盖对方的修改；草稿
@@ -3995,6 +4121,7 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4020,6 +4147,7 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext, monkeypatch) -> None:
     """基线机制引入前产出的存量草稿缺 meta.base_fingerprint 键：按无基线晋升，不被新校验卡死。"""
     _rv_source(fake_ctx)
@@ -4037,6 +4165,7 @@ async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_violation_quarantine_records_base_fingerprint(fake_ctx: ToolContext, monkeypatch) -> None:
     """拆分违约落隔离草稿时同样记基线：修好晋升前正式文件被并发改写的话按基线中止。
     首拆时正式文件不存在，基线为 null——晋升时若正式文件已被另一次拆分写出，同样判冲突。"""
@@ -4059,6 +4188,7 @@ async def test_split_violation_quarantine_records_base_fingerprint(fake_ctx: Too
     assert "并发冲突" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("mutate", "hint"),
     [
@@ -4092,6 +4222,7 @@ async def test_validate_and_promote_reference_draft_rejects_schema_breach(
     assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["schema_invalid"]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "mutate_content",
     [
@@ -4130,6 +4261,7 @@ async def test_validate_and_promote_reference_draft_reports_broken_outer_shape(
     assert refreshed["content"] == edited_content
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_requires_source_provenance(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4149,6 +4281,7 @@ async def test_validate_and_promote_reference_draft_requires_source_provenance(
     assert not _rv_step1_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_reports_promotion_not_split(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4165,6 +4298,7 @@ async def test_validate_and_promote_reference_draft_reports_promotion_not_split(
     assert "晋升" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_writing_reference_step1_clears_stale_step2_quarantine(fake_ctx: ToolContext, monkeypatch) -> None:
     """step1 一变即清掉在场的 step2 隔离草稿：它以旧 step1 为 diff 基底，留着就永远晋升不了。"""
     _rv_source(fake_ctx)
@@ -4184,6 +4318,7 @@ async def test_writing_reference_step1_clears_stale_step2_quarantine(fake_ctx: T
     assert not step2_path.exists()
 
 
+@pytest.mark.unit
 async def test_promote_reference_step1_preserves_step2_draft_when_content_unchanged(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4209,6 +4344,7 @@ async def test_promote_reference_step1_preserves_step2_draft_when_content_unchan
     assert step2_path.exists()
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_step2_uses_async_factory(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4243,6 +4379,7 @@ async def test_validate_and_promote_reference_draft_step2_uses_async_factory(
     assert "episode_1.json" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_refuses_after_mode_switch(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4261,6 +4398,7 @@ async def test_validate_and_promote_reference_draft_refuses_after_mode_switch(
     assert "不走参考生视频路径" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_step2_blocked_by_review_gate(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4289,12 +4427,14 @@ async def test_validate_and_promote_reference_draft_step2_blocked_by_review_gate
     assert "尚未经 web 审核确认" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_validate_and_promote_reference_draft_without_draft(fake_ctx: ToolContext, monkeypatch) -> None:
     out = await _promote(fake_ctx, monkeypatch)
     assert out.get("is_error") is True
     assert "没有待处置的隔离草稿" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_clears_stale_quarantine_on_success(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4308,6 +4448,7 @@ async def test_split_reference_video_units_clears_stale_quarantine_on_success(
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
+@pytest.mark.unit
 async def test_split_reference_video_units_surfaces_tolerated_voice_warnings(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4337,6 +4478,7 @@ def _write_rv_quarantine(fake_ctx: ToolContext) -> None:
     )
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_blocked_by_quarantine(fake_ctx: ToolContext) -> None:
     """隔离草稿在场时 step2 入口阻塞，且给出「改草稿再晋升」而非「去 Web 端确认」的出路。"""
     _rv_project(fake_ctx)
@@ -4351,6 +4493,7 @@ async def test_generate_episode_script_blocked_by_quarantine(fake_ctx: ToolConte
     assert "validate_and_promote_reference_draft" in out["content"][0]["text"]
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_quarantine_precedes_missing_step1(fake_ctx: ToolContext) -> None:
     """首次拆分就违约时正式 step1 本就不存在——先报缺文件会把 agent 引回重跑拆分（丢弃重抽）。"""
     _rv_project(fake_ctx)
@@ -4364,6 +4507,7 @@ async def test_generate_episode_script_quarantine_precedes_missing_step1(fake_ct
     assert "未找到 Step 1 文件" not in text
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_ignores_quarantine_after_mode_switch(fake_ctx: ToolContext) -> None:
     """切走参考路径后残留的隔离草稿与新路径无关：非参考路径不清它们，仍判会把该集永久卡死。"""
     _rv_project(fake_ctx, generation_mode="storyboard")
@@ -4423,6 +4567,7 @@ def _nr_segment(segment_id="E1S01", duration=4, novel_text="张三走向村口�
     return seg
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -4440,6 +4585,7 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypat
     assert "4" in prompt_text
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     """happy path：结构化片段 step1 落盘；模型经文本管道按 SCRIPT 任务解析并携带 project_name 入账。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -4470,6 +4616,7 @@ async def test_split_narration_segments_happy(fake_ctx: ToolContext, monkeypatch
     assert captured["generate_project_name"] == "demo"
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_out_of_enum_duration(fake_ctx: ToolContext, monkeypatch) -> None:
     """静态片段 schema 的 duration 是开区间，超出 supported_durations 的时长由工具后校验拦截，不落盘。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -4486,6 +4633,7 @@ async def test_split_narration_segments_rejects_out_of_enum_duration(fake_ctx: T
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_duplicate_segment_ids(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -4501,6 +4649,7 @@ async def test_split_narration_segments_rejects_duplicate_segment_ids(fake_ctx: 
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_blank_novel_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """novel_text 为纯空白（如单个空格）满足 schema min_length=1 却无实际旁白内容，须被后校验拦截，不落盘。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -4518,6 +4667,7 @@ async def test_split_narration_segments_rejects_blank_novel_text(fake_ctx: ToolC
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_empty_segments(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
@@ -4531,6 +4681,7 @@ async def test_split_narration_segments_rejects_empty_segments(fake_ctx: ToolCon
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_missing_field(fake_ctx: ToolContext, monkeypatch) -> None:
     """缺资产字段（characters_in_segment 等）由既有片段 schema（NarrationStep1Segment strict）拦截。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
@@ -4547,6 +4698,7 @@ async def test_split_narration_segments_rejects_missing_field(fake_ctx: ToolCont
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_unregistered_asset_reference(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4579,6 +4731,7 @@ async def _nr_source_and_call(fake_ctx: ToolContext, monkeypatch, source_text: s
     return await _call(tool_obj, {"episode": 1})
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_truncated_novel_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """片段合并后比源文短（模型删减）：novel_text 完整性校验拦截，不落盘。"""
     out = await _nr_source_and_call(
@@ -4592,6 +4745,7 @@ async def test_split_narration_segments_rejects_truncated_novel_text(fake_ctx: T
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_rewritten_novel_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """片段文字被模型改写（非逐字）：novel_text 完整性校验拦截，不落盘。"""
     out = await _nr_source_and_call(
@@ -4608,6 +4762,7 @@ async def test_split_narration_segments_rejects_rewritten_novel_text(fake_ctx: T
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_reordered_novel_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """片段顺序被模型打乱：novel_text 完整性校验拦截，不落盘。"""
     out = await _nr_source_and_call(
@@ -4624,6 +4779,7 @@ async def test_split_narration_segments_rejects_reordered_novel_text(fake_ctx: T
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_dropped_word_space(fake_ctx: ToolContext, monkeypatch) -> None:
     """空格分词语言里模型丢失词间空格（"Hello world" -> "Helloworld"）属实质内容损坏，须拦截。"""
     out = await _nr_source_and_call(
@@ -4637,6 +4793,7 @@ async def test_split_narration_segments_rejects_dropped_word_space(fake_ctx: Too
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_accepts_split_at_paragraph_break(fake_ctx: ToolContext, monkeypatch) -> None:
     """片段边界恰好落在源文的段落换行处：边界处允许可选空格，不应误报删减。"""
     out = await _nr_source_and_call(
@@ -4653,6 +4810,7 @@ async def test_split_narration_segments_accepts_split_at_paragraph_break(fake_ct
     assert step1_path.exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_accepts_split_at_halfwidth_punctuation(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4671,6 +4829,7 @@ async def test_split_narration_segments_accepts_split_at_halfwidth_punctuation(
     assert step1_path.exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_rejects_dropped_space_after_punctuation(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
@@ -4686,12 +4845,14 @@ async def test_split_narration_segments_rejects_dropped_space_after_punctuation(
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "step1_segments.json").exists()
 
 
+@pytest.mark.unit
 async def test_split_narration_segments_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = split_narration_segments_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
 
 
+@pytest.mark.unit
 async def test_generate_episode_script_reference_legacy_md_hints_resplit(fake_ctx: ToolContext) -> None:
     """reference_video 集仅存旧 .md 拆分表时，generate_episode_script 给出重跑拆分提示。"""
     project_path = fake_ctx.project_path

--- a/tests/server/test_ad_reference_video_tasks.py
+++ b/tests/server/test_ad_reference_video_tasks.py
@@ -183,6 +183,7 @@ def _wire_executor(
     return fake_generator
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_unit_generates_video_with_inherited_references(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from server.services import reference_video_tasks as rvt
@@ -265,6 +266,7 @@ async def test_ad_dialogue_speaker_binds_reference_audio_for_native_tier(
     assert "禁止出现：BGM、文字字幕、水印。" not in prompt
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_missing_asset_sheet_skipped_with_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """ad 参考集由分组器自动继承，缺图软跳过 + warning，不像 narration/drama 那样硬失败。"""
@@ -287,6 +289,7 @@ async def test_ad_missing_asset_sheet_skipped_with_warning(tmp_path: Path, monke
     assert any(w["key"] == "ref_ad_reference_skipped" and w["params"]["name"] == "小美" for w in result["warnings"])
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_product_without_sheet_injects_originals_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from server.services import reference_video_tasks as rvt
@@ -309,6 +312,7 @@ async def test_ad_product_without_sheet_injects_originals_only(tmp_path: Path, m
     assert ref_names == ["按摩仪_原图.jpg", "小美.png"]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_reference_clamp_keeps_product_sheets_alive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """超后端参考上限时产品 sheet 跨产品稳定前置存活，主体绑定行与实收列表对齐。"""
@@ -354,6 +358,7 @@ async def test_ad_reference_clamp_keeps_product_sheets_alive(tmp_path: Path, mon
     assert any(w["key"] == "ref_too_many_images" for w in result["warnings"])
 
 
+@pytest.mark.unit
 def test_clamp_zero_max_refs_drops_all_entries():
     """max_refs == 0（模型不支持参考图）裁到空集 + warning，不得当作「无上限」放行。"""
     from server.services.reference_video_tasks import _clamp_ad_reference_entries
@@ -365,6 +370,7 @@ def test_clamp_zero_max_refs_drops_all_entries():
     assert [w["key"] for w in warnings] == ["ref_too_many_images"]
 
 
+@pytest.mark.unit
 def test_clamp_none_max_refs_keeps_all_entries():
     """max_refs is None（能力未解析）不裁剪，交由 backend 自行报错。"""
     from server.services.reference_video_tasks import _clamp_ad_reference_entries
@@ -376,6 +382,7 @@ def test_clamp_none_max_refs_keeps_all_entries():
     assert warnings == []
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_dirty_asset_bucket_skips_with_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """project.json 资产 bucket 形状损坏（非 dict）时软跳过该参考 + warning，不抛 AttributeError。"""
@@ -400,6 +407,7 @@ async def test_ad_dirty_asset_bucket_skips_with_warning(tmp_path: Path, monkeypa
     assert any(w["key"] == "ref_ad_reference_skipped" and w["params"]["name"] == "小美" for w in result["warnings"])
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ad_stale_index_fails_loud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """镜头被删后索引悬空 → fail-loud 提示重新派生，不静默生成残缺视频。"""

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -145,6 +145,7 @@ async def _seed_custom_video_provider(session_factory) -> str:
 
 
 class TestLaneDeclaration:
+    @pytest.mark.unit
     async def test_only_declared_lanes_are_constructed(self, session_factory, project_env, fake_assemble):
         """只声明 image lane：不解析、不构造 video/audio，视频供应商缺配置不影响图片任务。"""
         project = {"image_provider_t2i": "ark/img-model-x"}
@@ -159,6 +160,7 @@ class TestLaneDeclaration:
         with pytest.raises(RuntimeError, match="audio lane 未声明"):
             _ = ctx.audio
 
+    @pytest.mark.unit
     async def test_no_lane_declared_still_returns_generator(self, session_factory, project_env, fake_assemble):
         ctx = await resolve_generation_context("demo", None, project={})
         assert isinstance(ctx.generator, MediaGenerator)
@@ -166,6 +168,7 @@ class TestLaneDeclaration:
         with pytest.raises(RuntimeError, match="image lane 未声明"):
             _ = ctx.image
 
+    @pytest.mark.unit
     async def test_i2i_capability_selects_i2i_slot(self, session_factory, project_env, fake_assemble):
         project = {
             "image_provider_t2i": "ark/img-t2i",
@@ -174,6 +177,7 @@ class TestLaneDeclaration:
         ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
         assert ctx.image.provider_model == ProviderModel("ark", "img-i2i")
 
+    @pytest.mark.unit
     async def test_all_three_lanes(self, session_factory, project_env, fake_assemble):
         video_model = _registry_video_model("ark")
         project = {
@@ -195,6 +199,7 @@ class TestLaneDeclaration:
 
 
 class TestVideoLane:
+    @pytest.mark.unit
     async def test_registry_capabilities_and_fallback_resolution(self, session_factory, project_env, fake_assemble):
         video_model = _registry_video_model("ark")
         expected = PROVIDER_REGISTRY["ark"].models[video_model]
@@ -208,6 +213,7 @@ class TestVideoLane:
         assert ctx.video.resolution is None
         assert ctx.video.resolution_or_fallback == get_provider_fallback("ark")
 
+    @pytest.mark.unit
     async def test_resolution_from_model_settings(self, session_factory, project_env, fake_assemble):
         video_model = _registry_video_model("ark")
         project = {
@@ -218,6 +224,7 @@ class TestVideoLane:
         assert ctx.video.resolution == "480p"
         assert ctx.video.resolution_or_fallback == "480p"
 
+    @pytest.mark.unit
     async def test_capability_query_failure_degrades_to_empty(self, session_factory, project_env, monkeypatch):
         """fake backend 报告 registry 之外的 model：能力查询失败降级空值，整次调用照常成功。"""
 
@@ -265,6 +272,7 @@ class TestVideoLane:
         )
         assert ctx.video.requested_generate_audio is False
 
+    @pytest.mark.unit
     async def test_payload_overrides_project(self, session_factory, project_env, fake_assemble):
         """payload > project：历史任务携带的 video_provider 决定实际解析身份。"""
         ark_model = _registry_video_model("ark")
@@ -279,6 +287,7 @@ class TestVideoLane:
 
 
 class TestActualIdentityQueries:
+    @pytest.mark.unit
     async def test_custom_model_fallback_queries_by_actual_model(self, session_factory, project_env, monkeypatch):
         """自定义供应商目标 model 被禁用回退：resolution 与能力按 backend 实际 model 查询。"""
         provider_id = await _seed_custom_video_provider(session_factory)
@@ -304,6 +313,7 @@ class TestActualIdentityQueries:
 
 
 class TestAudioLane:
+    @pytest.mark.unit
     async def test_narration_voice_and_speed_from_project(self, session_factory, project_env, fake_assemble):
         project = {
             "audio_backend": "dashscope/tts-model-x",
@@ -316,12 +326,14 @@ class TestAudioLane:
         assert ctx.audio.backend_name == "dashscope"
         assert ctx.audio.backend_model == "tts-model-x"
 
+    @pytest.mark.unit
     async def test_narration_defaults_when_unset(self, session_factory, project_env, fake_assemble):
         project = {"audio_backend": "dashscope/tts-model-x"}
         ctx = await resolve_generation_context("demo", None, project=project, audio=AudioLaneRequest())
         assert isinstance(ctx.audio.narration_voice, str) and ctx.audio.narration_voice
         assert ctx.audio.narration_speed is None
 
+    @pytest.mark.unit
     async def test_voice_catalog_snapshot_passed_through(self, session_factory, project_env, monkeypatch):
         """ctx.audio.voices 须是 backend.list_voices() 的真实快照，而非默认的空元组——
         断言字段存在不够，须证明 resolve_generation_context 确实转发了 backend 的音色目录。
@@ -339,6 +351,7 @@ class TestAudioLane:
 
 
 class TestAtomicFailure:
+    @pytest.mark.unit
     async def test_declared_lane_construction_failure_fails_whole_call(self, session_factory, project_env, monkeypatch):
         """image 成功后 video 构造失败：整次调用原样上抛，无部分结果。"""
 
@@ -358,12 +371,14 @@ class TestAtomicFailure:
                 video=VideoLaneRequest(),
             )
 
+    @pytest.mark.unit
     async def test_missing_project_dir_raises(self, session_factory, project_env, fake_assemble):
         with pytest.raises(FileNotFoundError):
             await resolve_generation_context("nope", None, project={}, image=ImageLaneRequest())
 
 
 class TestBackendCache:
+    @pytest.mark.unit
     async def test_backend_reused_until_invalidated(self, session_factory, project_env, fake_assemble):
         project = {"image_provider_t2i": "ark/img-model-x"}
         await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
@@ -374,6 +389,7 @@ class TestBackendCache:
         await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
         assert len(fake_assemble) == 2, "失效后须重建 backend"
 
+    @pytest.mark.unit
     async def test_invalidate_during_construction_discards_instance(self, monkeypatch):
         """构造中途（assemble_backend await 挂起期间）触发 invalidate：完成的实例不写回缓存。"""
         entered = asyncio.Event()
@@ -402,6 +418,7 @@ class TestBackendCache:
         assert stale is built[0] and fresh is built[1]
         assert fresh is not stale
 
+    @pytest.mark.unit
     async def test_concurrent_same_key_constructs_once(self, monkeypatch):
         """同 key 并发两次 get_or_create：只构造一次，两调用方拿到同一实例。"""
         entered = asyncio.Event()
@@ -430,6 +447,7 @@ class TestBackendCache:
         assert construct_count == 1, "同 key 并发 miss 须 single-flight，只构造一次"
         assert b1 is b2
 
+    @pytest.mark.unit
     async def test_follower_queued_before_invalidate_discards_instance(self, monkeypatch):
         """失效边界前已排队等锁的旧代际请求（follower）：跨越失效后拿到锁，仍不得写回缓存。
 
@@ -477,6 +495,7 @@ class TestBackendCache:
 
 
 class TestValueObjectAssembly:
+    @pytest.mark.unit
     def test_fake_context_assembles_from_frozen_dataclasses(self, tmp_path: Path):
         """消费方测试的拼装路径：frozen dataclass 直接构造假 context，property 原样返回。"""
         lane = VideoLaneResult(
@@ -494,6 +513,7 @@ class TestValueObjectAssembly:
         with pytest.raises(RuntimeError, match="image lane 未声明"):
             _ = ctx.image
 
+    @pytest.mark.unit
     def test_lane_results_are_frozen(self):
         lane = ImageLaneResult(
             provider_model=ProviderModel("ark", "m"),
@@ -504,6 +524,7 @@ class TestValueObjectAssembly:
         with pytest.raises(AttributeError):
             lane.resolution = "720p"  # type: ignore[misc]
 
+    @pytest.mark.unit
     def test_audio_lane_result_shape(self):
         lane = AudioLaneResult(
             provider_model=ProviderModel("dashscope", "tts"),

--- a/tests/server/test_project_cover.py
+++ b/tests/server/test_project_cover.py
@@ -8,6 +8,8 @@ import pytest
 
 from server.services.project_cover import resolve_project_cover
 
+pytestmark = pytest.mark.unit
+
 
 def _mk_manager(scripts_by_file: dict[str, dict]) -> MagicMock:
     """构造 fake ProjectManager，load_script 按文件名查表返回；缺失则抛 FileNotFoundError。"""

--- a/tests/server/test_reference_video_e2e_backend.py
+++ b/tests/server/test_reference_video_e2e_backend.py
@@ -17,6 +17,8 @@ from fastapi.testclient import TestClient
 from server.auth import CurrentUserInfo, get_current_user
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 _TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x04\x00\x00\x00\x04"
     b"\x08\x02\x00\x00\x00&\x93\t)\x00\x00\x00\x13IDATx\x9cc<\x91b\xc4\x00"

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -157,6 +157,7 @@ def _wire_locked_script(fake_pm: MagicMock) -> None:
     fake_pm.locked_script.side_effect = _locked
 
 
+@pytest.mark.unit
 def test_resolve_unit_references_maps_sheets(tmp_path: Path):
     proj_dir = _write_project(tmp_path)
     project, unit = _load_project_and_unit(proj_dir, "E1U1")
@@ -164,6 +165,7 @@ def test_resolve_unit_references_maps_sheets(tmp_path: Path):
     assert [p.name for p in resolved] == ["张三.png", "酒馆.png"]
 
 
+@pytest.mark.unit
 def test_resolve_unit_references_missing_sheet_raises(tmp_path: Path):
     proj_dir = _write_project(tmp_path)
     project, unit = _load_project_and_unit(proj_dir, "E1U1")
@@ -174,6 +176,7 @@ def test_resolve_unit_references_missing_sheet_raises(tmp_path: Path):
     assert ("character", "张三") in excinfo.value.missing
 
 
+@pytest.mark.unit
 def test_resolve_unit_references_unknown_name_raises(tmp_path: Path):
     proj_dir = _write_project(tmp_path)
     project, _ = _load_project_and_unit(proj_dir, "E1U1")
@@ -295,6 +298,7 @@ def test_resolve_ad_unit_reference_entries_no_false_positive_warning_for_nfd_pro
     assert warnings == []
 
 
+@pytest.mark.unit
 def test_render_unit_prompt_rejects_empty_shots():
     """执行层保留一道防御性空检查：提示词源是可变 script、执行期重读，结构校验上移到
     入队守卫点后仍需挡住「入队后被改空 / 在途遗留任务」漏过的空提示词，避免尾词追加后
@@ -318,6 +322,7 @@ def test_render_unit_prompt_rejects_empty_shots():
         )
 
 
+@pytest.mark.unit
 def test_render_unit_prompt_binds_subjects_in_reference_order():
     unit = {
         "shots": [
@@ -345,6 +350,7 @@ def test_render_unit_prompt_binds_subjects_in_reference_order():
     assert "[图1]" not in rendered.prompt
 
 
+@pytest.mark.unit
 def test_render_unit_prompt_preserves_shot_boundaries_when_shots_lack_headers():
     """经解析预览面板编辑回写的 unit，``shots[*].text`` 不带 ``镜头N：`` header——
     渲染仍须按数组结构切成对应数量的镜头，不能因裸拼接后找不到 header 被折叠成一镜头。"""
@@ -612,6 +618,7 @@ def test_apply_provider_constraints_narrows_by_call_conditions():
     assert without_images == 6
 
 
+@pytest.mark.unit
 def test_apply_provider_constraints_sora_single_ref():
     refs = [Path(f"/tmp/ref{i}.png") for i in range(3)]
     new_refs, _, warnings = _apply_provider_constraints(
@@ -626,6 +633,7 @@ def test_apply_provider_constraints_sora_single_ref():
     assert any("ref_sora_single_ref" in w["key"] for w in warnings)
 
 
+@pytest.mark.unit
 def test_apply_provider_constraints_ark_keeps_nine():
     refs = [Path(f"/tmp/ref{i}.png") for i in range(9)]
     new_refs, new_duration, warnings = _apply_provider_constraints(
@@ -641,6 +649,7 @@ def test_apply_provider_constraints_ark_keeps_nine():
     assert warnings == []
 
 
+@pytest.mark.unit
 def test_apply_provider_constraints_none_caps_skip_clamp():
     """当 ConfigResolver 解析失败（例如无 DB 的 CI 环境），调用方传 None / 空档位集 →
     不裁剪任何维度、时长原样透传，把决策推到 backend 自己去报错。"""
@@ -658,6 +667,7 @@ def test_apply_provider_constraints_none_caps_skip_clamp():
     assert warnings == []
 
 
+@pytest.mark.unit
 def test_apply_provider_constraints_custom_provider_model_granular():
     """Custom provider 场景：档位集由自定义 model.supported_durations 决定，
     无需 PROVIDER_MAX_DURATION 常量查表。传入 duration=18 超过最大档位 → 按 10 申请。"""
@@ -676,6 +686,7 @@ def test_apply_provider_constraints_custom_provider_model_granular():
     assert not any(w["key"] == "ref_too_many_images" for w in warnings)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     proj_dir = _write_project(tmp_path)
@@ -724,6 +735,7 @@ async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch:
     assert result["file_path"].endswith("E1U1.mp4")
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_sends_reference_audio_in_prompt_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -876,6 +888,7 @@ async def test_execute_reference_video_task_omits_reference_audio_when_episode_i
     assert {"key": "ref_warn_silent_episode", "params": {}} in result["warnings"]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_aligns_reference_audio_targets_for_per_image_backend(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -957,6 +970,7 @@ async def test_execute_reference_video_task_aligns_reference_audio_targets_for_p
     assert captured["reference_audio_targets"] == [1]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_omits_audio_field_for_soft_tier(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1019,6 +1033,7 @@ async def test_execute_reference_video_task_omits_audio_field_for_soft_tier(
     assert "@音频" not in captured["prompt"]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_surfaces_render_warnings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """渲染期降级 warning 与既有 result.warnings 通道贯通（超上限截断降级）。"""
@@ -1081,6 +1096,7 @@ async def test_execute_reference_video_task_surfaces_render_warnings(tmp_path: P
     assert {"key": "ref_warn_reference_audio_overflow", "params": {"limit": 1, "name": "李四"}} in result["warnings"]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail(
     tmp_path: Path,
@@ -1147,6 +1163,7 @@ async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail
     assert ga_after["status"] == "completed"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_grok_uses_provider_default_resolution(
     tmp_path: Path,
@@ -1273,6 +1290,7 @@ async def test_execute_reference_video_task_narrows_durations_by_registry_provid
     assert captured.get("duration_seconds") == 8
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     proj_dir = _write_project(tmp_path)
@@ -1298,6 +1316,7 @@ async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Pa
         )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """executor 必须走真实 MediaGenerator._get_output_path。
@@ -1415,6 +1434,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     assert any(p.suffix == ".mp4" for p in version_dir.iterdir())
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """executor 把**源 sheet 路径**直接交给 generate_video_async（单次调用），压缩下沉
@@ -1472,6 +1492,7 @@ async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, m
     ]
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_clamps_via_lane_caps(
     tmp_path: Path,
@@ -1541,6 +1562,7 @@ async def test_execute_reference_video_task_clamps_via_lane_caps(
     assert len(captured["reference_images"]) == 1
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     tmp_path: Path,
@@ -1778,6 +1800,7 @@ async def test_execute_reference_video_task_rounds_up_non_member_duration(
     assert warnings[0]["params"] == {"total": 5, "duration": 8, "model": "sora-2"}
 
 
+@pytest.mark.unit
 async def test_execute_reference_video_task_persists_effective_duration_when_rounded(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1835,6 +1858,7 @@ async def test_execute_reference_video_task_persists_effective_duration_when_rou
     fake_queue.persist_effective_duration.assert_awaited_once_with("task-1", 8)
 
 
+@pytest.mark.unit
 async def test_execute_reference_video_task_persists_duration_when_unchanged(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1888,6 +1912,7 @@ async def test_execute_reference_video_task_persists_duration_when_unchanged(
     fake_queue.persist_effective_duration.assert_awaited_once_with("task-1", 3)
 
 
+@pytest.mark.unit
 def test_apply_unit_video_assets_distinguishes_failures():
     """结构损坏与 unit 不存在抛不同异常：还原侧据此区分「脏脚本告警」与「正常跳过」。
 
@@ -1923,6 +1948,7 @@ def test_apply_unit_video_assets_distinguishes_failures():
     assert ga["status"] == "completed"
 
 
+@pytest.mark.unit
 def test_apply_unit_video_assets_stamps_video_generated_at():
     """每次写回 video_clip 都机械戳 video_generated_at（存量过渡横幅的计数依据）。"""
     from server.services.reference_video_tasks import apply_unit_video_assets
@@ -1938,6 +1964,7 @@ def test_apply_unit_video_assets_stamps_video_generated_at():
     assert isinstance(second_stamp, str) and second_stamp
 
 
+@pytest.mark.unit
 def test_apply_unit_video_assets_honors_explicit_generated_at():
     """版本还原传入被还原版本的原始入库时间，不把旧内容洗成「刚生成」。"""
     from server.services.reference_video_tasks import apply_unit_video_assets

--- a/tests/server/test_reference_videos_router.py
+++ b/tests/server/test_reference_videos_router.py
@@ -72,17 +72,20 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
+@pytest.mark.unit
 def test_list_units_empty(client: TestClient):
     resp = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units")
     assert resp.status_code == 200
     assert resp.json() == {"units": []}
 
 
+@pytest.mark.unit
 def test_list_units_404_for_unknown_project(client: TestClient):
     resp = client.get("/api/v1/projects/missing/reference-videos/episodes/1/units")
     assert resp.status_code == 404
 
 
+@pytest.mark.unit
 def test_add_unit_creates_minimal_entry(client: TestClient):
     resp = client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
@@ -126,6 +129,7 @@ def test_add_unit_rejects_non_positive_duration(client: TestClient, duration_sec
     assert resp.status_code == 422, resp.text
 
 
+@pytest.mark.unit
 def test_add_unit_rejects_unknown_asset_reference(client: TestClient):
     resp = client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
@@ -190,6 +194,7 @@ def test_patch_unit_rejects_non_positive_duration(client: TestClient, duration_s
     assert resp.status_code == 422, resp.text
 
 
+@pytest.mark.unit
 def test_patch_unit_references_only(client: TestClient):
     uid = _seed_unit(client)
     resp = client.patch(
@@ -205,6 +210,7 @@ def test_patch_unit_references_only(client: TestClient):
     assert len(resp.json()["unit"]["references"]) == 2
 
 
+@pytest.mark.unit
 def test_patch_unit_rejects_unknown_reference(client: TestClient):
     uid = _seed_unit(client)
     resp = client.patch(
@@ -272,6 +278,7 @@ def test_unit_references_persisted_as_nfc(client: TestClient):
     ]
 
 
+@pytest.mark.unit
 def test_patch_unknown_unit_404(client: TestClient):
     resp = client.patch(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9",
@@ -280,6 +287,7 @@ def test_patch_unknown_unit_404(client: TestClient):
     assert resp.status_code == 404
 
 
+@pytest.mark.unit
 def test_delete_unit_removes_entry(client: TestClient):
     uid = _seed_unit(client)
     resp = client.delete(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}")
@@ -288,11 +296,13 @@ def test_delete_unit_removes_entry(client: TestClient):
     assert resp.json()["units"] == []
 
 
+@pytest.mark.unit
 def test_delete_unknown_unit_404(client: TestClient):
     resp = client.delete("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9")
     assert resp.status_code == 404
 
 
+@pytest.mark.unit
 def test_reorder_units_applies_new_order(client: TestClient):
     uid1 = _seed_unit(client)
     uid2 = _seed_unit(client)
@@ -305,6 +315,7 @@ def test_reorder_units_applies_new_order(client: TestClient):
     assert [u["unit_id"] for u in units] == [uid2, uid1]
 
 
+@pytest.mark.unit
 def test_reorder_units_rejects_length_mismatch(client: TestClient):
     uid = _seed_unit(client)
     resp = client.post(
@@ -314,6 +325,7 @@ def test_reorder_units_rejects_length_mismatch(client: TestClient):
     assert resp.status_code == 400
 
 
+@pytest.mark.unit
 def test_reorder_units_rejects_duplicates(client: TestClient):
     uid = _seed_unit(client)
     resp = client.post(
@@ -323,6 +335,7 @@ def test_reorder_units_rejects_duplicates(client: TestClient):
     assert resp.status_code == 400
 
 
+@pytest.mark.unit
 def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.MonkeyPatch):
     uid = _seed_unit(client)
 
@@ -380,6 +393,7 @@ def test_generate_unit_bucket_capability_error_returns_400(client: TestClient, m
     assert enqueued == []
 
 
+@pytest.mark.unit
 def test_generate_unit_rejects_blank_prompt(client: TestClient, tmp_path: Path):
     """shots 文本全空白的 unit 在入队时被守卫点拒绝（400），不再漏到执行层失败。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
@@ -391,6 +405,7 @@ def test_generate_unit_rejects_blank_prompt(client: TestClient, tmp_path: Path):
     assert resp.status_code == 400, resp.text
 
 
+@pytest.mark.unit
 def test_generate_unit_missing_returns_404(client: TestClient):
     resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9/generate")
     assert resp.status_code == 404
@@ -465,6 +480,7 @@ def test_precheck_missing_unit_returns_404(client: TestClient):
     assert _precheck(client, "E9U9").status_code == 404
 
 
+@pytest.mark.unit
 def test_add_unit_stale_script_file_returns_404(client: TestClient, tmp_path: Path):
     """project.json 残留指向已删除文件的 script_file 时，写端点应返回 404 而非 500。"""
     (tmp_path / "projects" / "demo" / "scripts" / "episode_1.json").unlink()
@@ -475,6 +491,7 @@ def test_add_unit_stale_script_file_returns_404(client: TestClient, tmp_path: Pa
     assert resp.status_code == 404, resp.text
 
 
+@pytest.mark.unit
 def test_add_unit_unknown_project_returns_404(client: TestClient):
     resp = client.post(
         "/api/v1/projects/missing/reference-videos/episodes/1/units",
@@ -483,6 +500,7 @@ def test_add_unit_unknown_project_returns_404(client: TestClient):
     assert resp.status_code == 404
 
 
+@pytest.mark.unit
 def test_add_unit_unknown_episode_returns_404(client: TestClient):
     resp = client.post(
         "/api/v1/projects/demo/reference-videos/episodes/99/units",
@@ -491,6 +509,7 @@ def test_add_unit_unknown_episode_returns_404(client: TestClient):
     assert resp.status_code == 404
 
 
+@pytest.mark.unit
 def test_write_endpoint_rejects_non_reference_video_mode(client: TestClient, tmp_path: Path):
     """episode 非 reference_video 模式时，写端点应返回 409。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
@@ -509,6 +528,7 @@ def test_write_endpoint_rejects_non_reference_video_mode(client: TestClient, tmp
     assert resp.status_code == 409
 
 
+@pytest.mark.unit
 def test_patch_unit_duration_override_without_header(client: TestClient):
     """无 header 的 prompt → override=True，duration_seconds 直接生效。"""
     resp = client.post(
@@ -539,6 +559,7 @@ def test_patch_unit_duration_override_without_header(client: TestClient):
     assert resp.json()["unit"]["duration_seconds"] == 7
 
 
+@pytest.mark.unit
 def test_reorder_units_rejects_true_duplicate(client: TestClient):
     """长度匹配但含重复 ID → 命中 duplicate 校验分支。"""
     uid1 = _seed_unit(client)
@@ -551,6 +572,7 @@ def test_reorder_units_rejects_true_duplicate(client: TestClient):
     assert "重复" in resp.json()["detail"]
 
 
+@pytest.mark.unit
 def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
     """长度匹配、无重复，但 ID 集合与现有不一致 → set mismatch 分支。"""
     uid1 = _seed_unit(client)
@@ -563,6 +585,7 @@ def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
     assert "不匹配" in resp.json()["detail"]
 
 
+@pytest.mark.unit
 def test_add_unit_concurrent_rebind_returns_409(client: TestClient, monkeypatch: pytest.MonkeyPatch):
     """加锁前后 episode→script_file 被并发改绑 → 写端点返回 409（前端可重试）。"""
     from server.routers import reference_videos as router_mod

--- a/tests/server/test_reference_videos_router_ad.py
+++ b/tests/server/test_reference_videos_router_ad.py
@@ -117,6 +117,7 @@ def _read_script(client: TestClient) -> dict:
 
 
 class TestDeriveUnits:
+    @pytest.mark.unit
     def test_derive_persists_index_into_script(self, ad_client: TestClient):
         resp = ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
 
@@ -128,6 +129,7 @@ class TestDeriveUnits:
         script = _read_script(ad_client)
         assert script["reference_units"] == units
 
+    @pytest.mark.unit
     def test_rederive_is_reproducible_and_keeps_assets(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         script = _read_script(ad_client)
@@ -140,6 +142,7 @@ class TestDeriveUnits:
         units = resp.json()["units"]
         assert units[0]["generated_assets"]["video_clip"] == "reference_videos/E1U1.mp4"
 
+    @pytest.mark.unit
     def test_derive_rejected_for_non_ad_project(self, ad_client: TestClient):
         proj_dir: Path = ad_client.proj_dir  # type: ignore[attr-defined]
         project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
@@ -158,6 +161,7 @@ class TestDeriveUnits:
 
 
 class TestAdUnitListing:
+    @pytest.mark.unit
     def test_list_returns_persisted_index(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
 
@@ -168,6 +172,7 @@ class TestAdUnitListing:
         assert [u["unit_id"] for u in units] == ["E1U1"]
         assert units[0]["shot_ids"] == ["E1S1", "E1S2"]
 
+    @pytest.mark.unit
     def test_list_empty_before_derive(self, ad_client: TestClient):
         resp = ad_client.get("/api/v1/projects/ad-demo/reference-videos/episodes/1/units")
         assert resp.status_code == 200
@@ -175,6 +180,7 @@ class TestAdUnitListing:
 
 
 class TestAdMutationsRejected:
+    @pytest.mark.unit
     def test_add_unit_rejected(self, ad_client: TestClient):
         resp = ad_client.post(
             "/api/v1/projects/ad-demo/reference-videos/episodes/1/units",
@@ -182,6 +188,7 @@ class TestAdMutationsRejected:
         )
         assert resp.status_code == 409
 
+    @pytest.mark.unit
     def test_patch_unit_rejected(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         resp = ad_client.patch(
@@ -190,11 +197,13 @@ class TestAdMutationsRejected:
         )
         assert resp.status_code == 409
 
+    @pytest.mark.unit
     def test_delete_unit_rejected(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         resp = ad_client.delete("/api/v1/projects/ad-demo/reference-videos/episodes/1/units/E1U1")
         assert resp.status_code == 409
 
+    @pytest.mark.unit
     def test_reorder_rejected(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         resp = ad_client.post(
@@ -205,6 +214,7 @@ class TestAdMutationsRejected:
 
 
 class TestAdGenerate:
+    @pytest.mark.unit
     def test_generate_enqueues_reference_video_task(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
 
@@ -216,11 +226,13 @@ class TestAdGenerate:
         assert kwargs["task_type"] == "reference_video"
         assert kwargs["resource_id"] == "E1U1"
 
+    @pytest.mark.unit
     def test_generate_unknown_unit_404(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         resp = ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/units/E1U9/generate")
         assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_generate_with_blank_shot_prompts_rejected(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         proj_dir: Path = ad_client.proj_dir  # type: ignore[attr-defined]
@@ -265,6 +277,7 @@ class TestAdGenerate:
 
         assert resp.status_code == 409
 
+    @pytest.mark.unit
     def test_generate_with_stale_index_409(self, ad_client: TestClient):
         ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/derive-units")
         proj_dir: Path = ad_client.proj_dir  # type: ignore[attr-defined]

--- a/tests/server/test_startup_assertions.py
+++ b/tests/server/test_startup_assertions.py
@@ -17,6 +17,8 @@ from server.app import (
     detect_docker_environment,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _bwrap_probe_stub(returncode: int = 0, stderr: bytes = b""):
     """构造 subprocess.run 替身，用于桩 bwrap 试跑结果。"""

--- a/tests/source_loader/test_base.py
+++ b/tests/source_loader/test_base.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
+import pytest
+
 from lib.source_loader.base import ExtractedText, FormatExtractor, NormalizeResult  # noqa: F401
+
+pytestmark = pytest.mark.unit
 
 
 def test_extracted_text_defaults():

--- a/tests/source_loader/test_docx.py
+++ b/tests/source_loader/test_docx.py
@@ -1,4 +1,8 @@
+import pytest
+
 from lib.source_loader.docx import DocxExtractor
+
+pytestmark = pytest.mark.unit
 
 
 def test_docx_extracts_paragraphs(docx_factory):

--- a/tests/source_loader/test_epub.py
+++ b/tests/source_loader/test_epub.py
@@ -2,6 +2,8 @@ import pytest
 
 from lib.source_loader.epub import EpubExtractor
 
+pytestmark = pytest.mark.unit
+
 
 def test_epub_injects_chapter_markers_and_counts(epub_factory):
     src = epub_factory(

--- a/tests/source_loader/test_errors.py
+++ b/tests/source_loader/test_errors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lib.source_loader.errors import (
     ConflictError,
     CorruptFileError,
@@ -6,6 +8,8 @@ from lib.source_loader.errors import (
     SourceLoaderError,
     UnsupportedFormatError,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_unsupported_format_error_carries_ext():

--- a/tests/source_loader/test_loader.py
+++ b/tests/source_loader/test_loader.py
@@ -9,6 +9,8 @@ from lib.source_loader.errors import (
     UnsupportedFormatError,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_load_txt_utf8_no_raw_backup(tmp_path: Path):
     project_source = tmp_path / "source"

--- a/tests/source_loader/test_migration.py
+++ b/tests/source_loader/test_migration.py
@@ -1,7 +1,11 @@
 import random
 from pathlib import Path
 
+import pytest
+
 from lib.source_loader.migration import migrate_project_source_encoding
+
+pytestmark = pytest.mark.unit
 
 
 def _make_project(tmp_path: Path, name: str) -> Path:

--- a/tests/source_loader/test_pdf.py
+++ b/tests/source_loader/test_pdf.py
@@ -3,6 +3,8 @@ import pytest
 from lib.source_loader.errors import CorruptFileError
 from lib.source_loader.pdf import PdfOxideExtractor
 
+pytestmark = pytest.mark.unit
+
 # 取样自 data/sample_text.pdf 中确定出现的中文短语
 _EXPECTED_SNIPPET_PAGE_1 = "新股研究"
 _EXPECTED_SNIPPET_PAGE_2 = "打新基金"

--- a/tests/source_loader/test_txt.py
+++ b/tests/source_loader/test_txt.py
@@ -5,6 +5,8 @@ import pytest
 from lib.source_loader.errors import SourceDecodeError
 from lib.source_loader.txt import TxtExtractor, decode_txt
 
+pytestmark = pytest.mark.unit
+
 
 def test_decode_utf8_bom():
     raw = b"\xef\xbb\xbf\xe4\xbd\xa0\xe5\xa5\xbd"  # "你好"

--- a/tests/test_accounting_characterization.py
+++ b/tests/test_accounting_characterization.py
@@ -51,6 +51,8 @@ from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession, SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # 冻结时钟：写入侧（usage_repo.utc_now）是 aware datetime，SQLite 回读为 naive。
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -9,6 +9,7 @@ import contextlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -18,6 +19,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import agent_chat
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 def _make_client() -> TestClient:

--- a/tests/test_agent_config_router.py
+++ b/tests/test_agent_config_router.py
@@ -14,6 +14,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.routers import agent_config
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 def _make_app(session_factory) -> FastAPI:
     app = FastAPI()

--- a/tests/test_agent_credential_repo.py
+++ b/tests/test_agent_credential_repo.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.db.repositories.agent_credential_repo import AgentCredentialRepository
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.asyncio
 async def test_create_and_get(async_session) -> None:

--- a/tests/test_agent_provider_catalog.py
+++ b/tests/test_agent_provider_catalog.py
@@ -1,10 +1,14 @@
 """预设供应商目录单元测试。"""
 
+import pytest
+
 from lib.agent_provider_catalog import (
     CUSTOM_SENTINEL_ID,
     get_preset,
     list_presets,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_custom_sentinel_value() -> None:

--- a/tests/test_agnes_image_backend.py
+++ b/tests/test_agnes_image_backend.py
@@ -17,6 +17,8 @@ from lib.image_backends.base import (
 )
 from lib.providers import PROVIDER_AGNES
 
+pytestmark = pytest.mark.unit
+
 
 def _img_response(url: str = "https://x/out.png") -> MagicMock:
     resp = MagicMock()

--- a/tests/test_agnes_shared.py
+++ b/tests/test_agnes_shared.py
@@ -11,6 +11,8 @@ from lib.agnes_shared import (
     resolve_agnes_api_key,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestBaseUrlDerivation:
     def test_default_base(self):

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -16,6 +16,8 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
     resp = MagicMock()

--- a/tests/test_alembic_custom_provider_endpoint.py
+++ b/tests/test_alembic_custom_provider_endpoint.py
@@ -10,6 +10,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 

--- a/tests/test_alembic_custom_provider_max_workers.py
+++ b/tests/test_alembic_custom_provider_max_workers.py
@@ -10,6 +10,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:

--- a/tests/test_alembic_drop_task_events_downgrade.py
+++ b/tests/test_alembic_drop_task_events_downgrade.py
@@ -15,6 +15,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 #: 建表迁移 b942e8c5d545 使用的 FK 约束名，downgrade 重建时必须一致。
 _FK_NAME = "fk_task_events_task_id"
 

--- a/tests/test_alembic_resource_type_dedupe_downgrade.py
+++ b/tests/test_alembic_resource_type_dedupe_downgrade.py
@@ -14,6 +14,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:

--- a/tests/test_alembic_split_default_image_backend.py
+++ b/tests/test_alembic_split_default_image_backend.py
@@ -10,6 +10,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 # 本文件只覆盖拆分迁移本身，停在该 revision——后续 revision 会把两桶重新收敛回默认层。

--- a/tests/test_alembic_supported_durations_backfill.py
+++ b/tests/test_alembic_supported_durations_backfill.py
@@ -10,6 +10,8 @@ from alembic.config import Config
 
 from alembic import command
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:

--- a/tests/test_anthropic_probe.py
+++ b/tests/test_anthropic_probe.py
@@ -17,6 +17,8 @@ from lib.config.anthropic_probe import (
     run_test,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.asyncio
 async def test_probe_messages_success() -> None:

--- a/tests/test_anthropic_url.py
+++ b/tests/test_anthropic_url.py
@@ -4,6 +4,8 @@ import pytest
 
 from lib.config.anthropic_url import AnthropicEndpoints, derive_anthropic_endpoints
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     ("user_url", "expected"),

--- a/tests/test_api_keys_router.py
+++ b/tests/test_api_keys_router.py
@@ -6,12 +6,15 @@ API Key 管理路由集成测试
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import api_keys
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 def _make_client() -> TestClient:

--- a/tests/test_app_data_dir.py
+++ b/tests/test_app_data_dir.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 def _import_fresh():
     """Re-import the module fresh — `@functools.cache` traps env values."""

--- a/tests/test_app_module.py
+++ b/tests/test_app_module.py
@@ -6,6 +6,8 @@ import lib.db
 import server.app as app_module
 from server.routers import assistant as assistant_router
 
+pytestmark = pytest.mark.unit
+
 
 async def _noop_async(*args, **kwargs):
     """No-op coroutine for mocking async functions in tests."""

--- a/tests/test_app_startup_migration.py
+++ b/tests/test_app_startup_migration.py
@@ -9,6 +9,8 @@ import lib.db
 import server.app as app_module
 from server.routers import assistant as assistant_router
 
+pytestmark = pytest.mark.unit
+
 
 async def _noop_async(*args, **kwargs):
     """No-op coroutine for mocking async startup steps."""

--- a/tests/test_ark_video_resolution.py
+++ b/tests/test_ark_video_resolution.py
@@ -7,6 +7,8 @@ import pytest
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoGenerationRequest
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend():
     backend = ArkVideoBackend.__new__(ArkVideoBackend)

--- a/tests/test_aspect_size.py
+++ b/tests/test_aspect_size.py
@@ -15,6 +15,8 @@ from lib.aspect_size import (
     resolution_to_short_edge,
 )
 
+pytestmark = pytest.mark.unit
+
 ALL_ASPECTS = ["9:16", "16:9", "1:1", "3:4", "4:3", "2:3", "3:2", "21:9"]
 
 

--- a/tests/test_asset_fingerprints.py
+++ b/tests/test_asset_fingerprints.py
@@ -1,6 +1,10 @@
 import time
 
+import pytest
+
 from lib.asset_fingerprints import compute_asset_fingerprints
+
+pytestmark = pytest.mark.unit
 
 
 class TestComputeAssetFingerprints:

--- a/tests/test_asset_model.py
+++ b/tests/test_asset_model.py
@@ -9,6 +9,8 @@ import lib.db.models  # noqa: F401 — ensure all models registered for Base.met
 from lib.db.base import Base
 from lib.db.models.asset import Asset
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def engine():

--- a/tests/test_asset_name_validation.py
+++ b/tests/test_asset_name_validation.py
@@ -14,6 +14,8 @@ import pytest
 from lib.asset_types import resolve_asset_key, validate_asset_name
 from lib.project_manager import ProjectManager
 
+pytestmark = pytest.mark.unit
+
 _NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
 _NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
 

--- a/tests/test_asset_repo.py
+++ b/tests/test_asset_repo.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.db.base import Base
 from lib.db.repositories.asset_repo import AssetRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -345,6 +345,7 @@ class TestAssetRouterNoLeak:
 class TestNfcConvergence:
     """PATCH/DELETE 的路径参数与桶 key 形态可以不同：登记闸口落 NFC，存量 key 未迁移。"""
 
+    @pytest.mark.unit
     def test_patch_resolves_across_normalization_forms(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"][_NAME_NFD] = {"name": _NAME_NFD, "description": "legacy"}
@@ -356,6 +357,7 @@ class TestNfcConvergence:
         assert list(chars) == [_NAME_NFD]
         assert chars[_NAME_NFD]["description"] == "new"
 
+    @pytest.mark.unit
     def test_delete_resolves_across_normalization_forms(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"][_NAME_NFC] = {"name": _NAME_NFC, "description": "d"}

--- a/tests/test_asset_router_factory.py
+++ b/tests/test_asset_router_factory.py
@@ -62,6 +62,7 @@ def _client(monkeypatch):
 
 
 class TestAssetRouterFactory:
+    @pytest.mark.unit
     def test_character_post_passes_extra_voice_style(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         with client:
@@ -116,6 +117,7 @@ class TestAssetRouterFactory:
             assert resp.status_code == 422
             assert "Bob" not in fake_pm.projects["demo"]["characters"]
 
+    @pytest.mark.unit
     def test_character_post_400_on_path_unsafe_name(self, monkeypatch):
         """名字含路径分隔符须在 HTTP 边界拒绝：这类名字会让生成（嵌套文件路径）
         与后续单段路由（PATCH/DELETE/{name}）全部失效。"""
@@ -129,6 +131,7 @@ class TestAssetRouterFactory:
                 assert resp.status_code == 400, bad_name
                 assert bad_name not in fake_pm.projects["demo"]["characters"]
 
+    @pytest.mark.unit
     def test_character_post_409_on_duplicate(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"]["Alice"] = {
@@ -144,6 +147,7 @@ class TestAssetRouterFactory:
             )
             assert resp.status_code == 409
 
+    @pytest.mark.unit
     def test_character_patch_accepts_extra_fields(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"]["Alice"] = {
@@ -167,6 +171,7 @@ class TestAssetRouterFactory:
             assert entry["voice_style"] == "strong"
             assert entry["reference_image"] == "characters/refs/Alice.png"
 
+    @pytest.mark.unit
     def test_character_patch_rejects_non_string_value(self, monkeypatch):
         client, fake_pm = _client(monkeypatch)
         fake_pm.projects["demo"]["characters"]["Alice"] = {
@@ -268,6 +273,7 @@ class TestAssetRouterFactory:
             # entry 未被污染
             assert "voice_notice_dismissed_at" not in fake_pm.projects["demo"]["characters"]["Alice"]
 
+    @pytest.mark.unit
     def test_unknown_asset_type_raises(self):
         from server.routers._asset_router_factory import build_asset_router
 
@@ -287,6 +293,7 @@ class TestAssetRouterNoLeak:
     分支落到末端 except Exception，断言 500、detail 为通用 i18n 文案且哨兵串不出现在响应体。
     """
 
+    @pytest.mark.unit
     def test_add_unexpected_error_no_leak(self, monkeypatch):
         monkeypatch.setattr(
             characters,
@@ -302,6 +309,7 @@ class TestAssetRouterNoLeak:
             assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_add" not in resp.text
 
+    @pytest.mark.unit
     def test_update_unexpected_error_no_leak(self, monkeypatch):
         monkeypatch.setattr(
             characters,
@@ -317,6 +325,7 @@ class TestAssetRouterNoLeak:
             assert resp.json()["detail"] == _INTERNAL_ERROR_DETAIL
             assert "LEAK_update" not in resp.text
 
+    @pytest.mark.unit
     def test_delete_unexpected_error_no_leak(self, monkeypatch):
         monkeypatch.setattr(
             characters,

--- a/tests/test_asset_types_product.py
+++ b/tests/test_asset_types_product.py
@@ -1,5 +1,7 @@
 """product 资产类型的 spec 层行为：第 4 条目、列表字段抽象、全局库豁免。"""
 
+import pytest
+
 from lib.asset_types import (
     ASSET_SPECS,
     ASSET_TYPES,
@@ -7,6 +9,8 @@ from lib.asset_types import (
     GLOBAL_LIBRARY_ASSET_TYPES,
     SHEET_KEY,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestProductSpec:

--- a/tests/test_assets_router.py
+++ b/tests/test_assets_router.py
@@ -41,6 +41,7 @@ async def _assets_env(tmp_path, monkeypatch):
 
 
 class TestAssetsCRUD:
+    @pytest.mark.unit
     def test_create_and_list(self, _assets_env):
         client = _assets_env["client"]
         r = client.post(
@@ -56,6 +57,7 @@ class TestAssetsCRUD:
         assert len(r2.json()["items"]) == 1
         assert r2.json()["items"][0]["id"] == asset_id
 
+    @pytest.mark.unit
     def test_duplicate_type_name_returns_409(self, _assets_env):
         client = _assets_env["client"]
         r1 = client.post("/api/v1/assets", data={"type": "prop", "name": "玉佩"})
@@ -63,6 +65,7 @@ class TestAssetsCRUD:
         r = client.post("/api/v1/assets", data={"type": "prop", "name": "玉佩"})
         assert r.status_code == 409
 
+    @pytest.mark.unit
     def test_patch_and_delete(self, _assets_env):
         client = _assets_env["client"]
         r = client.post("/api/v1/assets", data={"type": "scene", "name": "A"})
@@ -79,11 +82,13 @@ class TestAssetsCRUD:
         r4 = client.get(f"/api/v1/assets/{aid}")
         assert r4.status_code == 404
 
+    @pytest.mark.unit
     def test_invalid_type_returns_400(self, _assets_env):
         client = _assets_env["client"]
         r = client.post("/api/v1/assets", data={"type": "invalid", "name": "X"})
         assert r.status_code == 400
 
+    @pytest.mark.unit
     def test_product_type_excluded_from_global_library(self, _assets_env):
         """product 是多图列表型资产，单图列模型的全局库不收：create 与 from-project 均 400。"""
         client = _assets_env["client"]
@@ -100,6 +105,7 @@ class TestAssetsCRUD:
         )
         assert r2.status_code == 400
 
+    @pytest.mark.unit
     def test_list_filters_by_q(self, _assets_env):
         client = _assets_env["client"]
         client.post("/api/v1/assets", data={"type": "character", "name": "王小明"})
@@ -108,6 +114,7 @@ class TestAssetsCRUD:
         assert r.status_code == 200
         assert len(r.json()["items"]) == 1
 
+    @pytest.mark.unit
     def test_create_conflict_does_not_leave_orphan_file(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -134,6 +141,7 @@ class TestAssetsCRUD:
         files_after_dup = list(global_dir.iterdir())
         assert len(files_after_dup) == len(files_after_first), "duplicate upload must not leave orphan files"
 
+    @pytest.mark.unit
     def test_replace_image(self, _assets_env):
         client = _assets_env["client"]
         r = client.post("/api/v1/assets", data={"type": "scene", "name": "A"})
@@ -147,6 +155,7 @@ class TestAssetsCRUD:
         assert r2.status_code == 200
         assert r2.json()["asset"]["image_path"] is not None
 
+    @pytest.mark.unit
     def test_replace_image_invalid_format_preserves_old_image(self, _assets_env):
         """If new upload fails validation, old image must NOT be deleted."""
         client = _assets_env["client"]
@@ -177,6 +186,7 @@ class TestAssetsCRUD:
 
 
 class TestFromProject:
+    @pytest.mark.unit
     def test_from_project_copies_image(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -207,6 +217,7 @@ class TestFromProject:
         # 落盘文件与源文件相同字节
         assert (pm.projects_root / ip).read_bytes() == b"img"
 
+    @pytest.mark.unit
     def test_from_project_conflict_409_and_overwrite(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -245,6 +256,7 @@ class TestFromProject:
         )
         assert r3.status_code == 200
 
+    @pytest.mark.unit
     def test_from_project_invalid_type_returns_400(self, _assets_env):
         client = _assets_env["client"]
         r = client.post(
@@ -257,6 +269,7 @@ class TestFromProject:
         )
         assert r.status_code == 400
 
+    @pytest.mark.unit
     def test_from_project_missing_project_returns_404(self, _assets_env):
         client = _assets_env["client"]
         r = client.post(
@@ -269,6 +282,7 @@ class TestFromProject:
         )
         assert r.status_code == 404
 
+    @pytest.mark.unit
     def test_from_project_missing_resource_returns_404(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -319,6 +333,7 @@ class TestFromProject:
         )
         assert "nhân vật" in vi.json()["detail"] and "character" not in vi.json()["detail"]
 
+    @pytest.mark.unit
     def test_from_project_copies_audio(self, _assets_env):
         """character 的 reference_audio 随 character_sheet 一起复制到全局资产库。"""
         client = _assets_env["client"]
@@ -411,6 +426,7 @@ class TestFromProject:
         assert r.status_code == 200, r.text
         assert r.json()["asset"]["audio_path"] is None
 
+    @pytest.mark.unit
     def test_from_project_without_audio_has_null_audio_path(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -430,6 +446,7 @@ class TestFromProject:
         assert r.status_code == 200
         assert r.json()["asset"]["audio_path"] is None
 
+    @pytest.mark.unit
     def test_from_project_missing_audio_file_degrades_quietly(self, _assets_env):
         """reference_audio 字段指向不存在的文件时静默降级为无音频，不中断入库。"""
         client = _assets_env["client"]
@@ -450,6 +467,7 @@ class TestFromProject:
         assert r.status_code == 200, r.text
         assert r.json()["asset"]["audio_path"] is None
 
+    @pytest.mark.unit
     def test_from_project_without_sheet_has_null_image_path(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -471,6 +489,7 @@ class TestFromProject:
 
 
 class TestApplyToProject:
+    @pytest.mark.unit
     def test_apply_with_skip_policy(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -509,6 +528,7 @@ class TestApplyToProject:
         assert len(body2["succeeded"]) == 0
         assert len(body2["skipped"]) == 2
 
+    @pytest.mark.unit
     def test_rename_policy_adds_numeric_suffix(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -541,6 +561,7 @@ class TestApplyToProject:
         data = pm.load_project("target")
         assert "玉佩" in data["props"] and "玉佩 (2)" in data["props"]
 
+    @pytest.mark.unit
     def test_overwrite_policy_replaces_existing(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -569,6 +590,7 @@ class TestApplyToProject:
         data = pm.load_project("target")
         assert data["characters"]["王"]["description"] == "library desc"
 
+    @pytest.mark.unit
     def test_invalid_policy_returns_400(self, _assets_env):
         client = _assets_env["client"]
         r = client.post(
@@ -581,6 +603,7 @@ class TestApplyToProject:
         )
         assert r.status_code == 400
 
+    @pytest.mark.unit
     def test_missing_project_returns_404(self, _assets_env):
         client = _assets_env["client"]
         r = client.post(
@@ -593,6 +616,7 @@ class TestApplyToProject:
         )
         assert r.status_code == 404
 
+    @pytest.mark.unit
     def test_unknown_asset_id_listed_in_failed(self, _assets_env):
         client = _assets_env["client"]
         pm = _assets_env["pm"]
@@ -611,6 +635,7 @@ class TestApplyToProject:
         assert len(r.json()["failed"]) == 1
         assert r.json()["failed"][0]["reason"] == "not_found"
 
+    @pytest.mark.unit
     def test_image_missing_adds_to_failed(self, _assets_env):
         """If asset.image_path is set but the file on disk is gone, record as failed."""
         client = _assets_env["client"]
@@ -648,6 +673,7 @@ class TestApplyToProject:
         data = pm.load_project("target")
         assert "A" not in (data.get("scenes") or {})
 
+    @pytest.mark.unit
     def test_audio_missing_adds_to_failed(self, _assets_env):
         """asset.audio_path 有值但磁盘文件缺失时记 failed，不中断整批（与 image_path 同口径）。"""
         client = _assets_env["client"]
@@ -689,6 +715,7 @@ class TestApplyToProject:
         data = pm.load_project("target")
         assert "王" not in (data.get("characters") or {})
 
+    @pytest.mark.unit
     def test_audio_copied_to_target_project(self, _assets_env):
         """端到端：from-project → 资产库 → apply-to-project 把音频也随图一起复制回项目。"""
         client = _assets_env["client"]
@@ -727,6 +754,7 @@ class TestApplyToProject:
         # 「资产即开关」：导入即视为该项目新设置了这个声音，存量过渡横幅计数须能感知到
         assert data["characters"]["王"]["voice_updated_at"]
 
+    @pytest.mark.unit
     def test_image_copied_to_target_project(self, _assets_env):
         """End-to-end: from-project → asset library → apply-to-project copies the image too."""
         client = _assets_env["client"]

--- a/tests/test_assistant_router_full.py
+++ b/tests/test_assistant_router_full.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -9,6 +10,8 @@ from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.conftest import make_translator
 from tests.factories import make_session_meta
+
+pytestmark = pytest.mark.unit
 
 PROJECT = "demo"
 PREFIX = f"/api/v1/projects/{PROJECT}/assistant"

--- a/tests/test_assistant_routes.py
+++ b/tests/test_assistant_routes.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -12,6 +13,8 @@ from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.conftest import make_translator
 from tests.factories import make_session_meta
+
+pytestmark = pytest.mark.unit
 
 PROJECT = "demo"
 PREFIX = f"/api/v1/projects/{PROJECT}/assistant"

--- a/tests/test_assistant_service_more.py
+++ b/tests/test_assistant_service_more.py
@@ -11,6 +11,8 @@ from server.agent_runtime.service import AssistantService
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.factories import make_session_meta
 
+pytestmark = pytest.mark.unit
+
 
 class _FakePM:
     def __init__(self, valid_project="demo"):

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from server.agent_runtime.service import AssistantService
+
+pytestmark = pytest.mark.unit
 
 
 class TestListAvailableSkills:

--- a/tests/test_audio_backends.py
+++ b/tests/test_audio_backends.py
@@ -19,6 +19,8 @@ from lib.audio_backends import (
 from lib.dashscope_shared import extract_audio_url
 from lib.providers import PROVIDER_DASHSCOPE
 
+pytestmark = pytest.mark.unit
+
 
 class TestRegistry:
     def test_dashscope_auto_registered(self):

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -69,6 +69,7 @@ def _m4a_bytes(duration_seconds: float = 3.0) -> bytes:
 
 
 class TestFfprobeUnavailable:
+    @pytest.mark.unit
     async def test_returns_none_without_spawning(self):
         with patch("lib.audio_utils.shutil.which", return_value=None):
             with patch("lib.audio_utils.asyncio.create_subprocess_exec") as spawn:
@@ -85,15 +86,18 @@ class TestFfprobeAvailable:
         if shutil.which("ffprobe") is None:
             pytest.skip("ffprobe not available")
 
+    @pytest.mark.unit
     async def test_probes_real_duration(self):
         duration = await audio_utils_module.probe_audio_duration_seconds(_wav_bytes(3), ".wav")
         assert duration is not None
         assert 2.5 < duration < 3.5
 
+    @pytest.mark.unit
     async def test_invalid_bytes_raise_value_error(self):
         with pytest.raises(ValueError):
             await audio_utils_module.probe_audio_duration_seconds(b"not audio at all", ".wav")
 
+    @pytest.mark.unit
     async def test_video_only_file_renamed_to_wav_is_rejected(self):
         """把无音轨的视频文件改名为 .wav 上传时，容器/时长校验会通过，但应无音频流可用而拒绝。"""
         if shutil.which("ffmpeg") is None:
@@ -101,6 +105,7 @@ class TestFfprobeAvailable:
         with pytest.raises(ValueError):
             await audio_utils_module.probe_audio_duration_seconds(_video_only_mp4_bytes(), ".wav")
 
+    @pytest.mark.unit
     async def test_m4a_renamed_to_wav_is_rejected(self):
         """m4a 有音轨也能探出时长，但容器不是 wav，改名上传应被拒绝而非当作 wav 收下。"""
         if shutil.which("ffmpeg") is None:
@@ -108,6 +113,7 @@ class TestFfprobeAvailable:
         with pytest.raises(ValueError):
             await audio_utils_module.probe_audio_duration_seconds(_m4a_bytes(), ".wav")
 
+    @pytest.mark.unit
     async def test_ffprobe_invoked_with_protocol_whitelist(self):
         """探测字节可能嵌套 HLS/RTMP 等播放列表引用；每次 ffprobe 调用都必须限制协议白名单为 file，防 SSRF。"""
         calls: list[tuple[object, ...]] = []

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,9 +8,12 @@ import os
 import time
 from unittest.mock import patch
 
+import pytest
 from fastapi import HTTPException
 
 import server.auth as auth_module
+
+pytestmark = pytest.mark.unit
 
 
 class TestGeneratePassword:

--- a/tests/test_auth_api_key.py
+++ b/tests/test_auth_api_key.py
@@ -13,6 +13,8 @@ from fastapi import HTTPException
 
 import server.auth as auth_module
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def clear_cache():

--- a/tests/test_auth_kill_switch.py
+++ b/tests/test_auth_kill_switch.py
@@ -10,6 +10,8 @@ from fastapi import HTTPException
 
 import server.auth as auth_module
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _isolated_auth_env():

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -12,6 +12,8 @@ from fastapi.testclient import TestClient
 
 import server.auth as auth_module
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _auth_env():

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -15,6 +15,8 @@ import server.auth as auth_module
 from server.routers import auth as auth_router
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def client():

--- a/tests/test_backend_assembly_loader.py
+++ b/tests/test_backend_assembly_loader.py
@@ -17,6 +17,8 @@ from lib.config.resolver import ConfigResolver
 from lib.config.service import ConfigService
 from lib.db.base import Base
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 async def session_factory():

--- a/tests/test_backend_assembly_specs.py
+++ b/tests/test_backend_assembly_specs.py
@@ -19,6 +19,8 @@ from lib.backend_assembly.specs import (
 )
 from lib.config.registry import PROVIDER_REGISTRY
 
+pytestmark = pytest.mark.unit
+
 
 def _loaded(*, credentials: dict, provider_id: str) -> LoadedConfig:
     return LoadedConfig(

--- a/tests/test_characters_router.py
+++ b/tests/test_characters_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -5,6 +6,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import characters
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakePM:

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = (
     REPO_ROOT / "agent_runtime_profile" / ".claude" / "skills" / "compose-video" / "scripts" / "compose_video.py"

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -8,6 +8,8 @@ from lib.config.migration import migrate_json_to_db
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
 from lib.db.base import Base
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -5,6 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.db.base import Base
 from lib.db.models.config import ProviderConfig, SystemSetting
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -3,6 +3,7 @@ import pytest
 from lib.config.registry import PROVIDER_REGISTRY, ModelInfo, ProviderMeta, model_has_audio_track
 
 
+@pytest.mark.unit
 def test_all_providers_registered():
     assert set(PROVIDER_REGISTRY.keys()) == {
         "gemini-aistudio",
@@ -19,6 +20,7 @@ def test_all_providers_registered():
     }
 
 
+@pytest.mark.unit
 def test_provider_meta_fields():
     meta = PROVIDER_REGISTRY["gemini-aistudio"]
     assert isinstance(meta, ProviderMeta)
@@ -30,12 +32,14 @@ def test_provider_meta_fields():
     assert "text_to_video" in meta.capabilities
 
 
+@pytest.mark.unit
 def test_ark_supports_video_and_image():
     meta = PROVIDER_REGISTRY["ark"]
     assert "video" in meta.media_types
     assert "image" in meta.media_types
 
 
+@pytest.mark.unit
 def test_required_keys_are_subset_of_all_keys():
     for name, meta in PROVIDER_REGISTRY.items():
         all_keys = set(meta.required_keys) | set(meta.optional_keys)
@@ -43,6 +47,7 @@ def test_required_keys_are_subset_of_all_keys():
             assert rk in all_keys, f"{name}: required key {rk} not in all keys"
 
 
+@pytest.mark.unit
 def test_secret_keys_are_subset_of_required_or_optional():
     for name, meta in PROVIDER_REGISTRY.items():
         all_keys = set(meta.required_keys) | set(meta.optional_keys)
@@ -58,6 +63,7 @@ _LANE_WORKER_KEY = {
 }
 
 
+@pytest.mark.unit
 def test_optional_keys_cover_every_supported_lane_worker():
     """每个 provider 支持的每条媒体 lane 都须在 optional_keys 声明对应 *_max_workers。"""
     for name, meta in PROVIDER_REGISTRY.items():
@@ -69,6 +75,7 @@ def test_optional_keys_cover_every_supported_lane_worker():
             assert worker_key in optional, f"{name}: 支持 {media_type} lane 但 optional_keys 未声明 {worker_key}"
 
 
+@pytest.mark.unit
 def test_optional_keys_have_no_worker_for_unsupported_lane():
     """provider 不支持的 lane 不应声明其 *_max_workers，避免设置页渲染无效字段。"""
     for name, meta in PROVIDER_REGISTRY.items():
@@ -79,6 +86,7 @@ def test_optional_keys_have_no_worker_for_unsupported_lane():
 
 
 class TestModelInfoDurations:
+    @pytest.mark.unit
     def test_video_models_have_supported_durations(self):
         """所有预置视频模型必须声明 supported_durations。"""
         for provider_id, meta in PROVIDER_REGISTRY.items():
@@ -88,6 +96,7 @@ class TestModelInfoDurations:
                         f"{provider_id}/{model_id} 是视频模型但未声明 supported_durations"
                     )
 
+    @pytest.mark.unit
     def test_non_video_models_have_empty_durations(self):
         """非视频模型的 supported_durations 应为空列表。"""
         for provider_id, meta in PROVIDER_REGISTRY.items():
@@ -97,6 +106,7 @@ class TestModelInfoDurations:
                         f"{provider_id}/{model_id} 不是视频模型但有 supported_durations"
                     )
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("provider_id", ["gemini-aistudio", "gemini-vertex"])
     def test_veo_declares_high_resolution_constraints(self, provider_id):
         """两侧 Veo 模型每个可选高分辨率档都声明「仅 8s」，UI 才能据此收窄时长选项。"""
@@ -110,6 +120,7 @@ class TestModelInfoDurations:
                         f"{provider_id}/{model_id} 的 {resolution} 未声明仅 8s"
                     )
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("provider_id", ["gemini-aistudio", "gemini-vertex"])
     def test_veo_declares_reference_image_durations(self, provider_id):
         """Veo 带参考图时只接受 8s，两侧全系声明，与 backend 的执行期拒绝对齐。"""
@@ -118,6 +129,7 @@ class TestModelInfoDurations:
             if model_info.media_type == "video":
                 assert model_info.reference_image_durations == [8], f"{provider_id}/{model_id} 参考图时长约束缺失"
 
+    @pytest.mark.unit
     def test_veo_4k_only_where_officially_supported(self):
         """4k 仅 Veo 3.1 Standard 两侧 + AI Studio 的 Fast 支持；Lite 与 Vertex Fast 不支持。"""
         expected_4k = {
@@ -131,6 +143,7 @@ class TestModelInfoDurations:
             resolutions = PROVIDER_REGISTRY[provider_id].models[model_id].resolutions
             assert ("4k" in resolutions) is supported, f"{provider_id}/{model_id} 的 4k 支持性与官方文档不符"
 
+    @pytest.mark.unit
     def test_model_info_default_values(self):
         """ModelInfo 新字段的默认值。"""
         mi = ModelInfo(display_name="test", media_type="text", capabilities=[])
@@ -142,10 +155,12 @@ class TestModelInfoDurations:
 class TestCredentialGroups:
     """凭证「二选一」分组声明的 fail-fast 校验。"""
 
+    @pytest.mark.unit
     def test_default_empty(self):
         meta = ProviderMeta(display_name="t", description="t", required_keys=["api_key"], secret_keys=["api_key"])
         assert meta.credential_groups == []
 
+    @pytest.mark.unit
     def test_group_keys_must_be_subset_of_required_and_secret(self):
         with pytest.raises(ValueError, match="credential_groups"):
             ProviderMeta(
@@ -156,6 +171,7 @@ class TestCredentialGroups:
                 credential_groups=[["api_key"], ["access_key"]],
             )
 
+    @pytest.mark.unit
     def test_valid_groups_accepted(self):
         meta = ProviderMeta(
             display_name="t",
@@ -166,6 +182,7 @@ class TestCredentialGroups:
         )
         assert meta.credential_groups == [["api_key"], ["access_key", "secret_key"]]
 
+    @pytest.mark.unit
     def test_empty_group_rejected(self):
         with pytest.raises(ValueError, match="空分组"):
             ProviderMeta(
@@ -176,6 +193,7 @@ class TestCredentialGroups:
                 credential_groups=[["api_key"], []],
             )
 
+    @pytest.mark.unit
     def test_uncovered_key_rejected(self):
         with pytest.raises(ValueError, match="未覆盖"):
             ProviderMeta(
@@ -199,25 +217,30 @@ class TestFullyCoveredCredentialGroups:
             credential_groups=[["api_key"], ["access_key", "secret_key"]],
         )
 
+    @pytest.mark.unit
     def test_no_groups_declared_always_empty(self):
         meta = ProviderMeta(display_name="t", description="t", required_keys=["api_key"], secret_keys=["api_key"])
         assert meta.fully_covered_credential_groups({"api_key": "k"}) == []
 
+    @pytest.mark.unit
     def test_single_group_fully_submitted(self):
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"api_key": "k"}) == [["api_key"]]
 
+    @pytest.mark.unit
     def test_dual_key_group_fully_submitted(self):
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"access_key": "ak", "secret_key": "sk"}) == [
             ["access_key", "secret_key"]
         ]
 
+    @pytest.mark.unit
     def test_dual_key_group_partially_submitted_not_matched(self):
         """只提交组内一个 key（如仅轮换 secret_key）不算完整覆盖该组。"""
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"secret_key": "sk"}) == []
 
+    @pytest.mark.unit
     def test_both_groups_fully_submitted(self):
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"api_key": "k", "access_key": "ak", "secret_key": "sk"}) == [
@@ -225,15 +248,18 @@ class TestFullyCoveredCredentialGroups:
             ["access_key", "secret_key"],
         ]
 
+    @pytest.mark.unit
     def test_empty_string_not_counted_as_covering(self):
         """空字符串视同未提交，不满足组覆盖。"""
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"api_key": ""}) == []
 
+    @pytest.mark.unit
     def test_none_not_counted_as_covering(self):
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({"api_key": None}) == []
 
+    @pytest.mark.unit
     def test_nothing_submitted(self):
         meta = self._kling_meta()
         assert meta.fully_covered_credential_groups({}) == []

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -4,6 +4,8 @@ import pytest
 
 from lib.config.registry import PROVIDER_REGISTRY, ModelInfo, ProviderMeta
 
+pytestmark = pytest.mark.unit
+
 
 class TestModelInfo:
     def test_basic(self):

--- a/tests/test_config_repository.py
+++ b/tests/test_config_repository.py
@@ -4,6 +4,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
 from lib.db.base import Base
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -993,14 +993,12 @@ class TestVoiceConsistency:
         caps = await self._caps({"video_backend": "openai/sora-2"})
         assert caps["voice_consistency"] == "soft"
 
-    @pytest.mark.unit
     async def test_kling_v3_audio_models_are_soft(self):
         """可灵 v3 系声明音频能力 → soft（注入 Voice_Profiles）。"""
         for model_id in ("kling-v3", "kling-v3-omni"):
             caps = await self._caps({"video_backend": f"kling/{model_id}"})
             assert caps["voice_consistency"] == "soft"
 
-    @pytest.mark.unit
     async def test_kling_turbo_true_silent_is_none(self):
         """可灵 v2-5-turbo 无音频开关 → none。"""
         caps = await self._caps({"video_backend": "kling/kling-v2-5-turbo"})

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -75,6 +75,7 @@ class _FakeConfigService:
 class TestVideoGenerateAudio:
     """验证 video_generate_audio 的默认值、全局配置、项目级覆盖优先级。"""
 
+    @pytest.mark.unit
     async def test_default_is_true_when_db_empty(self, tmp_path):
         """DB 无值时应返回 True（PR7 §11 决策：与 Seedance/Grok 默认开启一致）。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -82,6 +83,7 @@ class TestVideoGenerateAudio:
         result = await resolver._resolve_video_generate_audio(fake_svc, project_name=None)
         assert result is True
 
+    @pytest.mark.unit
     async def test_global_true(self, tmp_path):
         """DB 中值为 "true" 时返回 True。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -89,6 +91,7 @@ class TestVideoGenerateAudio:
         result = await resolver._resolve_video_generate_audio(fake_svc, project_name=None)
         assert result is True
 
+    @pytest.mark.unit
     async def test_global_false(self, tmp_path):
         """DB 中值为 "false" 时返回 False。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -96,6 +99,7 @@ class TestVideoGenerateAudio:
         result = await resolver._resolve_video_generate_audio(fake_svc, project_name=None)
         assert result is False
 
+    @pytest.mark.unit
     async def test_bool_parsing_variants(self, tmp_path):
         """验证各种布尔字符串的解析。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -104,6 +108,7 @@ class TestVideoGenerateAudio:
             result = await resolver._resolve_video_generate_audio(fake_svc, project_name=None)
             assert result is expected, f"Failed for {val!r}: got {result}"
 
+    @pytest.mark.unit
     async def test_project_override_true_over_global_false(self, tmp_path):
         """项目级覆盖 True 优先于全局 False。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -113,6 +118,7 @@ class TestVideoGenerateAudio:
             result = await resolver._resolve_video_generate_audio(fake_svc, project_name="demo")
         assert result is True
 
+    @pytest.mark.unit
     async def test_project_override_false_over_global_true(self, tmp_path):
         """项目级覆盖 False 优先于全局 True。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -122,6 +128,7 @@ class TestVideoGenerateAudio:
             result = await resolver._resolve_video_generate_audio(fake_svc, project_name="demo")
         assert result is False
 
+    @pytest.mark.unit
     async def test_project_none_skips_override(self, tmp_path):
         """project_name=None 时不读取项目配置。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -129,6 +136,7 @@ class TestVideoGenerateAudio:
         result = await resolver._resolve_video_generate_audio(fake_svc, project_name=None)
         assert result is True
 
+    @pytest.mark.unit
     async def test_project_override_string_value(self, tmp_path):
         """项目级覆盖值为字符串时也能正确解析。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -142,6 +150,7 @@ class TestVideoGenerateAudio:
 class TestDefaultBackends:
     """验证 video/image 后端解析：显式值 vs auto-resolve。"""
 
+    @pytest.mark.unit
     async def test_video_backend_explicit(self):
         """DB 有显式值时直接返回。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -151,6 +160,7 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_video_backend(fake_svc, None)
         assert result == ("ark", "doubao-seedance-1-5-pro")
 
+    @pytest.mark.unit
     async def test_video_backend_auto_resolve(self):
         """DB 无值时走 auto-resolve，选第一个 ready 供应商的默认 video 模型。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -164,6 +174,7 @@ class TestDefaultBackends:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_video_backend_auto_resolve_no_ready_provider(self):
         """无 ready 供应商且无自定义供应商时抛出 ValueError。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -176,6 +187,7 @@ class TestDefaultBackends:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_image_backend_explicit(self):
         """DB 有显式值时直接返回。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -185,6 +197,7 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None)
         assert result == ("grok", "grok-2-image")
 
+    @pytest.mark.unit
     async def test_image_backend_auto_resolve(self):
         """DB 无值时走 auto-resolve。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -197,6 +210,7 @@ class TestDefaultBackends:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_image_backend_auto_resolve_no_ready_provider(self):
         """无 ready 供应商且无自定义供应商时抛出 ValueError。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -292,6 +306,7 @@ class TestDefaultBackends:
 class TestProviderConfig:
     """验证供应商配置方法委托给 ConfigService。"""
 
+    @pytest.mark.unit
     async def test_provider_config(self):
         factory, engine = await _make_session()
         try:
@@ -303,6 +318,7 @@ class TestProviderConfig:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_all_provider_configs(self):
         factory, engine = await _make_session()
         try:
@@ -318,6 +334,7 @@ class TestProviderConfig:
 class TestSessionReuse:
     """验证 session() 上下文管理器的 session 复用行为。"""
 
+    @pytest.mark.unit
     async def test_session_context_manager_reuses_single_session(self):
         """resolver.session() 下多次调用只创建 1 个 session。"""
         factory, engine = await _make_session()
@@ -361,6 +378,7 @@ class TestSessionReuse:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_bound_resolver_shares_session_object(self):
         """bound resolver 的 _open_session 返回同一个 session 对象。"""
         factory, engine = await _make_session()
@@ -378,6 +396,7 @@ class TestSessionReuse:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_unbound_resolver_creates_separate_sessions(self):
         """未绑定的 resolver 每次 _open_session 创建不同 session。"""
         factory, engine = await _make_session()
@@ -398,6 +417,7 @@ class TestSessionReuse:
 class TestVideoBackendThreeLevelPriority:
     """验证 video_backend 三级优先级：项目设置 > 系统设置 > auto-resolve。"""
 
+    @pytest.mark.unit
     async def test_project_override_wins_over_system_setting(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
@@ -410,6 +430,7 @@ class TestVideoBackendThreeLevelPriority:
             result = await resolver._resolve_video_backend(fake_svc, None, "demo")
         assert result == ("gemini-aistudio", "veo-3.1-generate-preview")
 
+    @pytest.mark.unit
     async def test_project_empty_falls_back_to_system_setting(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
@@ -420,6 +441,7 @@ class TestVideoBackendThreeLevelPriority:
             result = await resolver._resolve_video_backend(fake_svc, None, "demo")
         assert result == ("grok", "grok-imagine-video")
 
+    @pytest.mark.unit
     async def test_no_project_name_uses_system_setting(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
@@ -534,6 +556,7 @@ class TestVideoCapabilitiesBucketing:
 class TestVideoCapabilities:
     """验证 video_capabilities：第一步模型选择 + 第二步 model 能力查询。"""
 
+    @pytest.mark.unit
     async def test_registry_grok(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
@@ -554,6 +577,7 @@ class TestVideoCapabilities:
         assert caps["max_duration"] == 15
         assert caps["max_reference_images"] == 7
 
+    @pytest.mark.unit
     async def test_registry_veo(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -575,6 +599,7 @@ class TestVideoCapabilities:
         # max_reference_images 来源：backend 的 VideoCapabilities 声明（与执行层同源）
         assert caps["max_reference_images"] == 3
 
+    @pytest.mark.unit
     async def test_reads_project_default_duration_and_modes(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -595,6 +620,7 @@ class TestVideoCapabilities:
         assert caps["content_mode"] == "narration"
         assert caps["generation_mode"] == "reference_video"
 
+    @pytest.mark.unit
     async def test_missing_default_duration_is_null(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -610,6 +636,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["default_duration"] is None
 
+    @pytest.mark.unit
     async def test_unknown_model_raises(self):
         """悬空模型引用在能力桶解析闸即报错，携带可本地化的 code。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -628,6 +655,7 @@ class TestVideoCapabilities:
         assert excinfo.value.code == "video_capability_reference_unavailable"
         assert excinfo.value.capability == "i2v"
 
+    @pytest.mark.unit
     async def test_unknown_provider_raises(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -643,6 +671,7 @@ class TestVideoCapabilities:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_video_capabilities_for_project_uses_passed_dict(self):
         """video_capabilities_for_project(dict) 不调用 load_project；直接消费传入 dict。
 
@@ -667,6 +696,7 @@ class TestVideoCapabilities:
         assert caps["default_duration"] == 9
         assert caps["max_reference_images"] == 7
 
+    @pytest.mark.unit
     async def test_max_reference_images_reads_model_info_for_openai_sora(self):
         """openai sora 的 max_reference_images 来自 registry ModelInfo（=1），不再依赖 provider 级 fallback。"""
         factory, engine = await _make_session()
@@ -678,6 +708,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 1
 
+    @pytest.mark.unit
     async def test_max_reference_images_reads_backend_caps_for_minimax_s2v(self):
         """minimax S2V-01 的 max_reference_images 来自 backend 声明（=1）；
 
@@ -695,6 +726,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 1
 
+    @pytest.mark.unit
     async def test_max_reference_images_reads_backend_caps_for_ark_seedance(self):
         """ark seedance 的 max_reference_images 来自 backend 声明（=9）。"""
         factory, engine = await _make_session()
@@ -708,6 +740,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 9
 
+    @pytest.mark.unit
     async def test_max_reference_images_reads_backend_caps_for_kling_v3_omni(self):
         """kling-v3-omni（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）；
 
@@ -722,6 +755,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 4
 
+    @pytest.mark.unit
     async def test_max_reference_images_reads_backend_caps_for_kling_video_o1(self):
         """kling-video-o1（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）。"""
         factory, engine = await _make_session()
@@ -733,6 +767,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 4
 
+    @pytest.mark.unit
     async def test_kling_v3_non_reference_model_has_zero_max_refs(self):
         """kling-v3（声明 4K + 首尾帧但非多图主体）max_reference_images=0，不误报参考能力。"""
         factory, engine = await _make_session()
@@ -744,6 +779,7 @@ class TestVideoCapabilities:
             await engine.dispose()
         assert caps["max_reference_images"] == 0
 
+    @pytest.mark.unit
     async def test_custom_provider_reads_db_supported_durations(self):
         """custom-<id>/<model> 走 DB 分支，返回 source='custom'。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -785,6 +821,7 @@ class TestVideoCapabilities:
         # newapi-video endpoint 不接受参考图，max=0（来源：EndpointSpec.video_max_reference_images）
         assert caps["max_reference_images"] == 0
 
+    @pytest.mark.unit
     async def test_custom_video_openai_endpoint_resolves_max_one(self):
         """custom-<id>/<model> 经 openai-video endpoint 解析出 max_reference_images=1（不再静默落 9）。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -1125,6 +1162,7 @@ class TestVideoPricingGenerateAudio:
 class TestResolveImageBackend:
     """resolve_image_backend：payload > 项目桶 > 项目默认 > 全局桶 > 全局默认 > 自动推断。"""
 
+    @pytest.mark.unit
     async def test_payload_capability_slot_wins(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -1135,6 +1173,7 @@ class TestResolveImageBackend:
         assert (t2i.provider_id, t2i.model_id) == ("openai", "pay-t2i")
         assert (i2i.provider_id, i2i.model_id) == ("openai", "pay-i2i")
 
+    @pytest.mark.unit
     async def test_payload_legacy_fields_for_historical_tasks(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -1142,6 +1181,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, {}, payload, "t2i")
         assert (resolved.provider_id, resolved.model_id) == ("openai", "legacy")
 
+    @pytest.mark.unit
     async def test_project_capability_slot_when_no_payload(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -1193,6 +1233,7 @@ class TestResolveImageBackend:
             resolved = await resolver._resolve_image_provider_model(fake_svc, None, None, None, capability)
             assert (resolved.provider_id, resolved.model_id) == ("grok", "grok-2-image")
 
+    @pytest.mark.unit
     async def test_falls_through_to_global_default(self):
         """payload/project 都缺 → 落到全局桶（显式 default_image_backend_t2i）。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1200,6 +1241,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, None, None, "t2i")
         assert (resolved.provider_id, resolved.model_id) == ("grok", "grok-2-image")
 
+    @pytest.mark.unit
     async def test_no_legacy_image_backend_fallback(self):
         """解析链不再认 legacy 单字段 image_backend（由迁移转规范字段），直接落全局默认。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1208,6 +1250,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, "t2i")
         assert resolved.provider_id == "grok"
 
+    @pytest.mark.unit
     async def test_project_bare_provider_pins_provider_with_default_model(self):
         """裸 provider 项目覆盖（写边界放行）→ pin 该 provider 并补全其默认 model，不静默回退全局默认。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1217,6 +1260,7 @@ class TestResolveImageBackend:
         assert resolved.provider_id == "openai"
         assert resolved.model_id == "gpt-image-2"  # registry 中 openai 的默认 image model
 
+    @pytest.mark.unit
     async def test_project_unknown_bare_provider_falls_through(self):
         """裸 provider 不在 registry（无默认 model 可补）→ 退回全局默认。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1225,6 +1269,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, "t2i")
         assert resolved.provider_id == "grok"
 
+    @pytest.mark.unit
     async def test_project_provider_with_trailing_slash_uses_provider_default(self):
         """脏值 "openai/"（缺 model，写校验器会放行）→ 取 openai 默认 model，不带空 model 下游。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1233,6 +1278,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, {}, "t2i")
         assert (resolved.provider_id, resolved.model_id) == ("openai", "gpt-image-2")
 
+    @pytest.mark.unit
     async def test_payload_legacy_provider_not_trusted_falls_through_to_project(self):
         """in-flight 历史任务 payload 携带 legacy 名（写边界拦不到）→ 不予信任，回退已迁移的 project。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1242,6 +1288,7 @@ class TestResolveImageBackend:
         resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, payload, "t2i")
         assert (resolved.provider_id, resolved.model_id) == ("openai", "gpt-image-2")
 
+    @pytest.mark.unit
     async def test_payload_known_provider_missing_model_uses_provider_default(self):
         """半截 payload（已知 provider 但缺 model）→ 补该 provider 默认 model，不带空 model 到执行层。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1333,6 +1380,7 @@ class TestLayeredBackendSkeleton:
 class TestResolveVideoBackend:
     """resolve_video_backend：payload > project > 全局默认。"""
 
+    @pytest.mark.unit
     async def test_payload_historical_provider_wins(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -1341,6 +1389,7 @@ class TestResolveVideoBackend:
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, payload)
         assert (resolved.provider_id, resolved.model_id) == ("ark", "seedance")
 
+    @pytest.mark.unit
     async def test_project_video_backend_when_no_payload(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
@@ -1394,12 +1443,14 @@ class TestResolveVideoBackend:
 
         assert (resolved.provider_id, resolved.model_id) == (f"custom-{provider.id}", "runtime-model")
 
+    @pytest.mark.unit
     async def test_falls_through_to_global_default(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={"default_video_backend": "ark/doubao-seedance-1-5-pro"})
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, None, None)
         assert (resolved.provider_id, resolved.model_id) == ("ark", "doubao-seedance-1-5-pro")
 
+    @pytest.mark.unit
     async def test_project_bare_provider_pins_provider_with_default_model(self):
         """裸 video_backend(如 "ark") → pin ark 并补全其默认 video model，不回退全局默认的另一供应商。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1409,6 +1460,7 @@ class TestResolveVideoBackend:
         assert resolved.provider_id == "ark"
         assert resolved.model_id == "doubao-seedance-2-0-mini-260615"  # registry 中 ark 的默认 video model
 
+    @pytest.mark.unit
     async def test_payload_legacy_provider_not_trusted_falls_through_to_project(self):
         """in-flight 历史任务 payload 携带 legacy video_provider（如 seedance）→ 不予信任，回退已迁移的 project。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1418,6 +1470,7 @@ class TestResolveVideoBackend:
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, payload)
         assert (resolved.provider_id, resolved.model_id) == ("ark", "seedance-1-0-pro")
 
+    @pytest.mark.unit
     async def test_payload_non_dict_video_provider_settings_does_not_crash(self):
         """脏 payload：video_provider_settings 非 dict → 不抛异常，按缺 model 补该 provider 默认。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1639,6 +1692,7 @@ class TestVideoBucketCapabilityGateCustomProvider:
         assert (resolved.provider_id, resolved.model_id) == (f"custom-{provider_id}", "live-model")
 
 
+@pytest.mark.unit
 def test_parse_int_variants():
     from lib.config.resolver import _parse_int
 
@@ -1655,6 +1709,7 @@ def test_parse_int_variants():
 class TestReferencePayloadLimits:
     """验证 reference_payload_limits 的默认、per-provider 覆盖、容错与 None 短路。"""
 
+    @pytest.mark.unit
     async def test_none_provider_returns_default_without_db(self):
         # 无需 DB：provider_id=None 直接返回保守通用默认
         resolver = ConfigResolver.__new__(ConfigResolver)
@@ -1667,6 +1722,7 @@ class TestReferencePayloadLimits:
         assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
         assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
+    @pytest.mark.unit
     async def test_default_when_unset(self):
         from lib.config.service import (
             _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
@@ -1682,6 +1738,7 @@ class TestReferencePayloadLimits:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_provider_override_applies(self):
         from lib.config.service import ConfigService
 
@@ -1698,6 +1755,7 @@ class TestReferencePayloadLimits:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_unknown_provider_falls_back_to_default(self):
         from lib.config.service import _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
 
@@ -1710,6 +1768,7 @@ class TestReferencePayloadLimits:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     async def test_non_numeric_override_falls_back(self):
         from lib.config.service import (
             _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
@@ -1736,6 +1795,7 @@ class TestTextBackendTierResolution:
 
     _AUTO = ("gemini-aistudio", "gemini-3-flash-preview")  # ready gemini 的 registry 默认 text model
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("p_tier", [False, True])
     @pytest.mark.parametrize("p_def", [False, True])
     @pytest.mark.parametrize("g_tier", [False, True])
@@ -1774,6 +1834,7 @@ class TestTextBackendTierResolution:
             result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, "demo")
         assert result == expected
 
+    @pytest.mark.unit
     async def test_no_project_name_skips_project_levels(self):
         from unittest.mock import MagicMock
 
@@ -1784,6 +1845,7 @@ class TestTextBackendTierResolution:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, None)
         assert result == ("g-tier", "m")
 
+    @pytest.mark.unit
     async def test_simple_tier_tasks_read_simple_key(self):
         """OVERVIEW / STYLE_ANALYSIS 归简单档，读 text_backend_simple 而非复杂档键。"""
         from unittest.mock import MagicMock
@@ -1796,6 +1858,7 @@ class TestTextBackendTierResolution:
             result = await resolver._resolve_text_backend(fake_svc, MagicMock(), task, None)
             assert result == ("simple", "m")
 
+    @pytest.mark.unit
     async def test_script_task_reads_complex_key(self):
         from unittest.mock import MagicMock
 
@@ -1806,6 +1869,7 @@ class TestTextBackendTierResolution:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, None)
         assert result == ("complex", "m")
 
+    @pytest.mark.unit
     async def test_malformed_value_without_slash_falls_through(self):
         """无 "/" 的脏值视为未设置，落到下一级。"""
         from unittest.mock import MagicMock
@@ -1835,6 +1899,7 @@ class TestTextBackendTierResolution:
 class TestStyleAnalysisVisionGuard:
     """简单档模型不支持图像输入时，风格分析解析直接报错，不静默换模型。"""
 
+    @pytest.mark.unit
     async def test_rejects_registry_model_without_vision(self):
         from unittest.mock import MagicMock
 
@@ -1846,6 +1911,7 @@ class TestStyleAnalysisVisionGuard:
         with pytest.raises(ValueError, match="vision"):
             await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.STYLE_ANALYSIS, None)
 
+    @pytest.mark.unit
     async def test_accepts_registry_model_with_vision(self):
         from unittest.mock import MagicMock
 
@@ -1856,6 +1922,7 @@ class TestStyleAnalysisVisionGuard:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.STYLE_ANALYSIS, None)
         assert result == ("gemini-aistudio", "gemini-3-flash-preview")
 
+    @pytest.mark.unit
     async def test_unknown_model_passes_without_guess(self):
         """registry 之外（自定义供应商等）无逐模型能力事实，放行不猜测。"""
         from unittest.mock import MagicMock
@@ -1867,6 +1934,7 @@ class TestStyleAnalysisVisionGuard:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.STYLE_ANALYSIS, None)
         assert result == ("custom-abc", "some-model")
 
+    @pytest.mark.unit
     async def test_complex_tier_task_not_vision_checked(self):
         """vision 校验只针对需要图像输入的任务，SCRIPT 不受限。"""
         from unittest.mock import MagicMock

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1879,6 +1879,7 @@ class TestTextBackendTierResolution:
         result = await resolver._resolve_text_backend(fake_svc, MagicMock(), TextTaskType.SCRIPT, None)
         assert result == ("g-def", "m")
 
+    @pytest.mark.unit
     async def test_project_bare_provider_pins_its_default_model(self):
         """项目档位写裸 provider（写边界放行的合法值）→ pin 住该 provider 补默认 model，
         不静默回退到全局默认的另一供应商。与图片 / 视频的项目层同构。"""

--- a/tests/test_config_resolver_resolution.py
+++ b/tests/test_config_resolver_resolution.py
@@ -66,17 +66,20 @@ async def _add_custom_video_model(db_session: AsyncSession, model_id: str, resol
 # --- 纯项目字典优先级（非自定义 provider，DB 默认恒 None） ---
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_returns_none_when_nothing_configured(resolver: ConfigResolver):
     assert await resolver.resolve_resolution({}, "gemini-aistudio", "veo-3.1-lite-generate-preview") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_legacy_only(resolver: ConfigResolver):
     project = {"video_model_settings": {"veo-3.1": {"resolution": "1080p"}}}
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "veo-3.1") == "1080p"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_model_settings_overrides_legacy(resolver: ConfigResolver):
     project = {
@@ -86,18 +89,21 @@ async def test_model_settings_overrides_legacy(resolver: ConfigResolver):
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "veo-3.1") == "720p"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_empty_string_override_treated_as_unset(resolver: ConfigResolver):
     project = {"model_settings": {"gemini-aistudio/m": {"resolution": ""}}}
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_composite_key_format_uses_slash(resolver: ConfigResolver):
     project = {"model_settings": {"gemini-aistudio/b": {"resolution": "4K"}}}
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "b") == "4K"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tolerates_null_entries(resolver: ConfigResolver):
     # project.json 可能被手编为 null 值；既不应崩也不应当作已配置。
@@ -109,6 +115,7 @@ async def test_tolerates_null_entries(resolver: ConfigResolver):
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tolerates_top_level_field_as_string(resolver: ConfigResolver):
     # 手编脏数据：model_settings / video_model_settings 顶层本身被写成字符串。
@@ -116,6 +123,7 @@ async def test_tolerates_top_level_field_as_string(resolver: ConfigResolver):
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tolerates_top_level_field_as_list(resolver: ConfigResolver):
     # 手编脏数据：model_settings / video_model_settings 顶层本身被写成列表。
@@ -123,6 +131,7 @@ async def test_tolerates_top_level_field_as_list(resolver: ConfigResolver):
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tolerates_composite_key_entry_as_string(resolver: ConfigResolver):
     # 手编脏数据：model_settings 里具体某个复合 key 的 entry 被写成字符串而非 dict。
@@ -130,6 +139,7 @@ async def test_tolerates_composite_key_entry_as_string(resolver: ConfigResolver)
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tolerates_legacy_model_entry_as_list(resolver: ConfigResolver):
     # 手编脏数据：legacy video_model_settings 里具体某个 model 的 entry 被写成列表。
@@ -137,6 +147,7 @@ async def test_tolerates_legacy_model_entry_as_list(resolver: ConfigResolver):
     assert await resolver.resolve_resolution(project, "gemini-aistudio", "m") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_dirty_model_settings_falls_through_to_legacy(resolver: ConfigResolver):
     # model_settings 顶层脏数据不应连坐拖垮 legacy 兜底路径的正常解析。
@@ -150,24 +161,28 @@ async def test_dirty_model_settings_falls_through_to_legacy(resolver: ConfigReso
 # --- 自定义供应商默认（真实 DB） ---
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_returns_custom_default_when_only_custom(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "my-model", "720p")
     assert await resolver.resolve_resolution({}, provider_id, "my-model") == "720p"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_custom_default_none_when_model_has_no_resolution(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "my-model", None)
     assert await resolver.resolve_resolution({}, provider_id, "my-model") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_custom_default_none_when_model_missing(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "my-model", "720p")
     assert await resolver.resolve_resolution({}, provider_id, "other-model") is None
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_project_override_wins_over_custom_default(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "m", "1K")
@@ -175,6 +190,7 @@ async def test_project_override_wins_over_custom_default(resolver: ConfigResolve
     assert await resolver.resolve_resolution(project, provider_id, "m") == "2K"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_legacy_wins_over_custom_default(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "m", "720p")
@@ -182,6 +198,7 @@ async def test_legacy_wins_over_custom_default(resolver: ConfigResolver, db_sess
     assert await resolver.resolve_resolution(project, provider_id, "m") == "1080p"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_falls_through_to_custom_when_project_empty_string(resolver: ConfigResolver, db_session: AsyncSession):
     provider_id = await _add_custom_video_model(db_session, "m", "1K")
@@ -192,6 +209,7 @@ async def test_falls_through_to_custom_when_project_empty_string(resolver: Confi
 # --- get_provider_fallback（纯查表，不触 DB） ---
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "provider_id, expected",
     [
@@ -210,6 +228,7 @@ def test_get_provider_fallback(provider_id: str | None, expected: str):
     assert get_provider_fallback(provider_id) == expected
 
 
+@pytest.mark.unit
 def test_get_provider_fallback_custom_default():
     assert get_provider_fallback("unknown", default="720p") == "720p"
 

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -5,6 +5,8 @@ from lib.config.service import ConfigService
 from lib.db.base import Base
 from lib.db.repositories.credential_repository import CredentialRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def reload_app_with_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -11,6 +11,8 @@ from lib.cost_calculator import CostCalculator, cost_calculator
 from lib.pricing.strategies import PricingParams
 from lib.providers import PROVIDER_ANTHROPIC
 
+pytestmark = pytest.mark.unit
+
 
 def _cost(provider, call_type, **params):
     """构造 ``PricingParams`` 并调统一入口——费用对拍只在意金额/币种，用薄封装免逐行铺展。"""

--- a/tests/test_cost_calculator_text.py
+++ b/tests/test_cost_calculator_text.py
@@ -1,5 +1,9 @@
+import pytest
+
 from lib.cost_calculator import CostCalculator
 from lib.pricing.strategies import PricingParams
+
+pytestmark = pytest.mark.unit
 
 
 class TestTextCost:

--- a/tests/test_cost_estimation_router.py
+++ b/tests/test_cost_estimation_router.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -9,6 +10,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import cost_estimation
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 def _make_app():

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -158,6 +158,7 @@ def _make_reference_video_script(episode: int, content_mode: str, unit_specs: li
 
 
 class TestCostEstimationService:
+    @pytest.mark.unit
     async def test_estimate_single_episode(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -181,6 +182,7 @@ class TestCostEstimationService:
                 assert isinstance(cost, dict)
                 assert all(isinstance(v, (int, float)) for v in cost.values())
 
+    @pytest.mark.unit
     async def test_actual_costs_included(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -424,6 +426,7 @@ class TestCostEstimationService:
         assert project_actual["video"]["USD"] == pytest.approx(3.0)
         assert "unassigned" not in project_actual
 
+    @pytest.mark.unit
     async def test_grid_actual_costs_apportioned_to_scenes(self, db_factory):
         """Grid actual cost should be split evenly among scenes sharing the grid_id."""
         resolver = ConfigResolver(db_factory)
@@ -513,6 +516,7 @@ class TestCostEstimationService:
         assert project_actual["image"]["USD"] == pytest.approx(0.6)
         assert project_actual["unassigned"]["USD"] == pytest.approx(1.4)
 
+    @pytest.mark.unit
     async def test_grid_partial_generation_some_without_grid_id(self, db_factory):
         """Scenes without grid_id should have empty actual image cost."""
         resolver = ConfigResolver(db_factory)
@@ -557,6 +561,7 @@ class TestCostEstimationService:
         for seg in segments[3:]:
             assert seg["actual"]["image"] == {}
 
+    @pytest.mark.unit
     async def test_single_mode_unaffected_by_grid_logic(self, db_factory):
         """Single generation mode should be completely unaffected by grid apportionment."""
         resolver = ConfigResolver(db_factory)
@@ -587,6 +592,7 @@ class TestCostEstimationService:
         seg2 = result["episodes"][0]["segments"][1]
         assert seg2["actual"]["image"] == {}
 
+    @pytest.mark.unit
     async def test_project_level_actual_split_by_asset_type(self, db_factory):
         """project-level image 成本应按 output_path 前缀拆分为 characters/scenes/props 三项。"""
         resolver = ConfigResolver(db_factory)
@@ -616,6 +622,7 @@ class TestCostEstimationService:
         # 旧 key 不应出现
         assert "character_and_clue" not in actual
 
+    @pytest.mark.unit
     async def test_dirty_script_skipped_with_warning(self, db_factory, caplog):
         """单集脏脚本(segments=null)不应让整个项目费用估算 5xx;脏集降级为 0 segments
         + warning,其他正常集仍参与估算。"""
@@ -662,6 +669,7 @@ class TestCostEstimationService:
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any("ep2.json" in m for m in warnings), warnings
 
+    @pytest.mark.unit
     async def test_audio_estimate_per_segment_by_characters(self, db_factory):
         """旁白配音预估 = novel_text 字符数 × 按字符费率；models 含 audio 条目。"""
         from lib.config.service import ConfigService
@@ -695,6 +703,7 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["estimate"]["audio"]["CNY"] == pytest.approx(0.008)
         assert result["project_totals"]["estimate"]["audio"]["CNY"] == pytest.approx(0.008)
 
+    @pytest.mark.unit
     async def test_audio_actual_costs_included(self, db_factory):
         """旁白实际费用按 segment 聚合进 actual.audio。"""
         resolver = ConfigResolver(db_factory)
@@ -724,6 +733,7 @@ class TestCostEstimationService:
         assert seg["actual"]["audio"]["CNY"] == pytest.approx(0.008)
         assert result["project_totals"]["actual"]["audio"]["CNY"] == pytest.approx(0.008)
 
+    @pytest.mark.unit
     async def test_ad_storyboard_estimates_per_shot(self, db_factory):
         """ad 项目（分镜路径）：逐镜头返回分镜图 + 视频估值，聚合进集/项目两级合计。"""
         resolver = ConfigResolver(db_factory)
@@ -750,6 +760,7 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["estimate"]["image"]
         assert result["project_totals"]["estimate"]["video"]
 
+    @pytest.mark.unit
     async def test_ad_voiceover_does_not_produce_audio_estimate(self, db_factory):
         """ad 镜头口播文案不产生旁白配音预估（本期草稿导出后在剪映配音）。"""
         from lib.config.service import ConfigService
@@ -772,6 +783,7 @@ class TestCostEstimationService:
 
         assert result["episodes"][0]["segments"][0]["estimate"]["audio"] == {}
 
+    @pytest.mark.unit
     async def test_ad_reference_video_skips_image_estimate(self, db_factory):
         """ad + 参考生视频路径跳过分镜步骤：不产生分镜图估值，视频估值按 unit 计费后摊回镜头。
 
@@ -802,6 +814,7 @@ class TestCostEstimationService:
         assert result["project_totals"]["estimate"].get("image", {}) == {}
         assert result["project_totals"]["estimate"]["video"]
 
+    @pytest.mark.unit
     async def test_ad_reference_video_apportions_unit_cost_across_shots(self, db_factory, monkeypatch):
         """unit 费用均摊到成员镜头，除不尽时余数补末镜，合计与 unit 原值分文不差。
 
@@ -844,6 +857,7 @@ class TestCostEstimationService:
         assert round(sum(shares), 6) == ep_total
         assert ep_total == result["project_totals"]["estimate"]["video"][currency]
 
+    @pytest.mark.unit
     async def test_ad_reference_video_apportions_actual_cost_across_shots(self, db_factory):
         """实际费用同样按 unit 分摊：usage 记录的 segment_id 是 unit ID，不是镜头 ID。
 
@@ -883,6 +897,7 @@ class TestCostEstimationService:
         assert result["episodes"][0]["totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
         assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.6)
 
+    @pytest.mark.unit
     async def test_ad_reference_video_merges_shot_level_legacy_video_actual(self, db_factory):
         """切换到 reference_video 前，某镜头已在 storyboard 模式产生过视频实付（按 shot_id
         记账），切换后与 unit 分摊额是两笔独立支出，须相加而非互相替换。
@@ -934,6 +949,7 @@ class TestCostEstimationService:
         assert ep_total == pytest.approx(1.5 + 0.4)
         assert result["project_totals"]["actual"]["video"]["USD"] == pytest.approx(1.5 + 0.4)
 
+    @pytest.mark.unit
     async def test_ad_reference_video_estimate_uses_rounded_up_unit_duration(self, db_factory, monkeypatch):
         """取档向上的 unit：预估金额按取档后的秒数（8s）计，而非剧本原始总时长（5s）。
 
@@ -981,6 +997,7 @@ class TestCostEstimationService:
         assert sum(seg["estimate"]["video"].values()) > sum(base_seg["estimate"]["video"].values())
         assert seg["estimate"]["video"] == rounded["episodes"][0]["totals"]["estimate"]["video"]
 
+    @pytest.mark.unit
     async def test_ad_reference_video_fallback_derivation_applies_max_unit_duration(self, db_factory, monkeypatch):
         """剧本尚未派生 reference_units 时，估算现推的分组与执行侧同受供应商时长上限约束。
 
@@ -1384,6 +1401,7 @@ class TestCostEstimationService:
         assert segments[0]["estimate"]["video"]
         assert result["project_totals"]["estimate"]["video"]
 
+    @pytest.mark.unit
     async def test_empty_episodes(self, db_factory):
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
@@ -1395,6 +1413,7 @@ class TestCostEstimationService:
         assert result["episodes"] == []
         assert result["project_totals"]["estimate"] == {}
 
+    @pytest.mark.unit
     async def test_cost_estimation_uses_t2i_default_when_split_fields_present(self, db_factory):
         """project 仅有 image_provider_t2i 时，cost estimation 用此值估算（T2I 是 cost estimation 锚点）。"""
         resolver = ConfigResolver(db_factory)
@@ -1414,6 +1433,7 @@ class TestCostEstimationService:
         assert result["models"]["image"]["provider"] == "openai"
         assert result["models"]["image"]["model"] == "gpt-image-1"
 
+    @pytest.mark.unit
     async def test_cost_estimation_no_image_provider_falls_back_to_resolver(self, db_factory):
         """project 没有 image_provider_t2i 时，cost_estimation 不再自行 fallback I2I 或 legacy
         （legacy 由 ProjectManager.load_project 的 lazy upgrade 处理；I2I 和 T2I 是正交能力槽，
@@ -1438,6 +1458,7 @@ class TestCostEstimationService:
         assert result["models"]["image"]["provider"] == "unknown"
         assert result["models"]["image"]["model"] == "unknown"
 
+    @pytest.mark.unit
     async def test_cost_estimation_resolve_resolution_exception_degrades_gracefully(self, db_factory, monkeypatch):
         """resolve_resolution 抛异常时预估整体降级而非中断，与 image/video/audio 三处 except 兜底同构。"""
         resolver = ConfigResolver(db_factory)
@@ -1717,6 +1738,7 @@ class TestCostEstimationService:
 
         assert priced_models == ["kling-v3-omni"]
 
+    @pytest.mark.unit
     async def test_custom_provider_estimates_use_db_prices(self, db_factory):
         """自定义供应商预估：image/video/audio 单价来自 DB（与实际记账同源），估值按配置价格非零。"""
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository
@@ -1784,6 +1806,7 @@ class TestCostEstimationService:
         # 集/项目两级合计同步纳入
         assert result["project_totals"]["estimate"]["video"]["USD"] == pytest.approx(0.60)
 
+    @pytest.mark.unit
     async def test_custom_provider_grid_estimate_uses_db_price(self, db_factory):
         """grid 模式下自定义供应商图片单价同样贯通（2K grid 单价 = DB flat 价）。"""
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository
@@ -1830,6 +1853,7 @@ class TestCostEstimationService:
         # 集合计 = 满张单价 0.09 USD
         assert result["episodes"][0]["totals"]["estimate"]["image"]["USD"] == pytest.approx(0.09, abs=1e-4)
 
+    @pytest.mark.unit
     async def test_custom_provider_without_price_degrades_to_zero(self, db_factory):
         """自定义供应商查无价格模型：预估降级为 0（记 debug 日志、不抛错），与现状降级口径一致。"""
         resolver = ConfigResolver(db_factory)
@@ -1851,6 +1875,7 @@ class TestCostEstimationService:
         seg = result["episodes"][0]["segments"][0]
         assert seg["estimate"]["image"] == {}
 
+    @pytest.mark.unit
     async def test_custom_provider_malformed_id_degrades_to_zero(self, db_factory):
         """畸形 custom- provider id（非数字后缀）：parse_provider_id 的 ValueError 需降级为 0，不抛错。"""
         resolver = ConfigResolver(db_factory)

--- a/tests/test_credential_api.py
+++ b/tests/test_credential_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -13,6 +14,8 @@ from lib.db.models.credential import ProviderCredential
 from lib.db.repositories.credential_repository import CredentialRepository
 from server.routers import providers
 from tests.auth_deps import AUTH_DEPENDENCIES, override_auth
+
+pytestmark = pytest.mark.unit
 
 
 def _make_app() -> tuple[FastAPI, MagicMock]:

--- a/tests/test_credential_repository.py
+++ b/tests/test_credential_repository.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.db.base import Base
 from lib.db.repositories.credential_repository import CredentialRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_custom_backends.py
+++ b/tests/test_custom_backends.py
@@ -28,6 +28,7 @@ from lib.video_backends.base import (
 
 
 class TestCustomTextBackend:
+    @pytest.mark.unit
     def test_properties(self):
         delegate = AsyncMock()
         delegate.capabilities = {TextCapability.TEXT_GENERATION}
@@ -37,6 +38,7 @@ class TestCustomTextBackend:
         assert backend.model == "deepseek-v3"
         assert backend.capabilities == {TextCapability.TEXT_GENERATION}
 
+    @pytest.mark.unit
     def test_capabilities_delegated(self):
         """capabilities 属性直接来自 delegate。"""
         delegate = AsyncMock()
@@ -49,6 +51,7 @@ class TestCustomTextBackend:
 
         assert backend.capabilities is delegate.capabilities
 
+    @pytest.mark.unit
     async def test_generate_delegates(self):
         expected_result = TextGenerationResult(
             text="hello world",
@@ -68,6 +71,7 @@ class TestCustomTextBackend:
         assert result is expected_result
         delegate.generate.assert_awaited_once_with(request)
 
+    @pytest.mark.unit
     async def test_generate_passes_request_unchanged(self):
         """generate() 不修改请求对象，原样传给 delegate。"""
         delegate = AsyncMock()
@@ -88,6 +92,7 @@ class TestCustomTextBackend:
 
 
 class TestCustomImageBackend:
+    @pytest.mark.unit
     def test_properties(self):
         delegate = AsyncMock()
         delegate.capabilities = {ImageCapability.TEXT_TO_IMAGE}
@@ -97,6 +102,7 @@ class TestCustomImageBackend:
         assert backend.model == "flux-1"
         assert backend.capabilities == {ImageCapability.TEXT_TO_IMAGE}
 
+    @pytest.mark.unit
     def test_capabilities_delegated(self):
         delegate = AsyncMock()
         delegate.capabilities = {ImageCapability.TEXT_TO_IMAGE, ImageCapability.IMAGE_TO_IMAGE}
@@ -104,6 +110,7 @@ class TestCustomImageBackend:
 
         assert backend.capabilities is delegate.capabilities
 
+    @pytest.mark.unit
     async def test_generate_delegates(self, tmp_path: Path):
         output_path = tmp_path / "output.png"
         expected_result = ImageGenerationResult(
@@ -122,6 +129,7 @@ class TestCustomImageBackend:
         assert result is expected_result
         delegate.generate.assert_awaited_once_with(request)
 
+    @pytest.mark.unit
     async def test_generate_passes_request_unchanged(self, tmp_path: Path):
         output_path = tmp_path / "img.png"
         delegate = AsyncMock()
@@ -144,6 +152,7 @@ class TestCustomImageBackend:
 
 
 class TestCustomVideoBackend:
+    @pytest.mark.unit
     def test_properties(self):
         delegate = AsyncMock()
         backend = CustomVideoBackend(provider_id="custom-vid", delegate=delegate, model="wan-pro")
@@ -151,6 +160,7 @@ class TestCustomVideoBackend:
         assert backend.name == "custom-vid"
         assert backend.model == "wan-pro"
 
+    @pytest.mark.unit
     async def test_generate_delegates(self, tmp_path: Path):
         output_path = tmp_path / "output.mp4"
         expected_result = VideoGenerationResult(
@@ -169,6 +179,7 @@ class TestCustomVideoBackend:
         assert result is expected_result
         delegate.generate.assert_awaited_once_with(request)
 
+    @pytest.mark.unit
     async def test_generate_passes_request_unchanged(self, tmp_path: Path):
         output_path = tmp_path / "vid.mp4"
         delegate = AsyncMock()
@@ -254,6 +265,7 @@ class TestCustomVideoBackend:
 
 
 class TestCustomAudioBackend:
+    @pytest.mark.unit
     def test_properties(self):
         delegate = AsyncMock()
         delegate.capabilities = {AudioCapability.TEXT_TO_SPEECH}
@@ -263,6 +275,7 @@ class TestCustomAudioBackend:
         assert backend.model == "tts-1"
         assert backend.capabilities == {AudioCapability.TEXT_TO_SPEECH}
 
+    @pytest.mark.unit
     def test_capabilities_delegated(self):
         delegate = AsyncMock()
         delegate.capabilities = {AudioCapability.TEXT_TO_SPEECH}
@@ -270,6 +283,7 @@ class TestCustomAudioBackend:
 
         assert backend.capabilities is delegate.capabilities
 
+    @pytest.mark.unit
     async def test_synthesize_delegates(self, tmp_path: Path):
         output_path = tmp_path / "out.wav"
         expected_result = AudioSynthesisResult(
@@ -289,6 +303,7 @@ class TestCustomAudioBackend:
         assert result is expected_result
         delegate.synthesize.assert_awaited_once_with(request)
 
+    @pytest.mark.unit
     def test_list_voices_delegates(self):
         from lib.audio_backends.base import VoiceOption
 
@@ -300,6 +315,7 @@ class TestCustomAudioBackend:
         assert backend.list_voices() is expected_voices
         delegate.list_voices.assert_called_once_with()
 
+    @pytest.mark.unit
     async def test_synthesize_passes_request_unchanged(self, tmp_path: Path):
         output_path = tmp_path / "seg.wav"
         delegate = AsyncMock()

--- a/tests/test_custom_cost.py
+++ b/tests/test_custom_cost.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.cost_calculator import CostCalculator
 from lib.pricing.strategies import PricingParams
+
+pytestmark = pytest.mark.unit
 
 
 class TestCustomTextCost:

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -13,6 +13,8 @@ from lib.custom_provider.endpoints import (
     list_endpoints_by_media_type,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestRegistry:
     def test_endpoint_count(self):

--- a/tests/test_custom_provider_factory.py
+++ b/tests/test_custom_provider_factory.py
@@ -14,6 +14,8 @@ from lib.custom_provider.backends import (
 )
 from lib.custom_provider.factory import create_custom_backend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_provider(*, base_url: str = "https://api.example.com/v1", api_key: str = "sk-test") -> MagicMock:
     p = MagicMock()

--- a/tests/test_custom_provider_loader.py
+++ b/tests/test_custom_provider_loader.py
@@ -47,6 +47,7 @@ async def _seed(session, *, models: list[dict]) -> str:
 
 
 class TestLoadCustomBackend:
+    @pytest.mark.unit
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
     async def test_resolves_named_model_and_delegates(self, mock_cls, session):
         pid = await _seed(
@@ -58,6 +59,7 @@ class TestLoadCustomBackend:
         assert result.model == "dall-e-3"
         mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")
 
+    @pytest.mark.unit
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
     async def test_falls_back_to_default_when_model_disabled(self, mock_cls, session):
         # 请求的 model 已禁用 → 回退到该 media_type 的默认启用 model
@@ -71,12 +73,14 @@ class TestLoadCustomBackend:
         result = await load_custom_backend(session=session, provider_id=pid, model_id="disabled-m", media_type="image")
         assert result.model == "active-m"
 
+    @pytest.mark.unit
     async def test_provider_not_found_fails_loud(self, session):
         with pytest.raises(ValueError, match="不存在"):
             await load_custom_backend(
                 session=session, provider_id=make_provider_id(999), model_id="x", media_type="image"
             )
 
+    @pytest.mark.unit
     async def test_no_default_model_for_media_fails_loud(self, session):
         # 只有 image model，请求 video → 无默认 video model
         pid = await _seed(

--- a/tests/test_custom_provider_models.py
+++ b/tests/test_custom_provider_models.py
@@ -10,6 +10,8 @@ import lib.db.models  # noqa: F401 — ensure all models registered
 from lib.db.base import Base
 from lib.db.models import CustomProvider, CustomProviderModel
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def engine():

--- a/tests/test_custom_provider_repo.py
+++ b/tests/test_custom_provider_repo.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderPrice, CustomProviderRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session():

--- a/tests/test_custom_provider_resolution.py
+++ b/tests/test_custom_provider_resolution.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def db_session():

--- a/tests/test_custom_providers_api.py
+++ b/tests/test_custom_providers_api.py
@@ -24,6 +24,8 @@ from server.error_handlers import register_error_handlers
 from server.routers import custom_providers
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_dashscope_image_backend.py
+++ b/tests/test_dashscope_image_backend.py
@@ -16,6 +16,8 @@ from lib.image_backends.base import (
 )
 from lib.providers import PROVIDER_DASHSCOPE
 
+pytestmark = pytest.mark.unit
+
 
 def _img_response(url: str = "https://x/out.png") -> MagicMock:
     resp = MagicMock()

--- a/tests/test_dashscope_integration.py
+++ b/tests/test_dashscope_integration.py
@@ -10,6 +10,8 @@ from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_OPENAI
 
+pytestmark = pytest.mark.unit
+
 
 def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> MagicMock:
     usage = MagicMock()

--- a/tests/test_dashscope_shared.py
+++ b/tests/test_dashscope_shared.py
@@ -24,6 +24,8 @@ from lib.dashscope_shared import (
     safe_body_for_log,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestBaseUrlDerivation:
     def test_text_base_from_host(self):

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -83,6 +83,7 @@ def _ref(tmp_path: Path, name: str) -> Path:
 
 
 class TestCapabilities:
+    @pytest.mark.unit
     def test_name_and_model(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -90,6 +91,7 @@ class TestCapabilities:
         assert b.name == PROVIDER_DASHSCOPE
         assert b.model == "happyhorse-1.0-i2v"
 
+    @pytest.mark.unit
     def test_happyhorse_r2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -99,6 +101,7 @@ class TestCapabilities:
         assert vc.max_reference_images == 9
         assert vc.first_frame is False
 
+    @pytest.mark.unit
     def test_wan_r2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -107,6 +110,7 @@ class TestCapabilities:
         assert vc.max_reference_images == 5
         assert vc.first_frame is True
 
+    @pytest.mark.unit
     def test_t2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -114,12 +118,14 @@ class TestCapabilities:
         assert b.video_capabilities.first_frame is False
         assert b.video_capabilities.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_i2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         b = DashScopeVideoBackend(api_key="sk", model="wan2.7-i2v")
         assert b.video_capabilities.first_frame is True
 
+    @pytest.mark.unit
     def test_decorated_model_name_resolves_r2v_caps(self):
         """代理中转的前缀/后缀装饰名（infer_endpoint 会按子串路由到 dashscope-async-video）
         必须解析出真实 r2v caps，而非退回 _DEFAULT_PROFILE 丢掉 reference_images。"""
@@ -138,6 +144,7 @@ class TestCapabilities:
             # resolver 侧（纯函数，不构造 backend）
             assert DashScopeVideoBackend.video_capabilities_for_model(model).max_reference_images == expected_max
 
+    @pytest.mark.unit
     def test_unknown_bare_series_falls_back_to_default(self):
         """仅系列名无变体后缀（裸 "happyhorse"）无法判别 t2v/i2v/r2v → 通用默认（无 r2v）。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend
@@ -163,6 +170,7 @@ class TestCapabilities:
 
 
 class TestReferenceToVideo:
+    @pytest.mark.unit
     async def test_r2v_happy_path(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit("t-r2v")))
         get = AsyncMock(return_value=_resp(_succeeded(duration=8)))
@@ -204,6 +212,7 @@ class TestReferenceToVideo:
         assert result.task_id == "t-r2v"
         download.assert_called_once()
 
+    @pytest.mark.unit
     async def test_r2v_ref_limit_happyhorse_9(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp(_succeeded()))
@@ -221,6 +230,7 @@ class TestReferenceToVideo:
             )
         assert len(post.call_args.kwargs["json"]["input"]["media"]) == 9
 
+    @pytest.mark.unit
     async def test_r2v_ref_limit_wan_5(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp(_succeeded()))
@@ -238,6 +248,7 @@ class TestReferenceToVideo:
             )
         assert len(post.call_args.kwargs["json"]["input"]["media"]) == 5
 
+    @pytest.mark.unit
     async def test_r2v_all_refs_missing_fail_loud(self, tmp_path: Path):
         # r2v 参考图缺失/不可读（含空串过滤后仍有声明项）须 fail-loud 报错列名，不静默退化
         post = AsyncMock(return_value=_resp(_submit()))
@@ -261,6 +272,7 @@ class TestReferenceToVideo:
         # 提交请求根本不应发出
         post.assert_not_called()
 
+    @pytest.mark.unit
     async def test_r2v_no_refs_provided_raises(self, tmp_path: Path):
         # r2v 模型但调用方完全未提供参考图（None/空）→ required 错误，不提交无 media 的 r2v 请求
         post = AsyncMock(return_value=_resp(_submit()))
@@ -275,6 +287,7 @@ class TestReferenceToVideo:
         assert ei.value.code == "video_reference_images_required"
         post.assert_not_called()
 
+    @pytest.mark.unit
     async def test_r2v_partial_unreadable_refs_fail_loud(self, tmp_path: Path):
         # 部分参考图 read 抛 OSError（is_file 通过但读失败）→ fail-loud 中止并列出不可读文件名，
         # 不静默用可读子集生成（会产出错误结果且照常计费）
@@ -306,6 +319,7 @@ class TestReferenceToVideo:
         assert "a.png" in ei.value.params["names"]
         post.assert_not_called()
 
+    @pytest.mark.unit
     async def test_r2v_all_refs_unreadable_oserror_fail_loud(self, tmp_path: Path):
         # 全部参考图 read 抛 OSError → fail-loud，不提交无 media 的 r2v 请求
         post = AsyncMock(return_value=_resp(_submit()))
@@ -327,6 +341,7 @@ class TestReferenceToVideo:
 
 
 class TestFirstFrameAndTextOnly:
+    @pytest.mark.unit
     async def test_i2v_start_image_oserror_fail_loud(self, tmp_path: Path):
         # 声明了首帧图却 read 抛 OSError（权限/IO）→ fail-loud 中止，不静默忽略首帧照常出片
         post = AsyncMock(return_value=_resp(_submit()))
@@ -348,6 +363,7 @@ class TestFirstFrameAndTextOnly:
         assert "start.png" in ei.value.params["name"]
         post.assert_not_called()
 
+    @pytest.mark.unit
     async def test_i2v_first_frame(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp(_succeeded()))
@@ -367,6 +383,7 @@ class TestFirstFrameAndTextOnly:
         # 带首帧（图生视频）按首帧定宽高比：默认 aspect_ratio 非空也不得下传 ratio，否则上游拒绝
         assert "ratio" not in post.call_args.kwargs["json"]["parameters"]
 
+    @pytest.mark.unit
     async def test_t2v_no_media(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp(_succeeded()))
@@ -382,6 +399,7 @@ class TestFirstFrameAndTextOnly:
 
 
 class TestPollingAndFailures:
+    @pytest.mark.unit
     async def test_polls_through_running(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit("t3")))
         get = AsyncMock(
@@ -403,6 +421,7 @@ class TestPollingAndFailures:
         assert get.call_count == 3
         assert result.task_id == "t3"
 
+    @pytest.mark.unit
     async def test_failed_raises(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp({"output": {"task_status": "FAILED", "code": "X", "message": "boom"}}))
@@ -417,6 +436,7 @@ class TestPollingAndFailures:
                 await b.generate(VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p"))
         download.assert_not_called()
 
+    @pytest.mark.unit
     async def test_generate_unknown_raises_runtime(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit("t-new")))
         get = AsyncMock(return_value=_resp({"output": {"task_status": "UNKNOWN"}}))
@@ -433,6 +453,7 @@ class TestPollingAndFailures:
 
 
 class TestResume:
+    @pytest.mark.unit
     async def test_resume_polls_without_post(self, tmp_path: Path):
         post = AsyncMock(side_effect=AssertionError("resume 不应 POST"))
         get = AsyncMock(return_value=_resp(_succeeded(url="https://x/r.mp4")))
@@ -451,6 +472,7 @@ class TestResume:
         assert get.call_args.args[0].endswith("/tasks/t-resume")
         assert result.task_id == "t-resume"
 
+    @pytest.mark.unit
     async def test_resume_unknown_raises_resume_expired(self, tmp_path: Path):
         get = AsyncMock(return_value=_resp({"output": {"task_status": "UNKNOWN"}}))
         client = _client(get=get)
@@ -467,6 +489,7 @@ class TestResume:
             assert ei.value.job_id == "t-exp"
             assert ei.value.provider == PROVIDER_DASHSCOPE
 
+    @pytest.mark.unit
     async def test_resume_404_raises_without_retry(self, tmp_path: Path):
         not_found = _resp({"error": "nope"}, status_code=404)
         not_found.raise_for_status = MagicMock(side_effect=_http_error(404, "not found"))
@@ -486,6 +509,7 @@ class TestResume:
 
 
 class TestPersist:
+    @pytest.mark.unit
     async def test_persist_called_with_task_id(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit("job-9")))
         get = AsyncMock(return_value=_resp(_succeeded()))
@@ -508,6 +532,7 @@ class TestPersist:
 
 
 class TestSubmit413:
+    @pytest.mark.unit
     async def test_submit_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
         err413 = _resp({"code": "PayloadTooLarge"}, status_code=413)
         err413.raise_for_status = MagicMock(side_effect=_http_error(413, "Request Entity Too Large"))
@@ -540,6 +565,7 @@ class TestSubmit413:
 class TestRetryStatusGating:
     """提交/轮询按 HTTP status_code 决定重试，消除字符串子串误判。"""
 
+    @pytest.mark.unit
     async def test_submit_4xx_with_503_substring_no_retry(self, tmp_path: Path):
         # 4xx 错误消息里带 "503" 子串（URL/task_id）：旧字符串兜底会误判重试，新谓词按 400 fail-fast。
         err = _http_error_503_in_message(400)
@@ -558,6 +584,7 @@ class TestRetryStatusGating:
         assert ei.value.response.status_code == 400
         assert post.call_count == 1
 
+    @pytest.mark.unit
     async def test_submit_real_503_retries_then_succeeds(self, tmp_path: Path):
         # 真 5xx：按 status_code 重试，第三次成功。
         err503 = _resp({"code": "ServiceUnavailable"}, status_code=503)
@@ -576,6 +603,7 @@ class TestRetryStatusGating:
         assert post.call_count == 3
         assert result.task_id == "t-ok"
 
+    @pytest.mark.unit
     async def test_submit_connect_error_retries(self, tmp_path: Path):
         # 网络层错误（连接确定未送达）维持重试。
         post = AsyncMock(side_effect=[httpx.ConnectError("refused"), _resp(_submit("t-ok"))])
@@ -592,6 +620,7 @@ class TestRetryStatusGating:
         assert post.call_count == 2
         assert result.task_id == "t-ok"
 
+    @pytest.mark.unit
     async def test_poll_timeout_retries(self, tmp_path: Path):
         # 轮询（幂等 GET）网络层 Timeout 维持重试。
         post = AsyncMock(return_value=_resp(_submit("t-poll")))

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -36,6 +36,7 @@ def _project_payload(content_mode: str = "narration") -> dict:
 
 
 class TestDataValidator:
+    @pytest.mark.unit
     def test_validate_project_success(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload())
@@ -47,6 +48,7 @@ class TestDataValidator:
         assert result.errors == []
         assert "验证通过" in str(result)
 
+    @pytest.mark.unit
     def test_validate_project_reports_missing_and_invalid_fields(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         # title 字段完全缺失才报错;空字符串在新策略下属于合法状态(前端 i18n 兜底)
@@ -76,6 +78,7 @@ class TestDataValidator:
         assert any("场景 'X'" in error for error in result.errors)
         assert any("道具 'Y'" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_project_rejects_non_string_title(self, tmp_path):
         # title 字段存在但类型不是 string(如 int / null / list)应给出区分于"缺失"的明确文案,
         # 避免调用方误以为字段没写。
@@ -90,6 +93,7 @@ class TestDataValidator:
         assert any("字段类型错误: title 应为字符串" in error for error in result.errors)
         assert not any("缺少必填字段: title" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_project_allows_empty_title(self, tmp_path):
         # title 为空字符串属于合法状态:前端会以「未命名项目」i18n 兜底,
         # lib 层不再要求 title 非空,避免 ProjectManager 写路径被迫存 slug 作 fallback。
@@ -158,6 +162,7 @@ class TestDataValidator:
 
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_narration_success_with_warnings(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("narration"))
@@ -186,6 +191,7 @@ class TestDataValidator:
         assert result.valid
         assert any("缺少 duration_seconds" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_rejects_missing_narration_audio_file(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("narration"))
@@ -214,6 +220,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("narration_audio" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_accepts_existing_narration_audio(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("narration"))
@@ -245,6 +252,7 @@ class TestDataValidator:
         assert result.valid
         assert not any("narration_audio" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_accepts_split_segment_ids_and_missing_scenes_props_warning(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("narration"))
@@ -273,6 +281,7 @@ class TestDataValidator:
         assert any("缺少 scenes" in warning for warning in result.warnings)
         assert any("缺少 props" in warning for warning in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_reports_invalid_references_and_fields(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("narration"))
@@ -308,6 +317,7 @@ class TestDataValidator:
         assert any("不存在于 project.json 的场景" in error for error in result.errors)
         assert any("不存在于 project.json 的道具" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_accepts_nfc_nfd_mismatch_on_narration_segment_refs(self, tmp_path):
         """segment 的角色/场景/道具引用一律按 NFC 归一比对：登记闸口落 NFC 后，
         保留原 NFD 拼写的存量剧本仍须放行，否则合法剧本会被判为引用了未登记资产。"""
@@ -348,6 +358,7 @@ class TestDataValidator:
         result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_validate_episode_accepts_nfc_nfd_mismatch_on_drama_scene_refs(self, tmp_path):
         """drama 场景的三类引用与 narration segment 同口径归一。"""
         import unicodedata
@@ -385,6 +396,7 @@ class TestDataValidator:
         result = validate_episode("demo", "episode_2.json", projects_root=str(tmp_path / "projects"))
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad_duration", [0, -1, "5", 4.5, True])
     def test_validate_episode_rejects_non_positive_integer_duration(self, tmp_path, bad_duration):
         """非正整数的 duration_seconds 仍应报错（0 / 负数 / 字符串 / 浮点 / bool）。"""
@@ -413,6 +425,7 @@ class TestDataValidator:
         assert not result.valid, f"bad={bad_duration}"
         assert any("duration_seconds 值无效" in e for e in result.errors), f"bad={bad_duration}; errors={result.errors}"
 
+    @pytest.mark.unit
     def test_validate_episode_drama_mode(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("drama"))
@@ -459,6 +472,7 @@ class TestDataValidator:
         )
         return validate_episode("demo", "episode_2.json", projects_root=str(tmp_path / "projects"))
 
+    @pytest.mark.unit
     def test_validate_episode_drama_accepts_valid_utterances(self, tmp_path):
         # 合法 utterances（dialogue 带 speaker、voiceover 无 speaker）→ 通过
         result = self._drama_episode_with_scene(
@@ -472,12 +486,14 @@ class TestDataValidator:
         )
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_non_list_utterances(self, tmp_path):
         # utterances 出现但不是数组 → 结构错误
         result = self._drama_episode_with_scene(tmp_path, {"utterances": "这不是数组"})
         assert not result.valid
         assert any("utterances" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_dialogue_without_speaker(self, tmp_path):
         # kind ⇄ speaker：dialogue 缺非空 speaker → 校验失败
         result = self._drama_episode_with_scene(
@@ -486,6 +502,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("speaker" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_voiceover_with_speaker(self, tmp_path):
         # kind ⇄ speaker：voiceover 带 speaker → 校验失败
         result = self._drama_episode_with_scene(
@@ -494,6 +511,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("speaker" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_non_string_speaker(self, tmp_path):
         # speaker 非字符串非 null（如数字）→ 校验失败：镜像 Pydantic 的 speaker: str | None 类型约束，
         # 不在结构校验里静默放行、到 Pydantic 才崩
@@ -503,6 +521,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("speaker" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_accepts_voiceover_blank_speaker(self, tmp_path):
         # voiceover 的空串 / 纯空白 speaker 等价「无 speaker」（与 Pydantic _normalize_speaker 同口径）→ 放行，
         # 不比权威 Pydantic 模型更严
@@ -511,11 +530,13 @@ class TestDataValidator:
         )
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_drama_legacy_voiceover_tolerated(self, tmp_path):
         # 存量 drama（无 utterances、残留旧 voiceover）走读时迁移，校验层放行、不阻塞导出
         result = self._drama_episode_with_scene(tmp_path, {"voiceover": ["旧画外音"]})
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_drama_warns_when_speech_overflows_scene(self, tmp_path):
         # 单向上界：估算说话时长（台词）超场景 duration × 容差 → 仅 warn，不阻塞保存
         long_line = "台词" * 60  # 120 个汉字阅读单位，远超 8 秒场景的容差上界
@@ -530,6 +551,7 @@ class TestDataValidator:
         assert result.valid, result.errors
         assert any("说话时长" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_speech_overflow_counts_voiceover(self, tmp_path):
         # 说话量含画外音：台词 + 画外音一并计入估算（与字幕派生同口径）
         long_vo = "旁白" * 60
@@ -543,6 +565,7 @@ class TestDataValidator:
         assert result.valid, result.errors
         assert any("说话时长" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_no_warning_when_speech_fits(self, tmp_path):
         # 界内：说话量在场景 duration × 容差以内 → 不产说话量 warning
         result = self._drama_episode_with_scene(
@@ -558,6 +581,7 @@ class TestDataValidator:
         assert result.valid, result.errors
         assert not any("说话时长" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_no_warning_when_speech_far_under_duration(self, tmp_path):
         # 单向上界：说话量远少于场景时长不警告（duration 由画面驱动、留白合法，不管「说话太少」）
         result = self._drama_episode_with_scene(
@@ -570,28 +594,33 @@ class TestDataValidator:
         assert result.valid, result.errors
         assert not any("说话时长" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_no_speech_warning_without_utterances(self, tmp_path):
         # 无 utterances（存量 / 未填）→ 不产说话量 warning，也不崩
         result = self._drama_episode_with_scene(tmp_path, {"duration_seconds": 8})
         assert result.valid, result.errors
         assert not any("说话时长" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_accepts_source_text(self, tmp_path):
         # source_text（逐字原文锚）为字符串 → 通过
         result = self._drama_episode_with_scene(tmp_path, {"source_text": "推门而入，信纸还在桌上。"})
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_drama_accepts_missing_source_text(self, tmp_path):
         # source_text 缺失（存量 / best-effort 留空）→ 放行，默认空串
         result = self._drama_episode_with_scene(tmp_path, {})
         assert result.valid
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_non_string_source_text(self, tmp_path):
         # source_text 非字符串（如数字）→ 校验失败：镜像 Pydantic 的 source_text: str 类型约束
         result = self._drama_episode_with_scene(tmp_path, {"source_text": 123})
         assert not result.valid
         assert any("source_text" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_rejects_null_source_text(self, tmp_path):
         # source_text 显式 null → 校验失败：区分「键缺失」（放行、默认空串）与「显式 null」（拒绝），
         # 与共享模型 source_text: str（extra=forbid 下拒 null）同口径，避免校验器先放行、模型层再失败
@@ -599,6 +628,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("source_text" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_helpers_on_missing_files(self, tmp_path):
         result = validate_project("missing", projects_root=str(tmp_path / "projects"))
         assert not result.valid
@@ -606,6 +636,7 @@ class TestDataValidator:
 
     # ── 新增测试 ──────────────────────────────────────────────
 
+    @pytest.mark.unit
     def test_project_json_validates_scenes_and_props(self, tmp_path):
         """新 schema：scenes + props 两个字典都通过校验"""
         project_dir = tmp_path / "projects" / "demo"
@@ -631,6 +662,7 @@ class TestDataValidator:
         assert result.valid
         assert result.errors == []
 
+    @pytest.mark.unit
     def test_project_json_rejects_legacy_clues(self, tmp_path):
         """顶层 clues 字段应报废弃错误"""
         project_dir = tmp_path / "projects" / "demo"
@@ -649,6 +681,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("已废弃字段 clues" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_scenes_dict_missing_description(self, tmp_path):
         """scenes 字典中某个场景缺少 description 应报错"""
         project_dir = tmp_path / "projects" / "demo"
@@ -670,6 +703,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("场景 '书房'" in error and "description" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_props_dict_missing_description(self, tmp_path):
         """props 字典中某个道具缺少 description 应报错"""
         project_dir = tmp_path / "projects" / "demo"
@@ -691,6 +725,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("道具 '玉佩'" in error and "description" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_validate_episode_drama_invalid_scene_prop_refs(self, tmp_path):
         """drama 模式：引用未定义的 scenes/props 应报错"""
         project_dir = tmp_path / "projects" / "demo"
@@ -752,6 +787,7 @@ class TestDataValidator:
         assert not result.valid
         assert any("不存在于 project.json 的场景" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_legacy_scene_type_field_does_not_block_export(self, tmp_path):
         """存量项目里残留 scene_type='对话'/'动作'/'过渡' 等任意值不该阻断导出。
 
@@ -798,15 +834,18 @@ class TestEpisodeLedgerFields:
     def _entry(self, **ledger_fields):
         return {"episode": 1, "title": "开端", "script_file": "scripts/episode_1.json", **ledger_fields}
 
+    @pytest.mark.unit
     def test_legacy_entry_without_ledger_fields_is_valid(self, tmp_path):
         result = self._validate(tmp_path, self._entry())
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_bool_episode_num_rejected(self, tmp_path):
         """True/False 是 int 子类但不是合法集号：会与第 1/0 集同键碰撞，须显式拒绝。"""
         result = self._validate(tmp_path, self._entry(episode=True))
         assert any("episode" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_full_ledger_entry_is_valid(self, tmp_path):
         result = self._validate(
             tmp_path,
@@ -820,6 +859,7 @@ class TestEpisodeLedgerFields:
         )
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_empty_title_allowed_on_episode_entry(self, tmp_path):
         # 孤儿条目登记新建的条目 title 为空串；写入方（剧本同步）在剧本缺 title 时也写 ""
         entry = self._entry()
@@ -827,21 +867,25 @@ class TestEpisodeLedgerFields:
         result = self._validate(tmp_path, entry)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_missing_title_still_reported(self, tmp_path):
         entry = self._entry()
         del entry["title"]
         result = self._validate(tmp_path, entry)
         assert any("title" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_unknown_ledger_status_tolerated(self, tmp_path):
         """当前状态集之外的取值按「无状态」容忍：存量项目可能留有已废弃的状态值。"""
         result = self._validate(tmp_path, self._entry(ledger_status="done"))
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_non_string_ledger_status_rejected(self, tmp_path):
         result = self._validate(tmp_path, self._entry(ledger_status=3))
         assert any("ledger_status" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_malformed_source_range_rejected(self, tmp_path):
         result = self._validate(
             tmp_path,
@@ -849,6 +893,7 @@ class TestEpisodeLedgerFields:
         )
         assert any("source_range" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_escaping_source_file_rejected(self, tmp_path):
         # source_file 是消费方按路径读源文的依据，越界值（..）必须在校验层拒绝
         result = self._validate(
@@ -857,10 +902,12 @@ class TestEpisodeLedgerFields:
         )
         assert any("source_range" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_absolute_planning_cursor_source_file_rejected(self, tmp_path):
         result = self._validate(tmp_path, planning_cursor={"source_file": "/etc/passwd", "offset": 0})
         assert any("planning_cursor" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_legacy_status_with_source_range_tolerated(self, tmp_path):
         """遗留状态值 + 合法 source_range 不再互斥校验：位置真相只看 source_range 本身。"""
         result = self._validate(
@@ -872,22 +919,27 @@ class TestEpisodeLedgerFields:
         )
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_non_string_hook_rejected(self, tmp_path):
         result = self._validate(tmp_path, self._entry(hook=123))
         assert any("hook" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_malformed_outline_rejected(self, tmp_path):
         result = self._validate(tmp_path, self._entry(outline={"story_beats": "不是列表"}))
         assert any("outline" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_malformed_planning_cursor_rejected(self, tmp_path):
         result = self._validate(tmp_path, planning_cursor={"offset": -1})
         assert any("planning_cursor" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_null_planning_cursor_is_valid(self, tmp_path):
         result = self._validate(tmp_path, planning_cursor=None)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_tree_validation_allows_missing_script_for_ledgered_entry(self, tmp_path):
         """账本条目的 script_file 是前瞻性契约：剧本尚未生成不算 tree 校验错误。"""
         payload = _project_payload()
@@ -906,6 +958,7 @@ class TestEpisodeLedgerFields:
         )
         assert not any("script_file" in e for e in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_tree_validation_allows_missing_script_for_entry_without_ledger_status(self, tmp_path):
         """v2→v3 迁移不再回填 ledger_status，老项目升级后的条目可能永远没有该字段：
         形状合法（集号可解析）即视为正常账本条目，剧本未生成同样不阻断。"""
@@ -917,6 +970,7 @@ class TestEpisodeLedgerFields:
         )
         assert not any("script_file" in e for e in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_tree_validation_missing_script_still_blocks_malformed_entry(self, tmp_path):
         """集号无法解析的畸形条目不是合法账本条目：script_file 仍须实际存在。"""
         payload = _project_payload()
@@ -927,6 +981,7 @@ class TestEpisodeLedgerFields:
         )
         assert any("episodes[0].script_file" in e for e in result.errors)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad_episode_num", [0, -1])
     def test_tree_validation_missing_script_still_blocks_non_positive_episode_num(self, tmp_path, bad_episode_num):
         """0/负数集号能被 parse_episode_num 解析，但不是合法集号：script_file 仍须实际存在。"""
@@ -938,6 +993,7 @@ class TestEpisodeLedgerFields:
         )
         assert any("episodes[0].script_file" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_tree_validation_traversal_still_rejected_for_ledgered_entry(self, tmp_path):
         """missing_ok 只豁免「文件不存在」，路径越界对账本条目照常拒绝。"""
         payload = _project_payload()
@@ -955,6 +1011,7 @@ class TestEpisodeLedgerFields:
         )
         assert any("越界" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_tree_validation_reference_audio_missing_field_is_valid(self, tmp_path):
         """reference_audio 是可选字段：角色没有该字段/为空串时不应报错。"""
         payload = _project_payload()
@@ -964,6 +1021,7 @@ class TestEpisodeLedgerFields:
         )
         assert not any("reference_audio" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_tree_validation_reference_audio_accepts_existing_file(self, tmp_path):
         payload = _project_payload()
         payload["characters"]["姜月茴"]["reference_audio"] = "characters/refs_audio/姜月茴.wav"
@@ -977,6 +1035,7 @@ class TestEpisodeLedgerFields:
         )
         assert not any("reference_audio" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_tree_validation_reference_audio_missing_file_rejected(self, tmp_path):
         payload = _project_payload()
         payload["characters"]["姜月茴"]["reference_audio"] = "characters/refs_audio/姜月茴.wav"
@@ -987,6 +1046,7 @@ class TestEpisodeLedgerFields:
         )
         assert any("reference_audio" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_tree_validation_reference_audio_rejects_path_traversal(self, tmp_path):
         payload = _project_payload()
         payload["characters"]["姜月茴"]["reference_audio"] = "../outside.wav"
@@ -1022,15 +1082,18 @@ class TestAdProjectValidation:
         _write_json(tmp_path / "projects" / "demo" / "project.json", payload)
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
 
+    @pytest.mark.unit
     def test_valid_ad_project_passes(self, tmp_path):
         result = self._validate(tmp_path, _ad_project_payload())
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_ad_accepts_arbitrary_positive_target_duration(self, tmp_path):
         # UI 只给四档，但数据层接受任意正整数秒
         result = self._validate(tmp_path, _ad_project_payload(target_duration=47))
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_ad_missing_target_duration_rejected(self, tmp_path):
         payload = _ad_project_payload()
         del payload["target_duration"]
@@ -1038,22 +1101,26 @@ class TestAdProjectValidation:
         assert not result.valid
         assert any("target_duration" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_non_positive_target_duration_rejected(self, tmp_path):
         for bad in (0, -5, "60", True):
             result = self._validate(tmp_path, _ad_project_payload(target_duration=bad))
             assert not result.valid, f"target_duration={bad!r} 应被拒绝"
             assert any("target_duration" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_non_string_brief_rejected(self, tmp_path):
         result = self._validate(tmp_path, _ad_project_payload(brief=123))
         assert not result.valid
         assert any("brief" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_with_default_duration_rejected(self, tmp_path):
         result = self._validate(tmp_path, _ad_project_payload(default_duration=8))
         assert not result.valid
         assert any("default_duration" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_episodes_must_be_single_episode_one(self, tmp_path):
         multi = _ad_project_payload(
             episodes=[
@@ -1073,6 +1140,7 @@ class TestAdProjectValidation:
         result = self._validate(tmp_path, empty)
         assert not result.valid
 
+    @pytest.mark.unit
     def test_target_duration_and_brief_rejected_outside_ad(self, tmp_path):
         payload = _project_payload("narration")
         payload["target_duration"] = 60
@@ -1086,16 +1154,19 @@ class TestAdProjectValidation:
         assert not result.valid
         assert any("brief" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_narration_and_drama_payloads_unaffected(self, tmp_path):
         for mode in ("narration", "drama"):
             result = self._validate(tmp_path, _project_payload(mode))
             assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_ad_grid_storyboard_rejected(self, tmp_path):
         result = self._validate(tmp_path, _ad_project_payload(grid_storyboard=True))
         assert not result.valid
         assert any("grid_storyboard" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_grid_storyboard_false_passes(self, tmp_path):
         result = self._validate(tmp_path, _ad_project_payload(grid_storyboard=False))
         assert result.valid, result.errors
@@ -1108,6 +1179,7 @@ class TestGenerationModeValidation:
         _write_json(tmp_path / "projects" / "demo" / "project.json", payload)
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("mode", ["storyboard", "reference_video"])
     def test_binary_route_values_pass(self, tmp_path, mode):
         payload = _project_payload()
@@ -1115,6 +1187,7 @@ class TestGenerationModeValidation:
         result = self._validate(tmp_path, payload)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_missing_generation_mode_rejected(self, tmp_path):
         payload = _project_payload()
         del payload["generation_mode"]
@@ -1122,6 +1195,7 @@ class TestGenerationModeValidation:
         assert not result.valid
         assert any("缺少必填字段: generation_mode" in e for e in result.errors)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("mode", ["grid", "single", "bogus"])
     def test_non_binary_route_rejected(self, tmp_path, mode):
         payload = _project_payload()
@@ -1130,6 +1204,7 @@ class TestGenerationModeValidation:
         assert not result.valid
         assert any("generation_mode 值无效" in e for e in result.errors)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("mode", [{"value": "storyboard"}, ["storyboard"], 5])
     def test_non_scalar_route_reported_as_error(self, tmp_path, mode):
         """非标量脏值报校验错误而非抛异常——归档导入据此返回 400 而不是 500。"""
@@ -1139,12 +1214,14 @@ class TestGenerationModeValidation:
         assert not result.valid
         assert any("generation_mode 值无效" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_grid_storyboard_true_passes_on_storyboard_route(self, tmp_path):
         payload = _project_payload()
         payload["grid_storyboard"] = True
         result = self._validate(tmp_path, payload)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_grid_storyboard_non_bool_rejected(self, tmp_path):
         payload = _project_payload()
         payload["grid_storyboard"] = "yes"
@@ -1181,20 +1258,24 @@ class TestAdEpisodeValidation:
         )
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
 
+    @pytest.mark.unit
     def test_valid_ad_script_passes(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot()])
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_empty_shots_rejected(self, tmp_path):
         result = self._validate(tmp_path, [])
         assert not result.valid
         assert any("shots" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_bad_shot_id_rejected(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot(shot_id="S01")])
         assert not result.valid
         assert any("shot_id" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_missing_voiceover_text_rejected(self, tmp_path):
         shot = self._ad_shot()
         del shot["voiceover_text"]
@@ -1202,16 +1283,19 @@ class TestAdEpisodeValidation:
         assert not result.valid
         assert any("voiceover_text" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_non_string_voiceover_text_rejected(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot(voiceover_text=42)])
         assert not result.valid
         assert any("voiceover_text" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_unknown_character_reference_rejected(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot(characters_in_shot=["不存在的人"])])
         assert not result.valid
         assert any("characters_in_shot" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_unknown_product_reference_rejected(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot(products_in_shot=["不存在的产品"])])
         assert not result.valid
@@ -1274,6 +1358,7 @@ class TestAdEpisodeValidation:
         result = self._validate(tmp_path, [self._ad_shot(characters_in_shot=[name_nfc])], project=project)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_missing_duration_warns_with_default(self, tmp_path):
         shot = self._ad_shot()
         del shot["duration_seconds"]
@@ -1281,12 +1366,14 @@ class TestAdEpisodeValidation:
         assert result.valid, result.errors
         assert any("duration_seconds" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_storyboard_path_accepts_duration_above_reference_cap(self, tmp_path):
         """storyboard 路径的成员校验在生成 schema 层（supported_durations 枚举）；
         校验器只把关正整数，16 秒不按 reference 区间拒。"""
         result = self._validate(tmp_path, [self._ad_shot(duration_seconds=16)])
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_reference_path_rejects_duration_out_of_range(self, tmp_path):
         """ad + reference_video：镜头时长必须是 1-15 自由整数。"""
         project = _ad_project_payload(generation_mode="reference_video")
@@ -1294,6 +1381,7 @@ class TestAdEpisodeValidation:
         assert not result.valid
         assert any("1-15" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_reference_path_accepts_free_integers_in_range(self, tmp_path):
         project = _ad_project_payload(generation_mode="reference_video")
         result = self._validate(
@@ -1303,6 +1391,7 @@ class TestAdEpisodeValidation:
         )
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_total_duration_drift_warns_but_passes(self, tmp_path):
         """剧本总时长与 target_duration 偏差超阈值仅 warn，不阻塞。"""
         project = _ad_project_payload(target_duration=60)
@@ -1310,6 +1399,7 @@ class TestAdEpisodeValidation:
         assert result.valid, result.errors
         assert any("target_duration" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_total_duration_close_to_target_no_warning(self, tmp_path):
         project = _ad_project_payload(target_duration=12)
         shots = [
@@ -1325,6 +1415,7 @@ class TestAdEpisodeValidation:
 class TestAdEpisodeValidationEdgeCases:
     """ad 剧本骨架唯一与脏数据容错。"""
 
+    @pytest.mark.unit
     def test_ad_reference_generation_mode_still_validates_shots(self, tmp_path):
         """ad 剧本不随生成路径换骨架：generation_mode=reference_video 仍按 shots 校验。"""
         project = _ad_project_payload(generation_mode="reference_video")
@@ -1352,6 +1443,7 @@ class TestAdEpisodeValidationEdgeCases:
         result = DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_non_string_shot_id_reported_not_crash(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _ad_project_payload())
@@ -1368,6 +1460,7 @@ class TestAdEpisodeValidationEdgeCases:
         assert not result.valid
         assert any("shot_id" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_products_bucket_not_dict_reported_not_crash(self, tmp_path):
         project = _ad_project_payload()
         project["products"] = ["速干杯"]
@@ -1394,6 +1487,7 @@ class TestAdEpisodeValidationEdgeCases:
         assert not result.valid
         assert any("products_in_shot" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_ad_missing_episodes_key_rejected(self, tmp_path):
         payload = _ad_project_payload()
         del payload["episodes"]
@@ -1431,6 +1525,7 @@ class TestAdReferenceUnitsValidation:
         _write_json(project_dir / "scripts" / "episode_1.json", script)
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
 
+    @pytest.mark.unit
     def test_valid_index_passes(self, tmp_path):
         units = [
             {
@@ -1443,6 +1538,7 @@ class TestAdReferenceUnitsValidation:
         result = self._validate(tmp_path, [self._ad_shot()], units)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_missing_index_is_legal(self, tmp_path):
         result = self._validate(tmp_path, [self._ad_shot()], None)
         assert result.valid, result.errors
@@ -1464,6 +1560,7 @@ class TestAdReferenceUnitsValidation:
         assert not result.valid
         assert any("video_generated_at 不是合法的 ISO8601 时间戳" in error for error in result.errors)
 
+    @pytest.mark.unit
     def test_dangling_shot_id_warns_not_errors(self, tmp_path):
         """镜头删除后索引短暂悬空是合法中间态（重新派生即愈）：warn 不 error。"""
         units = [{"unit_id": "E1U1", "shot_ids": ["E1S01", "E1S99"], "references": []}]
@@ -1471,6 +1568,7 @@ class TestAdReferenceUnitsValidation:
         assert result.valid, result.errors
         assert any("E1S99" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_malformed_entry_rejected(self, tmp_path):
         units = ["not-a-dict", {"unit_id": "E1U2"}]
         result = self._validate(tmp_path, [self._ad_shot()], units)
@@ -1478,11 +1576,13 @@ class TestAdReferenceUnitsValidation:
         assert any("reference_units[0]" in e for e in result.errors)
         assert any("shot_ids" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_invalid_reference_type_rejected(self, tmp_path):
         units = [{"unit_id": "E1U1", "shot_ids": ["E1S01"], "references": [{"type": "voice", "name": "x"}]}]
         result = self._validate(tmp_path, [self._ad_shot()], units)
         assert not result.valid
 
+    @pytest.mark.unit
     def test_unregistered_reference_name_warns(self, tmp_path):
         units = [{"unit_id": "E1U1", "shot_ids": ["E1S01"], "references": [{"type": "product", "name": "不存在"}]}]
         result = self._validate(tmp_path, [self._ad_shot()], units)
@@ -1523,12 +1623,14 @@ class TestSourceKindValidation:
         _write_json(project_dir / "project.json", project)
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_project("demo")
 
+    @pytest.mark.unit
     def test_missing_source_kind_is_valid(self, tmp_path):
         # 存量项目无 source_kind 字段：缺省 novel，不报错
         result = self._validate(tmp_path, _project_payload("drama"))
         assert result.valid, result.errors
         assert not any("source_kind" in e for e in result.errors)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", ["novel", "screenplay"])
     def test_valid_source_kind_passes(self, tmp_path, kind):
         payload = _project_payload("drama")
@@ -1536,6 +1638,7 @@ class TestSourceKindValidation:
         result = self._validate(tmp_path, payload)
         assert result.valid, result.errors
 
+    @pytest.mark.unit
     def test_invalid_source_kind_rejected(self, tmp_path):
         payload = _project_payload("drama")
         payload["source_kind"] = "screen_play"
@@ -1543,6 +1646,7 @@ class TestSourceKindValidation:
         assert not result.valid
         assert any("source_kind" in e for e in result.errors)
 
+    @pytest.mark.unit
     def test_generic_speaker_in_drama_dialogue_passes_validation(self, tmp_path):
         """泛指 speaker（未注册角色）只进 dialogue、不进 characters_in_scene → 校验通过。
 
@@ -1611,6 +1715,7 @@ class TestSkeletonEntryTypeGuards:
         _write_json(project_dir / "scripts" / "episode_1.json", episode)
         return DataValidator(projects_root=str(tmp_path / "projects")).validate_episode("demo", "episode_1.json")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("kind", "array_key"),
         [
@@ -1627,6 +1732,7 @@ class TestSkeletonEntryTypeGuards:
         assert not result.valid
         assert any(f"{array_key}[0]" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("kind", "array_key"),
         [
@@ -1647,6 +1753,7 @@ class TestSkeletonEntryTypeGuards:
 class TestRouteSkeletonMismatchValidation:
     """存量失配剧本（集级路线覆盖时代的混排集）：报结构结论 + 重拆指引，不逐字段报缺失。"""
 
+    @pytest.mark.unit
     def test_unit_script_under_storyboard_route_is_rejected(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload())
@@ -1662,6 +1769,7 @@ class TestRouteSkeletonMismatchValidation:
         # 只报路线结论，不再叠一份"缺少 segments"之类的下游噪声。
         assert len(result.errors) == 1, result.errors
 
+    @pytest.mark.unit
     def test_storyboard_script_under_reference_route_is_rejected(self, tmp_path):
         payload = _project_payload()
         payload["generation_mode"] = "reference_video"
@@ -1677,6 +1785,7 @@ class TestRouteSkeletonMismatchValidation:
         assert not result.valid
         assert any("split-reference-video-units" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_reference_route_script_with_residual_segments_is_not_a_mismatch(self, tmp_path):
         """参考路线剧本残留分镜数组不算失配：video_units 在场即按 units 校验，导入不被阻断。"""
         payload = _project_payload()
@@ -1698,6 +1807,7 @@ class TestRouteSkeletonMismatchValidation:
 
         assert not any("骨架" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_residual_route_stamp_is_ignored(self, tmp_path):
         """存量剧本残留的 generation_mode 戳是未知字段：不参与判别，也不让校验失败。"""
         project_dir = tmp_path / "projects" / "demo"
@@ -1723,6 +1833,7 @@ class TestInvalidContentModeEpisodeValidation:
     """content_mode 存在但非法（遗留/脏数据）：resolve_declared_kind 对此 fail-loud 抛 ValueError，
     但剧集级校验的契约是把脏数据报告成结构化错误，不让异常向外传播。"""
 
+    @pytest.mark.unit
     def test_validate_episode_reports_structured_error_not_crash(self, tmp_path):
         project_dir = tmp_path / "projects" / "demo"
         _write_json(project_dir / "project.json", _project_payload("bogus_legacy"))
@@ -1736,6 +1847,7 @@ class TestInvalidContentModeEpisodeValidation:
         assert not result.valid
         assert any("content_mode" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_validate_project_tree_reports_structured_error_not_crash(self, tmp_path):
         payload = _project_payload("bogus_legacy")
         payload["episodes"] = [{"episode": 1, "title": "x", "script_file": "scripts/episode_1.json"}]
@@ -1751,6 +1863,7 @@ class TestInvalidContentModeEpisodeValidation:
         assert not result.valid
         assert any("content_mode" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_episode_level_invalid_content_mode_also_reported(self, tmp_path):
         # 项目级 content_mode 合法，但剧集自身声明的 content_mode 非法（覆盖项目级值）：
         # 同样结构化报错，不抛异常。
@@ -1766,6 +1879,7 @@ class TestInvalidContentModeEpisodeValidation:
         assert not result.valid
         assert any("content_mode" in error for error in result.errors), result.errors
 
+    @pytest.mark.unit
     def test_missing_episode_content_mode_still_falls_back_to_project_value(self, tmp_path):
         # 回归防线：剧集级 content_mode 完全缺失时仍应回落项目级值 / "narration"，不触发本次改动
         # 新增的错误分支。
@@ -1818,6 +1932,7 @@ class TestDataValidatorSkeletonExhaustiveness:
     第五种骨架加入 SKELETONS（+ 规范解析映射）时，分派 else 分支 fail-loud，此测试逐个报红。
     """
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
     def test_episode_dispatch_covers_every_skeleton_kind(self, kind, tmp_path, monkeypatch):
         from lib.script_skeleton import SKELETONS

--- a/tests/test_db_engine.py
+++ b/tests/test_db_engine.py
@@ -3,7 +3,11 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from lib.db.engine import get_database_url, is_sqlite_backend
+
+pytestmark = pytest.mark.unit
 
 
 class TestGetDatabaseUrl:

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -10,6 +10,8 @@ import lib.db.models  # noqa: F401 — ensure all models registered for Base.met
 from lib.db.base import Base, TimestampMixin, UserOwnedMixin
 from lib.db.models import AgentSession, Task, User
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def engine():

--- a/tests/test_diagnostics_service.py
+++ b/tests/test_diagnostics_service.py
@@ -9,6 +9,8 @@ import pytest
 import server.services.diagnostics as diag_mod
 from lib.app_data_dir import _reset_for_tests
 
+pytestmark = pytest.mark.unit
+
 
 def test_collect_returns_text(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path))

--- a/tests/test_discover_anthropic_fallback.py
+++ b/tests/test_discover_anthropic_fallback.py
@@ -14,6 +14,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.routers import agent_config, custom_providers
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 def _make_app(session_factory) -> FastAPI:
     app = FastAPI()

--- a/tests/test_discover_anthropic_path_fix.py
+++ b/tests/test_discover_anthropic_path_fix.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.asyncio
 async def test_discover_strips_anthropic_suffix() -> None:

--- a/tests/test_drama_pipeline_split.py
+++ b/tests/test_drama_pipeline_split.py
@@ -25,6 +25,8 @@ from lib.script_models import (
     merge_drama_visual_into_scenes,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _content_scene(scene_id: str = "E1S01", **overrides) -> dict:
     base = {

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -9,6 +9,8 @@ from lib.custom_provider.duration_presets import (
     infer_supported_durations,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     "model_id, expected",

--- a/tests/test_episode_ledger.py
+++ b/tests/test_episode_ledger.py
@@ -40,6 +40,7 @@ def _write_script(project_dir: Path, rel_path: str) -> None:
 
 
 class TestNormalizeSourceText:
+    @pytest.mark.unit
     def test_nfc_and_newlines(self):
         nfd_cafe = unicodedata.normalize("NFD", "café")
         assert normalize_source_text(nfd_cafe) == "café"

--- a/tests/test_episode_paths.py
+++ b/tests/test_episode_paths.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from lib import episode_paths, script_review, status_calculator
 from server.agent_runtime.sdk_tools import text_generation
 from server.routers import files
+
+pytestmark = pytest.mark.unit
 
 
 def test_step1_filename_by_content_mode():

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -96,9 +96,11 @@ def _plan_response(episodes: list[dict]) -> str:
 
 
 class TestFindAllOverlapping:
+    @pytest.mark.unit
     def test_collects_overlapping_starts(self):
         assert _find_all_overlapping("aaaa", "aaa") == [0, 1]
 
+    @pytest.mark.unit
     def test_empty_needle_returns_empty_without_hanging(self):
         # 空 needle 防御边界：直接返回 []，不进入逐位滑动（调用方 anchor 受 min_length=2 约束）
         assert _find_all_overlapping("abcabc", "") == []
@@ -106,6 +108,7 @@ class TestFindAllOverlapping:
 
 
 class TestPlan:
+    @pytest.mark.unit
     async def test_plan_writes_ledger_derives_files_and_advances_cursor(self, tmp_path: Path):
         project_dir = _write_project(tmp_path)
         fake = _FakeTextGenerator(
@@ -147,6 +150,7 @@ class TestPlan:
         assert result.episodes[0].reading_units > 0
         assert result.source_exhausted is False
 
+    @pytest.mark.unit
     async def test_plan_rejects_old_flow_episodes_without_source_range(self, tmp_path: Path):
         """旧拆分流程留下的集（无位置记录）拦住规划：指名集号并指路全量重置，不调模型。"""
         project_dir = _write_project(
@@ -166,6 +170,7 @@ class TestPlan:
             {"episode": 1, "title": "旧集", "script_file": "scripts/episode_1.json"}
         ]
 
+    @pytest.mark.unit
     async def test_plan_registers_orphan_episode_file_and_rejects_instead_of_overwriting(self, tmp_path: Path):
         """账本为空但磁盘已有手动预拆分的集文件：规划先自愈识别出这是孤儿集号再拒绝，
         不会因为账本读起来是空的就当无主原文重新生成并覆盖手动内容。"""
@@ -182,6 +187,7 @@ class TestPlan:
         # 手动预拆分的集文件原样保留，未被规划重新生成覆盖
         assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == "人工预拆分的旧集内容。"
 
+    @pytest.mark.unit
     async def test_plan_rejects_legacy_status_entry_without_source_range(self, tmp_path: Path):
         """存量项目遗留的已废弃状态值不影响判定：看的是有没有 source_range。"""
         project_dir = _write_project(
@@ -207,6 +213,7 @@ class TestPlan:
         # 集文件不动：没有位置记录的集，其物理文件就是最终记录
         assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == "人工改过的内容。"
 
+    @pytest.mark.unit
     async def test_full_reset_unblocks_planning_for_legacy_ledger(self, tmp_path: Path):
         """老项目出路：无位置记录的账本先被 plan 拒绝，全量重置后可正常从头规划。"""
         project_dir = _write_project(
@@ -232,6 +239,7 @@ class TestPlan:
         assert [e["episode"] for e in eps] == [1]
         assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": _end_of(ANCHOR_EP1)}
 
+    @pytest.mark.unit
     async def test_plan_retries_with_failure_reason_when_anchor_invalid(self, tmp_path: Path):
         """机械校验失败自动重试：锚点不存在 → 重试 prompt 附失败原因，第二轮通过。"""
         project_dir = _write_project(tmp_path)
@@ -253,6 +261,7 @@ class TestPlan:
         project = _load_project(project_dir)
         assert len(project["episodes"]) == 1
 
+    @pytest.mark.unit
     async def test_plan_retries_on_ambiguous_and_non_monotonic_anchors(self, tmp_path: Path):
         """锚点不唯一 / 范围不连续同样触发重试，失败原因可区分。"""
         repeated = "李恒抬头看了看天。"
@@ -278,6 +287,7 @@ class TestPlan:
         assert "连续" in fake.requests[2].prompt  # 不连续：报范围推进问题
         assert [s.title for s in result.episodes] == ["丙"]
 
+    @pytest.mark.unit
     async def test_plan_rejects_overlapping_anchor_occurrences_as_ambiguous(self, tmp_path: Path):
         """锚点重叠出现同样判不唯一：非重叠计数会把 "哪哪哪" 中的 "哪哪" 误判为唯一定位。"""
         source = "天哪哪哪，山里炸开了锅。李恒收剑而立。"
@@ -295,6 +305,7 @@ class TestPlan:
         assert "2 次" in fake.requests[1].prompt  # 按允许重叠的口径计数
         assert [s.title for s in result.episodes] == ["乙"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_halfwidth_punctuation(self, tmp_path: Path):
         """锚点与源文仅差全/半角标点宽度（，→ , 与 。→ .）：折叠容错还原精确 NFC 偏移，一次通过不重试。"""
         project_dir = _write_project(tmp_path)
@@ -314,6 +325,7 @@ class TestPlan:
         assert ep1.endswith("玉中藏着剑诀。")  # 源文标点未被改写（仍是全角 。）
         assert [s.title for s in result.episodes] == ["古玉藏诀"]
 
+    @pytest.mark.unit
     async def test_plan_drama_resolves_anchor_with_punctuation_width_mismatch(self, tmp_path: Path):
         """drama 草稿同样走折叠容错：标点宽度不匹配（。→ .）时解析到正确精确偏移。"""
         project_dir = _write_project(tmp_path, content_mode="drama")
@@ -344,6 +356,7 @@ class TestPlan:
         assert ep1 == SOURCE[: _end_of(ANCHOR_EP2)]
         assert [s.title for s in result.episodes] == ["城门遇袭"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_whitespace_width_mismatch(self, tmp_path: Path):
         """锚点空白宽度不匹配（全角空格 ↔ 半角空格）：折叠容错还原精确偏移。"""
         source = "The hero　rose at dawn. Then darkness fell over the land."  # 含全角空格 U+3000
@@ -362,6 +375,7 @@ class TestPlan:
         assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == source[:end]
         assert [s.title for s in result.episodes] == ["Dawn"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_unicode_nfc_mismatch(self, tmp_path: Path):
         """锚点与源文 Unicode 规范形不一致（锚为 NFD 分解形 ↔ 源文 NFC）：折叠兜底对锚副本
         施加与 window 相同的 normalize_source_text 归一再匹配，还原精确偏移；Tier1 与源文坐标不变。"""
@@ -382,6 +396,7 @@ class TestPlan:
         assert ep1 == source[:end]  # 切片取 NFC 原文，未改写源文
         assert [s.title for s in result.episodes] == ["Mở đầu"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_crlf_and_combining_length_change(self, tmp_path: Path):
         """长度护栏：锚同时含 \\r\\n 与会改变长度的组合字符（NFD），两者都让锚比源文对应子串更长。
         归一副本走 normalize_source_text（NFC + 换行统一），end 跨度按归一锚长还原，断言源文偏移/
@@ -408,6 +423,7 @@ class TestPlan:
         assert ep1 == source[:end]  # 切片逐字节落在源文坐标上，未被 \r/组合字符撑长漂移
         assert [s.title for s in result.episodes] == ["Mở đầu"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_curly_double_quote_mismatch(self, tmp_path: Path):
         """源文用弯双引号（U+201C/U+201D），模型回显成直双引号：折叠表新增映射令其对齐。"""
         source = "他说：“古玉里藏着剑诀。”少女沉默不语。"
@@ -429,6 +445,7 @@ class TestPlan:
         assert ep1.endswith("”")  # 源文标点未被改写（仍是弯引号）
         assert [s.title for s in result.episodes] == ["古玉藏诀"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_curly_double_quote_mismatch_reverse(self, tmp_path: Path):
         """反向：源文用直双引号，模型回显成弯双引号，同一折叠表对齐两个方向。"""
         source = '他说："古玉里藏着剑诀。"少女沉默不语。'
@@ -447,6 +464,7 @@ class TestPlan:
         assert ep1 == source[:end]
         assert [s.title for s in result.episodes] == ["古玉藏诀"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_curly_single_quote_mismatch(self, tmp_path: Path):
         """源文用弯单引号（U+2018/U+2019），模型回显成直单引号：折叠表新增映射令其对齐。"""
         source = "少女低声说：‘我不是坏人。’李恒不再追问。"
@@ -468,6 +486,7 @@ class TestPlan:
         assert ep1.endswith("’")  # 源文标点未被改写（仍是弯引号）
         assert [s.title for s in result.episodes] == ["少女辩白"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_cjk_wave_dash_fullwidth_anchor(self, tmp_path: Path):
         """源文用 CJK 波浪号（U+301C），模型回显成全角波浪号（U+FF5E）：两者折叠后同归半角 ~。"""
         source = "古玉估价约〜百金，来历不明。少女转身离去。"
@@ -489,6 +508,7 @@ class TestPlan:
         assert ep1.endswith("〜百金，来历不明。")  # 源文标点未被改写（仍是 CJK 波浪号）
         assert [s.title for s in result.episodes] == ["估价成谜"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_cjk_wave_dash_halfwidth_anchor(self, tmp_path: Path):
         """源文用 CJK 波浪号（U+301C），模型回显成半角 ~：折叠表新增映射令其对齐。"""
         source = "古玉估价约〜百金，来历不明。少女转身离去。"
@@ -509,6 +529,7 @@ class TestPlan:
         assert ep1 == source[:end]
         assert [s.title for s in result.episodes] == ["估价成谜"]
 
+    @pytest.mark.unit
     async def test_plan_resolves_anchor_with_fullwidth_straight_quote_mismatch(self, tmp_path: Path):
         """源文用全角直引号（U+FF02/U+FF07），模型回显成半角直引号：折叠表新增映射令其对齐。"""
         source = "少女喊道：＂别跑，＇等等我＇！＂李恒停下脚步。"
@@ -530,6 +551,7 @@ class TestPlan:
         assert ep1.endswith("＂")  # 源文标点未被改写（仍是全角直引号）
         assert [s.title for s in result.episodes] == ["城门呼喊"]
 
+    @pytest.mark.unit
     async def test_plan_rejects_anchor_ambiguous_after_punctuation_folding(self, tmp_path: Path):
         """折叠后仍命中多处：维持「无法唯一定位」拒绝并重试，不静默挑第一处。"""
         source = "他说好的。她说好的。后来他离开了。"  # 两处「说好的。」全角句号
@@ -548,6 +570,7 @@ class TestPlan:
         assert "2 次" in fake.requests[1].prompt
         assert [s.title for s in result.episodes] == ["乙"]
 
+    @pytest.mark.unit
     async def test_plan_ignores_negative_cursor_offset(self, tmp_path: Path):
         """游标 offset 为负：按非法游标忽略，从源文开头规划而非尾部静默取段。"""
         project_dir = _write_project(tmp_path, planning_cursor={"source_file": "source/novel.txt", "offset": -5})
@@ -560,6 +583,7 @@ class TestPlan:
         eps = _load_project(project_dir)["episodes"]
         assert eps[0]["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": _end_of(ANCHOR_EP1)}
 
+    @pytest.mark.unit
     async def test_plan_continues_from_cursor_advanced_into_next_source_file(self, tmp_path: Path):
         """游标已合法推进到后一个源文件：续规划从游标起，不重复规划该文件前缀。"""
         c = _end_of(ANCHOR2_MID, SOURCE2)
@@ -578,6 +602,7 @@ class TestPlan:
         eps = {e["episode"]: e for e in _load_project(project_dir)["episodes"]}
         assert eps[2]["source_range"] == {"source_file": "source/novel2.txt", "start": c, "end": len(SOURCE2)}
 
+    @pytest.mark.unit
     async def test_plan_raises_and_leaves_project_untouched_after_retry_exhaustion(self, tmp_path: Path):
         """重试耗尽：抛 EpisodePlanningError，账本与文件零变更（原子性）。"""
         project_dir = _write_project(tmp_path)
@@ -618,6 +643,7 @@ class TestPlan:
         assert (project_dir / "project.json").read_text(encoding="utf-8") == after_concurrent_commit[0]
         assert not list((project_dir / "source").glob("episode_*.txt"))
 
+    @pytest.mark.unit
     async def test_plan_truncation_short_circuits_retry_and_hints_leverage(self, tmp_path: Path):
         """结构化输出被截断时不重试，直接冒泡 EpisodePlanningError 并附带调小窗口/集数的提示（见 docs/adr/0044）。"""
         from lib.text_backends.base import TextOutputTruncatedError
@@ -645,6 +671,7 @@ class TestPlan:
         assert "planning_max_episodes" in str(exc_info.value)
         assert (project_dir / "project.json").read_text(encoding="utf-8") == before
 
+    @pytest.mark.unit
     async def test_plan_accepts_uppercase_json_fence(self, tmp_path: Path):
         """模型输出大写 ```JSON 围栏也能解析（围栏标记不区分大小写）。"""
         project_dir = _write_project(tmp_path)
@@ -658,6 +685,7 @@ class TestPlan:
         assert [s.title for s in result.episodes] == ["古玉藏诀"]
         assert len(fake.requests) == 1  # 一次通过，未触发重试
 
+    @pytest.mark.unit
     async def test_plan_drama_writes_outline_to_ledger(self, tmp_path: Path):
         """drama 条目加厚为分集大纲：story_beats + next_episode_teaser 落账本 outline。"""
         project_dir = _write_project(tmp_path, content_mode="drama")
@@ -685,6 +713,7 @@ class TestPlan:
             "next_episode_teaser": "下集李恒下山",
         }
 
+    @pytest.mark.unit
     async def test_plan_drama_rejects_response_missing_story_beats(self, tmp_path: Path):
         """drama 模式缺 story_beats 的输出被 schema 校验打回重试。"""
         project_dir = _write_project(tmp_path, content_mode="drama")
@@ -710,6 +739,7 @@ class TestPlan:
         assert len(fake.requests) == 2
         assert "schema" in fake.requests[1].prompt
 
+    @pytest.mark.unit
     async def test_plan_screenplay_respects_author_divisions(self, tmp_path: Path):
         """screenplay：mock 返回尊重作者分集的规划 → 账本落作者的边界 / 标题 / 钩子 / 大纲。"""
         project_dir = _write_project(tmp_path, content_mode="drama", extra={"source_kind": "screenplay"})
@@ -749,6 +779,7 @@ class TestPlan:
         }
         assert eps[0]["outline"] == {"story_beats": ["山村习武", "后山得玉"], "next_episode_teaser": "下集李恒下山"}
 
+    @pytest.mark.unit
     async def test_plan_prompt_branches_on_source_kind(self, tmp_path: Path):
         """screenplay 规划 prompt 携带「尊重作者分集 / 无则按剧情弧语义切 / 不依赖固定标记」；novel 不翻面。"""
 
@@ -789,6 +820,7 @@ class TestPlan:
         assert "固定标记" not in nov_prompt
         assert "小说原文片段" in nov_prompt
 
+    @pytest.mark.unit
     async def test_plan_window_setting_limits_prompt_window(self, tmp_path: Path):
         """planning_window_chars 项目设置覆盖内部默认：窗口外内容不进 prompt。"""
         window_chars = _end_of(ANCHOR_EP1) + 4
@@ -802,6 +834,7 @@ class TestPlan:
         cursor = _load_project(project_dir)["planning_cursor"]
         assert cursor == {"source_file": "source/novel.txt", "offset": _end_of(ANCHOR_EP1)}
 
+    @pytest.mark.unit
     async def test_plan_window_elasticity_extends_to_full_text_when_remainder_small(self, tmp_path: Path):
         """剩余全文不足窗口 1.2 倍时窗口直接延伸到全文末尾，避免残余被迫单独成集。"""
         window_chars = len(SOURCE) - 8  # 小于全文长度，但剩余量仍在 1.2 倍窗口以内
@@ -826,6 +859,7 @@ class TestPlan:
         project = _load_project(project_dir)
         assert project["planning_cursor"]["offset"] == len(SOURCE)
 
+    @pytest.mark.unit
     async def test_plan_max_episodes_setting_truncates_batch(self, tmp_path: Path):
         """planning_max_episodes 覆盖每批集数上限：超出的集截断留给下一批。"""
         project_dir = _write_project(tmp_path, extra={"planning_max_episodes": 1})
@@ -847,6 +881,7 @@ class TestPlan:
         assert len(project["episodes"]) == 1
         assert project["planning_cursor"]["offset"] == _end_of(ANCHOR_EP1)
 
+    @pytest.mark.unit
     async def test_plan_final_window_with_whitespace_tail_marks_source_exhausted(self, tmp_path: Path):
         """规划到全文结尾（仅剩空白）：末集贴齐文末，cursor 到文末，报告源文耗尽。"""
         source = SOURCE + "\n\n"
@@ -872,6 +907,7 @@ class TestPlan:
         ep2_file = (project_dir / "source" / "episode_2.txt").read_text(encoding="utf-8")
         assert ep2_file.endswith("漩涡之中。\n\n")
 
+    @pytest.mark.unit
     async def test_plan_on_exhausted_source_returns_without_llm_call(self, tmp_path: Path):
         """游标已到文末：直接返回 source_exhausted，不调模型、不动账本。"""
         project_dir = _write_project(
@@ -886,6 +922,7 @@ class TestPlan:
         assert result.episodes == []
         assert fake.requests == []
 
+    @pytest.mark.unit
     async def test_plan_advances_to_next_source_when_current_exhausted(self, tmp_path: Path):
         """多源文件：当前源文件已规划完时，自动从下一个源文件起点续规划。"""
         source2 = "第二部 新的征程。李恒踏入上界，结识了新的同伴。"
@@ -911,6 +948,7 @@ class TestPlan:
         assert (project_dir / "source" / "episode_2.txt").read_text(encoding="utf-8") == source2
         assert result.source_exhausted is True  # 第二个文件也到结尾，且没有更多源文件
 
+    @pytest.mark.unit
     async def test_plan_not_exhausted_when_more_source_files_remain(self, tmp_path: Path):
         """规划到当前源文件结尾但还有后续源文件：不报源文耗尽。"""
         project_dir = _write_project(tmp_path)
@@ -932,6 +970,7 @@ class TestPlan:
         cursor = _load_project(project_dir)["planning_cursor"]
         assert cursor == {"source_file": "source/novel.txt", "offset": len(SOURCE)}
 
+    @pytest.mark.unit
     async def test_plan_rejects_when_entry_loses_source_range_during_model_call(self, tmp_path: Path):
         """锁内复核：模型调用期间账本被补进无位置记录的条目，提交仍被拦下、账本不写入。"""
         project_dir = _write_project(tmp_path)
@@ -956,6 +995,7 @@ class TestPlan:
         assert [e["episode"] for e in episodes] == [7]
         assert not (project_dir / "source" / "episode_1.txt").exists()
 
+    @pytest.mark.unit
     async def test_plan_forwards_instructions_into_prompt(self, tmp_path: Path):
         """首批规划带 instructions 时，原文进「用户规划意见（必须全部落实）」分节。"""
         project_dir = _write_project(tmp_path)
@@ -969,6 +1009,7 @@ class TestPlan:
         assert "# 用户规划意见（必须全部落实）" in prompt
         assert "严格按章节切分，一章一集" in prompt
 
+    @pytest.mark.unit
     async def test_plan_without_instructions_omits_section(self, tmp_path: Path):
         """不传 instructions 时 prompt 无指令分节，与今日纯剧情弧行为逐字一致。"""
         project_dir = _write_project(tmp_path)
@@ -982,6 +1023,7 @@ class TestPlan:
         assert "用户规划意见" not in prompt
         assert "必须全部落实" not in prompt
 
+    @pytest.mark.unit
     async def test_plan_blank_instructions_treated_as_absent(self, tmp_path: Path):
         """纯空白 instructions strip 后视同未传：prompt 与不传时逐字一致（无指令分节）。"""
         blank = _FakeTextGenerator(
@@ -996,6 +1038,7 @@ class TestPlan:
 
         assert blank.requests[0].prompt == none.requests[0].prompt
 
+    @pytest.mark.unit
     async def test_plan_with_instructions_injects_global_progress_section(self, tmp_path: Path):
         """有 instructions 时才注入「全局进度」分节：已规划集数/余量/本窗口体量按阅读单位现算。"""
         ep1_end = _end_of(ANCHOR_EP1)
@@ -1018,6 +1061,7 @@ class TestPlan:
         assert f"未规划余量约 {remaining_units} 字" in prompt
         assert f"本窗口为其中前 {window_units} 字" in prompt
 
+    @pytest.mark.unit
     async def test_plan_normal_batch_omits_ledger_stats(self, tmp_path: Path):
         """常规（非耗尽）批次不附全局核对材料，只报累计已规划集数。"""
         window_chars = _end_of(ANCHOR_EP1) + 4
@@ -1030,6 +1074,7 @@ class TestPlan:
         assert result.ledger_stats is None
         assert result.total_planned == 1
 
+    @pytest.mark.unit
     async def test_plan_exhausted_batch_includes_ledger_stats(self, tmp_path: Path):
         """末批即耗尽：附全局核对材料——累计集数、最小体量集（升序）、中位数。"""
         last_anchor = "卷入漩涡之中。"
@@ -1055,6 +1100,7 @@ class TestPlan:
         assert stats.median_units == 37
         assert stats.target_units is None  # 未配置 episode_target_units 时不报
 
+    @pytest.mark.unit
     async def test_plan_exhausted_batch_reports_target_units_when_configured(self, tmp_path: Path):
         """episode_target_units 项目设置存在时，核对材料里带出该目标体量。"""
         last_anchor = "卷入漩涡之中。"
@@ -1076,6 +1122,7 @@ class TestPlan:
         assert result.ledger_stats is not None
         assert result.ledger_stats.target_units == 800
 
+    @pytest.mark.unit
     async def test_plan_no_new_content_early_exit_includes_ledger_stats(self, tmp_path: Path):
         """再次调用无新内容（早退路径）：不调模型，仍附全局核对材料供复核。"""
         project_dir = _planned_three(tmp_path)
@@ -1091,6 +1138,7 @@ class TestPlan:
         assert [num for num, _units in stats.smallest] == [3, 2, 1]
         assert stats.median_units == 37
 
+    @pytest.mark.unit
     async def test_plan_marks_stale_when_new_episode_num_has_downstream_products(self, tmp_path: Path):
         """新提交的集号若在磁盘上已有剧本产物（如重置到更早集号后重新规划、与原消费范围重叠），标 stale，不删产物。"""
         project_dir = _write_project(tmp_path)
@@ -1108,6 +1156,7 @@ class TestPlan:
         assert eps[1]["ledger_status"] == "stale"
         assert (project_dir / "scripts" / "episode_1.json").exists()  # 产物不删除
 
+    @pytest.mark.unit
     async def test_plan_keeps_planned_when_no_downstream_products(self, tmp_path: Path):
         """新提交的集号磁盘上没有任何产物：照常标 planned，stale_episodes 为空。"""
         project_dir = _write_project(tmp_path)
@@ -1411,6 +1460,7 @@ class TestReconcileFailFast:
     与 plan() 从 planning_cursor 续接新一批无关——plan() 的提交路径已由 TestPlan 覆盖。
     """
 
+    @pytest.mark.unit
     def test_commit_aborts_when_anchored_entry_has_invalid_source_range(self, tmp_path: Path):
         """账本中锚定集的原文范围类型非法：对账中止，派生文件零变更。"""
         project_dir = _planned_three(tmp_path)
@@ -1423,6 +1473,7 @@ class TestReconcileFailFast:
 
         assert (project_dir / "source" / "episode_3.txt").exists()  # 旧文件未被清理
 
+    @pytest.mark.unit
     def test_commit_aborts_when_source_range_out_of_bounds(self, tmp_path: Path):
         """账本中锚定集的原文范围越界（end 超源文长度）：对账中止。"""
         project_dir = _planned_three(tmp_path)
@@ -1433,6 +1484,7 @@ class TestReconcileFailFast:
         with pytest.raises(EpisodePlanningError, match="越界"):
             planner._reconcile_derived_files(project, {})
 
+    @pytest.mark.unit
     def test_commit_aborts_when_entry_source_file_missing(self, tmp_path: Path):
         """账本引用的源文件缺失：派生文件重写失败中止对账。"""
         project_dir = _planned_three(tmp_path)
@@ -1445,6 +1497,7 @@ class TestReconcileFailFast:
 
         assert (project_dir / "source" / "episode_3.txt").exists()
 
+    @pytest.mark.unit
     def test_commit_validation_failure_leaves_derived_files_untouched(self, tmp_path: Path):
         """校验类失败中止时不得留下部分重写的派生文件：全部校验通过后才统一落盘。"""
         project_dir = _planned_three(tmp_path)
@@ -1460,6 +1513,7 @@ class TestReconcileFailFast:
         # 排序在前的第 1 集合法，但因第 2 集校验失败，其派生文件不得被提前重写
         assert (project_dir / "source" / "episode_1.txt").read_text(encoding="utf-8") == sentinel
 
+    @pytest.mark.unit
     def test_commit_aborts_when_derived_episode_file_is_symlink(self, tmp_path: Path):
         """派生集文件是符号链接：写入会跟随链接落到项目外，必须中止对账。"""
         project_dir = _planned_three(tmp_path)

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -61,30 +61,35 @@ def _make_client() -> TestClient:
 
 
 class TestApiErrorHandler:
+    @pytest.mark.unit
     def test_not_found_translated_zh_default(self):
         client = _make_client()
         resp = client.get("/api-error-404")
         assert resp.status_code == 404
         assert resp.json()["detail"] == "片段 'E1S01' 不存在"
 
+    @pytest.mark.unit
     def test_bad_request_400(self):
         client = _make_client()
         resp = client.get("/api-error-400")
         assert resp.status_code == 400
         assert "音频" in resp.json()["detail"]
 
+    @pytest.mark.unit
     def test_accept_language_en(self):
         client = _make_client()
         resp = client.get("/api-error-404", headers={"Accept-Language": "en-US,en;q=0.9"})
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Segment 'E1S01' does not exist"
 
+    @pytest.mark.unit
     def test_accept_language_vi(self):
         client = _make_client()
         resp = client.get("/api-error-404", headers={"Accept-Language": "vi"})
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Đoạn 'E1S01' không tồn tại"
 
+    @pytest.mark.unit
     def test_custom_status_code(self):
         client = _make_client()
         resp = client.get("/api-error-custom-status")
@@ -92,6 +97,7 @@ class TestApiErrorHandler:
 
 
 class TestLibExceptionHandlers:
+    @pytest.mark.unit
     def test_task_spec_validation_error_400(self):
         client = _make_client()
         resp = client.get("/task-spec-error")
@@ -99,6 +105,7 @@ class TestLibExceptionHandlers:
         # detail 是翻译后的成品文案，不是裸 code
         assert resp.json()["detail"] != "prompt_text_empty"
 
+    @pytest.mark.unit
     def test_script_edit_error_400(self):
         client = _make_client()
         resp = client.get("/script-edit-error")
@@ -125,6 +132,7 @@ class TestLibExceptionHandlers:
         assert detail == "Dữ liệu kịch bản bị hỏng: segments phải là một danh sách, nhưng nhận được NoneType"
         assert not any("一" <= ch <= "鿿" for ch in detail)
 
+    @pytest.mark.unit
     def test_file_not_found_404_hides_server_path(self):
         client = _make_client()
         resp = client.get("/file-not-found")
@@ -132,6 +140,7 @@ class TestLibExceptionHandlers:
         assert resp.json()["detail"] == "请求的资源不存在"
         assert _SERVER_PATH not in resp.text
 
+    @pytest.mark.unit
     def test_unexpected_exception_500_hides_details(self):
         client = _make_client()
         resp = client.get("/unexpected")
@@ -142,6 +151,7 @@ class TestLibExceptionHandlers:
 
 
 class TestRealAppRegistration:
+    @pytest.mark.unit
     def test_server_app_registers_all_handlers(self):
         from server.app import app as real_app
 
@@ -164,6 +174,7 @@ class TestUnexpectedErrorCorsHeaders:
     """ServerErrorMiddleware 兜底发 500 时绕过 CORSMiddleware（走最外层原始 send），
     handler 需手工补齐 CORS 头，否则跨域前端把 500 当成 network error。"""
 
+    @pytest.mark.unit
     def test_wildcard_origin_gets_wildcard_header(self):
         client = _make_cors_client(["*"], False)
         resp = client.get("/unexpected", headers={"Origin": "https://example.com"})
@@ -171,6 +182,7 @@ class TestUnexpectedErrorCorsHeaders:
         assert resp.headers.get("access-control-allow-origin") == "*"
         assert "access-control-allow-credentials" not in resp.headers
 
+    @pytest.mark.unit
     def test_allowlisted_origin_with_credentials_gets_explicit_origin(self):
         client = _make_cors_client(["https://example.com"], True)
         resp = client.get("/unexpected", headers={"Origin": "https://example.com"})
@@ -179,18 +191,21 @@ class TestUnexpectedErrorCorsHeaders:
         assert resp.headers.get("access-control-allow-credentials") == "true"
         assert resp.headers.get("vary") == "Origin"
 
+    @pytest.mark.unit
     def test_disallowed_origin_gets_no_allow_origin_header(self):
         client = _make_cors_client(["https://allowed.example.com"], True)
         resp = client.get("/unexpected", headers={"Origin": "https://evil.example.com"})
         assert resp.status_code == 500
         assert "access-control-allow-origin" not in resp.headers
 
+    @pytest.mark.unit
     def test_no_origin_header_means_no_cors_headers(self):
         client = _make_cors_client(["*"], False)
         resp = client.get("/unexpected")
         assert resp.status_code == 500
         assert "access-control-allow-origin" not in resp.headers
 
+    @pytest.mark.unit
     def test_default_kwargs_fall_back_to_wildcard(self):
         # register_error_handlers 不传 cors 参数时的保守默认值：通配 origins，不开 credentials。
         app = FastAPI()

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -13,6 +13,8 @@ from lib.config.resolver import ConfigResolver, ProviderModel
 from server.services import generation_context, generation_tasks
 from server.services.generation_context import AudioLaneResult, GenerationContext
 
+pytestmark = pytest.mark.unit
+
 
 def _audio_ctx(generator, *, voice="Cherry", speed=None):
     """把 audio lane 解析产物拼成假 GenerationContext，替换 resolve_generation_context 单点。"""

--- a/tests/test_execute_voice_sample_task.py
+++ b/tests/test_execute_voice_sample_task.py
@@ -12,6 +12,8 @@ from lib.resource_paths import resource_relative_path
 from server.services import generation_tasks
 from server.services.generation_context import AudioLaneResult, GenerationContext
 
+pytestmark = pytest.mark.unit
+
 
 def _audio_ctx(generator):
     ctx = GenerationContext(

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -70,6 +70,7 @@ def _client(monkeypatch, tmp_path):
 
 
 class TestFilesRouter:
+    @pytest.mark.unit
     def test_source_and_file_endpoints(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
 
@@ -107,6 +108,7 @@ class TestFilesRouter:
             missing = client.get("/api/v1/projects/demo/source/missing.txt")
             assert missing.status_code == 404
 
+    @pytest.mark.unit
     def test_source_upload_race_project_deleted_reports_project_not_found(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
 
@@ -125,6 +127,7 @@ class TestFilesRouter:
             assert resp.status_code == 404
             assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="demo")
 
+    @pytest.mark.unit
     def test_source_upload_loader_file_missing_with_project_intact_stays_generic(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
 
@@ -142,6 +145,7 @@ class TestFilesRouter:
             assert resp.status_code == 404
             assert resp.json()["detail"] == zh_errors.MESSAGES["resource_not_found"]
 
+    @pytest.mark.unit
     def test_upload_assets_and_drafts(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
 
@@ -220,6 +224,7 @@ class TestFilesRouter:
             assert project["characters"]["Alice"]["reference_image"] == "characters/refs/Alice.webp"
             assert project["props"]["玉佩"]["prop_sheet"] == "props/玉佩.jpg"
 
+    @pytest.mark.unit
     def test_character_audio_ref_upload_success(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -232,6 +237,7 @@ class TestFilesRouter:
             project = pm.load_project("demo")
             assert project["characters"]["Alice"]["reference_audio"] == "characters/refs_audio/Alice.wav"
 
+    @pytest.mark.unit
     def test_character_audio_ref_rejects_bad_extension(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -242,6 +248,7 @@ class TestFilesRouter:
             assert resp.status_code == 400
             assert "音频类型" in resp.json()["detail"] or "audio type" in resp.json()["detail"].lower()
 
+    @pytest.mark.unit
     def test_character_audio_ref_rejects_oversized(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         oversized = b"\x00" * (files.AUDIO_REFERENCE_MAX_BYTES + 1)
@@ -253,6 +260,7 @@ class TestFilesRouter:
             assert resp.status_code == 400
             assert resp.json()["detail"] == zh_errors.MESSAGES["upload_too_large"].format(max_mb=15)
 
+    @pytest.mark.unit
     def test_character_audio_ref_rejects_duration_out_of_range(self, tmp_path, monkeypatch):
         import shutil as _shutil
 
@@ -273,6 +281,7 @@ class TestFilesRouter:
             )
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio", "") == ""
 
+    @pytest.mark.unit
     def test_character_audio_ref_replace_removes_old_extension(self, tmp_path, monkeypatch):
         """替换参考音频且新旧扩展名不同（wav -> mp3）时旧文件应被清理，不留孤儿。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -302,6 +311,7 @@ class TestFilesRouter:
             new_path = project_dir / "characters" / "refs_audio" / "Alice.mp3"
             assert new_path.exists()
 
+    @pytest.mark.unit
     def test_character_audio_ref_replace_succeeds_when_stale_cleanup_fails(self, tmp_path, monkeypatch):
         """替换成功但旧文件物理删除失败（权限/IO 错误）时，请求仍应成功——新文件与字段已提交，
         不应因清理失败误报整次替换失败并诱导重试（重试时旧文件已找不到指针，成为孤儿）。"""
@@ -344,6 +354,7 @@ class TestFilesRouter:
                 pm.load_project("demo")["characters"]["Alice"]["reference_audio"] == "characters/refs_audio/Alice.mp3"
             )
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -361,6 +372,7 @@ class TestFilesRouter:
             assert not audio_path.exists()
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio") == ""
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio_preserves_pointer_on_unlink_failure(self, tmp_path, monkeypatch):
         """物理删除失败（权限/IO 错误，含 Windows 文件占用）时保留字段指针，允许重试发现并清理该文件。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -390,12 +402,14 @@ class TestFilesRouter:
             )
             assert audio_path.exists()
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio_unknown_character_404(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
             resp = client.delete("/api/v1/projects/demo/characters/Ghost/reference-audio")
             assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio_noop_when_no_audio(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -403,6 +417,7 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio", "") == ""
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio_ignores_out_of_project_path(self, tmp_path, monkeypatch):
         """reference_audio 可经资产 PATCH 写成任意字符串；越界路径只清字段，不得删项目外文件。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -416,6 +431,7 @@ class TestFilesRouter:
             assert outsider.exists()
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio") == ""
 
+    @pytest.mark.unit
     def test_character_audio_ref_replace_ignores_out_of_project_old_path(self, tmp_path, monkeypatch):
         """替换时的旧文件清理同样受项目目录约束，越界的存量值不触发删除。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -439,6 +455,7 @@ class TestFilesRouter:
                 pm.load_project("demo")["characters"]["Alice"]["reference_audio"] == "characters/refs_audio/Alice.mp3"
             )
 
+    @pytest.mark.unit
     def test_delete_character_reference_audio_ignores_path_outside_refs_audio(self, tmp_path, monkeypatch):
         """reference_audio 越权指向项目内 refs_audio 之外的文件（如 project.json）时，只清字段，不得删该文件。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -452,6 +469,7 @@ class TestFilesRouter:
             assert project_json.exists()
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio") == ""
 
+    @pytest.mark.unit
     def test_character_audio_ref_replace_ignores_stale_path_outside_refs_audio(self, tmp_path, monkeypatch):
         """替换时的旧文件清理同样限定在 refs_audio 目录内，落在项目目录内其它位置的存量值不触发删除。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -475,6 +493,7 @@ class TestFilesRouter:
                 pm.load_project("demo")["characters"]["Alice"]["reference_audio"] == "characters/refs_audio/Alice.mp3"
             )
 
+    @pytest.mark.unit
     def test_product_ref_upload_preserves_original_bytes(self, tmp_path, monkeypatch):
         """产品原图是保真验收锚点：保存管线保留原件字节，不做阈值压缩/重编码。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -505,6 +524,7 @@ class TestFilesRouter:
             project = pm.load_project("demo")
             assert project["products"]["保温杯"]["reference_images"] == [path]
 
+    @pytest.mark.unit
     def test_product_ref_multiple_uploads_accumulate(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -524,6 +544,7 @@ class TestFilesRouter:
             for p in paths:
                 assert (project_dir / p).exists()
 
+    @pytest.mark.unit
     def test_product_ref_upload_resolves_nfd_registered_host(self, tmp_path, monkeypatch):
         """宿主资产的存量 key 可能是 NFD：上传入口按坐标系解析存在性，
         否则闸口把 name 归一到 NFC 后会先返回 404，写回侧的解析根本走不到。"""
@@ -549,6 +570,7 @@ class TestFilesRouter:
             assert name_nfc not in products  # 不因上传新造一条 NFC 产品
             assert products[name_nfd]["reference_images"] == [resp.json()["path"]]
 
+    @pytest.mark.unit
     def test_product_ref_unknown_product_404(self, tmp_path, monkeypatch):
         """原图列表是文件的唯一指针：产品不存在时拒收，避免落下孤儿文件。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -561,6 +583,7 @@ class TestFilesRouter:
             refs_dir = pm.get_project_path("demo") / "products" / "refs"
             assert not refs_dir.exists() or not any(refs_dir.iterdir())
 
+    @pytest.mark.unit
     def test_product_ref_invalid_image_rejected(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -570,6 +593,7 @@ class TestFilesRouter:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_product_sheet_upload_updates_metadata(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -582,6 +606,7 @@ class TestFilesRouter:
             project = pm.load_project("demo")
             assert project["products"]["保温杯"]["product_sheet"] == "products/保温杯.jpg"
 
+    @pytest.mark.unit
     def test_list_files_includes_products(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -593,6 +618,7 @@ class TestFilesRouter:
             assert listed.status_code == 200
             assert any(item["name"] == "保温杯.jpg" for item in listed.json()["files"]["products"])
 
+    @pytest.mark.unit
     def test_style_image_endpoints(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
 
@@ -622,6 +648,7 @@ class TestFilesRouter:
             )
             assert bad_style_ext.status_code == 400
 
+    @pytest.mark.unit
     def test_security_and_error_paths(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
 
@@ -642,6 +669,7 @@ class TestFilesRouter:
             )
             assert missing_source.status_code == 404
 
+    @pytest.mark.unit
     def test_upload_without_name_and_keyerror_tolerance(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -816,6 +844,7 @@ class TestFilesRouter:
             # 上限取整 MB，文案里的 max_mb 才是对用户有意义的数字
             assert resp.json()["detail"] == zh_errors.MESSAGES["upload_too_large"].format(max_mb=1)
 
+    @pytest.mark.unit
     def test_source_decode_and_draft_mode_helpers(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         project_dir = pm.get_project_path("demo")
@@ -911,6 +940,7 @@ class TestFilesRouter:
             unknown_draft = client.delete("/api/v1/projects/demo/drafts/9/step1")
             assert unknown_draft.status_code == 404
 
+    @pytest.mark.unit
     def test_cache_control_immutable_with_version_param(self, tmp_path, monkeypatch):
         """带 ?v= 参数时应返回 immutable 缓存头"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -924,6 +954,7 @@ class TestFilesRouter:
             assert "immutable" in resp.headers.get("cache-control", "")
             assert "max-age=31536000" in resp.headers.get("cache-control", "")
 
+    @pytest.mark.unit
     def test_cache_control_immutable_for_version_files(self, tmp_path, monkeypatch):
         """versions/ 路径下的文件应返回 immutable 缓存头"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -936,6 +967,7 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert "immutable" in resp.headers.get("cache-control", "")
 
+    @pytest.mark.unit
     def test_no_cache_control_without_version(self, tmp_path, monkeypatch):
         """无 ?v= 参数且非 versions 路径时不应有 immutable 头"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -948,6 +980,7 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert "immutable" not in resp.headers.get("cache-control", "")
 
+    @pytest.mark.unit
     def test_files_helper_functions(self, tmp_path):
         assert files._get_step_files("narration") == {1: "step1_segments.json"}
         assert files._get_step_files("drama") == {1: "step1_normalized_script.json"}
@@ -957,6 +990,7 @@ class TestFilesRouter:
         # 其他 generation_mode 回落到 content_mode
         assert files._get_step_files("narration", "storyboard") == {1: "step1_segments.json"}
 
+    @pytest.mark.unit
     def test_resolve_step1_path_narration_prefers_own_legacy_md(self, tmp_path):
         """narration step1 缺 .json 时优先回落自家旧 .md，不被跨模式遗留 reference_units.md 抢占。"""
         drafts_dir = tmp_path / "drafts" / "episode_1"
@@ -966,6 +1000,7 @@ class TestFilesRouter:
         resolved = files._resolve_step1_path(drafts_dir, 1, drafts_dir / "step1_segments.json")
         assert resolved.name == "step1_segments.md"
 
+    @pytest.mark.unit
     def test_draft_content_reference_video_mode(self, tmp_path, monkeypatch):
         """参考生视频模式下读/写 step1_reference_units.json，避免被按 content_mode 错误路由；
         旧 .md 仅存量兼读，写入经 ScriptReviewService 单一出口做结构校验后落结构化 .json"""
@@ -1021,6 +1056,7 @@ class TestFilesRouter:
             saved = json.loads(resp.text)
             assert saved["units"][0]["unit_id"] == "E1U01"
 
+    @pytest.mark.unit
     def test_draft_content_fallback_when_mode_mismatches_file(self, tmp_path, monkeypatch):
         """content_mode=narration 但磁盘上只有 reference_units 文件（集级模式切换/历史项目）也能读到"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -1035,6 +1071,7 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert resp.text == "fallback content"
 
+    @pytest.mark.unit
     def test_draft_content_routes_by_project_generation_mode(self, tmp_path, monkeypatch):
         """草稿文件名按项目生成路线路由：参考路线全项目落 step1_reference_units.json。"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -1069,6 +1106,7 @@ class TestFilesRouter:
         assert content_mode == "narration"
         assert gen_mode == "reference_video"
 
+    @pytest.mark.unit
     def test_draft_event_emission(self, tmp_path, monkeypatch):
         """PUT drafts 端点应发射 draft:created/updated 事件"""
         from unittest.mock import patch
@@ -1106,6 +1144,7 @@ class TestFilesRouter:
             assert change2["action"] == "updated"
             assert change2["important"] is False
 
+    @pytest.mark.unit
     def test_serve_global_asset_image(self, tmp_path, monkeypatch):
         """全局资产图片能够被正确读取返回"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -1117,6 +1156,7 @@ class TestFilesRouter:
             assert resp.status_code == 200
             assert resp.content == b"img-bytes"
 
+    @pytest.mark.unit
     def test_serve_global_asset_scene_and_prop(self, tmp_path, monkeypatch):
         """scene/prop 子目录也能正确读取"""
         client, pm = _client(monkeypatch, tmp_path)
@@ -1133,6 +1173,7 @@ class TestFilesRouter:
             assert r_prop.status_code == 200
             assert r_prop.content == b"prop-bytes"
 
+    @pytest.mark.unit
     def test_global_asset_invalid_type_returns_400(self, tmp_path, monkeypatch):
         """非法 asset_type 返回 400"""
         client, _ = _client(monkeypatch, tmp_path)
@@ -1141,6 +1182,7 @@ class TestFilesRouter:
             resp = client.get("/api/v1/global-assets/invalid/abc.png")
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_global_asset_missing_file_returns_404(self, tmp_path, monkeypatch):
         """文件不存在时返回 404"""
         client, _ = _client(monkeypatch, tmp_path)
@@ -1149,6 +1191,7 @@ class TestFilesRouter:
             resp = client.get("/api/v1/global-assets/character/nonexistent.png")
             assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_global_asset_path_traversal_rejected(self, tmp_path, monkeypatch):
         """filename 中包含 .. 应被阻止（400/403/404 均可接受）"""
         client, _ = _client(monkeypatch, tmp_path)
@@ -1158,6 +1201,7 @@ class TestFilesRouter:
             resp = client.get("/api/v1/global-assets/character/..%2Fevil.png")
             assert resp.status_code in (400, 403, 404)
 
+    @pytest.mark.unit
     def test_global_asset_symlink_escape_returns_403(self, tmp_path, monkeypatch):
         """在 _global_assets/character/ 里放一个指向外部文件的 symlink,应被 resolve-relative 检查拦截为 403。"""
         import os
@@ -1203,6 +1247,7 @@ def _upload_source(client, project_name: str, filename: str, content: bytes, on_
 
 
 class TestSourceMultiFormatUpload:
+    @pytest.mark.unit
     def test_upload_source_utf8_txt_normalized(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1214,6 +1259,7 @@ class TestSourceMultiFormatUpload:
             assert body["original_kept"] is False
             assert body["chapter_count"] == 0
 
+    @pytest.mark.unit
     def test_upload_source_gbk_txt_normalized_and_raw_kept(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1225,12 +1271,14 @@ class TestSourceMultiFormatUpload:
             assert body["used_encoding"] and body["used_encoding"].lower() != "utf-8"
             assert body["original_kept"] is True
 
+    @pytest.mark.unit
     def test_upload_source_doc_rejected_with_400(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
             resp = _upload_source(client, "demo", "x.doc", b"binary")
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_upload_source_conflict_returns_409_with_suggestion(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1241,6 +1289,7 @@ class TestSourceMultiFormatUpload:
             assert body["detail"]["existing"] == "novel.txt"
             assert body["detail"]["suggested_name"] == "novel_1"
 
+    @pytest.mark.unit
     def test_upload_source_on_conflict_replace(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1252,6 +1301,7 @@ class TestSourceMultiFormatUpload:
             assert get_resp.status_code == 200
             assert get_resp.text == "新内容"
 
+    @pytest.mark.unit
     def test_upload_source_on_conflict_rename(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1261,6 +1311,7 @@ class TestSourceMultiFormatUpload:
             body = resp.json()
             assert body["filename"] == "novel_1.txt"
 
+    @pytest.mark.unit
     def test_delete_source_cascades_raw(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -1275,6 +1326,7 @@ class TestSourceMultiFormatUpload:
             assert resp.status_code == 200
             assert not raw_path.exists()
 
+    @pytest.mark.unit
     def test_upload_source_invalid_on_conflict_returns_422(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1285,6 +1337,7 @@ class TestSourceMultiFormatUpload:
             # FastAPI 用 Literal 自动校验 query param，非法值返回 422
             assert resp.status_code == 422
 
+    @pytest.mark.unit
     def test_upload_source_rejects_oversized_upload_by_content_length(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         from lib.source_loader import SourceLoader
@@ -1301,6 +1354,7 @@ class TestSourceMultiFormatUpload:
             )
             assert resp.status_code == 413
 
+    @pytest.mark.unit
     def test_list_files_source_includes_raw_filename(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1312,6 +1366,7 @@ class TestSourceMultiFormatUpload:
             entry = next(e for e in source if e["name"] == "old.txt")
             assert entry["raw_filename"] == "old.txt"
 
+    @pytest.mark.unit
     def test_list_files_source_raw_filename_none_for_pure_utf8(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -1345,6 +1400,7 @@ def _client_with_pm_raising(monkeypatch, sentinel: str):
 class TestFilesUnexpectedErrorsMapTo500:
     """未预期异常应映射为通用 500，且不在响应体泄露内部异常细节。"""
 
+    @pytest.mark.unit
     def test_upload_file_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "upload-boom-a1b2"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1356,6 +1412,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_list_project_files_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "list-boom-c3d4"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1364,6 +1421,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_get_source_file_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "get-source-boom-e5f6"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1372,6 +1430,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_update_source_file_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "update-source-boom-7890"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1384,6 +1443,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_delete_source_file_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "delete-source-boom-1a2b"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1392,6 +1452,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_upload_style_image_unexpected_error_maps_to_500(self, monkeypatch):
         sentinel = "style-image-boom-3c4d"
         client = _client_with_pm_raising(monkeypatch, sentinel)
@@ -1403,6 +1464,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         assert resp.status_code == 500
         assert sentinel not in resp.text
 
+    @pytest.mark.unit
     def test_upload_style_image_vision_unsupported_maps_to_localized_400(self, tmp_path, monkeypatch):
         """简单档模型不支持 vision 时，400 detail 走 i18n 翻译，不透出裸中文技术消息。"""
         from lib.config.resolver import VisionCapabilityError
@@ -1429,6 +1491,7 @@ class TestFilesUnexpectedErrorsMapTo500:
         # 英文 zh 环境默认无 Accept-Language，走中文翻译文案，而非 __str__ 的英文技术消息
         assert "不支持图像输入" in detail
 
+    @pytest.mark.unit
     def test_upload_style_image_backend_value_error_maps_to_500_not_leaked(self, tmp_path, monkeypatch):
         """非 vision 校验的后端构造 ValueError（如凭证文件路径缺失 project_id）不得原样透出为 400。"""
         sentinel = "/secret/vertex_keys/service-account-9f8e.json"

--- a/tests/test_frontend_mcp_tool_i18n.py
+++ b/tests/test_frontend_mcp_tool_i18n.py
@@ -17,6 +17,8 @@ import pytest
 
 from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DASHBOARD_TS = "frontend/src/i18n/{locale}/dashboard.ts"
 LOCALES = ("zh", "en", "vi")

--- a/tests/test_frontend_mount.py
+++ b/tests/test_frontend_mount.py
@@ -11,6 +11,8 @@ from httpx import ASGITransport, AsyncClient
 import lib
 from server import app as app_module
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def reload_app_cleanup(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_frontend_skill_i18n.py
+++ b/tests/test_frontend_skill_i18n.py
@@ -20,6 +20,8 @@ import pytest
 
 from lib.profile_manifest import VALID_CONTENT_MODES
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "agent_runtime_profile" / ".claude" / "skills"
 DASHBOARD_TS = "frontend/src/i18n/{locale}/dashboard.ts"

--- a/tests/test_frontend_task_type_i18n.py
+++ b/tests/test_frontend_task_type_i18n.py
@@ -28,6 +28,8 @@ import pytest
 
 from lib.asset_types import ASSET_SPECS
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DASHBOARD_TS = "frontend/src/i18n/{locale}/dashboard.ts"
 LOCALES = ("zh", "en", "vi")

--- a/tests/test_gemini_image_resolution.py
+++ b/tests/test_gemini_image_resolution.py
@@ -7,6 +7,8 @@ import pytest
 from lib.image_backends.base import ImageGenerationRequest
 from lib.image_backends.gemini import GeminiImageBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend():
     backend = GeminiImageBackend.__new__(GeminiImageBackend)

--- a/tests/test_gemini_video_resolution.py
+++ b/tests/test_gemini_video_resolution.py
@@ -8,6 +8,8 @@ from lib.config.registry import ModelInfo
 from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.gemini import GeminiVideoBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend(model="veo-3.1-lite-generate-preview", backend_type="aistudio"):
     backend = GeminiVideoBackend.__new__(GeminiVideoBackend)

--- a/tests/test_generate_router.py
+++ b/tests/test_generate_router.py
@@ -137,6 +137,7 @@ def _client(monkeypatch, fake_pm, fake_queue):
 
 
 class TestGenerateRouter:
+    @pytest.mark.unit
     def test_storyboard_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -168,6 +169,7 @@ class TestGenerateRouter:
             assert call["resource_id"] == "E1S02"
             assert call["source"] == "webui"
 
+    @pytest.mark.unit
     def test_video_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -225,6 +227,7 @@ class TestGenerateRouter:
         )
         assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_video_enqueue_grid_mode_uses_first_frame(self, tmp_path, monkeypatch):
         """宫格模式：storyboard 写入 _first.png 并记录于 generated_assets，路由应识别该路径。"""
         project_path = _prepare_files(tmp_path)
@@ -321,6 +324,7 @@ class TestGenerateRouter:
             assert video.json()["detail"] == i18n_message("invalid_storyboard_image_path", segment_id="E1S01")
             assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_video_dirty_script_fail_fast_400(self, tmp_path, monkeypatch):
         """脏脚本(分镜数组键损坏)时,/generate/video 应在路由层 4xx 失败,
         而不是 silently 走 default storyboard 路径继续 enqueue —— 后者会让用户
@@ -361,6 +365,7 @@ class TestGenerateRouter:
             # 任务未入队
             assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_video_missing_script_fail_fast_404(self, tmp_path, monkeypatch):
         """剧本文件缺失（FileNotFoundError）时,/generate/video 应 404 fail-fast,
         而不是 silently 走 default storyboard 路径继续 enqueue —— 后者会让用户
@@ -394,6 +399,7 @@ class TestGenerateRouter:
             # 任务未入队
             assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_video_missing_segment_404(self, tmp_path, monkeypatch):
         """segment_id 在脚本中根本不存在时,/generate/video 应 404,而不是
         悄悄走 default storyboard 路径——即使 default 文件恰好存在(如与旧
@@ -419,6 +425,7 @@ class TestGenerateRouter:
             # 任务未入队
             assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_character_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -440,6 +447,7 @@ class TestGenerateRouter:
             assert call["media_type"] == "image"
             assert call["resource_id"] == "Alice"
 
+    @pytest.mark.unit
     def test_character_enqueue_resolves_nfd_registered_key(self, tmp_path, monkeypatch):
         """路径参数与桶 key 形态可以不同：登记闸口落 NFC 后，仍须能按 NFD 原文发起生成，
         且入队的 resource_id 用真实落盘 key，不新造一种编码形式。"""
@@ -462,6 +470,7 @@ class TestGenerateRouter:
             assert resp.status_code == 200, resp.text
             assert fake_queue.calls[0]["resource_id"] == name_nfd
 
+    @pytest.mark.unit
     def test_scene_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -483,6 +492,7 @@ class TestGenerateRouter:
             assert call["media_type"] == "image"
             assert call["resource_id"] == "祠堂"
 
+    @pytest.mark.unit
     def test_prop_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -504,6 +514,7 @@ class TestGenerateRouter:
             assert call["media_type"] == "image"
             assert call["resource_id"] == "玉佩"
 
+    @pytest.mark.unit
     def test_product_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -524,6 +535,7 @@ class TestGenerateRouter:
             assert call["media_type"] == "image"
             assert call["resource_id"] == "保温杯"
 
+    @pytest.mark.unit
     def test_product_enqueue_unknown_product_404(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -538,6 +550,7 @@ class TestGenerateRouter:
             assert resp.status_code == 404
             assert fake_queue.calls == []
 
+    @pytest.mark.unit
     def test_error_paths(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -635,6 +648,7 @@ class TestUnexpectedErrorMapsTo500:
         app.include_router(generate.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
         return TestClient(app, raise_server_exceptions=False)
 
+    @pytest.mark.unit
     def test_storyboard_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_storyboard")
         with client:
@@ -645,6 +659,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_storyboard" not in resp.text
 
+    @pytest.mark.unit
     def test_video_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_video")
         with client:
@@ -655,6 +670,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_video" not in resp.text
 
+    @pytest.mark.unit
     def test_tts_segment_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_tts_segment")
         with client:
@@ -665,6 +681,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_tts_segment" not in resp.text
 
+    @pytest.mark.unit
     def test_tts_batch_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_tts_batch")
         with client:
@@ -675,6 +692,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_tts_batch" not in resp.text
 
+    @pytest.mark.unit
     def test_character_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_character")
         with client:
@@ -685,6 +703,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_character" not in resp.text
 
+    @pytest.mark.unit
     def test_scene_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_scene")
         with client:
@@ -695,6 +714,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_scene" not in resp.text
 
+    @pytest.mark.unit
     def test_prop_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_prop")
         with client:
@@ -705,6 +725,7 @@ class TestUnexpectedErrorMapsTo500:
             assert resp.status_code == 500
             assert "LEAK_prop" not in resp.text
 
+    @pytest.mark.unit
     def test_product_unexpected_error_maps_to_500(self, monkeypatch):
         client = self._client_with_leak(monkeypatch, "LEAK_product")
         with client:
@@ -819,6 +840,7 @@ class TestAdStoryboardRegeneration:
         }
         return fake_pm
 
+    @pytest.mark.unit
     def test_ad_shot_storyboard_enqueue_success(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = self._ad_pm(project_path)
@@ -836,6 +858,7 @@ class TestAdStoryboardRegeneration:
             assert call["task_type"] == "storyboard"
             assert call["resource_id"] == "E1S01"
 
+    @pytest.mark.unit
     def test_ad_shot_not_found_is_404(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = self._ad_pm(project_path)
@@ -875,6 +898,7 @@ class TestNoServerPathLeak:
         fake_pm.load_project = _raise  # type: ignore[method-assign]
         return _client(monkeypatch, fake_pm, _FakeQueue())
 
+    @pytest.mark.unit
     def test_file_not_found_404_hides_path_for_all_endpoints(self, tmp_path, monkeypatch):
         client = self._client_project_missing(tmp_path, monkeypatch)
         requests = [
@@ -894,6 +918,7 @@ class TestNoServerPathLeak:
                 assert "/Users" not in resp.text, f"{url} 泄露路径: {resp.text}"
                 self._assert_no_path(resp)
 
+    @pytest.mark.unit
     def test_script_file_not_found_404_hides_path(self, tmp_path, monkeypatch):
         """load_script 的 FileNotFoundError 是原始泄漏源（消息含绝对路径）。"""
         project_path = _prepare_files(tmp_path)
@@ -913,6 +938,7 @@ class TestNoServerPathLeak:
             assert resp.status_code == 404, resp.text
             self._assert_no_path(resp)
 
+    @pytest.mark.unit
     def test_bad_prompt_400_shape(self, tmp_path, monkeypatch):
         """TaskSpecValidationError → app 级 handler 翻译为 400，无路径片段。"""
         project_path = _prepare_files(tmp_path)
@@ -926,6 +952,7 @@ class TestNoServerPathLeak:
             assert resp.status_code == 400, resp.text
             self._assert_no_path(resp)
 
+    @pytest.mark.unit
     def test_unexpected_error_500_hides_path(self, tmp_path, monkeypatch):
         """未预期异常消息含路径时，500 响应仍为通用文案。"""
         fake_pm = _FakePM(tmp_path / "projects" / "demo")
@@ -957,6 +984,7 @@ class _FakeDedupeHitQueue(_FakeQueue):
 class TestDedupedPassthrough:
     """入队响应透出队列层的 deduped 事实，供前端识别「本次未新建任务」。"""
 
+    @pytest.mark.unit
     def test_fresh_enqueue_reports_deduped_false(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         client = _client(monkeypatch, _FakePM(project_path), _FakeQueue())
@@ -972,6 +1000,7 @@ class TestDedupedPassthrough:
             assert resp.status_code == 200, resp.text
             assert resp.json()["deduped"] is False
 
+    @pytest.mark.unit
     def test_dedupe_hit_reports_deduped_true_with_existing_task_id(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         client = _client(monkeypatch, _FakePM(project_path), _FakeDedupeHitQueue())
@@ -989,6 +1018,7 @@ class TestDedupedPassthrough:
             assert body["deduped"] is True
             assert body["task_id"] == "task-existing"
 
+    @pytest.mark.unit
     def test_asset_generation_exposes_deduped(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         client = _client(monkeypatch, _FakePM(project_path), _FakeDedupeHitQueue())

--- a/tests/test_generate_router_tts.py
+++ b/tests/test_generate_router_tts.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -10,6 +11,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import generate
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeQueue:

--- a/tests/test_generate_router_voice_sample.py
+++ b/tests/test_generate_router_voice_sample.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -13,6 +14,8 @@ from server.error_handlers import register_error_handlers
 from server.routers import generate
 from server.services.generation_context import AudioLaneResult, GenerationContext
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeQueue:

--- a/tests/test_generation_queue.py
+++ b/tests/test_generation_queue.py
@@ -9,6 +9,8 @@ from lib.db.base import Base
 from lib.generation_queue import GenerationQueue
 from lib.task_failure import encode_failure
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def queue():

--- a/tests/test_generation_queue_client.py
+++ b/tests/test_generation_queue_client.py
@@ -17,6 +17,8 @@ from lib.generation_queue_client import (
     wait_for_task,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestTaskSpecFromRequest:
     def test_video_string_prompt_builds_spec(self):

--- a/tests/test_generation_tasks_dispatch.py
+++ b/tests/test_generation_tasks_dispatch.py
@@ -8,10 +8,12 @@ from lib.video_backends.base import VideoCapabilityError
 from server.services.generation_tasks import _SKELETON_DRIVEN_TASK_ACTIONS, _TASK_EXECUTORS
 
 
+@pytest.mark.unit
 def test_task_executors_registered_for_reference_video():
     assert "reference_video" in _TASK_EXECUTORS
 
 
+@pytest.mark.unit
 def test_task_change_action_registered_for_reference_video():
     # entity_type 不再是静态 spec：按剧本骨架种类动态解析（见
     # test_generation_tasks_service.py 里对 emit_generation_success_batch 的骨架覆盖用例），
@@ -20,6 +22,7 @@ def test_task_change_action_registered_for_reference_video():
     assert _SKELETON_DRIVEN_TASK_ACTIONS.get("reference_video") == "reference_video_ready"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_generation_task_rejects_unknown_type():
     from server.services.generation_tasks import execute_generation_task
@@ -73,6 +76,7 @@ async def test_execute_generation_task_propagates_capability_errors_unrendered(m
     assert exc_info.value.code == error.code
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_generation_task_propagates_other_exceptions(monkeypatch):
     """非能力类异常同样原样冒泡"""

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -12,9 +12,11 @@ from server.services.generation_tasks import assert_duration_supported
 
 
 class TestAssertDurationSupported:
+    @pytest.mark.unit
     def test_supported_duration_passes(self):
         assert_duration_supported(8, [4, 6, 8])  # no raise
 
+    @pytest.mark.unit
     def test_unsupported_duration_rejected(self):
         # 抛带稳定 code 的能力错误（与 ImageCapabilityError 对称），细节在 params。
         with pytest.raises(VideoCapabilityError) as exc:
@@ -22,15 +24,18 @@ class TestAssertDurationSupported:
         assert exc.value.code == "video_duration_not_supported"
         assert exc.value.params["duration"] == 5
 
+    @pytest.mark.unit
     def test_empty_supported_list_passes(self):
         # 能力不可解析时不更坏：空列表放行，保持既有行为不被本次改动弄坏。
         assert_duration_supported(99, [])  # no raise
 
+    @pytest.mark.unit
     def test_integer_like_string_and_float_accepted(self):
         # 外部配置可能给字符串 / 浮点，可解析为整数秒的归一化后通过，不抛裸异常。
         assert_duration_supported("6", [4, 6, 8])  # no raise
         assert_duration_supported(6.0, [4, 6, 8])  # no raise
 
+    @pytest.mark.unit
     def test_fractional_duration_rejected_not_truncated(self):
         # 非整数秒一律拒绝，绝不截断成「碰巧合法」的 4。
         with pytest.raises(VideoCapabilityError) as exc:
@@ -39,6 +44,7 @@ class TestAssertDurationSupported:
         with pytest.raises(VideoCapabilityError):
             assert_duration_supported("4.5", [4, 6, 8])
 
+    @pytest.mark.unit
     def test_non_numeric_duration_rejected(self):
         with pytest.raises(VideoCapabilityError) as exc:
             assert_duration_supported("abc", [4, 6, 8])
@@ -46,6 +52,7 @@ class TestAssertDurationSupported:
 
 
 class TestCollectSheetReferences:
+    @pytest.mark.unit
     def test_max_count_truncates_refs_from_single_item(self, tmp_path):
         # 单个 item 内的角色数就超过 max_count 时，_group 内层三段循环不会在
         # item 中途触发外层 break，需要在返回前再做一次显式切片。
@@ -283,6 +290,7 @@ def _prepare_files(tmp_path: Path):
 
 
 class TestGenerationTasks:
+    @pytest.mark.unit
     def test_helper_functions(self, tmp_path):
         from lib.storyboard_sequence import get_storyboard_items
 
@@ -328,6 +336,7 @@ class TestGenerationTasks:
         with pytest.raises(ValueError):
             generation_tasks._normalize_video_prompt("   ")
 
+    @pytest.mark.unit
     async def test_execute_task_dispatch(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -434,6 +443,7 @@ class TestGenerationTasks:
                 {"task_type": "unknown", "project_name": "demo", "resource_id": "x", "payload": {}}
             )
 
+    @pytest.mark.unit
     async def test_execute_product_task_injects_reference_images(self, tmp_path, monkeypatch):
         """product sheet 生成把用户上传原图作为参考注入（标准化整理的输入），缺失文件跳过；
         完成后回写 product_sheet。"""
@@ -458,6 +468,7 @@ class TestGenerationTasks:
         assert call["reference_images"] == [project_path / "products" / "refs" / "保温杯_1.jpg"]
         assert "保温杯" in call["prompt"]
 
+    @pytest.mark.unit
     async def test_execute_product_task_without_refs_is_t2i(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -470,6 +481,7 @@ class TestGenerationTasks:
         await generation_tasks.execute_product_task("demo", "保温杯", {"prompt": "保温杯"})
         assert fake_generator.image_calls[0]["reference_images"] is None
 
+    @pytest.mark.unit
     def test_collect_product_reference_images_rejects_path_escape(self, tmp_path):
         """reference_images 中的绝对路径与 `..` 穿越值不得越出项目目录读取宿主机文件；目录路径同样跳过。"""
         project_path = _prepare_files(tmp_path)
@@ -493,6 +505,7 @@ class TestGenerationTasks:
 
         assert result == [project_path / "products" / "refs" / "保温杯_1.jpg"]
 
+    @pytest.mark.unit
     def test_product_fingerprints(self, monkeypatch, tmp_path):
         project_path = _prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
@@ -502,6 +515,7 @@ class TestGenerationTasks:
         fps = generation_tasks.compute_affected_fingerprints("demo", "product", "保温杯")
         assert "products/保温杯.png" in fps
 
+    @pytest.mark.unit
     async def test_execute_video_task_generates_thumbnail(self, monkeypatch, tmp_path):
         """视频生成后应自动提取首帧缩略图"""
         project_path = _prepare_files(tmp_path)
@@ -560,6 +574,7 @@ class TestGenerationTasks:
         await generation_tasks.execute_video_task("demo", "E1S01", payload)
         assert seen_lanes[-1]["video"].capability == "r2v"
 
+    @pytest.mark.unit
     async def test_execute_video_task_rejects_unsupported_duration(self, monkeypatch, tmp_path):
         """执行层在解析出 ProviderModel 后，对越界 duration 以明确错误拒绝。"""
         project_path = _prepare_files(tmp_path)
@@ -583,6 +598,7 @@ class TestGenerationTasks:
         # 越界 duration 在起跑时被拒，绝不应调用后端生成。
         assert fake_generator.video_calls == []
 
+    @pytest.mark.unit
     async def test_execute_video_task_supported_duration_passes(self, monkeypatch, tmp_path):
         """合法 duration 通过守卫，正常进入后端生成。"""
         project_path = _prepare_files(tmp_path)
@@ -1102,6 +1118,7 @@ class TestGenerationTasks:
         for call in fake_generator.video_calls:
             assert call["end_image"] == end_frame_dir / "scene_E1S01.png"
 
+    @pytest.mark.unit
     async def test_execute_video_task_drama_dialogue_from_utterances(self, monkeypatch, tmp_path):
         """drama 口型台词从场景级 dialogue-kind utterances 取（覆盖 payload 已不带的
         video_prompt.dialogue）；voiceover-kind 不进视频 YAML。"""
@@ -1172,6 +1189,7 @@ class TestGenerationTasks:
             ],
         }
 
+    @pytest.mark.unit
     async def test_execute_video_task_injects_voice_profiles_for_audible_model(self, monkeypatch, tmp_path):
         """有音轨模型（voice_consistency != none）：dialogue speaker 命中的角色资产
         非空 voice_style 机械派生进 Voice_Profiles 顶部声明段。"""
@@ -1204,6 +1222,7 @@ class TestGenerationTasks:
         # 顶部集中声明段须先于 Action 出现
         assert prompt_yaml.index("Voice_Profiles") < prompt_yaml.index("Action")
 
+    @pytest.mark.unit
     async def test_execute_video_task_skips_voice_profiles_for_silent_model(self, monkeypatch, tmp_path):
         """C 类（真无声，voice_consistency == none）模型不注入 Voice_Profiles。"""
         project_path = _prepare_files(tmp_path)
@@ -1233,6 +1252,7 @@ class TestGenerationTasks:
         assert "Voice_Profiles" not in prompt_yaml
         assert "低沉沙哑" not in prompt_yaml
 
+    @pytest.mark.unit
     async def test_execute_video_task_strips_caller_supplied_voice_profiles_for_non_drama(self, monkeypatch, tmp_path):
         """narration/ad（item 无 utterances 字段）请求体自带 voice_profiles 时一律剥离：
         该声明段唯一来源是 build_drama_video_prompt 的机械派生，调用方不得越权注入、绕过
@@ -1264,6 +1284,7 @@ class TestGenerationTasks:
         assert "Voice_Profiles" not in prompt_yaml
         assert "越权" not in prompt_yaml
 
+    @pytest.mark.unit
     async def test_execute_video_task_injects_voice_profiles_from_legacy_dialogue(self, monkeypatch, tmp_path):
         """utterances 迁移前的存量 drama 剧本（scene 无 utterances 字段，台词仍在
         video_prompt.dialogue）：load_script 按原始 JSON 读盘不过 pydantic 迁移，改走 legacy
@@ -1315,6 +1336,7 @@ class TestGenerationTasks:
         assert "低沉沙哑" in prompt_yaml
         assert "你来了。" in prompt_yaml
 
+    @pytest.mark.unit
     async def test_execute_video_task_content_mode_falls_back_to_project_when_episode_omits_it(
         self, monkeypatch, tmp_path
     ):
@@ -1367,6 +1389,7 @@ class TestGenerationTasks:
         assert "低沉沙哑" in prompt_yaml
         assert "你来了。" in prompt_yaml
 
+    @pytest.mark.unit
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
         project_path = _prepare_files(tmp_path)
@@ -1392,6 +1415,7 @@ class TestGenerationTasks:
         assert result["resource_type"] == "videos"
         assert fake_generator.video_calls[0]["duration_seconds"] == 6
 
+    @pytest.mark.unit
     async def test_execute_video_task_default_duration_respects_resolution_constraint(self, monkeypatch, tmp_path):
         """Auto（无显式 duration）在受约束分辨率下取约束内的时长，而非 supported_durations 首项。
 
@@ -1423,6 +1447,7 @@ class TestGenerationTasks:
         )
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
 
+    @pytest.mark.unit
     async def test_empty_supported_durations_guard_permissive(self, monkeypatch, tmp_path):
         """能力不可解析时 lane 交付空 supported_durations：守卫放行（不更坏），
         resolution 仍取自 lane 已解析出的值，不因能力缺失被改写。"""
@@ -1452,6 +1477,7 @@ class TestGenerationTasks:
         assert fake_generator.video_calls[0]["duration_seconds"] == 9
         assert fake_generator.video_calls[0]["resolution"] == "720p"
 
+    @pytest.mark.unit
     async def test_video_resolve_failure_fails_task_without_fallback(self, monkeypatch, tmp_path):
         """视频解析失败即任务失败：异常原样上抛留痕，无硬编码 provider/model 兜底，后端不被调用。"""
         project_path = _prepare_files(tmp_path)
@@ -1475,6 +1501,7 @@ class TestGenerationTasks:
             )
         assert fake_generator.video_calls == []
 
+    @pytest.mark.unit
     async def test_tasks_declare_only_needed_lanes(self, monkeypatch, tmp_path):
         """任务只声明自己用到的 lane：图片类任务不声明 video/audio（只配置图片供应商的项目
         不因视频供应商缺配置失败，未声明 lane 不解析见 tests/server/test_generation_context.py），
@@ -1520,6 +1547,7 @@ class TestGenerationTasks:
         assert seen[0]["image"] is None
         assert seen[0]["audio"] is None
 
+    @pytest.mark.unit
     def test_emit_success_batch_includes_fingerprints(self, monkeypatch, tmp_path):
         """生成成功事件应携带 asset_fingerprints"""
         captured = []
@@ -1551,6 +1579,7 @@ class TestGenerationTasks:
         assert "storyboards/scene_E1S01.png" in change["asset_fingerprints"]
         assert isinstance(change["asset_fingerprints"]["storyboards/scene_E1S01.png"], int)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("script", "expected_entity_type", "expected_label"),
         [
@@ -1606,6 +1635,7 @@ class TestGenerationTasks:
             assert change["action"] == action
             assert change["label"] == expected_label
 
+    @pytest.mark.unit
     def test_emit_success_batch_reference_video_entity_type_aligns_with_frontend(self, monkeypatch, tmp_path):
         """参考生视频任务完成通知的 entity_type 需为前端联合类型认识的 "reference_unit"
         （而非仅本侧认识的 "reference_video_unit"），分组标题才能落「视频单元」而非「内容」
@@ -1636,6 +1666,7 @@ class TestGenerationTasks:
         assert change["action"] == "reference_video_ready"
         assert change["label"] == "参考视频「U01」"
 
+    @pytest.mark.unit
     def test_emit_success_batch_reference_video_ad_entity_type_not_shot(self, monkeypatch, tmp_path):
         """ad 剧本骨架恒为 shots[]，reference_video 路径派生的 video_unit 索引与 shots
         同存于一份剧本 JSON——resolve_script_kind 的数据形状判别会因 shots 键仍在而落回
@@ -1671,6 +1702,7 @@ class TestGenerationTasks:
         assert change["action"] == "reference_video_ready"
         assert change["label"] == "参考视频「U01」"
 
+    @pytest.mark.unit
     def test_emit_success_batch_falls_back_to_segments_when_script_load_fails(self, monkeypatch, tmp_path):
         """骨架判定拿不到剧本（脚本缺失/损坏）时兜底 segments/「分镜」，不让通知发送中断。"""
         captured = []
@@ -1702,6 +1734,7 @@ class TestGenerationTasks:
         assert change["entity_type"] == "segment"
         assert change["label"] == "分镜「E1S01」"
 
+    @pytest.mark.unit
     def test_emit_success_batch_falls_back_to_segments_when_script_not_a_dict(self, monkeypatch, tmp_path):
         """剧本文件内容损坏成非 dict（如顶层数组）时兜底 segments/「分镜」，不让
         resolve_script_kind 内部的 .get() 调用抛 AttributeError 中断通知发送。"""
@@ -1730,6 +1763,7 @@ class TestGenerationTasks:
         assert change["entity_type"] == "segment"
         assert change["label"] == "分镜「E1S01」"
 
+    @pytest.mark.unit
     def test_emit_success_batch_attaches_script_file_and_episode(self, monkeypatch, tmp_path):
         """骨架驱动的完成事件须挂 script_file 与 episode（供 episode 作用域消费方使用）——
         锁死这条挂载，防将来改动 emit 时静默丢字段。"""
@@ -1759,6 +1793,7 @@ class TestGenerationTasks:
             assert change["script_file"] == "ep03.json"
             assert change["episode"] == 3
 
+    @pytest.mark.unit
     def test_grid_fingerprints_include_split_cells(self, monkeypatch, tmp_path):
         """宫格指纹应包含切割覆写的 canonical 分镜图（cache-bust），但拒绝越出项目目录的路径"""
         from lib.grid.models import FrameCell, GridGeneration
@@ -1822,6 +1857,7 @@ class TestGenerationTasks:
         assert all("outside" not in key for key in fps)
         assert all(not key.startswith("/") for key in fps)
 
+    @pytest.mark.unit
     async def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -1849,24 +1885,29 @@ class TestGenerationTasks:
 
 
 class TestGetAspectRatio:
+    @pytest.mark.unit
     def test_reads_top_level_aspect_ratio(self):
         project = {"aspect_ratio": "16:9", "content_mode": "narration"}
         assert generation_tasks.get_aspect_ratio(project, "videos") == "16:9"
         assert generation_tasks.get_aspect_ratio(project, "storyboards") == "16:9"
 
+    @pytest.mark.unit
     def test_fallback_to_content_mode_narration(self):
         project = {"content_mode": "narration"}
         assert generation_tasks.get_aspect_ratio(project, "videos") == "9:16"
 
+    @pytest.mark.unit
     def test_fallback_to_content_mode_drama(self):
         project = {"content_mode": "drama"}
         assert generation_tasks.get_aspect_ratio(project, "videos") == "16:9"
 
+    @pytest.mark.unit
     def test_characters_always_16_9(self):
         # 角色资产统一采用四视图横版，与项目整体画幅无关
         project = {"aspect_ratio": "9:16"}
         assert generation_tasks.get_aspect_ratio(project, "characters") == "16:9"
 
+    @pytest.mark.unit
     def test_scenes_and_props_always_16_9(self):
         project = {"aspect_ratio": "9:16"}
         assert generation_tasks.get_aspect_ratio(project, "scenes") == "16:9"
@@ -1920,6 +1961,7 @@ class TestAdProductFidelityStoryboard:
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
 
+    @pytest.mark.unit
     async def test_product_shot_injects_sheet_then_originals_before_other_sheets(self, tmp_path, monkeypatch):
         """有确认 sheet 的产品镜头：注入集为「sheet 多角度 + 原图压阵」，排序绝对优先于角色/场景 sheet。"""
         project_path = _prepare_files(tmp_path)
@@ -1950,6 +1992,7 @@ class TestAdProductFidelityStoryboard:
         assert "「保温杯」" in prompt
         assert "参考图" in prompt
 
+    @pytest.mark.unit
     async def test_product_shot_without_sheet_injects_originals_directly(self, tmp_path, monkeypatch):
         """无 sheet 的产品镜头：原图直注、仍排首位；声明但缺失的原图跳过。"""
         project_path = _prepare_files(tmp_path)
@@ -1967,6 +2010,7 @@ class TestAdProductFidelityStoryboard:
         assert all("missing" not in str(p) for p in paths)
         assert "「保温杯」" in generator.image_calls[0]["prompt"]
 
+    @pytest.mark.unit
     async def test_fidelity_instruction_only_names_products_with_injected_references(self, tmp_path, monkeypatch):
         """指令点名的产品与实际注入参考的产品一致：图全缺的产品不被指令点名（避免指向不存在的参考）。"""
         project_path = _prepare_files(tmp_path)
@@ -1990,6 +2034,7 @@ class TestAdProductFidelityStoryboard:
         assert "「保温杯」" in prompt
         assert "「杯刷」" not in prompt
 
+    @pytest.mark.unit
     async def test_atmosphere_shot_zero_product_images(self, tmp_path, monkeypatch):
         """氛围镜头（products_in_shot 为空）：零产品图，场景/角色 sheet 照常注入，prompt 无保真指令。"""
         project_path = _prepare_files(tmp_path)
@@ -2012,6 +2057,7 @@ class TestAdProductFidelityStoryboard:
         assert prompt.startswith("氛围开场")
         assert "产品高保真还原" not in prompt
 
+    @pytest.mark.unit
     def test_collect_shot_product_references_skips_non_list_products_in_shot(self, tmp_path):
         """products_in_shot 为 str/dict 等非列表脏数据：跳过不抛，零产品参考（str 不得被逐字符迭代）。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -75,14 +75,17 @@ class _FakeQueue:
 
 
 class TestReadIntEnv:
+    @pytest.mark.unit
     def test_default_when_unset(self, monkeypatch):
         monkeypatch.delenv("ARCREEL_INT", raising=False)
         assert _read_int_env("ARCREEL_INT", 3, minimum=1) == 3
 
+    @pytest.mark.unit
     def test_default_when_bad(self, monkeypatch):
         monkeypatch.setenv("ARCREEL_INT", "bad")
         assert _read_int_env("ARCREEL_INT", 3, minimum=1) == 3
 
+    @pytest.mark.unit
     def test_minimum_enforced(self, monkeypatch):
         monkeypatch.setenv("ARCREEL_INT", "0")
         assert _read_int_env("ARCREEL_INT", 3, minimum=2) == 2
@@ -114,16 +117,19 @@ async def _patch_empty_db(monkeypatch):
 class TestExtractProvider:
     """_extract_provider 是解析链的薄投影：按 task_type 派发，取 .provider_id。"""
 
+    @pytest.mark.unit
     async def test_video_payload_provider(self):
         """payload 携带历史 video_provider → 投影直接取到（payload 层短路，无需 DB）。"""
         task = {"payload": {"video_provider": "ark"}, "task_type": "video"}
         assert await _extract_provider(task) == "ark"
 
+    @pytest.mark.unit
     async def test_image_payload_provider(self):
         """payload 携带历史 image_provider → 投影取到。"""
         task = {"payload": {"image_provider": "gemini-vertex"}, "task_type": "storyboard"}
         assert await _extract_provider(task) == "gemini-vertex"
 
+    @pytest.mark.unit
     async def test_default_when_unresolvable(self, _patch_empty_db):
         """无 project、无 payload、全局未配供应商 → 回退 DEFAULT_PROVIDER（仅供限流）。
 
@@ -133,18 +139,21 @@ class TestExtractProvider:
         task = {"payload": {}}
         assert await _extract_provider(task) == DEFAULT_PROVIDER
 
+    @pytest.mark.unit
     async def test_project_level_video_backend(self, monkeypatch):
         """项目级 video_backend 优先于全局默认。"""
         _patch_pm(monkeypatch, {"video_backend": "ark/doubao-seedance-1-5-pro-251215"})
         task = {"payload": {}, "project_name": "demo", "task_type": "video"}
         assert await _extract_provider(task) == "ark"
 
+    @pytest.mark.unit
     async def test_project_level_image_t2i(self, monkeypatch):
         """image 投影按代表性 capability=t2i 取项目级 image_provider_t2i。"""
         _patch_pm(monkeypatch, {"image_provider_t2i": "gemini-vertex/imagen-3"})
         task = {"payload": {}, "project_name": "demo", "task_type": "storyboard"}
         assert await _extract_provider(task) == "gemini-vertex"
 
+    @pytest.mark.unit
     async def test_reference_video_routes_to_video_lane(self, monkeypatch):
         """reference_video task_type 必须按 video lane 解析 video_backend，而非 image 槽。
 
@@ -176,12 +185,14 @@ class TestExtractProvider:
         task = {"payload": {}, "project_name": "demo", "task_type": "reference_video"}
         assert await _extract_provider(task) == "minimax"
 
+    @pytest.mark.unit
     async def test_payload_provider_takes_precedence_over_project(self, monkeypatch):
         """payload 历史 provider 优先于项目级。"""
         _patch_pm(monkeypatch, {"video_backend": "grok/grok-imagine-video"})
         task = {"payload": {"video_provider": "ark"}, "project_name": "demo", "task_type": "video"}
         assert await _extract_provider(task) == "ark"
 
+    @pytest.mark.unit
     async def test_deleted_project_load_failure_falls_back_not_raises(self, monkeypatch):
         """指向已删除/不可读项目的历史任务：load_project 抛错也须回退 DEFAULT_PROVIDER，
         绝不冒泡阻断认领循环（否则一个坏任务会拖垮整个 worker）。"""
@@ -200,6 +211,7 @@ class TestExtractProvider:
 class TestExtractProviderAlignsWithExecution:
     """M5 投影对齐：worker 取到的 provider_id 与执行层解析在同一 project/payload 下一致。"""
 
+    @pytest.mark.unit
     async def test_image_alignment(self, monkeypatch):
         from lib.config.resolver import ConfigResolver
         from lib.db import async_session_factory
@@ -212,6 +224,7 @@ class TestExtractProviderAlignsWithExecution:
         resolved = await ConfigResolver(async_session_factory).resolve_image_backend(project, {}, capability="t2i")
         assert worker_provider == resolved.provider_id == "openai"
 
+    @pytest.mark.unit
     async def test_video_alignment(self, monkeypatch):
         from lib.config.resolver import ConfigResolver
         from lib.db import async_session_factory
@@ -228,6 +241,7 @@ class TestExtractProviderAlignsWithExecution:
 class TestCapacityTable:
     """容量表：provider × media_type → 上限，三态 get + reload 只换数字。"""
 
+    @pytest.mark.unit
     def test_get_three_states(self):
         table = CapacityTable(
             _limits={"known": {"image": 4, "video": 0}},
@@ -243,6 +257,7 @@ class TestCapacityTable:
         assert table.get("unknown", "video") == 3
         assert "unknown" not in table._limits
 
+    @pytest.mark.unit
     def test_replace_only_swaps_numbers(self):
         table = CapacityTable(_limits={"p": {"image": 3, "video": 3}}, _defaults={"image": 5, "video": 3})
         table.replace({"p": {"image": 9, "video": 1}})
@@ -251,6 +266,7 @@ class TestCapacityTable:
         # 默认不受 replace 影响
         assert table.get("unknown", "image") == 5
 
+    @pytest.mark.unit
     def test_from_env_derives_support_and_defaults(self, monkeypatch):
         from lib.config.registry import PROVIDER_REGISTRY
 
@@ -270,6 +286,7 @@ class TestCapacityTable:
                     # 反推，否则对任何声明值都恒真，等于不设防。
                     assert table.get(pid, lane) == global_default
 
+    @pytest.mark.unit
     def test_from_env_reads_env(self, monkeypatch):
         monkeypatch.setenv("IMAGE_MAX_WORKERS", "7")
         monkeypatch.setenv("VIDEO_MAX_WORKERS", "2")
@@ -278,6 +295,7 @@ class TestCapacityTable:
         assert table.get("unknown", "image") == 7
         assert table.get("unknown", "video") == 2
 
+    @pytest.mark.unit
     async def test_from_db_known_providers_and_unsupported_lanes_zero(self):
         """from_db：所有 registry provider 已知，不支持的 lane 强制 0。
 
@@ -337,6 +355,7 @@ class TestCapacityTable:
         models = [SimpleNamespace(endpoint=ep, is_enabled=True) for ep in endpoints]
         return provider, models
 
+    @pytest.mark.unit
     async def test_from_db_custom_provider_columns_used(self, monkeypatch):
         """自定义供应商：列有值 → 取列值（投影到其支持的 lane）。"""
         self._stub_from_db_sources(
@@ -359,6 +378,7 @@ class TestCapacityTable:
         # 不支持的 lane（无 audio 模型）投影为 0
         assert table.get("custom-1", "audio") == 0
 
+    @pytest.mark.unit
     async def test_from_db_custom_provider_null_falls_back_to_global_default(self, monkeypatch):
         """自定义供应商：列为 None → 回退全局默认（两层回退，无声明默认层）。"""
         self._stub_from_db_sources(
@@ -380,6 +400,7 @@ class TestCapacityTable:
         assert table.get("custom-9", "image") == 5
         assert table.get("custom-9", "video") == 3
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("dirty", ["", "3.7", "abc"])
     async def test_from_db_dirty_value_falls_back_per_key(self, monkeypatch, caplog, dirty):
         """单个 key 的存量脏值只回退该 key 默认值并告警，不拖垮整表加载。"""
@@ -403,6 +424,7 @@ class TestCapacityTable:
         assert table.get("ark", "video") == 2
         assert table.get("gemini-aistudio", "image") == 7
 
+    @pytest.mark.unit
     async def test_from_db_negative_value_clamps_to_zero(self, monkeypatch, caplog):
         """可解析的负数沿用 clamp 语义（→0），不视为脏值回退默认，但留告警可观测。"""
         import logging
@@ -461,6 +483,7 @@ class TestCapacityTable:
         }
         monkeypatch.setattr("lib.config.registry.PROVIDER_REGISTRY", registry)
 
+    @pytest.mark.unit
     def test_from_env_uses_registry_declared_default(self, monkeypatch):
         self._registry_with_declared_defaults(monkeypatch)
         monkeypatch.delenv("IMAGE_MAX_WORKERS", raising=False)
@@ -480,6 +503,7 @@ class TestCapacityTable:
         # 声明了 image 默认但该 provider 不支持 image → 投影为 0（_lane_limits 不回归）
         assert table.get("declared-unsupported", "image") == 0
 
+    @pytest.mark.unit
     async def test_from_db_declared_default_when_user_unconfigured(self, monkeypatch):
         """用户未配 → 取注册表声明默认（而非全局默认）；未声明 provider 仍走全局默认。"""
         self._registry_with_declared_defaults(monkeypatch)
@@ -493,6 +517,7 @@ class TestCapacityTable:
         assert table.get("plain-video", "video") == 3
         assert table.get("declared-unsupported", "image") == 0
 
+    @pytest.mark.unit
     async def test_from_db_user_value_overrides_declared_default(self, monkeypatch):
         """用户配了值 → 覆盖注册表声明默认。"""
         self._registry_with_declared_defaults(monkeypatch)
@@ -502,6 +527,7 @@ class TestCapacityTable:
 
         assert table.get("declared-video", "video") == 4
 
+    @pytest.mark.unit
     async def test_from_db_and_from_env_consistent_fallback(self, monkeypatch):
         """两条装载路径对同一回退语义（用户未配）逐 lane 结果一致。"""
         self._registry_with_declared_defaults(monkeypatch)
@@ -514,6 +540,7 @@ class TestCapacityTable:
             for lane in ("image", "video", "audio"):
                 assert db_table.get(pid, lane) == env_table.get(pid, lane)
 
+    @pytest.mark.unit
     def test_agnes_video_default_one_outranks_active_global_env(self, monkeypatch):
         """真实注册表：Agnes 视频 lane 出厂钉死 1，即便部署把全局 VIDEO_MAX_WORKERS 调高也不解除。
 
@@ -533,6 +560,7 @@ class TestCapacityTable:
 
 
 class TestGenerationWorker:
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_success_and_failure(self, monkeypatch):
         queue = _FakeQueue()
@@ -626,6 +654,7 @@ class TestGenerationWorker:
         await worker._process_task({"task_id": "t_circular"})
         assert queue.failed and queue.failed[0] == ("t_circular", "[script_edit_error]")
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_cancelled_error_marks_cancelled(self, monkeypatch):
         """ADR 0006: asyncio.CancelledError 走 finally → mark_cancelled。"""
@@ -640,6 +669,7 @@ class TestGenerationWorker:
             await worker._process_task({"task_id": "tc"})
         assert queue.cancelled and queue.cancelled[0][0] == "tc"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_task_zero_rows_succeeded_falls_through_to_cancelled(self, monkeypatch):
         """ADR 0006 0-rows-cancelled 协议：mark_succeeded 返回 0 时 finally 调 mark_cancelled。"""
@@ -655,6 +685,7 @@ class TestGenerationWorker:
         assert queue.succeeded == [("t0rows", {"result": "ok"})]
         assert queue.cancelled and queue.cancelled[0][0] == "t0rows"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_request_cancel_signals_inflight_task(self):
         queue = _FakeQueue()
@@ -674,6 +705,7 @@ class TestGenerationWorker:
         # 不在 inflight → False
         assert worker.request_cancel("ghost") is False
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_drain_finished_tasks_absorbs_cancelled_error(self):
         """取消的 inflight task 被 drain：不抛、从台账移除，并 drain 端兜底 mark_cancelled。"""
@@ -695,6 +727,7 @@ class TestGenerationWorker:
         # 子任务来不及自落终态时，drain 端兜底 mark_cancelled。
         assert queue.cancelled and queue.cancelled[0][0] == "tid"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_drain_finished_tasks_drains_success_and_failure(self):
         """非取消路径：成功 task 走 .result() 无异常，失败 task 走 except 分支，均不触发兜底取消。"""
@@ -719,6 +752,7 @@ class TestGenerationWorker:
         # 非取消任务不应触发 drain 兜底 mark_cancelled
         assert queue.cancelled == []
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_drain_fallback_mark_cancelled_failure_does_not_propagate(self):
         """drain 端兜底 mark_cancelled 自身抛错时只 warning，不冒泡（不挂掉主循环）。"""
@@ -743,6 +777,7 @@ class TestGenerationWorker:
         await worker._drain_finished_tasks()
         assert worker._slots.occupied("test", "video") == 0
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_drain_marks_cancelled_when_cancel_hits_before_process_task_try(self, monkeypatch):
         """取消落在 _process_task 进 try 之前（_extract_provider await）：drain 端兜底落终态。"""
@@ -783,6 +818,7 @@ class TestGenerationWorker:
 
         await asyncio.wait_for(worker.stop(), timeout=2.0)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_run_loop_survives_inflight_task_cancellation(self, monkeypatch):
         """用户取消运行中的任务：任务 mark_cancelled，但 worker 主循环不退出。"""
@@ -819,6 +855,7 @@ class TestGenerationWorker:
         await asyncio.wait_for(worker.stop(), timeout=2.0)
         assert queue.released
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_run_loop_survives_consecutive_cancellations_and_keeps_claiming(self, monkeypatch):
         """连续取消多个 inflight 任务后，主循环仍存活并能继续 claim 新任务。"""
@@ -886,6 +923,7 @@ class TestGenerationWorker:
         await asyncio.wait_for(worker.stop(), timeout=2.0)
         assert queue.released
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_stop_event_exits_loop_even_with_cancellations(self, monkeypatch):
         """语义对比：单任务取消不退出，但显式 stop（set stop event）必须让 worker 退出。"""
@@ -921,6 +959,7 @@ class TestGenerationWorker:
         assert worker._main_task is None
         assert queue.released
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_cancelling_marks_cancelled(self, monkeypatch):
         """ADR 0007：orphan cancelling 状态 → mark_cancelled。"""
@@ -941,6 +980,7 @@ class TestGenerationWorker:
         await worker._handle_orphan_tasks_on_start()
         assert queue.cancelled and queue.cancelled[0][0] == "orphan-cancelling"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_running_no_job_id_marks_restart_lost(self, monkeypatch):
         """ADR 0007：running 但无 provider_job_id → [restart_lost]。"""
@@ -962,6 +1002,7 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "orphan-lost"
         assert "[restart_lost_no_job_id]" in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_start_stop_run_loop_releases_lease(self):
         queue = _FakeQueue()
@@ -976,6 +1017,7 @@ class TestGenerationWorker:
         assert queue.released
         assert worker._main_task is None
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_claim_tasks_dispatches_to_correct_pool(self, monkeypatch):
         """Tasks are dispatched to the correct provider slot."""
@@ -1031,6 +1073,7 @@ class TestGenerationWorker:
     # ------------------------------------------------------------------
     # _pool_full_providers
     # ------------------------------------------------------------------
+    @pytest.mark.unit
     def test_pool_full_providers_sources_from_occupancy_with_cap_guard(self):
         """池满黑名单源 = 有占用的 provider；cap==0 守卫短路降级 lane 的在跑占用。
 
@@ -1073,6 +1116,7 @@ class TestGenerationWorker:
     # ------------------------------------------------------------------
     # _handle_orphan_tasks_on_start：分流补全
     # ------------------------------------------------------------------
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_image_running_marks_restart_lost(self, monkeypatch):
         """image 孤儿无 resume 入口 → [restart_lost]，绝不主动 requeue（避免重复扣费）。"""
@@ -1101,6 +1145,7 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "img-orphan"
         assert "[restart_lost_image]" in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_non_resumable_video_marks_resume_unsupported(self, monkeypatch):
         """Grok/Vidu video 孤儿 → [resume_unsupported]（backend 无 resume，绝不重跑）。"""
@@ -1132,6 +1177,7 @@ class TestGenerationWorker:
         assert "[resume_unsupported_provider]" in queue.failed[0][1]
         assert PROVIDER_GROK in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_discard_paths_fallback_to_cancelled_on_zero_rows(self, monkeypatch):
         """非 resumable 路径 mark_failed 返 0 rows（race：被外部 cancel）→ 兜底 mark_cancelled。
@@ -1169,6 +1215,7 @@ class TestGenerationWorker:
         cancelled_ids = {tid for tid, _by in queue.cancelled}
         assert cancelled_ids == {"img-raced", "grok-raced"}
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_uses_persisted_provider_id(self, monkeypatch):
         """task.provider_id 优先于 _extract_provider 的当前项目解析（CR round-2 N2 回归）。
@@ -1212,6 +1259,7 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "ghost-orphan"
         assert "[resume_unsupported_provider]" in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_resumable_dispatches_process_resume_task(self, monkeypatch):
         """video resumable provider + 有 job_id → 后台 dispatcher 派发 _process_resume_task。
@@ -1260,6 +1308,7 @@ class TestGenerationWorker:
         assert len(dispatched) == 1
         assert dispatched[0]["task_id"] == "ark-orphan"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_fast_path_returns_immediately(self, monkeypatch):
         """fix #647 #1：fast path 不阻塞——5 个可 resume orphan + video_max=2，
@@ -1302,6 +1351,7 @@ class TestGenerationWorker:
                 t.cancel()
         await asyncio.sleep(0)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_dispatcher_respects_pool_capacity(self, monkeypatch):
         """fix #647 #1：后台 dispatcher 受 video 容量约束分批 promote 进 INFLIGHT，
@@ -1373,6 +1423,7 @@ class TestGenerationWorker:
                     t.cancel()
         await asyncio.sleep(0)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_dispatcher_exits_on_stop_event(self, monkeypatch):
         """fix #647 #1：`_stop_event` 触发时 dispatcher 干净退出，不再 dispatch 剩余 orphan。"""
@@ -1423,6 +1474,7 @@ class TestGenerationWorker:
     # ------------------------------------------------------------------
     # _process_resume_task：分流 + provider 锁定
     # ------------------------------------------------------------------
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_locks_persisted_provider_to_payload(self, monkeypatch):
         """C2 回归：persisted provider_id 应注入 payload.video_provider。"""
@@ -1455,6 +1507,7 @@ class TestGenerationWorker:
         assert captured_job_id == "openai-job"
         assert queue.succeeded == [("resume-locked", {"ok": True})]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_resume_expired(self, monkeypatch):
         """ResumeExpiredError → mark_failed [resume_expired]。"""
@@ -1480,6 +1533,7 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "exp"
         assert "[resume_expired_detail]" in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_resume_unsupported(self, monkeypatch):
         """NotImplementedError → mark_failed [resume_unsupported]。"""
@@ -1503,6 +1557,7 @@ class TestGenerationWorker:
         assert queue.failed and queue.failed[0][0] == "uns"
         assert "[resume_unsupported_detail]" in queue.failed[0][1]
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_generic_exception(self, monkeypatch):
         """通用 Exception → mark_failed（无前缀，与运行期 backend 失败同款）。"""
@@ -1555,6 +1610,7 @@ class TestGenerationWorker:
             "[script_edit_generated_assets_invalid]",
         )
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_cancelled_error(self, monkeypatch):
         """CancelledError → mark_cancelled + 重新抛出。"""
@@ -1578,6 +1634,7 @@ class TestGenerationWorker:
             await worker._process_resume_task(task)
         assert queue.cancelled and queue.cancelled[0][0] == "rc"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_process_resume_task_no_job_id_fails_fast(self):
         """无 provider_job_id 的 task 被派发到 _process_resume_task 时直接 mark_failed。"""
@@ -1599,6 +1656,7 @@ class TestGenerationWorker:
 class TestDispatcherFailFastAndPendingTracking:
     """dispatcher fail-fast + pending/inflight 分集合精确容量与 cancel 跟踪。"""
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_dispatch_provider_bucket_fail_fast_when_video_max_zero(self, monkeypatch):
         """video 容量=0 → 直接 mark_failed[resume_unsupported]，不进 Semaphore(0) 死锁。"""
@@ -1616,6 +1674,7 @@ class TestDispatcherFailFastAndPendingTracking:
         assert {tid for tid, _ in queue.failed} == {"orphan-0", "orphan-1", "orphan-2"}
         assert all("[resume_unsupported_capacity_zero]" in msg for _, msg in queue.failed)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_sub_task_registered_in_pending_before_sem_acquire(self, monkeypatch):
         """sem=1 + 2 task：第 2 个 sub-task sem 排队期间应以 PENDING 登记在台账。"""
@@ -1646,6 +1705,7 @@ class TestDispatcherFailFastAndPendingTracking:
         gate.set()
         await dispatcher
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_request_cancel_finds_sem_queued_task_in_pending(self, monkeypatch):
         """cancel sem 排队中的 task → request_cancel 命中并触发 cancel。"""
@@ -1674,6 +1734,7 @@ class TestDispatcherFailFastAndPendingTracking:
         gate.set()
         await dispatcher
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_sem_queued_cancel_marks_task_cancelled(self, monkeypatch):
         """sem 排队期被 cancel：_run_one 应显式 mark_task_cancelled，DB 不留 cancelling。"""
@@ -1710,6 +1771,7 @@ class TestDispatcherFailFastAndPendingTracking:
         cancelled_ids = {tid for tid, _ in queue.cancelled}
         assert "orphan-1" in cancelled_ids
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_acquired_pre_process_cancel_marks_task_cancelled(self, monkeypatch):
         """acquire 后、_process_resume_task 入 try 之前 cancel：_run_one 应兜底 mark cancelled。
@@ -1749,6 +1811,7 @@ class TestDispatcherFailFastAndPendingTracking:
         # 必须落 cancelled 终态，不能停在 cancelling
         assert "orphan-pre-try" in {tid for tid, _ in queue.cancelled}
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch):
         """_handle_orphan_tasks_on_start 后 self._orphan_dispatcher_task 应被设置。"""
@@ -1785,6 +1848,7 @@ class TestDispatcherFailFastAndPendingTracking:
 class TestOrphanScanSelfPreemption:
     """lease flap > 3×TTL 重夺时，本进程仍 inflight 的 task 不应被当孤儿处理。"""
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_image_inflight_not_marked_restart_lost(self, monkeypatch):
         """本进程 image_inflight 含 task → 孤儿扫描应跳过，不标 [restart_lost]。"""
@@ -1813,6 +1877,7 @@ class TestOrphanScanSelfPreemption:
         # 清理
         fut.set_result(None)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_inflight_not_dispatched_to_resume(self, monkeypatch):
         """本进程 video_inflight 含 task → 孤儿扫描应跳过，不启动重复 resume 流。"""
@@ -1850,6 +1915,7 @@ class TestOrphanScanSelfPreemption:
         assert "vid-active" not in {tid for tid, _ in queue.failed}
         fut.set_result(None)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_pending_also_skipped(self):
         """本进程 video_pending（sem 排队中）含 task → 孤儿扫描应跳过。"""
@@ -1883,6 +1949,7 @@ class TestOrphanDispatcherNonBlockingOverride:
     """lease 重夺时旧 dispatcher 仍在跑：本轮直接覆盖句柄，不 await（liveness）也不 cancel
     （避免错误中断 in-flight resume）。"""
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_old_dispatcher_not_awaited_on_re_scan(self, monkeypatch):
         """旧 dispatcher 跑 5s 时，再次进 _handle_orphan_tasks_on_start 应秒级返回（不阻塞）。"""
@@ -1948,6 +2015,7 @@ class TestOrphanOnceAndLeaseFlap:
         worker._handle_orphan_tasks_on_start = _spy_scan  # type: ignore[assignment]
         return worker, queue, scan_count
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_orphan_scanned_once_on_first_lease_acquire(self):
         worker, _, scan_count = self._build_worker()
@@ -1962,6 +2030,7 @@ class TestOrphanOnceAndLeaseFlap:
         assert len(scan_count) == 1
         assert worker._orphan_handled_once is True
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_orphan_not_rescanned_in_steady_state(self):
         """稳定持 lease 多拍主循环：扫描仅 1 次。"""
@@ -1975,6 +2044,7 @@ class TestOrphanOnceAndLeaseFlap:
 
         assert len(scan_count) == 1
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_orphan_does_not_rescan_on_short_lease_flap(self):
         """lease flap < lease_ttl：不重扫。"""
@@ -2002,6 +2072,7 @@ class TestOrphanOnceAndLeaseFlap:
             await worker._handle_orphan_tasks_on_start()
         assert len(scan_count) == 1, "短 flap 不应重扫"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_orphan_does_not_rescan_below_3x_ttl(self):
         """lease_ttl < lost < 3×lease_ttl：仍不重扫（边界）。"""
@@ -2026,6 +2097,7 @@ class TestOrphanOnceAndLeaseFlap:
             await worker._handle_orphan_tasks_on_start()
         assert len(scan_count) == 1, "15s 仍 < 3×ttl=30s，不应重扫"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_orphan_rescans_after_real_lease_handoff(self):
         """lost > 3×lease_ttl：清零开关，下次重扫。"""

--- a/tests/test_grid_executor.py
+++ b/tests/test_grid_executor.py
@@ -9,6 +9,8 @@ import pytest
 from lib.config.resolver import ProviderModel
 from server.services.generation_context import GenerationContext, ImageLaneResult
 
+pytestmark = pytest.mark.unit
+
 
 def _image_ctx(generator, *, provider="openai", model="gpt-image-2", resolution="2K", backend_model=None):
     """把 image lane 解析产物拼成假 GenerationContext，替换 resolve_generation_context 单点。

--- a/tests/test_grid_layout.py
+++ b/tests/test_grid_layout.py
@@ -1,7 +1,11 @@
 """Tests for grid layout calculator."""
 
+import pytest
+
 from lib.grid.layout import calculate_grid_layout
 from lib.grid.models import GridGeneration, build_frame_chain
+
+pytestmark = pytest.mark.unit
 
 
 class TestCalculateGridLayout:

--- a/tests/test_grid_manager.py
+++ b/tests/test_grid_manager.py
@@ -1,7 +1,11 @@
 """Tests for GridManager file-based CRUD."""
 
+import pytest
+
 from lib.grid.models import GridGeneration
 from lib.grid_manager import GridManager
+
+pytestmark = pytest.mark.unit
 
 
 def _make_grid(**kwargs) -> GridGeneration:

--- a/tests/test_grid_prompt_builder.py
+++ b/tests/test_grid_prompt_builder.py
@@ -1,6 +1,10 @@
 """Tests for lib/grid/prompt_builder.py"""
 
+import pytest
+
 from lib.grid.prompt_builder import _compute_panel_aspect, _extract_action, _extract_image_desc, build_grid_prompt
+
+pytestmark = pytest.mark.unit
 
 
 class TestExtractImageDesc:

--- a/tests/test_grid_router.py
+++ b/tests/test_grid_router.py
@@ -1,7 +1,11 @@
 """基本路由存在性测试：验证 grids router 注册了预期路径。"""
 
+import pytest
+
 from server.routers.grids import router
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class TestGridRouterExists:

--- a/tests/test_grid_splitter.py
+++ b/tests/test_grid_splitter.py
@@ -1,8 +1,11 @@
 """Tests for lib/grid/splitter.py."""
 
+import pytest
 from PIL import Image
 
 from lib.grid.splitter import center_crop_to_ratio, is_placeholder_cell, split_grid_image
+
+pytestmark = pytest.mark.unit
 
 
 class TestCenterCropToRatio:

--- a/tests/test_grids_router.py
+++ b/tests/test_grids_router.py
@@ -19,6 +19,8 @@ from server.error_handlers import register_error_handlers
 from server.routers import grids
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 def _narration_script():
     """四个无 segment_break 的分段，凑成单组 grid_4（cell_count=4）。"""

--- a/tests/test_grok_image_resolution.py
+++ b/tests/test_grok_image_resolution.py
@@ -7,6 +7,8 @@ import pytest
 from lib.image_backends.base import ImageGenerationRequest
 from lib.image_backends.grok import GrokImageBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend():
     backend = GrokImageBackend.__new__(GrokImageBackend)

--- a/tests/test_grok_shared.py
+++ b/tests/test_grok_shared.py
@@ -11,6 +11,8 @@ import pytest
 from lib.grok_shared import grok_should_retry
 from lib.retry import with_retry_async
 
+pytestmark = pytest.mark.unit
+
 
 def _make_aio_rpc_error(code: grpc.StatusCode, details: str = "") -> grpc.aio.AioRpcError:
     """构造一个 AioRpcError 用于测试。"""

--- a/tests/test_grok_video_backend.py
+++ b/tests/test_grok_video_backend.py
@@ -10,6 +10,8 @@ import pytest
 from lib.providers import PROVIDER_GROK
 from lib.video_backends.base import VideoGenerationRequest
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def output_path(tmp_path: Path) -> Path:

--- a/tests/test_grok_video_resolution.py
+++ b/tests/test_grok_video_resolution.py
@@ -7,6 +7,8 @@ import pytest
 from lib.video_backends.base import VideoGenerationRequest
 from lib.video_backends.grok import GrokVideoBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend():
     backend = GrokVideoBackend.__new__(GrokVideoBackend)

--- a/tests/test_i18n_assets_namespace.py
+++ b/tests/test_i18n_assets_namespace.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.i18n import MESSAGES, _
+
+pytestmark = pytest.mark.unit
 
 
 def test_asset_not_found_key_present_both_locales():

--- a/tests/test_i18n_consistency.py
+++ b/tests/test_i18n_consistency.py
@@ -1,5 +1,7 @@
 """Verify that i18n translation dictionaries are consistent across locales."""
 
+import pytest
+
 from lib.i18n import MESSAGES, SUPPORTED_LOCALES
 from lib.i18n.en import emails as en_emails
 from lib.i18n.en import errors as en_errors
@@ -14,6 +16,8 @@ from lib.i18n.zh import errors as zh_errors
 from lib.i18n.zh import system as zh_system
 from lib.i18n.zh import templates as zh_templates
 from lib.style_templates import STYLE_TEMPLATES
+
+pytestmark = pytest.mark.unit
 
 
 def test_all_locales_have_same_keys():

--- a/tests/test_image_backends/test_ark.py
+++ b/tests/test_image_backends/test_ark.py
@@ -17,6 +17,8 @@ from lib.image_backends.base import (
 )
 from lib.providers import PROVIDER_ARK
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_image_backends/test_base.py
+++ b/tests/test_image_backends/test_base.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 
+import pytest
+
 from lib.image_backends.base import (
     ImageCapability,
     ImageGenerationRequest,
     ImageGenerationResult,
     ReferenceImage,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_image_capability_is_str_enum():

--- a/tests/test_image_backends/test_gemini.py
+++ b/tests/test_image_backends/test_gemini.py
@@ -10,6 +10,8 @@ from PIL import Image as PILImage
 
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ReferenceImage
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_image_backends/test_grok.py
+++ b/tests/test_image_backends/test_grok.py
@@ -8,6 +8,8 @@ import pytest
 
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ReferenceImage
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_image_backends/test_registry.py
+++ b/tests/test_image_backends/test_registry.py
@@ -2,6 +2,8 @@ import pytest
 
 from lib.image_backends.registry import create_backend, get_registered_backends, register_backend
 
+pytestmark = pytest.mark.unit
+
 
 class _DummyBackend:
     def __init__(self, **kwargs):

--- a/tests/test_image_capability_error.py
+++ b/tests/test_image_capability_error.py
@@ -1,6 +1,10 @@
 """ImageCapabilityError 携带稳定 code + 上下文 params。"""
 
+import pytest
+
 from lib.image_backends import ImageCapabilityError
+
+pytestmark = pytest.mark.unit
 
 
 def test_carries_code_and_params():

--- a/tests/test_image_edit_executor.py
+++ b/tests/test_image_edit_executor.py
@@ -24,6 +24,8 @@ from server.services.image_edit_tasks import (
     resolve_current_image_rel,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def session_factory(monkeypatch):

--- a/tests/test_image_edit_router.py
+++ b/tests/test_image_edit_router.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -10,6 +11,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import generate
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeQueue:

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -10,6 +10,8 @@ from PIL import Image
 
 from lib.image_utils import compress_image_bytes, normalize_uploaded_image
 
+pytestmark = pytest.mark.unit
+
 
 class TestCompressImageBytes:
     """compress_image_bytes 测试。"""

--- a/tests/test_jianying_draft_routes.py
+++ b/tests/test_jianying_draft_routes.py
@@ -4,11 +4,14 @@ import json
 import zipfile
 from io import BytesIO
 
+import pytest
 from fastapi.testclient import TestClient
 
 from lib.project_manager import ProjectManager
 from server.auth import create_download_token
 from tests.conftest import make_test_video
+
+pytestmark = pytest.mark.integration
 
 
 def _setup_project(pm: ProjectManager):

--- a/tests/test_jianying_draft_service.py
+++ b/tests/test_jianying_draft_service.py
@@ -385,6 +385,8 @@ class TestResolveCanvasSize:
 
 from tests.conftest import make_test_audio, make_test_video
 
+pytestmark = pytest.mark.integration
+
 
 class TestGenerateDraft:
     """测试 pyjianyingdraft 草稿生成"""

--- a/tests/test_kling_backend_base.py
+++ b/tests/test_kling_backend_base.py
@@ -12,6 +12,8 @@ from lib.image_backends.kling import KlingImageBackend
 from lib.kling_backend_base import KlingBackendBase
 from lib.video_backends.kling import KlingVideoBackend
 
+pytestmark = pytest.mark.unit
+
 _SECRET = "s" * 40
 
 

--- a/tests/test_kling_image_backend.py
+++ b/tests/test_kling_image_backend.py
@@ -22,6 +22,8 @@ from lib.image_backends.base import (
 from lib.image_backends.kling import KlingImageBackend
 from lib.providers import PROVIDER_KLING
 
+pytestmark = pytest.mark.unit
+
 _SECRET = "s" * 40
 
 

--- a/tests/test_kling_shared.py
+++ b/tests/test_kling_shared.py
@@ -23,6 +23,8 @@ from lib.kling_shared import (
     resolve_kling_jwt_credentials,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _Clock:
     """可推进的注入时钟。"""

--- a/tests/test_kling_video_backend.py
+++ b/tests/test_kling_video_backend.py
@@ -70,23 +70,28 @@ def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
 
 
 class TestConstructionAndCapabilities:
+    @pytest.mark.unit
     def test_name_and_default_model(self):
         b = _jwt_backend()
         assert b.name == PROVIDER_KLING
         assert b.model == "kling-v2-5-turbo"
 
+    @pytest.mark.unit
     def test_jwt_missing_credentials_raises(self):
         with pytest.raises(ValueError):
             KlingVideoBackend(auth_mode="jwt", access_key="ak", secret_key=None)
 
+    @pytest.mark.unit
     def test_bearer_missing_api_key_raises(self):
         with pytest.raises(ValueError):
             KlingVideoBackend(auth_mode="bearer", api_key=None)
 
+    @pytest.mark.unit
     def test_unknown_auth_mode_raises(self):
         with pytest.raises(ValueError):
             KlingVideoBackend(auth_mode="oauth", api_key="k")
 
+    @pytest.mark.unit
     def test_video_capabilities_first_and_last_frame(self):
         caps = _jwt_backend().video_capabilities
         assert caps.first_frame is True
@@ -137,21 +142,25 @@ class TestVideoCapabilitiesForTier:
 
 
 class TestPerModelCapabilities:
+    @pytest.mark.unit
     def test_v3_t2v_i2v_no_audio_no_reference(self):
         b = _jwt_backend("kling-v3")
         vc = b.video_capabilities
         assert vc.first_frame is True and vc.last_frame is True
         assert vc.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_v3_omni_declares_reference_images(self):
         b = _jwt_backend("kling-v3-omni")
         vc = b.video_capabilities
         assert vc.max_reference_images == 4  # 保守值，待控制台核对
 
+    @pytest.mark.unit
     def test_v2_6_declares_generate_audio_no_reference(self):
         b = _jwt_backend("kling-v2-6")
         assert b.video_capabilities.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_video_o1_i2v_only_with_reference_images(self):
         b = _jwt_backend("kling-video-o1")
         # 多图主体 R2V
@@ -159,6 +168,7 @@ class TestPerModelCapabilities:
         assert vc.last_frame is True
         assert vc.max_reference_images == 4
 
+    @pytest.mark.unit
     def test_video_o1_pricing_audio_matches_effective_request(self, tmp_path):
         """预估消费的 backend 能力接口与真实请求的 `_effective_audio` 对参考模型给出同一静音档。"""
         backend = _jwt_backend("kling-video-o1")
@@ -167,6 +177,7 @@ class TestPerModelCapabilities:
         assert effective_generate_audio_for_model("kling", "kling-video-o1") is False
         assert backend._effective_audio(request, subpath="text2video") is False
 
+    @pytest.mark.unit
     def test_unknown_model_falls_back_to_default_caps(self):
         # bearer 透传原生 model_name：未登记 → 保守默认（t2v+i2v、尾帧仅 pro 档，声明按 std 档保守
         # 为 False；无音频/参考）
@@ -175,6 +186,7 @@ class TestPerModelCapabilities:
         assert vc.last_frame is False
         assert vc.max_reference_images == 0
 
+    @pytest.mark.unit
     def test_prefixed_and_cased_model_normalizes_to_registered_caps(self):
         # 中转 model_id 带厂商前缀（仓库既有约定 / 与 :）+ 非规范大小写/空白：归一化后实例 caps 仍精确命中
         # 已登记档，生成时防御与 resolver 裁剪同源——否则编排层放 4 张参考图、backend 却按默认 0 拒收。
@@ -182,6 +194,7 @@ class TestPerModelCapabilities:
             vc = _bearer_backend(model).video_capabilities
             assert vc.max_reference_images > 0 and vc.max_reference_images == 4
 
+    @pytest.mark.unit
     def test_future_version_does_not_inherit_caps_by_substring(self):
         # kling-v4 含子串 "kling-v3"？不含——但即便形如 kling-v3-omni-pro 也不得被子串误判继承能力；
         # 未登记一律保守默认，不猜未知 model 的参考图上限。
@@ -191,31 +204,37 @@ class TestPerModelCapabilities:
 
 
 class TestModeAndResolution:
+    @pytest.mark.unit
     def test_resolution_4k_maps_to_mode_4k(self, tmp_path):
         _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="4k"))
         assert payload["mode"] == "4k"
 
+    @pytest.mark.unit
     def test_resolution_4k_case_insensitive(self, tmp_path):
         _, payload = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, resolution="4K"))
         assert payload["mode"] == "4k"
 
+    @pytest.mark.unit
     def test_4k_overrides_service_tier(self, tmp_path):
         # 4k 档优先于 std/pro（与 per_second_tiered 档位派生一致）
         _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="4k", service_tier="pro"))
         assert payload["mode"] == "4k"
 
+    @pytest.mark.unit
     def test_non_4k_resolution_keeps_service_tier_mode(self, tmp_path):
         _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, resolution="1080p", service_tier="pro"))
         assert payload["mode"] == "pro"
 
 
 class TestAudioGating:
+    @pytest.mark.unit
     def test_v2_6_pro_audio_enabled(self, tmp_path):
         _, payload = _jwt_backend("kling-v2-6")._build_payload(
             _request(tmp_path, resolution="1080p", service_tier="pro", generate_audio=True)
         )
         assert payload["sound"] == "on"
 
+    @pytest.mark.unit
     def test_v2_6_std_audio_forced_off(self, tmp_path):
         # v2-6 有声官方限 1080P，而可灵只能经 mode 请求该档位：std 档拿不到 1080P，
         # 即使 request.resolution 写 1080p 也压制为无声——否则拿到无声片却按有声价出账
@@ -276,6 +295,7 @@ class TestMultiImageSubpath:
             paths.append(p)
         return paths
 
+    @pytest.mark.unit
     def test_reference_images_select_multi_image2video(self, tmp_path):
         refs = self._refs(tmp_path, 2)
         subpath, payload = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, reference_images=refs))
@@ -302,6 +322,7 @@ class TestMultiImageSubpath:
             is False
         )
 
+    @pytest.mark.unit
     def test_reference_images_take_precedence_over_start_image(self, tmp_path):
         refs = self._refs(tmp_path, 1)
         start = tmp_path / "start.png"
@@ -312,10 +333,12 @@ class TestMultiImageSubpath:
         assert subpath == "multi-image2video"
         assert "image_list" in payload
 
+    @pytest.mark.unit
     def test_empty_reference_images_falls_through(self, tmp_path):
         subpath, _ = _jwt_backend("kling-v3-omni")._build_payload(_request(tmp_path, reference_images=[]))
         assert subpath == "text2video"
 
+    @pytest.mark.unit
     def test_unreadable_reference_image_raises(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             _jwt_backend("kling-v3-omni")._build_payload(
@@ -336,12 +359,14 @@ class TestCapabilityValidation:
             paths.append(p)
         return paths
 
+    @pytest.mark.unit
     def test_reference_images_on_unsupported_model_raises(self, tmp_path):
         # kling-v3 未声明多图主体能力：带参考图即拒绝，不误升级到 multi-image2video 子路径
         with pytest.raises(VideoCapabilityError) as exc:
             _jwt_backend("kling-v3")._build_payload(_request(tmp_path, reference_images=self._refs(tmp_path, 1)))
         assert exc.value.code == "video_reference_images_unsupported"
 
+    @pytest.mark.unit
     def test_reference_images_over_limit_raises(self, tmp_path):
         # v3-omni 上限 4：传 5 张即拒绝
         with pytest.raises(VideoCapabilityError) as exc:
@@ -350,12 +375,14 @@ class TestCapabilityValidation:
         assert exc.value.params["limit"] == 4
         assert exc.value.params["count"] == 5
 
+    @pytest.mark.unit
     def test_text2video_on_model_without_t2v_raises(self, tmp_path):
         # kling-video-o1 不支持文生视频：无首帧/无参考即拒绝，不回落 text2video 子路径
         with pytest.raises(VideoCapabilityError) as exc:
             _jwt_backend("kling-video-o1")._build_payload(_request(tmp_path))
         assert exc.value.code == "video_capability_missing_t2v"
 
+    @pytest.mark.unit
     def test_reference_at_limit_allowed(self, tmp_path):
         # 恰好达上限（4 张）放行
         subpath, payload = _jwt_backend("kling-v3-omni")._build_payload(
@@ -366,6 +393,7 @@ class TestCapabilityValidation:
 
 
 class TestAuthHeaders:
+    @pytest.mark.unit
     def test_jwt_mode_signs_bearer_token(self):
         headers = _jwt_backend()._headers()
         assert headers["Content-Type"] == "application/json"
@@ -373,6 +401,7 @@ class TestAuthHeaders:
         claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
         assert claims["iss"] == "ak-1"
 
+    @pytest.mark.unit
     def test_bearer_mode_uses_static_key(self):
         # bearer 模式旁路 JWT 管理器：Authorization 是静态 key，非签名 token
         headers = _bearer_backend()._headers()
@@ -380,6 +409,7 @@ class TestAuthHeaders:
 
 
 class TestPayloadBuilding:
+    @pytest.mark.unit
     def test_text2video_no_image(self, tmp_path):
         subpath, payload = _jwt_backend()._build_payload(_request(tmp_path))
         assert subpath == "text2video"
@@ -389,14 +419,17 @@ class TestPayloadBuilding:
         assert payload["aspect_ratio"] == "9:16"
         assert "image" not in payload
 
+    @pytest.mark.unit
     def test_service_tier_pro_maps_to_mode_pro(self, tmp_path):
         _, payload = _jwt_backend()._build_payload(_request(tmp_path, service_tier="pro"))
         assert payload["mode"] == "pro"
 
+    @pytest.mark.unit
     def test_service_tier_default_maps_to_std(self, tmp_path):
         _, payload = _jwt_backend()._build_payload(_request(tmp_path, service_tier="default"))
         assert payload["mode"] == "std"
 
+    @pytest.mark.unit
     def test_image2video_embeds_base64_frame(self, tmp_path):
         img = tmp_path / "first.png"
         img.write_bytes(b"\x89PNG\r\n")
@@ -407,6 +440,7 @@ class TestPayloadBuilding:
         assert not payload["image"].startswith("data:")
         assert "image_tail" not in payload
 
+    @pytest.mark.unit
     def test_image2video_with_end_frame(self, tmp_path):
         # kling-v2-5-turbo 首尾帧仅 pro 档生效，须显式带 service_tier="pro" 才会放行 image_tail。
         first = tmp_path / "first.png"
@@ -440,6 +474,7 @@ class TestPayloadBuilding:
         _, payload = _jwt_backend("kling-v3")._build_payload(_request(tmp_path, start_image=first, end_image=last))
         assert "image" in payload and "image_tail" in payload
 
+    @pytest.mark.unit
     def test_image2video_empty_end_frame_is_omitted(self, tmp_path):
         # 空串 end_image 等价于"无尾帧"，按 truthy 判定跳过，不应误当路径去编码而崩溃。
         first = tmp_path / "first.png"
@@ -448,6 +483,7 @@ class TestPayloadBuilding:
         assert subpath == "image2video"
         assert "image" in payload and "image_tail" not in payload
 
+    @pytest.mark.unit
     def test_unreadable_start_image_raises(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             _jwt_backend()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))
@@ -455,6 +491,7 @@ class TestPayloadBuilding:
 
 
 class TestSafeLogView:
+    @pytest.mark.unit
     def test_no_base64_or_prompt_leaks(self, tmp_path):
         img = tmp_path / "f.png"
         img.write_bytes(b"\x89PNG\r\n")
@@ -470,6 +507,7 @@ class TestSafeLogView:
 
 
 class TestGenerateHappyPath:
+    @pytest.mark.unit
     async def test_submit_poll_download(self, tmp_path):
         post = AsyncMock(return_value=_resp(_submit("task-9")))
         get = AsyncMock(
@@ -494,6 +532,7 @@ class TestGenerateHappyPath:
         # text2video 提交端点
         assert post.await_args.args[0].endswith("/videos/text2video")
 
+    @pytest.mark.unit
     async def test_jwt_injected_on_submit(self, tmp_path):
         captured: dict = {}
 
@@ -515,6 +554,7 @@ class TestGenerateHappyPath:
         claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
         assert claims["iss"] == "ak-1"
 
+    @pytest.mark.unit
     async def test_bearer_static_key_on_submit(self, tmp_path):
         captured: dict = {}
 
@@ -533,6 +573,7 @@ class TestGenerateHappyPath:
             await _bearer_backend().generate(_request(tmp_path))
         assert captured["headers"]["Authorization"] == "Bearer static-key"
 
+    @pytest.mark.unit
     async def test_failed_status_raises(self, tmp_path):
         post = AsyncMock(return_value=_resp(_submit()))
         get = AsyncMock(return_value=_resp(_query("failed", status_msg="content rejected")))
@@ -545,6 +586,7 @@ class TestGenerateHappyPath:
             with pytest.raises(RuntimeError, match="content rejected"):
                 await _jwt_backend().generate(_request(tmp_path))
 
+    @pytest.mark.unit
     async def test_persists_provider_job_id_when_task_id_present(self, tmp_path):
         post = AsyncMock(return_value=_resp(_submit("task-x")))
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
@@ -561,6 +603,7 @@ class TestGenerateHappyPath:
         # 持久化的是「子路径:task_id:有声标志」，resume 据此复原查询端点（text2video 因无首帧）+ 有声决策（turbo 恒 0）
         assert persist.await_args.args[1] == "text2video:task-x:0"
 
+    @pytest.mark.unit
     async def test_persists_image2video_subpath_in_job_id(self, tmp_path):
         img = tmp_path / "first.png"
         img.write_bytes(b"\x89PNG\r\n")
@@ -580,6 +623,7 @@ class TestGenerateHappyPath:
 
 
 class TestResume:
+    @pytest.mark.unit
     async def test_resume_polls_without_resubmit(self, tmp_path):
         post = AsyncMock()  # must NOT be called
         get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
@@ -598,6 +642,7 @@ class TestResume:
         assert get.await_args.args[0].endswith("/videos/text2video/task-resume")
         dl.assert_awaited_once()
 
+    @pytest.mark.unit
     async def test_resume_image2video_subpath_from_encoded_job_id(self, tmp_path):
         # resume 请求不带 start_image（真实重启路径如此）：子路径必须来自持久化 job_id 前缀，
         # 否则 image2video 任务会误查 text2video 端点取不到。
@@ -614,6 +659,7 @@ class TestResume:
         assert result.task_id == "task-r2"
         assert get.await_args.args[0].endswith("/videos/image2video/task-r2")
 
+    @pytest.mark.unit
     async def test_resume_bare_job_id_falls_back_to_text2video(self, tmp_path):
         # 无已知前缀（异常/旧数据）回落 text2video，整串作 task_id。
         post = AsyncMock()
@@ -628,6 +674,7 @@ class TestResume:
         assert result.task_id == "legacy-bare-id"
         assert get.await_args.args[0].endswith("/videos/text2video/legacy-bare-id")
 
+    @pytest.mark.unit
     async def test_resume_multi_image2video_subpath_from_encoded_job_id(self, tmp_path):
         # 多图主体任务 resume：子路径从持久化 job_id 前缀复原，查 multi-image2video 端点。
         post = AsyncMock()
@@ -645,6 +692,7 @@ class TestResume:
 
 
 class TestAudioGatingResult:
+    @pytest.mark.unit
     async def test_v2_6_pro_audio_result_true(self, tmp_path):
         # v2-6 pro（即 1080P 档）+ 请求有声 → result.generate_audio=True（下游计费取有声价）
         post = AsyncMock(return_value=_resp(_submit("task-a")))
@@ -744,6 +792,7 @@ class TestAudioGatingResult:
         assert persist.await_args is not None
         assert persist.await_args.args[1] == "text2video:task-c:1"
 
+    @pytest.mark.unit
     async def test_resume_reuses_persisted_audio_over_recompute(self, tmp_path):
         # 持久化有声标志（:1）优先于 resume 时按请求重算：即使请求 generate_audio=False，
         # 结果仍取 submit 时算定的有声（避免计费漂移）
@@ -764,6 +813,7 @@ class TestAudioGatingResult:
         assert result.task_id == "task-c"
         assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
+    @pytest.mark.unit
     async def test_resume_legacy_job_id_stays_silent(self, tmp_path):
         # 不含有声标志的 2 段 job_id 一律判无声：这类任务的成片必然无声，不得按当前能力表重算为有声
         post = AsyncMock()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -21,6 +21,8 @@ from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
 from lib.ledger import Ledger, _settlement_from_result
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def factory() -> Any:

--- a/tests/test_locked_episode_script_toctou.py
+++ b/tests/test_locked_episode_script_toctou.py
@@ -18,6 +18,8 @@ import pytest
 
 from lib.project_manager import EpisodeScriptReboundError, ProjectManager
 
+pytestmark = pytest.mark.unit
+
 
 def _seed(pm: ProjectManager, name: str) -> None:
     """创建项目 + 一个 reference_video 模式的 episode_1 剧本。"""

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,6 +1,10 @@
 import logging
 
+import pytest
+
 from lib.logging_config import _HANDLER_ATTR, setup_logging
+
+pytestmark = pytest.mark.unit
 
 
 class TestSetupLogging:

--- a/tests/test_logging_persistence.py
+++ b/tests/test_logging_persistence.py
@@ -12,6 +12,8 @@ import pytest
 from lib import app_data_dir as app_data_dir_mod
 from lib import logging_config
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _reset_root_logger():

--- a/tests/test_media_generator_image_capability.py
+++ b/tests/test_media_generator_image_capability.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.image_backends.base import ImageCapability, ImageCapabilityError
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend(caps: set[ImageCapability]) -> MagicMock:
     backend = MagicMock()

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -197,6 +197,7 @@ class TestSegmentIdFor:
 
 
 class TestMediaGenerator:
+    @pytest.mark.unit
     def test_get_output_path_and_invalid_type(self, tmp_path):
         gen = _build_generator(tmp_path)
         assert gen._get_output_path("storyboards", "E1S01").name == "scene_E1S01.png"
@@ -206,6 +207,7 @@ class TestMediaGenerator:
         with pytest.raises(ValueError):
             gen._get_output_path("bad", "x")
 
+    @pytest.mark.unit
     def test_generate_image_success_and_failure(self, tmp_path):
         gen = _build_generator(tmp_path)
         output_path, version = gen.generate_image(
@@ -231,6 +233,7 @@ class TestMediaGenerator:
 
         assert any(o["status"] == "failed" for o in gen.ledger.outcomes)
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_generate_video_sync_and_async(self, tmp_path):
         gen = _build_generator(tmp_path)
@@ -273,6 +276,7 @@ class TestMediaGenerator:
         await gen.generate_video_async(prompt="p", resource_type="grids", resource_id="E1G1")
         assert gen.ledger.started[-1]["segment_id"] is None
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_billed_duration_passed_to_finish_call(self, tmp_path):
         """backend 返回与请求不同的实际计费时长时，视频路径透传给 finish_call。"""
@@ -289,6 +293,7 @@ class TestMediaGenerator:
         # billed_duration_seconds 由真 Ledger union 分发从结果对象提取；此处确认递交了 duration=15 的结果
         assert gen.ledger.outcomes[-1]["result"].duration_seconds == 15
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_billed_duration_lands_in_ledger(self, tmp_path):
         """端到端：真 Ledger 落库，backend 返回与请求不同的实际计费时长，ApiCall 账本记录 backend 值。"""
@@ -322,6 +327,7 @@ class TestMediaGenerator:
         finally:
             await engine.dispose()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_generate_audio_from_config_resolver(self, tmp_path):
         """验证 generate_video_async 通过 ConfigResolver 获取 audio 设置。"""
@@ -336,6 +342,7 @@ class TestMediaGenerator:
         # VideoBackend 路径尊重 ConfigResolver 返回的值
         assert gen.ledger.started[-1]["generate_audio"] is False
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_generate_audio_respects_config_true(self, tmp_path):
         """验证 video_backend 尊重 ConfigResolver 返回的 True。"""
@@ -349,6 +356,7 @@ class TestMediaGenerator:
         )
         assert gen.ledger.started[-1]["generate_audio"] is True
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_video_generate_audio_defaults_true_when_config_none(self, tmp_path):
         """当 self._config is None 时，fallback 默认 True，
@@ -529,24 +537,29 @@ class _ConfigurableImageBackend:
 
 
 class TestIs413:
+    @pytest.mark.unit
     def test_httpx_413(self):
         assert _is_413(_http_413_error()) is True
 
+    @pytest.mark.unit
     def test_phrase_match(self):
         assert _is_413(RuntimeError("Request Entity Too Large")) is True
         assert _is_413(RuntimeError("oops: PAYLOAD TOO LARGE")) is True
 
+    @pytest.mark.unit
     def test_byte_count_not_misread(self):
         # 修正④：不用裸 "413" 子串，避免字节数 / 请求 ID 误命中
         assert _is_413(RuntimeError("only 41300 bytes uploaded")) is False
         assert _is_413(RuntimeError("error code 413xyz")) is False
 
+    @pytest.mark.unit
     def test_non_413_status(self):
         req = httpx.Request("POST", "https://example.test")
         resp = httpx.Response(status_code=400, request=req)
         err = httpx.HTTPStatusError("bad request", request=req, response=resp)
         assert _is_413(err) is False
 
+    @pytest.mark.unit
     def test_sdk_status_code_attr(self):
         # OpenAI/xai 风格 SDK 异常：直接带 .status_code
         class _SdkErr(Exception):
@@ -554,6 +567,7 @@ class TestIs413:
 
         assert _is_413(_SdkErr("too big")) is True
 
+    @pytest.mark.unit
     def test_sdk_code_attr(self):
         # google-genai 风格 APIError：带 .code
         class _ApiErr(Exception):
@@ -561,12 +575,14 @@ class TestIs413:
 
         assert _is_413(_ApiErr("Request payload size exceeds the limit")) is True
 
+    @pytest.mark.unit
     def test_sdk_non_413_code_not_matched(self):
         class _ApiErr(Exception):
             code = 400
 
         assert _is_413(_ApiErr("bad request")) is False
 
+    @pytest.mark.unit
     def test_string_status_code_413(self):
         # 个别 SDK / mock 把状态码给成字符串 "413"，需防御性 int 转换
         class _StrErr(Exception):
@@ -574,6 +590,7 @@ class TestIs413:
 
         assert _is_413(_StrErr("too big")) is True
 
+    @pytest.mark.unit
     def test_non_numeric_status_code_falls_back_to_phrase(self):
         # 非数字状态码不应抛 ValueError，落回短语匹配
         class _WeirdErr(Exception):
@@ -584,6 +601,7 @@ class TestIs413:
 
 
 class TestReferenceCompressionSeam:
+    @pytest.mark.unit
     async def test_backend_receives_compressed_copy_source_untouched(self, tmp_path):
         gen = _build_generator(tmp_path)
         backend = _ConfigurableImageBackend()
@@ -608,6 +626,7 @@ class TestReferenceCompressionSeam:
         # 临时副本退出后清理
         assert not received[0].exists()
 
+    @pytest.mark.unit
     async def test_413_retry_then_success_single_finish_call(self, tmp_path):
         gen = _build_generator(tmp_path)
         backend = _ConfigurableImageBackend(fail_413_times=1)
@@ -627,6 +646,7 @@ class TestReferenceCompressionSeam:
         assert len(gen.ledger.outcomes) == 1
         assert gen.ledger.outcomes[0]["status"] == "success"
 
+    @pytest.mark.unit
     async def test_413_exhausted_raises_floor_records_failed(self, tmp_path):
         gen = _build_generator(tmp_path)
         backend = _ConfigurableImageBackend(fail_413_times=99)
@@ -647,6 +667,7 @@ class TestReferenceCompressionSeam:
         assert len(gen.ledger.outcomes) == 1
         assert gen.ledger.outcomes[0]["status"] == "failed"
 
+    @pytest.mark.unit
     async def test_t2i_no_refs_413_not_converted_to_floor(self, tmp_path):
         # 无参考图（T2I）的 413 与参考图无关，不应被误转成 floor、也不降档
         gen = _build_generator(tmp_path)
@@ -662,6 +683,7 @@ class TestReferenceCompressionSeam:
         # 单次调用，无降档重试
         assert len(backend.calls) == 1
 
+    @pytest.mark.unit
     async def test_video_frame_not_resized_array_laddered(self, tmp_path):
         gen = _build_generator(tmp_path)
 
@@ -706,6 +728,7 @@ class TestReferenceCompressionSeam:
         assert backend.start_dims == (3000, 2000)  # FRAME 尺寸保持
         assert max(backend.ref_dims[0]) == 2048  # ARRAY 缩到长边 2048
 
+    @pytest.mark.unit
     async def test_reference_audio_reaches_backend_unreordered(self, tmp_path):
         """参考音频原样透传到请求：gate 放行后若不下传，音频会在校验之后被静默丢弃。
 

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -20,6 +20,8 @@ import pytest
 from lib.media_generator import MediaGenerator
 from lib.video_backends.base import ResumeExpiredError
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeVideoResult:
     def __init__(self) -> None:

--- a/tests/test_message_serialization.py
+++ b/tests/test_message_serialization.py
@@ -7,6 +7,7 @@ constructing a SessionManager instance.
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import pytest
 from pydantic import BaseModel
 
 from server.agent_runtime.message_serialization import (
@@ -19,6 +20,8 @@ from server.agent_runtime.message_serialization import (
     message_to_dict,
     serialize_value,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TextBlock(BaseModel):

--- a/tests/test_minimax_image_backend.py
+++ b/tests/test_minimax_image_backend.py
@@ -17,6 +17,8 @@ from lib.image_backends.base import (
 )
 from lib.providers import PROVIDER_MINIMAX
 
+pytestmark = pytest.mark.unit
+
 
 def _img_response(url: str = "https://x/out.png") -> MagicMock:
     resp = MagicMock()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -10,6 +10,8 @@ from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.providers import PROVIDER_MINIMAX, PROVIDER_OPENAI
 
+pytestmark = pytest.mark.unit
+
 
 def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> MagicMock:
     usage = MagicMock()

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -27,6 +27,8 @@ from lib.minimax_shared import (
     safe_body_for_log,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestBaseUrlDerivation:
     def test_default_is_domestic(self):

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -11,6 +11,8 @@ from lib.providers import PROVIDER_MINIMAX
 from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.minimax import MiniMaxVideoBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
     resp = MagicMock()

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # infer_endpoint smoke check（主体已在 test_custom_provider_endpoints.py 覆盖）
 # ---------------------------------------------------------------------------

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -12,6 +12,8 @@ import pytest
 from lib.providers import PROVIDER_NEWAPI
 from lib.video_backends.base import VideoGenerationRequest
 
+pytestmark = pytest.mark.unit
+
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
     resp = MagicMock()

--- a/tests/test_normalize_base_url.py
+++ b/tests/test_normalize_base_url.py
@@ -1,11 +1,15 @@
 """base_url 归一化工具函数测试。"""
 
+import pytest
+
 from lib.config.url_utils import (
     ensure_google_base_url,
     ensure_openai_base_url,
     is_official_openai_base_url,
     normalize_base_url,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestIsOfficialOpenAIBaseURL:

--- a/tests/test_openai_connection.py
+++ b/tests/test_openai_connection.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from server.routers.providers import _test_openai
 from tests.conftest import make_translator
+
+pytestmark = pytest.mark.unit
 
 _t = make_translator()
 

--- a/tests/test_openai_image_backend.py
+++ b/tests/test_openai_image_backend.py
@@ -16,6 +16,8 @@ from lib.image_backends.base import (
 )
 from lib.providers import PROVIDER_OPENAI
 
+pytestmark = pytest.mark.unit
+
 
 def _make_mock_image_response(
     b64_data: str | None = "aW1hZ2VfZGF0YQ==",

--- a/tests/test_openai_image_resolution.py
+++ b/tests/test_openai_image_resolution.py
@@ -13,6 +13,8 @@ import pytest
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ReferenceImage
 from lib.image_backends.openai import OpenAIImageBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend():
     backend = OpenAIImageBackend.__new__(OpenAIImageBackend)

--- a/tests/test_openai_shared.py
+++ b/tests/test_openai_shared.py
@@ -1,7 +1,11 @@
 """create_openai_client 客户端工厂行为。"""
 
+import pytest
+
 from lib.config.url_utils import OFFICIAL_OPENAI_BASE_URL
 from lib.openai_shared import create_openai_client
+
+pytestmark = pytest.mark.unit
 
 
 class TestCreateOpenAIClientBaseURL:

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 from openai import BadRequestError
 from pydantic import BaseModel
 
@@ -15,6 +16,8 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -11,6 +11,8 @@ from openai import InternalServerError
 from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.base import VideoGenerationRequest
 
+pytestmark = pytest.mark.unit
+
 
 def _make_mock_video(status="completed", seconds="8", video_id="vid_123"):
     """构造 mock Video 响应。"""

--- a/tests/test_openai_video_resolution.py
+++ b/tests/test_openai_video_resolution.py
@@ -10,6 +10,8 @@ import pytest
 from lib.video_backends.base import VideoGenerationRequest
 from lib.video_backends.openai import _SORA_LEGAL_SIZES, OpenAIVideoBackend
 
+pytestmark = pytest.mark.unit
+
 
 def _make_backend(model: str = "sora-2"):
     backend = OpenAIVideoBackend.__new__(OpenAIVideoBackend)

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -14,6 +14,8 @@ from lib.path_safety import (
     try_safe_join,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_existing_relative_path(tmp_path: Path):
     (tmp_path / "a.txt").write_text("x", encoding="utf-8")

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -20,6 +20,8 @@ from lib.pricing.types import (
     ViduDelegate,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestRegistryHit:
     def test_gemini_image_flash(self):

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -17,6 +17,8 @@ from lib.pricing.types import (
     ViduDelegate,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestPerToken:
     pricing = PerToken(

--- a/tests/test_products_router.py
+++ b/tests/test_products_router.py
@@ -1,11 +1,14 @@
 """products 资产路由（spec 工厂自动生成）：CRUD 全通 + 列表字段读写。"""
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import products
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakePM:

--- a/tests/test_profile_manifest.py
+++ b/tests/test_profile_manifest.py
@@ -26,6 +26,8 @@ from lib.profile_manifest import (
     sha256_file,
 )
 
+pytestmark = pytest.mark.unit
+
 # ---------- sha256 ----------
 
 

--- a/tests/test_project_archive_ad_reference.py
+++ b/tests/test_project_archive_ad_reference.py
@@ -10,8 +10,12 @@ import shutil
 import zipfile
 from pathlib import Path
 
+import pytest
+
 from lib.project_manager import ProjectManager
 from server.services.project_archive import ProjectArchiveService
+
+pytestmark = pytest.mark.unit
 
 
 def _write_bytes(path: Path, content: bytes) -> None:

--- a/tests/test_project_archive_reference_video.py
+++ b/tests/test_project_archive_reference_video.py
@@ -124,10 +124,12 @@ def _create_reference_video_project(
 
 
 class TestProjectArchiveReferenceVideo:
+    @pytest.mark.unit
     def test_canonical_resource_path_reference_videos(self):
         # 验收项：reference_videos 走 unit_id 无前缀分支（路径形状由 lib.resource_paths 独家拥有）
         assert resource_relative_path("reference_videos", "E1U1") == "reference_videos/E1U1.mp4"
 
+    @pytest.mark.unit
     def test_round_trip_preserves_video_units(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_reference_video_project(pm)
@@ -234,6 +236,7 @@ class TestProjectArchiveReferenceVideo:
         veo_tiers = PROVIDER_REGISTRY["gemini-aistudio"].models["veo-3.1-generate-preview"].supported_durations
         assert imported["video_units"][0]["duration_seconds"] in veo_tiers
 
+    @pytest.mark.unit
     def test_import_restores_video_clip_from_version(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         # video_clip 指向失效的版本路径，靠 versions.json 回溯物化当前文件
@@ -283,6 +286,7 @@ class TestProjectArchiveReferenceVideo:
         assert (pm.get_project_path(result.project_name) / "reference_videos" / "E1U1.mp4").exists()
         assert result.diagnostics["auto_fixed"]
 
+    @pytest.mark.unit
     def test_import_backfills_missing_generated_assets(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         unit = _build_unit(video_clip=None, generated_assets=None)
@@ -303,6 +307,7 @@ class TestProjectArchiveReferenceVideo:
         assert "video_thumbnail" in assets
         assert assets["status"] == "pending"
 
+    @pytest.mark.unit
     def test_import_resets_invalid_generated_assets(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         unit = _build_unit(video_clip=None, generated_assets="corrupted-value")
@@ -323,6 +328,7 @@ class TestProjectArchiveReferenceVideo:
         assert assets["status"] == "pending"
         assert any(item["code"] == "invalid_generated_assets" for item in result.diagnostics["auto_fixed"])
 
+    @pytest.mark.unit
     def test_export_resets_invalid_generated_assets(self, tmp_path):
         # 导出与导入共用 _repair_project_tree，但导出修的是快照副本：包内是干净结构，
         # 源项目磁盘上的脏值保持原样（导出不改用户数据）。
@@ -348,6 +354,7 @@ class TestProjectArchiveReferenceVideo:
         on_disk = json.loads((project_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
         assert on_disk["video_units"][0]["generated_assets"] == "corrupted-value"
 
+    @pytest.mark.unit
     def test_import_adds_placeholder_for_missing_character_reference(self, tmp_path):
         # 与 narration/drama 对齐：references 引用了 project.json 缺失的角色 → 自动补占位定义
         pm = ProjectManager(tmp_path / "projects")
@@ -400,6 +407,7 @@ class TestProjectArchiveReferenceVideo:
         assert imported_project["characters"].keys() == {name_nfd}
         assert not any(item["code"] == "placeholder_character_added" for item in result.diagnostics["auto_fixed"])
 
+    @pytest.mark.unit
     def test_import_blocks_missing_scene_reference(self, tmp_path):
         # 与 narration/drama 对齐：references 引用了缺失的场景 → 阻断导入
         pm = ProjectManager(tmp_path / "projects")
@@ -418,6 +426,7 @@ class TestProjectArchiveReferenceVideo:
 
         assert exc_info.value.extra["diagnostics"]["blocking"]
 
+    @pytest.mark.unit
     def test_import_blocks_missing_prop_reference(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         unit = _build_unit(

--- a/tests/test_project_archive_service.py
+++ b/tests/test_project_archive_service.py
@@ -168,6 +168,7 @@ def _make_manual_zip(project_dir: Path, zip_path: Path) -> None:
 
 
 class TestProjectArchiveService:
+    @pytest.mark.unit
     def test_export_includes_full_snapshot_and_empty_dirs(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm)
@@ -211,6 +212,7 @@ class TestProjectArchiveService:
         with zipfile.ZipFile(archive_path) as archive:
             assert "demo/end_frames/scene_E1S01.png" in set(archive.namelist())
 
+    @pytest.mark.unit
     def test_export_excludes_agent_runtime_symlinks(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -229,6 +231,7 @@ class TestProjectArchiveService:
             assert "demo/project.json" in names
             assert "demo/source/chapter.txt" in names
 
+    @pytest.mark.unit
     def test_export_excludes_agent_runtime_real_files(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -242,6 +245,7 @@ class TestProjectArchiveService:
             assert not any("CLAUDE.md" in n for n in names)
             assert "demo/project.json" in names
 
+    @pytest.mark.unit
     def test_export_excludes_broken_agent_runtime_symlinks(self, tmp_path):
         import shutil as _shutil
 
@@ -266,6 +270,7 @@ class TestProjectArchiveService:
             assert not any(".claude" in n for n in names)
             assert not any("CLAUDE.md" in n for n in names)
 
+    @pytest.mark.unit
     def test_import_official_export_round_trip(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm)
@@ -284,6 +289,7 @@ class TestProjectArchiveService:
         assert (pm.get_project_path("demo") / "videos" / "scene_E1S01.mp4").exists()
         assert (pm.get_project_path("demo") / "drafts" / "episode_2").is_dir()
 
+    @pytest.mark.unit
     def test_import_manual_zip_without_manifest(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -302,6 +308,7 @@ class TestProjectArchiveService:
         assert result.project_name != "demo"
         assert (pm.get_project_path(result.project_name) / "project.json").exists()
 
+    @pytest.mark.unit
     def test_import_legacy_v1_archive_runs_migration(self, tmp_path):
         """启动后导入的旧归档（schema_version=1 + legacy image_backend）在导入入口走完整迁移链。"""
         import json as _json
@@ -333,6 +340,7 @@ class TestProjectArchiveService:
         assert installed["image_provider_i2i"] == "gemini-vertex/imagen-3"  # image_backend 拆分到两槽
         assert "image_backend" not in installed
 
+    @pytest.mark.unit
     def test_import_rejects_missing_project_json(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         service = ProjectArchiveService(pm)
@@ -347,6 +355,7 @@ class TestProjectArchiveService:
         assert exc_info.value.detail == "导入包校验失败"
         assert any("project.json" in error for error in exc_info.value.errors)
 
+    @pytest.mark.unit
     def test_import_rejects_missing_script_reference_for_malformed_entry(self, tmp_path):
         """集号无法解析的畸形条目不是合法账本条目：剧本缺失仍阻断导入。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -366,6 +375,7 @@ class TestProjectArchiveService:
 
         assert any("episodes[0].script_file" in error for error in exc_info.value.errors)
 
+    @pytest.mark.unit
     def test_import_allows_missing_script_for_ledgered_entry(self, tmp_path):
         """账本条目（带 ledger_status）的剧本可以尚未生成：导入放行并落 warning。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -383,6 +393,7 @@ class TestProjectArchiveService:
         result = service.import_project_archive(archive_path, uploaded_filename="ledgered.zip")
         assert any("episodes[0].script_file" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_import_allows_missing_script_for_entry_without_ledger_status(self, tmp_path):
         """v2→v3 迁移不再回填 ledger_status，老项目升级后的条目可能永远没有该字段：
         形状合法（集号可解析）即视为正常账本条目，导入放行并落 warning。"""
@@ -398,6 +409,7 @@ class TestProjectArchiveService:
         result = service.import_project_archive(archive_path, uploaded_filename="unledgered.zip")
         assert any("episodes[0].script_file" in w for w in result.warnings)
 
+    @pytest.mark.unit
     def test_import_rejects_missing_script_reference_for_non_positive_episode_num(self, tmp_path):
         """0/负数集号能被 parse_episode_num 解析，但不是合法集号：剧本缺失仍阻断导入。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -417,6 +429,7 @@ class TestProjectArchiveService:
 
         assert any("episodes[0].script_file" in error for error in exc_info.value.errors)
 
+    @pytest.mark.unit
     def test_migrated_project_archive_roundtrip_with_unscripted_episode(self, tmp_path):
         """自愈登记的孤儿集条目（无位置记录、剧本未生成）不破坏导出→再导入往返。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -444,6 +457,7 @@ class TestProjectArchiveService:
         # 孤儿条目不写入位置记录：导出/导入往返不应凭空补出 source_range
         assert "source_range" not in imported["episodes"][1]
 
+    @pytest.mark.unit
     def test_import_surfaces_unconvertible_source_encoding_as_warning(self, tmp_path, monkeypatch):
         """源文件编码无法识别时导入不中止（局部损坏不阻断整体），failed 文件浮到导入 warnings。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -466,6 +480,7 @@ class TestProjectArchiveService:
         result = service.import_project_archive(archive_path, uploaded_filename="bad.zip")
         assert any("novel.txt" in w and "编码" in w for w in result.warnings)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("field_name", "target_path"),
         [
@@ -503,6 +518,7 @@ class TestProjectArchiveService:
 
         assert any(field_name in error for error in exc_info.value.errors)
 
+    @pytest.mark.unit
     def test_import_allows_external_video_uri(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm, video_uri="gs://bucket/video-ref")
@@ -519,6 +535,7 @@ class TestProjectArchiveService:
 
         assert result.project["episodes"][0]["script_file"] == "scripts/episode_1.json"
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "archive_builder",
         ["absolute", "traversal", "symlink", "encrypted"],
@@ -547,6 +564,7 @@ class TestProjectArchiveService:
         with pytest.raises(ProjectArchiveValidationError):
             service.import_project_archive(archive_path, uploaded_filename="unsafe.zip")
 
+    @pytest.mark.unit
     def test_import_rename_conflict_generates_new_project_id(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm)
@@ -565,6 +583,7 @@ class TestProjectArchiveService:
         assert pm.get_project_path("demo").exists()
         assert pm.get_project_path(result.project_name).exists()
 
+    @pytest.mark.unit
     def test_import_prompt_conflict_requires_user_confirmation(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm)
@@ -582,6 +601,7 @@ class TestProjectArchiveService:
         assert exc_info.value.detail == "检测到项目编号冲突"
         assert exc_info.value.extra["conflict_project_name"] == "demo"
 
+    @pytest.mark.unit
     def test_import_overwrite_replaces_existing_project(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm, style="Fresh")
@@ -604,6 +624,7 @@ class TestProjectArchiveService:
         assert pm.load_project("demo")["style"] == "Fresh"
         assert (pm.get_project_path("demo") / "source" / "chapter.txt").read_text(encoding="utf-8") == "source"
 
+    @pytest.mark.unit
     def test_import_materializes_claude_with_manifest(self, tmp_path, monkeypatch):
         """导入项目应物化 .claude 为真目录 + 写 manifest（非 symlink）。
 
@@ -639,6 +660,7 @@ class TestProjectArchiveService:
         # profile 内容真实落盘
         assert (claude_dir / "skills" / "demo" / "SKILL.md").read_text() == "demo"
 
+    @pytest.mark.unit
     def test_import_overwrite_rolls_back_on_install_failure(self, tmp_path, monkeypatch):
         pm = ProjectManager(tmp_path / "projects")
         _create_project(pm, style="Fresh")
@@ -666,6 +688,7 @@ class TestProjectArchiveService:
         monkeypatch.setattr(project_archive_module.shutil, "move", original_move)
         assert pm.load_project("demo")["style"] == "Stale"
 
+    @pytest.mark.unit
     def test_import_overwrite_rolls_back_on_profile_sync_failure(self, tmp_path, monkeypatch):
         """sync_agent_profile 失败时必须回滚（删 target_dir + 恢复 backup_dir）。
         否则 overwrite 分支已删旧备份，用户会丢数据。
@@ -697,6 +720,7 @@ class TestProjectArchiveService:
         assert pm.load_project("demo")["style"] == "Stale"
         assert not any(p.name.startswith(".import-backup-") for p in (tmp_path / "projects").iterdir())
 
+    @pytest.mark.unit
     def test_create_project_rolls_back_on_profile_sync_failure(self, tmp_path, monkeypatch):
         """create_project 内 sync_agent_profile 失败必须 rmtree 残缺 project_dir，
         否则同名重试撞 FileExistsError。
@@ -717,6 +741,7 @@ class TestProjectArchiveService:
         pm.create_project("ghost")  # 不撞 FileExistsError
         assert (tmp_path / "projects" / "ghost").is_dir()
 
+    @pytest.mark.unit
     def test_import_repairs_legacy_narration_payload(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -801,6 +826,7 @@ class TestProjectArchiveService:
         assert imported_script["segments"][0]["generated_assets"]["video_clip"] == "videos/scene_E1S01_1.mp4"
         assert result.diagnostics["auto_fixed"]
 
+    @pytest.mark.unit
     def test_export_repairs_narration_audio_from_version_history(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -860,6 +886,7 @@ class TestProjectArchiveService:
 
         assert exported_script["segments"][0]["generated_assets"]["narration_audio"] == "audio/segment_E1S01.wav"
 
+    @pytest.mark.unit
     def test_import_blocks_missing_scene_definition(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -899,6 +926,7 @@ class TestProjectArchiveService:
         assert any("不存在于 project.json 的场景" in error for error in exc_info.value.errors)
         assert exc_info.value.extra["diagnostics"]["blocking"]
 
+    @pytest.mark.unit
     def test_import_resolves_nfd_script_refs_against_nfc_registered_assets(self, tmp_path):
         """剧本与 project.json 可以各自是 NFC/NFD：修复期的成员判定按坐标系解析，
         否则已登记的角色会被补出一份重复占位定义（后写入胜出会盖掉真实元数据），
@@ -950,6 +978,7 @@ class TestProjectArchiveService:
         assert name_nfd not in imported["characters"]  # 不补重复占位角色
         assert not any(item["code"] == "placeholder_character_added" for item in result.diagnostics["auto_fixed"])
 
+    @pytest.mark.unit
     def test_import_blocks_missing_prop_definition(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -989,6 +1018,7 @@ class TestProjectArchiveService:
         assert any("不存在于 project.json 的道具" in error for error in exc_info.value.errors)
         assert exc_info.value.extra["diagnostics"]["blocking"]
 
+    @pytest.mark.unit
     def test_export_dirty_project_emits_diagnostics_and_repairs_snapshot(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -1058,6 +1088,7 @@ class TestProjectArchiveService:
         assert "clues_in_segment" not in exported_script["segments"][0]
         assert exported_script["segments"][0]["generated_assets"]["video_clip"] == "videos/scene_E1S01.mp4"
 
+    @pytest.mark.unit
     def test_export_includes_reference_audio_file_both_scopes(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
@@ -1073,6 +1104,7 @@ class TestProjectArchiveService:
                 names = set(archive.namelist())
             assert "demo/characters/refs_audio/Hero.wav" in names
 
+    @pytest.mark.unit
     def test_export_repairs_reference_audio_canonical_path(self, tmp_path):
         """reference_audio 不像 reference_image 强制统一扩展名，规范化路径按字段自身的
         扩展名推导——指针错位（如手工恢复留下的旧路径）但文件已在规范位置时应改写字段。"""
@@ -1132,6 +1164,7 @@ class TestExportScope:
         _write_json(project_dir / "versions" / "versions.json", versions_data)
         return project_dir
 
+    @pytest.mark.unit
     def test_export_scope_full_includes_version_history(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         self._create_project_with_versions(pm)
@@ -1148,6 +1181,7 @@ class TestExportScope:
             assert "demo/versions/scenes/Temple_v1.png" in names
             assert "demo/versions/props/Key_v1.png" in names
 
+    @pytest.mark.unit
     def test_export_scope_current_skips_version_history_files(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         self._create_project_with_versions(pm)
@@ -1170,6 +1204,7 @@ class TestExportScope:
             # versions.json 应保留（裁剪后）
             assert "demo/versions/versions.json" in names
 
+    @pytest.mark.unit
     def test_export_scope_current_trims_versions_json(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         self._create_project_with_versions(pm)
@@ -1189,6 +1224,7 @@ class TestExportScope:
             assert len(vid_versions) == 1
             assert vid_versions[0]["version"] == 2
 
+    @pytest.mark.unit
     def test_export_scope_current_manifest_scope_field(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         self._create_project_with_versions(pm)
@@ -1200,6 +1236,7 @@ class TestExportScope:
             manifest = json.loads(archive.read(f"demo/{ARCHIVE_MANIFEST_NAME}"))
             assert manifest["scope"] == "current"
 
+    @pytest.mark.unit
     def test_export_scope_full_manifest_scope_field(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         self._create_project_with_versions(pm)

--- a/tests/test_project_events_router.py
+++ b/tests/test_project_events_router.py
@@ -6,6 +6,8 @@ import pytest
 from lib.api_errors import BadRequestError, NotFoundError
 from server.routers import project_events as project_events_router
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeRequest:
     def __init__(self, app, *, disconnect_after: int | None = None):

--- a/tests/test_project_events_service.py
+++ b/tests/test_project_events_service.py
@@ -58,6 +58,7 @@ async def _next_event(stream, *, timeout: float) -> tuple[str, dict]:
 
 
 class TestProjectEventService:
+    @pytest.mark.unit
     def test_diff_snapshots_reports_character_and_storyboard_changes(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -124,6 +125,7 @@ class TestProjectEventService:
         # narration 分镜走时间线画布：锚点类型恒为 segment（回归守卫，不得漂移）。
         assert all(c["focus"]["anchor_type"] == "segment" for c in segment_updated)
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_reference_audio_change(self, tmp_path):
         """挂载/更换参考音频要推项目事件，否则其他会话的角色卡停留在旧样本。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -154,6 +156,7 @@ class TestProjectEventService:
 
         assert any(change["entity_type"] == "character" and change["action"] == "updated" for change in changes)
 
+    @pytest.mark.unit
     def test_build_snapshot_survives_null_episodes(self, tmp_path):
         # project.json 的 episodes 显式为 null 时快照构建不崩:load_project 直接回读磁盘
         # JSON、不规范化 episodes,读侧按 fail-soft 用 ``or []`` 兜底而非 ``get(..., [])``。
@@ -171,6 +174,7 @@ class TestProjectEventService:
 
         assert snapshot["project"]["episodes"] == {}
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_project_metadata_and_new_segments(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -246,6 +250,7 @@ class TestProjectEventService:
             for change in changes
         )
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_poll_detects_direct_script_write_and_syncs_episode_index(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
@@ -286,6 +291,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_emitted_batch_is_broadcast_without_waiting_for_snapshot_diff(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
@@ -797,6 +803,7 @@ class TestProjectEventService:
         finally:
             await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_subscribe_cancellation_cleans_up_subscriber(self, tmp_path, monkeypatch):
         """客户端在首次扫描期间断开 → _subscribe 被取消 → 订阅者与 watch task 不泄漏。"""
@@ -829,6 +836,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_new_subscriber_entering_during_stop_watch_stays_registered(self, tmp_path, monkeypatch):
         """末订阅者收尾挂起在 watch task 收尾等待点时，并发进入的新订阅者归属注册表现行通道，
@@ -907,6 +915,7 @@ class TestProjectEventService:
                 await asyncio.gather(stop_task, return_exceptions=True)
             await service.shutdown()
 
+    @pytest.mark.unit
     def test_projects_root_kwarg_overrides_default_subdir(self, tmp_path):
         """显式传 projects_root 时，service.pm 走该目录而非 project_root/'projects'。
 
@@ -922,6 +931,7 @@ class TestProjectEventService:
         assert service.pm.projects_root == custom_projects.resolve()
         assert service.pm.get_project_path("demo") == (custom_projects / "demo").resolve()
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_ad_shot_lifecycle_events(self, tmp_path):
         """ad(shots) 项目的分镜级事件：created / storyboard_ready / video_ready / updated。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -993,6 +1003,7 @@ class TestProjectEventService:
         video_changes = service._diff_snapshots(mid, final)
         assert any(c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in video_changes)
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_drama_scene_lifecycle_events(self, tmp_path):
         """drama(scenes) 项目的分镜级事件：created / storyboard_ready / video_ready。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -1056,6 +1067,7 @@ class TestProjectEventService:
         # drama 场景走时间线画布：可导航事件的锚点类型为 segment。
         assert all(c["focus"]["anchor_type"] == "segment" for c in scene_changes if c["focus"] is not None)
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_reference_video_unit_lifecycle_events(self, tmp_path):
         """reference_video(video_units) 项目的分镜级事件全周期，且 characters 从 references 派生。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -1131,6 +1143,7 @@ class TestProjectEventService:
         video_changes = service._diff_snapshots(mid, final)
         assert any(c["action"] == "video_ready" and c["entity_id"] == "E1U01" for c in video_changes)
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_reference_video_content_edits(self, tmp_path):
         """reference_video 单元的内容体编辑（成员镜头文本 / 场景引用）触发 updated 事件——
 
@@ -1188,6 +1201,7 @@ class TestProjectEventService:
         scene_changes = service._diff_snapshots(after_text, after_scene)
         assert any(c["action"] == "updated" and c["entity_id"] == "E1U01" for c in scene_changes)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", sorted(SKELETONS))
     def test_normalize_snapshot_covers_every_skeleton_kind(self, tmp_path, kind):
         """每个骨架种类都被 _normalize_script_snapshot 正确抽取条目——
@@ -1217,15 +1231,18 @@ class TestProjectEventService:
         label = service._build_script_item_label("X1", normalized)
         assert label.endswith("「X1」") and not label.startswith("「")
 
+    @pytest.mark.unit
     def test_every_skeleton_kind_has_label_noun(self):
         """标签名词表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出名词补全。"""
         assert set(SKELETON_ITEM_NOUNS) == set(SKELETONS)
 
+    @pytest.mark.unit
     def test_every_skeleton_kind_has_entity_and_anchor_type(self):
         """实体/锚点类型表覆盖全部骨架种类——第五种骨架出现时此处失败，逼出补全。"""
         assert set(SKELETON_ENTITY_TYPES) == set(SKELETONS)
         assert set(SKELETON_ANCHOR_TYPES) == set(SKELETONS)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("kind", "content_mode", "generation_mode", "entity_type", "anchor_type"),
         [
@@ -1264,6 +1281,7 @@ class TestProjectEventService:
         assert change["focus"]["anchor_type"] == anchor_type
         assert change["focus"]["anchor_id"] == "X1"
 
+    @pytest.mark.unit
     def test_diff_snapshots_reports_ad_reference_unit_video_ready(self, tmp_path):
         """ad + reference_video：unit 的 video_clip 空→非空发一条 video_ready（实体类型 reference_unit）。
 
@@ -1331,6 +1349,7 @@ class TestProjectEventService:
         # shots 不承载该路径产物：不发 shot 级 video_ready。
         assert not any(c["entity_type"] == "shot" and c["action"] == "video_ready" for c in changes)
 
+    @pytest.mark.unit
     def test_ad_reference_unit_redrive_does_not_emit_unit_events(self, tmp_path):
         """ad + reference_video：unit 增删/成员变化是 shots 编辑的派生回声，不产生 unit 级事件。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -1395,6 +1414,7 @@ class TestProjectEventService:
         # unit 增删/成员变化不发 unit 级事件（内容变更由 shots 差分承载）。
         assert not any(c["entity_type"] == "reference_unit" for c in changes)
 
+    @pytest.mark.unit
     def test_ad_storyboard_path_ignores_residual_reference_units(self, tmp_path):
         """generation_mode 非 reference_video 的 ad 项目：残留 reference_units 不发 unit 级事件，
 
@@ -1459,6 +1479,7 @@ class TestProjectEventService:
             c["entity_type"] == "shot" and c["action"] == "video_ready" and c["entity_id"] == "E1S01" for c in changes
         )
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_watch_terminates_stream_when_project_directory_deleted(self, tmp_path, caplog):
         """订阅存续期间删除项目目录：一个轮询周期内扫描终止——广播终止事件、
@@ -1494,6 +1515,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_watch_keeps_error_logging_when_only_project_json_missing(self, tmp_path, caplog):
         """项目目录仍存在、仅 project.json 缺失——不属于本次修复范围：维持现状，
@@ -1517,6 +1539,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_hint_rebuild_terminates_channel_without_error_when_project_deleted(self, tmp_path, caplog):
         """hint 触发的显式重建路径对已删除项目同样走终止处理，不产生 ERROR 日志。"""
@@ -1559,6 +1582,7 @@ class TestProjectEventService:
 
         await service.shutdown()
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_new_subscriber_after_project_recreated_gets_fresh_channel(self, tmp_path):
         """项目删除后原通道终止；同名项目重建后新订阅走全新通道，行为与现在一致。"""

--- a/tests/test_project_manager_ad_mode.py
+++ b/tests/test_project_manager_ad_mode.py
@@ -12,6 +12,8 @@ import pytest
 
 from lib.project_manager import ProjectManager
 
+pytestmark = pytest.mark.unit
+
 
 def _pm(tmp_path: Path) -> ProjectManager:
     return ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_compat.py
+++ b/tests/test_project_manager_compat.py
@@ -4,6 +4,8 @@ import pytest
 
 from lib.project_manager import ProjectManager
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def pm_env(tmp_path):

--- a/tests/test_project_manager_concurrent_save.py
+++ b/tests/test_project_manager_concurrent_save.py
@@ -12,8 +12,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+import pytest
+
 from lib.project_manager import ProjectManager
 from server.services.project_archive import ProjectArchiveService
+
+pytestmark = pytest.mark.unit
 
 
 def _seed_project(pm: ProjectManager, name: str) -> None:

--- a/tests/test_project_manager_global_assets.py
+++ b/tests/test_project_manager_global_assets.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.project_manager import ProjectManager
+
+pytestmark = pytest.mark.unit
 
 
 def test_get_global_assets_root_creates_subdirs(tmp_path):

--- a/tests/test_project_manager_legacy_migration.py
+++ b/tests/test_project_manager_legacy_migration.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.project_manager import ProjectManager
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def pm_tmp(tmp_path):

--- a/tests/test_project_manager_migration.py
+++ b/tests/test_project_manager_migration.py
@@ -8,6 +8,8 @@ import pytest
 from lib.project_manager import ProjectManager
 from lib.style_templates import resolve_template_prompt
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def pm(tmp_path: Path) -> ProjectManager:

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -54,6 +54,7 @@ class _FakeTextBackend:
 
 
 class TestProjectManagerMore:
+    @pytest.mark.unit
     def test_project_and_status_lifecycle(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = pm.create_project("demo")
@@ -86,6 +87,7 @@ class TestProjectManagerMore:
         pm.save_project("demo", loaded)
         assert pm.load_project("demo")["style"] == "Noir"
 
+    @pytest.mark.unit
     def test_create_project_metadata_rejects_legacy_image_backend(self, tmp_path):
         """数据层守卫：extras 含退役的 image_backend → 直接 ValueError，绝不写回 legacy 形态。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -95,6 +97,7 @@ class TestProjectManagerMore:
                 "demo", "Demo", "Anime", "narration", extras={"image_backend": "openai/gpt-image-1"}
             )
 
+    @pytest.mark.unit
     def test_create_project_metadata_accepts_new_image_provider_fields(self, tmp_path):
         """新字段 image_provider_t2i/i2i 正常写入（不受守卫影响）。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -104,6 +107,7 @@ class TestProjectManagerMore:
         )
         assert project["image_provider_t2i"] == "openai/gpt-image-1"
 
+    @pytest.mark.unit
     def test_create_project_metadata_is_latest_schema_with_planning_cursor(self, tmp_path):
         """新项目即最新 schema 形态：版本对齐迁移目标版本，planning_cursor 以 null 初始。"""
         from lib.project_migrations import CURRENT_SCHEMA_VERSION
@@ -114,6 +118,7 @@ class TestProjectManagerMore:
         assert project["schema_version"] == CURRENT_SCHEMA_VERSION
         assert project["planning_cursor"] is None
 
+    @pytest.mark.unit
     def test_project_identifier_validation_and_empty_title(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
 
@@ -128,6 +133,7 @@ class TestProjectManagerMore:
         # 空 title 直接保留为空字符串,由前端 i18n 兜底,不再 fallback 为 project_name(slug)
         assert project["title"] == ""
 
+    @pytest.mark.unit
     def test_create_project_metadata_preserves_cjk_title(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_name = pm.generate_project_name("第1集")
@@ -135,6 +141,7 @@ class TestProjectManagerMore:
         project = pm.create_project_metadata(project_name, "第1集")
         assert project["title"] == "第1集"
 
+    @pytest.mark.unit
     def test_generate_project_name_is_unique_and_safe(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
 
@@ -151,6 +158,7 @@ class TestProjectManagerMore:
         assert pm.normalize_project_name(second) == second
         assert pm.normalize_project_name(third) == third
 
+    @pytest.mark.unit
     def test_generate_project_name_truncates_before_letter_check(self, tmp_path):
         # 长 ASCII 标题前 24 字符全是数字/连字符、字母被截掉时,应塌成 proj-,
         # 而不是返回 "1234567890-1234567890-12" 这种纯数字 slug。
@@ -158,6 +166,7 @@ class TestProjectManagerMore:
         candidate = pm.generate_project_name("1234567890-1234567890-1234-letters")
         assert candidate.startswith("proj-")
 
+    @pytest.mark.unit
     def test_script_operations_and_scene_updates(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -219,6 +228,7 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_scene_asset("demo", "episode_1.json", "NOT_FOUND", "video_clip", "x.mp4")
 
+    @pytest.mark.unit
     def test_locked_script_helpers_drama_paths(self, tmp_path):
         """覆盖经 locked_script 迁移的 helper 在 drama/scenes 分支与默认资产填充。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -245,6 +255,7 @@ class TestProjectManagerMore:
         loaded = pm.load_script("demo", "episode_1.json")
         assert loaded["scenes"][0]["generated_assets"]["storyboard_image"] == "sb/001.png"
 
+    @pytest.mark.unit
     def test_batch_update_scene_assets_persists_all(self, tmp_path):
         """batch_update_scene_assets 单次锁内写多个场景，命中全部 id 时持久化所有更新。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -297,6 +308,7 @@ class TestProjectManagerMore:
         seg = pm.load_script("demo", "episode_2.json")["segments"][0]
         assert seg["generated_assets"]["storyboard_image"] == "sb/E2S01.png"
 
+    @pytest.mark.unit
     def test_batch_update_scene_assets_fails_loud_on_missing_ids(self, tmp_path):
         """batch_update 遇到不存在的 scene_id 抛 KeyError 列出所有缺失 id,with 体整体回滚不写回。
 
@@ -334,6 +346,7 @@ class TestProjectManagerMore:
         loaded = pm.load_script("demo", "episode_1.json")
         assert loaded["scenes"][0]["generated_assets"] == {}
 
+    @pytest.mark.unit
     def test_update_character_sheet_success_and_missing(self, tmp_path):
         """update_character_sheet 写入 sheet 路径；角色缺失时锁内 raise 且跳过写回。"""
         pm = ProjectManager(tmp_path / "projects")
@@ -359,6 +372,7 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_character_sheet("demo", "episode_1.json", "李四", "sheets/lisi.png")
 
+    @pytest.mark.unit
     def test_save_script_rejects_mismatch_before_write(self, tmp_path):
         """save_script 在 filename/内部 episode 不一致时必须写盘前 fail-fast。
 
@@ -385,6 +399,7 @@ class TestProjectManagerMore:
         scripts_dir = pm.get_project_path("demo") / "scripts"
         assert not (scripts_dir / "episode_10.json").exists()
 
+    @pytest.mark.unit
     def test_sync_episode_rejects_filename_episode_mismatch(self, tmp_path):
         """文件名隐含集号与脚本内 episode 字段不一致时必须拒绝同步。
 
@@ -423,6 +438,7 @@ class TestProjectManagerMore:
         assert ep1_entry["title"] == "第一集原标题"
         assert ep1_entry["script_file"] == "scripts/episode_1.json"
 
+    @pytest.mark.unit
     def test_load_script_strips_scripts_prefix(self, tmp_path):
         """load_script / save_script / update_scene_asset 应兼容带 scripts/ 前缀的文件名"""
         pm = ProjectManager(tmp_path / "projects")
@@ -458,6 +474,7 @@ class TestProjectManagerMore:
         updated = pm.load_script("demo", "episode_1.json")
         assert updated["segments"][0]["generated_assets"]["storyboard_image"] == "storyboards/scene_E1S01.png"
 
+    @pytest.mark.unit
     def test_normalize_and_templates(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -493,6 +510,7 @@ class TestProjectManagerMore:
 
         assert normalized["generated_assets"]["status"] == "pending"
 
+    @pytest.mark.unit
     def test_entity_and_batch_management_and_paths(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -578,6 +596,7 @@ class TestProjectManagerMore:
         with pytest.raises(KeyError):
             pm.update_prop_sheet("demo", "none", "x")
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_reference_read_source_and_generate_overview(self, tmp_path, monkeypatch):
         pm = ProjectManager(tmp_path / "projects")
@@ -631,6 +650,7 @@ class TestProjectManagerMore:
         with pytest.raises(ValueError):
             await pm_empty.generate_overview("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("lang", ["zh", "en", "vi"])
     @pytest.mark.asyncio
     async def test_generate_overview_source_language_synced(self, tmp_path, monkeypatch, lang):
@@ -647,6 +667,7 @@ class TestProjectManagerMore:
         assert overview["language"] == lang
         assert pm.load_project("demo")["source_language"] == lang
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_generate_overview_invalid_language_raises(self, tmp_path, monkeypatch):
         """schema 违反 → ValidationError 干净抛出,source_language 不被写入."""
@@ -665,6 +686,7 @@ class TestProjectManagerMore:
             await pm.generate_overview("demo")
         assert "source_language" not in pm.load_project("demo")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("source_kind", [None, "novel", "screenplay"])
     @pytest.mark.asyncio
     async def test_generate_overview_routes_prompt_by_source_kind(self, tmp_path, monkeypatch, source_kind):
@@ -690,6 +712,7 @@ class TestProjectManagerMore:
         assert backend.last_request is not None
         assert backend.last_request.prompt == build_overview_prompt(source_content, source_kind=expected_kind)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("dirty_source_language", [123, ["zh"], {}, "", "   "])
     @pytest.mark.asyncio
     async def test_generate_overview_dirty_source_language_falls_back_to_default(
@@ -719,6 +742,7 @@ class TestProjectManagerMore:
             source_content, source_kind="novel", target_language="中文"
         )
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_generate_overview_legacy_project_without_source_kind_falls_back_to_novel(
         self, tmp_path, monkeypatch
@@ -750,6 +774,7 @@ class TestProjectManagerMore:
 class TestFromCwd:
     """Tests for ProjectManager.from_cwd() classmethod."""
 
+    @pytest.mark.unit
     def test_from_cwd_infers_project(self, tmp_path, monkeypatch):
         projects_root = tmp_path / "projects"
         project_dir = projects_root / "my-proj"
@@ -761,6 +786,7 @@ class TestFromCwd:
         assert name == "my-proj"
         assert pm.projects_root == projects_root
 
+    @pytest.mark.unit
     def test_from_cwd_raises_when_no_project_json(self, tmp_path, monkeypatch):
         project_dir = tmp_path / "projects" / "empty"
         project_dir.mkdir(parents=True)
@@ -773,6 +799,7 @@ class TestFromCwd:
 class TestPathTraversalProtection:
     """路径遍历防护测试"""
 
+    @pytest.mark.unit
     def test_get_project_path_rejects_traversal(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -782,6 +809,7 @@ class TestPathTraversalProtection:
         with pytest.raises(ValueError):
             pm.get_project_path("demo/../../etc")
 
+    @pytest.mark.unit
     def test_normalize_project_name_rejects_special_chars(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         with pytest.raises(ValueError):
@@ -791,6 +819,7 @@ class TestPathTraversalProtection:
         with pytest.raises(ValueError):
             pm.normalize_project_name("")
 
+    @pytest.mark.unit
     def test_load_script_rejects_traversal_filename(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -798,6 +827,7 @@ class TestPathTraversalProtection:
         with pytest.raises(ValueError, match="非法文件名"):
             pm.load_script("demo", "../../etc/passwd")
 
+    @pytest.mark.unit
     def test_save_script_rejects_traversal_filename(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -806,6 +836,7 @@ class TestPathTraversalProtection:
         with pytest.raises(ValueError, match="非法文件名"):
             pm.save_script("demo", script, filename="../../evil.json")
 
+    @pytest.mark.unit
     def test_safe_subpath_allows_normal_filenames(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -818,29 +849,36 @@ class TestPathTraversalProtection:
 
 
 class TestResolveEpisodeFromScript:
+    @pytest.mark.unit
     def test_prefers_script_top_level_episode(self):
         ep = ProjectManager.resolve_episode_from_script({"episode": 7, "scenes": []}, "whatever.json")
         assert ep == 7
 
+    @pytest.mark.unit
     def test_falls_back_to_filename_regex(self):
         ep = ProjectManager.resolve_episode_from_script({"scenes": []}, "episode_3.json")
         assert ep == 3
 
+    @pytest.mark.unit
     def test_filename_regex_case_insensitive_and_spaced(self):
         assert ProjectManager.resolve_episode_from_script({}, "Episode 12.json") == 12
 
+    @pytest.mark.unit
     def test_filename_regex_supports_hyphen(self):
         assert ProjectManager.resolve_episode_from_script({}, "episode-5.json") == 5
 
+    @pytest.mark.unit
     def test_ignores_non_int_episode_field(self):
         """非整数的 episode 字段（如 '1'）应回退到文件名。"""
         ep = ProjectManager.resolve_episode_from_script({"episode": "1"}, "episode_9.json")
         assert ep == 9
 
+    @pytest.mark.unit
     def test_ignores_bool_episode_field(self):
         """bool 是 int 子类：episode: true 当作字段缺失走文件名，不静默算成第 1 集。"""
         assert ProjectManager.resolve_episode_from_script({"episode": True}, "episode_9.json") == 9
 
+    @pytest.mark.unit
     def test_raises_when_unresolvable(self):
         with pytest.raises(ValueError, match="无法确定集号"):
             ProjectManager.resolve_episode_from_script({}, "random_name.json")
@@ -849,6 +887,7 @@ class TestResolveEpisodeFromScript:
 class TestScenePropLifecycle:
     """scene / prop 生命周期测试（Task 9）"""
 
+    @pytest.mark.unit
     def test_add_scene_creates_entry(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -862,6 +901,7 @@ class TestScenePropLifecycle:
         assert project["scenes"]["客厅"]["description"] == "宽敞的客厅"
         assert project["scenes"]["客厅"]["scene_sheet"] == ""
 
+    @pytest.mark.unit
     def test_add_prop_creates_entry(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -875,6 +915,7 @@ class TestScenePropLifecycle:
         assert project["props"]["玉佩"]["description"] == "一块古玉"
         assert project["props"]["玉佩"]["prop_sheet"] == ""
 
+    @pytest.mark.unit
     def test_get_pending_scenes_lists_without_sheet(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -900,6 +941,7 @@ class TestScenePropLifecycle:
         assert len(pending3) == 1
         assert pending3[0]["name"] == "书房"
 
+    @pytest.mark.unit
     def test_get_pending_props_lists_without_sheet(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -920,6 +962,7 @@ class TestScenePropLifecycle:
         assert len(pending2) == 1
         assert pending2[0]["name"] == "宝剑"
 
+    @pytest.mark.unit
     def test_add_scenes_batch_skips_existing(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -935,6 +978,7 @@ class TestScenePropLifecycle:
         # 新的被添加
         assert "书房" in project["scenes"]
 
+    @pytest.mark.unit
     def test_add_props_batch_skips_existing(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
@@ -949,6 +993,7 @@ class TestScenePropLifecycle:
         assert "宝剑" in project["props"]
 
 
+@pytest.mark.unit
 def test_read_source_files_raises_on_non_utf8(tmp_path):
     import random
 

--- a/tests/test_project_manager_save_validation.py
+++ b/tests/test_project_manager_save_validation.py
@@ -15,6 +15,8 @@ from lib.project_manager import ProjectManager
 from lib.script_editor import ScriptEditError
 from lib.script_structure_validator import ScriptStructureValidationError
 
+pytestmark = pytest.mark.unit
+
 
 def _segment(segment_id: str = "E1S01", duration: int = 4) -> dict:
     return {

--- a/tests/test_project_manager_source_kind.py
+++ b/tests/test_project_manager_source_kind.py
@@ -11,6 +11,8 @@ import pytest
 
 from lib.project_manager import ProjectManager, resolve_source_kind
 
+pytestmark = pytest.mark.unit
+
 
 def _pm(tmp_path: Path) -> ProjectManager:
     return ProjectManager(tmp_path / "projects")

--- a/tests/test_project_manager_symlink.py
+++ b/tests/test_project_manager_symlink.py
@@ -26,6 +26,8 @@ from lib.profile_manifest import (
 )
 from lib.project_manager import ProjectManager
 
+pytestmark = pytest.mark.unit
+
 # ---------- 公共 fixtures ----------
 
 

--- a/tests/test_project_migration_runner.py
+++ b/tests/test_project_migration_runner.py
@@ -13,6 +13,8 @@ from lib.project_migrations.runner import (
     run_project_migrations,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def tmp_projects(tmp_path: Path) -> Path:

--- a/tests/test_project_migration_v0_v1.py
+++ b/tests/test_project_migration_v0_v1.py
@@ -7,6 +7,8 @@ import pytest
 
 from lib.project_migrations import v0_to_v1_clues_to_scenes_props as mod
 
+pytestmark = pytest.mark.unit
+
 migrate_v0_to_v1 = mod.migrate_v0_to_v1
 
 

--- a/tests/test_project_migration_v1_v2.py
+++ b/tests/test_project_migration_v1_v2.py
@@ -3,10 +3,14 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from lib.project_migrations.v1_to_v2_normalize_providers import (
     migrate_project_dict,
     migrate_v1_to_v2,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestMigrateProjectDictPureFunction:

--- a/tests/test_project_migration_v2_v3.py
+++ b/tests/test_project_migration_v2_v3.py
@@ -10,6 +10,8 @@ from lib.project_migrations import v2_to_v3_episode_ledger
 from lib.project_migrations.runner import migrate_project_dir
 from lib.project_migrations.v2_to_v3_episode_ledger import migrate_v2_to_v3
 
+pytestmark = pytest.mark.unit
+
 NOVEL = "第一集的正文内容。第二集还没拆出来的余文。"
 EP1 = "第一集的正文内容。"
 

--- a/tests/test_project_migration_v3_v4.py
+++ b/tests/test_project_migration_v3_v4.py
@@ -7,6 +7,8 @@ import pytest
 
 from lib.project_migrations.v3_to_v4_text_tiers import migrate_project_dict, migrate_v3_to_v4
 
+pytestmark = pytest.mark.unit
+
 
 def _write(tmp_path: Path, data: dict) -> Path:
     d = tmp_path / "demo"

--- a/tests/test_project_migration_v4_v5.py
+++ b/tests/test_project_migration_v4_v5.py
@@ -7,6 +7,8 @@ import pytest
 
 from lib.project_migrations.v4_to_v5_generation_route import migrate_project_dict, migrate_v4_to_v5
 
+pytestmark = pytest.mark.unit
+
 
 def _write(tmp_path: Path, data: dict) -> Path:
     d = tmp_path / "demo"

--- a/tests/test_projects_archive_routes.py
+++ b/tests/test_projects_archive_routes.py
@@ -4,6 +4,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -11,6 +12,8 @@ from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, create_download_token, create_token, get_current_user
 from server.routers import projects
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 def _write_text(path: Path, content: str) -> None:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -268,6 +268,7 @@ def _client(monkeypatch, fake_pm, fake_calc):
 
 
 class TestProjectsRouter:
+    @pytest.mark.unit
     def test_list_and_create_and_delete(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -333,6 +334,7 @@ class TestProjectsRouter:
             delete_ok = client.delete("/api/v1/projects/remove-me")
             assert delete_ok.status_code == 200
 
+    @pytest.mark.unit
     def test_create_persists_source_kind_and_defaults_novel(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -371,6 +373,7 @@ class TestProjectsRouter:
             )
             assert invalid.status_code == 422
 
+    @pytest.mark.unit
     def test_source_kind_not_editable_after_create(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -380,6 +383,7 @@ class TestProjectsRouter:
             rejected_null = client.patch("/api/v1/projects/ready", json={"source_kind": None})
             assert rejected_null.status_code == 400
 
+    @pytest.mark.unit
     def test_project_details_and_updates(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -434,6 +438,7 @@ class TestProjectsRouter:
             get_script_missing = client.get("/api/v1/projects/ready/scripts/missing.json")
             assert get_script_missing.status_code == 404
 
+    @pytest.mark.unit
     def test_create_ad_project(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -471,6 +476,7 @@ class TestProjectsRouter:
             assert custom.json()["project"]["target_duration"] == 47
             assert custom.json()["project"]["brief"] == "卖点"
 
+    @pytest.mark.unit
     def test_create_ad_project_rejects_incompatible_fields(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -512,6 +518,7 @@ class TestProjectsRouter:
             )
             assert narration_with_brief.status_code == 400
 
+    @pytest.mark.unit
     def test_create_requires_binary_generation_mode(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -538,6 +545,7 @@ class TestProjectsRouter:
                 assert created.status_code == 200, created.text
                 assert created.json()["project"]["generation_mode"] == mode
 
+    @pytest.mark.unit
     def test_create_persists_grid_storyboard(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -556,6 +564,7 @@ class TestProjectsRouter:
             assert enabled.status_code == 200
             assert enabled.json()["project"]["grid_storyboard"] is True
 
+    @pytest.mark.unit
     def test_patch_toggles_grid_storyboard_but_not_route(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.project_data["ready"]["generation_mode"] = "storyboard"
@@ -575,6 +584,7 @@ class TestProjectsRouter:
             assert route.status_code == 200
             assert fake_pm.project_data["ready"]["generation_mode"] == "storyboard"
 
+    @pytest.mark.unit
     def test_patch_ad_project_fields(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -619,6 +629,7 @@ class TestProjectsRouter:
             assert client.patch("/api/v1/projects/ready", json={"target_duration": 60}).status_code == 400
             assert client.patch("/api/v1/projects/ready", json={"brief": "x"}).status_code == 400
 
+    @pytest.mark.unit
     def test_scene_segment_and_overview_endpoints(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ready", "episode_1.json")] = {
@@ -667,6 +678,7 @@ class TestProjectsRouter:
             gen_overview_ok = client.post("/api/v1/projects/ready/generate-overview")
             assert gen_overview_ok.status_code == 200
 
+    @pytest.mark.unit
     def test_update_segment_writes_character_and_clue_refs(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ready", "narration.json")] = {
@@ -713,6 +725,7 @@ class TestProjectsRouter:
             assert seg2["scenes"] == ["Castle"]
             assert seg2["props"] == []
 
+    @pytest.mark.unit
     def test_update_segment_rejects_drama_script_with_residual_segments(self, tmp_path, monkeypatch):
         # drama 脚本残留 segments 键不应被当 narration 改写：须返回 400 而非放行
         fake_pm = _FakePM(tmp_path)
@@ -731,6 +744,7 @@ class TestProjectsRouter:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_update_segment_write_value_error_returns_422(self, tmp_path, monkeypatch):
         # 写盘统一入口对客户端错误（结构非法 / 集号错配 / 非法文件名）抛 ValueError，
         # router 须统一转 422 而非落到 500 兜底。
@@ -757,6 +771,7 @@ class TestProjectsRouter:
             assert resp.status_code == 422
             assert "不一致" in resp.json()["detail"]
 
+    @pytest.mark.unit
     def test_update_scene_supports_character_and_clue_refs(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ready", "episode_1.json")] = {
@@ -808,6 +823,7 @@ class TestProjectsRouter:
             assert update_overview.status_code == 200
             assert update_overview.json()["overview"]["synopsis"] == "new synopsis"
 
+    @pytest.mark.unit
     def test_update_scene_accepts_utterances(self, tmp_path, monkeypatch):
         # drama 分镜详情编辑场景级发声序列：utterances 在白名单内，PATCH 写回并持久化
         fake_pm = _FakePM(tmp_path)
@@ -857,6 +873,7 @@ class TestProjectsRouter:
             ],
         }
 
+    @pytest.mark.unit
     def test_update_shot_edits_voiceover_section_duration(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02"])
@@ -885,6 +902,7 @@ class TestProjectsRouter:
             saved = fake_pm.scripts[("ad-ready", "episode_1.json")]["shots"][0]
             assert saved["voiceover_text"] == "新口播"
 
+    @pytest.mark.unit
     def test_update_shot_ignores_non_whitelisted_fields(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01"])
@@ -904,6 +922,7 @@ class TestProjectsRouter:
             assert "generated_assets" not in saved
             assert saved["note"] == "备注"
 
+    @pytest.mark.unit
     def test_update_shot_rejects_non_ad_script(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -915,6 +934,7 @@ class TestProjectsRouter:
             )
             assert rejected.status_code == 400
 
+    @pytest.mark.unit
     def test_update_shot_unknown_id_404(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01"])
@@ -927,6 +947,7 @@ class TestProjectsRouter:
             )
             assert missing.status_code == 404
 
+    @pytest.mark.unit
     def test_reorder_shots_full_permutation(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02", "E1S03"])
@@ -942,6 +963,7 @@ class TestProjectsRouter:
             saved = fake_pm.scripts[("ad-ready", "episode_1.json")]["shots"]
             assert [s["shot_id"] for s in saved] == ["E1S03", "E1S01", "E1S02"]
 
+    @pytest.mark.unit
     def test_reorder_shots_rejects_mismatched_ids(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02"])
@@ -970,6 +992,7 @@ class TestProjectsRouter:
             saved = fake_pm.scripts[("ad-ready", "episode_1.json")]["shots"]
             assert [s["shot_id"] for s in saved] == ["E1S01", "E1S02"]
 
+    @pytest.mark.unit
     def test_reorder_shots_rejects_non_ad_script(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -981,6 +1004,7 @@ class TestProjectsRouter:
             )
             assert rejected.status_code == 400
 
+    @pytest.mark.unit
     def test_corrupted_shots_shape_fails_loud_not_silently_wiped(self, tmp_path, monkeypatch):
         """shots 非列表 / 含非对象元素时返回 422，且不被 reorder 空排列覆盖成 []。"""
         fake_pm = _FakePM(tmp_path)
@@ -1043,6 +1067,7 @@ class TestProjectsRouter:
             )
             assert dup_id.status_code == 422
 
+    @pytest.mark.unit
     def test_get_project_includes_asset_fingerprints(self, tmp_path, monkeypatch):
         """项目 API 应返回 asset_fingerprints 字段"""
         fake_pm = _FakePM(tmp_path)
@@ -1056,6 +1081,7 @@ class TestProjectsRouter:
             assert "storyboards/scene_E1S01.png" in data["asset_fingerprints"]
             assert isinstance(data["asset_fingerprints"]["storyboards/scene_E1S01.png"], int)
 
+    @pytest.mark.unit
     def test_create_project_with_style_template_id_expands_prompt(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1077,6 +1103,7 @@ class TestProjectsRouter:
             assert data["style_template_id"] == "live_premium_drama"
             assert "真人电视剧" in data["style"] or "精品短剧" in data["style"]
 
+    @pytest.mark.unit
     def test_create_project_with_unknown_template_id_returns_400(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1093,6 +1120,7 @@ class TestProjectsRouter:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_create_project_with_model_fields_persists(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1169,6 +1197,7 @@ class TestProjectsRouter:
             )
             assert wrong_media.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_text_tier_fields_set_and_clear(self, tmp_path, monkeypatch):
         """项目级档位 / 默认模型三字段可设置；空值 = 清除、继承全局。"""
         fake_pm = _FakePM(tmp_path)
@@ -1253,6 +1282,7 @@ class TestProjectsRouter:
             )
             assert rejected.status_code == 400
 
+    @pytest.mark.unit
     def test_create_project_rejects_legacy_image_backend(self, tmp_path, monkeypatch):
         """退役的 image_backend 字段在写路径被直接 400 拒绝，避免静默错配（应改用 image_provider_t2i/i2i）。"""
         fake_pm = _FakePM(tmp_path)
@@ -1271,6 +1301,7 @@ class TestProjectsRouter:
             assert resp.status_code == 400
             assert "legacy-1" not in fake_pm.project_data
 
+    @pytest.mark.unit
     def test_create_project_empty_model_fields_not_written(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1291,6 +1322,7 @@ class TestProjectsRouter:
             assert "video_backend" not in data
             assert "image_backend" not in data
 
+    @pytest.mark.unit
     def test_create_project_with_invalid_backend_returns_400(self, tmp_path, monkeypatch):
         """非法 backend 字符串应被校验器拒绝。"""
         fake_pm = _FakePM(tmp_path)
@@ -1308,6 +1340,7 @@ class TestProjectsRouter:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_update_project_with_style_template_id_expands_and_clears_image(self, tmp_path, monkeypatch):
         """PATCH style_template_id：写入 id + 展开 prompt 到 style，并清掉 style_image/description。"""
         fake_pm = _FakePM(tmp_path)
@@ -1328,6 +1361,7 @@ class TestProjectsRouter:
             assert "style_image" not in data
             assert "style_description" not in data
 
+    @pytest.mark.unit
     def test_update_project_with_unknown_template_id_returns_400(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:
@@ -1337,6 +1371,7 @@ class TestProjectsRouter:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_update_project_clear_style_template(self, tmp_path, monkeypatch):
         """PATCH style_template_id=null：同时清掉 id 与派生的 style 长文本。"""
         fake_pm = _FakePM(tmp_path)
@@ -1354,6 +1389,7 @@ class TestProjectsRouter:
             assert "style_template_id" not in data
             assert data["style"] == ""
 
+    @pytest.mark.unit
     def test_update_project_clear_style_image(self, tmp_path, monkeypatch):
         """PATCH clear_style_image=true：清掉 style_image 与 style_description。"""
         fake_pm = _FakePM(tmp_path)
@@ -1371,6 +1407,7 @@ class TestProjectsRouter:
             assert "style_image" not in data
             assert "style_description" not in data
 
+    @pytest.mark.unit
     def test_update_project_persists_narration_overrides(self, tmp_path, monkeypatch):
         """PATCH 旁白配音项目级覆盖：audio_backend / narration_voice / narration_speed 写入 project.json。"""
         fake_pm = _FakePM(tmp_path)
@@ -1390,6 +1427,7 @@ class TestProjectsRouter:
             assert data["narration_voice"] == "Cherry"
             assert data["narration_speed"] == 1.2
 
+    @pytest.mark.unit
     def test_update_project_clears_narration_overrides(self, tmp_path, monkeypatch):
         """PATCH 空值/null：旁白配音覆盖回落全局默认（从 project.json 移除）。"""
         fake_pm = _FakePM(tmp_path)
@@ -1418,6 +1456,7 @@ class TestProjectsRouter:
             assert resp.status_code == 200
             assert "narration_voice" not in fake_pm.project_data["ready"]
 
+    @pytest.mark.unit
     def test_update_project_rejects_non_positive_narration_speed(self, tmp_path, monkeypatch):
         """语速 0/负数应 422，且不写回 project.json。"""
         fake_pm = _FakePM(tmp_path)
@@ -1427,6 +1466,7 @@ class TestProjectsRouter:
             assert resp.status_code == 422
             assert "narration_speed" not in fake_pm.project_data["ready"]
 
+    @pytest.mark.unit
     def test_update_project_rejects_invalid_audio_backend(self, tmp_path, monkeypatch):
         """audio_backend 非法 provider 应 400（复用 backend 格式校验）。"""
         fake_pm = _FakePM(tmp_path)
@@ -1435,6 +1475,7 @@ class TestProjectsRouter:
             resp = client.patch("/api/v1/projects/ready", json={"audio_backend": "garbage"})
             assert resp.status_code == 400
 
+    @pytest.mark.unit
     def test_list_projects_shares_script_preload_with_status(self, tmp_path, monkeypatch):
         """list_projects 一次性加载 episode scripts，传给 StatusCalculator，去除 cover + status 双重 I/O。"""
         fake_pm = _FakePM(tmp_path)
@@ -1463,6 +1504,7 @@ class TestProjectsRouter:
         assert fake_calc.last_preloaded_scripts is not None
         assert "scripts/episode_1.json" in fake_calc.last_preloaded_scripts
 
+    @pytest.mark.unit
     def test_list_projects_returns_style_image_field(self, tmp_path, monkeypatch):
         """列表端点需返回 style_image：否则前端无法区分"自定义风格"与"未设置"。"""
         fake_pm = _FakePM(tmp_path)
@@ -1479,6 +1521,7 @@ class TestProjectsRouter:
             assert ready["style_image"] == "style_reference.png"
             assert ready.get("style_template_id") is None
 
+    @pytest.mark.unit
     def test_update_project_clear_style_combined(self, tmp_path, monkeypatch):
         """一次性清空所有风格：style_template_id=null + clear_style_image=true。"""
         fake_pm = _FakePM(tmp_path)
@@ -1504,6 +1547,7 @@ class TestProjectsRouter:
     # Episodes PATCH tests
     # ---------------------------------------------------------------------------
 
+    @pytest.mark.unit
     def test_patch_project_episodes_updates_script_file(self, tmp_path, monkeypatch):
         """PATCH /projects/{name} with episodes[] 只更新匹配集的白名单字段。"""
         fake_pm = _FakePM(tmp_path)
@@ -1526,6 +1570,7 @@ class TestProjectsRouter:
             # 第二集不受影响
             assert ep2["script_file"] == "scripts/ep2.json"
 
+    @pytest.mark.unit
     def test_patch_project_episodes_has_no_route_field(self, tmp_path, monkeypatch):
         """生成路线按项目定轴：集级 PATCH 模型结构上无 generation_mode，出现即被静默丢弃、不写盘。"""
         fake_pm = _FakePM(tmp_path)
@@ -1543,6 +1588,7 @@ class TestProjectsRouter:
             ep1 = fake_pm.project_data["ready"]["episodes"][0]
             assert "generation_mode" not in ep1
 
+    @pytest.mark.unit
     def test_patch_project_episodes_strips_computed_fields(self, tmp_path, monkeypatch):
         """PATCH 不得将 StatusCalculator 注入的计算字段写回 project.json；title 也已移出白名单。"""
         fake_pm = _FakePM(tmp_path)
@@ -1585,6 +1631,7 @@ class TestProjectsRouter:
             assert "script_status" not in ep1
             assert "duration_seconds" not in ep1
 
+    @pytest.mark.unit
     def test_patch_project_episodes_skips_unknown_episode(self, tmp_path, monkeypatch):
         """PATCH 传入未知 episode 编号时，静默跳过，不改变已有 episodes。"""
         fake_pm = _FakePM(tmp_path)
@@ -1607,6 +1654,7 @@ class TestProjectsRouter:
             assert episodes[0]["script_file"] == "scripts/ep1.json"
             assert episodes[1]["script_file"] == "scripts/ep2.json"
 
+    @pytest.mark.unit
     def test_update_episode_title_renames_script_and_mirror(self, tmp_path, monkeypatch):
         """PATCH /episodes/{episode}：剧本顶层 title 与 project.json 镜像都反映新值，标题首尾空白被裁剪。"""
         fake_pm = _FakePM(tmp_path)
@@ -1624,6 +1672,7 @@ class TestProjectsRouter:
             ep = next(e for e in fake_pm.project_data["ready"]["episodes"] if e["episode"] == 1)
             assert ep["title"] == "新集名"
 
+    @pytest.mark.unit
     def test_update_episode_title_empty_rejected(self, tmp_path, monkeypatch):
         """空/纯空白标题被拒（422），不进锁。"""
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1632,6 +1681,7 @@ class TestProjectsRouter:
                 resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": blank})
                 assert resp.status_code == 422
 
+    @pytest.mark.unit
     def test_update_episode_missing_episode_404(self, tmp_path, monkeypatch):
         """不存在的 episode → 404。"""
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1639,6 +1689,7 @@ class TestProjectsRouter:
             resp = client.patch("/api/v1/projects/ready/episodes/99", json={"title": "x"})
             assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_update_episode_missing_project_404(self, tmp_path, monkeypatch):
         """项目不存在 → 404，不退化成 500。
 
@@ -1651,6 +1702,7 @@ class TestProjectsRouter:
             assert resp.status_code == 404
             assert resp.json()["detail"] == zh_errors.MESSAGES["project_not_found"].format(name="nope")
 
+    @pytest.mark.unit
     def test_update_episode_stale_script_binding_404(self, tmp_path, monkeypatch):
         """项目在但 project.json 指向的剧本文件已丢失（stale 绑定）→ 404 而非 500。"""
         fake_pm = _FakePM(tmp_path)
@@ -1678,6 +1730,7 @@ class TestGetVideoCapabilities:
         monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
         return resolver_instance
 
+    @pytest.mark.unit
     def test_returns_capabilities_json(self, tmp_path, monkeypatch):
         fake_caps = {
             "provider_id": "grok",
@@ -1798,6 +1851,7 @@ class TestGetVideoCapabilities:
         assert provider_id == "openai"
         assert model_id
 
+    @pytest.mark.unit
     def test_unknown_project_returns_404(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, side_effect=FileNotFoundError("项目 'nonexistent' 不存在"))
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1805,6 +1859,7 @@ class TestGetVideoCapabilities:
             resp = client.get("/api/v1/projects/nonexistent/video-capabilities")
             assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_resolver_value_error_returns_422(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, side_effect=ValueError("model not found: grok/unknown"))
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1841,6 +1896,7 @@ class TestGetVideoCapabilities:
 
 
 class TestModelSettingsApi:
+    @pytest.mark.unit
     def test_create_project_with_model_settings(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1864,6 +1920,7 @@ class TestModelSettingsApi:
             stored = fake_pm.project_data["demo-res"]
             assert stored["model_settings"]["gemini-aistudio/veo-3.1-lite-generate-preview"]["resolution"] == "720p"
 
+    @pytest.mark.unit
     def test_patch_project_model_settings(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         client = _client(monkeypatch, fake_pm, _FakeCalc())
@@ -1907,6 +1964,7 @@ class TestUnexpectedErrorsDoNotLeak:
         # 这里直接断言整段原始文本，覆盖 detail / errors / warnings 任意字段都不泄露。
         return resp.text
 
+    @pytest.mark.unit
     def test_create_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_create_project"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1920,6 +1978,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_get_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_get_project"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1929,6 +1988,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_project"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1938,6 +1998,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_delete_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_delete_project"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1947,6 +2008,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_get_script_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_get_script"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1956,6 +2018,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_scene_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_scene"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1968,6 +2031,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_shot_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_shot"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1980,6 +2044,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_reorder_shots_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_reorder_shots"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -1992,6 +2057,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_segment_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_segment"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2004,6 +2070,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_episode_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_episode"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2014,6 +2081,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_set_project_source_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_set_source"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2027,6 +2095,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_set_project_source_overview_error_does_not_leak_path(self, tmp_path, monkeypatch):
         # 概览生成是上传的可选后续：失败时上传仍成功（200），错误只降级回传 overview_error。
         # 底层异常文本可能携带服务器绝对路径，该分支不得把裸 str(e) 透传给客户端。
@@ -2048,6 +2117,7 @@ class TestUnexpectedErrorsDoNotLeak:
             # 回传的是翻译后的通用文案，而非裸异常串
             assert payload["overview_error"] == zh_errors.MESSAGES["overview_generation_failed"]
 
+    @pytest.mark.unit
     def test_generate_overview_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_generate_overview"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2057,6 +2127,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_generate_overview_corrupted_project_maps_to_500_not_provider_error(self, tmp_path, monkeypatch):
         # JSONDecodeError 是 ValueError 子类：损坏的 project.json 不能被 except ValueError
         # 误判为「未配置文本供应商」，须先于其拦截并映射为通用 500
@@ -2066,6 +2137,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert "配置文本供应商" not in self._body(resp)
 
+    @pytest.mark.unit
     def test_generate_overview_schema_failure_maps_to_ai_response_invalid(self, tmp_path, monkeypatch):
         # pydantic ValidationError 也是 ValueError 子类：模型输出不合 schema 时须命中
         # 「AI 响应无效」专属分支，不能被通用 ValueError 处理误判为「未配置文本供应商」
@@ -2075,6 +2147,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 400
             assert resp.json()["detail"] == zh_errors.MESSAGES["overview_ai_response_invalid"]
 
+    @pytest.mark.unit
     def test_generate_overview_invalid_project_name_maps_to_400_not_provider_error(self, tmp_path, monkeypatch):
         # get_project_path 抛出的非法项目名 ValueError（路径穿越等）不能被 generate_overview()
         # 内部供应商解析链路的 except ValueError 误判为「未配置文本供应商」
@@ -2085,6 +2158,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert "配置文本供应商" not in self._body(resp)
             assert "illegal-name" in self._body(resp)
 
+    @pytest.mark.unit
     def test_update_overview_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_overview"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2094,6 +2168,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_create_export_token_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_export_token"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2104,6 +2179,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_export_project_archive_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_export_archive"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
@@ -2115,6 +2191,7 @@ class TestUnexpectedErrorsDoNotLeak:
             assert resp.status_code == 500
             assert sentinel not in self._body(resp)
 
+    @pytest.mark.unit
     def test_import_project_archive_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_import_archive"
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())

--- a/tests/test_prompt_builders.py
+++ b/tests/test_prompt_builders.py
@@ -12,6 +12,7 @@ from lib.prompt_builders import (
 
 
 class TestCharacterPrompt:
+    @pytest.mark.unit
     def test_includes_name_description_and_quad_layout(self):
         prompt = build_character_prompt(
             "姜月茴",
@@ -32,6 +33,7 @@ class TestCharacterPrompt:
         # 反向提示尾部
         assert "画面避免" in prompt
 
+    @pytest.mark.unit
     def test_no_negative_prompt_field_returned(self):
         # build_character_prompt 仅返回字符串；反向提示已 inline 到末尾
         prompt = build_character_prompt("张三", "短发青年")
@@ -41,6 +43,7 @@ class TestCharacterPrompt:
 
 
 class TestScenePromptAndPropPrompt:
+    @pytest.mark.unit
     def test_prop_three_views(self):
         prompt = build_prop_prompt("玉佩", "古朴温润")
         assert "玉佩" in prompt
@@ -48,6 +51,7 @@ class TestScenePromptAndPropPrompt:
         assert "三视图" in prompt or "三个视图" in prompt
         assert "画面避免" in prompt
 
+    @pytest.mark.unit
     def test_scene_main_detail_layout(self):
         prompt = build_scene_prompt("祠堂", "昏暗古朴")
         assert "祠堂" in prompt
@@ -75,20 +79,24 @@ class TestFigureExclusion:
 
 
 class TestVideoNegativeTail:
+    @pytest.mark.unit
     def test_appends_when_missing(self):
         result = append_video_negative_tail("林清缓缓抬头")
         assert "林清缓缓抬头" in result
         assert "BGM" in result
 
+    @pytest.mark.unit
     def test_idempotent(self):
         once = append_video_negative_tail("林清缓缓抬头")
         twice = append_video_negative_tail(once)
         assert once == twice
 
+    @pytest.mark.unit
     def test_handles_empty_input(self):
         result = append_video_negative_tail("")
         assert "BGM" in result
 
+    @pytest.mark.unit
     def test_handles_whitespace_only_input(self):
         # 纯空白等同空：避免拼出前导空行 + 尾词的怪异输出
         for blank in ("   ", "\n\n", "\t \n"):
@@ -97,16 +105,19 @@ class TestVideoNegativeTail:
 
 
 class TestImageNegativeTail:
+    @pytest.mark.unit
     def test_appends_when_missing(self):
         result = append_image_negative_tail("林清坐在窗边木桌前")
         assert result.startswith("林清坐在窗边木桌前")
         assert "画面避免" in result
 
+    @pytest.mark.unit
     def test_idempotent(self):
         once = append_image_negative_tail("林清坐在窗边木桌前")
         twice = append_image_negative_tail(once)
         assert once == twice
 
+    @pytest.mark.unit
     def test_handles_empty_and_whitespace_input(self):
         for blank in ("", "   ", "\n\n", "\t \n"):
             result = append_image_negative_tail(blank)
@@ -114,27 +125,32 @@ class TestImageNegativeTail:
 
 
 class TestProductFidelityTail:
+    @pytest.mark.unit
     def test_appends_instruction_with_product_names(self):
         result = append_product_fidelity_tail("手持保温杯特写", ["保温杯"])
         assert result.startswith("手持保温杯特写")
         assert "「保温杯」" in result
         assert "参考图" in result
 
+    @pytest.mark.unit
     def test_idempotent(self):
         once = append_product_fidelity_tail("手持保温杯特写", ["保温杯"])
         twice = append_product_fidelity_tail(once, ["保温杯"])
         assert once == twice
 
+    @pytest.mark.unit
     def test_no_products_returns_prompt_unchanged(self):
         assert append_product_fidelity_tail("氛围镜头", []) == "氛围镜头"
         # None 等同为空：早退返回原 prompt，不抛 TypeError
         assert append_product_fidelity_tail("氛围镜头", None) == "氛围镜头"
 
+    @pytest.mark.unit
     def test_multiple_products_all_named(self):
         result = append_product_fidelity_tail("双产品同框", ["保温杯", "杯刷"])
         assert "「保温杯」" in result
         assert "「杯刷」" in result
 
+    @pytest.mark.unit
     def test_single_string_treated_as_single_product(self):
         """误传单字符串按单产品名处理，而非逐字符迭代拼出畸形指令。"""
         result = append_product_fidelity_tail("产品特写", "保温杯")

--- a/tests/test_prompt_builders_ad.py
+++ b/tests/test_prompt_builders_ad.py
@@ -8,6 +8,8 @@ import pytest
 from lib.prompt_builders_ad import build_ad_prompt
 from lib.speech_rate import speech_rate_units_per_second
 
+pytestmark = pytest.mark.unit
+
 
 def _build(**overrides):
     kwargs = dict(

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lib.prompt_builders_ad import build_ad_prompt
 from lib.prompt_builders_script import (
     _format_names,
@@ -10,6 +12,8 @@ from lib.prompt_builders_script import (
 )
 from lib.prompt_rules.episode_pacing import DRAMA_PACING_RULES, NARRATION_PACING_RULES
 from lib.speech_rate import speech_rate_units_per_second
+
+pytestmark = pytest.mark.unit
 
 
 class TestPromptBuildersScript:

--- a/tests/test_prompt_builders_script_duration.py
+++ b/tests/test_prompt_builders_script_duration.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.prompt_builders_script import _format_duration_constraint
 
+pytestmark = pytest.mark.unit
+
 
 class TestFormatDurationConstraint:
     def test_discrete_set(self):

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,5 +1,6 @@
 import unicodedata
 
+import pytest
 import yaml
 
 from lib.prompt_utils import (
@@ -13,6 +14,8 @@ from lib.prompt_utils import (
     validate_shot_type,
     video_prompt_to_yaml,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestNormalizeStyle:

--- a/tests/test_props_router.py
+++ b/tests/test_props_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -5,6 +6,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import props
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakePM:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,6 +1,10 @@
 """PROVIDER_REGISTRY 字段与注册完整性单元测试。"""
 
+import pytest
+
 from lib.config.registry import PROVIDER_REGISTRY
+
+pytestmark = pytest.mark.unit
 
 
 def test_ark_has_default_base_url() -> None:

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -81,23 +81,27 @@ class TestListProviders:
         )
         return svc
 
+    @pytest.mark.unit
     def test_returns_200(self):
         with _make_client(self._mock_svc()) as client:
             resp = client.get("/api/v1/providers")
         assert resp.status_code == 200
 
+    @pytest.mark.unit
     def test_contains_providers_key(self):
         with _make_client(self._mock_svc()) as client:
             resp = client.get("/api/v1/providers")
         body = resp.json()
         assert "providers" in body
 
+    @pytest.mark.unit
     def test_provider_count(self):
         with _make_client(self._mock_svc()) as client:
             resp = client.get("/api/v1/providers")
         body = resp.json()
         assert len(body["providers"]) == 2
 
+    @pytest.mark.unit
     def test_provider_structure(self):
         with _make_client(self._mock_svc()) as client:
             resp = client.get("/api/v1/providers")
@@ -108,6 +112,7 @@ class TestListProviders:
         assert "video" in first["media_types"]
         assert first["missing_keys"] == []
 
+    @pytest.mark.unit
     def test_unconfigured_provider(self):
         with _make_client(self._mock_svc()) as client:
             resp = client.get("/api/v1/providers")
@@ -155,6 +160,7 @@ class TestListProviders:
         )
         return svc
 
+    @pytest.mark.unit
     def test_models_expose_resolutions_field(self):
         """ModelInfoResponse 必须包含 resolutions 字段（即便为空列表）。"""
         with _make_client(self._mock_svc_with_models()) as client:
@@ -168,6 +174,7 @@ class TestListProviders:
             assert "resolutions" in minfo
             assert isinstance(minfo["resolutions"], list)
 
+    @pytest.mark.unit
     def test_models_resolutions_values_passthrough(self):
         """resolutions 的具体值应按原样透传到 response。"""
         with _make_client(self._mock_svc_with_models()) as client:
@@ -288,6 +295,7 @@ class TestGetProviderConfig:
         repo.has_active_credential = AsyncMock(return_value=False)
         return repo
 
+    @pytest.mark.unit
     def test_returns_200_for_known_provider(self):
         app, _ = _make_session_app()
         with (
@@ -298,6 +306,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/gemini-aistudio/config")
         assert resp.status_code == 200
 
+    @pytest.mark.unit
     def test_returns_404_for_unknown_provider(self):
         app, _ = _make_session_app()
         with (
@@ -308,6 +317,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/nonexistent/config")
         assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_response_structure(self):
         app, _ = _make_session_app()
         with (
@@ -322,6 +332,7 @@ class TestGetProviderConfig:
         assert body["status"] == "ready"
         assert isinstance(body["fields"], list)
 
+    @pytest.mark.unit
     def test_credential_fields_not_in_response(self):
         """api_key / base_url / credentials_path 不应出现在 fields 中。"""
         app, _ = _make_session_app()
@@ -336,6 +347,7 @@ class TestGetProviderConfig:
         assert "base_url" not in field_keys
         assert "credentials_path" not in field_keys
 
+    @pytest.mark.unit
     def test_optional_non_credential_field_present(self):
         """非凭证 optional key（如 image_rpm）应出现在 fields 中。"""
         app, _ = _make_session_app()
@@ -349,6 +361,7 @@ class TestGetProviderConfig:
         assert "image_rpm" in fields
         assert fields["image_rpm"]["required"] is False
 
+    @pytest.mark.unit
     def test_ready_status_when_active_credential(self):
         app, _ = _make_session_app()
         with (
@@ -359,6 +372,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/gemini-aistudio/config")
         assert resp.json()["status"] == "ready"
 
+    @pytest.mark.unit
     def test_unconfigured_status_when_no_active_credential(self):
         app, _ = _make_session_app()
         with (
@@ -369,6 +383,7 @@ class TestGetProviderConfig:
                 resp = client.get("/api/v1/providers/gemini-aistudio/config")
         assert resp.json()["status"] == "unconfigured"
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("provider_id", "expected"),
         [
@@ -393,6 +408,7 @@ class TestGetProviderConfig:
         assert resp.status_code == 200
         assert resp.json()["supports_base_url"] is expected
 
+    @pytest.mark.unit
     def test_secret_fields_single_secret_provider(self):
         """单 secret provider（如 gemini-aistudio）→ secret_fields = [api_key]。"""
         app, _ = _make_session_app()
@@ -405,6 +421,7 @@ class TestGetProviderConfig:
         assert resp.status_code == 200
         assert [f["key"] for f in resp.json()["secret_fields"]] == ["api_key"]
 
+    @pytest.mark.unit
     def test_secret_fields_kling_three_ordered_secrets(self):
         """可灵 → secret_fields = [api_key, access_key, secret_key]（保留 required_keys 顺序）。"""
         app, _ = _make_session_app()
@@ -424,6 +441,7 @@ class TestGetProviderConfig:
         assert "access_key" not in field_keys
         assert "secret_key" not in field_keys
 
+    @pytest.mark.unit
     def test_secret_field_groups_kling_api_key_or_dual_secret(self):
         """可灵 secret_field_groups 二选一分组：[api_key] 或 [access_key, secret_key]。"""
         app, _ = _make_session_app()
@@ -436,6 +454,7 @@ class TestGetProviderConfig:
         assert resp.status_code == 200
         assert resp.json()["secret_field_groups"] == [["api_key"], ["access_key", "secret_key"]]
 
+    @pytest.mark.unit
     def test_secret_field_groups_single_secret_provider_falls_back_to_one_group(self):
         """未声明 credential_groups 的 provider → secret_field_groups 回退为 [全部 secret_fields] 单组。"""
         app, _ = _make_session_app()
@@ -448,6 +467,7 @@ class TestGetProviderConfig:
         assert resp.status_code == 200
         assert resp.json()["secret_field_groups"] == [["api_key"]]
 
+    @pytest.mark.unit
     def test_secret_fields_vertex_empty(self):
         """gemini-vertex 凭证是文件路径（非 secret）→ secret_fields 为空，前端走文件上传。
 
@@ -497,6 +517,7 @@ def _make_mock_svc() -> ConfigService:
 
 
 class TestPatchProviderConfig:
+    @pytest.mark.unit
     def test_returns_204(self):
         mock_svc = _make_mock_svc()
         with patch("server.routers.providers.ConfigService", return_value=mock_svc):
@@ -518,6 +539,7 @@ class TestPatchProviderConfig:
                 )
         assert resp.status_code == 204
 
+    @pytest.mark.unit
     def test_returns_404_for_unknown_provider(self):
         app = FastAPI()
         mock_session = AsyncMock()
@@ -537,6 +559,7 @@ class TestPatchProviderConfig:
             )
         assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_null_value_calls_delete(self):
         mock_svc = _make_mock_svc()
         with patch("server.routers.providers.ConfigService", return_value=mock_svc):
@@ -560,6 +583,7 @@ class TestPatchProviderConfig:
         assert resp.status_code == 204
         mock_svc.delete_provider_config.assert_awaited_once_with("gemini-aistudio", "base_url", flush=False)
 
+    @pytest.mark.unit
     def test_non_null_value_calls_set(self):
         mock_svc = _make_mock_svc()
         with patch("server.routers.providers.ConfigService", return_value=mock_svc):
@@ -624,6 +648,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         app.include_router(providers.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
         return app
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("bad_value", ["", "3.7", "abc", "-1", "0"])
     @pytest.mark.parametrize("key", ["image_max_workers", "video_max_workers", "audio_max_workers"])
     def test_invalid_value_returns_422(self, key: str, bad_value: str):
@@ -635,6 +660,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         assert detail != "max_workers_must_be_positive_integer"
         assert providers._FIELD_META[key]["label"] in detail
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
     def test_error_message_renders_in_all_locales(self, locale: str):
         with TestClient(self._make_db_app(locale)) as client:
@@ -645,6 +671,7 @@ class TestPatchProviderConfigMaxWorkersValidation:
         assert providers._FIELD_META["video_max_workers"]["label"] in detail
         assert "abc" in detail
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("good_value", ["1", "5"])
     def test_valid_value_returns_204(self, good_value: str):
         with TestClient(self._make_db_app()) as client:
@@ -690,6 +717,7 @@ class TestTestProviderConnection:
             message="连接成功",
         )
 
+    @pytest.mark.unit
     def test_returns_200(self):
         app, _ = _make_session_app()
         with (
@@ -701,6 +729,7 @@ class TestTestProviderConnection:
                 resp = client.post("/api/v1/providers/gemini-aistudio/test")
         assert resp.status_code == 200
 
+    @pytest.mark.unit
     def test_returns_404_for_unknown_provider(self):
         app, _ = _make_session_app()
         with (
@@ -711,6 +740,7 @@ class TestTestProviderConnection:
                 resp = client.post("/api/v1/providers/nonexistent/test")
         assert resp.status_code == 404
 
+    @pytest.mark.unit
     def test_success_true_when_configured(self):
         app, _ = _make_session_app()
         with (
@@ -725,6 +755,7 @@ class TestTestProviderConnection:
         assert body["available_models"] == ["model-a"]
         assert body["message"] == "连接成功"
 
+    @pytest.mark.unit
     def test_success_false_when_no_credential(self):
         app, _ = _make_session_app()
         with (
@@ -737,6 +768,7 @@ class TestTestProviderConnection:
         assert body["success"] is False
         assert "凭证" in body["message"]
 
+    @pytest.mark.unit
     def test_response_has_required_fields(self):
         app, _ = _make_session_app()
         with (
@@ -751,6 +783,7 @@ class TestTestProviderConnection:
         assert "available_models" in body
         assert "message" in body
 
+    @pytest.mark.unit
     def test_connection_failure_returns_error(self):
         def _failing_fn(config: dict, _t=None) -> providers.ConnectionTestResponse:
             raise RuntimeError("API key invalid")
@@ -767,11 +800,13 @@ class TestTestProviderConnection:
         assert body["success"] is False
         assert "API key invalid" in body["message"]
 
+    @pytest.mark.unit
     def test_dashscope_registered_in_dispatch(self):
         # dashscope 作为内置 provider 暴露在设置页，连接测试必须有 dispatcher，
         # 否则点"测试连接"会落到 unsupported_test 分支（即便 API Key 有效）
         assert "dashscope" in providers._TEST_DISPATCH
 
+    @pytest.mark.unit
     def test_dashscope_test_fn_uses_compatible_mode_and_filters_models(self):
         from types import SimpleNamespace
 
@@ -803,11 +838,13 @@ class TestTestProviderConnection:
         assert resp.available_models == ["qwen-plus", "wan2.7-image"]
         assert resp.success is True
 
+    @pytest.mark.unit
     def test_minimax_registered_in_dispatch(self):
         # minimax 作为内置 provider 暴露在设置页，连接测试必须有 dispatcher，
         # 否则点"测试连接"会落到 unsupported_test 分支（即便 API Key 有效）
         assert "minimax" in providers._TEST_DISPATCH
 
+    @pytest.mark.unit
     def test_minimax_test_fn_uses_v1_base_and_filters_models(self):
         from types import SimpleNamespace
 
@@ -837,6 +874,7 @@ class TestTestProviderConnection:
         assert resp.available_models == ["MiniMax-M2.7", "abab6.5s-chat"]
         assert resp.success is True
 
+    @pytest.mark.unit
     def test_kling_registered_in_dispatch(self):
         # kling 作为内置 provider 暴露在设置页，连接测试必须有 dispatcher，
         # 否则点"测试连接"会落到 unsupported_test 分支（即便凭证有效）
@@ -853,6 +891,7 @@ class TestTestProviderConnection:
         def json(self) -> dict:
             return self._payload
 
+    @pytest.mark.unit
     def test_kling_test_fn_uses_bearer_when_api_key_set(self):
         """填了 api_key → bearer 静态头，不走 JWT（与 _build_kling 的优先级一致）。"""
         captured: dict = {}
@@ -870,6 +909,7 @@ class TestTestProviderConnection:
         assert "start_time" in captured["params"]
         assert "end_time" in captured["params"]
 
+    @pytest.mark.unit
     def test_kling_test_fn_uses_jwt_when_only_dual_secret_set(self):
         """只填 access_key + secret_key（无 api_key）→ JWT Bearer token（三段式）。"""
         captured: dict = {}
@@ -885,6 +925,7 @@ class TestTestProviderConnection:
         assert auth.startswith("Bearer ")
         assert auth.removeprefix("Bearer ").count(".") == 2  # JWT: header.payload.signature
 
+    @pytest.mark.unit
     def test_kling_test_fn_api_key_takes_priority_when_both_set(self):
         """两者都填时 api_key 优先，与 _build_kling 分派顺序一致。"""
         captured: dict = {}
@@ -899,6 +940,7 @@ class TestTestProviderConnection:
             )
         assert captured["headers"]["Authorization"] == "Bearer sk-kling"
 
+    @pytest.mark.unit
     def test_kling_test_fn_strips_v1_suffix_for_account_costs_root_path(self):
         """自定义 base_url 带 /v1 后缀 → account/costs 请求剥离该后缀，落到域名根路径。"""
         captured: dict = {}
@@ -913,11 +955,13 @@ class TestTestProviderConnection:
             )
         assert captured["url"] == "https://relay.example.com/account/costs"
 
+    @pytest.mark.unit
     def test_kling_test_fn_raises_clear_error_when_no_credentials(self):
         """两种凭证形态都未填 → 明确报错（不静默发出无鉴权请求）。"""
         with pytest.raises(ValueError, match="Access Key"):
             providers._test_kling({}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_test_fn_raises_on_code_error(self):
         """响应 code != 0 → RuntimeError 携带官方错误信息，经上层转 connection_failed 文案。"""
 
@@ -928,6 +972,7 @@ class TestTestProviderConnection:
             with pytest.raises(RuntimeError, match="auth failed"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_test_fn_prefers_json_body_error_over_raise_for_status(self):
         """HTTP 状态非 2xx 但响应体带 JSON 业务错误 → 优先暴露具体原因，而非泛化的 HTTP 状态文案。"""
 
@@ -942,6 +987,7 @@ class TestTestProviderConnection:
             with pytest.raises(RuntimeError, match="access key not found"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_test_fn_raises_http_status_error_when_body_not_json(self):
         """非 JSON 响应体（如网关错误页）跳过业务错误解析，走 raise_for_status 兜底暴露 HTTP 状态。"""
 
@@ -956,6 +1002,7 @@ class TestTestProviderConnection:
             with pytest.raises(httpx.HTTPStatusError, match="502 Bad Gateway"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_test_fn_falls_back_to_raise_for_status_on_malformed_json(self):
         """content-type 声称 JSON 但响应体非法/空（如异常网关截断）→ 解析失败不崩溃，走 raise_for_status 兜底。"""
 
@@ -973,6 +1020,7 @@ class TestTestProviderConnection:
             with pytest.raises(httpx.HTTPStatusError, match="504 Gateway Timeout"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_test_fn_raises_on_inner_data_code_error(self):
         """顶层 code=0 但 data 内嵌业务级 code != 0（如资源包查询失败）→ 同样 RuntimeError。"""
 
@@ -985,6 +1033,7 @@ class TestTestProviderConnection:
             with pytest.raises(RuntimeError, match="resource pack not found"):
                 providers._test_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
+    @pytest.mark.unit
     def test_kling_connection_test_via_router_with_api_key_only(self):
         """端到端：只填 api_key 的可灵凭证通过 /test 端点即可测通（验收标准之一）。
 
@@ -1007,6 +1056,7 @@ class TestTestProviderConnection:
         assert resp.status_code == 200
         assert resp.json()["success"] is True
 
+    @pytest.mark.unit
     def test_specific_credential_id(self):
         """使用 credential_id 参数测试特定凭证。"""
         repo = MagicMock(spec=CredentialRepository)
@@ -1047,10 +1097,12 @@ class TestArkAgentPlanConnectionTest:
         svc.get_provider_config = AsyncMock(return_value={"api_key": "ark-fake"})
         return svc
 
+    @pytest.mark.unit
     def test_ark_agent_plan_is_dispatched(self):
         assert "ark-agent-plan" in providers._TEST_DISPATCH
         assert providers._TEST_DISPATCH["ark-agent-plan"] is providers._test_ark
 
+    @pytest.mark.unit
     def test_default_base_url_injected_when_user_did_not_set(self):
         captured: dict = {}
 
@@ -1069,6 +1121,7 @@ class TestArkAgentPlanConnectionTest:
         assert resp.status_code == 200
         assert captured["base_url"] == "https://ark.cn-beijing.volces.com/api/plan/v3"
 
+    @pytest.mark.unit
     def test_user_base_url_overrides_default(self):
         captured: dict = {}
 

--- a/tests/test_quality_propagation.py
+++ b/tests/test_quality_propagation.py
@@ -13,6 +13,10 @@ import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # 1 & 2: ImageGenerationResult dataclass
 # ---------------------------------------------------------------------------

--- a/tests/test_reference_compression.py
+++ b/tests/test_reference_compression.py
@@ -27,6 +27,8 @@ from lib.reference_compression import (
     select_ladder_step,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _noise_jpeg_bytes(w: int, h: int) -> bytes:
     """高熵噪声图（压缩体积随分辨率变化），存为 JPEG。"""

--- a/tests/test_reference_video_concurrent_rmw.py
+++ b/tests/test_reference_video_concurrent_rmw.py
@@ -11,7 +11,11 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+import pytest
+
 from lib.project_manager import ProjectManager
+
+pytestmark = pytest.mark.unit
 
 
 def _seed_reference_video_project(pm: ProjectManager, name: str, n_units: int) -> None:

--- a/tests/test_registry_resolutions.py
+++ b/tests/test_registry_resolutions.py
@@ -1,6 +1,10 @@
 """测试 ModelInfo.resolutions 字段与预置模型填充。"""
 
+import pytest
+
 from lib.config.registry import PROVIDER_REGISTRY, ModelInfo
+
+pytestmark = pytest.mark.unit
 
 
 def test_model_info_has_resolutions_default_empty_list():

--- a/tests/test_repository_base.py
+++ b/tests/test_repository_base.py
@@ -1,9 +1,12 @@
 """Tests for BaseRepository and _scope_query mechanism."""
 
+import pytest
 from sqlalchemy import select
 
 from lib.db.models import Task
 from lib.db.repositories.base import BaseRepository
+
+pytestmark = pytest.mark.unit
 
 
 class TestBaseRepository:

--- a/tests/test_request_logging_middleware.py
+++ b/tests/test_request_logging_middleware.py
@@ -10,6 +10,8 @@ from httpx import ASGITransport, AsyncClient
 
 from server.app import request_logging_middleware
 
+pytestmark = pytest.mark.unit
+
 _ACCESS_LOG_FMT = "%s %s %d %.0fms"
 
 

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -18,6 +18,8 @@ import pytest
 
 from lib.video_backends.base import ResumeExpiredError
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeProjectManager:
     def __init__(self, project_path: Path, project: dict[str, Any]) -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -16,6 +16,8 @@ from lib.retry import (
     with_retry_async,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestShouldRetry:
     """_should_retry 判断逻辑测试。"""

--- a/tests/test_scenes_router.py
+++ b/tests/test_scenes_router.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -5,6 +6,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import scenes
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakePM:

--- a/tests/test_script_editor.py
+++ b/tests/test_script_editor.py
@@ -96,29 +96,34 @@ def _reference(units: list[dict] | None = None) -> dict:
 
 
 class TestResolveItems:
+    @pytest.mark.unit
     def test_narration(self):
         items, id_field, kind = resolve_items(_narration())
         assert id_field == "segment_id"
         assert kind == "segments"
         assert len(items) == 2
 
+    @pytest.mark.unit
     def test_returned_list_is_live_reference(self):
         script = _narration()
         items, _id, _kind = resolve_items(script)
         items.append(_segment("E1S03"))
         assert len(script["segments"]) == 3
 
+    @pytest.mark.unit
     def test_missing_key_is_empty_list(self):
         # 内容数组键缺失 → 空列表（合法的「空草稿」），不报错
         items, _id, kind = resolve_items({"content_mode": "narration"})
         assert kind == "segments"
         assert items == []
 
+    @pytest.mark.unit
     def test_non_list_items_fail_loud(self):
         # 键存在但类型非 list（数据损坏）→ fail-loud，而非静默降级为 []
         with pytest.raises(ScriptEditError):
             resolve_items({"content_mode": "narration", "segments": "oops"})
 
+    @pytest.mark.unit
     def test_present_but_null_fails_loud(self):
         # 键存在但值为 null（损坏数据）→ fail-loud，不与「键缺失」混为空草稿
         with pytest.raises(ScriptEditError):
@@ -126,22 +131,27 @@ class TestResolveItems:
 
 
 class TestPatchField:
+    @pytest.mark.unit
     def test_patch_top_level_field(self):
         script = patch_field(_narration(), "E1S02", "duration_seconds", 9)
         assert script["segments"][1]["duration_seconds"] == 9
 
+    @pytest.mark.unit
     def test_patch_nested_field(self):
         script = patch_field(_narration(), "E1S01", "image_prompt.scene", "新场景")
         assert script["segments"][0]["image_prompt"]["scene"] == "新场景"
 
+    @pytest.mark.unit
     def test_patch_drama_by_scene_id(self):
         script = patch_field(_drama(), "E1S02", "scene_type", "空镜")
         assert script["scenes"][1]["scene_type"] == "空镜"
 
+    @pytest.mark.unit
     def test_patch_reference_unit_field(self):
         script = patch_field(_reference(), "E1U2", "transition_to_next", "fade")
         assert script["video_units"][1]["transition_to_next"] == "fade"
 
+    @pytest.mark.unit
     def test_patch_unknown_leaf_field_succeeds_at_set_nested_layer(self):
         # _set_nested 单元层面允许叶子写入——dict 操作不查 schema。
         # 但这里写的是 video_prompt.note(VideoPrompt 实际无 note 字段),
@@ -151,6 +161,7 @@ class TestPatchField:
         script = patch_field(_narration(), "E1S01", "video_prompt.note", "新增备注")
         assert script["segments"][0]["video_prompt"]["note"] == "新增备注"
 
+    @pytest.mark.unit
     def test_patch_optional_leaf_present_in_schema_succeeds(self):
         # 合法的「补 LLM 漏写的 optional 字段」:NarrationSegment.note 是 schema 内的
         # SkipJsonSchema[str | None] 字段,允许通过 patch 补;此路径既在 _set_nested
@@ -164,14 +175,17 @@ class TestPatchField:
         script = patch_field(script, "E1S01", "note", "补全的备注")
         assert script["segments"][0]["note"] == "补全的备注"
 
+    @pytest.mark.unit
     def test_patch_unknown_id_raises(self):
         with pytest.raises(ScriptEditError):
             patch_field(_narration(), "E9S99", "duration_seconds", 9)
 
+    @pytest.mark.unit
     def test_patch_generated_assets_rejected(self):
         with pytest.raises(ScriptEditError):
             patch_field(_narration(), "E1S01", "generated_assets.status", "completed")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("id_field", ["segment_id", "scene_id", "unit_id"])
     def test_patch_id_field_rejected(self, id_field):
         # 三类 id 字段（segment/scene/unit）均不可直改：id 由 insert/split 派生，agent 改 id
@@ -186,21 +200,25 @@ class TestPatchField:
         with pytest.raises(ScriptEditError, match="不可改 end_frame_image"):
             patch_field(_narration(), "E1S01", "end_frame_image", "../../../etc/passwd")
 
+    @pytest.mark.unit
     def test_patch_does_not_touch_generated_assets(self):
         script = patch_field(_narration(), "E1S01", "duration_seconds", 7)
         assert script["segments"][0]["generated_assets"]["status"] == "completed"
 
+    @pytest.mark.unit
     def test_patch_missing_parent_path_raises(self):
         with pytest.raises(ScriptEditError):
             patch_field(_narration(), "E1S01", "no_such.deep", 1)
 
 
 class TestInsertSegment:
+    @pytest.mark.unit
     def test_insert_after_assigns_unique_suffixed_id_at_right_position(self):
         script = insert_segment(_narration(), "E1S01", _segment("IGNORED"))
         ids = [s["segment_id"] for s in script["segments"]]
         assert ids == ["E1S01", "E1S01_1", "E1S02"]
 
+    @pytest.mark.unit
     def test_insert_clears_generated_assets(self):
         script = insert_segment(_narration(), "E1S01", _segment("X"))
         assert script["segments"][1]["generated_assets"] == {}
@@ -212,12 +230,14 @@ class TestInsertSegment:
         script = insert_segment(_narration(), "E1S01", new_item)
         assert script["segments"][1].get("end_frame_image") is None
 
+    @pytest.mark.unit
     def test_insert_id_avoids_collision(self):
         seg = _segment("E1S01_1")
         script = insert_segment(_narration([_segment("E1S01"), seg]), "E1S01", _segment("X"))
         ids = [s["segment_id"] for s in script["segments"]]
         assert ids == ["E1S01", "E1S01_2", "E1S01_1"]
 
+    @pytest.mark.unit
     def test_insert_anchor_already_suffixed_flattens_subindex(self):
         # 锚点本身已含子序号（E1S01_1）→ 新 id 取 stem `E1S01` + 下一个空闲子序号，
         # 不产生 `E1S01_1_1` 这种多层后缀（违反 data_validator.ID_PATTERN）。
@@ -226,10 +246,12 @@ class TestInsertSegment:
         # 跳过已占用的 E1S01_1，得到 E1S01_2，仍是合法单层后缀
         assert ids == ["E1S01", "E1S01_1", "E1S01_2"]
 
+    @pytest.mark.unit
     def test_insert_unknown_anchor_raises(self):
         with pytest.raises(ScriptEditError):
             insert_segment(_narration(), "E9S99", _segment("X"))
 
+    @pytest.mark.unit
     def test_insert_reference_unit(self):
         script = insert_segment(_reference(), "E1U1", _unit("X"))
         ids = [u["unit_id"] for u in script["video_units"]]
@@ -237,26 +259,31 @@ class TestInsertSegment:
 
 
 class TestRemoveSegment:
+    @pytest.mark.unit
     def test_remove_by_id(self):
         script = remove_segment(_narration(), "E1S01")
         assert [s["segment_id"] for s in script["segments"]] == ["E1S02"]
 
+    @pytest.mark.unit
     def test_remove_does_not_renumber_others(self):
         script = remove_segment(_narration([_segment("E1S01"), _segment("E1S02"), _segment("E1S03")]), "E1S02")
         assert [s["segment_id"] for s in script["segments"]] == ["E1S01", "E1S03"]
 
+    @pytest.mark.unit
     def test_remove_unknown_id_raises(self):
         with pytest.raises(ScriptEditError):
             remove_segment(_narration(), "E9S99")
 
 
 class TestSplitSegment:
+    @pytest.mark.unit
     def test_split_keeps_first_id_and_suffixes_rest(self):
         parts = [_segment("a"), _segment("b"), _segment("c")]
         script = split_segment(_narration(), "E1S01", parts)
         ids = [s["segment_id"] for s in script["segments"]]
         assert ids == ["E1S01", "E1S01_1", "E1S01_2", "E1S02"]
 
+    @pytest.mark.unit
     def test_split_keeps_anchor_assets_clears_new_parts(self):
         # 锚点(parts[0],保留原 id)的 generated_assets 不动,与 insert_segment 的「锚点资产
         # 不动」语义对齐;其余 parts(新派生 id)清空 generated_assets 退回 pending 待重生。
@@ -284,14 +311,17 @@ class TestSplitSegment:
         script = split_segment(_narration(), "E1S01", parts)
         assert script["segments"][0].get("end_frame_image") is None
 
+    @pytest.mark.unit
     def test_split_requires_at_least_two_parts(self):
         with pytest.raises(ScriptEditError):
             split_segment(_narration(), "E1S01", [_segment("a")])
 
+    @pytest.mark.unit
     def test_split_unknown_id_raises(self):
         with pytest.raises(ScriptEditError):
             split_segment(_narration(), "E9S99", [_segment("a"), _segment("b")])
 
+    @pytest.mark.unit
     def test_split_reference_units_act_on_video_units(self):
         anchor_assets = _reference()["video_units"][0]["generated_assets"]
         script = split_segment(_reference(), "E1U1", [_unit("a"), _unit("b")])
@@ -301,6 +331,7 @@ class TestSplitSegment:
         assert script["video_units"][0]["generated_assets"] == anchor_assets
         assert script["video_units"][1]["generated_assets"] == {}
 
+    @pytest.mark.unit
     def test_split_warns_when_anchor_assets_dirty_non_dict(self, caplog):
         """锚点 generated_assets 形态异常(非 dict 的脏数据)时退化为空 dict,
         但必须 warning——符合 ADR-0003 增补「禁止零信号成功」原则。anchor_assets is None
@@ -317,6 +348,7 @@ class TestSplitSegment:
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any("E1S01" in m and "list" in m for m in warnings), warnings
 
+    @pytest.mark.unit
     def test_split_no_warn_when_anchor_assets_none(self, caplog):
         """anchor generated_assets is None / 缺失是合法初始态(未生成),不应 warning。"""
         import logging

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -162,6 +162,7 @@ class _FakeTextGenerator:
 
 
 class TestScriptGenerator:
+    @pytest.mark.unit
     async def test_build_prompt_uses_step1_content(self, tmp_path):
         """build_prompt 无需 client 即可使用（dry-run 模式）：narration 渲染结构化 step1。"""
         project_path = tmp_path / "demo"
@@ -189,6 +190,7 @@ class TestScriptGenerator:
         # 透传式 prompt：不再要求 LLM 复制 novel_text，只产视觉层
         assert "只产视觉层" in prompt
 
+    @pytest.mark.unit
     async def test_narration_step2_build_prompt_uses_project_source_language(self, tmp_path):
         """narration step2（视觉层）prompt 的输出语言须取项目 source_language（与 drama 同口径），非中文项目不得回落中文。"""
         project_path = tmp_path / "demo"
@@ -214,6 +216,7 @@ class TestScriptGenerator:
         assert "所有字符串值必须使用 English" in prompt
         assert "所有字符串值必须使用 中文" not in prompt
 
+    @pytest.mark.unit
     async def test_load_step1_drama_missing_raises_without_fallback(self, tmp_path):
         """drama 集缺 step1_normalized_script.json 时显式报错；不得降级改读 narration 的拆分表。"""
         project_path = tmp_path / "demo"
@@ -233,6 +236,7 @@ class TestScriptGenerator:
         with pytest.raises(FileNotFoundError, match="step1_normalized_script.json"):
             generator._load_step1(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_non_dict_top_level(self, tmp_path):
         """drama step1 顶层非对象（如 JSON 数组）→ ValueError，不静默当空剧本。"""
         project_path = tmp_path / "demo"
@@ -245,6 +249,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="顶层应为对象"):
             generator._load_drama_step1_content(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_non_list_scenes(self, tmp_path):
         """drama step1 scenes 非列表（如对象）→ ValueError fail-fast，不被当成空剧本继续。"""
         project_path = tmp_path / "demo"
@@ -260,6 +265,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="scenes 必须是非空"):
             generator._load_drama_step1_content(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_empty_scenes(self, tmp_path):
         """drama step1 scenes 为空列表 → ValueError fail-fast（空剧本不是合法 step1 产物，避免落盘 scenes=[]）。"""
         project_path = tmp_path / "demo"
@@ -275,6 +281,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="scenes 必须是非空"):
             generator._load_drama_step1_content(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_non_dict_scene_item(self, tmp_path):
         """drama step1 scenes 列表含非对象项（数字 / 字符串）→ ValueError，不拖到 render/merge 阶段才炸。"""
         project_path = tmp_path / "demo"
@@ -290,6 +297,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="必须是场景对象"):
             generator._load_drama_step1_content(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_empty_scene_id(self, tmp_path):
         """drama step1 场景 scene_id 为空串 / 缺失 → ValueError fail-fast（空 scene_id 拖到合并阶段才暴露）。"""
         project_path = tmp_path / "demo"
@@ -305,6 +313,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError, match="scene_id 必须是非空字符串"):
             generator._load_drama_step1_content(1)
 
+    @pytest.mark.unit
     async def test_load_drama_step1_content_rejects_rewritten_scene_id_collision(self, tmp_path):
         """原始 scene_id 互异但改写 episode 前缀后相撞（E1S02_1 与 E2S02_1 在 ep2 都成 E2S02_1）→ fail-loud，
         避免下游产物文件名 / 资产键撞车（与 _load_narration_step1 同口径）。"""
@@ -400,6 +409,7 @@ class TestScriptGenerator:
             _drama_step1_content()["scenes"], episode=1, gen_mode="storyboard"
         )
 
+    @pytest.mark.unit
     async def test_drama_step2_build_prompt_renders_step1_content(self, tmp_path):
         """drama step2（视觉层）build_prompt 须把 step1 已定稿内容渲染入 prompt，仅求视觉字段。"""
         project_path = tmp_path / "demo"
@@ -420,6 +430,7 @@ class TestScriptGenerator:
         assert "image_prompt" in prompt
         assert "video_prompt" in prompt
 
+    @pytest.mark.unit
     async def test_drama_step2_build_prompt_omits_outline(self, tmp_path):
         """分集大纲随内容抽取前移到 step1（normalize）；step2 视觉层 prompt 不再渲染大纲段。"""
         project_path = tmp_path / "demo"
@@ -446,6 +457,7 @@ class TestScriptGenerator:
         assert "<episode_outline>" not in prompt
         assert "少年坠崖生死未卜" not in prompt
 
+    @pytest.mark.unit
     async def test_drama_step2_build_prompt_uses_project_source_language(self, tmp_path):
         """step2 视觉层 prompt 的输出语言须取项目 source_language（与 step1 同源），非中文项目不得回落中文。"""
         project_path = tmp_path / "demo"
@@ -468,6 +480,7 @@ class TestScriptGenerator:
         assert "所有字符串值必须使用 English" in prompt
         assert "所有字符串值必须使用 中文" not in prompt
 
+    @pytest.mark.unit
     async def test_parse_response_invalid_json_raises(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_json(project_path / "project.json", {"title": "项目"})
@@ -476,6 +489,7 @@ class TestScriptGenerator:
         with pytest.raises(ValueError):
             generator._parse_response("not-json", 1)
 
+    @pytest.mark.unit
     async def test_parse_response_validation_error_returns_raw_data(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_json(project_path / "project.json", {"title": "项目"})
@@ -485,6 +499,7 @@ class TestScriptGenerator:
         # 校验失败降级返回原始数据；title 兜底在校验前注入，故降级结果也携带
         assert parsed == {"foo": "bar", "title": "第1集"}
 
+    @pytest.mark.unit
     async def test_generate_writes_script_and_metadata(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_json(
@@ -522,6 +537,7 @@ class TestScriptGenerator:
         assert payload["metadata"]["generator"] == "fake-model"
         assert "created_at" in payload["metadata"]
 
+    @pytest.mark.unit
     async def test_generate_injects_hook_and_teaser_from_ledger(self, tmp_path):
         """剧本 JSON 的集级 hook / next_episode_teaser 元数据来自分集账本（经写盘严格校验）。"""
         project_path = tmp_path / "demo"
@@ -559,6 +575,7 @@ class TestScriptGenerator:
         assert scene["utterances"][0]["text"] == "你来了。"
         assert scene["image_prompt"]["scene"] == "场景"
 
+    @pytest.mark.unit
     async def test_generate_without_ledger_hook_leaves_fields_null(self, tmp_path):
         """旧式条目（账本无钩子/预告）：字段为 null，写盘校验仍通过。"""
         project_path = tmp_path / "demo"
@@ -587,6 +604,7 @@ class TestScriptGenerator:
         assert payload["hook"] is None
         assert payload["next_episode_teaser"] is None
 
+    @pytest.mark.unit
     async def test_generate_narration_stamps_cli_episode_and_rewrites_prefix(self, tmp_path):
         """narration 两段式：CLI 集号是唯一真相（视觉 schema 无 episode 字段），且 _add_metadata
         兜底改写 segment_id 前缀——step1 误写 E1S01、生成第 10 集时应改为 E10S01。
@@ -618,6 +636,7 @@ class TestScriptGenerator:
         assert payload["episode"] == 10
         assert payload["segments"][0]["segment_id"] == "E10S01"
 
+    @pytest.mark.unit
     async def test_generate_drama_step2_passes_visual_schema(self, tmp_path):
         """drama step2 LLM 输出 schema 是 DramaVisualScript（仅 scene_id + 视觉字段，无非视觉字段）。"""
         from lib.script_models import DramaVisualScript
@@ -643,6 +662,7 @@ class TestScriptGenerator:
         assert "source_text" not in props
         assert "duration_seconds" not in props
 
+    @pytest.mark.unit
     async def test_generate_sets_script_max_output_tokens(self, tmp_path):
         """drama step2 generate 应在 TextGenerationRequest 上设置共享输出上限（DEFAULT_MAX_OUTPUT_TOKENS）。"""
         from lib.script_models import DramaVisualMergeError
@@ -666,6 +686,7 @@ class TestScriptGenerator:
         assert fake.backend.last_request.max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS
         assert DEFAULT_MAX_OUTPUT_TOKENS >= 16000
 
+    @pytest.mark.unit
     async def test_generate_without_backend_raises(self, tmp_path):
         """未注入 backend 时调用 generate() 应抛 RuntimeError。"""
         project_path = tmp_path / "demo"
@@ -676,6 +697,7 @@ class TestScriptGenerator:
         with pytest.raises(RuntimeError, match="TextGenerator 未初始化"):
             await generator.generate(1)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "bad_filename",
         [
@@ -715,6 +737,7 @@ class TestAddMetadataRewritesEpisodePrefix:
         )
         return ScriptGenerator(project_path)
 
+    @pytest.mark.unit
     def test_drama_rewrites_scene_ids(self, tmp_path: Path) -> None:
         sg = self._make_generator(tmp_path, content_mode="drama")
         data = {
@@ -728,6 +751,7 @@ class TestAddMetadataRewritesEpisodePrefix:
         assert out["scenes"][1]["scene_id"] == "E2S04_2"
         assert out["scenes"][0]["other"] == "keep"
 
+    @pytest.mark.unit
     def test_narration_rewrites_segment_ids(self, tmp_path: Path) -> None:
         sg = self._make_generator(tmp_path, content_mode="narration")
         data = {
@@ -740,6 +764,7 @@ class TestAddMetadataRewritesEpisodePrefix:
         assert out["segments"][0]["segment_id"] == "E3S01"
         assert out["segments"][1]["segment_id"] == "E3S02_1"
 
+    @pytest.mark.unit
     def test_reference_video_rewrites_unit_ids(self, tmp_path: Path) -> None:
         project_path = tmp_path / "demo"
         _write_json(
@@ -761,6 +786,7 @@ class TestAddMetadataRewritesEpisodePrefix:
         assert out["video_units"][0]["unit_id"] == "E2U01"
         assert out["video_units"][1]["unit_id"] == "E2U02_1"
 
+    @pytest.mark.unit
     def test_idempotent_when_prefix_already_correct(self, tmp_path: Path) -> None:
         """ID 前缀已经匹配 episode 时，rewrite 不应改动（不破坏正确数据）。"""
         sg = self._make_generator(tmp_path, content_mode="narration")
@@ -769,6 +795,7 @@ class TestAddMetadataRewritesEpisodePrefix:
         assert out["segments"][0]["segment_id"] == "E2S01"
         assert out["segments"][1]["segment_id"] == "E2S02_3"
 
+    @pytest.mark.unit
     def test_unknown_id_format_unchanged(self, tmp_path: Path) -> None:
         """ID 不带 `E\\d+[SU]` 前缀时不应被改写（避免误伤）。"""
         sg = self._make_generator(tmp_path, content_mode="narration")
@@ -797,6 +824,7 @@ class TestAddMetadataInjectsHiddenFields:
         )
         return ScriptGenerator(project_path)
 
+    @pytest.mark.unit
     def test_drama_injects_content_mode_and_novel_when_llm_omits(self, tmp_path: Path) -> None:
         sg = self._make_generator(tmp_path, content_mode="drama")
         data = {"title": "第一集", "scenes": [{"scene_id": "E1S01"}]}
@@ -804,6 +832,7 @@ class TestAddMetadataInjectsHiddenFields:
         assert out["content_mode"] == "drama"
         assert out["novel"] == {"title": "项目标题", "chapter": "第1集"}
 
+    @pytest.mark.unit
     def test_narration_injects_content_mode_and_novel_when_llm_omits(self, tmp_path: Path) -> None:
         sg = self._make_generator(tmp_path, content_mode="narration")
         data = {"title": "第一集", "segments": [{"segment_id": "E1S01"}]}
@@ -820,6 +849,7 @@ class TestAddMetadataInjectsHiddenFields:
         out = sg._add_metadata(data, episode=1)
         assert "generation_mode" not in out
 
+    @pytest.mark.unit
     def test_setdefault_does_not_overwrite_existing_values(self, tmp_path: Path) -> None:
         """LLM 若主动填了 content_mode / novel(理论上不会,但兜底要稳),setdefault 不应覆盖。"""
         sg = self._make_generator(tmp_path, content_mode="drama")
@@ -833,6 +863,7 @@ class TestAddMetadataInjectsHiddenFields:
         assert out["content_mode"] == "drama"
         assert out["novel"] == {"title": "用户的小说", "chapter": "卷一·风起"}
 
+    @pytest.mark.unit
     def test_drama_overrides_empty_novel_after_model_dump(self, tmp_path: Path) -> None:
         """e2e: model_validate → model_dump 后 novel 永远存在但为空字典,_add_metadata
         必须按"内容是否为空"判断而非"key 是否存在",否则 compose-video 输出文件名将退化为
@@ -863,6 +894,7 @@ class TestAddMetadataInjectsHiddenFields:
         out = sg._add_metadata(dumped, episode=1)
         assert out["novel"] == {"title": "项目标题", "chapter": "第1集"}
 
+    @pytest.mark.unit
     def test_narration_overrides_empty_novel_after_model_dump(self, tmp_path: Path) -> None:
         from lib.script_models import NarrationEpisodeScript
 
@@ -889,6 +921,7 @@ class TestAddMetadataInjectsHiddenFields:
         out = sg._add_metadata(dumped, episode=2)
         assert out["novel"] == {"title": "项目标题", "chapter": "第2集"}
 
+    @pytest.mark.unit
     def test_partial_novel_only_title_is_also_reinjected(self, tmp_path: Path) -> None:
         """半填 novel(只有 title 或只有 chapter)也应触发重注入,避免 compose-video 文件名残缺。"""
         sg = self._make_generator(tmp_path, content_mode="drama")
@@ -902,6 +935,7 @@ class TestAddMetadataInjectsHiddenFields:
         assert out["novel"]["title"] == "项目标题"
 
 
+@pytest.mark.unit
 def test_resolve_supported_durations_raises_when_unset(tmp_path):
     """caps、project.json、registry 三处都查不到时应抛 ValueError，不再 silent fallback。"""
     project_dir = tmp_path / "p"
@@ -1164,18 +1198,21 @@ class TestScriptGeneratorSkeletonExhaustiveness:
     第五种骨架加入 SKELETONS（+ 规范解析映射）时，未登记的本地映射与未处置的分派逐个报红。
     """
 
+    @pytest.mark.unit
     def test_parse_schema_covers_every_skeleton_kind(self):
         from lib.script_generator import _KIND_PARSE_SCHEMA
         from lib.script_skeleton import SKELETONS
 
         assert set(_KIND_PARSE_SCHEMA) == set(SKELETONS)
 
+    @pytest.mark.unit
     def test_metadata_count_key_covers_every_skeleton_kind(self):
         from lib.script_generator import _METADATA_COUNT_KEY
         from lib.script_skeleton import SKELETONS
 
         assert set(_METADATA_COUNT_KEY) == set(SKELETONS)
 
+    @pytest.mark.unit
     def test_item_fallback_duration_covers_every_skeleton_kind(self):
         # 时长兜底表单点化到 script_models，四骨架全登记（含 shots/video_units→0）；
         # 第五种骨架加入 SKELETONS 而未登记即在 item_duration 查表 KeyError 报红。
@@ -1184,6 +1221,7 @@ class TestScriptGeneratorSkeletonExhaustiveness:
 
         assert set(_ITEM_FALLBACK_DURATIONS) == set(SKELETONS)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
     def test_add_metadata_handles_every_skeleton_kind(self, kind: str, tmp_path: Path):
         from lib.script_generator import _METADATA_COUNT_KEY
@@ -1206,6 +1244,7 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         # 计数键随 kind 显式落位
         assert out["metadata"][_METADATA_COUNT_KEY[kind]] == 1
 
+    @pytest.mark.unit
     def test_add_metadata_survives_dirty_degraded_items(self, tmp_path: Path):
         # 校验失败降级保存的原始 dict 里 segments 可能含非 dict / duration_seconds 非数字的脏条目；
         # 前缀改写与时长求和都不得崩溃，时长按稳健口径逐条兜底。
@@ -1234,6 +1273,7 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         # 时长：5(有效) + 0(非 dict) + 4(缺失→兜底) + 4(None→兜底) + 4(非正数→兜底) = 17
         assert out["duration_seconds"] == 17
 
+    @pytest.mark.unit
     def test_add_metadata_survives_non_list_array(self, tmp_path: Path):
         # 数组键为真值标量（LLM 误写）时 `... or []` 挡不住，isinstance 守卫避免迭代/求和崩溃。
         sg = _bare_generator(tmp_path, {"content_mode": "narration"})
@@ -1243,6 +1283,7 @@ class TestScriptGeneratorSkeletonExhaustiveness:
         assert out["metadata"]["total_segments"] == 0
         assert out["duration_seconds"] == 0
 
+    @pytest.mark.unit
     def test_quality_probe_survives_non_list_array(self, tmp_path: Path, caplog):
         # 数组键为真值标量时,_quality_probe 应被 isinstance 守卫收敛为空;外层 try/except 虽会
         # 吞异常,但不得走 “quality probe skipped” 兜底(那意味着守卫失效、整段探针被误跳过)。
@@ -1304,6 +1345,7 @@ async def _fixed_caps_468(_episode=None) -> dict:
 class TestMergeNarrationVisual:
     """step2 视觉层按 segment_id 合并回 step1 结构：novel_text 逐字透传、不经 LLM 重出。"""
 
+    @pytest.mark.unit
     def test_novel_text_passthrough_verbatim(self, tmp_path):
         sg = _bare_generator(tmp_path)
         step1 = [_step1_seg("E1S01", "原文甲。", duration=6, brk=True), _step1_seg("E1S02", "原文乙！")]
@@ -1322,6 +1364,7 @@ class TestMergeNarrationVisual:
         assert merged["segments"][0]["image_prompt"]["scene"] == "画面"
         assert merged["segments"][0]["video_prompt"]["action"] == "动作"
 
+    @pytest.mark.unit
     def test_merge_aligns_by_id_not_order(self, tmp_path):
         """LLM 视觉层乱序也按 segment_id 对齐，合并顺序随 step1。"""
         sg = _bare_generator(tmp_path)
@@ -1337,6 +1380,7 @@ class TestMergeNarrationVisual:
         assert merged["segments"][0]["image_prompt"]["scene"] == "甲画面"
         assert merged["segments"][1]["image_prompt"]["scene"] == "乙画面"
 
+    @pytest.mark.unit
     def test_missing_visual_segment_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         step1 = [_step1_seg("E1S01", "甲"), _step1_seg("E1S02", "乙")]
@@ -1344,6 +1388,7 @@ class TestMergeNarrationVisual:
         with pytest.raises(ValueError, match="E1S02"):
             sg._merge_narration_visual(step1, visual, episode=1)
 
+    @pytest.mark.unit
     def test_extra_visual_segment_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         step1 = [_step1_seg("E1S01", "甲")]
@@ -1351,6 +1396,7 @@ class TestMergeNarrationVisual:
         with pytest.raises(ValueError, match="E1S09"):
             sg._merge_narration_visual(step1, visual, episode=1)
 
+    @pytest.mark.unit
     def test_duplicate_visual_segment_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         step1 = [_step1_seg("E1S01", "甲")]
@@ -1358,6 +1404,7 @@ class TestMergeNarrationVisual:
         with pytest.raises(ValueError, match="E1S01"):
             sg._merge_narration_visual(step1, visual, episode=1)
 
+    @pytest.mark.unit
     def test_title_fallback_when_missing(self, tmp_path):
         sg = _bare_generator(tmp_path)
         step1 = [_step1_seg("E1S01", "甲")]
@@ -1378,6 +1425,7 @@ class TestLoadNarrationStep1:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 
+    @pytest.mark.unit
     def test_loads_structured_segments_verbatim(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(
@@ -1397,11 +1445,13 @@ class TestLoadNarrationStep1:
         assert segments[0]["duration_seconds"] == 6
         assert segments[0]["segment_break"] is True
 
+    @pytest.mark.unit
     def test_missing_json_without_legacy_md_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         with pytest.raises(FileNotFoundError, match="step1_segments.json"):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_legacy_md_only_raises_rerun_hint(self, tmp_path):
         """仅有结构化前的旧 step1_segments.md：明确要求重跑拆分，不读旧 md。"""
         sg = _bare_generator(tmp_path)
@@ -1411,6 +1461,7 @@ class TestLoadNarrationStep1:
         with pytest.raises(FileNotFoundError, match="split-narration-segments|重跑"):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_malformed_json_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         path = self._step1_path(sg, 1)
@@ -1419,18 +1470,21 @@ class TestLoadNarrationStep1:
         with pytest.raises(ValueError):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_invalid_structure_missing_novel_text_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"segments": [{"segment_id": "E1S01", "duration_seconds": 4}]})
         with pytest.raises(ValueError):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_duplicate_segment_id_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"segments": [_step1_seg("E1S01", "甲"), _step1_seg("E1S01", "乙")]})
         with pytest.raises(ValueError, match="重复|E1S01"):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_post_rewrite_collision_raises(self, tmp_path):
         """原始 id 互异但改写 episode 前缀后相撞（E1S02_1 与 E2S02_1 在 ep2 都成 E2S02_1）→ fail-loud。"""
         sg = _bare_generator(tmp_path)
@@ -1438,18 +1492,21 @@ class TestLoadNarrationStep1:
         with pytest.raises(ValueError, match="改写|E2S02_1"):
             sg._load_narration_step1(2, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_duration_outside_supported_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"segments": [_step1_seg("E1S01", "甲", duration=5)]})  # 5 ∉ [4,6,8]
         with pytest.raises(ValueError, match="duration"):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_empty_segments_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"segments": []})
         with pytest.raises(ValueError):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_missing_asset_arrays_raises(self, tmp_path):
         """step1 资产字段必填：漏写 characters_in_segment/scenes/props → fail-loud（不静默补 []）。"""
         sg = _bare_generator(tmp_path)
@@ -1457,6 +1514,7 @@ class TestLoadNarrationStep1:
         with pytest.raises(ValueError):
             sg._load_narration_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_explicit_empty_asset_arrays_pass(self, tmp_path):
         """无资产时显式写 [] 合法，通过校验。"""
         sg = _bare_generator(tmp_path)
@@ -1481,18 +1539,21 @@ class TestLoadReferenceStep1:
     def _unit(unit_id: str, *, duration: int = 6) -> dict:
         return {"unit_id": unit_id, "shots": [{"text": "甲走进屋子"}], "duration_seconds": duration}
 
+    @pytest.mark.unit
     def test_loads_structured_units_verbatim(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"units": [self._unit("E1U01"), self._unit("E1U02", duration=8)]})
         units = sg._load_reference_step1(1, [4, 6, 8])
         assert [u["unit_id"] for u in units] == ["E1U01", "E1U02"]
 
+    @pytest.mark.unit
     def test_duplicate_unit_id_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"units": [self._unit("E1U01"), self._unit("E1U01")]})
         with pytest.raises(ValueError, match="重复|E1U01"):
             sg._load_reference_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_post_rewrite_collision_raises(self, tmp_path):
         """原始 unit_id 互异但改写 episode 前缀后相撞（E1U01 与 E2U01 在 ep2 都成 E2U01）→ fail-loud。
 
@@ -1505,6 +1566,7 @@ class TestLoadReferenceStep1:
         with pytest.raises(ValueError, match="改写|E2U01"):
             sg._load_reference_step1(2, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_duration_outside_supported_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"units": [self._unit("E1U01", duration=5)]})  # 5 ∉ [4,6,8]
@@ -1593,6 +1655,7 @@ class TestLoadReferenceStep1:
         with pytest.raises(ValueError, match="尚未经审阅确认"):
             sg._load_reference_step1(1, [4, 6, 8])
 
+    @pytest.mark.unit
     def test_empty_units_raises(self, tmp_path):
         sg = _bare_generator(tmp_path)
         self._write(sg, 1, {"units": []})
@@ -1646,6 +1709,7 @@ def _ad_shot(shot_id: str, *, duration: int = 4, section: str = "hook", voiceove
 
 
 class TestAdScriptGeneration:
+    @pytest.mark.unit
     async def test_build_prompt_without_step1_uses_brief_and_products(self, tmp_path):
         """ad 一键生成不走 step1 中间文件：prompt 直接来自 brief + 产品信息 + 配比表。"""
         project_path = tmp_path / "demo"
@@ -1660,6 +1724,7 @@ class TestAdScriptGeneration:
         assert "突出速干卖点" in prompt
         assert "### 速干杯" in prompt
 
+    @pytest.mark.unit
     async def test_build_prompt_reference_path_uses_free_duration(self, tmp_path):
         """ad + reference_video：仍是 ad prompt（shots 骨架），时长约束为 1-15 自由整数。"""
         project_path = tmp_path / "demo"
@@ -1673,6 +1738,7 @@ class TestAdScriptGeneration:
         # 不得落入参考视频 video_units prompt
         assert "video_units" not in prompt
 
+    @pytest.mark.unit
     async def test_build_prompt_uses_project_source_language(self, tmp_path):
         """ad prompt 的口播语速折算与输出语言须取项目 source_language（与 drama/narration 同口径），非中文项目不得回落中文/zh 语速。"""
         project_path = tmp_path / "demo"
@@ -1693,6 +1759,7 @@ class TestAdScriptGeneration:
         assert "所有字符串值必须使用 en" in prompt
         assert "所有字符串值必须使用 中文" not in prompt
 
+    @pytest.mark.unit
     async def test_build_prompt_tolerates_null_project_fields(self, tmp_path):
         """project.json 手工编辑后字段显式为 null：prompt 构建按空值归一化，不抛 AttributeError。"""
         project_path = tmp_path / "demo"
@@ -1724,6 +1791,7 @@ class TestAdScriptGeneration:
         assert "带货八段框架" not in prompt
         assert isinstance(prompt, str) and prompt
 
+    @pytest.mark.unit
     async def test_generate_writes_ad_script_with_metadata(self, tmp_path):
         """generate 写盘 ad 剧本：shots 骨架、content_mode=ad、total_shots 与总时长统计。"""
         project_path = tmp_path / "demo"
@@ -1754,6 +1822,7 @@ class TestAdScriptGeneration:
         assert saved["metadata"]["total_shots"] == 2
         assert saved["duration_seconds"] == 10
 
+    @pytest.mark.unit
     async def test_generate_ad_storyboard_passes_enum_schema(self, tmp_path):
         """ad + storyboard：response_schema 是 AdEpisodeScript 的 duration 枚举子类。"""
         from lib.script_models import AdEpisodeScript
@@ -1780,6 +1849,7 @@ class TestAdScriptGeneration:
         ]
         assert [4, 6, 8] in duration_enums
 
+    @pytest.mark.unit
     async def test_generate_ad_reference_passes_free_range_schema(self, tmp_path):
         """ad + reference_video：response_schema 收紧为 1-15 区间而非枚举。"""
         from lib.script_models import AdEpisodeScript
@@ -1801,6 +1871,7 @@ class TestAdScriptGeneration:
         ]
         assert any(fs.get("minimum") == 1 and fs.get("maximum") == 15 and "enum" not in fs for fs in field_schemas)
 
+    @pytest.mark.unit
     async def test_generate_rewrites_wrong_episode_prefix_on_shot_ids(self, tmp_path):
         """LLM 写错集号前缀时兜底改写为 E1（ad 恒单集）。"""
         project_path = tmp_path / "demo"
@@ -1849,6 +1920,7 @@ class TestAdParseResponseDriftRecovery:
             },
         }
 
+    @pytest.mark.unit
     def test_parse_response_recovers_drifted_payload_without_title(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_ad_project(project_path)
@@ -1874,6 +1946,7 @@ class TestAdParseResponseDriftRecovery:
         assert second["image_prompt"]["composition"]["shot_type"] == "Medium Shot"
         assert second["video_prompt"]["camera_motion"] == "Static"
 
+    @pytest.mark.unit
     def test_parse_response_keeps_model_title_when_present(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_ad_project(project_path)
@@ -1907,18 +1980,21 @@ class TestAdQualityProbe:
     def _script(self, durations: list[int]) -> dict:
         return {"shots": [_ad_shot(f"E1S{i:02d}", duration=d) for i, d in enumerate(durations, start=1)]}
 
+    @pytest.mark.unit
     def test_drift_above_threshold_warns(self, tmp_path, caplog):
         sg = self._sg(tmp_path, target_duration=30)
         with caplog.at_level("WARNING", logger="lib.script_generator"):
             sg._quality_probe(self._script([4, 4]), episode=1)  # 8 秒 vs 30 秒
         assert any("target_duration drift" in r.message for r in caplog.records)
 
+    @pytest.mark.unit
     def test_drift_within_threshold_silent(self, tmp_path, caplog):
         sg = self._sg(tmp_path, target_duration=30)
         with caplog.at_level("WARNING", logger="lib.script_generator"):
             sg._quality_probe(self._script([4, 6, 6, 6, 4, 6]), episode=1)  # 32 秒 vs 30 秒
         assert not any("target_duration drift" in r.message for r in caplog.records)
 
+    @pytest.mark.unit
     def test_short_prompt_probe_covers_shots(self, tmp_path, caplog):
         sg = self._sg(tmp_path)
         script = self._script([4])
@@ -1927,6 +2003,7 @@ class TestAdQualityProbe:
             sg._quality_probe(script, episode=1)
         assert any("quality probe" in r.message and "E1S01" in r.message for r in caplog.records)
 
+    @pytest.mark.unit
     async def test_save_not_blocked_by_drift(self, tmp_path, caplog):
         """偏差超阈值时保存照常成功（探针仅 WARN，不抛、不拒）。"""
         project_path = tmp_path / "demo"
@@ -1948,6 +2025,7 @@ class TestAdQualityProbe:
 
 
 class TestAdAspectRatioFallback:
+    @pytest.mark.unit
     def test_ad_without_aspect_ratio_falls_back_to_portrait(self, tmp_path):
         """ad 项目缺 aspect_ratio 时回退 9:16 竖屏（与创建向导默认一致）。"""
         sg = ScriptGenerator.__new__(ScriptGenerator)
@@ -1961,6 +2039,7 @@ class TestAdAspectRatioFallback:
 class TestAdReferenceSkeletonUnity:
     """ad + reference_video 生成的剧本不携带 generation_mode 戳（骨架唯一）。"""
 
+    @pytest.mark.unit
     async def test_generate_ad_reference_script_carries_no_generation_mode(self, tmp_path):
         project_path = tmp_path / "demo"
         _write_ad_project(project_path, generation_mode="reference_video")

--- a/tests/test_script_models.py
+++ b/tests/test_script_models.py
@@ -52,6 +52,7 @@ def _drama_video_prompt() -> DramaVideoPrompt:
 
 
 class TestScriptModels:
+    @pytest.mark.unit
     def test_narration_segment_defaults_and_validation(self):
         segment = NarrationSegment(
             segment_id="E1S01",
@@ -82,6 +83,7 @@ class TestScriptModels:
         assert segment.props == ["玉佩"]
         assert not hasattr(segment, "clues_in_segment")
 
+    @pytest.mark.unit
     def test_drama_scene_has_scenes_and_props_fields(self):
         scene = DramaScene(
             scene_id="E1S01",
@@ -95,12 +97,14 @@ class TestScriptModels:
         assert scene.props == ["玉佩"]
         assert not hasattr(scene, "clues_in_scene")
 
+    @pytest.mark.unit
     def test_drama_video_prompt_has_no_dialogue_field(self):
         """drama 用无-dialogue 变体：video_prompt 不携带 dialogue 字段（台词迁入 utterances）。"""
         assert "dialogue" not in DramaVideoPrompt.model_fields
         # narration / ad 共享的 VideoPrompt 仍保留 dialogue
         assert "dialogue" in VideoPrompt.model_fields
 
+    @pytest.mark.unit
     def test_drama_scene_utterances_defaults_empty(self):
         """未提供 utterances 时默认空数组（无口播场景）。"""
         scene = DramaScene(
@@ -111,6 +115,7 @@ class TestScriptModels:
         )
         assert scene.utterances == []
 
+    @pytest.mark.unit
     def test_drama_scene_utterances_round_trips_ordered(self):
         """utterances 按时序接受 dialogue / voiceover 混合条目并 round-trip 不丢、不重排。"""
         utterances = [
@@ -133,6 +138,7 @@ class TestScriptModels:
         ]
         assert DramaScene.model_validate(dumped).utterances == utterances
 
+    @pytest.mark.unit
     def test_utterance_dialogue_requires_speaker(self):
         """kind ⇄ speaker：dialogue 必带非空 speaker，缺失 / 空白则校验失败。"""
         with pytest.raises(ValidationError):
@@ -140,16 +146,19 @@ class TestScriptModels:
         with pytest.raises(ValidationError):
             Utterance(kind="dialogue", speaker="   ", text="空白说话人")
 
+    @pytest.mark.unit
     def test_utterance_voiceover_rejects_speaker(self):
         """kind ⇄ speaker：voiceover 不得带 speaker。"""
         with pytest.raises(ValidationError):
             Utterance(kind="voiceover", speaker="王", text="画外音不该有说话人")
 
+    @pytest.mark.unit
     def test_utterance_voiceover_blank_speaker_normalized_to_none(self):
         """voiceover 的空白 speaker 归一为 None（既可写 null 也可写 ""）。"""
         assert Utterance(kind="voiceover", speaker="", text="旁白").speaker is None
         assert Utterance(kind="voiceover", text="旁白").speaker is None
 
+    @pytest.mark.unit
     def test_drama_scene_migrates_legacy_dialogue_and_voiceover(self):
         """存量 drama 读时迁移：旧 video_prompt.dialogue + voiceover 合成 utterances 并剥离旧字段。"""
         legacy = {
@@ -177,6 +186,7 @@ class TestScriptModels:
         assert not hasattr(scene, "voiceover")
         assert "dialogue" not in scene.video_prompt.model_dump()
 
+    @pytest.mark.unit
     def test_drama_scene_migrates_speakerless_legacy_dialogue_to_voiceover(self):
         """缺说话人的旧台词归为无说话人 voiceover（保内容、不编造 speaker、不致校验失败）。"""
         legacy = {
@@ -196,6 +206,7 @@ class TestScriptModels:
         scene = DramaScene.model_validate(legacy)
         assert scene.utterances == [Utterance(kind="voiceover", text="无主台词")]
 
+    @pytest.mark.unit
     def test_drama_scene_rejects_dialogue_in_video_prompt_for_new_data(self):
         """新数据（utterances 已在）不再迁移：video_prompt 残留 dialogue 触发 extra='forbid'。"""
         with pytest.raises(ValidationError):
@@ -217,6 +228,7 @@ class TestScriptModels:
                 }
             )
 
+    @pytest.mark.unit
     def test_drama_scene_rejects_unknown_field(self):
         """extra='forbid' 守卫仍生效：utterances 不放松未知字段拒绝。"""
         with pytest.raises(ValidationError):
@@ -234,6 +246,7 @@ class TestScriptModels:
                 }
             )
 
+    @pytest.mark.unit
     def test_duration_accepts_any_positive_int_within_range(self):
         """duration_seconds 接受 1-60 范围内任意整数。"""
         segment = NarrationSegment(
@@ -249,6 +262,7 @@ class TestScriptModels:
         )
         assert segment.duration_seconds == 10
 
+    @pytest.mark.unit
     def test_duration_rejects_out_of_range(self):
         """duration_seconds 拒绝范围外的值。"""
         with pytest.raises(ValidationError):
@@ -276,6 +290,7 @@ class TestScriptModels:
                 video_prompt=VideoPrompt(action="转身", camera_motion="Static", ambiance_audio="风声"),
             )
 
+    @pytest.mark.unit
     def test_drama_scene_default_duration_is_8(self):
         """DramaScene 的默认 duration_seconds 仍为 8。"""
         scene = DramaScene(
@@ -286,6 +301,7 @@ class TestScriptModels:
         )
         assert scene.duration_seconds == 8
 
+    @pytest.mark.unit
     def test_episode_models_build_successfully(self):
         narration = NarrationEpisodeScript(
             title="第一集",
@@ -313,6 +329,7 @@ class TestScriptModels:
 class TestAdScriptModels:
     """广告/短片模式剧本骨架：平铺 shots[]，口播文案一等。"""
 
+    @pytest.mark.unit
     def test_ad_shot_carries_section_and_voiceover(self):
         shot = AdShot(
             shot_id="E1S01",
@@ -331,6 +348,7 @@ class TestAdScriptModels:
         assert shot.transition_to_next == "cut"
         assert shot.generated_assets.status == "pending"
 
+    @pytest.mark.unit
     def test_ad_shot_requires_voiceover_text_field(self):
         with pytest.raises(ValidationError):
             AdShot.model_validate(
@@ -343,6 +361,7 @@ class TestAdScriptModels:
                 }
             )
 
+    @pytest.mark.unit
     def test_ad_episode_script_builds_with_shots(self):
         script = AdEpisodeScript(
             title="新品速干杯",
@@ -361,6 +380,7 @@ class TestAdScriptModels:
         assert script.content_mode == "ad"
         assert script.shots[0].products_in_shot == ["速干杯"]
 
+    @pytest.mark.unit
     def test_ad_shot_rejects_unknown_fields(self):
         with pytest.raises(ValidationError):
             AdShot.model_validate(
@@ -384,13 +404,16 @@ class TestItemDurationCoercion:
     项目列表 API 5xx）。此处穷举脏值矩阵 × 四骨架，钉住单点化后的统一口径。
     """
 
+    @pytest.mark.unit
     def test_fallback_table_covers_four_skeletons(self):
         assert _ITEM_FALLBACK_DURATIONS == {"segments": 4, "scenes": 8, "shots": 0, "video_units": 0}
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
     def test_valid_positive_int_passes_through(self, kind: str):
         assert item_duration(kind, {"duration_seconds": 7}) == 7
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
     @pytest.mark.parametrize(
         "dirty",
@@ -410,12 +433,14 @@ class TestItemDurationCoercion:
         # 缺失与所有脏值一律回退到骨架兜底时长（shots/video_units 兜底为 0）。
         assert item_duration(kind, dirty) == _ITEM_FALLBACK_DURATIONS[kind]
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
     def test_non_dict_item_counts_zero(self, kind: str):
         # 非 dict 条目无时长语义，恒按 0 计，不挪用骨架兜底。
         for junk in ("junk", 5, None, ["x"]):
             assert item_duration(kind, junk) == 0
 
+    @pytest.mark.unit
     def test_script_total_sums_mixed_dirty_items(self):
         # 混合脏条目求和不抛：5(有效) + 0(非 dict) + 4(缺失) + 4(None) + 4(负数) = 17。
         items = [
@@ -427,11 +452,13 @@ class TestItemDurationCoercion:
         ]
         assert script_duration_total("segments", items) == 17
 
+    @pytest.mark.unit
     def test_script_total_video_units_missing_is_zero(self):
         # 口径拍板：video_units 缺时长统一按 0 计（不再沿历史 8 秒 else 兜底）。
         assert script_duration_total("video_units", [{}, {"duration_seconds": None}]) == 0
         assert script_duration_total("video_units", [{"duration_seconds": 6}, {}]) == 6
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", ["segments", "scenes", "shots", "video_units"])
     def test_script_total_non_list_is_zero(self, kind: str):
         # items 为 null / 真值标量（降级保存脏值）按空处理返回 0、不抛。
@@ -456,6 +483,7 @@ class TestEnumDriftNormalization:
     def _video_prompt(camera_motion: str, **extra: object) -> dict:
         return {"action": "旋转舞动", "camera_motion": camera_motion, "ambiance_audio": "广场音乐", **extra}
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("drifted", "expected"),
         [
@@ -471,6 +499,7 @@ class TestEnumDriftNormalization:
         comp = Composition.model_validate(self._composition(drifted))
         assert comp.shot_type == expected
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         ("drifted", "expected"),
         [
@@ -489,6 +518,7 @@ class TestEnumDriftNormalization:
         vp = VideoPrompt.model_validate(self._video_prompt(drifted))
         assert vp.camera_motion == expected
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("drifted", ["WIDE_SHOT", "第一视角特写"])
     def test_out_of_vocab_shot_type_falls_back_to_default_with_warning(self, caplog, drifted: str):
         """词表外值不做语义近义映射（穷举不全），一律降级默认并 warn 保留原值。"""
@@ -497,6 +527,7 @@ class TestEnumDriftNormalization:
         assert comp.shot_type == "Medium Shot"
         assert drifted in caplog.text
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("drifted", ["dolly_in", "crane_up_spiral"])
     def test_out_of_vocab_camera_motion_falls_back_to_default_with_warning(self, caplog, drifted: str):
         with caplog.at_level("WARNING", logger="lib.script_models"):
@@ -504,22 +535,26 @@ class TestEnumDriftNormalization:
         assert vp.camera_motion == "Static"
         assert drifted in caplog.text
 
+    @pytest.mark.unit
     def test_canonical_values_pass_through_unchanged(self):
         comp = Composition.model_validate(self._composition("Over-the-shoulder"))
         assert comp.shot_type == "Over-the-shoulder"
         vp = VideoPrompt.model_validate(self._video_prompt("Pan Left"))
         assert vp.camera_motion == "Pan Left"
 
+    @pytest.mark.unit
     def test_non_string_enum_still_rejected(self):
         with pytest.raises(ValidationError):
             Composition.model_validate(self._composition(123))  # type: ignore[arg-type]
         with pytest.raises(ValidationError):
             VideoPrompt.model_validate(self._video_prompt(None))  # type: ignore[arg-type]
 
+    @pytest.mark.unit
     def test_dialogue_null_coerces_to_empty_list(self):
         vp = VideoPrompt.model_validate(self._video_prompt("Static", dialogue=None))
         assert vp.dialogue == []
 
+    @pytest.mark.unit
     def test_llm_schema_still_declares_enum(self):
         """BeforeValidator 不得改变 LLM 侧 schema：enum 仍是约束解码通道的硬约束。"""
         comp_schema = Composition.model_json_schema()
@@ -573,6 +608,7 @@ class TestLLMSchemaExclusion:
     def _all_keys(self, schema):
         return {key for _, key in self._walk(schema)}
 
+    @pytest.mark.unit
     def test_narration_schema_excludes_runtime_fields(self):
         from lib.script_models import NarrationEpisodeScript
 
@@ -582,6 +618,7 @@ class TestLLMSchemaExclusion:
         # 顶层 duration_seconds 由 caller 重算
         assert "duration_seconds" not in NarrationEpisodeScript.model_json_schema()["properties"]
 
+    @pytest.mark.unit
     def test_drama_schema_excludes_runtime_fields(self):
         from lib.script_models import DramaEpisodeScript
 
@@ -601,6 +638,7 @@ class TestLLMSchemaExclusion:
         for forbidden in ("note", "generated_assets", "end_frame_image"):
             assert forbidden not in keys
 
+    @pytest.mark.unit
     def test_reference_video_schema_excludes_runtime_fields(self):
         from lib.script_models import ReferenceVideoScript
 
@@ -609,6 +647,7 @@ class TestLLMSchemaExclusion:
             assert forbidden not in keys
         assert "duration_seconds" not in ReferenceVideoScript.model_json_schema()["properties"]
 
+    @pytest.mark.unit
     def test_runtime_fields_still_validate_in_python(self):
         """虽然 LLM 看不到，但 Python 端仍能 model_validate 含这些字段的旧数据（向后兼容）。"""
         from lib.script_models import NarrationSegment
@@ -631,6 +670,7 @@ class TestLLMSchemaExclusion:
         assert seg.note == "用户标注"
         assert seg.generated_assets.status == "completed"
 
+    @pytest.mark.unit
     def test_schema_excludes_scene_type_summary_content_mode_novel_transition(self):
         """LLM 不该看到 scene_type / summary / content_mode / novel / transition_to_next。
 
@@ -653,6 +693,7 @@ class TestLLMSchemaExclusion:
             assert "scene_type" not in keys, f"{model.__name__} 不应有 scene_type"
             assert "transition_to_next" not in keys, f"{model.__name__} 不应有 transition_to_next"
 
+    @pytest.mark.unit
     def test_schema_excludes_hook_and_teaser_including_derived_models(self):
         """hook / next_episode_teaser 由分集账本注入，LLM 不该看到——
         含 build_*_script_model 动态约束子类（response_schema 实际取自它们）。"""
@@ -679,6 +720,7 @@ class TestLLMSchemaExclusion:
 class TestRuntimeBackwardCompat:
     """LLM schema 隐藏的字段在 Python 端 model_validate 时仍能接受旧数据,并由 default 兜底。"""
 
+    @pytest.mark.unit
     def test_drama_scene_accepts_legacy_scene_type_field(self):
         """存量项目里残留 scene_type 字段不该让 model_validate 炸。"""
         scene = DramaScene.model_validate(
@@ -697,6 +739,7 @@ class TestRuntimeBackwardCompat:
         assert scene.scene_id == "E1S01"
         assert not hasattr(scene, "scene_type")
 
+    @pytest.mark.unit
     def test_narration_segment_accepts_legacy_clues_in_segment_field(self):
         """v0→v1 migration 删的 clues_in_segment 残留时 model_validate 不该炸。"""
         segment = NarrationSegment.model_validate(
@@ -716,6 +759,7 @@ class TestRuntimeBackwardCompat:
         assert segment.segment_id == "E1S01"
         assert not hasattr(segment, "clues_in_segment")
 
+    @pytest.mark.unit
     def test_drama_scene_accepts_legacy_clues_in_scene_field(self):
         """v0→v1 migration 删的 clues_in_scene 残留时 model_validate 不该炸。"""
         scene = DramaScene.model_validate(
@@ -734,6 +778,7 @@ class TestRuntimeBackwardCompat:
         assert scene.scene_id == "E1S01"
         assert not hasattr(scene, "clues_in_scene")
 
+    @pytest.mark.unit
     def test_episode_models_validate_without_optional_fields(self):
         """LLM 不写 content_mode / novel / summary 时,model_validate 仍应成功并用 default 兜底。"""
         drama = DramaEpisodeScript.model_validate(
@@ -765,6 +810,7 @@ class TestRuntimeBackwardCompat:
         assert narration.content_mode == "narration"
         assert narration.novel.title == ""
 
+    @pytest.mark.unit
     def test_segment_transition_to_next_defaults_to_cut(self):
         """LLM 不写 transition_to_next 时,default='cut' 兜底。"""
         seg = NarrationSegment.model_validate(
@@ -792,6 +838,7 @@ class TestGeneratedAssetsTemplateContract:
     写入字段⊆模型声明字段」契约。
     """
 
+    @pytest.mark.unit
     def test_template_dict_validates_against_generated_assets_model(self):
         from lib.project_manager import ProjectManager
         from lib.script_models import GeneratedAssets
@@ -800,6 +847,7 @@ class TestGeneratedAssetsTemplateContract:
         GeneratedAssets.model_validate(ProjectManager.create_generated_assets())
         GeneratedAssets.model_validate(ProjectManager.create_generated_assets("drama"))
 
+    @pytest.mark.unit
     def test_video_thumbnail_runtime_write_passes_strict_validation(self):
         """reference_video_tasks 在视频生成后会写 ga['video_thumbnail'],模型必须接受。"""
         from lib.script_models import GeneratedAssets
@@ -819,11 +867,14 @@ class TestResolveContentMode:
     """episode/剧本级 content_mode 缺失时回退到项目级配置，与
     lib.data_validator._validate_episode_payload 已校验通过的既定口径一致。"""
 
+    @pytest.mark.unit
     def test_episode_level_wins_when_present(self):
         assert resolve_content_mode({"content_mode": "drama"}, {"content_mode": "narration"}) == "drama"
 
+    @pytest.mark.unit
     def test_falls_back_to_project_when_episode_omits_it(self):
         assert resolve_content_mode({}, {"content_mode": "drama"}) == "drama"
 
+    @pytest.mark.unit
     def test_falls_back_to_narration_when_both_omit_it(self):
         assert resolve_content_mode({}, {}) == "narration"

--- a/tests/test_script_models_duration_enum.py
+++ b/tests/test_script_models_duration_enum.py
@@ -12,6 +12,8 @@ from lib.script_models import (
     build_episode_script_model,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _duration_enum(model: type[BaseModel]) -> list[int] | None:
     """从模型 JSON schema 的 $defs 里取出 duration_seconds 的 enum（无则 None）。"""

--- a/tests/test_script_review.py
+++ b/tests/test_script_review.py
@@ -203,6 +203,7 @@ def _write_source_text(pm: ProjectManager, filename: str, text: str) -> Path:
 
 
 class TestDramaGateFlow:
+    @pytest.mark.unit
     async def test_no_step1_then_pending_then_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
@@ -227,6 +228,7 @@ class TestDramaGateFlow:
         project = pm.load_project("demo")
         assert script_review.gate_blocks_step2(project_path, project, 1) is False
 
+    @pytest.mark.unit
     async def test_editing_step1_after_confirm_repends(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
@@ -243,6 +245,7 @@ class TestDramaGateFlow:
         assert state["status"] == "pending_review"
         assert state["content"]["scenes"][0]["utterances"][1]["text"] == "你怎么才回来。"
 
+    @pytest.mark.unit
     async def test_whitespace_reformat_keeps_confirmed(self, tmp_path):
         """纯键序 / 空白重排不改语义 → 指纹不变、保持 confirmed。"""
         pm = _make_project(tmp_path, "drama")
@@ -261,6 +264,7 @@ class TestDramaGateFlow:
 
 
 class TestNarrationGateFlow:
+    @pytest.mark.unit
     async def test_pending_then_confirm(self, tmp_path):
         pm = _make_project(tmp_path, "narration")
         svc = ScriptReviewService(pm)
@@ -272,6 +276,7 @@ class TestNarrationGateFlow:
 
         assert (await svc.confirm("demo", 1))["status"] == "confirmed"
 
+    @pytest.mark.unit
     async def test_edit_novel_text_repends(self, tmp_path):
         pm = _make_project(tmp_path, "narration")
         svc = ScriptReviewService(pm)
@@ -290,6 +295,7 @@ class TestNarrationGateFlow:
 
 
 class TestReferenceVideoGateFlow:
+    @pytest.mark.unit
     async def test_no_step1_then_pending_then_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         svc = ScriptReviewService(pm)
@@ -312,6 +318,7 @@ class TestReferenceVideoGateFlow:
         assert confirmed["confirmed_at"]
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     async def test_editing_shot_text_repends_and_rederives_references(self, tmp_path):
         """编辑 shot 文本 → 重新待审；references 随正文 @ 引用机械重派生（不采用入参陈旧值）。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
@@ -331,6 +338,7 @@ class TestReferenceVideoGateFlow:
         refs = state["content"]["units"][0]["references"]
         assert [(r["type"], r["name"]) for r in refs] == [("character", "阿离"), ("scene", "屋檐")]
 
+    @pytest.mark.unit
     async def test_quarantined_step1_blocks_confirm_and_step2(self, tmp_path):
         """隔离草稿在场 → 确认被拒、step2 被阻塞，即使正式 step1 早已确认过。
 
@@ -362,6 +370,7 @@ class TestReferenceVideoGateFlow:
         clear_quarantine(project_path, 1, QUARANTINE_KIND_STEP1)
         assert (await svc.get_state("demo", 1))["status"] == "confirmed"
 
+    @pytest.mark.unit
     def test_quarantine_not_applicable_to_non_reference_paths(self, tmp_path):
         """drama / narration 无隔离草稿概念：路径解析返回 None，状态判定不受影响。"""
         pm = _make_project(tmp_path, "drama")
@@ -369,6 +378,7 @@ class TestReferenceVideoGateFlow:
         assert script_review.step1_quarantine_path(project_path, pm.load_project("demo"), 1) is None
         assert script_review.step1_quarantined(project_path, pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     async def test_confirm_rejects_unit_duration_out_of_range(self, tmp_path):
         """损坏的 step1（unit 时长越界）→ 确认被结构校验拒绝，不放行 step2。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
@@ -380,6 +390,7 @@ class TestReferenceVideoGateFlow:
             await svc.confirm("demo", 1)
         assert exc.value.code == "invalid_content"
 
+    @pytest.mark.unit
     async def test_confirm_rederives_references_when_step1_edited_outside_save_content(self, tmp_path):
         """confirm 前直改 step1 文件（绕过 save_content，如 agent Write/Edit 直改 drafts/）→
         确认时按当前正文重派生 references 并落盘，不放行陈旧引用。"""
@@ -812,6 +823,7 @@ class TestReferenceVideoStep1Migration:
 
 
 class TestReferenceVideoStep2Enforcement:
+    @pytest.mark.unit
     async def test_generate_blocked_then_confirm_tool_unblocks(self, tmp_path):
         """agent 路径：rv 的 step1 未确认时 step2 阻塞，confirm_script_review 工具确认后放行。"""
         from server.agent_runtime.sdk_tools._context import ToolContext
@@ -841,6 +853,7 @@ class TestReferenceVideoStep2Enforcement:
 
 
 class TestApplicability:
+    @pytest.mark.unit
     async def test_reference_video_applicable(self, tmp_path):
         """reference_video（跨 content_mode）纳入 gate，step1 变体判为 reference_video。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
@@ -850,6 +863,7 @@ class TestApplicability:
         # 未产 step1 → no_step1（区别于 ad 的 not_applicable）。
         assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "no_step1"
 
+    @pytest.mark.unit
     async def test_ad_not_applicable(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         pm.create_project("addemo")
@@ -865,6 +879,7 @@ class TestApplicability:
 
 
 class TestErrors:
+    @pytest.mark.unit
     async def test_save_invalid_content_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
@@ -877,6 +892,7 @@ class TestErrors:
             await svc.save_content("demo", 1, bad)
         assert exc.value.code == "invalid_content"
 
+    @pytest.mark.unit
     async def test_confirm_without_step1_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         svc = ScriptReviewService(pm)
@@ -884,6 +900,7 @@ class TestErrors:
             await svc.confirm("demo", 1)
         assert exc.value.code == "no_step1"
 
+    @pytest.mark.unit
     async def test_save_not_applicable_rejected(self, tmp_path):
         pm = _make_project(tmp_path, "ad")  # ad 无结构化 step1，gate 不适用
         svc = ScriptReviewService(pm)
@@ -891,6 +908,7 @@ class TestErrors:
             await svc.save_content("demo", 1, _drama_step1())
         assert exc.value.code == "not_applicable"
 
+    @pytest.mark.unit
     async def test_get_state_unregistered_episode_rejected(self, tmp_path):
         """适用 gate 但分集未登记 project.json → episode_not_found（而非误报 no_step1）。"""
         pm = _make_project(tmp_path, "drama")  # 仅登记第 1 集
@@ -899,6 +917,7 @@ class TestErrors:
             await svc.get_state("demo", 99)
         assert exc.value.code == "episode_not_found"
 
+    @pytest.mark.unit
     async def test_save_unregistered_episode_writes_no_orphan(self, tmp_path):
         """给未登记分集保存 → episode_not_found，且不落 drafts/episode_99 孤儿 step1 文件。"""
         pm = _make_project(tmp_path, "drama")
@@ -909,6 +928,7 @@ class TestErrors:
         orphan = pm.get_project_path("demo") / "drafts" / "episode_99" / "step1_normalized_script.json"
         assert not orphan.exists()
 
+    @pytest.mark.unit
     async def test_save_with_stale_fingerprint_conflicts_reference_video(self, tmp_path):
         """rv 并发编辑：保存携带的基线指纹与盘上现值不一致（编辑期间另一方已保存）→ conflict、
         不落盘不覆盖；拿最新指纹（等价于刷新合并后）重试放行。"""
@@ -935,6 +955,7 @@ class TestErrors:
         assert state["status"] == "pending_review"
         assert json.loads(path.read_text(encoding="utf-8"))["units"][0]["shots"][1]["text"] == "@[裴与] 下马。"
 
+    @pytest.mark.unit
     async def test_save_with_stale_fingerprint_conflicts_drama(self, tmp_path):
         """drama/narration 的 web 保存同样受基线比对保护：同一个 conflict 错误码。"""
         pm = _make_project(tmp_path, "drama")
@@ -952,6 +973,7 @@ class TestErrors:
         assert exc.value.code == "conflict"
         assert path.read_text(encoding="utf-8") == before
 
+    @pytest.mark.unit
     async def test_save_without_fingerprint_skips_baseline_check(self, tmp_path):
         """不带基线指纹的直连调用维持原语义：不比对、直接落盘。"""
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
@@ -964,6 +986,7 @@ class TestErrors:
         state = await svc.save_content("demo", 1, _rv_step1())
         assert state["status"] == "pending_review"
 
+    @pytest.mark.unit
     async def test_rv_save_clears_stale_step2_quarantine_on_change(self, tmp_path):
         """web 保存改了 step1 内容 → 在场的 step2 隔离草稿作废（其保结构 diff 以旧 step1 为
         基底）；内容未变的保存不清。与 agent 侧写盘同一出口、同一语义。"""
@@ -984,6 +1007,7 @@ class TestErrors:
         await svc.save_content("demo", 1, edited)
         assert not step2_q.exists()
 
+    @pytest.mark.unit
     async def test_confirm_corrupt_step1_rejected(self, tmp_path):
         """step1 文件损坏（非法 JSON，但 content_fingerprint 仍产哈希）→ 确认被结构校验拒绝。"""
         pm = _make_project(tmp_path, "drama")
@@ -1005,6 +1029,7 @@ class TestStep1WriteStore:
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
         return pm.get_project_path("demo")
 
+    @pytest.mark.unit
     def test_conflict_on_stale_baseline_keeps_file(self, tmp_path: Path):
         project_path = self._project_path(tmp_path)
         with script_review.step1_write_lock(project_path, 1):
@@ -1021,6 +1046,7 @@ class TestStep1WriteStore:
         path = script_review.official_reference_step1_path(project_path, 1)
         assert json.loads(path.read_text(encoding="utf-8")) == {"units": [{"v": 1}]}
 
+    @pytest.mark.unit
     def test_matching_baseline_and_none_baseline_write(self, tmp_path: Path):
         """基线一致放行；``None`` 基线表示「取基线时文件不存在」，首写同样放行。"""
         project_path = self._project_path(tmp_path)
@@ -1032,6 +1058,7 @@ class TestStep1WriteStore:
         path = script_review.official_reference_step1_path(project_path, 1)
         assert json.loads(path.read_text(encoding="utf-8")) == {"units": [{"v": 2}]}
 
+    @pytest.mark.unit
     def test_none_baseline_conflicts_when_file_appeared(self, tmp_path: Path):
         """基线 None（取基线时无正式文件）而写盘前文件已被另一方写出 → 冲突，不覆盖。"""
         project_path = self._project_path(tmp_path)
@@ -1041,6 +1068,7 @@ class TestStep1WriteStore:
             with script_review.step1_write_lock(project_path, 1):
                 script_review.write_step1_locked(project_path, 1, {"units": [{"v": 2}]}, expected_fingerprint=None)
 
+    @pytest.mark.unit
     def test_step2_quarantine_cleared_only_on_change(self, tmp_path: Path):
         project_path = self._project_path(tmp_path)
         step2_q = quarantine_path(project_path, 1, QUARANTINE_KIND_STEP2)
@@ -1071,6 +1099,7 @@ class TestStep1WriteStore:
 
 
 class TestStep2Enforcement:
+    @pytest.mark.unit
     async def test_generate_blocked_when_pending(self, tmp_path):
         from server.agent_runtime.sdk_tools._context import ToolContext
         from server.agent_runtime.sdk_tools.text_generation import generate_episode_script_tool
@@ -1086,6 +1115,7 @@ class TestStep2Enforcement:
         text = result["content"][0]["text"]
         assert "step1" in text and "阻塞" in text
 
+    @pytest.mark.unit
     async def test_confirm_tool_unblocks_step2(self, tmp_path):
         """agent 路径：confirm_script_review 工具确认后，gate 放行（既有 step1→step2 不被破坏）。"""
         from server.agent_runtime.sdk_tools._context import ToolContext
@@ -1109,16 +1139,19 @@ class TestStep2Enforcement:
 
 
 class TestLegacyEnumeration:
+    @pytest.mark.unit
     async def test_no_step1(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "no_step1"
 
+    @pytest.mark.unit
     async def test_step1_no_step2_no_review_pending(self, tmp_path):
         """feature 后首次产 step1（未产 step2、无确认）→ 待审、阻塞。"""
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
         assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "pending_review"
 
+    @pytest.mark.unit
     async def test_step1_step2_no_review_grandfathered_confirmed(self, tmp_path):
         """存量项目（已产 step1 + step2、无 step1_review 字段）→ grandfather 放行，不阻塞重跑。"""
         pm = _make_project(tmp_path, "drama")
@@ -1128,6 +1161,7 @@ class TestLegacyEnumeration:
         assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "confirmed"
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     async def test_step1_step2_review_matching_confirmed(self, tmp_path):
         pm = _make_project(tmp_path, "drama")
         _write_step1(pm, "drama", _drama_step1())
@@ -1135,6 +1169,7 @@ class TestLegacyEnumeration:
         await ScriptReviewService(pm).confirm("demo", 1)
         assert (await ScriptReviewService(pm).get_state("demo", 1))["status"] == "confirmed"
 
+    @pytest.mark.unit
     async def test_step1_step2_review_mismatch_pending(self, tmp_path):
         """已确认后 step1 又被改（即便 step2 在）→ 重新待审，指纹优先于 grandfather。"""
         pm = _make_project(tmp_path, "drama")
@@ -1154,6 +1189,7 @@ class TestLegacyEnumeration:
 
 
 class TestManualSplitSelfHeal:
+    @pytest.mark.unit
     async def test_get_state_self_heals_orphan_without_source_range(self, tmp_path):
         """孤儿派生文件 → 自愈登记条目（不写 source_range），get_state 不再 episode_not_found。"""
         pm = _make_manual_split_project(tmp_path, "narration")
@@ -1168,6 +1204,7 @@ class TestManualSplitSelfHeal:
         assert ep["ledger_status"] == "consumed"  # 已有 step1 中间文件
         assert "source_range" not in ep
 
+    @pytest.mark.unit
     async def test_confirm_self_heals_and_unblocks_step2(self, tmp_path):
         """confirm（web 与 agent 工具共用同一 service）在空账本下不再 episode_not_found，且放行 step2。"""
         pm = _make_manual_split_project(tmp_path, "drama")
@@ -1180,6 +1217,7 @@ class TestManualSplitSelfHeal:
         project_path = pm.get_project_path("demo")
         assert script_review.gate_blocks_step2(project_path, pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     async def test_self_heal_never_anchors_even_when_source_text_matches(self, tmp_path):
         """派生文件内容即使能在原文中精确匹配，自愈也只登记不锚定：位置记录只由规划工具写入。"""
         pm = _make_manual_split_project(tmp_path, "narration")
@@ -1193,6 +1231,7 @@ class TestManualSplitSelfHeal:
         assert ep is not None
         assert "source_range" not in ep
 
+    @pytest.mark.unit
     async def test_self_heal_registers_all_orphans_not_just_requested(self, tmp_path):
         """自愈一次登记账本中所有孤儿集号的派生文件，不只是当前请求的那一集。"""
         pm = _make_manual_split_project(tmp_path, "narration")
@@ -1205,6 +1244,7 @@ class TestManualSplitSelfHeal:
         assert script_review.find_episode(project, 1) is not None
         assert script_review.find_episode(project, 2) is not None
 
+    @pytest.mark.unit
     async def test_self_heal_preserves_existing_ledger_status_entries(self, tmp_path):
         """已带 ledger_status 的条目（规划工具写入）不因其他集号的自愈触发被改写。"""
         pm = _make_manual_split_project(tmp_path, "narration")
@@ -1228,6 +1268,7 @@ class TestManualSplitSelfHeal:
         assert ep1["source_range"] == {"source_file": "source/novel.txt", "start": 0, "end": 5}
         assert script_review.find_episode(project, 2) is not None
 
+    @pytest.mark.unit
     async def test_self_heal_does_not_apply_when_derivative_file_missing(self, tmp_path):
         """账本为空且该集派生文件也不存在（真正缺失的集号）→ 仍抛 episode_not_found，不自愈。"""
         pm = _make_manual_split_project(tmp_path, "narration")
@@ -1236,6 +1277,7 @@ class TestManualSplitSelfHeal:
         assert exc.value.code == "episode_not_found"
         assert pm.load_project("demo")["episodes"] == []
 
+    @pytest.mark.unit
     async def test_self_heal_idempotent_no_duplicate_entries(self, tmp_path):
         """重复触发自愈（同集反复读状态）不产生重复集号条目，也不重复改写已登记条目。"""
         pm = _make_manual_split_project(tmp_path, "narration")

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -82,6 +82,7 @@ def _write_rv_step1(pm: ProjectManager, content: dict) -> None:
 
 
 class TestScriptReviewRouter:
+    @pytest.mark.unit
     def test_full_gate_flow(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -110,6 +111,7 @@ class TestScriptReviewRouter:
             assert confirmed.json()["status"] == "confirmed"
             assert script_review.gate_blocks_step2(pm.get_project_path("demo"), pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     def test_edit_content_repends(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -126,6 +128,7 @@ class TestScriptReviewRouter:
             got = client.get(base)
             assert got.json()["content"]["scenes"][0]["utterances"][1]["text"] == "你怎么才回来。"
 
+    @pytest.mark.unit
     def test_put_invalid_content_422(self, tmp_path, monkeypatch):
         client, pm = _client(monkeypatch, tmp_path)
         with client:
@@ -136,6 +139,7 @@ class TestScriptReviewRouter:
             put = client.put(f"{base}/content", json=bad)
             assert put.status_code == 422
 
+    @pytest.mark.unit
     def test_confirm_without_step1_409(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -143,6 +147,7 @@ class TestScriptReviewRouter:
             confirmed = client.post(f"{base}/confirm")
             assert confirmed.status_code == 409
 
+    @pytest.mark.unit
     def test_get_unregistered_episode_404(self, tmp_path, monkeypatch):
         """未在 project.json 登记的分集 → GET 返回 404，而非误报 no_step1 的 200。"""
         client, _ = _client(monkeypatch, tmp_path)
@@ -152,6 +157,7 @@ class TestScriptReviewRouter:
 
 
 class TestReferenceVideoRouter:
+    @pytest.mark.unit
     def test_full_gate_flow(self, tmp_path, monkeypatch):
         """rv 走同一 HTTP gate：结构化 units 可读、可编辑、web 确认放行 step2（与 web 确认等价）。"""
         from lib import script_review
@@ -183,6 +189,7 @@ class TestReferenceVideoRouter:
             assert confirmed.json()["status"] == "confirmed"
             assert script_review.gate_blocks_step2(pm.get_project_path("demo"), pm.load_project("demo"), 1) is False
 
+    @pytest.mark.unit
     def test_quarantine_surfaced_with_recomputed_line_anchored_violations(self, tmp_path, monkeypatch):
         """隔离草稿在场时 GET 附带 ``quarantine`` 字段：违约按产出时那套校验器读时重算，
         不信任草稿里上一轮的快照（这里把快照消息故意写成 "stale" 来验证）。"""
@@ -234,6 +241,7 @@ class TestReferenceVideoRouter:
             confirmed = client.post(f"{base}/confirm")
             assert confirmed.status_code == 409
 
+    @pytest.mark.unit
     def test_quarantine_schema_invalid_keeps_raw_content(self, tmp_path, monkeypatch):
         """草稿 units 被改成非数组：违约报 schema_invalid，``content`` 原样回传（不做收编），
         呈现层据此退回原始文本视图而非当作 units 列表遍历。"""
@@ -274,6 +282,7 @@ class TestReferenceVideoRouter:
             assert [v["code"] for v in quarantine["violations"]] == ["schema_invalid"]
             assert quarantine["violations"][0]["message"] != "stale"
 
+    @pytest.mark.unit
     def test_quarantine_meta_broken_reports_recompute_failure_not_snapshot(self, tmp_path, monkeypatch):
         """``meta.source`` 缺失 → 无从重算：报「无法重算」本身，而不是退回草稿里那份上一轮
         快照——报告一律对现值负责。"""
@@ -297,6 +306,7 @@ class TestReferenceVideoRouter:
             assert "stale" not in violations[0]["message"]
             assert violations[0]["label"] == ""
 
+    @pytest.mark.unit
     def test_supported_durations_exposed_for_reference_video_only(self, tmp_path, monkeypatch):
         """rv 变体的 GET 带出档位表供 web 渲染时长选择；drama 变体下为 None。"""
         rv_client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
@@ -525,6 +535,7 @@ class TestReferenceVideoRouter:
             codes = [v["code"] for v in put_body["quarantine"]["violations"]]
             assert codes and "quarantine_unreadable" not in codes
 
+    @pytest.mark.unit
     def test_put_with_stale_base_fingerprint_conflicts_409(self, tmp_path, monkeypatch):
         """PUT 携带的 ``base_fingerprint`` 与盘上现值不一致（编辑期间另一方已保存）→ 409、
         不落盘；拿最新指纹重试放行。缺省不带指纹的调用维持原语义（不比对）。"""

--- a/tests/test_script_structure_validator.py
+++ b/tests/test_script_structure_validator.py
@@ -6,7 +6,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.script_structure_validator import validate_script_structure
+
+pytestmark = pytest.mark.unit
 
 
 def _segment(segment_id: str = "E1S01", duration: int = 4) -> dict:

--- a/tests/test_sdk_transcript_adapter.py
+++ b/tests/test_sdk_transcript_adapter.py
@@ -8,6 +8,8 @@ import pytest
 
 from server.agent_runtime.sdk_transcript_adapter import SdkTranscriptAdapter
 
+pytestmark = pytest.mark.unit
+
 
 class TestSdkTranscriptAdapterLegacyPath:
     """Tests for the filesystem fallback path (store=None)."""

--- a/tests/test_session_actor.py
+++ b/tests/test_session_actor.py
@@ -16,6 +16,8 @@ from server.agent_runtime.session_actor import (
 )
 from tests.fakes import FakeSDKClient
 
+pytestmark = pytest.mark.unit
+
 
 def test_session_command_default_fields():
     cmd = SessionCommand(type="query", prompt="hello")

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -17,6 +17,8 @@ from server.agent_runtime.session_manager import (
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.fakes import FakeSDKClient
 
+pytestmark = pytest.mark.unit
+
 
 def _make_manager(tmp_path: Path) -> SessionManager:
     """Create a SessionManager with a real MetaStore for testing."""

--- a/tests/test_session_manager_more.py
+++ b/tests/test_session_manager_more.py
@@ -16,6 +16,8 @@ from server.agent_runtime.session_manager import ManagedSession, SessionBusyErro
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.fakes import FakeSDKClient
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeOptions:
     def __init__(self, **kwargs):

--- a/tests/test_session_manager_project_scope.py
+++ b/tests/test_session_manager_project_scope.py
@@ -10,6 +10,8 @@ from lib.db.base import Base
 from server.agent_runtime.session_manager import SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeOptions:
     def __init__(self, **kwargs):

--- a/tests/test_session_manager_sdk_session_id.py
+++ b/tests/test_session_manager_sdk_session_id.py
@@ -12,6 +12,8 @@ from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession
 from tests.fakes import FakeSDKClient
 
+pytestmark = pytest.mark.unit
+
 
 class StreamEvent:
     def __init__(self, session_id: str, uuid: str = "stream-1"):

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -8,6 +8,8 @@ from server.agent_runtime.message_serialization import is_duplicate_user_echo, m
 from server.agent_runtime.session_manager import SDK_AVAILABLE
 from tests.fakes import build_managed_with_actor
 
+pytestmark = pytest.mark.unit
+
 
 async def _seed(session_manager, meta_store, *, messages=None, status="idle", block_forever=False):
     """Create a session meta + pre-connected managed session with actor + FakeSDKClient."""

--- a/tests/test_session_meta_store.py
+++ b/tests/test_session_meta_store.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.db.base import Base
 from server.agent_runtime.session_store import SessionMetaStore
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def store():

--- a/tests/test_session_repo.py
+++ b/tests/test_session_repo.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.db.base import Base
 from lib.db.repositories.session_repo import SessionRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def engine():

--- a/tests/test_session_store_startup_migration.py
+++ b/tests/test_session_store_startup_migration.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.asyncio
 async def test_lifespan_invokes_session_store_migration():

--- a/tests/test_shot_uploads_router.py
+++ b/tests/test_shot_uploads_router.py
@@ -19,6 +19,8 @@ from server.routers import reference_videos, shot_uploads
 from server.services import generation_tasks, reference_video_tasks, upload_finalize
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 def _img_bytes(fmt="JPEG", size=(8, 8)):
     image = Image.new("RGB", size, (255, 0, 0))

--- a/tests/test_skill_script_path_guards.py
+++ b/tests/test_skill_script_path_guards.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_ROOT = REPO_ROOT / "agent_runtime_profile" / ".claude" / "skills"
 COMPOSE_VIDEO = SKILLS_ROOT / "compose-video" / "scripts" / "compose_video.py"

--- a/tests/test_slot_table.py
+++ b/tests/test_slot_table.py
@@ -6,7 +6,11 @@ occupied_providers / find_by_task。用 ``loop.create_future()`` 造 dummy 执�
 
 import asyncio
 
+import pytest
+
 from lib.generation_worker import SlotTable
+
+pytestmark = pytest.mark.unit
 
 
 def _pending_future() -> asyncio.Future:

--- a/tests/test_speech_rate.py
+++ b/tests/test_speech_rate.py
@@ -12,6 +12,8 @@ from lib.speech_rate import (
     speech_rate_units_per_second,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestSpeechRateUnitsPerSecond:
     def test_none_and_empty_fall_back_to_default(self):

--- a/tests/test_sse_channel.py
+++ b/tests/test_sse_channel.py
@@ -10,6 +10,8 @@ import pytest
 
 from server.sse_channel import IDLE, DropSubscriber, EvictNonCriticalAndSignal, SseChannel
 
+pytestmark = pytest.mark.unit
+
 
 def _is_critical(message) -> bool:
     return message.get("type") in {"result", "runtime_status", "user", "assistant"}

--- a/tests/test_startup_source_migration.py
+++ b/tests/test_startup_source_migration.py
@@ -1,7 +1,11 @@
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from server.app import _migrate_source_encoding_on_startup  # 即将新增的内部函数
+
+pytestmark = pytest.mark.unit
 
 
 def test_startup_migration_creates_marker_after_run(tmp_path: Path):

--- a/tests/test_status_calculator.py
+++ b/tests/test_status_calculator.py
@@ -26,6 +26,7 @@ class _FakePM:
 
 
 class TestStatusCalculator:
+    @pytest.mark.unit
     def test_select_kind_and_items(self):
         kind, items = StatusCalculator._select_kind_and_items(
             {"content_mode": "narration", "segments": [{"segment_id": "E1S01"}]}, "storyboard"
@@ -37,6 +38,7 @@ class TestStatusCalculator:
         assert kind2 == "scenes"
         assert len(items2) == 1
 
+    @pytest.mark.unit
     def test_calculate_episode_stats_statuses(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
 
@@ -80,6 +82,7 @@ class TestStatusCalculator:
         assert completed["storyboards"] == {"total": 1, "completed": 0}
         assert completed["videos"] == {"total": 1, "completed": 1}
 
+    @pytest.mark.unit
     def test_calculate_episode_stats_tolerates_corrupt_generated_assets(self, tmp_path):
         """generated_assets 为非 dict 脏数据（如字符串）时按缺失处理，不抛 AttributeError。"""
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -97,6 +100,7 @@ class TestStatusCalculator:
         assert stats["storyboards"] == {"total": 2, "completed": 1}
         assert stats["videos"] == {"total": 2, "completed": 0}
 
+    @pytest.mark.unit
     def test_load_episode_script(self, tmp_path):
         project_root = tmp_path / "projects"
         project_path = project_root / "demo"
@@ -172,6 +176,7 @@ class TestStatusCalculator:
         assert status7 == "segmented"
         assert script7 is None
 
+    @pytest.mark.unit
     def test_calculate_current_phase_setup(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         project_no_overview = {}
@@ -179,6 +184,7 @@ class TestStatusCalculator:
         # 即使有空集列表，但无 overview 且无资产 → 仍是 setup
         assert calc.calculate_current_phase(project_no_overview, [], assets_completed=0) == "setup"
 
+    @pytest.mark.unit
     def test_calculate_current_phase_worldbuilding(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         project = {"overview": {"synopsis": "test"}}
@@ -192,6 +198,7 @@ class TestStatusCalculator:
         # 没有 overview / 资产，但已有分段草稿 → 仍判定为 worldbuilding
         assert calc.calculate_current_phase({}, [{"script_status": "segmented"}], assets_completed=0) == "worldbuilding"
 
+    @pytest.mark.unit
     def test_calculate_current_phase_scripting(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         project = {"overview": {"synopsis": "test"}}
@@ -204,6 +211,7 @@ class TestStatusCalculator:
         # 没有 overview 也一样：脚本产物本身就是更强信号
         assert calc.calculate_current_phase({}, episodes_stats) == "scripting"
 
+    @pytest.mark.unit
     def test_calculate_current_phase_production_and_completed(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         project = {"overview": {"synopsis": "test"}}
@@ -248,6 +256,7 @@ class TestStatusCalculator:
         ]
         assert calc.calculate_current_phase(project, all_scripts_in_prod, assets_completed=3) == "production"
 
+    @pytest.mark.unit
     def test_calculate_project_status(self, tmp_path):
         project_root = tmp_path / "projects"
         project_path = project_root / "demo"
@@ -290,6 +299,7 @@ class TestStatusCalculator:
         assert status["props"] == {"total": 1, "completed": 1}
         assert status["episodes_summary"] == {"total": 1, "scripted": 1, "in_production": 0, "completed": 1}
 
+    @pytest.mark.unit
     def test_enrich_project(self, tmp_path):
         project_root = tmp_path / "projects"
         project_root.mkdir(parents=True)
@@ -340,6 +350,7 @@ class TestStatusCalculator:
         assert ep2["script_status"] == "none"
         assert ep2["status"] == "draft"
 
+    @pytest.mark.unit
     def test_stale_ledger_episode_regresses_to_pending_preprocess(self, tmp_path):
         """账本标 stale 的集：读时状态回退为待预处理（script_status=none），已有产物不删除。
 
@@ -386,6 +397,7 @@ class TestStatusCalculator:
         # 项目级汇总同步回退：仅 1 集计为已生成剧本
         assert enriched["status"]["episodes_summary"]["scripted"] == 1
 
+    @pytest.mark.unit
     def test_enrich_script(self, tmp_path):
         script = {
             "content_mode": "narration",
@@ -408,6 +420,7 @@ class TestStatusCalculator:
         assert enriched_script["scenes_in_episode"] == ["S1"]
         assert enriched_script["props_in_episode"] == ["P1"]
 
+    @pytest.mark.unit
     def test_load_episode_script_corrupted_json(self, tmp_path):
         """JSON 损坏时应降级返回 ('generated', None)，而不是上抛异常。"""
         import json
@@ -421,6 +434,7 @@ class TestStatusCalculator:
         assert status == "generated"
         assert script is None
 
+    @pytest.mark.unit
     def test_calculate_project_status_preloaded_scripts_skips_pm_load(self, tmp_path):
         """preloaded_scripts 覆盖所有集时，不应再调用 pm.load_script。
 
@@ -465,6 +479,7 @@ class TestStatusCalculator:
         assert status["episodes_summary"]["total"] == 1
         assert status["episodes_summary"]["scripted"] == 1
 
+    @pytest.mark.unit
     def test_calculate_project_status_preloaded_scripts_falls_back_for_missing(self, tmp_path):
         """preloaded_scripts 未覆盖的集：回退 pm.load_script，保持"尽力而为"合同。"""
         project_root = tmp_path / "projects"
@@ -513,12 +528,14 @@ class TestStatusCalculator:
 class TestAdStatusCalculation:
     """广告/短片模式（平铺 shots[]）的状态与统计计算。"""
 
+    @pytest.mark.unit
     def test_select_ad_by_duck_typing_when_content_mode_absent(self):
         # 本地 legacy 容忍：缺 content_mode 的存量 ad 剧本按 shots 键鸭子推断（矩阵不覆盖本地阶梯）。
         kind, items = StatusCalculator._select_kind_and_items({"shots": [{"shot_id": "E1S01"}]}, "storyboard")
         assert kind == "shots"
         assert len(items) == 1
 
+    @pytest.mark.unit
     def test_calculate_episode_stats_for_ad(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
 
@@ -538,6 +555,7 @@ class TestAdStatusCalculation:
         assert stats["storyboards"] == {"total": 2, "completed": 1}
         assert stats["videos"] == {"total": 2, "completed": 0}
 
+    @pytest.mark.unit
     def test_ad_reference_path_scores_videos_by_units(self, tmp_path):
         """ad + reference_video：视频进度按派生 unit 计，分镜仍按 shots 计（该路径恒 0）。"""
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -564,6 +582,7 @@ class TestAdStatusCalculation:
         assert stats["duration_seconds"] == 5
         assert stats["scenes_count"] == 2
 
+    @pytest.mark.unit
     def test_ad_reference_path_without_index_stays_draft(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         script = {"content_mode": "ad", "shots": [{"shot_id": "E1S01", "duration_seconds": 3}]}
@@ -573,6 +592,7 @@ class TestAdStatusCalculation:
         assert stats["videos"] == {"total": 0, "completed": 0}
         assert stats["status"] == "draft"
 
+    @pytest.mark.unit
     def test_ad_reference_path_malformed_index_scores_as_not_derived(self, tmp_path):
         """索引形状损坏（非数组 / 夹非 dict 条目）按未派生计分，不部分计数、不抛错。"""
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -599,6 +619,7 @@ class TestAdStatusCalculation:
             assert stats["videos"] == {"total": 0, "completed": 0}
             assert stats["status"] == "draft"
 
+    @pytest.mark.unit
     def test_ad_storyboard_path_ignores_leftover_index(self, tmp_path):
         """切回 storyboard 路径后按 shots 计分，残留索引不污染状态。"""
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
@@ -618,6 +639,7 @@ class TestAdStatusCalculation:
 
         assert stats["videos"] == {"total": 1, "completed": 0}
 
+    @pytest.mark.unit
     def test_ad_missing_duration_counts_zero(self, tmp_path):
         # ad 无单镜头默认时长偏好：缺 duration_seconds 的镜头按 0 计入，
         # 不挪用 narration(4)/drama(8) 的默认值污染 target_duration 对照
@@ -628,6 +650,7 @@ class TestAdStatusCalculation:
         )
         assert stats["duration_seconds"] == 3
 
+    @pytest.mark.unit
     def test_enrich_script_aggregates_ad_references(self, tmp_path):
         calc = StatusCalculator(_FakePM(tmp_path, {}, {}))
         script = {
@@ -729,6 +752,7 @@ class TestAdStatusCalculation:
         assert enriched["scenes_in_episode"] == []
         assert enriched["props_in_episode"] == []
 
+    @pytest.mark.unit
     def test_duck_typing_precedence_segments_over_scenes_over_shots(self):
         """缺 content_mode 的老脚本同时残留多种键时，鸭子类型优先级固定为
         segments > scenes > shots（依赖 _LEGACY_DUCK_TYPE_KINDS 顺序，本测试钉住该顺序）。"""
@@ -756,6 +780,7 @@ class TestStatusCalculatorSkeletonExhaustiveness:
     KeyError，逐个报红。
     """
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("kind", list(_KIND_TO_MODES))
     def test_calculate_episode_stats_covers_every_skeleton_kind(self, kind, tmp_path):
         from lib.script_skeleton import SKELETONS

--- a/tests/test_storyboard_sequence.py
+++ b/tests/test_storyboard_sequence.py
@@ -8,6 +8,8 @@ from lib.storyboard_sequence import (
     resolve_previous_storyboard_path,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestStoryboardSequence:
     def test_resolve_previous_storyboard_path_respects_first_item_and_segment_break(self, tmp_path: Path):

--- a/tests/test_style_templates.py
+++ b/tests/test_style_templates.py
@@ -9,6 +9,8 @@ from lib.style_templates import (
     resolve_template_prompt,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_templates_count_and_categories():
     assert len(STYLE_TEMPLATES) == 36

--- a/tests/test_system_config.py
+++ b/tests/test_system_config.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from lib.system_config import SystemConfigManager
+
+pytestmark = pytest.mark.unit
 
 
 class TestSystemConfigMigration:

--- a/tests/test_system_config_options.py
+++ b/tests/test_system_config_options.py
@@ -17,6 +17,8 @@ from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from server.routers.system_config import _build_options
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_system_config_router.py
+++ b/tests/test_system_config_router.py
@@ -119,12 +119,14 @@ def _make_mock_svc(
 
 
 class TestGetSystemConfig:
+    @pytest.mark.unit
     def test_returns_200(self):
         mock_svc = _make_mock_svc()
         with TestClient(_make_app_with_mock(mock_svc)) as client:
             res = client.get("/api/v1/system/config")
         assert res.status_code == 200
 
+    @pytest.mark.unit
     def test_response_has_settings_and_options(self):
         mock_svc = _make_mock_svc()
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -133,6 +135,7 @@ class TestGetSystemConfig:
         assert "settings" in body
         assert "options" in body
 
+    @pytest.mark.unit
     def test_settings_keys(self):
         mock_svc = _make_mock_svc()
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -164,6 +167,7 @@ class TestGetSystemConfig:
         }
         assert set(settings.keys()) == expected_keys
 
+    @pytest.mark.unit
     def test_options_contain_backend_lists(self):
         mock_svc = _make_mock_svc(ready_providers=["gemini-aistudio"])
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -174,6 +178,7 @@ class TestGetSystemConfig:
         assert "gemini-aistudio/veo-3.1-generate-preview" in options["video_backends"]
         assert "gemini-aistudio/gemini-3.1-flash-image-preview" in options["image_backends"]
 
+    @pytest.mark.unit
     def test_options_exclude_unconfigured_providers(self):
         mock_svc = _make_mock_svc(ready_providers=[])
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -183,6 +188,7 @@ class TestGetSystemConfig:
         assert options["image_backends"] == []
         assert options["audio_backends"] == []
 
+    @pytest.mark.unit
     def test_options_exclude_hidden_models(self):
         """registry 的 hidden 语义是「从下拉剔除、条目保留供算价」，options 是那个下拉。"""
         from dataclasses import replace
@@ -199,6 +205,7 @@ class TestGetSystemConfig:
         assert "gemini-aistudio/veo-3.1-generate-preview" not in options["video_backends"]
         assert "gemini-aistudio/veo-3.1-fast-generate-preview" in options["video_backends"]
 
+    @pytest.mark.unit
     def test_options_include_multiple_ready_providers(self):
         mock_svc = _make_mock_svc(ready_providers=["gemini-aistudio", "ark"])
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -207,6 +214,7 @@ class TestGetSystemConfig:
         assert "gemini-aistudio/veo-3.1-generate-preview" in options["video_backends"]
         assert "ark/doubao-seedance-1-5-pro-251215" in options["video_backends"]
 
+    @pytest.mark.unit
     def test_anthropic_key_masked(self):
         mock_svc = _make_mock_svc(settings={"anthropic_api_key": "sk-ant-test-secret-123456"})
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -217,6 +225,7 @@ class TestGetSystemConfig:
         assert "sk-a" in ak["masked"]
         assert "test-secret-123456" not in ak["masked"]
 
+    @pytest.mark.unit
     def test_anthropic_key_unset(self):
         mock_svc = _make_mock_svc()
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -225,6 +234,7 @@ class TestGetSystemConfig:
         assert ak["is_set"] is False
         assert ak["masked"] is None
 
+    @pytest.mark.unit
     def test_settings_reflect_stored_values(self):
         mock_svc = _make_mock_svc(
             settings={
@@ -240,6 +250,7 @@ class TestGetSystemConfig:
         assert settings["video_generate_audio"] is True
         assert settings["anthropic_base_url"] == "https://proxy.example.com"
 
+    @pytest.mark.unit
     def test_options_include_audio_backends(self):
         mock_svc = _make_mock_svc(ready_providers=["dashscope"])
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -247,6 +258,7 @@ class TestGetSystemConfig:
         options = res.json()["options"]
         assert "dashscope/qwen3-tts-flash" in options["audio_backends"]
 
+    @pytest.mark.unit
     def test_audio_settings_reflect_stored_values(self):
         mock_svc = _make_mock_svc(
             settings={
@@ -262,6 +274,7 @@ class TestGetSystemConfig:
         assert settings["narration_voice"] == "Ethan"
         assert settings["narration_speed"] == 1.2
 
+    @pytest.mark.unit
     def test_audio_settings_default_empty(self):
         mock_svc = _make_mock_svc()
         with TestClient(_make_app_with_mock(mock_svc)) as client:
@@ -271,6 +284,7 @@ class TestGetSystemConfig:
         assert settings["narration_voice"] == ""
         assert settings["narration_speed"] is None
 
+    @pytest.mark.unit
     def test_video_generate_audio_defaults_to_true_on_empty_db(self):
         """新装系统 DB 为空时，GET /system/config 应返回 video_generate_audio=True，
         与 ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO=True 保持一致。"""
@@ -310,6 +324,7 @@ class TestPatchSystemConfig:
         app.include_router(system_config_router.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
         return app
 
+    @pytest.mark.unit
     def test_patch_returns_200(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -319,6 +334,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 200
 
+    @pytest.mark.unit
     def test_patch_sets_backend(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -368,6 +384,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_rejects_invalid_backend_format(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -377,6 +394,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_sets_anthropic_key(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -388,6 +406,7 @@ class TestPatchSystemConfig:
         ak = res.json()["settings"]["anthropic_api_key"]
         assert ak["is_set"] is True
 
+    @pytest.mark.unit
     def test_patch_clears_anthropic_key(self):
         mock_svc = _make_mock_svc(settings={"anthropic_api_key": "sk-ant-old"})
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -399,6 +418,7 @@ class TestPatchSystemConfig:
         ak = res.json()["settings"]["anthropic_api_key"]
         assert ak["is_set"] is False
 
+    @pytest.mark.unit
     def test_patch_sets_anthropic_base_url(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -410,6 +430,7 @@ class TestPatchSystemConfig:
         settings = res.json()["settings"]
         assert settings["anthropic_base_url"] == "https://proxy.example.com/v1"
 
+    @pytest.mark.unit
     def test_patch_sets_audio_toggle(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -420,6 +441,7 @@ class TestPatchSystemConfig:
         assert res.status_code == 200
         assert res.json()["settings"]["video_generate_audio"] is False
 
+    @pytest.mark.unit
     def test_patch_sets_model_fields(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -435,6 +457,7 @@ class TestPatchSystemConfig:
         assert settings["anthropic_model"] == "claude-sonnet-4-20250514"
         assert settings["claude_code_subagent_model"] == "claude-haiku-4-20250514"
 
+    @pytest.mark.unit
     def test_patch_sets_audio_backend_and_voice(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -452,6 +475,7 @@ class TestPatchSystemConfig:
         assert settings["narration_voice"] == "Cherry"
         assert settings["narration_speed"] == 1.5
 
+    @pytest.mark.unit
     def test_patch_rejects_non_positive_narration_speed(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -461,6 +485,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 422
 
+    @pytest.mark.unit
     def test_patch_rejects_non_finite_narration_speed(self):
         # Pydantic lax 模式会把 "nan"/"inf" 字符串转成 float，必须在卫生校验层拒绝
         mock_svc = _make_mock_svc()
@@ -472,6 +497,7 @@ class TestPatchSystemConfig:
                 )
                 assert res.status_code == 422, raw
 
+    @pytest.mark.unit
     def test_patch_clears_narration_speed_with_null(self):
         mock_svc = _make_mock_svc(settings={"narration_speed": "1.5"})
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -482,6 +508,7 @@ class TestPatchSystemConfig:
         assert res.status_code == 200
         assert res.json()["settings"]["narration_speed"] is None
 
+    @pytest.mark.unit
     def test_patch_rejects_invalid_audio_backend(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -491,6 +518,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_returns_full_response(self):
         mock_svc = _make_mock_svc(ready_providers=["gemini-aistudio"])
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -502,6 +530,7 @@ class TestPatchSystemConfig:
         assert "settings" in body
         assert "options" in body
 
+    @pytest.mark.unit
     def test_patch_sets_text_tier_backends(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -517,6 +546,7 @@ class TestPatchSystemConfig:
         assert settings["text_backend_simple"] == "gemini-aistudio/gemini-3-flash-preview"
         assert settings["text_backend_complex"] == "gemini-aistudio/gemini-3.1-pro-preview"
 
+    @pytest.mark.unit
     def test_patch_clears_text_tier_backend_with_empty_string(self):
         mock_svc = _make_mock_svc(settings={"text_backend_simple": "gemini-aistudio/gemini-3-flash-preview"})
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -524,6 +554,7 @@ class TestPatchSystemConfig:
         assert res.status_code == 200
         assert res.json()["settings"]["text_backend_simple"] == ""
 
+    @pytest.mark.unit
     def test_patch_rejects_invalid_text_tier_backend(self):
         mock_svc = _make_mock_svc()
         with TestClient(self._make_patch_app(mock_svc)) as client:
@@ -533,6 +564,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_rejects_text_tier_backend_with_video_model(self):
         """text_backend_simple 引用一个真实存在但是 video 类型的模型，应被 media_type 校验拒绝。"""
         mock_svc = _make_mock_svc()
@@ -543,6 +575,7 @@ class TestPatchSystemConfig:
             )
         assert res.status_code == 400
 
+    @pytest.mark.unit
     def test_patch_ignores_legacy_text_task_keys(self):
         """旧任务级键已从请求模型移除，提交后既不落库也不出现在响应里。"""
         mock_svc = _make_mock_svc()

--- a/tests/test_system_logs_router.py
+++ b/tests/test_system_logs_router.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_system_version_api.py
+++ b/tests/test_system_version_api.py
@@ -15,6 +15,8 @@ from server.routers.system_config import _parse_version
 from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.conftest import make_translator
 
+pytestmark = pytest.mark.unit
+
 _FIXED_FETCHED_AT = datetime(2026, 4, 21, 8, 5, 0, tzinfo=UTC)
 
 

--- a/tests/test_task_cancel_router.py
+++ b/tests/test_task_cancel_router.py
@@ -82,6 +82,7 @@ def _make_app() -> FastAPI:
 
 
 class TestCancelPreview:
+    @pytest.mark.unit
     def test_returns_preview_for_queued_task(self, monkeypatch):
         preview = {
             "task": {"task_id": "t1", "task_type": "image", "resource_id": "scene-1"},
@@ -99,6 +100,7 @@ class TestCancelPreview:
         assert body["task"]["task_id"] == "t1"
         assert body["cascaded"] == []
 
+    @pytest.mark.unit
     def test_running_task_preview_returns_status(self, monkeypatch):
         """ADR 0006 放宽：preview 不再因 running 而拒绝，返回 task.status 让前端判断。"""
         preview = {
@@ -115,6 +117,7 @@ class TestCancelPreview:
         assert resp.status_code == 200
         assert resp.json()["task"]["status"] == "running"
 
+    @pytest.mark.unit
     def test_returns_400_for_nonexistent_task(self, monkeypatch):
         fake = _FakeQueue(cancel_preview_error="任务 'missing' 不存在")
         monkeypatch.setattr(tasks_router, "get_task_queue", lambda: fake)
@@ -133,6 +136,7 @@ class TestCancelPreview:
 
 
 class TestCancelTask:
+    @pytest.mark.unit
     def test_cancels_queued_task(self, monkeypatch):
         result = {
             "cancelled": [{"task_id": "t1", "status": "cancelled"}],
@@ -153,6 +157,7 @@ class TestCancelTask:
         assert body["cancelling"] == []
         assert body["skipped_terminal"] == []
 
+    @pytest.mark.unit
     def test_cancels_running_task_returns_cancelling(self, monkeypatch):
         result = {
             "cancelled": [],
@@ -171,6 +176,7 @@ class TestCancelTask:
         assert body["cancelling"] == ["running-task"]
         assert body["cancelled"] == []
 
+    @pytest.mark.unit
     def test_returns_400_for_nonexistent_task(self, monkeypatch):
         fake = _FakeQueue(cancel_task_error="任务 'ghost' 不存在")
         monkeypatch.setattr(tasks_router, "get_task_queue", lambda: fake)
@@ -182,6 +188,7 @@ class TestCancelTask:
         assert resp.status_code == 400
         assert "不存在" in resp.json()["detail"]
 
+    @pytest.mark.unit
     def test_cancels_terminal_task_returns_skipped_terminal(self, monkeypatch):
         result = {
             "cancelled": [],
@@ -226,6 +233,7 @@ class TestCancelTask:
 
 
 class TestCancelAllPreview:
+    @pytest.mark.unit
     def test_returns_queued_count(self, monkeypatch):
         fake = _FakeQueue(cancel_all_preview_count=5)
         monkeypatch.setattr(tasks_router, "get_task_queue", lambda: fake)
@@ -237,6 +245,7 @@ class TestCancelAllPreview:
         assert resp.status_code == 200
         assert resp.json() == {"queued_count": 5}
 
+    @pytest.mark.unit
     def test_returns_zero_when_no_queued_tasks(self, monkeypatch):
         fake = _FakeQueue(cancel_all_preview_count=0)
         monkeypatch.setattr(tasks_router, "get_task_queue", lambda: fake)
@@ -255,6 +264,7 @@ class TestCancelAllPreview:
 
 
 class TestCancelAllQueued:
+    @pytest.mark.unit
     def test_cancels_all_queued_tasks(self, monkeypatch):
         result = {
             "cancelled_count": 3,
@@ -272,6 +282,7 @@ class TestCancelAllQueued:
         assert body["cancelled_count"] == 3
         assert body["skipped_running_count"] == 0
 
+    @pytest.mark.unit
     def test_returns_zero_when_nothing_to_cancel(self, monkeypatch):
         result = {"cancelled_count": 0, "skipped_running_count": 0}
         fake = _FakeQueue(cancel_all_result=result)

--- a/tests/test_task_failure.py
+++ b/tests/test_task_failure.py
@@ -14,17 +14,21 @@ def _translator(locale: str):
 
 
 class TestEncodeFailure:
+    @pytest.mark.unit
     def test_encode_code_only(self):
         assert encode_failure("restart_lost_image") == "[restart_lost_image]"
 
+    @pytest.mark.unit
     def test_encode_with_params_is_sorted_json(self):
         encoded = encode_failure("provider_unsupported_media", provider_id="grok", media_type="image")
         assert encoded == '[provider_unsupported_media] {"media_type": "image", "provider_id": "grok"}'
 
+    @pytest.mark.unit
     def test_encode_unknown_code_raises(self):
         with pytest.raises(KeyError):
             encode_failure("totally_unknown_code")
 
+    @pytest.mark.unit
     def test_every_known_code_round_trips_through_render(self):
         # Each known code must encode and render to a non-empty, non-raw string.
         translate = _translator("en")
@@ -36,6 +40,7 @@ class TestEncodeFailure:
 
 
 class TestRenderKnownCodes:
+    @pytest.mark.unit
     def test_renders_per_locale(self):
         encoded = encode_failure("provider_unsupported_media", provider_id="grok", media_type="image")
         assert render_failure(encoded, _translator("zh")) == "供应商 grok 不支持 image 生成"
@@ -45,6 +50,7 @@ class TestRenderKnownCodes:
         # locales differ
         assert render_failure(encoded, _translator("zh")) != render_failure(encoded, _translator("en"))
 
+    @pytest.mark.unit
     def test_renders_code_only(self):
         encoded = encode_failure("restart_lost_image")
         zh = render_failure(encoded, _translator("zh"))
@@ -52,6 +58,7 @@ class TestRenderKnownCodes:
         assert zh and en and zh != en
         assert "[" not in zh
 
+    @pytest.mark.unit
     def test_detail_param_is_interpolated_untranslated(self):
         encoded = encode_failure("resume_expired_detail", detail="HTTP 404 job gone")
         zh = render_failure(encoded, _translator("zh"))
@@ -124,35 +131,43 @@ class TestBoundReason:
 
 
 class TestPassthrough:
+    @pytest.mark.unit
     def test_none_and_empty(self):
         assert render_failure(None, _translator("en")) is None
         assert render_failure("", _translator("en")) == ""
 
+    @pytest.mark.unit
     def test_raw_exception_text_passthrough(self):
         raw = "RuntimeError: provider returned 500"
         assert render_failure(raw, _translator("en")) == raw
 
+    @pytest.mark.unit
     def test_legacy_chinese_row_passthrough(self):
         legacy = "供应商 grok 不支持 image 生成"
         assert render_failure(legacy, _translator("en")) == legacy
 
+    @pytest.mark.unit
     def test_legacy_bracket_prefix_with_chinese_tail_passthrough(self):
         # Old format: [code] followed by free Chinese text (non-JSON tail).
         legacy = "[restart_lost] image 任务无法接续，需手动重试以避免重复计费"
         assert render_failure(legacy, _translator("en")) == legacy
 
+    @pytest.mark.unit
     def test_unknown_bracket_code_passthrough(self):
         msg = '[some_future_code] {"x": 1}'
         assert render_failure(msg, _translator("en")) == msg
 
+    @pytest.mark.unit
     def test_malformed_json_params_passthrough(self):
         msg = "[provider_unsupported_media] {not valid json"
         assert render_failure(msg, _translator("en")) == msg
 
+    @pytest.mark.unit
     def test_non_object_json_params_passthrough(self):
         msg = "[provider_unsupported_media] [1, 2, 3]"
         assert render_failure(msg, _translator("en")) == msg
 
+    @pytest.mark.unit
     def test_detail_with_braces_does_not_break_format(self):
         # str(exc) can contain literal braces; they must not be re-interpreted by .format.
         encoded = encode_failure("resume_unsupported_detail", detail="weird {placeholder} text")

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -35,6 +35,7 @@ async def db_session(engine):
 
 
 class TestTaskRepository:
+    @pytest.mark.unit
     async def test_enqueue_dedupe_claim_succeed(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -68,6 +69,7 @@ class TestTaskRepository:
         done = await repo.get(first["task_id"])
         assert done["status"] == "succeeded"
 
+    @pytest.mark.unit
     async def test_enqueue_dedupe_respects_resource_type(self, db_session):
         """同名不同资产类型（如角色和道具都叫「玉佩」）不应互相去重。"""
         repo = TaskRepository(db_session)
@@ -105,6 +107,7 @@ class TestTaskRepository:
         assert character_edit_again["deduped"]
         assert character_edit_again["task_id"] == character_edit["task_id"]
 
+    @pytest.mark.unit
     async def test_dependency_cascade_failure(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -210,6 +213,7 @@ class TestTaskRepository:
             assert "[" not in rendered
             assert "cascade_blocked_dependency" not in rendered
 
+    @pytest.mark.unit
     async def test_requeue_running_tasks(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -228,6 +232,7 @@ class TestTaskRepository:
         queued = await repo.get(task["task_id"])
         assert queued["status"] == "queued"
 
+    @pytest.mark.unit
     async def test_worker_lease(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -238,6 +243,7 @@ class TestTaskRepository:
         await repo.release_lease(name="default", owner_id="a")
         assert not await repo.is_worker_online(name="default")
 
+    @pytest.mark.unit
     async def test_worker_lease_concurrent_first_acquire(self, tmp_path):
         db_path = tmp_path / "lease-race.db"
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -272,6 +278,7 @@ class TestTaskRepository:
 
         await engine.dispose()
 
+    @pytest.mark.unit
     async def test_list_tasks_with_filters(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -298,6 +305,7 @@ class TestTaskRepository:
         result = await repo.list_tasks()
         assert result["total"] == 2
 
+    @pytest.mark.unit
     async def test_task_has_cancelled_by_field(self, db_session):
         repo = TaskRepository(db_session)
         task = await repo.enqueue(
@@ -311,6 +319,7 @@ class TestTaskRepository:
         fetched = await repo.get(task["task_id"])
         assert fetched["cancelled_by"] is None
 
+    @pytest.mark.unit
     async def test_cancel_single_queued_task(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -334,6 +343,7 @@ class TestTaskRepository:
         assert cancelled["status"] == "cancelled"
         assert cancelled["cancelled_by"] == "user"
 
+    @pytest.mark.unit
     async def test_get_stats(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -349,6 +359,7 @@ class TestTaskRepository:
         assert stats["queued"] == 1
         assert stats["total"] == 1
 
+    @pytest.mark.unit
     async def test_cancel_task_cascades_to_dependents(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -381,6 +392,7 @@ class TestTaskRepository:
         assert dep_task["status"] == "cancelled"
         assert dep_task["cancelled_by"] == "cascade"
 
+    @pytest.mark.unit
     async def test_cancel_running_task_marks_cancelling(self, db_session):
         """ADR 0006: 取消 running task 转入 cancelling 中间态；
         Repository 不再 raise，由上层 GenerationQueue 分发 worker 信号。"""
@@ -404,6 +416,7 @@ class TestTaskRepository:
         refreshed = await repo.get(task["task_id"])
         assert refreshed["status"] == "cancelling"
 
+    @pytest.mark.unit
     async def test_cancel_preview(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -430,6 +443,7 @@ class TestTaskRepository:
         assert len(preview["cascaded"]) == 1
         assert preview["cascaded"][0]["task_id"] == second["task_id"]
 
+    @pytest.mark.unit
     async def test_cancel_all_queued(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -459,6 +473,7 @@ class TestTaskRepository:
         task = await repo.get(t2["task_id"])
         assert task["status"] == "cancelled"
 
+    @pytest.mark.unit
     async def test_get_stats_includes_cancelled(self, db_session):
         repo = TaskRepository(db_session)
 
@@ -494,6 +509,7 @@ class TestPersistApiCallId:
         )
         return result["task_id"]
 
+    @pytest.mark.unit
     async def test_persist_writes_api_call_id_into_payload(self, db_session):
         repo = TaskRepository(db_session)
         task_id = await self._enqueue(repo, payload={"prompt": "p"})
@@ -505,6 +521,7 @@ class TestPersistApiCallId:
         assert task["payload"]["api_call_id"] == 42
         assert task["payload"]["prompt"] == "p", "其它 payload 字段不应被覆盖"
 
+    @pytest.mark.unit
     async def test_persist_overwrites_existing_api_call_id(self, db_session):
         """重试场景：同一 task 第二次走 generate 写新 call_id 应覆盖。"""
         repo = TaskRepository(db_session)
@@ -517,6 +534,7 @@ class TestPersistApiCallId:
         assert task is not None
         assert task["payload"]["api_call_id"] == 20
 
+    @pytest.mark.unit
     async def test_persist_handles_empty_payload(self, db_session):
         """Payload 为空 JSON 也能正常写。"""
         repo = TaskRepository(db_session)
@@ -528,12 +546,14 @@ class TestPersistApiCallId:
         assert task is not None
         assert task["payload"] == {"api_call_id": 7}
 
+    @pytest.mark.unit
     async def test_persist_raises_when_task_not_found(self, db_session):
         """task_id 不存在 → 显式 ValueError，避免静默 commit 让上层以为已持久化。"""
         repo = TaskRepository(db_session)
         with pytest.raises(ValueError, match="task not found"):
             await repo.persist_api_call_id("nonexistent-task-id", 42)
 
+    @pytest.mark.unit
     async def test_persist_handles_null_payload_json_row(self, db_session):
         """task 存在但 payload_json IS NULL（迁移历史/旧任务）→ 走 first() 判存在性，不应误判 task not found。"""
         from sqlalchemy import update as sql_update
@@ -570,6 +590,7 @@ class TestPersistEffectiveDuration:
         )
         return result["task_id"]
 
+    @pytest.mark.unit
     async def test_persist_overwrites_duration_seconds_in_payload(self, db_session):
         repo = TaskRepository(db_session)
         task_id = await self._enqueue(repo, payload={"duration_seconds": 5, "prompt": "p"})
@@ -581,6 +602,7 @@ class TestPersistEffectiveDuration:
         assert task["payload"]["duration_seconds"] == 8
         assert task["payload"]["prompt"] == "p", "其它 payload 字段不应被覆盖"
 
+    @pytest.mark.unit
     async def test_persist_handles_empty_payload(self, db_session):
         repo = TaskRepository(db_session)
         task_id = await self._enqueue(repo, payload={})
@@ -591,6 +613,7 @@ class TestPersistEffectiveDuration:
         assert task is not None
         assert task["payload"] == {"duration_seconds": 8}
 
+    @pytest.mark.unit
     async def test_persist_silently_skips_when_task_not_found(self, db_session):
         """metadata-only 写回：task 不存在时静默跳过，不 fail-fast（与 persist_api_call_id 不同）。"""
         repo = TaskRepository(db_session)
@@ -630,6 +653,7 @@ class TestCancelCascadeAcrossCancelling:
         )
         return a["task_id"], b["task_id"], c["task_id"]
 
+    @pytest.mark.unit
     async def test_cancel_running_task_returns_only_cancelling(self, db_session):
         """A running → cancel_task 响应体 cancelled=[]、cancelling=[A]、下游变动靠后续 SSE/finalize。"""
         repo = TaskRepository(db_session)
@@ -645,6 +669,7 @@ class TestCancelCascadeAcrossCancelling:
         assert (await repo.get(b))["status"] == "queued"
         assert (await repo.get(c))["status"] == "queued"
 
+    @pytest.mark.unit
     async def test_cancel_link_running_to_queued(self, db_session):
         """A(running)→B(queued)→C(queued)：finalize_cancelled(A) → A/B/C 全 cancelled，
         B/C 的 cancelled_by="cascade"。"""
@@ -660,6 +685,7 @@ class TestCancelCascadeAcrossCancelling:
             assert t["status"] == "cancelled", f"{tid} expected cancelled, got {t['status']}"
             assert t["cancelled_by"] == expected
 
+    @pytest.mark.unit
     async def test_finalize_cancelled_returns_cascading_cancelling_ids(self, db_session):
         """finalize_cancelled 应返回级联出来的 running 子任务 task_id 列表，
         让上层 GenerationQueue 同步分发 in-process cancel 信号给 worker。
@@ -684,6 +710,7 @@ class TestCancelCascadeAcrossCancelling:
         # C 是 queued（依赖 B 还没结束），不进 cancelling 列表
         assert c not in result["cancelling"]
 
+    @pytest.mark.unit
     async def test_cancel_link_running_running_queued(self, db_session):
         """A(running)→B(running)→C(queued)：finalize(A) → A cancelled、B cancelling、C queued；
         finalize(B) → B cancelled、C cancelled。"""
@@ -712,6 +739,7 @@ class TestCancelCascadeAcrossCancelling:
         assert (await repo.get(c))["status"] == "cancelled"
         assert (await repo.get(c))["cancelled_by"] == "cascade"
 
+    @pytest.mark.unit
     async def test_cancel_cascade_task_rows_carry_cancelled_by(self, db_session):
         """级联取消的下游任务与发起方在 cancelled_by 字段上须能区分。
 
@@ -728,6 +756,7 @@ class TestCancelCascadeAcrossCancelling:
         assert (await repo.get(b))["cancelled_by"] == "cascade"
         assert (await repo.get(c))["cancelled_by"] == "cascade"
 
+    @pytest.mark.unit
     async def test_cancel_records_each_terminal_event_at_most_once(self, db_session):
         """每个 task 的终态推送（project_events SSE 依赖的 terminal_events）不重复记账。"""
         repo = TaskRepository(db_session)

--- a/tests/test_task_repo_state_machine.py
+++ b/tests/test_task_repo_state_machine.py
@@ -11,6 +11,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from lib.db.base import Base
 from lib.db.repositories.task_repo import TaskRepository
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def engine():

--- a/tests/test_tasks_router_more.py
+++ b/tests/test_tasks_router_more.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -5,6 +6,8 @@ from server.auth import CurrentUserInfo, get_current_user, get_current_user_flex
 from server.error_handlers import register_error_handlers
 from server.routers import tasks as tasks_router
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeQueue:

--- a/tests/test_tasks_router_smoke.py
+++ b/tests/test_tasks_router_smoke.py
@@ -1,11 +1,14 @@
 """Smoke tests for task router endpoints against a real generation queue."""
 
+import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from server.auth import CurrentUserInfo, get_current_user, get_current_user_flexible
 from server.routers import tasks as tasks_router
 from tests.auth_deps import AUTH_DEPENDENCIES
+
+pytestmark = pytest.mark.unit
 
 
 def _build_app():

--- a/tests/test_text_backends/test_agnes_text_backend.py
+++ b/tests/test_text_backends/test_agnes_text_backend.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel
 from lib.providers import PROVIDER_AGNES
 from lib.text_backends.base import TextCapability, TextGenerationRequest
 
+pytestmark = pytest.mark.unit
+
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
     """构造 mock ChatCompletion 响应。"""

--- a/tests/test_text_backends/test_ark.py
+++ b/tests/test_text_backends/test_ark.py
@@ -8,6 +8,8 @@ import pytest
 from lib.text_backends.ark import ArkTextBackend
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_ark():

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from pydantic import BaseModel
 
 from lib.text_backends.base import (
@@ -16,6 +17,8 @@ from lib.text_backends.base import (
     TextTaskType,
     resolve_schema,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestTextCapability:

--- a/tests/test_text_backends/test_factory.py
+++ b/tests/test_text_backends/test_factory.py
@@ -8,8 +8,12 @@ provider/model，构造经统一缝下沉到 ProviderSpec 表。这些测试 moc
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from lib.text_backends.base import TextTaskType
 from lib.text_backends.factory import create_text_backend_for_task
+
+pytestmark = pytest.mark.unit
 
 
 def _make_mock_resolver(**async_methods):

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -13,6 +13,8 @@ from lib.text_backends.base import (
 )
 from lib.text_backends.gemini import GeminiTextBackend
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_genai():

--- a/tests/test_text_backends/test_grok.py
+++ b/tests/test_text_backends/test_grok.py
@@ -7,6 +7,8 @@ import pytest
 
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_xai():

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -15,6 +15,8 @@ from lib.text_backends.instructor_support import (
     instructor_fallback_sync,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class SampleModel(BaseModel):
     name: str

--- a/tests/test_text_backends/test_registry.py
+++ b/tests/test_text_backends/test_registry.py
@@ -10,6 +10,8 @@ from lib.text_backends.registry import (
     register_backend,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class FakeTextBackend:
     def __init__(self, *, api_key=None, model=None):

--- a/tests/test_text_generator.py
+++ b/tests/test_text_generator.py
@@ -12,6 +12,8 @@ from lib.ledger import Ledger
 from lib.text_backends.base import TextGenerationRequest, TextGenerationResult
 from lib.text_generator import TextGenerator
 
+pytestmark = pytest.mark.unit
+
 
 @dataclass
 class _Wired:

--- a/tests/test_text_metrics.py
+++ b/tests/test_text_metrics.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lib.text_metrics import count_reading_units, find_reading_unit_offset, reading_unit_noun
+
+pytestmark = pytest.mark.unit
 
 
 class TestZh:

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.text_utils import strip_json_code_fences
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     "raw",

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -5,6 +5,8 @@ import pytest
 
 from lib.thumbnail import extract_video_last_frame, extract_video_thumbnail
 
+pytestmark = pytest.mark.unit
+
 
 class TestExtractVideoThumbnail:
     @pytest.fixture(autouse=True)

--- a/tests/test_thumbnail_fallback.py
+++ b/tests/test_thumbnail_fallback.py
@@ -9,6 +9,8 @@ import pytest
 
 import lib.thumbnail as thumbnail_module
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _reset_ffmpeg_cache():

--- a/tests/test_tts_pricing.py
+++ b/tests/test_tts_pricing.py
@@ -9,6 +9,8 @@ from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.pricing.types import PerCharacter
 
+pytestmark = pytest.mark.unit
+
 
 class TestPerCharacterStrategy:
     pricing = PerCharacter(rates={"qwen3-tts-flash": 0.8}, default_model="qwen3-tts-flash", currency="CNY")

--- a/tests/test_tts_resolver.py
+++ b/tests/test_tts_resolver.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.config.resolver import ConfigResolver, ProviderModel
 from lib.config.service import ProviderStatus
 from lib.db.base import Base
+
+pytestmark = pytest.mark.unit
 
 
 def _ready(name: str, media_types: list[str]) -> ProviderStatus:

--- a/tests/test_tts_skeleton.py
+++ b/tests/test_tts_skeleton.py
@@ -20,6 +20,8 @@ from lib.resource_paths import RESOURCE_TYPES, resource_extension, resource_rela
 from lib.script_models import GeneratedAssets
 from lib.version_manager import VersionManager
 
+pytestmark = pytest.mark.unit
+
 
 class TestResourcePaths:
     def test_audio_relative_path(self):

--- a/tests/test_turn_schema.py
+++ b/tests/test_turn_schema.py
@@ -1,11 +1,15 @@
 """Unit tests for turn_schema shared normalization."""
 
+import pytest
+
 from server.agent_runtime.turn_schema import (
     _stringify_content,
     infer_block_type,
     normalize_block,
     normalize_content,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestInferBlockType:

--- a/tests/test_update_project_atomicity.py
+++ b/tests/test_update_project_atomicity.py
@@ -4,7 +4,11 @@ import asyncio
 import json
 from pathlib import Path
 
+import pytest
+
 from lib.project_manager import ProjectManager
+
+pytestmark = pytest.mark.unit
 
 
 def _make_project(tmp_path: Path, characters: dict) -> str:

--- a/tests/test_upload_restore_png.py
+++ b/tests/test_upload_restore_png.py
@@ -1,11 +1,14 @@
 from io import BytesIO
 
+import pytest
 from PIL import Image
 
 import server.routers.versions as versions_router
 from lib.image_utils import convert_image_bytes_to_png
 from lib.project_manager import ProjectManager
 from lib.version_manager import VersionManager
+
+pytestmark = pytest.mark.unit
 
 
 class TestUploadRestorePng:

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib.config.url_utils import ensure_anthropic_base_url
 
+pytestmark = pytest.mark.unit
+
 
 class TestEnsureAnthropicBaseUrl:
     def test_official_root_unchanged(self):

--- a/tests/test_usage_extraction.py
+++ b/tests/test_usage_extraction.py
@@ -17,6 +17,8 @@ from server.agent_runtime.usage_extraction import (
     resolve_configured_assistant_model,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestExtractTextTokenUsage:
     def test_extract_text_token_usage_accepts_numeric_strings(self):

--- a/tests/test_usage_repo.py
+++ b/tests/test_usage_repo.py
@@ -26,6 +26,7 @@ async def db_session(engine):
 
 
 class TestUsageRepository:
+    @pytest.mark.unit
     async def test_start_and_finish_call(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -48,6 +49,7 @@ class TestUsageRepository:
         assert calls["total"] == 1
         assert calls["items"][0]["status"] == "success"
 
+    @pytest.mark.unit
     async def test_get_stats(self, db_session):
         repo = UsageRepository(db_session)
         call1 = await repo.start_call(
@@ -71,6 +73,7 @@ class TestUsageRepository:
         assert stats["failed_count"] == 1
         assert stats["total_count"] == 2
 
+    @pytest.mark.unit
     async def test_get_projects_list(self, db_session):
         repo = UsageRepository(db_session)
         await repo.start_call(project_name="project_a", call_type="image", model="m")
@@ -79,6 +82,7 @@ class TestUsageRepository:
         projects = await repo.get_projects_list()
         assert set(projects) == {"project_a", "project_b"}
 
+    @pytest.mark.unit
     async def test_pagination(self, db_session):
         repo = UsageRepository(db_session)
         for i in range(5):
@@ -93,6 +97,7 @@ class TestUsageRepository:
 
 
 class TestClassifyAssetOutputPath:
+    @pytest.mark.unit
     def test_products_bucketed_separately_from_props(self):
         from lib.db.repositories.usage_repo import _classify_asset_output_path
 
@@ -106,6 +111,7 @@ class TestClassifyAssetOutputPath:
 class TestFinalizePendingByCallId:
     """Resume 路径专用：按 call_id 精准翻 pending → success/failed。"""
 
+    @pytest.mark.unit
     async def test_flips_pending_to_success(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
@@ -118,6 +124,7 @@ class TestFinalizePendingByCallId:
         assert calls["items"][0]["status"] == "success"
         assert calls["items"][0]["cost_amount"] == 0.0
 
+    @pytest.mark.unit
     async def test_auto_calculates_cost_when_amount_omitted(self, db_session):
         """cost_amount=None + status='success' → 按 ApiCall 行字段调 cost_calculator 算实际 cost。"""
         repo = UsageRepository(db_session)
@@ -140,6 +147,7 @@ class TestFinalizePendingByCallId:
         assert calls["items"][0]["status"] == "success"
         assert calls["items"][0]["cost_amount"] > 0.0, "auto-calc 应算出真实 cost，不应是 0"
 
+    @pytest.mark.unit
     async def test_service_tier_passed_to_cost_calculator(self, db_session, monkeypatch):
         """service_tier 应从 caller 透传到 cost_calculator.calculate_cost，非 default 档位才算对。"""
         from lib import cost_calculator as cc_module
@@ -167,6 +175,7 @@ class TestFinalizePendingByCallId:
         assert affected == 1
         assert captured["service_tier"] == "priority", "service_tier 必须从 caller 透传到 cost_calculator"
 
+    @pytest.mark.unit
     async def test_usage_tokens_passed_to_cost_calculator(self, db_session, monkeypatch):
         """Ark video 按 usage_tokens 计费，repo 必须把 caller 传入的 usage_tokens 透传到 cost_calculator，
         否则按 token 计费的视频走 usage_tokens or 0 路径 → cost 永远为 0 CNY。"""
@@ -222,6 +231,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["cost_amount"] == 0.0, "usage_tokens 缺失时实付结算不得伪造近似金额"
 
+    @pytest.mark.unit
     async def test_billed_duration_passed_to_cost_calculator_and_ledger(self, db_session, monkeypatch):
         """provider 回报的实际计费时长必须透传到 cost_calculator 并回写 ApiCall.duration_seconds，
         与 finish_call 的 billed_duration_seconds 覆盖语义一致（resume 路径不分叉）。"""
@@ -253,6 +263,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["duration_seconds"] == 15, "实际计费时长必须 UPDATE 写回 ApiCall 行"
 
+    @pytest.mark.unit
     async def test_billed_duration_non_positive_falls_back_to_request_duration(self, db_session, monkeypatch):
         """非正的实际计费时长视同未提供：cost_calculator 入参与账本均回落 start_call 的请求时长。"""
         from lib import cost_calculator as cc_module
@@ -283,6 +294,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["duration_seconds"] == 6, "非正计费时长不得写回账本，应保留请求时长"
 
+    @pytest.mark.unit
     async def test_billed_duration_over_limit_falls_back_to_request_duration(self, db_session, monkeypatch):
         """超出合理上限（24h）的计费时长视同未提供：repo 写入层是全部 backend 的最后防线，
         防超大数值写入 DB Integer 列溢出。"""
@@ -315,6 +327,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["duration_seconds"] == 6, "超限计费时长不得写回账本，应保留请求时长"
 
+    @pytest.mark.unit
     async def test_does_not_touch_other_pending_call(self, db_session):
         repo = UsageRepository(db_session)
         cid_a = await repo.start_call(project_name="demo", call_type="video", model="m", segment_id="E1S01")
@@ -329,6 +342,7 @@ class TestFinalizePendingByCallId:
         assert by_id[cid_a]["status"] == "success"
         assert by_id[cid_b]["status"] == "pending", "另一条 pending 不应被 touch"
 
+    @pytest.mark.unit
     async def test_idempotent_when_already_success(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
@@ -342,6 +356,7 @@ class TestFinalizePendingByCallId:
         calls = await repo.get_calls(project_name="demo")
         assert calls["items"][0]["cost_amount"] == 5.0, "cost 未被覆写"
 
+    @pytest.mark.unit
     async def test_finalize_failed_status(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(project_name="demo", call_type="video", model="m")
@@ -355,11 +370,13 @@ class TestFinalizePendingByCallId:
         assert calls["items"][0]["status"] == "failed"
         assert calls["items"][0]["cost_amount"] == 0.0
 
+    @pytest.mark.unit
     async def test_unknown_call_id_returns_zero(self, db_session):
         repo = UsageRepository(db_session)
         affected = await repo.finalize_pending_by_call_id(call_id=99999, settlement=SettlementInput())
         assert affected == 0
 
+    @pytest.mark.unit
     async def test_writes_duration_ms(self, db_session):
         """resume 完成的调用必须回写 duration_ms，否则 get_stats_grouped_by_provider 的
         provider 级时长统计会因 NULL 系统性压低。"""
@@ -375,6 +392,7 @@ class TestFinalizePendingByCallId:
         assert item["duration_ms"] is not None
         assert item["duration_ms"] >= 0
 
+    @pytest.mark.unit
     async def test_generate_audio_override_passed_to_cost_calculator(self, db_session, monkeypatch):
         """provider 在 submit 后可能降级/关闭音频；finalize 接受 caller 透传的 generate_audio
         覆盖 ApiCall 行上 start_call 时的请求值（与 finish_call 同语义），cost_calculator 也应收到
@@ -413,6 +431,7 @@ class TestFinalizePendingByCallId:
 
 
 class TestMultiProviderUsage:
+    @pytest.mark.unit
     async def test_ark_call_records_provider_and_tokens(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -439,6 +458,7 @@ class TestMultiProviderUsage:
         assert item["usage_tokens"] == 246840
         assert item["cost_amount"] == pytest.approx(3.9494, rel=1e-3)
 
+    @pytest.mark.unit
     async def test_gemini_call_defaults_to_usd(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -457,6 +477,7 @@ class TestMultiProviderUsage:
         assert item["currency"] == "USD"
         assert item["cost_amount"] == pytest.approx(3.2)
 
+    @pytest.mark.unit
     async def test_get_stats_groups_by_currency(self, db_session):
         repo = UsageRepository(db_session)
 
@@ -492,6 +513,7 @@ class TestMultiProviderUsage:
         assert stats["cost_by_currency"]["CNY"] == pytest.approx(3.9494, rel=1e-3)
         assert stats["total_cost"] == pytest.approx(3.2)
 
+    @pytest.mark.unit
     async def test_get_stats_cost_by_currency_excludes_failed_billed_calls(self, db_session):
         """金额维度与项目成本口径一致：只统计 success 且已扣费调用。"""
         repo = UsageRepository(db_session)
@@ -545,6 +567,7 @@ class TestMultiProviderUsage:
             "CNY": pytest.approx(0.25),
         }
 
+    @pytest.mark.unit
     async def test_get_stats_grouped_by_provider_includes_cost_by_currency(self, db_session):
         repo = UsageRepository(db_session)
 
@@ -609,6 +632,7 @@ class TestMultiProviderUsage:
         assert by_group[("vidu", "image")]["total_calls"] == 2
         assert by_group[("vidu", "image")]["success_calls"] == 1
 
+    @pytest.mark.unit
     async def test_text_call_gemini_cost(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -634,6 +658,7 @@ class TestMultiProviderUsage:
         # cost = (1000 * 0.50 + 500 * 3.00) / 1_000_000 = 0.002
         assert item["cost_amount"] == pytest.approx((1000 * 0.50 + 500 * 3.00) / 1_000_000)
 
+    @pytest.mark.unit
     async def test_text_call_ark_cost(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -656,6 +681,7 @@ class TestMultiProviderUsage:
         # cost = (2000 * 0.60 + 1000 * 3.60) / 1_000_000 = 0.0048
         assert item["cost_amount"] == pytest.approx((2000 * 0.60 + 1000 * 3.60) / 1_000_000)
 
+    @pytest.mark.unit
     async def test_text_call_failed_zero_cost(self, db_session):
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(
@@ -676,6 +702,7 @@ class TestMultiProviderUsage:
         item = calls["items"][0]
         assert item["cost_amount"] == 0.0
 
+    @pytest.mark.unit
     async def test_get_stats_includes_text_count(self, db_session):
         repo = UsageRepository(db_session)
         c1 = await repo.start_call(project_name="demo", call_type="image", model="m")

--- a/tests/test_usage_router.py
+++ b/tests/test_usage_router.py
@@ -9,6 +9,8 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.routers import usage
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 async def _usage_env(monkeypatch):

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -32,6 +32,8 @@ from lib.video_backends.v2_video_generations import (
     V2VideoGenerationsBackend as _V2Backend,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
     resp = MagicMock()

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -3,6 +3,8 @@ import pytest
 from lib.api_errors import BadRequestError, NotFoundError
 from lib.version_manager import VersionManager, _get_versions_file_lock
 
+pytestmark = pytest.mark.unit
+
 
 class TestVersionManagerMore:
     def test_lock_is_reused_for_same_file(self, tmp_path):

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -13,6 +13,8 @@ from server.error_handlers import register_error_handlers
 from server.routers import versions
 from tests.auth_deps import AUTH_DEPENDENCIES
 
+pytestmark = pytest.mark.unit
+
 
 class _FakePM:
     def __init__(self):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -59,11 +59,13 @@ def _mock_httpx_stream(data: bytes = b"fake-mp4-data"):
 
 
 class TestArkProperties:
+    @pytest.mark.unit
     def test_name(self, backend):
         assert backend.name == "ark"
 
 
 class TestArkGenerate:
+    @pytest.mark.unit
     async def test_text_to_video(self, backend, tmp_path):
         """文生视频：无 start_image。"""
         output = tmp_path / "out.mp4"
@@ -99,6 +101,7 @@ class TestArkGenerate:
         assert result.usage_tokens == 246840
         assert result.task_id == "cgt-20250101-test"
 
+    @pytest.mark.unit
     async def test_image_to_video(self, backend, tmp_path):
         """图生视频：有 start_image，必须带 role=first_frame。"""
         output = tmp_path / "out.mp4"
@@ -139,6 +142,7 @@ class TestArkGenerate:
         assert content_arg[1]["image_url"]["url"].startswith("data:image/")
         assert content_arg[1]["role"] == "first_frame"
 
+    @pytest.mark.unit
     async def test_first_last_frame_role_fields(self, backend, tmp_path):
         """首尾帧：start_image/end_image 必须分别带 role=first_frame / role=last_frame，
         且 image_url 对象不再使用 position（由 role 表达位置）。"""
@@ -181,6 +185,7 @@ class TestArkGenerate:
         # role 表达位置后，不应再塞 position 到 image_url
         assert "position" not in image_items[1]["image_url"]
 
+    @pytest.mark.unit
     async def test_reference_images_role(self, backend, tmp_path):
         """参考图：每张 reference_images 必须带 role=reference_image（Ark 多图触发条件）。"""
         output = tmp_path / "out.mp4"
@@ -218,6 +223,7 @@ class TestArkGenerate:
         assert len(image_items) == 2
         assert all(item["role"] == "reference_image" for item in image_items)
 
+    @pytest.mark.unit
     async def test_failed_task_raises(self, backend, tmp_path):
         output = tmp_path / "out.mp4"
 
@@ -234,6 +240,7 @@ class TestArkGenerate:
         with pytest.raises(RuntimeError, match="Ark 视频生成失败"):
             await backend.generate(request)
 
+    @pytest.mark.unit
     async def test_with_seed_and_flex(self, backend, tmp_path):
         output = tmp_path / "out.mp4"
 
@@ -267,6 +274,7 @@ class TestArkGenerate:
         assert call_kwargs.kwargs.get("seed") == 42 or call_kwargs[1].get("seed") == 42
         assert call_kwargs.kwargs.get("service_tier") == "flex" or call_kwargs[1].get("service_tier") == "flex"
 
+    @pytest.mark.unit
     def test_missing_api_key_raises(self):
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError, match="Ark API Key"):
@@ -276,6 +284,7 @@ class TestArkGenerate:
 class TestArkRetryBehavior:
     """测试任务创建与轮询的重试分离行为。"""
 
+    @pytest.mark.unit
     async def test_poll_transient_error_retries_without_recreating_task(self, backend, tmp_path):
         """轮询阶段瞬态错误应重试轮询，而不是重新创建任务。"""
         output = tmp_path / "out.mp4"
@@ -310,6 +319,7 @@ class TestArkRetryBehavior:
         # 轮询调用了两次（一次失败 + 一次成功）
         assert backend._client.content_generation.tasks.get.call_count == 2
 
+    @pytest.mark.unit
     async def test_create_retries_on_transient_error(self, backend, tmp_path):
         """任务创建阶段的瞬态错误应由 @with_retry_async 重试。"""
         output = tmp_path / "out.mp4"
@@ -344,6 +354,7 @@ class TestArkRetryBehavior:
         # 创建调用了两次（一次失败 + 一次成功）
         assert backend._client.content_generation.tasks.create.call_count == 2
 
+    @pytest.mark.unit
     async def test_poll_non_retryable_error_propagates(self, backend, tmp_path):
         """轮询阶段不可重试的错误应直接抛出。"""
         output = tmp_path / "out.mp4"
@@ -485,6 +496,7 @@ class TestArkModelCapabilities:
 class TestArkServiceTierParam:
     """service_tier 只对支持该参数的模型传入，否则 API 会报错。"""
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "model",
         [
@@ -531,6 +543,7 @@ class TestArkServiceTierParam:
         create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
         assert "service_tier" not in create_kwargs
 
+    @pytest.mark.unit
     async def test_seedance_1_5_sends_service_tier(self, backend, tmp_path):
         output = tmp_path / "out.mp4"
 
@@ -559,6 +572,7 @@ class TestArkServiceTierParam:
 
 
 class TestArkVideoBackendBaseUrl:
+    @pytest.mark.unit
     def test_custom_base_url_passed_through(self):
         with patch("lib.video_backends.ark.create_ark_client") as mock_create:
             ArkVideoBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
@@ -567,6 +581,7 @@ class TestArkVideoBackendBaseUrl:
                 base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
             )
 
+    @pytest.mark.unit
     def test_default_base_url_is_none(self):
         with patch("lib.video_backends.ark.create_ark_client") as mock_create:
             ArkVideoBackend(api_key="k")
@@ -577,22 +592,26 @@ class TestIsArkNotFound:
     """fix #647 #6：用 task_not_found / tasknotfound 精确匹配，剔除宽泛 "not found" 兜底；
     保留 "expired" 字串识别（_poll_until_done 把 status=expired 转 RuntimeError）。"""
 
+    @pytest.mark.unit
     def test_excludes_business_not_found(self):
         from lib.video_backends.ark import _is_ark_not_found
 
         exc = RuntimeError("reference image not found in storage")
         assert _is_ark_not_found(exc) is False
 
+    @pytest.mark.unit
     def test_recognizes_task_not_found(self):
         from lib.video_backends.ark import _is_ark_not_found
 
         assert _is_ark_not_found(RuntimeError("task_not_found: invalid id")) is True
 
+    @pytest.mark.unit
     def test_recognizes_expired_status(self):
         from lib.video_backends.ark import _is_ark_not_found
 
         assert _is_ark_not_found(RuntimeError("Ark 任务失败 ... status=expired")) is True
 
+    @pytest.mark.unit
     def test_recognizes_404(self):
         from lib.video_backends.ark import _is_ark_not_found
 
@@ -657,6 +676,7 @@ class TestArkReferenceAudio:
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-251215")
         assert caps.reference_audio_mode is ReferenceAudioMode.NONE
 
+    @pytest.mark.unit
     async def test_reference_audio_sent_as_audio_url_entries(self, tmp_path):
         """每段音频发一条 type=audio_url + role=reference_audio，且顺序与请求字段一致。"""
         backend = self._seedance_2_backend()
@@ -686,6 +706,7 @@ class TestArkReferenceAudio:
         assert audio_items[0]["audio_url"]["url"].startswith("data:audio/mp3;base64,")
         assert audio_items[1]["audio_url"]["url"].startswith("data:audio/wav;base64,")
 
+    @pytest.mark.unit
     async def test_no_audio_entries_when_request_has_none(self, tmp_path):
         backend = self._seedance_2_backend()
         ref = tmp_path / "r.png"
@@ -700,6 +721,7 @@ class TestArkReferenceAudio:
         content = backend._client.content_generation.tasks.create.call_args.kwargs["content"]
         assert not [c for c in content if c["type"] == "audio_url"]
 
+    @pytest.mark.unit
     async def test_unsupported_audio_format_raises(self, tmp_path):
         """格式不受支持时抛错而非跳过：跳过会让其后所有音频编号整体前移、错绑角色音色。"""
         backend = self._seedance_2_backend()
@@ -713,6 +735,7 @@ class TestArkReferenceAudio:
 
         assert exc.value.code == "video_reference_audio_format_unsupported"
 
+    @pytest.mark.unit
     async def test_missing_audio_file_raises(self, tmp_path):
         backend = self._seedance_2_backend()
 

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -22,6 +22,8 @@ from lib.video_backends.base import (
     submit_post,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _http_status_error(status_code: int, *, text: str = "boom") -> httpx.HTTPStatusError:
     """构造真实 httpx.HTTPStatusError；URL 故意含 "503" 子串以验证不再走字符串误判。"""

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -6,6 +6,7 @@ from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, Video
 
 
 class TestVideoCapabilities:
+    @pytest.mark.unit
     def test_defaults(self):
         caps = VideoCapabilities()
         assert caps.first_frame is True
@@ -14,10 +15,12 @@ class TestVideoCapabilities:
         assert caps.reference_audio_mode is ReferenceAudioMode.NONE
         assert caps.max_reference_audio_count == 0
 
+    @pytest.mark.unit
     def test_first_last(self):
         caps = VideoCapabilities(last_frame=True)
         assert caps.last_frame is True
 
+    @pytest.mark.unit
     def test_custom_values(self):
         caps = VideoCapabilities(
             last_frame=True,
@@ -32,11 +35,13 @@ class TestVideoCapabilities:
 
 
 class TestVideoGenerationRequestNewFields:
+    @pytest.mark.unit
     def test_end_image_default_none(self):
         req = VideoGenerationRequest(prompt="t", output_path=Path("/tmp/o.mp4"))
         assert req.end_image is None
         assert req.reference_images is None
 
+    @pytest.mark.unit
     def test_end_image_set(self):
         req = VideoGenerationRequest(
             prompt="t",
@@ -46,6 +51,7 @@ class TestVideoGenerationRequestNewFields:
         )
         assert req.end_image == Path("/tmp/l.png")
 
+    @pytest.mark.unit
     def test_reference_images(self):
         req = VideoGenerationRequest(
             prompt="t",
@@ -54,6 +60,7 @@ class TestVideoGenerationRequestNewFields:
         )
         assert len(req.reference_images) == 2
 
+    @pytest.mark.unit
     def test_existing_fields_unchanged(self):
         """Ensure existing fields still work as before."""
         req = VideoGenerationRequest(
@@ -94,6 +101,7 @@ class TestVideoCapabilitiesForModel:
 
     resolver 解析参考图上限走这条纯函数路径，故不应触发 SDK client 构造或 api_key 校验。"""
 
+    @pytest.mark.unit
     def test_ark_seedance_2_returns_nine(self):
         from lib.video_backends.ark import ArkVideoBackend
 
@@ -102,21 +110,25 @@ class TestVideoCapabilitiesForModel:
         assert caps.max_reference_images == 9
         assert caps.max_reference_images > 0
 
+    @pytest.mark.unit
     def test_ark_non_seedance_2_returns_zero(self):
         from lib.video_backends.ark import ArkVideoBackend
 
         assert ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0").max_reference_images == 0
 
+    @pytest.mark.unit
     def test_vidu_returns_seven(self):
         from lib.video_backends.vidu import ViduVideoBackend
 
         assert ViduVideoBackend.video_capabilities_for_model("viduq3-turbo").max_reference_images == 7
 
+    @pytest.mark.unit
     def test_v2_returns_four(self):
         from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
 
         assert V2VideoGenerationsBackend.video_capabilities_for_model("whatever").max_reference_images == 4
 
+    @pytest.mark.unit
     def test_instance_property_delegates_to_static(self):
         """instance video_capabilities 委托至静态方法，保持 backend 为单一真相源。
 

--- a/tests/test_video_backend_gemini.py
+++ b/tests/test_video_backend_gemini.py
@@ -9,6 +9,8 @@ from lib.video_backends.base import (
     VideoGenerationResult,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_rate_limiter():

--- a/tests/test_video_backend_registry.py
+++ b/tests/test_video_backend_registry.py
@@ -7,6 +7,8 @@ from lib.video_backends.registry import (
     register_backend,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeBackend:
     name = "fake"

--- a/tests/test_vidu_cost.py
+++ b/tests/test_vidu_cost.py
@@ -11,6 +11,8 @@ from lib.vidu_shared import (
     calculate_vidu_cost,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestViduMainPath:
     """主路径：响应里有 credits（=usage_tokens），按 ¥0.03125/credit 折算。"""

--- a/tests/test_vidu_image_backend.py
+++ b/tests/test_vidu_image_backend.py
@@ -22,6 +22,8 @@ from lib.image_backends.vidu import (
 )
 from lib.providers import PROVIDER_VIDU
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def output_path(tmp_path: Path) -> Path:

--- a/tests/test_vidu_shared.py
+++ b/tests/test_vidu_shared.py
@@ -6,6 +6,8 @@ import pytest
 
 from lib import vidu_shared
 
+pytestmark = pytest.mark.unit
+
 
 class TestResolveViduApiKey:
     def test_explicit_key_wins(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_vidu_video_backend.py
+++ b/tests/test_vidu_video_backend.py
@@ -32,11 +32,13 @@ def output_path(tmp_path: Path) -> Path:
 
 
 class TestBackendBasics:
+    @pytest.mark.unit
     def test_default_model_is_q3_turbo(self):
         backend = ViduVideoBackend(api_key="test-key")
         assert backend.name == PROVIDER_VIDU
         assert backend.model == DEFAULT_MODEL == "viduq3-turbo"
 
+    @pytest.mark.unit
     def test_max_reference_images_seven(self):
         backend = ViduVideoBackend(api_key="test-key")
         assert backend.video_capabilities.max_reference_images == 7
@@ -64,11 +66,13 @@ class TestEndpointSelection:
     def _backend(self, model: str = "viduq3-turbo") -> ViduVideoBackend:
         return ViduVideoBackend(api_key="test-key", model=model)
 
+    @pytest.mark.unit
     def test_text_only_picks_text2video(self, output_path: Path):
         backend = self._backend()
         req = VideoGenerationRequest(prompt="x", output_path=output_path)
         assert backend._select_endpoint(req) == "/text2video"
 
+    @pytest.mark.unit
     def test_start_image_picks_img2video(self, tmp_path: Path, output_path: Path):
         backend = self._backend()
         start = tmp_path / "start.png"
@@ -76,6 +80,7 @@ class TestEndpointSelection:
         req = VideoGenerationRequest(prompt="x", output_path=output_path, start_image=start)
         assert backend._select_endpoint(req) == "/img2video"
 
+    @pytest.mark.unit
     def test_start_and_end_image_picks_start_end2video(self, tmp_path: Path, output_path: Path):
         backend = self._backend()
         start, end = tmp_path / "s.png", tmp_path / "e.png"
@@ -84,6 +89,7 @@ class TestEndpointSelection:
         req = VideoGenerationRequest(prompt="x", output_path=output_path, start_image=start, end_image=end)
         assert backend._select_endpoint(req) == "/start-end2video"
 
+    @pytest.mark.unit
     def test_reference_images_take_priority(self, tmp_path: Path, output_path: Path):
         """有 refs 时即使带 start_image 也应走 reference2video（依实现：refs 先判）。"""
         backend = self._backend()
@@ -96,19 +102,24 @@ class TestEndpointSelection:
 class TestEndpointModelMatrix:
     """端点支持模型集合是 spec，钉死，避免误改。"""
 
+    @pytest.mark.unit
     def test_reference2video_does_not_include_q3_pro(self):
         # q3-pro 在 reference2video 上不被官方文档列出
         assert "viduq3-pro" not in _ENDPOINT_MODELS["/reference2video"]
 
+    @pytest.mark.unit
     def test_reference2video_includes_q3_turbo(self):
         assert "viduq3-turbo" in _ENDPOINT_MODELS["/reference2video"]
 
+    @pytest.mark.unit
     def test_text2video_excludes_vidu2_0(self):
         assert "vidu2.0" not in _ENDPOINT_MODELS["/text2video"]
 
+    @pytest.mark.unit
     def test_aspect_ratio_only_text2video_and_reference2video(self):
         assert _ENDPOINTS_WITH_ASPECT_RATIO == frozenset({"/text2video", "/reference2video"})
 
+    @pytest.mark.unit
     def test_q3_models_set(self):
         assert "viduq3-turbo" in _Q3_MODELS
         assert "viduq3-pro" in _Q3_MODELS
@@ -116,29 +127,36 @@ class TestEndpointModelMatrix:
 
 
 class TestCoerceDuration:
+    @pytest.mark.unit
     def test_q3_turbo_text2video_passthrough_in_range(self):
         assert _coerce_duration("viduq3-turbo", "/text2video", 8) == 8
 
+    @pytest.mark.unit
     def test_q3_turbo_text2video_clamps_to_nearest(self):
         # range 1..16；超过 16 应取 16
         assert _coerce_duration("viduq3-turbo", "/text2video", 30) == 16
 
+    @pytest.mark.unit
     def test_vidu2_0_img2video_only_4_or_8(self):
         assert _coerce_duration("vidu2.0", "/img2video", 12) == 8
         assert _coerce_duration("vidu2.0", "/img2video", 5) == 4
         assert _coerce_duration("vidu2.0", "/img2video", 4) == 4
         assert _coerce_duration("vidu2.0", "/img2video", 8) == 8
 
+    @pytest.mark.unit
     def test_vidu2_0_reference2video_only_4(self):
         assert _coerce_duration("vidu2.0", "/reference2video", 8) == 4
 
+    @pytest.mark.unit
     def test_q1_text2video_only_5(self):
         assert _coerce_duration("viduq1", "/text2video", 10) == 5
 
+    @pytest.mark.unit
     def test_q3_reference2video_min_3(self):
         # range 3..16；请求 1 → 取最近 3
         assert _coerce_duration("viduq3", "/reference2video", 1) == 3
 
+    @pytest.mark.unit
     def test_unknown_combination_passthrough(self):
         # 表里无项时不强校（透传 / 兜底 5）
         assert _coerce_duration("unknown-model", "/img2video", 9) == 9
@@ -146,19 +164,24 @@ class TestCoerceDuration:
 
 
 class TestCoerceResolution:
+    @pytest.mark.unit
     def test_q1_only_1080p_falls_back(self):
         assert _coerce_resolution("viduq1", "720p") == "1080p"
 
+    @pytest.mark.unit
     def test_q3_turbo_passes_720p(self):
         assert _coerce_resolution("viduq3-turbo", "720p") == "720p"
 
+    @pytest.mark.unit
     def test_default_for_q3_turbo_when_none(self):
         # whitelist 里有 720p → 取 720p
         assert _coerce_resolution("viduq3-turbo", None) == "720p"
 
+    @pytest.mark.unit
     def test_unknown_model_passthrough(self):
         assert _coerce_resolution("unknown", "9000p") == "9000p"
 
+    @pytest.mark.unit
     def test_all_known_models_have_whitelist(self):
         # registry 中暴露的模型都得在白名单里
         for model in {
@@ -176,6 +199,7 @@ class TestCoerceResolution:
 class TestBuildRequest:
     """_build_request 是核心串联函数：endpoint 选择 + duration/resolution/aspect_ratio/audio 字段拼装。"""
 
+    @pytest.mark.unit
     @patch("lib.video_backends.vidu.image_to_data_uri")
     def test_text2video_body_minimal(self, mock_data_uri, output_path: Path):
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
@@ -199,6 +223,7 @@ class TestBuildRequest:
         # text2video 不携带 images
         assert "images" not in body
 
+    @pytest.mark.unit
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
     def test_img2video_passes_one_image_no_aspect_ratio(self, _mock, tmp_path: Path, output_path: Path):
         start = tmp_path / "s.png"
@@ -219,6 +244,7 @@ class TestBuildRequest:
         # img2video 不接受 aspect_ratio
         assert "aspect_ratio" not in body
 
+    @pytest.mark.unit
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
     def test_reference2video_with_q3_turbo(self, _mock, tmp_path: Path, output_path: Path):
         ref1, ref2 = tmp_path / "r1.png", tmp_path / "r2.png"
@@ -242,6 +268,7 @@ class TestBuildRequest:
         # range 3..16，5 透传
         assert body["duration"] == 5
 
+    @pytest.mark.unit
     def test_reference2video_with_q3_pro_raises_model_mismatch(self, tmp_path: Path, output_path: Path):
         ref = tmp_path / "r.png"
         ref.write_bytes(b"x")
@@ -256,6 +283,7 @@ class TestBuildRequest:
         with pytest.raises(RuntimeError, match="不支持"):
             backend._build_request(req)
 
+    @pytest.mark.unit
     def test_non_q3_model_does_not_send_audio(self, output_path: Path):
         backend = ViduVideoBackend(api_key="test-key", model="vidu2.0")
         # vidu2.0 走 img2video，不能 text2video
@@ -335,6 +363,7 @@ class TestPromptLength:
 class TestDurationRulesSpec:
     """直接钉死 _DURATION_RULES 关键条目，避免误改。"""
 
+    @pytest.mark.unit
     def test_q1_text2video_only_5(self):
         assert _DURATION_RULES[("viduq1", "/text2video")] == [5]
 
@@ -346,12 +375,15 @@ class TestDurationRulesSpec:
         assert _DURATION_RULES[("viduq2-pro-fast", "/img2video")] == list(range(1, 11))
         assert _DURATION_RULES[("viduq2-pro", "/start-end2video")] == list(range(1, 9))
 
+    @pytest.mark.unit
     def test_vidu2_0_img2video_only_4_8(self):
         assert _DURATION_RULES[("vidu2.0", "/img2video")] == [4, 8]
 
+    @pytest.mark.unit
     def test_vidu2_0_reference2video_only_4(self):
         assert _DURATION_RULES[("vidu2.0", "/reference2video")] == [4]
 
+    @pytest.mark.unit
     def test_q3_turbo_text2video_full_range(self):
         assert _DURATION_RULES[("viduq3-turbo", "/text2video")] == list(range(1, 17))
 
@@ -362,10 +394,12 @@ class TestRegistryBackendConsistency:
     def _vidu2_model_info(self):
         return PROVIDER_REGISTRY["vidu"].models["vidu2.0"]
 
+    @pytest.mark.unit
     def test_reference_image_durations_matches_reference2video_rule(self):
         model_info = self._vidu2_model_info()
         assert model_info.reference_image_durations == _DURATION_RULES[("vidu2.0", "/reference2video")]
 
+    @pytest.mark.unit
     def test_supported_durations_covers_img2video_and_start_end2video(self):
         model_info = self._vidu2_model_info()
         expected_durations = set(_DURATION_RULES[("vidu2.0", "/img2video")]) | set(
@@ -373,11 +407,13 @@ class TestRegistryBackendConsistency:
         )
         assert set(model_info.supported_durations) == expected_durations
 
+    @pytest.mark.unit
     def test_duration_resolution_constraints_confines_non_720p_to_4s(self):
         """8 秒档只出 720p——360p / 1080p 须声明仅 4 秒可选，UI 才不会给出无效的时长×分辨率组合。"""
         model_info = self._vidu2_model_info()
         assert model_info.duration_resolution_constraints == {"360p": [4], "1080p": [4]}
 
+    @pytest.mark.unit
     def test_resolutions_matches_backend_whitelist(self):
         model_info = self._vidu2_model_info()
         assert set(model_info.resolutions) == set(_RESOLUTION_WHITELIST["vidu2.0"])
@@ -386,6 +422,7 @@ class TestRegistryBackendConsistency:
 class TestCreateTask413:
     """413 规整：_create_task 透出保留状态码的 httpx.HTTPStatusError（咽喉层据此降档）。"""
 
+    @pytest.mark.unit
     async def test_create_task_413_surfaces_httpstatuserror_no_retry(self):
         from unittest.mock import AsyncMock, MagicMock
 
@@ -413,6 +450,7 @@ class TestCreateTask413:
 class TestCreateTaskAmbiguity:
     """create 阶段按「请求是否确定送达」收窄重试，避免重复建任务 + 重复计费。"""
 
+    @pytest.mark.unit
     async def test_read_timeout_fails_fast_with_manual_retry_hint(self):
         from unittest.mock import AsyncMock
 
@@ -432,6 +470,7 @@ class TestCreateTaskAmbiguity:
         # 歧义态：请求可能已送达，不重试
         assert client.post.call_count == 1
 
+    @pytest.mark.unit
     async def test_connect_error_retries(self):
         from unittest.mock import AsyncMock, MagicMock
 


### PR DESCRIPTION
Closes #1620

漏标分类 marker 此前只能靠人工 review 发现，现在交给收集期校验。

## 改动

- `pyproject.toml` 启用 `--strict-markers`：未在 `markers` 注册的 marker 在收集期失败
- `tests/conftest.py::_enforce_classification_markers`：收集到的每个用例必须恰好带一个 `unit`/`integration`/`e2e`。漏标与多标都让收集失败并列出具体 nodeid（marker 可来自用例/类/模块三层，叠加时容易出现 unit + integration 这类自相矛盾的组合，会让 `-m` 选集同时命中）
- 存量 6311 个漏标用例一次性补齐
- `CONTRIBUTING.md` 的 markers 纪律同步为现状

## 分类口径（如实说明）

存量补标**不是逐条语义分类**，是批量默认档：

- `tests/test_jianying_draft_routes.py`、`tests/test_jianying_draft_service.py`（真实生成音视频资源）标 `integration`
- `uses_db` 命中的标 `integration`
- 其余默认 `unit`

按验收标准字面要求对 6311 个用例（占全量 81%）逐条判断语义，工作量远超本票规模，已就此请示并按折中方案推进。因此 `unit`/`integration` 之间的分类精度不保证逐条准确——已知 `integration` 的两个识别信号未覆盖「直接 spawn ffmpeg」与「测试内自建 engine」的用例，这类用例目前落在默认 `unit` 档。CI 现有调度不依赖这一维度的精度（`-m "not e2e"` 与 `-m uses_db` 两个选集均不受影响）。精细分类另开 follow-up。

## e2e 排查结论

不只靠既有 skip 标记倒推，一维扫描了真实网络请求（`httpx`/`requests`/`aiohttp`）、未 mock 的外部 SDK 实例化（`AsyncAnthropic`/`boto3`/`openai`/`ClaudeSDKClient`）、非 ffmpeg 的外部二进制 subprocess 调用与 socket，均未命中真实外部调用。关键字粗筛出的 5 个文件逐一核实后确认全是注释误报。结论：当前不存在需要标 `e2e` 的用例，全库 `e2e` 标记数为 0。

## 验证

- 漏标用例 → 收集失败 exit 4，stderr 逐条列出 nodeid
- 多标用例 → 收集失败 exit 4，报出冲突的 marker 组合
- 未注册 marker → `--strict-markers` 收集失败 exit 2
- 绕过路径实测无效：`-m unit` / `-m integration` 选集、`--co`、`-p no:cacheprovider` 均仍失败（钩子在 mark 插件 deselect 之前拿到完整 items）
- CI backend-tests 跑无路径参数的 pytest，走 `testpaths = ["tests"]` 必然触发该校验，无需改 workflow
- 质量门：`ruff check` / `ruff format --check` 全过；`basedpyright` 0 error；`lint-imports` 契约 kept；`pytest -m "not e2e" --cov` 7803 passed，覆盖率 92.20%
