### PR TITLE
fix(设置): 模型候选接口失败时给出可感知的错误态与重试入口

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -446,8 +446,10 @@ class API {
    * 能力桶下拉的候选数据源（docs/adr/0054）：默认层全量 + 每个桶按能力过滤后的模型列表。
    * 与 getSystemConfig 的 options 同口径（同样剔除 hidden 模型），过滤只加在桶层。
    */
-  static async getModelCandidates(): Promise<ModelCandidatesResponse> {
-    return this.request("/system/config/model-candidates");
+  static async getModelCandidates(
+    options: { signal?: AbortSignal } = {}
+  ): Promise<ModelCandidatesResponse> {
+    return this.request("/system/config/model-candidates", { signal: options.signal });
   }
 
   static async getSystemVersion(): Promise<GetSystemVersionResponse> {

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -13,7 +13,8 @@ import { executingImageModel, executingVideoModel } from "@/components/shared/La
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
 import { StylePicker, type StylePickerValue } from "@/components/shared/StylePicker";
 import { DEFAULT_TEMPLATE_ID, STYLE_TEMPLATES } from "@/data/style-templates";
-import type { CustomProviderInfo, ModelCandidatesResponse, ProviderInfo } from "@/types";
+import type { CustomProviderInfo, ProviderInfo } from "@/types";
+import { useModelCandidates } from "@/hooks/useModelCandidates";
 import { ROUTE_META, RouteLockBadge } from "@/components/shared/GenerationRouteCards";
 import { GridStoryboardBar } from "@/components/shared/GridStoryboardBar";
 import { ACCENT_BTN_CLS, ACCENT_BUTTON_STYLE, GHOST_BTN_LG_CLS, radioCardClass } from "@/components/ui/darkroom-tokens";
@@ -102,9 +103,12 @@ export function ProjectSettingsPage() {
     audio_backends: string[];
     provider_names?: Record<string, string>;
   } | null>(null);
-  const [candidates, setCandidates] = useState<ModelCandidatesResponse | null>(null);
-  const [candidatesError, setCandidatesError] = useState(false);
-  const candidatesAbortRef = useRef<AbortController | null>(null);
+  const {
+    candidates,
+    error: candidatesError,
+    retrying: candidatesRetrying,
+    reload: reloadCandidates,
+  } = useModelCandidates();
   const [globalDefaults, setGlobalDefaults] = useState<{
     video: string;
     videoI2V: string;
@@ -174,30 +178,11 @@ export function ProjectSettingsPage() {
   // 风格区独立保存，但"未保存就离开"也需被 isDirty 拦截。
   const initialStyleRef = useRef<StylePickerValue | null>(null);
 
-  // 候选是全局配置，与项目无关，独立于下面按 projectName 重取的效果；失败时不动其余表单状态，
-  // 供挂载与重试共用。接管方轮换 controller——重试可能在上一轮请求尚未回来时触发。
-  const loadCandidates = useCallback(async () => {
-    candidatesAbortRef.current?.abort();
-    const controller = new AbortController();
-    candidatesAbortRef.current = controller;
-    try {
-      const cand = await API.getModelCandidates({ signal: controller.signal });
-      if (controller.signal.aborted) return;
-      setCandidates(cand);
-      setCandidatesError(false);
-    } catch {
-      if (controller.signal.aborted) return;
-      setCandidates(null);
-      setCandidatesError(true);
-    }
-  }, []);
-
+  // 候选是全局配置、与项目无关，故只在挂载时取一次，不跟随下面按 projectName 重取的效果；
+  // 拉取失败也只影响细分区，其余表单状态照常。
   useEffect(() => {
-    // 挂载时异步拉取候选，回调内 setCandidates 等（异步 fetch 后回写）
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void loadCandidates();
-    return () => candidatesAbortRef.current?.abort();
-  }, [loadCandidates]);
+    void reloadCandidates();
+  }, [reloadCandidates]);
 
   useEffect(() => {
     let disposed = false;
@@ -657,8 +642,11 @@ export function ProjectSettingsPage() {
                     providerNames: allProviderNames,
                   }}
                   candidates={candidates}
-                  candidatesError={candidatesError}
-                  onRetryCandidates={() => void loadCandidates()}
+                  candidatesError={
+                    candidatesError
+                      ? { onRetry: () => void reloadCandidates(), retrying: candidatesRetrying }
+                      : undefined
+                  }
                   globalDefaults={{
                     video: globalDefaults.video,
                     videoI2V: globalDefaults.videoI2V,

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -103,6 +103,8 @@ export function ProjectSettingsPage() {
     provider_names?: Record<string, string>;
   } | null>(null);
   const [candidates, setCandidates] = useState<ModelCandidatesResponse | null>(null);
+  const [candidatesError, setCandidatesError] = useState(false);
+  const candidatesAbortRef = useRef<AbortController | null>(null);
   const [globalDefaults, setGlobalDefaults] = useState<{
     video: string;
     videoI2V: string;
@@ -172,19 +174,41 @@ export function ProjectSettingsPage() {
   // 风格区独立保存，但"未保存就离开"也需被 isDirty 拦截。
   const initialStyleRef = useRef<StylePickerValue | null>(null);
 
+  // 候选是全局配置，与项目无关，独立于下面按 projectName 重取的效果；失败时不动其余表单状态，
+  // 供挂载与重试共用。接管方轮换 controller——重试可能在上一轮请求尚未回来时触发。
+  const loadCandidates = useCallback(async () => {
+    candidatesAbortRef.current?.abort();
+    const controller = new AbortController();
+    candidatesAbortRef.current = controller;
+    try {
+      const cand = await API.getModelCandidates({ signal: controller.signal });
+      if (controller.signal.aborted) return;
+      setCandidates(cand);
+      setCandidatesError(false);
+    } catch {
+      if (controller.signal.aborted) return;
+      setCandidates(null);
+      setCandidatesError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    // 挂载时异步拉取候选，回调内 setCandidates 等（异步 fetch 后回写）
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadCandidates();
+    return () => candidatesAbortRef.current?.abort();
+  }, [loadCandidates]);
+
   useEffect(() => {
     let disposed = false;
 
     voidCall(Promise.all([
       API.getSystemConfig(),
-      API.getModelCandidates().catch(() => null),
       API.getProject(projectName),
       getProviderModels().catch(() => [] as ProviderInfo[]),
       getCustomProviderModels().catch(() => [] as CustomProviderInfo[]),
-    ]).then(([configRes, candidatesRes, projectRes, providerList, customProviderList]) => {
+    ]).then(([configRes, projectRes, providerList, customProviderList]) => {
       if (disposed) return;
-
-      setCandidates(candidatesRes);
 
       setOptions({
         video_backends: configRes.options?.video_backends ?? [],
@@ -633,6 +657,8 @@ export function ProjectSettingsPage() {
                     providerNames: allProviderNames,
                   }}
                   candidates={candidates}
+                  candidatesError={candidatesError}
+                  onRetryCandidates={() => void loadCandidates()}
                   globalDefaults={{
                     video: globalDefaults.video,
                     videoI2V: globalDefaults.videoI2V,

--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -80,6 +80,37 @@ describe("MediaModelSection", () => {
     expect(screen.queryByRole("combobox", { name: "参考生视频" })).not.toBeInTheDocument();
   });
 
+  it("shows an explicit error notice with a retry entry when the candidate fetch fails, even with no saved overrides", async () => {
+    // 候选失败但全局层未配置过任何细分项时，旧行为是整块折叠区消失——用户拿不到失败信号
+    vi.spyOn(API, "getModelCandidates").mockRejectedValue(new Error("boom"));
+    render(<MediaModelSection />);
+    await screen.findByRole("combobox", { name: "默认视频模型" });
+    const alerts = await screen.findAllByRole("alert");
+    expect(alerts.length).toBeGreaterThanOrEqual(2); // video + image 两处折叠区
+    for (const alert of alerts) {
+      expect(alert).toHaveTextContent(/候选/);
+    }
+    expect(screen.getAllByRole("button", { name: "重试" }).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("recovers normal rendering after a retry succeeds", async () => {
+    const user = userEvent.setup();
+    const getCandidates = vi
+      .spyOn(API, "getModelCandidates")
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(CANDIDATES as unknown as Awaited<ReturnType<typeof API.getModelCandidates>>);
+    render(<MediaModelSection />);
+    await screen.findByRole("combobox", { name: "默认视频模型" });
+    const retryButtons = await screen.findAllByRole("button", { name: "重试" });
+    await user.click(retryButtons[0]);
+
+    await waitFor(() => expect(getCandidates).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryAllByRole("alert")).toHaveLength(0));
+    // 失败态强制展开过折叠区，重试成功后仍展开，无需再次点开
+    await user.click(screen.getByRole("combobox", { name: "参考生视频" }));
+    expect(screen.getByRole("option", { name: /seedance/ })).toBeInTheDocument();
+  });
+
   it("filters sub-field candidates by purpose while the default dropdown stays unfiltered", async () => {
     const user = userEvent.setup();
     render(<MediaModelSection />);

--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -81,14 +81,14 @@ describe("MediaModelSection", () => {
   });
 
   it("shows an explicit error notice with a retry entry when the candidate fetch fails, even with no saved overrides", async () => {
-    // 候选失败但全局层未配置过任何细分项时，旧行为是整块折叠区消失——用户拿不到失败信号
+    // 全局层未配置过任何细分项时折叠区本会整块消失，失败态须把它留下，用户才拿得到失败信号
     vi.spyOn(API, "getModelCandidates").mockRejectedValue(new Error("boom"));
     render(<MediaModelSection />);
     await screen.findByRole("combobox", { name: "默认视频模型" });
     const alerts = await screen.findAllByRole("alert");
     expect(alerts.length).toBeGreaterThanOrEqual(2); // video + image 两处折叠区
     for (const alert of alerts) {
-      expect(alert).toHaveTextContent(/候选/);
+      expect(alert).toHaveTextContent(/可选模型列表加载失败/);
     }
     expect(screen.getAllByRole("button", { name: "重试" }).length).toBeGreaterThanOrEqual(2);
   });

--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -155,6 +155,31 @@ describe("MediaModelSection", () => {
     );
   });
 
+  it("renders the form and completes a save while the candidate request never settles", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(API, "getModelCandidates").mockReturnValue(
+      new Promise(() => {}) as ReturnType<typeof API.getModelCandidates>,
+    );
+    const patch = vi
+      .spyOn(API, "updateSystemConfig")
+      .mockResolvedValue(CONFIG as unknown as Awaited<ReturnType<typeof API.updateSystemConfig>>);
+    render(<MediaModelSection />);
+
+    await screen.findByRole("combobox", { name: "默认视频模型" });
+    await user.click(screen.getByRole("combobox", { name: "默认视频模型" }));
+    await user.click(screen.getByRole("option", { name: /seedance/ }));
+    await user.click(screen.getByRole("button", { name: /保存|Save/ }));
+
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith({ default_video_backend: "ark/seedance" }),
+    );
+    // 保存结束的可观测证据：成功 toast 已推出——PATCH 已返回但流程仍卡在候选请求上时，
+    // finally 里的 setSaving(false) 与这条 toast 都不会发生。
+    await waitFor(() =>
+      expect(useAppStore.getState().toast?.text).toBe("媒体模型配置已保存"),
+    );
+  });
+
   it("auto-expands a channel whose sub-field is already configured", async () => {
     mockConfig({ default_image_backend_i2i: "openai/gpt-image-edit" });
     const { container } = render(<MediaModelSection />);

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -1,11 +1,10 @@
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
 import { API } from "@/api";
 import type {
-  ModelCandidatesResponse,
   SystemConfigSettings,
   SystemConfigOptions,
   SystemConfigPatch,
@@ -26,6 +25,7 @@ import { useCapabilitiesStore } from "@/stores/capabilities-store";
 import { useConfigStatusStore } from "@/stores/config-status-store";
 import { useEndpointCatalogStore } from "@/stores/endpoint-catalog-store";
 import { catalogDurations } from "@/hooks/useModelCapabilities";
+import { useModelCandidates } from "@/hooks/useModelCandidates";
 import { errMsg } from "@/utils/async";
 import {
   getCustomProviderModels,
@@ -70,9 +70,12 @@ export function MediaModelSection() {
 
   const [settings, setSettings] = useState<SystemConfigSettings | null>(null);
   const [options, setOptions] = useState<SystemConfigOptions | null>(null);
-  const [candidates, setCandidates] = useState<ModelCandidatesResponse | null>(null);
-  const [candidatesError, setCandidatesError] = useState(false);
-  const candidatesAbortRef = useRef<AbortController | null>(null);
+  const {
+    candidates,
+    error: candidatesError,
+    retrying: candidatesRetrying,
+    reload: reloadCandidates,
+  } = useModelCandidates();
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
   const [draft, setDraft] = useState<SystemConfigPatch>({});
@@ -93,39 +96,21 @@ export function MediaModelSection() {
   );
   const bucketLabels = useCapabilityBucketLabels();
 
-  // 候选拉取独立于其余配置：写错误态、失败时不动其它已加载的表单状态，供挂载与重试共用。
-  // 接管方轮换 controller——重试可能在上一轮请求尚未回来时触发，旧响应回来时已经过期。
-  const loadCandidates = useCallback(async () => {
-    candidatesAbortRef.current?.abort();
-    const controller = new AbortController();
-    candidatesAbortRef.current = controller;
-    try {
-      const cand = await API.getModelCandidates({ signal: controller.signal });
-      if (controller.signal.aborted) return;
-      setCandidates(cand);
-      setCandidatesError(false);
-    } catch {
-      if (controller.signal.aborted) return;
-      setCandidates(null);
-      setCandidatesError(true);
-    }
-  }, []);
-
-  useEffect(() => () => candidatesAbortRef.current?.abort(), []);
-
+  // 候选与其余配置分开拉：它自带失败态，失败时只影响细分区、不牵动已加载的表单状态，
+  // 也让重试不必重取整页配置（会连带清空未保存的 draft）。
   const fetchConfig = useCallback(async () => {
     const [res, catalog, custom] = await Promise.all([
       API.getSystemConfig(),
       getProviderModels().catch(() => [] as ProviderInfo[]),
       getCustomProviderModels().catch(() => [] as CustomProviderInfo[]),
-      loadCandidates(),
+      reloadCandidates(),
     ]);
     setSettings(res.settings);
     setOptions(res.options);
     setProviders(catalog);
     setCustomProviders(custom);
     setDraft({});
-  }, [loadCandidates]);
+  }, [reloadCandidates]);
 
   useEffect(() => {
     // mount/依赖变更时异步拉取配置，回调内 setSettings 等（异步 fetch 后回写）
@@ -245,7 +230,9 @@ export function MediaModelSection() {
     complex: draft.text_backend_complex ?? settings.text_backend_complex ?? "",
   };
 
-  const candidatesSubFieldsError = candidatesError ? { onRetry: () => void loadCandidates() } : undefined;
+  const candidatesSubFieldsError = candidatesError
+    ? { onRetry: () => void reloadCandidates(), retrying: candidatesRetrying }
+    : undefined;
 
   const emptyHint = (msg: string) => (
     <div className="rounded-[8px] border border-hairline-soft bg-bg-grad-a/45 px-3 py-2.5 text-[12px] text-text-3">

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { useWarnUnsaved } from "@/hooks/useWarnUnsaved";
@@ -71,6 +71,8 @@ export function MediaModelSection() {
   const [settings, setSettings] = useState<SystemConfigSettings | null>(null);
   const [options, setOptions] = useState<SystemConfigOptions | null>(null);
   const [candidates, setCandidates] = useState<ModelCandidatesResponse | null>(null);
+  const [candidatesError, setCandidatesError] = useState(false);
+  const candidatesAbortRef = useRef<AbortController | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
   const [draft, setDraft] = useState<SystemConfigPatch>({});
@@ -91,20 +93,39 @@ export function MediaModelSection() {
   );
   const bucketLabels = useCapabilityBucketLabels();
 
+  // 候选拉取独立于其余配置：写错误态、失败时不动其它已加载的表单状态，供挂载与重试共用。
+  // 接管方轮换 controller——重试可能在上一轮请求尚未回来时触发，旧响应回来时已经过期。
+  const loadCandidates = useCallback(async () => {
+    candidatesAbortRef.current?.abort();
+    const controller = new AbortController();
+    candidatesAbortRef.current = controller;
+    try {
+      const cand = await API.getModelCandidates({ signal: controller.signal });
+      if (controller.signal.aborted) return;
+      setCandidates(cand);
+      setCandidatesError(false);
+    } catch {
+      if (controller.signal.aborted) return;
+      setCandidates(null);
+      setCandidatesError(true);
+    }
+  }, []);
+
+  useEffect(() => () => candidatesAbortRef.current?.abort(), []);
+
   const fetchConfig = useCallback(async () => {
-    const [res, cand, catalog, custom] = await Promise.all([
+    const [res, catalog, custom] = await Promise.all([
       API.getSystemConfig(),
-      API.getModelCandidates().catch(() => null),
       getProviderModels().catch(() => [] as ProviderInfo[]),
       getCustomProviderModels().catch(() => [] as CustomProviderInfo[]),
+      loadCandidates(),
     ]);
     setSettings(res.settings);
     setOptions(res.options);
-    setCandidates(cand);
     setProviders(catalog);
     setCustomProviders(custom);
     setDraft({});
-  }, []);
+  }, [loadCandidates]);
 
   useEffect(() => {
     // mount/依赖变更时异步拉取配置，回调内 setSettings 等（异步 fetch 后回写）
@@ -224,6 +245,8 @@ export function MediaModelSection() {
     complex: draft.text_backend_complex ?? settings.text_backend_complex ?? "",
   };
 
+  const candidatesSubFieldsError = candidatesError ? { onRetry: () => void loadCandidates() } : undefined;
+
   const emptyHint = (msg: string) => (
     <div className="rounded-[8px] border border-hairline-soft bg-bg-grad-a/45 px-3 py-2.5 text-[12px] text-text-3">
       {msg}
@@ -267,6 +290,7 @@ export function MediaModelSection() {
             providerNames={allProviderNames}
             renderOptionMeta={renderVideoOptionMeta}
             subFields={videoSubFields}
+            subFieldsError={candidatesSubFieldsError}
           >
             {currentVideo && (
               <VideoModelSpecBar
@@ -309,6 +333,7 @@ export function MediaModelSection() {
             emptyHint={t("auto")}
             providerNames={allProviderNames}
             subFields={imageSubFields}
+            subFieldsError={candidatesSubFieldsError}
           />
         ) : (
           emptyHint(t("no_image_providers_hint"))

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -97,13 +97,14 @@ export function MediaModelSection() {
   const bucketLabels = useCapabilityBucketLabels();
 
   // 候选与其余配置分开拉：它自带失败态，失败时只影响细分区、不牵动已加载的表单状态，
-  // 也让重试不必重取整页配置（会连带清空未保存的 draft）。
+  // 也让重试不必重取整页配置（会连带清空未保存的 draft）。启动后不等它落地——候选接口
+  // 慢或悬挂时，整页 spinner 和保存流程都会跟着卡住，而细分区本就有自己的加载叙事。
   const fetchConfig = useCallback(async () => {
+    void reloadCandidates();
     const [res, catalog, custom] = await Promise.all([
       API.getSystemConfig(),
       getProviderModels().catch(() => [] as ProviderInfo[]),
       getCustomProviderModels().catch(() => [] as CustomProviderInfo[]),
-      reloadCandidates(),
     ]);
     setSettings(res.settings);
     setOptions(res.options);

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -110,4 +110,34 @@ describe("LayeredModelFields", () => {
     expect(onChange).toHaveBeenCalledWith("gemini/veo-3");
     expect(onDefaultChange).not.toHaveBeenCalled();
   });
+
+  it("force-opens the disclosure and shows an error notice with retry when subFieldsError is set, even with no sub-fields", () => {
+    const onRetry = vi.fn();
+    const { container } = renderFields({ subFields: [], subFieldsError: { onRetry } });
+    // 无任何细分项本应让整块折叠区消失，但错误态下仍需展示，用户才能感知失败并重试
+    expect(container.querySelector("details")).not.toBeNull();
+    expect(container.querySelector("details")?.open).toBe(true);
+    expect(screen.getByRole("alert")).toHaveTextContent(/候选/);
+    expect(screen.queryByText("留空的用途沿用上方默认模型。")).not.toBeInTheDocument();
+  });
+
+  it("still renders degraded sub-fields alongside the error notice when some carry a saved value", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    renderFields({
+      subFields: [subField({ value: "gemini/veo-3" })],
+      subFieldsError: { onRetry },
+    });
+    expect(screen.getByRole("combobox", { name: "图生视频" })).toHaveTextContent("veo-3");
+    await user.click(screen.getByRole("button", { name: "重试" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user collapse the disclosure again after the forced-open error state", async () => {
+    const user = userEvent.setup();
+    const { container } = renderFields({ subFields: [], subFieldsError: { onRetry: () => {} } });
+    expect(container.querySelector("details")?.open).toBe(true);
+    await user.click(screen.getByText("按用途指定模型"));
+    expect(container.querySelector("details")?.open).toBe(false);
+  });
 });

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -117,7 +117,7 @@ describe("LayeredModelFields", () => {
     // 无任何细分项本应让整块折叠区消失，但错误态下仍需展示，用户才能感知失败并重试
     expect(container.querySelector("details")).not.toBeNull();
     expect(container.querySelector("details")?.open).toBe(true);
-    expect(screen.getByRole("alert")).toHaveTextContent(/候选/);
+    expect(screen.getByRole("alert")).toHaveTextContent(/可选模型列表加载失败/);
     expect(screen.queryByText("留空的用途沿用上方默认模型。")).not.toBeInTheDocument();
   });
 
@@ -131,6 +131,11 @@ describe("LayeredModelFields", () => {
     expect(screen.getByRole("combobox", { name: "图生视频" })).toHaveTextContent("veo-3");
     await user.click(screen.getByRole("button", { name: "重试" }));
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the retry button while a retry is in flight", () => {
+    renderFields({ subFields: [], subFieldsError: { onRetry: () => {}, retrying: true } });
+    expect(screen.getByRole("button", { name: "重试" })).toBeDisabled();
   });
 
   it("lets the user collapse the disclosure again after the forced-open error state", async () => {

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -138,6 +138,27 @@ describe("LayeredModelFields", () => {
     expect(screen.getByRole("button", { name: "重试" })).toBeDisabled();
   });
 
+  it("expands the collapsed disclosure when the error appears after mount", () => {
+    // 候选请求失败通常晚于挂载，初始 open 已经算过；只在初始渲染就带错误的用例下，
+    // useState 初值即为 true，删掉挂载后的强制展开也照样通过。
+    const { container, rerender } = renderFields();
+    expect(container.querySelector("details")?.open).toBe(false);
+
+    rerender(
+      <LayeredModelFields
+        defaultLabel="默认视频模型"
+        defaultValue=""
+        defaultOptions={OPTIONS}
+        onDefaultChange={() => {}}
+        emptyLabel="自动选择"
+        providerNames={PROVIDER_NAMES}
+        subFields={[subField()]}
+        subFieldsError={{ onRetry: () => {} }}
+      />,
+    );
+    expect(container.querySelector("details")?.open).toBe(true);
+  });
+
   it("lets the user collapse the disclosure again after the forced-open error state", async () => {
     const user = userEvent.setup();
     const { container } = renderFields({ subFields: [], subFieldsError: { onRetry: () => {} } });

--- a/frontend/src/components/shared/LayeredModelFields.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.tsx
@@ -111,11 +111,17 @@ export interface LayeredModelFieldsProps {
   /** 细分项；省略或空数组即不渲染折叠区（创建向导只暴露默认层）。 */
   subFields?: LayeredSubField[];
   /**
-   * 候选拉取失败态：非空即在折叠区内渲染统一的错误文案与重试入口（替换 subFields 为空时
-   * 折叠区整块消失的降级路径），文案由本组件维护、调用方只传重试回调。成功但候选为空是
-   * 另一种状态，不落入此分支——折叠区照常渲染（细分项按 degradeSubFieldsToSaved 降级）。
+   * 细分项候选拉取失败态：非空即渲染折叠区（哪怕一个细分项都没有）并在其中给出错误文案与
+   * 重试入口，文案由本组件维护、调用方只传重试回调，两处调用点因而措辞一致。
+   *
+   * 只对应「拉取失败」；候选仍在加载、或成功但为空都不传此项——那两种情况下折叠区按
+   * `subFields` 自身的有无渲染，不出现错误叙事。
    */
-  subFieldsError?: { onRetry: () => void };
+  subFieldsError?: {
+    onRetry: () => void;
+    /** 重试在途；置位时按钮灰化，避免慢响应下点击毫无反馈。 */
+    retrying?: boolean;
+  };
   /** 折叠区之后常驻的补充说明（如文本档位的智能体边界）。 */
   footnote?: React.ReactNode;
 }
@@ -197,7 +203,11 @@ export function LayeredModelFields({
             {subFieldsError ? (
               <InlineWarning
                 message={t("model_bucket_candidates_error")}
-                action={{ label: t("common:retry"), onClick: subFieldsError.onRetry }}
+                action={{
+                  label: t("common:retry"),
+                  onClick: subFieldsError.onRetry,
+                  disabled: subFieldsError.retrying,
+                }}
               />
             ) : (
               <p className="text-[11px] leading-[1.5] text-text-4">{t("model_bucket_section_hint")}</p>

--- a/frontend/src/components/shared/LayeredModelFields.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.tsx
@@ -10,10 +10,11 @@
  * 界面文案统一用「按用途指定模型」，不出现「能力」「桶」字样（见 CONTEXT.md 能力桶词条）。
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronRight } from "lucide-react";
 import { ProviderModelSelect } from "@/components/ui/ProviderModelSelect";
+import { InlineWarning } from "@/components/ui/InlineWarning";
 import type { CapabilityBucket } from "@/types/system";
 
 /**
@@ -109,6 +110,12 @@ export interface LayeredModelFieldsProps {
   children?: React.ReactNode;
   /** 细分项；省略或空数组即不渲染折叠区（创建向导只暴露默认层）。 */
   subFields?: LayeredSubField[];
+  /**
+   * 候选拉取失败态：非空即在折叠区内渲染统一的错误文案与重试入口（替换 subFields 为空时
+   * 折叠区整块消失的降级路径），文案由本组件维护、调用方只传重试回调。成功但候选为空是
+   * 另一种状态，不落入此分支——折叠区照常渲染（细分项按 degradeSubFieldsToSaved 降级）。
+   */
+  subFieldsError?: { onRetry: () => void };
   /** 折叠区之后常驻的补充说明（如文本档位的智能体边界）。 */
   footnote?: React.ReactNode;
 }
@@ -127,15 +134,25 @@ export function LayeredModelFields({
   renderOptionMeta,
   children,
   subFields,
+  subFieldsError,
   footnote,
 }: LayeredModelFieldsProps) {
-  const { t } = useTranslation("templates");
+  const { t } = useTranslation(["templates", "common"]);
   const fields = subFields ?? [];
   const configuredCount = fields.filter((f) => !!f.value).length;
+  const hasError = !!subFieldsError;
 
   // 默认收起；但已指定过细分项时初始展开——收起会让已生效的覆盖完全不可见，
   // 用户改默认模型时会误以为改动即刻生效。挂载后由用户自行开合。
-  const [open, setOpen] = useState(() => fields.some((f) => !!f.value));
+  const [open, setOpen] = useState(() => fields.some((f) => !!f.value) || hasError);
+
+  // 候选拉取失败通常发生在挂载之后（异步请求才回来），初始 state 已算过的 open 赶不上；
+  // 错误从无到有时强制展开一次，确保用户不必先展开折叠区才能看到失败提示。之后允许用户
+  // 手动收起——不在 hasError 保持 true 期间反复重开，重试按钮已给出下一步。
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 错误从无到有时强制展开一次，是有意的 UI 状态重置
+    if (hasError) setOpen(true);
+  }, [hasError]);
 
   return (
     <div className="space-y-3">
@@ -157,7 +174,7 @@ export function LayeredModelFields({
 
       {children}
 
-      {fields.length > 0 && (
+      {(fields.length > 0 || hasError) && (
         <details
           className="group border-t border-hairline-soft pt-3"
           open={open}
@@ -177,7 +194,14 @@ export function LayeredModelFields({
           </summary>
 
           <div className="mt-3 space-y-3.5 border-l border-hairline-soft pl-3">
-            <p className="text-[11px] leading-[1.5] text-text-4">{t("model_bucket_section_hint")}</p>
+            {subFieldsError ? (
+              <InlineWarning
+                message={t("model_bucket_candidates_error")}
+                action={{ label: t("common:retry"), onClick: subFieldsError.onRetry }}
+              />
+            ) : (
+              <p className="text-[11px] leading-[1.5] text-text-4">{t("model_bucket_section_hint")}</p>
+            )}
             {fields.map((field) => (
               <div key={field.key}>
                 <div className={SUB_LABEL_CLS}>{field.label}</div>

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -158,6 +158,47 @@ describe("ModelConfigSection", () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ imageBackendT2I: "" }));
   });
 
+  it("shows an explicit error notice with a retry entry when candidatesError is set, even with no saved overrides", async () => {
+    // 候选拉取失败态与"仍在加载中"（candidates=null 但未标记失败）不同：前者要给出可感知的错误信号
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <ModelConfigSection
+        candidates={null}
+        candidatesError
+        onRetryCandidates={onRetry}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+        providers={PROVIDERS}
+        options={OPTIONS}
+        globalDefaults={EMPTY_GLOBALS}
+      />,
+    );
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(2); // video + image；文本档位不取用候选数据，不参与
+    for (const alert of alerts) {
+      expect(alert).toHaveTextContent(/候选/);
+    }
+    const retryButtons = screen.getAllByRole("button", { name: "重试" });
+    expect(retryButtons).toHaveLength(2);
+    await user.click(retryButtons[0]);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show the error notice when candidates is merely absent without candidatesError", () => {
+    render(
+      <ModelConfigSection
+        candidates={null}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+        providers={PROVIDERS}
+        options={OPTIONS}
+        globalDefaults={EMPTY_GLOBALS}
+      />,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   describe("按用途指定模型（项目层）", () => {
     const CANDIDATES = {
       image: {

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -159,14 +159,13 @@ describe("ModelConfigSection", () => {
   });
 
   it("shows an explicit error notice with a retry entry when candidatesError is set, even with no saved overrides", async () => {
-    // 候选拉取失败态与"仍在加载中"（candidates=null 但未标记失败）不同：前者要给出可感知的错误信号
+    // 候选拉取失败态与「仍在加载中」（candidates=null 但未标记失败）不同：前者要给出可感知的错误信号
     const user = userEvent.setup();
     const onRetry = vi.fn();
     render(
       <ModelConfigSection
         candidates={null}
-        candidatesError
-        onRetryCandidates={onRetry}
+        candidatesError={{ onRetry }}
         value={EMPTY_VALUE}
         onChange={() => {}}
         providers={PROVIDERS}
@@ -177,7 +176,7 @@ describe("ModelConfigSection", () => {
     const alerts = screen.getAllByRole("alert");
     expect(alerts).toHaveLength(2); // video + image；文本档位不取用候选数据，不参与
     for (const alert of alerts) {
-      expect(alert).toHaveTextContent(/候选/);
+      expect(alert).toHaveTextContent(/可选模型列表加载失败/);
     }
     const retryButtons = screen.getAllByRole("button", { name: "重试" });
     expect(retryButtons).toHaveLength(2);

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -70,6 +70,12 @@ export interface ModelConfigSectionProps {
    * 候选只列其当前值，未配置项不渲染；全部未配置即整块折叠区不渲染。
    */
   candidates?: ModelCandidatesResponse | null;
+  /**
+   * 候选拉取是否处于失败态；true 时视频/图片折叠区渲染错误文案与重试入口（onRetryCandidates），
+   * 与 candidates 缺席但未失败（仍在加载中）区分——后者沿用上面的静默降级，不显示错误态。
+   */
+  candidatesError?: boolean;
+  onRetryCandidates?: () => void;
   providers: ProviderInfo[];
   customProviders?: CustomProviderInfo[];
   /** 全局各层的已配置值（原样传入、不在调用处折叠回退），穿透演算按解析链就地推导。 */
@@ -131,6 +137,8 @@ export function ModelConfigSection({
   options,
   showSubFields = true,
   candidates,
+  candidatesError,
+  onRetryCandidates,
   providers,
   customProviders = EMPTY_CUSTOM_PROVIDERS,
   globalDefaults,
@@ -163,6 +171,8 @@ export function ModelConfigSection({
 
   // 穿透演算（docs/adr/0054，项目优先）：细分项留空 → 项目默认模型 → 全局同名细分 → 全局默认模型。
   const mediaCandidates = showSubFields ? candidates : null;
+  const mediaCandidatesError =
+    showSubFields && candidatesError && onRetryCandidates ? { onRetry: onRetryCandidates } : undefined;
 
   // 时长与分辨率都按执行模型取值，故默认层与细分项的任何一次改动都先看执行模型变没变：
   // 没变（细分项已覆盖时改默认层就是这种）原样写入，变了才清掉不再适用的分辨率、并把落在
@@ -341,6 +351,7 @@ export function ModelConfigSection({
             providerNames={options.providerNames}
             renderOptionMeta={renderVideoOptionMeta}
             subFields={videoSubFields}
+            subFieldsError={mediaCandidatesError}
           >
           {executingVideo && (
             <VideoModelSpecBar
@@ -440,6 +451,7 @@ export function ModelConfigSection({
             defaultEffective={globalDefaults.image || undefined}
             providerNames={options.providerNames}
             subFields={imageSubFields}
+            subFieldsError={mediaCandidatesError}
           >
             {renderResolutionField(executingImage, value.imageResolution, (v) =>
               onChange({ ...value, imageResolution: v }),

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -71,11 +71,11 @@ export interface ModelConfigSectionProps {
    */
   candidates?: ModelCandidatesResponse | null;
   /**
-   * 候选拉取是否处于失败态；true 时视频/图片折叠区渲染错误文案与重试入口（onRetryCandidates），
-   * 与 candidates 缺席但未失败（仍在加载中）区分——后者沿用上面的静默降级，不显示错误态。
+   * 候选拉取的失败态与重试入口；非空时视频 / 图片两处折叠区各渲染一条错误提示。与
+   * `candidates` 缺席但未失败（仍在加载中）区分——后者沿用上面的静默降级，不显示错误态。
+   * 文本档位不取用候选数据，不参与。
    */
-  candidatesError?: boolean;
-  onRetryCandidates?: () => void;
+  candidatesError?: { onRetry: () => void; retrying?: boolean };
   providers: ProviderInfo[];
   customProviders?: CustomProviderInfo[];
   /** 全局各层的已配置值（原样传入、不在调用处折叠回退），穿透演算按解析链就地推导。 */
@@ -138,7 +138,6 @@ export function ModelConfigSection({
   showSubFields = true,
   candidates,
   candidatesError,
-  onRetryCandidates,
   providers,
   customProviders = EMPTY_CUSTOM_PROVIDERS,
   globalDefaults,
@@ -171,8 +170,7 @@ export function ModelConfigSection({
 
   // 穿透演算（docs/adr/0054，项目优先）：细分项留空 → 项目默认模型 → 全局同名细分 → 全局默认模型。
   const mediaCandidates = showSubFields ? candidates : null;
-  const mediaCandidatesError =
-    showSubFields && candidatesError && onRetryCandidates ? { onRetry: onRetryCandidates } : undefined;
+  const mediaCandidatesError = showSubFields ? candidatesError : undefined;
 
   // 时长与分辨率都按执行模型取值，故默认层与细分项的任何一次改动都先看执行模型变没变：
   // 没变（细分项已覆盖时改默认层就是这种）原样写入，变了才清掉不再适用的分辨率、并把落在

--- a/frontend/src/hooks/useModelCandidates.test.tsx
+++ b/frontend/src/hooks/useModelCandidates.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API } from "@/api";
+import { useModelCandidates } from "@/hooks/useModelCandidates";
+import type { ModelCandidatesResponse } from "@/types/system";
+
+const CANDIDATES = {
+  video: { default: ["gemini/veo-3"], buckets: { i2v: ["gemini/veo-3"], r2v: [] } },
+  image: { default: ["gemini/imagen-4"], buckets: { t2i: ["gemini/imagen-4"], i2i: [] } },
+} as unknown as ModelCandidatesResponse;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useModelCandidates", () => {
+  it("starts neutral: neither loaded nor failed until reload is called", () => {
+    const { result } = renderHook(() => useModelCandidates());
+    expect(result.current.candidates).toBeNull();
+    expect(result.current.error).toBe(false);
+    expect(result.current.retrying).toBe(false);
+  });
+
+  it("marks the error state on failure and clears it once a later attempt succeeds", async () => {
+    const spy = vi
+      .spyOn(API, "getModelCandidates")
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(CANDIDATES);
+    const { result } = renderHook(() => useModelCandidates());
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(result.current.error).toBe(true);
+    expect(result.current.candidates).toBeNull();
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(result.current.error).toBe(false);
+    expect(result.current.candidates).toEqual(CANDIDATES);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(result.current.retrying).toBe(false);
+  });
+
+  it("does not treat an empty candidate set as a failure", async () => {
+    const empty = {
+      video: { default: [], buckets: { i2v: [], r2v: [] } },
+      image: { default: [], buckets: { t2i: [], i2i: [] } },
+    } as unknown as ModelCandidatesResponse;
+    vi.spyOn(API, "getModelCandidates").mockResolvedValue(empty);
+    const { result } = renderHook(() => useModelCandidates());
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(result.current.error).toBe(false);
+    expect(result.current.candidates).toEqual(empty);
+  });
+
+  it("aborts the in-flight request when a new reload takes over, and keeps the newer result", async () => {
+    const signals: AbortSignal[] = [];
+    let settleFirst: ((v: ModelCandidatesResponse) => void) | undefined;
+    vi.spyOn(API, "getModelCandidates").mockImplementation((options = {}) => {
+      if (options.signal) signals.push(options.signal);
+      if (signals.length === 1) {
+        return new Promise<ModelCandidatesResponse>((resolve) => {
+          settleFirst = resolve;
+        });
+      }
+      return Promise.resolve(CANDIDATES);
+    });
+    const { result } = renderHook(() => useModelCandidates());
+
+    let first: Promise<void>;
+    act(() => {
+      first = result.current.reload();
+    });
+    await waitFor(() => expect(result.current.retrying).toBe(true));
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(signals[0].aborted).toBe(true);
+    expect(result.current.candidates).toEqual(CANDIDATES);
+
+    // 过期响应即便晚到也不得回写，否则会用旧结果盖掉接管方刚落地的值。
+    const stale = { video: null, image: null } as unknown as ModelCandidatesResponse;
+    await act(async () => {
+      settleFirst?.(stale);
+      await first;
+    });
+    expect(result.current.candidates).toEqual(CANDIDATES);
+    expect(result.current.retrying).toBe(false);
+  });
+
+  it("aborts the in-flight request on unmount", async () => {
+    const signals: AbortSignal[] = [];
+    vi.spyOn(API, "getModelCandidates").mockImplementation((options = {}) => {
+      if (options.signal) signals.push(options.signal);
+      return new Promise<ModelCandidatesResponse>(() => {});
+    });
+    const { result, unmount } = renderHook(() => useModelCandidates());
+
+    act(() => {
+      void result.current.reload();
+    });
+    await waitFor(() => expect(signals).toHaveLength(1));
+    unmount();
+    expect(signals[0].aborted).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useModelCandidates.ts
+++ b/frontend/src/hooks/useModelCandidates.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { API } from "@/api";
+import type { ModelCandidatesResponse } from "@/types/system";
+
+/**
+ * 能力桶候选（docs/adr/0054）的加载态：全局设置与项目设置两处都消费同一份全局数据，
+ * 加载与失败叙事收在这里，调用点只拿结果。
+ *
+ * 三态互不重叠，因为「细分区静默降级」与「显式报错」的分岔全靠它们区分：
+ *   candidates=null, error=false  → 仍在加载（或尚未触发），沿用静默降级
+ *   candidates!=null              → 成功；桶为空也走这支，不报错
+ *   error=true                    → 拉取失败，调用点渲染错误文案与重试入口
+ */
+export interface ModelCandidatesState {
+  candidates: ModelCandidatesResponse | null;
+  error: boolean;
+  /** 重试在途；重试按钮据此灰化，否则慢响应下点击没有任何反馈。 */
+  retrying: boolean;
+  /** 拉取一次；组件卸载与下一次调用都会作废在途请求。 */
+  reload: () => Promise<void>;
+}
+
+/**
+ * 不在挂载时自动拉取：两处调用点的触发时机不同——项目设置只在挂载时取一次，全局设置把它
+ * 并进保存后的整页重取里。由调用点决定何时 `reload()`，hook 只保证不会有过期响应回写。
+ */
+export function useModelCandidates(): ModelCandidatesState {
+  const [candidates, setCandidates] = useState<ModelCandidatesResponse | null>(null);
+  const [error, setError] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const reload = useCallback(async () => {
+    // 接管方轮换 controller（见 .claude/rules/frontend-async-race.md）：重试可能在上一轮
+    // 请求尚未回来时触发，旧响应回来时已经过期。
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRetrying(true);
+    try {
+      const next = await API.getModelCandidates({ signal: controller.signal });
+      // 网络 await 之后的写 state 断点：abort 可能发生在响应已 resolve 之后。
+      if (controller.signal.aborted) return;
+      setCandidates(next);
+      setError(false);
+    } catch {
+      if (controller.signal.aborted) return;
+      setCandidates(null);
+      setError(true);
+    } finally {
+      // 被接管方让位：作废后不复位共享状态，否则会灭掉接管方刚点亮的在途标记。
+      if (!controller.signal.aborted) setRetrying(false);
+    }
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return { candidates, error, retrying, reload };
+}

--- a/frontend/src/i18n/en/templates.ts
+++ b/frontend/src/i18n/en/templates.ts
@@ -90,7 +90,7 @@ export default {
   model_text: "Text models",
   model_bucket_section: "Set models by purpose",
   model_bucket_section_hint: "Purposes left empty use the default model above.",
-  model_bucket_candidates_error: "Couldn't load candidates for per-purpose models. Any saved overrides are still editable.",
+  model_bucket_candidates_error: "Couldn't load the list of available models. Models already set per purpose are still editable.",
   model_bucket_configured_count: "{{n}} set",
   follow_model_default: "Follows default",
   bucket_t2i_label: "Text to image",

--- a/frontend/src/i18n/en/templates.ts
+++ b/frontend/src/i18n/en/templates.ts
@@ -90,6 +90,7 @@ export default {
   model_text: "Text models",
   model_bucket_section: "Set models by purpose",
   model_bucket_section_hint: "Purposes left empty use the default model above.",
+  model_bucket_candidates_error: "Couldn't load candidates for per-purpose models. Any saved overrides are still editable.",
   model_bucket_configured_count: "{{n}} set",
   follow_model_default: "Follows default",
   bucket_t2i_label: "Text to image",

--- a/frontend/src/i18n/vi/templates.ts
+++ b/frontend/src/i18n/vi/templates.ts
@@ -100,7 +100,7 @@ export default {
   model_text: "Mô hình văn bản",
   model_bucket_section: "Chỉ định mô hình theo mục đích",
   model_bucket_section_hint: "Mục đích để trống sẽ dùng mô hình mặc định ở trên.",
-  model_bucket_candidates_error: "Không tải được danh sách mô hình theo mục đích. Các mục đã lưu vẫn có thể chỉnh sửa.",
+  model_bucket_candidates_error: "Không tải được danh sách mô hình khả dụng. Các mô hình đã chỉ định theo mục đích vẫn có thể chỉnh sửa.",
   model_bucket_configured_count: "Đã chỉ định {{n}}",
   follow_model_default: "Theo mặc định",
   bucket_t2i_label: "Văn bản sang ảnh",

--- a/frontend/src/i18n/vi/templates.ts
+++ b/frontend/src/i18n/vi/templates.ts
@@ -100,6 +100,7 @@ export default {
   model_text: "Mô hình văn bản",
   model_bucket_section: "Chỉ định mô hình theo mục đích",
   model_bucket_section_hint: "Mục đích để trống sẽ dùng mô hình mặc định ở trên.",
+  model_bucket_candidates_error: "Không tải được danh sách mô hình theo mục đích. Các mục đã lưu vẫn có thể chỉnh sửa.",
   model_bucket_configured_count: "Đã chỉ định {{n}}",
   follow_model_default: "Theo mặc định",
   bucket_t2i_label: "Văn bản sang ảnh",

--- a/frontend/src/i18n/zh/templates.ts
+++ b/frontend/src/i18n/zh/templates.ts
@@ -90,6 +90,7 @@ export default {
   model_text: "文本模型",
   model_bucket_section: "按用途指定模型",
   model_bucket_section_hint: "留空的用途沿用上方默认模型。",
+  model_bucket_candidates_error: "按用途指定模型的候选加载失败，已生效的覆盖仍可编辑。",
   model_bucket_configured_count: "已指定 {{n}} 项",
   follow_model_default: "跟随默认",
   bucket_t2i_label: "文生图",

--- a/frontend/src/i18n/zh/templates.ts
+++ b/frontend/src/i18n/zh/templates.ts
@@ -90,7 +90,7 @@ export default {
   model_text: "文本模型",
   model_bucket_section: "按用途指定模型",
   model_bucket_section_hint: "留空的用途沿用上方默认模型。",
-  model_bucket_candidates_error: "按用途指定模型的候选加载失败，已生效的覆盖仍可编辑。",
+  model_bucket_candidates_error: "可选模型列表加载失败，已保存的用途指定仍可编辑。",
   model_bucket_configured_count: "已指定 {{n}} 项",
   follow_model_default: "跟随默认",
   bucket_t2i_label: "文生图",


### PR DESCRIPTION
Closes #1572

## 变更

设置页「按用途指定模型」的可选模型列表拉取失败时，此前整块折叠区静默消失，用户无法区分「本来就没有可选模型」与「加载失败」。现在失败会在折叠区内显示明确的错误提示与重试入口，重试成功后恢复正常渲染。

- 失败态与「仍在加载」「成功但为空」三态互不重叠：只有真正 reject 才显示错误叙事，另两种沿用原有的静默降级
- 失败从无到有时强制展开一次折叠区（否则提示藏在收起的 `<details>` 里），之后允许用户手动收起
- 候选加载从整页配置的 `Promise.all` 中拆出，重试不再连带重取整页配置、不清空未保存的表单草稿
- 加载与失败态收敛为 `useModelCandidates` hook，全局设置与项目设置两处调用点共用；重试按 `AbortController` 轮换接管在途请求，重试在途时按钮灰化
- 新增文案 zh / en / vi 三语齐备，重试按钮复用既有 `common:retry`

## 验证

- `pnpm lint`、`pnpm check`（typecheck + 141 文件 / 1648 测试）全过
- `uv run python -m pytest tests/test_i18n_consistency.py`（12 测试）全过
- 新增测试覆盖：hook 的三态与 controller 轮换 / 卸载中止；两处调用点在无任何已保存指定时仍渲染错误提示与重试；重试成功后恢复渲染；`candidates` 仅为缺席（未失败）时不出现错误提示；重试在途按钮灰化

## 说明

- 错误提示复用 `InlineWarning`（`role="alert"`），视频 / 图片两处折叠区各一条；文本档位不取用该接口，不参与
- issue 验收标准里「成功但候选为空时不渲染细分区」括号内对现状的描述与代码不符：成功但桶为空时折叠区照常渲染（细分项按 `degradeSubFieldsToSaved` 降级）。本次未改动该路径，「维持现状」成立，与错误态可区分
- 用户可见文案（`model_bucket_candidates_error`）建议校对

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 模型候选列表加载失败时，显示清晰的错误提示和“重试”按钮。
  * 候选列表加载失败不会阻止其他项目配置继续加载、编辑或保存。
  * 重试期间按钮会禁用，成功后恢复候选模型显示。
  * 即使没有可用候选模型，错误状态仍会保留，并支持手动收起相关区域。

* **本地化**
  * 新增中文、英文和越南语错误提示文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->