### PR TITLE
refactor(供应商能力): 视频模型的图生/参考生/文生能力收敛到单一声明处

### DIFF
--- a/docs/adr/0054-media-model-capability-buckets.md
+++ b/docs/adr/0054-media-model-capability-buckets.md
@@ -16,7 +16,7 @@ status: accepted
 
 ## Consequences
 
-- 能力真相源维持既有声明、不新增副本：两桶都取 backend `VideoCapabilities`——i2v 看 `first_frame`（分镜路线由首帧驱动，宫格装配不改变这一点），r2v 看 `max_reference_images > 0`；自定义供应商 = endpoint 系统判定 ⊕ 模型级 `capability_overrides` 合成。registry `ModelInfo.capabilities` 的 `image_to_video` 不区分这两条路径（`happyhorse-1.0-r2v` 声明该位、backend `first_frame=False`），不作桶候选的过滤依据。桶下拉据此预过滤候选；默认层下拉不过滤——默认层不承诺任何能力。
+- 能力真相源维持既有声明、不新增副本：两桶都取 backend `VideoCapabilities`——i2v 看 `first_frame`（分镜路线由首帧驱动，宫格装配不改变这一点），r2v 看 `max_reference_images > 0`；自定义供应商 = endpoint 系统判定 ⊕ 模型级 `capability_overrides` 合成。内置视频模型的这两维只在 backend 声明，registry `ModelInfo` 不带视频能力位与参考图上限——单一 token 无从区分图生与参考生两条路径（如 `happyhorse-1.0-r2v` 只接受参考图、不接受首帧）。桶下拉据此预过滤候选；默认层下拉不过滤——默认层不承诺任何能力。
 - 全部读侧（`video_capabilities` 查询与 agent 工具、费用估算、时长 / 分辨率约束收窄）与执行侧同口径：按上述口径定桶后走同一解析函数。能力查询与费用估算都按项目路线一次定轴、不需要剧集与剧本上下文，三种 content_mode 不分支；WebUI 的逐条视频生成端点同口径：入队预检与 `generation_tasks.execute_video_task` 都按项目路线定桶，参考路线项目在该入口直接被拒并指引改走参考生视频流程（见 `docs/adr/0055`）。路线创建即定不可变，能力查询结果因此在项目生命周期内不会换桶。
 - 图片侧空桶语义是「回退默认层」，不存在「空 = 跟随自动推断」的读法；存量配置的键组合在迁移中穷举处置。
 - 前端呈现与 per-model 存储按**执行模型**取键：凡按模型查能力或按模型存配置的界面元素（能力面板、`model_settings` 下的分辨率等），一律取当前配置真正会执行的模型——细分桶生效时是桶内模型，否则是默认层穿透演算的结果；视频侧先按项目路线定桶再求值，与后端按路线定桶的口径同源，项目内全集一致。图片侧一类例外：`executingImageModel` 只取 T2I 层的执行模型，图片分辨率据此存取键，I2I 走独立的执行模型——两者配置不同模型时，I2I 执行期按自己的模型查 `model_settings` 查不到该键，回落供应商默认分辨率档位。默认层模型不作查询或存储的键，除非它就是执行模型。

--- a/lib/capability_buckets.py
+++ b/lib/capability_buckets.py
@@ -10,7 +10,7 @@
 
 内置视频两个维度取 backend 而非 registry ``ModelInfo``：backend 的能力声明与请求构造同源
 （例如 ``vidu`` 按端点白名单算 caps，白名单外的 model 提交首帧会在构造请求时报错），registry
-不再声明这两维。桶承诺的是「选中的组合执行得了」，故以执行期同源的那一份为准。视频两维的判定式本身由
+不声明这两维。桶承诺的是「选中的组合执行得了」，故以执行期同源的那一份为准。视频两维的判定式本身由
 ``lib.config.resolver.video_capability_satisfied`` 提供，与解析层的能力闸共用同一份，两处不会漂。
 
 判定不出（endpoint 已下线、backend 未声明能力函数）时返回空集而非全集：候选列表宁缺勿滥，

--- a/lib/capability_buckets.py
+++ b/lib/capability_buckets.py
@@ -8,10 +8,9 @@
 - 自定义供应商视频：endpoint 系统判定 ⊕ 模型级覆盖的既有合成点，同样取 ``first_frame`` 与
   ``max_reference_images``。
 
-内置视频两个维度都取 backend 而不取 registry ``ModelInfo``：backend 的能力声明与请求构造同源
-（例如 ``vidu`` 按端点白名单算 caps，白名单外的 model 提交首帧会在构造请求时报错），而 registry
-的 ``image_to_video`` token 与 ``max_reference_images`` 是另一份并行声明，两者在若干 model 上已
-实际漂移。桶承诺的是「选中的组合执行得了」，故以执行期同源的那一份为准。视频两维的判定式本身由
+内置视频两个维度取 backend 而非 registry ``ModelInfo``：backend 的能力声明与请求构造同源
+（例如 ``vidu`` 按端点白名单算 caps，白名单外的 model 提交首帧会在构造请求时报错），registry
+不再声明这两维。桶承诺的是「选中的组合执行得了」，故以执行期同源的那一份为准。视频两维的判定式本身由
 ``lib.config.resolver.video_capability_satisfied`` 提供，与解析层的能力闸共用同一份，两处不会漂。
 
 判定不出（endpoint 已下线、backend 未声明能力函数）时返回空集而非全集：候选列表宁缺勿滥，

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -30,7 +30,8 @@ class ModelInfo:
     # 输入模式（t2v / i2v / r2v）与参考图上限一概不在此声明——它们的真相源是各 backend 的
     # VideoCapabilities 与请求期 gate，与请求构造同源。视频模型在此只声明与输入模式无关的
     # 特性 token（generate_audio 是音轨开关的真相源，见下方注；其余为文档性声明）。
-    # 补一份视频输入模式或参考图上限声明即引入第二份手写来源：两份无人比对，漂了也没有守卫能发现。
+    # 补一份视频输入模式或参考图上限声明即引入第二份手写来源，由
+    # tests/test_video_backend_capabilities.py::TestVideoCapabilitySingleSourceOfTruth 拦下。
     capabilities: list[str]
     default: bool = False
     supported_durations: list[int] = field(default_factory=list)

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -26,6 +26,10 @@ from lib.pricing.types import (
 class ModelInfo:
     display_name: str
     media_type: str
+    # 能力 token。图片模型的 text_to_image / image_to_image 是能力桶判定的真相源；视频模型的
+    # 图生（i2v）与参考生（r2v）两维不在此声明——它们的真相源是各 backend 的 VideoCapabilities
+    # （first_frame 与 max_reference_images），与请求构造同源。此处不得再补一份视频 i2v/r2v 或
+    # 参考图上限声明：两份手写来源无人比对，漂了也没有守卫能发现。
     capabilities: list[str]
     default: bool = False
     supported_durations: list[int] = field(default_factory=list)
@@ -35,8 +39,6 @@ class ModelInfo:
     # 与「带参考图」两种，故按条件各立一字段，不引入通用「条件→约束」语言。
     reference_image_durations: list[int] = field(default_factory=list)
     resolutions: list[str] = field(default_factory=list)
-    # 参考生视频单镜头参考图上限；0 = 不适用（图像/文本模型，或视频模型未声明）。
-    max_reference_images: int = 0
     # 计费定价声明（单一真相源）；None = 该模型按 provider 默认模型 / Gemini 默认费率兜底计费。
     pricing: Pricing | None = None
     # 从 UI 下拉剔除但保留条目（供"入队后、finish 前被下线"的边角仍能算价）。
@@ -408,35 +410,32 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-generate-preview": ModelInfo(
                 display_name="Veo 3.1",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "negative_prompt", "video_extend"],
+                capabilities=["text_to_video", "negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
                 resolutions=["720p", "1080p", "4k"],
-                max_reference_images=3,
                 pricing=_veo_video_pricing("veo-3.1-generate-preview", _VEO_STANDARD_RATES),
             ),
             "veo-3.1-fast-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "negative_prompt", "video_extend"],
+                capabilities=["text_to_video", "negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
                 resolutions=["720p", "1080p", "4k"],
-                max_reference_images=3,
                 pricing=_veo_video_pricing("veo-3.1-fast-generate-preview", _VEO_FAST_RATES),
             ),
             "veo-3.1-lite-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Lite",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "negative_prompt", "video_extend"],
+                capabilities=["text_to_video", "negative_prompt", "video_extend"],
                 default=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8]},
                 reference_image_durations=[8],
                 resolutions=["720p", "1080p"],
-                max_reference_images=3,
                 pricing=_veo_video_pricing("veo-3.1-lite-generate-preview", _VEO_LITE_RATES),
             ),
         },
@@ -497,24 +496,22 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-generate-001": ModelInfo(
                 display_name="Veo 3.1",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "negative_prompt", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
                 resolutions=["720p", "1080p", "4k"],
-                max_reference_images=3,
                 pricing=_veo_video_pricing("veo-3.1-generate-001", _VEO_STANDARD_RATES),
             ),
             "veo-3.1-fast-generate-001": ModelInfo(
                 display_name="Veo 3.1 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "negative_prompt", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "negative_prompt", "video_extend"],
                 default=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8]},
                 reference_image_durations=[8],
                 resolutions=["720p", "1080p"],
-                max_reference_images=3,
                 pricing=_veo_video_pricing("veo-3.1-fast-generate-001", _VEO_FAST_RATES),
             ),
         },
@@ -582,10 +579,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-1-5-pro-251215": ModelInfo(
                 display_name="Seedance 1.5 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "flex_tier"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "flex_tier"],
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
-                max_reference_images=9,
                 pricing=_ark_video_pricing(
                     "doubao-seedance-1-5-pro-251215",
                     {
@@ -599,10 +595,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-260128": ModelInfo(
                 display_name="Seedance 2.0",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
-                max_reference_images=9,
                 pricing=_ark_video_pricing(
                     "doubao-seedance-2-0-260128",
                     {("default", True): 46.00, ("default", False): 46.00},
@@ -611,10 +606,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-fast-260128": ModelInfo(
                 display_name="Seedance 2.0 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
-                max_reference_images=9,
                 pricing=_ark_video_pricing(
                     "doubao-seedance-2-0-fast-260128",
                     {("default", True): 37.00, ("default", False): 37.00},
@@ -623,11 +617,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-mini-260615": ModelInfo(
                 display_name="Seedance 2.0 Mini",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 default=True,
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
-                max_reference_images=9,
                 pricing=_ark_video_pricing(
                     "doubao-seedance-2-0-mini-260615",
                     {("default", True): 23.00, ("default", False): 23.00},
@@ -702,35 +695,31 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-1.5-pro": ModelInfo(
                 display_name="Seedance 1.5 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "flex_tier"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "flex_tier"],
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
-                max_reference_images=9,
             ),
             "doubao-seedance-2.0": ModelInfo(
                 display_name="Seedance 2.0",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
-                max_reference_images=9,
             ),
             "doubao-seedance-2.0-fast": ModelInfo(
                 display_name="Seedance 2.0 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
-                max_reference_images=9,
             ),
             "doubao-seedance-2.0-mini": ModelInfo(
                 display_name="Seedance 2.0 Mini",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
                 default=True,
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
-                max_reference_images=9,
             ),
         },
         default_base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
@@ -788,12 +777,10 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "grok-imagine-video": ModelInfo(
                 display_name="Grok Imagine Video",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video"],
                 default=True,
                 supported_durations=list(range(1, 16)),
                 resolutions=["480p", "720p"],
-                # 参考图上限值来自第三方来源，官方文档未明确列出。
-                max_reference_images=7,
                 # 不区分分辨率/音频的单一秒费率。
                 pricing=PerSecondMatrix(
                     rates={"grok-imagine-video": {("", None): 0.050}},
@@ -872,20 +859,18 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "sora-2": ModelInfo(
                 display_name="Sora 2",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                capabilities=["text_to_video", "generate_audio"],
                 default=True,
                 supported_durations=[4, 8, 12],
                 resolutions=["720p"],
-                max_reference_images=1,
                 pricing=_sora_video_pricing("sora-2", {"720p": 0.10}),
             ),
             "sora-2-pro": ModelInfo(
                 display_name="Sora 2 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                capabilities=["text_to_video", "generate_audio"],
                 supported_durations=[4, 8, 12],
                 resolutions=["720p", "1080p"],
-                max_reference_images=1,
                 pricing=_sora_video_pricing("sora-2-pro", {"720p": 0.30, "1024p": 0.50, "1080p": 0.70}),
             ),
         },
@@ -918,41 +903,36 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "viduq3-turbo": ModelInfo(
                 display_name="Vidu Q3 Turbo",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control"],
+                capabilities=["text_to_video", "generate_audio", "seed_control"],
                 default=True,
                 supported_durations=list(range(1, 17)),
                 # 参考生视频端点的时长下限是 3 秒（文/图生视频仍为 1 起），不收窄会让 r2v 项目的
                 # 时长下拉出现 1s / 2s 幽灵档位——选中后被 backend 静默取到 3 秒并按 3 秒计费。
                 reference_image_durations=list(range(3, 17)),
                 resolutions=["540p", "720p", "1080p"],
-                max_reference_images=7,
                 pricing=ViduDelegate(),
             ),
             "viduq3-pro": ModelInfo(
                 display_name="Vidu Q3 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio", "seed_control"],
+                capabilities=["text_to_video", "generate_audio", "seed_control"],
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
-                # 官方 /reference2video 的模型清单不含 viduq3-pro，参考图路径不可用，
-                # 与 backend 的 r2v 白名单同口径声明为 0。
-                max_reference_images=0,
                 pricing=ViduDelegate(),
             ),
             "viduq3": ModelInfo(
                 display_name="Vidu Q3 (Reference)",
                 media_type="video",
-                capabilities=["image_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(3, 17)),
                 reference_image_durations=list(range(3, 17)),
                 resolutions=["540p", "720p", "1080p"],
-                max_reference_images=7,
                 pricing=ViduDelegate(),
             ),
             "vidu2.0": ModelInfo(
                 display_name="Vidu 2.0",
                 media_type="video",
-                capabilities=["image_to_video", "seed_control"],
+                capabilities=["seed_control"],
                 supported_durations=[4, 8],
                 # 图生/首尾帧端点 8 秒档只出 720p，360p 与 1080p 均仅 4 秒档可选。
                 duration_resolution_constraints={"360p": [4], "1080p": [4]},
@@ -960,7 +940,6 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 # 8 秒幽灵档位——选中后被 backend 静默取到 4 秒。
                 reference_image_durations=[4],
                 resolutions=["360p", "720p", "1080p"],
-                max_reference_images=7,
                 pricing=ViduDelegate(),
             ),
         },
@@ -1063,7 +1042,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "happyhorse-1.0-i2v": ModelInfo(
                 display_name="HappyHorse 1.0 图生视频",
                 media_type="video",
-                capabilities=["image_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 default=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
@@ -1080,17 +1059,16 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "happyhorse-1.0-r2v": ModelInfo(
                 display_name="HappyHorse 1.0 参考生视频",
                 media_type="video",
-                capabilities=["image_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
-                max_reference_images=9,
                 pricing=_dashscope_video_pricing("happyhorse-1.0-r2v", {"720p": 0.9, "1080p": 1.6}),
             ),
             # 万相 2.7 视频系列：720P ¥0.6/s，1080P ¥1.0/s（音频恒开）。
             "wan2.7-i2v": ModelInfo(
                 display_name="万相 2.7 图生视频",
                 media_type="video",
-                capabilities=["image_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("wan2.7-i2v", {"720p": 0.6, "1080p": 1.0}),
@@ -1106,10 +1084,9 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "wan2.7-r2v": ModelInfo(
                 display_name="万相 2.7 参考生视频",
                 media_type="video",
-                capabilities=["image_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
-                max_reference_images=5,
                 pricing=_dashscope_video_pricing("wan2.7-r2v", {"720p": 0.6, "1080p": 1.0}),
             ),
             # --- audio ---
@@ -1154,7 +1131,6 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["text_to_image", "image_to_image"],
                 default=True,
                 resolutions=["1K", "2K"],
-                max_reference_images=1,
                 pricing=_minimax_image_pricing("image-01", 0.025),
             ),
             # --- video ---
@@ -1163,7 +1139,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "MiniMax-Hailuo-2.3": ModelInfo(
                 display_name="MiniMax Hailuo 2.3",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video"],
                 default=True,
                 supported_durations=[6, 10],
                 resolutions=["768p", "1080p"],
@@ -1176,7 +1152,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "MiniMax-Hailuo-2.3-Fast": ModelInfo(
                 display_name="MiniMax Hailuo 2.3 Fast",
                 media_type="video",
-                capabilities=["image_to_video"],
+                capabilities=[],
                 supported_durations=[6, 10],
                 resolutions=["768p", "1080p"],
                 duration_resolution_constraints={"1080p": [6]},
@@ -1188,17 +1164,14 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             # S2V-01：单张人脸驱动整段视频角色一致性（subject_reference 单脸 R2V）。固定输出
             # 720P/6s，请求不接受 resolution/duration（MiniMaxVideoBackend 走专门的 subject_reference
             # 路径，忽略这两项）；supported_durations=[6] 仅供编排层时长守卫与档价口径。
-            # max_reference_images=1：与 MiniMaxVideoBackend 声明同值的并行声明，不参与解析
-            # （编排层裁剪与能力桶判定读 backend 的 VideoCapabilities）。
             # 定价单档约 ¥3（资源包 1.5 积分近似，半核实）；键到 minimax 缺省档 768P/6s 求精确命中，
             # 任意分辨率漂移由 per_video_bucket 最近档回落到唯一档。
             "S2V-01": ModelInfo(
                 display_name="MiniMax S2V-01",
                 media_type="video",
-                capabilities=["image_to_video"],
+                capabilities=[],
                 supported_durations=[6],
                 resolutions=["768p"],
-                max_reference_images=1,
                 pricing=_minimax_video_pricing("S2V-01", {("768p", 6): 3.0}),
             ),
         },
@@ -1225,7 +1198,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v2-5-turbo": ModelInfo(
                 display_name="可灵 2.5 Turbo",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video"],
                 default=True,
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
@@ -1254,7 +1227,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3": ModelInfo(
                 display_name="可灵 v3",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                capabilities=["text_to_video", "generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 pricing=_kling_video_pricing("kling-v3"),
@@ -1262,18 +1235,17 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3-omni": ModelInfo(
                 display_name="可灵 v3 Omni",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                capabilities=["text_to_video", "generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
                 # 待 app.klingai.com 控制台核对，不硬编当既成事实。
-                max_reference_images=4,
                 pricing=_kling_video_pricing("kling-v3-omni"),
             ),
             "kling-v2-6": ModelInfo(
                 display_name="可灵 v2.6",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video", "generate_audio"],
+                capabilities=["text_to_video", "generate_audio"],
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
                 pricing=_kling_video_pricing("kling-v2-6"),
@@ -1281,12 +1253,11 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-video-o1": ModelInfo(
                 display_name="可灵 Video O1",
                 media_type="video",
-                capabilities=["image_to_video"],
+                capabilities=[],
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
                 # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
                 # 待 app.klingai.com 控制台核对，不硬编当既成事实。
-                max_reference_images=4,
                 pricing=_kling_video_pricing("kling-video-o1"),
             ),
         },
@@ -1326,15 +1297,13 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             # --- video ---
             # agnes-video-v2.0：apihub 异步 /v1/videos，图生 / 首尾帧 / 多图主体参考；fps 固定 24、
             # 时长 1–18s。resolutions 为保守 UI 档位；实际尺寸由 backend aspect_size 计算、与此无耦合。
-            # max_reference_images 保守值，待 console / 实测核对，不硬编当既成事实。
             "agnes-video-v2.0": ModelInfo(
                 display_name="Agnes Video 2.0",
                 media_type="video",
-                capabilities=["text_to_video", "image_to_video"],
+                capabilities=["text_to_video"],
                 default=True,
                 supported_durations=list(range(1, 19)),
                 resolutions=["480p", "720p", "1080p"],
-                max_reference_images=4,
                 pricing=_agnes_video_pricing("agnes-video-v2.0", 0.005),
             ),
         },

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1240,8 +1240,6 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=["generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
-                # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
-                # 待 app.klingai.com 控制台核对，不硬编当既成事实。
                 pricing=_kling_video_pricing("kling-v3-omni"),
             ),
             "kling-v2-6": ModelInfo(
@@ -1258,8 +1256,6 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 capabilities=[],
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
-                # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
-                # 待 app.klingai.com 控制台核对，不硬编当既成事实。
                 pricing=_kling_video_pricing("kling-video-o1"),
             ),
         },

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -27,9 +27,10 @@ class ModelInfo:
     display_name: str
     media_type: str
     # 能力 token。图片模型的 text_to_image / image_to_image 是能力桶判定的真相源；视频模型的
-    # 图生（i2v）与参考生（r2v）两维不在此声明——它们的真相源是各 backend 的 VideoCapabilities
-    # （first_frame 与 max_reference_images），与请求构造同源。此处不得再补一份视频 i2v/r2v 或
-    # 参考图上限声明：两份手写来源无人比对，漂了也没有守卫能发现。
+    # 输入模式（t2v / i2v / r2v）与参考图上限一概不在此声明——它们的真相源是各 backend 的
+    # VideoCapabilities 与请求期 gate，与请求构造同源。视频模型在此只声明与输入模式无关的
+    # 特性 token（generate_audio 是音轨开关的真相源，见下方注；其余为文档性声明）。
+    # 补一份视频输入模式或参考图上限声明即引入第二份手写来源：两份无人比对，漂了也没有守卫能发现。
     capabilities: list[str]
     default: bool = False
     supported_durations: list[int] = field(default_factory=list)
@@ -410,7 +411,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-generate-preview": ModelInfo(
                 display_name="Veo 3.1",
                 media_type="video",
-                capabilities=["text_to_video", "negative_prompt", "video_extend"],
+                capabilities=["negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
@@ -420,7 +421,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-fast-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "negative_prompt", "video_extend"],
+                capabilities=["negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
@@ -430,7 +431,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-lite-generate-preview": ModelInfo(
                 display_name="Veo 3.1 Lite",
                 media_type="video",
-                capabilities=["text_to_video", "negative_prompt", "video_extend"],
+                capabilities=["negative_prompt", "video_extend"],
                 default=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8]},
@@ -496,7 +497,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-generate-001": ModelInfo(
                 display_name="Veo 3.1",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "negative_prompt", "video_extend"],
+                capabilities=["generate_audio", "negative_prompt", "video_extend"],
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
@@ -506,7 +507,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "veo-3.1-fast-generate-001": ModelInfo(
                 display_name="Veo 3.1 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "negative_prompt", "video_extend"],
+                capabilities=["generate_audio", "negative_prompt", "video_extend"],
                 default=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8]},
@@ -579,7 +580,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-1-5-pro-251215": ModelInfo(
                 display_name="Seedance 1.5 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "flex_tier"],
+                capabilities=["generate_audio", "seed_control", "flex_tier"],
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
                 pricing=_ark_video_pricing(
@@ -595,7 +596,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-260128": ModelInfo(
                 display_name="Seedance 2.0",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
                 pricing=_ark_video_pricing(
@@ -606,7 +607,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-fast-260128": ModelInfo(
                 display_name="Seedance 2.0 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
                 pricing=_ark_video_pricing(
@@ -617,7 +618,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-2-0-mini-260615": ModelInfo(
                 display_name="Seedance 2.0 Mini",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 default=True,
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
@@ -695,28 +696,28 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "doubao-seedance-1.5-pro": ModelInfo(
                 display_name="Seedance 1.5 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "flex_tier"],
+                capabilities=["generate_audio", "seed_control", "flex_tier"],
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
             ),
             "doubao-seedance-2.0": ModelInfo(
                 display_name="Seedance 2.0",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p", "1080p"],
             ),
             "doubao-seedance-2.0-fast": ModelInfo(
                 display_name="Seedance 2.0 Fast",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
             ),
             "doubao-seedance-2.0-mini": ModelInfo(
                 display_name="Seedance 2.0 Mini",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control", "video_extend"],
+                capabilities=["generate_audio", "seed_control", "video_extend"],
                 default=True,
                 supported_durations=list(range(4, 16)),
                 resolutions=["480p", "720p"],
@@ -777,7 +778,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "grok-imagine-video": ModelInfo(
                 display_name="Grok Imagine Video",
                 media_type="video",
-                capabilities=["text_to_video"],
+                capabilities=[],
                 default=True,
                 supported_durations=list(range(1, 16)),
                 resolutions=["480p", "720p"],
@@ -859,7 +860,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "sora-2": ModelInfo(
                 display_name="Sora 2",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio"],
+                capabilities=["generate_audio"],
                 default=True,
                 supported_durations=[4, 8, 12],
                 resolutions=["720p"],
@@ -868,7 +869,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "sora-2-pro": ModelInfo(
                 display_name="Sora 2 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio"],
+                capabilities=["generate_audio"],
                 supported_durations=[4, 8, 12],
                 resolutions=["720p", "1080p"],
                 pricing=_sora_video_pricing("sora-2-pro", {"720p": 0.30, "1024p": 0.50, "1080p": 0.70}),
@@ -903,7 +904,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "viduq3-turbo": ModelInfo(
                 display_name="Vidu Q3 Turbo",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 default=True,
                 supported_durations=list(range(1, 17)),
                 # 参考生视频端点的时长下限是 3 秒（文/图生视频仍为 1 起），不收窄会让 r2v 项目的
@@ -915,7 +916,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "viduq3-pro": ModelInfo(
                 display_name="Vidu Q3 Pro",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(1, 17)),
                 resolutions=["540p", "720p", "1080p"],
                 pricing=ViduDelegate(),
@@ -1051,7 +1052,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "happyhorse-1.0-t2v": ModelInfo(
                 display_name="HappyHorse 1.0 文生视频",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.0-t2v", {"720p": 0.9, "1080p": 1.6}),
@@ -1076,7 +1077,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "wan2.7-t2v": ModelInfo(
                 display_name="万相 2.7 文生视频",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio", "seed_control"],
+                capabilities=["generate_audio", "seed_control"],
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("wan2.7-t2v", {"720p": 0.6, "1080p": 1.0}),
@@ -1139,7 +1140,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "MiniMax-Hailuo-2.3": ModelInfo(
                 display_name="MiniMax Hailuo 2.3",
                 media_type="video",
-                capabilities=["text_to_video"],
+                capabilities=[],
                 default=True,
                 supported_durations=[6, 10],
                 resolutions=["768p", "1080p"],
@@ -1198,7 +1199,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v2-5-turbo": ModelInfo(
                 display_name="可灵 2.5 Turbo",
                 media_type="video",
-                capabilities=["text_to_video"],
+                capabilities=[],
                 default=True,
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
@@ -1227,7 +1228,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3": ModelInfo(
                 display_name="可灵 v3",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio"],
+                capabilities=["generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 pricing=_kling_video_pricing("kling-v3"),
@@ -1235,7 +1236,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v3-omni": ModelInfo(
                 display_name="可灵 v3 Omni",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio"],
+                capabilities=["generate_audio"],
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p", "4k"],
                 # 多图主体（R2V）参考上限保守值；编排层裁剪读此处，与 backend caps 同值，
@@ -1245,7 +1246,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "kling-v2-6": ModelInfo(
                 display_name="可灵 v2.6",
                 media_type="video",
-                capabilities=["text_to_video", "generate_audio"],
+                capabilities=["generate_audio"],
                 supported_durations=[5, 10],
                 resolutions=["720p", "1080p"],
                 pricing=_kling_video_pricing("kling-v2-6"),
@@ -1300,7 +1301,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             "agnes-video-v2.0": ModelInfo(
                 display_name="Agnes Video 2.0",
                 media_type="video",
-                capabilities=["text_to_video"],
+                capabilities=[],
                 default=True,
                 supported_durations=list(range(1, 19)),
                 resolutions=["480p", "720p", "1080p"],

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -1119,8 +1119,8 @@ class ConfigResolver:
         """能力闸：校验解析出的模型具备该桶所需能力，不满足直接报错、不静默换模型。
 
         判定经 ``video_capability_satisfied`` 与桶候选下拉（``lib.capability_buckets``）共用一份
-        口径：内置模型两维都取 backend ``VideoCapabilities``（与请求构造同源），不读 registry
-        ``ModelInfo`` 的并行声明。悬空引用（模型被删 /
+        口径：内置模型两维都取 backend ``VideoCapabilities``（与请求构造同源，也是这两维唯一的
+        声明处；registry ``ModelInfo`` 不声明视频能力位）。悬空引用（模型被删 /
         能力被事后修改 / 供应商被删 / endpoint 变更）在此统一报错兜底，写入侧不拦截、不级联清理
         （``docs/adr/0054``）。
         """
@@ -1336,8 +1336,8 @@ class ConfigResolver:
             if model_info is None:
                 raise ValueError(f"model not found in registry: {provider_id}/{model_id}")
             supported_durations = list(model_info.supported_durations or [])
-            # 能力位一律读 backend 声明，不读 ModelInfo 的并行声明：backend 是执行期真正构造
-            # 请求的一方，也是能力闸（`_ensure_video_bucket_capability`）与桶候选下拉
+            # 视频能力位与参考图上限只在 backend 声明：backend 是执行期真正构造请求的一方，
+            # 也是能力闸（`_ensure_video_bucket_capability`）与桶候选下拉
             # （`lib.capability_buckets`）的口径，展示层与执行层因此严格同源。
             try:
                 spec = get_provider_spec(provider_id, "video")

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -775,8 +775,8 @@ class ScriptGenerator:
         caps 解析失败（DB/migration 故障等）时退到 project.json 按 generation_mode 定桶取的身份
         （``project_video_backend_ids``）直查 backend 声明——与 _resolve_supported_durations
         同构，避免丢失上限导致后端按多张参考图发出而被上游拒。
-        取 backend 而非 registry ModelInfo 的并行声明：两者在若干 model 上已漂移，而 backend 是
-        执行期构造请求的一方。注册表身份仍要查——backend 的 caps 函数不都校验 model 存在性与
+        上限的唯一声明处是 backend（执行期构造请求的一方），registry ModelInfo 不声明该值。
+        注册表身份仍要查——backend 的 caps 函数不都校验 model 存在性与
         media_type，对任意 id 返回静态能力。0 在这条降级路径上按未声明处理（下传 0 会把降级前
         本可申请的参考图整批裁掉，而执行期仍有 backend 校验兜底）。
         """

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -66,9 +66,8 @@ _MAX_NUM_FRAMES = 441
 _MIN_DURATION_SECONDS = 1
 _MAX_DURATION_SECONDS = 18
 
-# 参考图（多图主体）上限——保守值，编排层裁剪与 backend 生成时防御同读此处（registry
-# ModelInfo.max_reference_images 另有一份同值的并行声明，不参与解析）。取值未经 Agnes console
-# 核对，不硬编当既成事实。
+# 参考图（多图主体）上限——保守值，编排层裁剪与 backend 生成时防御同读此处（唯一声明处）。
+# 取值未经 Agnes console 核对，不硬编当既成事实。
 _MAX_REFERENCE_IMAGES = 4
 
 # 尺寸约束：长宽被 8 整除、长边收口 1920（保守值，覆盖上游 480p/720p/1080p 三档标准化）。

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -237,7 +237,7 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         denied_last_frame = any(sub in model_lower for sub in ArkVideoBackend._NO_LAST_FRAME_SUBSTRINGS)
         # _create_task 对任何 model 都会把 reference_images 序列化成 role="reference_image"，
         # 参考生视频在 1.5 pro 上是既有可用路径；此处不声明容量会让 gate_video_request 把编排层
-        # 按 registry 正常派好参考图的请求整批拒掉。未上表的型号仍保守判 0。
+        # 正常派好参考图的请求整批拒掉——编排层的派图上限同样读这里。未上表的型号仍保守判 0。
         return VideoCapabilities(
             first_frame=not no_first_frame,
             last_frame=allowed_last_frame and not denied_last_frame,

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -37,7 +37,7 @@ _SEEDANCE_2_MAX_REFERENCE_AUDIO = 3
 # ModelInfo 至今没有任何 reference_audio 维度；请求期硬拒绝的判定一律读 VideoCapabilities。
 _SEEDANCE_2_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
 
-# Seedance 1.5 pro 的参考图上限，与 lib/config/registry.py 的同名 ModelInfo 字段同值。
+# Seedance 1.5 pro 的参考图上限，唯一声明处（编排层裁剪与请求期校验同读 VideoCapabilities）。
 _SEEDANCE_1_5_MAX_REFERENCE_IMAGES = 9
 
 # 参考音频的 data URI MIME：官方接受 wav / mp3 两种格式，要求 `data:audio/<格式>;base64,<内容>`
@@ -164,11 +164,8 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
     # 被误判为继承已验证型号的尾帧能力，绕过本模块新增的硬拒绝。
     _KNOWN_MODEL_SUFFIX_RE = re.compile(r"^(-\d+)?$")
 
-    # 非 2.0 系列里支持参考生视频的型号：1.5 pro 的参考图上限与 registry ModelInfo 声明
-    # （doubao-seedance-1-5-pro-251215 / doubao-seedance-1.5-pro 均为 9）一致。两处必须同值——
-    # 编排层按 registry 决定给一个 unit 派几张参考图，请求期按本声明校验，声明低于 registry
-    # 会让编排层正常派图的请求在 gate 上被拒。守卫见 tests/test_video_backend_ark.py 的
-    # registry 一致性用例。
+    # 非 2.0 系列里支持参考生视频的型号：1.5 pro 的参考图上限由本模块的 VideoCapabilities
+    # 单独声明，编排层裁剪与请求期校验同读该声明。
     _REFERENCE_IMAGE_ALLOW_SUBSTRINGS = ("seedance-1-5-pro", "seedance-1.5-pro")
 
     # Seedance 2.0 系列已验证支持首尾帧的三个变体（lib/config/registry.py 内建型号：

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -51,7 +51,8 @@ class GrokVideoBackend:
         """按 model_id 纯计算 caps —— 不构造 SDK client（无需 api_key）。
 
         当前全系模型能力一致，不按 model_id 分支；instance property 委托至此，
-        保持 backend 为单一真相源。
+        保持 backend 为单一真相源。参考图上限取自第三方来源，官方文档未明确列出，
+        不硬编当既成事实。
         """
         return VideoCapabilities(max_reference_images=7)
 

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -223,8 +223,8 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
         # _KLING_VIDEO_CAPS 读（_lookup_video_caps 归一化前缀/大小写后精确命中，未登记回落保守默认）。
-        # max_reference_images 以此处为准（编排层裁剪与生成时防御同读它；registry ModelInfo 另有一份
-        # 并行声明，不参与解析），取保守值、未经 app.klingai.com 控制台核对。纯函数（不构造 client /
+        # max_reference_images 只在此处声明（编排层裁剪与生成时防御同读它），取保守值、
+        # 未经 app.klingai.com 控制台核对。纯函数（不构造 client /
         # 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
         #
         # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -65,8 +65,9 @@ _R2V_MAX_REFERENCE_IMAGES = 4
 class _KlingVideoModelCaps:
     """单个可灵视频模型的能力位（官方一手核实）。"""
 
+    # 文生视频闸：为假的 model 不接受无首帧的请求（_build_payload 处拒）。图生视频没有对应位
+    # ——各档首帧恒可用，video_capabilities_for_model 直接声明 first_frame=True。
     text_to_video: bool
-    image_to_video: bool
     last_frame: bool
     # last_frame=True 但仅 pro 档可用（官方一手：kling-v2-5-turbo、kling-v2-6 首尾帧均标"仅 pro"，
     # 出处 docs/research/arcreel-vendor-integration-research.md）；std 档提交 image_tail 请求体虽会
@@ -87,7 +88,6 @@ class _KlingVideoModelCaps:
 # turbo / 未登记 model（bearer 透传原生 model_name）兜底：文/图生视频、首尾帧，无音频/参考。
 _DEFAULT_VIDEO_CAPS = _KlingVideoModelCaps(
     text_to_video=True,
-    image_to_video=True,
     last_frame=True,
     last_frame_requires_pro=True,
     reference_images=False,
@@ -100,7 +100,6 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
     "kling-v2-5-turbo": _DEFAULT_VIDEO_CAPS,
     "kling-v3": _KlingVideoModelCaps(
         text_to_video=True,
-        image_to_video=True,
         last_frame=True,
         last_frame_requires_pro=False,
         reference_images=False,
@@ -110,7 +109,6 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
     ),
     "kling-v3-omni": _KlingVideoModelCaps(
         text_to_video=True,
-        image_to_video=True,
         last_frame=True,
         last_frame_requires_pro=False,
         reference_images=True,
@@ -120,7 +118,6 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
     ),
     "kling-v2-6": _KlingVideoModelCaps(
         text_to_video=True,
-        image_to_video=True,
         last_frame=True,
         last_frame_requires_pro=True,
         reference_images=False,
@@ -130,7 +127,6 @@ _KLING_VIDEO_CAPS: dict[str, _KlingVideoModelCaps] = {
     ),
     "kling-video-o1": _KlingVideoModelCaps(
         text_to_video=False,
-        image_to_video=True,
         last_frame=True,
         last_frame_requires_pro=False,
         reference_images=True,

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -56,8 +56,8 @@ _IMAGE2VIDEO = "image2video"
 _MULTI_IMAGE2VIDEO = "multi-image2video"
 _RESUMABLE_SUBPATHS = frozenset({_TEXT2VIDEO, _IMAGE2VIDEO, _MULTI_IMAGE2VIDEO})
 
-# 多图主体（R2V）参考图上限保守值，由 backend caps 单独声明（编排层裁剪与生成时防御同读）。
-# 待 app.klingai.com 控制台核对，不硬编当既成事实。
+# 多图主体（R2V）参考图上限，由 backend caps 单独声明（编排层裁剪与生成时防御同读）。
+# 取保守值：官方文档未明确列出该上限。
 _R2V_MAX_REFERENCE_IMAGES = 4
 
 
@@ -219,8 +219,8 @@ class KlingVideoBackend(KlingBackendBase, ProviderJobIdPersistenceMixin):
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
         # first_frame 恒真（各档均支持 i2v 首帧）；last_frame / reference_images / 上限按 model 从
         # _KLING_VIDEO_CAPS 读（_lookup_video_caps 归一化前缀/大小写后精确命中，未登记回落保守默认）。
-        # max_reference_images 只在此处声明（编排层裁剪与生成时防御同读它），取保守值、
-        # 未经 app.klingai.com 控制台核对。纯函数（不构造 client /
+        # max_reference_images 只在此处声明（编排层裁剪与生成时防御同读它），取保守值——
+        # 官方文档未明确列出该上限。纯函数（不构造 client /
         # 不需 api_key），供 custom endpoint resolver 按 model_id 读上限复用。
         #
         # last_frame_requires_pro 为真的 model（kling-v2-5-turbo、kling-v2-6）：该位不按 service_tier

--- a/lib/video_backends/kling.py
+++ b/lib/video_backends/kling.py
@@ -56,8 +56,8 @@ _IMAGE2VIDEO = "image2video"
 _MULTI_IMAGE2VIDEO = "multi-image2video"
 _RESUMABLE_SUBPATHS = frozenset({_TEXT2VIDEO, _IMAGE2VIDEO, _MULTI_IMAGE2VIDEO})
 
-# 多图主体（R2V）参考图上限保守值；同时声明于 registry ModelInfo（编排层裁剪读它）与
-# backend caps（生成时防御）。待 app.klingai.com 控制台核对，不硬编当既成事实。
+# 多图主体（R2V）参考图上限保守值，由 backend caps 单独声明（编排层裁剪与生成时防御同读）。
+# 待 app.klingai.com 控制台核对，不硬编当既成事实。
 _R2V_MAX_REFERENCE_IMAGES = 4
 
 

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -17,6 +17,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from lib.audio_backends.base import VoiceOption
+from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver, ProviderModel, get_provider_fallback
 from lib.custom_provider import make_provider_id
@@ -24,6 +25,8 @@ from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.media_generator import MediaGenerator
 from lib.project_manager import ProjectManager
+from lib.video_backends.base import VideoCapabilities
+from lib.video_backends.registry import video_capabilities_for_model
 from server.services import generation_context
 from server.services.generation_context import (
     AudioLaneRequest,
@@ -41,6 +44,12 @@ def _registry_video_model(provider_id: str) -> str:
     """从 registry 取该 provider 的任一视频 model id，避免硬编码供应商数据。"""
     meta = PROVIDER_REGISTRY[provider_id]
     return next(mid for mid, mi in meta.models.items() if mi.media_type == "video")
+
+
+def _backend_video_caps(provider_id: str, model_id: str) -> VideoCapabilities:
+    """视频能力位与参考图上限的唯一声明处是 backend，registry ModelInfo 不带这些字段。"""
+    spec = get_provider_spec(provider_id, "video")
+    return video_capabilities_for_model(spec.registry_backend, model_id)
 
 
 @dataclass
@@ -209,7 +218,7 @@ class TestVideoLane:
 
         assert ctx.video.supported_durations == tuple(expected.supported_durations or [])
         assert ctx.video.max_duration == max(expected.supported_durations or [0])
-        assert ctx.video.max_reference_images == expected.max_reference_images
+        assert ctx.video.max_reference_images == _backend_video_caps("ark", video_model).max_reference_images
         assert ctx.video.resolution is None
         assert ctx.video.resolution_or_fallback == get_provider_fallback("ark")
 

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -29,7 +29,8 @@ def test_provider_meta_fields():
     assert "image" in meta.media_types
     assert "api_key" in meta.required_keys
     assert "api_key" in meta.secret_keys
-    assert "text_to_video" in meta.capabilities
+    # 视频模型只声明与输入模式无关的特性 token（输入模式的真相源是 backend VideoCapabilities）。
+    assert "video_extend" in meta.capabilities
 
 
 @pytest.mark.unit

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -697,8 +697,8 @@ class TestVideoCapabilities:
         assert caps["max_reference_images"] == 7
 
     @pytest.mark.unit
-    async def test_max_reference_images_reads_model_info_for_openai_sora(self):
-        """openai sora 的 max_reference_images 来自 registry ModelInfo（=1），不再依赖 provider 级 fallback。"""
+    async def test_max_reference_images_reads_backend_caps_for_openai_sora(self):
+        """openai sora 的 max_reference_images 来自 backend 声明（=1），不依赖 provider 级 fallback。"""
         factory, engine = await _make_session()
         try:
             resolver = ConfigResolver(factory)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -180,13 +180,13 @@ class TestVideoRegistry:
         models = PROVIDER_REGISTRY[PROVIDER_MINIMAX].models
         hailuo = models["MiniMax-Hailuo-2.3"]
         assert hailuo.media_type == "video"
-        assert "text_to_video" in hailuo.capabilities
         assert hailuo.supported_durations == [6, 10]
         assert hailuo.duration_resolution_constraints == {"1080p": [6]}
 
-        fast = models["MiniMax-Hailuo-2.3-Fast"]
-        # 纯图生型号：registry 不声明视频能力位，故 capabilities 为空——i2v 判定读 backend。
-        assert fast.capabilities == []
+        # registry 不声明视频输入模式，minimax 两个型号均无其他特性 token，故 capabilities 为空
+        # ——t2v / i2v 判定读 backend。
+        assert hailuo.capabilities == []
+        assert models["MiniMax-Hailuo-2.3-Fast"].capabilities == []
 
     def test_s2v01_registered_with_single_reference_cap(self):
         from lib.config.registry import PROVIDER_REGISTRY

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -43,12 +43,11 @@ class TestRegistry:
         assert "vision" in meta.models["MiniMax-M3"].capabilities
         assert "MiniMax-M2.7" in meta.models
         assert meta.models["MiniMax-M2.7"].default is False
-        # image-01：默认图像模型，T2I + I2I，单脸参考
+        # image-01：默认图像模型，T2I + I2I
         image = meta.models["image-01"]
         assert image.media_type == "image"
         assert image.default is True
         assert image.capabilities == ["text_to_image", "image_to_image"]
-        assert image.max_reference_images == 1
 
     def test_env_keys_registered(self):
         from lib.config.env_keys import OTHER_PROVIDER_ENV_KEYS, PROVIDER_SECRET_KEYS
@@ -182,22 +181,23 @@ class TestVideoRegistry:
         hailuo = models["MiniMax-Hailuo-2.3"]
         assert hailuo.media_type == "video"
         assert "text_to_video" in hailuo.capabilities
-        assert "image_to_video" in hailuo.capabilities
         assert hailuo.supported_durations == [6, 10]
         assert hailuo.duration_resolution_constraints == {"1080p": [6]}
 
         fast = models["MiniMax-Hailuo-2.3-Fast"]
-        assert fast.capabilities == ["image_to_video"]
+        # 纯图生型号：registry 不声明视频能力位，故 capabilities 为空——i2v 判定读 backend。
+        assert fast.capabilities == []
 
     def test_s2v01_registered_with_single_reference_cap(self):
         from lib.config.registry import PROVIDER_REGISTRY
+        from lib.video_backends.minimax import MiniMaxVideoBackend
 
         s2v = PROVIDER_REGISTRY[PROVIDER_MINIMAX].models["S2V-01"]
         assert s2v.media_type == "video"
-        # 单脸参考生视频：编排层据 registry max_reference_images 只取 1 张。
-        assert s2v.max_reference_images == 1
         # 固定 6s 输出。
         assert s2v.supported_durations == [6]
+        # 单脸参考生视频：编排层据 backend 声明只取 1 张（参考图上限的唯一声明处）。
+        assert MiniMaxVideoBackend.video_capabilities_for_model("S2V-01").max_reference_images == 1
 
     def test_video_backend_registered(self):
         from lib.video_backends import get_registered_backends

--- a/tests/test_model_candidates_api.py
+++ b/tests/test_model_candidates_api.py
@@ -271,15 +271,16 @@ class TestBucketJudgement:
         model_info = PROVIDER_REGISTRY[provider_id].models[model_id]
         assert builtin_model_buckets(provider_id, model_id, model_info) == frozenset()
 
-    def test_builtin_video_r2v_reads_backend_not_registry(self):
-        """registry 的 max_reference_images 与 backend 声明冲突时，判定以 backend 为准。
+    def test_builtin_video_r2v_reads_backend_declaration(self):
+        """r2v 归属只看 backend 的 max_reference_images，registry ModelInfo 不参与。
 
         viduq3-pro 不在 Vidu 的 /reference2video 端点白名单内，backend 据此声明
-        max_reference_images=0。此处人为把 registry 侧的并行声明改成非 0，断言桶判定不受其影响。
+        max_reference_images=0；同 provider 的 viduq3 在白名单内、声明 7。两者的 registry
+        条目都不带能力位，桶归属仍按 backend 分开。
         """
         meta = PROVIDER_REGISTRY["vidu"]
-        model_info = replace(meta.models["viduq3-pro"], max_reference_images=7)
-        assert "r2v" not in builtin_model_buckets("vidu", "viduq3-pro", model_info)
+        assert "r2v" not in builtin_model_buckets("vidu", "viduq3-pro", meta.models["viduq3-pro"])
+        assert "r2v" in builtin_model_buckets("vidu", "viduq3", meta.models["viduq3"])
 
     @pytest.mark.parametrize(
         ("provider_id", "model_id"),
@@ -289,14 +290,13 @@ class TestBucketJudgement:
             ("minimax", "S2V-01"),  # 单脸 subject_reference 驱动，不接受 first_frame_image
         ],
     )
-    def test_builtin_video_i2v_reads_backend_not_registry(self, provider_id: str, model_id: str):
-        """registry 的 image_to_video token 与 backend first_frame 冲突时，判定以 backend 为准。
+    def test_builtin_video_i2v_reads_backend_declaration(self, provider_id: str, model_id: str):
+        """i2v 归属只看 backend 的 first_frame，registry ModelInfo 不参与。
 
-        这三个 model 的 token 声称支持图生视频，但 backend 的 first_frame=False 与请求构造同源，
-        执行期不接首帧——放进 i2v 桶就等于让用户配出必败的组合。
+        这三个 model 的 backend first_frame=False 与请求构造同源，执行期不接首帧——放进 i2v 桶
+        就等于让用户配出必败的组合。
         """
         model_info = PROVIDER_REGISTRY[provider_id].models[model_id]
-        assert "image_to_video" in model_info.capabilities
         assert "i2v" not in builtin_model_buckets(provider_id, model_id, model_info)
 
     def test_unknown_endpoint_yields_no_buckets(self):

--- a/tests/test_video_backend_ark.py
+++ b/tests/test_video_backend_ark.py
@@ -437,25 +437,6 @@ class TestArkModelCapabilities:
         assert ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-future").max_reference_images == 0
 
     @pytest.mark.unit
-    def test_backend_reference_capacity_matches_registry(self):
-        """registry 与 backend 的参考图上限必须同值。
-
-        编排层按 registry.ModelInfo.max_reference_images 决定给一个 unit 派几张参考图，
-        gate_video_request 按 backend 声明校验；backend 声明低于 registry 时，编排层正常派好
-        图的请求会在 gate 上被拒——两侧漂移没有别的守卫能发现。
-        """
-        from lib.config.registry import PROVIDER_REGISTRY
-
-        for provider_id in ("ark", "ark-agent-plan"):
-            for model_id, info in PROVIDER_REGISTRY[provider_id].models.items():
-                if info.media_type != "video":
-                    continue
-                declared = ArkVideoBackend.video_capabilities_for_model(model_id).max_reference_images
-                assert declared == info.max_reference_images, (
-                    f"{provider_id}/{model_id}: registry={info.max_reference_images} backend={declared}"
-                )
-
-    @pytest.mark.unit
     def test_seedance_1_0_lite_t2v_no_last_frame(self):
         """纯文生视频型号，能力表「图生视频-首帧」「图生视频-首尾帧」均标 "-"，不接受任何图片输入。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-0-lite-t2v-250428")

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -141,3 +141,54 @@ class TestVideoCapabilitiesForModel:
         with patch("lib.video_backends.ark.create_ark_client"):
             backend = ArkVideoBackend(api_key="k", model="doubao-seedance-2-0")
         assert backend.video_capabilities == ArkVideoBackend.video_capabilities_for_model("doubao-seedance-2-0")
+
+
+class TestVideoCapabilitySingleSourceOfTruth:
+    """全注册表扫描：内置视频模型的 i2v / r2v 能力与参考图上限只有 backend 一处手写声明。
+
+    registry 侧曾并行声明 `image_to_video` token 与 `max_reference_images`，两份无人比对、
+    在若干 model 上实际漂移（backend 不接首帧而 token 声称支持、参考图上限两侧不同值），
+    还两次误导审查者按已失效的那份提意见。这两个用例守住收敛后的形状。
+    """
+
+    @pytest.mark.unit
+    def test_registry_declares_no_video_capability_bits(self):
+        """视频模型的 capabilities 不得含图生 / 参考生能力位——它们的真相源是 VideoCapabilities。"""
+        from lib.config.registry import PROVIDER_REGISTRY
+
+        banned = {"image_to_video", "reference_to_video", "max_reference_images"}
+        offenders = [
+            f"{provider_id}/{model_id}: {sorted(banned & set(info.capabilities))}"
+            for provider_id, meta in PROVIDER_REGISTRY.items()
+            for model_id, info in meta.models.items()
+            if info.media_type == "video" and banned & set(info.capabilities)
+        ]
+        assert offenders == []
+
+    @pytest.mark.unit
+    def test_model_info_has_no_reference_image_cap_field(self):
+        """ModelInfo 不得重新长出参考图上限字段：加回去就等于把第二份手写来源请回来。"""
+        from dataclasses import fields
+
+        from lib.config.registry import ModelInfo
+
+        assert "max_reference_images" not in {f.name for f in fields(ModelInfo)}
+
+    @pytest.mark.unit
+    def test_every_registry_video_model_resolves_backend_capabilities(self):
+        """每个内置视频模型都能从 backend 取到能力声明——单一真相源须覆盖全注册表。"""
+        from lib.backend_assembly.specs import get_provider_spec
+        from lib.config.registry import PROVIDER_REGISTRY
+        from lib.video_backends.registry import video_capabilities_for_model
+
+        unresolved: list[str] = []
+        for provider_id, meta in PROVIDER_REGISTRY.items():
+            for model_id, info in meta.models.items():
+                if info.media_type != "video":
+                    continue
+                try:
+                    spec = get_provider_spec(provider_id, "video")
+                    video_capabilities_for_model(spec.registry_backend, model_id)
+                except ValueError as exc:
+                    unresolved.append(f"{provider_id}/{model_id}: {exc}")
+        assert unresolved == []

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -146,9 +146,8 @@ class TestVideoCapabilitiesForModel:
 class TestVideoCapabilitySingleSourceOfTruth:
     """全注册表扫描：内置视频模型的输入模式与参考图上限只有 backend 一处手写声明。
 
-    registry 侧曾并行声明 `text_to_video` / `image_to_video` token 与 `max_reference_images`，
-    两份无人比对、在若干 model 上实际漂移（backend 不接首帧而 token 声称支持、参考图上限两侧
-    不同值），还两次误导审查者按已失效的那份提意见。这三个用例守住收敛后的形状。
+    registry `ModelInfo` 不描述视频输入模式与参考图上限——第二份手写声明没有比对方，两侧漂了
+    也无人发现，还会把审查者引到不参与解析的那一份上。这三个用例守住单一真相源的形状。
     """
 
     @pytest.mark.unit
@@ -156,7 +155,7 @@ class TestVideoCapabilitySingleSourceOfTruth:
         """视频模型的 capabilities 不得含输入模式 token——它们的真相源是 VideoCapabilities。"""
         from lib.config.registry import PROVIDER_REGISTRY
 
-        banned = {"text_to_video", "image_to_video", "reference_to_video", "max_reference_images"}
+        banned = {"text_to_video", "image_to_video", "reference_to_video"}
         offenders = [
             f"{provider_id}/{model_id}: {sorted(banned & set(info.capabilities))}"
             for provider_id, meta in PROVIDER_REGISTRY.items()

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -144,19 +144,19 @@ class TestVideoCapabilitiesForModel:
 
 
 class TestVideoCapabilitySingleSourceOfTruth:
-    """全注册表扫描：内置视频模型的 i2v / r2v 能力与参考图上限只有 backend 一处手写声明。
+    """全注册表扫描：内置视频模型的输入模式与参考图上限只有 backend 一处手写声明。
 
-    registry 侧曾并行声明 `image_to_video` token 与 `max_reference_images`，两份无人比对、
-    在若干 model 上实际漂移（backend 不接首帧而 token 声称支持、参考图上限两侧不同值），
-    还两次误导审查者按已失效的那份提意见。这两个用例守住收敛后的形状。
+    registry 侧曾并行声明 `text_to_video` / `image_to_video` token 与 `max_reference_images`，
+    两份无人比对、在若干 model 上实际漂移（backend 不接首帧而 token 声称支持、参考图上限两侧
+    不同值），还两次误导审查者按已失效的那份提意见。这三个用例守住收敛后的形状。
     """
 
     @pytest.mark.unit
     def test_registry_declares_no_video_capability_bits(self):
-        """视频模型的 capabilities 不得含图生 / 参考生能力位——它们的真相源是 VideoCapabilities。"""
+        """视频模型的 capabilities 不得含输入模式 token——它们的真相源是 VideoCapabilities。"""
         from lib.config.registry import PROVIDER_REGISTRY
 
-        banned = {"image_to_video", "reference_to_video", "max_reference_images"}
+        banned = {"text_to_video", "image_to_video", "reference_to_video", "max_reference_images"}
         offenders = [
             f"{provider_id}/{model_id}: {sorted(banned & set(info.capabilities))}"
             for provider_id, meta in PROVIDER_REGISTRY.items()


### PR DESCRIPTION
Closes #1570

## 改动

内置视频模型的输入模式与参考图上限此前有两份手写声明：`lib/config/registry.py` 的 `ModelInfo`（`text_to_video` / `image_to_video` token、`max_reference_images` 字段）与各 backend 的 `VideoCapabilities`。执行闸、桶候选下拉、解析读侧早已一律读 backend，registry 那份不参与任何决策，却仍需在新增模型时维护，并已在若干型号上实际漂移（`vidu/viduq3-pro` registry 7 / backend 0；`vidu/viduq3`、`dashscope/happyhorse-1.0-r2v`、`minimax/S2V-01` 的 i2v token 为真而 backend `first_frame=False`），两次把 AI reviewer 引向已失效的那一份。

本 PR 删除 registry 侧的并行声明，backend 成为这三维的唯一声明处：

- `ModelInfo.max_reference_images` 字段整体删除（全仓零消费，`ModelInfoResponse` 本就不出网）
- 视频型号的 `capabilities` 移除 `text_to_video` / `image_to_video`，只保留与输入模式无关的特性 token（`generate_audio` 仍是音轨开关的真相源）
- backend 侧的 t2v 执行期闸（可灵 `_MODEL_PROFILES.text_to_video`、MiniMax `_supports_text_to_video`）原样保留
- 可灵能力表的 `image_to_video` 位同样删除：全表恒 True 且无读取方，i2v 判定走 `video_capabilities_for_model` 直接声明的 `first_frame=True`

`docs/adr/0054` 的能力真相源表述随之订正。

## 行为影响

无。删除的每个 registry 数值与对应 backend 同值（gemini 3 / openai 1 / ark 9 / grok 7 / vidu 7 / kling 4 / agnes 4 / minimax 1 / dashscope 9 与 5），两处漂移条目按 backend 收口。计价走 `ModelInfo.pricing`，时长与分辨率约束走 `supported_durations` 等字段，均未触及。`/providers` 响应里若干型号的 `capabilities` 数组变空——前端声明了该字段但无一处读取。

## 守卫

新增 `tests/test_video_backend_capabilities.py::TestVideoCapabilitySingleSourceOfTruth` 三个用例锁住收敛后的形状：全注册表扫描视频型号 `capabilities` 不含输入模式 token、`ModelInfo` 不得重新长出参考图上限字段、每个注册表视频型号都能从 backend 解析出能力声明。ark 原有的两侧同值断言随并行声明一并删除。

## 验证

`uv run ruff check .` / `uv run ruff format --check .` / `uv run basedpyright`（0 error）/ `uv run lint-imports` / `uv run python -m pytest`（7831 passed）/ `cd frontend && pnpm lint` 全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 统一视频能力判定来源，使图生视频、参考图生视频及参考图数量限制更贴合实际后端能力。
  * 优化视频模型候选展示与请求校验，减少能力信息不一致导致的误判。
  * 同步完善视频模型的音频、种子控制、时长、分辨率及参考图能力信息。
* **测试**
  * 更新视频能力、模型候选和后端集成测试，验证能力声明的一致性与完整性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->