### PR TITLE
docs(上传): 说明镜头上传与通用上传表的边界及判据

### DIFF
--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -94,6 +94,9 @@ class UploadSpec:
 
     新增上传类型只在 ``UPLOAD_SPECS`` 登记表项，不复制分支逻辑。``source`` 是唯一例外：
     它由 ``_handle_source_upload`` 全权接管，表项只提供类型校验与扩展名白名单。
+
+    按剧本条目定位（script_file + shot_id）、需回写剧本元数据的上传不入本表，走各自的
+    镜头级路由，校验与落盘共用 ``server.services.upload_finalize`` 的 helper。
     """
 
     allowed_exts: tuple[str, ...]

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -1,17 +1,13 @@
 """镜头级分镜图/视频自主上传路由。
 
-与通用资产上传（files.py）分离：镜头上传需要 script_file + shot_id 定位剧本条目、
-纳入版本管理，并返回 asset_fingerprints 供上传方即时 cache-bust（SSE 兜底其他客户端）。
+与通用资产上传（files.py）分离，不是 UPLOAD_SPECS 的表项：表项按 name 定位、单文件覆写，
+其 subdir + naming 路径模型与 MetadataSetter 签名不覆盖本路由这条管线——按 script_file +
+shot_id 定位剧本条目、纳入版本管理（VersionManager）、经 finalize_shot_* 回写剧本元数据，
+并返回 asset_fingerprints 供上传方即时 cache-bust（SSE 兜底其他客户端）。扩展名与大小校验
+共用 upload_finalize.validate_upload。
 
 宫格模式无独立端点：拆分后的单元格图 canonical 路径与图生视频模式相同
 （storyboards/scene_{id}.png），按镜头上传即覆盖该单元格，宫格记录不动。
-
-不收编进 files.py 的 UPLOAD_SPECS：该表驱动的是按 name 定位、单文件覆写的通用资产上传，
-与本路由按 shot_id + script_file 定位、集成版本管理（VersionManager）、剧本元数据回写
-（finalize_shot_* helpers）、SSE 指纹推送的镜头级管线不同源；kind 相关的扩展名/大小校验
-已由 upload_finalize.py::validate_upload 表驱动（与 reference_videos.py 共用）。收编需要
-给 UploadSpec 塞入只服务本路由的版本/剧本回写字段，或让 upload_file 的通用分支承载与自己
-无关的复杂度，两者都不划算。
 """
 
 from __future__ import annotations

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -1,10 +1,10 @@
 """镜头级分镜图/视频自主上传路由。
 
-与通用资产上传（files.py）分离，不是 UPLOAD_SPECS 的表项：表项按 name 定位、单文件覆写，
-其 subdir + naming 路径模型与 MetadataSetter 签名不覆盖本路由这条管线——按 script_file +
-shot_id 定位剧本条目、纳入版本管理（VersionManager）、经 finalize_shot_* 回写剧本元数据，
-并返回 asset_fingerprints 供上传方即时 cache-bust（SSE 兜底其他客户端）。扩展名与大小校验
-共用 upload_finalize.validate_upload。
+与通用资产上传（files.py）分离，不是 UPLOAD_SPECS 的表项：本路由按 script_file + shot_id
+定位剧本条目、纳入版本管理（VersionManager）、经 finalize_shot_* 回写剧本元数据，并返回
+asset_fingerprints 供上传方即时 cache-bust（SSE 兜底其他客户端）——UploadSpec 的
+subdir + naming 路径模型与 MetadataSetter 签名不覆盖这条管线。扩展名与大小校验共用
+upload_finalize.validate_upload。
 
 宫格模式无独立端点：拆分后的单元格图 canonical 路径与图生视频模式相同
 （storyboards/scene_{id}.png），按镜头上传即覆盖该单元格，宫格记录不动。

--- a/server/routers/shot_uploads.py
+++ b/server/routers/shot_uploads.py
@@ -5,6 +5,13 @@
 
 宫格模式无独立端点：拆分后的单元格图 canonical 路径与图生视频模式相同
 （storyboards/scene_{id}.png），按镜头上传即覆盖该单元格，宫格记录不动。
+
+不收编进 files.py 的 UPLOAD_SPECS：该表驱动的是按 name 定位、单文件覆写的通用资产上传，
+与本路由按 shot_id + script_file 定位、集成版本管理（VersionManager）、剧本元数据回写
+（finalize_shot_* helpers）、SSE 指纹推送的镜头级管线不同源；kind 相关的扩展名/大小校验
+已由 upload_finalize.py::validate_upload 表驱动（与 reference_videos.py 共用）。收编需要
+给 UploadSpec 塞入只服务本路由的版本/剧本回写字段，或让 upload_file 的通用分支承载与自己
+无关的复杂度，两者都不划算。
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #1619

## 结论

评估后判定镜头上传不宜收编进 `UPLOAD_SPECS`，按验收标准 1 的书面结论出口交付；代码侧只补边界说明，无运行时改动，验收标准 2（既有上传行为与错误码不变）天然满足。

## 评估依据

`UPLOAD_SPECS` 描述的是「按 name 定位、单文件覆写」的通用资产上传，其字段模型表达不了镜头级管线：

- **定位方式**：`subdir` + `naming`（stable_png / keep_ext / sequenced）拼路径，表达不了 `resource_relative_path(resource_type, shot_id)`；镜头上传的定位键是 `script_file` + `shot_id`，不是 `name`。
- **元数据回写**：`MetadataSetter` 是 `(ProjectManager, str, str, str)` 四参签名，表达不了 `finalize_shot_video_upload` 的抽缩略图 + 单锁内多字段回写。
- **版本管理与事件**：`upload_file` 全程无 `VersionManager`、无 `emit_generation_success_batch`，响应体也不同（`version` / `asset_fingerprints` vs `filename` / `url`）。
- **落盘方式**：`upload_file` 用 `file.read()` 整体读入内存；镜头视频走 `save_uploaded_video_stream` 分块落盘（200MB 上限），收编需要给通用分支另加一条流式路径。

部分收编同样不划算：可表化的只有 storyboard / video 两行，而这两行在内容处理（内存归一化 PNG vs 流式落盘）与 finalize 上各不相同，表化后仍要 per-kind 分支，等于用 dataclass 换掉几个 `if kind ==`，净增一层间接。若改为往 `UPLOAD_SPECS` 加 `naming="delegated"` 的委派项，则与 issue 已认可为例外的 `source` 同形，零复用。

扩展名与大小校验此前已收敛：镜头上传与其他表外上传路由共用 `upload_finalize.validate_upload`，不存在校验逻辑各写一份的问题。

## 改动

- `shot_uploads.py`：模块 docstring 说明本路由不是 `UPLOAD_SPECS` 表项及其判据。
- `files.py`：`UploadSpec` docstring 补反向指针——原文只声明 `source` 是表内唯一例外，而 issue 的动机（新增上传类型时存在两套写法）下，读者是从表侧出发的，需要在表侧看到「按剧本条目定位、需回写剧本元数据的上传走专属路由」这条边界。

## 验证

`ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `lint-imports`（契约 KEPT）/ `pytest -k upload`（67 passed）均通过，rebase 到最新 main 后重新验证一遍。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 补充上传规则说明，明确镜头级上传与通用资产上传流程的区别。
  * 说明镜头上传会按剧本文件和镜头编号定位、纳入版本管理，并回写剧本元数据。
  * 补充上传校验、落盘及资产指纹返回等流程说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->