### PR TITLE
fix(分镜生视频): 关闭本集音频后不再向模型描述角色声音特征

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,7 +209,7 @@ _Avoid_: 与「旁白配音」混为一谈——旁白是成片素材，试听�
 _Avoid_: 用 `generate_audio` 的真假直接代指有无音轨。
 
 **声音描述声明段（Voice_Profiles）**：
-drama 视频提示词 YAML 顶部的集中声明段，形如 `Voice_Profiles: [{Speaker, Voice_Style}]`，由编排层从角色资产的 `voice_style` 机械派生——收录集合为「本场景 dialogue 的 speaker」∩「角色资产 `voice_style` 非空」，只出场不开口的角色不收录。剧本 JSON 与 step2 LLM 零承载：编排层是它唯一的来源（`lib/prompt_utils.py::build_drama_video_prompt`），故角色 `voice_style` 改动下次生成即生效。档位为 `none` 时不注入。
+drama 视频提示词 YAML 顶部的集中声明段，形如 `Voice_Profiles: [{Speaker, Voice_Style}]`，由编排层从角色资产的 `voice_style` 机械派生——收录集合为「本场景 dialogue 的 speaker」∩「角色资产 `voice_style` 非空」，只出场不开口的角色不收录。剧本 JSON 与 step2 LLM 零承载：编排层是它唯一的来源（`lib/prompt_utils.py::build_drama_video_prompt`），故角色 `voice_style` 改动下次生成即生效。无声时不注入——`none`（模型不产音）与本集关闭音频（`requested_generate_audio` 为假）同口径，入队前判据收在 `server/services/video_caps.py::resolve_project_is_silent`、执行期收在 `VideoLaneResult.is_silent`；台词不看这一位，无声成片里照常下发供口型参考。
 _Avoid_: 与既有 `Dialogue` 条目混为一谈——前者声明音色、每 speaker 一条，后者是台词、按时序逐条。
 
 **"audio" 的三种含义（歧义警示）**：

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -47,7 +47,7 @@ from server.services.reference_video_tasks import (
     resolve_max_unit_duration,
     resolve_project_duration_context,
 )
-from server.services.video_caps import resolve_project_voice_consistency
+from server.services.video_caps import resolve_project_is_silent
 
 _CONFIRM_DURATION_SCHEMA_PROPERTY = {
     "type": "boolean",
@@ -168,13 +168,13 @@ def _get_video_prompt(
 async def _resolve_voice_characters(ctx: ToolContext, content_mode: str) -> dict[str, Any] | None:
     """供 Voice_Profiles 注入的角色资产；``None`` 表示不注入。
 
-    非 drama 直接返回 None（无需为 narration/ad 项目多付一次视频能力解析），drama 再按
-    声音一致性档位排除 C 类（真无声）模型。
+    非 drama 直接返回 None（无需为 narration/ad 项目多付一次视频能力解析），drama 再按无声
+    判据排除：C 类模型不产音、或本集关闭了音频，两条路径同口径。台词不受影响、照常下发。
     """
     if content_mode != "drama":
         return None
     project = ctx.pm.load_project(ctx.project_name)
-    if await resolve_project_voice_consistency(project) == "none":
+    if await resolve_project_is_silent(project):
         return None
     return project.get("characters") or {}
 

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -223,6 +223,17 @@ class VideoLaneResult:
     # 与其余能力字段同口径，不明时不额外收紧。
     reference_audio_per_image: bool = False
 
+    @property
+    def is_silent(self) -> bool:
+        """这一集是否听不到声音——模型不产音（C 类）或本集关闭了音频，两条路径同口径。
+
+        声音特征描述随该判据一并不注入：它虽是提示词文本而非音频负载，但描述的是听得到的
+        音色，无声成片里注入只会让模型把配额花在用不上的约束上。台词不看这一位——无声视频
+        里台词文本照常下发，供应商可用作口型参考。参考路线的同名判据见
+        ``lib.reference_video.voice_settings.VoiceRenderSettings.is_silent``。
+        """
+        return self.voice_consistency == "none" or not self.requested_generate_audio
+
 
 @dataclass(frozen=True)
 class AudioLaneResult:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -950,9 +950,10 @@ async def execute_video_task(
     # 的 dialogue 出口（覆盖 payload 里 drama 已不再携带的 video_prompt.dialogue）。narration / ad
     # 的 item 无 utterances 字段，payload.dialogue 原样透传；SDK 路径 prompt 已是渲染好的字符串、跳过。
     if isinstance(item, dict) and isinstance(prompt, dict) and content_mode == "drama":
-        # C 类（真无声）模型传 characters=None 即不注入 Voice_Profiles；有音轨模型（含恒有声、
-        # 开关不可控的 gemini-aistudio/grok）机械派生角色声音风格，口径与 voice_consistency 同源。
-        voice_characters = (project.get("characters") or {}) if ctx.video.voice_consistency != "none" else None
+        # 无声（C 类模型不产音、或本集关闭音频）传 characters=None 即不注入 Voice_Profiles；
+        # 有音轨模型（含恒有声、开关不可控的 gemini-aistudio/grok）机械派生角色声音风格。
+        # 两条无声路径同口径，判据落在 VideoLaneResult.is_silent。台词不受影响、照常下发。
+        voice_characters = None if ctx.video.is_silent else (project.get("characters") or {})
         if "utterances" in item:
             prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
         else:

--- a/server/services/video_caps.py
+++ b/server/services/video_caps.py
@@ -12,8 +12,9 @@ import logging
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from lib.config.resolver import ConfigResolver, VoiceConsistency
+from lib.config.resolver import ConfigResolver
 from lib.db import async_session_factory
+from lib.reference_video.voice_settings import VoiceRenderSettings
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +42,16 @@ async def project_video_caps(project: dict, *, degraded_to: str) -> dict:
         return caps
 
 
-async def resolve_project_voice_consistency(project: dict) -> VoiceConsistency:
-    """项目视频后端的声音一致性档位，供 drama Voice_Profiles 注入前的 C 类（真无声）判定。
+async def resolve_project_is_silent(project: dict) -> bool:
+    """这一集是否听不到声音，供 drama Voice_Profiles 注入前的判定。
 
-    解析失败按既有「无信号不判定为真无声」口径退化为 ``soft``（同 ``derive_voice_consistency``
-    对自定义供应商缺失 ``generate_audio`` 声明时的处理）。
+    两条无声路径（模型不产音的 C 类档位、本集关闭音频）在产品口径上同形，判据取自
+    ``VoiceRenderSettings.is_silent``，与参考路线渲染层、执行层
+    ``server.services.generation_context.VideoLaneResult.is_silent`` 同源。
+
+    能力解析失败时档位按「无信号不判定为真无声」退化为 ``soft``，而无声开关由
+    ``project_video_caps`` 独立解析（双重失败才落 ``False``）——即解析全线失败时按无声处理，
+    宁可少注入声音风格也不把用户已关闭的音频当成有声。
     """
-    caps = await project_video_caps(project, degraded_to="Voice_Profiles 按 soft 兜底注入")
-    return caps.get("voice_consistency") or "soft"
+    caps = await project_video_caps(project, degraded_to="Voice_Profiles 按无声兜底不注入")
+    return VoiceRenderSettings.from_caps(caps).is_silent

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -2003,20 +2003,20 @@ async def test_resolve_voice_characters_skips_non_drama(fake_ctx: ToolContext) -
 async def test_resolve_voice_characters_drama_reads_project_characters_and_gate(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
-    """drama：读项目角色资产，voice_consistency 为 none（C 类真无声）时退回不注入。"""
+    """drama：读项目角色资产，无声（C 类真无声、或本集关闭音频）时退回不注入。"""
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
-    async def fake_voice_consistency(_project, _episode=None):
-        return "soft"
+    async def fake_not_silent(_project, _episode=None):
+        return False
 
-    monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency)
+    monkeypatch.setattr(mod, "resolve_project_is_silent", fake_not_silent)
     characters = await mod._resolve_voice_characters(fake_ctx, "drama")
     assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
 
-    async def fake_voice_consistency_none(_project, _episode=None):
-        return "none"
+    async def fake_silent(_project, _episode=None):
+        return True
 
-    monkeypatch.setattr(mod, "resolve_project_voice_consistency", fake_voice_consistency_none)
+    monkeypatch.setattr(mod, "resolve_project_is_silent", fake_silent)
     assert await mod._resolve_voice_characters(fake_ctx, "drama") is None
 
 

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -547,7 +547,7 @@ class TestValueObjectAssembly:
         ],
     )
     def test_video_lane_is_silent_covers_both_paths(
-        self, voice_consistency: str, requested_generate_audio: bool, expected: bool
+        self, voice_consistency: VoiceConsistency, requested_generate_audio: bool, expected: bool
     ):
         """无声判据合并模型档与本集开关两条路径，渲染层据此决定是否注入声音风格。"""
         lane = VideoLaneResult(
@@ -559,7 +559,7 @@ class TestValueObjectAssembly:
             supported_durations=(4, 8),
             max_duration=8,
             max_reference_images=9,
-            voice_consistency=cast(VoiceConsistency, voice_consistency),
+            voice_consistency=voice_consistency,
             requested_generate_audio=requested_generate_audio,
         )
         assert lane.is_silent is expected

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from lib.audio_backends.base import VoiceOption
 from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY
-from lib.config.resolver import ConfigResolver, ProviderModel, get_provider_fallback
+from lib.config.resolver import ConfigResolver, ProviderModel, VoiceConsistency, get_provider_fallback
 from lib.custom_provider import make_provider_id
 from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
@@ -532,6 +532,37 @@ class TestValueObjectAssembly:
         )
         with pytest.raises(AttributeError):
             lane.resolution = "720p"  # type: ignore[misc]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("voice_consistency", "requested_generate_audio", "expected"),
+        [
+            ("soft", True, False),
+            ("native", True, False),
+            # C 类模型不产音
+            ("none", True, True),
+            # 本集关闭音频：模型有音轨也听不到声音
+            ("soft", False, True),
+            ("none", False, True),
+        ],
+    )
+    def test_video_lane_is_silent_covers_both_paths(
+        self, voice_consistency: str, requested_generate_audio: bool, expected: bool
+    ):
+        """无声判据合并模型档与本集开关两条路径，渲染层据此决定是否注入声音风格。"""
+        lane = VideoLaneResult(
+            provider_model=ProviderModel("ark", "m"),
+            backend_name="ark",
+            backend_model="m",
+            resolution=None,
+            resolution_or_fallback="720p",
+            supported_durations=(4, 8),
+            max_duration=8,
+            max_reference_images=9,
+            voice_consistency=cast(VoiceConsistency, voice_consistency),
+            requested_generate_audio=requested_generate_audio,
+        )
+        assert lane.is_silent is expected
 
     @pytest.mark.unit
     def test_audio_lane_result_shape(self):

--- a/tests/server/test_video_caps.py
+++ b/tests/server/test_video_caps.py
@@ -6,25 +6,29 @@ from server.services import video_caps
 
 
 @pytest.mark.unit
-async def test_resolve_project_voice_consistency_reads_caps_field(monkeypatch: pytest.MonkeyPatch):
-    """正常解析：直接读 caps 的 voice_consistency 字段，不重新派生。"""
+@pytest.mark.parametrize(
+    ("caps", "expected"),
+    [
+        # 有音轨且本集开着音频：有声
+        ({"voice_consistency": "soft", "requested_generate_audio": True}, False),
+        ({"voice_consistency": "native", "requested_generate_audio": True}, False),
+        # C 类模型不产音
+        ({"voice_consistency": "none", "requested_generate_audio": True}, True),
+        # 本集关闭音频：模型有音轨也听不到声音
+        ({"voice_consistency": "soft", "requested_generate_audio": False}, True),
+        # 能力解析失败：档位缺失退化为 soft，无声开关由 project_video_caps 独立解析后写入
+        ({"requested_generate_audio": False}, True),
+        ({"requested_generate_audio": True}, False),
+    ],
+)
+async def test_resolve_project_is_silent_covers_both_paths(monkeypatch: pytest.MonkeyPatch, caps: dict, expected: bool):
+    """无声判据合并模型档与本集开关两条路径，入队层据此决定是否注入 Voice_Profiles。"""
 
     async def fake_caps(_project, *, degraded_to, episode=None):
-        return {"voice_consistency": "none"}
+        return caps
 
     monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)
-    assert await video_caps.resolve_project_voice_consistency({}) == "none"
-
-
-@pytest.mark.unit
-async def test_resolve_project_voice_consistency_degrades_to_soft(monkeypatch: pytest.MonkeyPatch):
-    """caps 解析失败（空 dict）时按既有「无信号不判定为真无声」口径退化为 soft。"""
-
-    async def fake_caps(_project, *, degraded_to, episode=None):
-        return {}
-
-    monkeypatch.setattr(video_caps, "project_video_caps", fake_caps)
-    assert await video_caps.resolve_project_voice_consistency({}) == "soft"
+    assert await video_caps.resolve_project_is_silent({}) is expected
 
 
 @pytest.mark.unit

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1191,6 +1191,12 @@ class TestGenerationTasks:
             ],
         }
 
+    def _legacy_drama_script(self):
+        """utterances 迁移前的存量 drama 剧本：scene 无 utterances，台词仍留在 video_prompt.dialogue。"""
+        script = self._drama_script()
+        del script["scenes"][0]["utterances"]
+        return script
+
     @pytest.mark.unit
     async def test_execute_video_task_injects_voice_profiles_for_audible_model(self, monkeypatch, tmp_path):
         """有音轨模型（voice_consistency != none）：dialogue speaker 命中的角色资产
@@ -1332,21 +1338,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = _FakeGenerator()
-        fake_pm.script = {
-            "content_mode": "drama",
-            "scenes": [
-                {
-                    "scene_id": "E1S01",
-                    "duration_seconds": 8,
-                    "segment_break": False,
-                    "characters_in_scene": ["王"],
-                    "scenes": [],
-                    "props": [],
-                    "image_prompt": "首镜头",
-                    "video_prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
-                }
-            ],
-        }
+        fake_pm.script = self._legacy_drama_script()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
@@ -1373,6 +1365,46 @@ class TestGenerationTasks:
         prompt_yaml = fake_generator.video_calls[0]["prompt"]
         assert "Voice_Profiles" in prompt_yaml
         assert "低沉沙哑" in prompt_yaml
+        assert "你来了。" in prompt_yaml
+
+    @pytest.mark.unit
+    async def test_execute_video_task_skips_voice_profiles_from_legacy_dialogue_when_silent(
+        self, monkeypatch, tmp_path
+    ):
+        """legacy dialogue 出口同过无声门控：本集关闭音频时不注入 Voice_Profiles，台词照常下发。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = self._legacy_drama_script()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {
+                    "action": "起身",
+                    "camera_motion": "Static",
+                    "ambiance_audio": "风声",
+                    "dialogue": [{"speaker": "王", "line": "你来了。"}],
+                },
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" not in prompt_yaml
+        assert "低沉沙哑" not in prompt_yaml
         assert "你来了。" in prompt_yaml
 
     @pytest.mark.unit

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -100,6 +100,7 @@ def _fake_resolve_ctx(
     video_resolution="720p",
     supported_durations=(4, 6, 8),
     voice_consistency="soft",
+    requested_generate_audio=True,
     seen_lane_requests=None,
 ):
     """lane 感知的假 resolve_generation_context：按调用方声明的 lane 拼装 frozen dataclass 产物。
@@ -135,6 +136,7 @@ def _fake_resolve_ctx(
                 max_duration=None,
                 max_reference_images=None,
                 voice_consistency=voice_consistency,
+                requested_generate_audio=requested_generate_audio,
             )
         return GenerationContext(generator=generator, image_lane=image_lane, video_lane=video_lane)
 
@@ -1251,6 +1253,43 @@ class TestGenerationTasks:
         prompt_yaml = fake_generator.video_calls[0]["prompt"]
         assert "Voice_Profiles" not in prompt_yaml
         assert "低沉沙哑" not in prompt_yaml
+        # 台词不随声音风格一并省略：无声成片里台词文本照常下发，供应商可用作口型参考
+        assert "你来了。" in prompt_yaml
+
+    @pytest.mark.unit
+    async def test_execute_video_task_skips_voice_profiles_when_episode_audio_disabled(self, monkeypatch, tmp_path):
+        """本集关闭音频（requested_generate_audio=False）：即便模型有音轨也不注入 Voice_Profiles，
+        与 C 类真无声模型同口径。"""
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
+        fake_generator = _FakeGenerator()
+        fake_pm.script = self._drama_script()
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {"action": "起身", "camera_motion": "Static", "ambiance_audio": "风声"},
+                "duration_seconds": 8,
+            },
+        )
+
+        prompt_yaml = fake_generator.video_calls[0]["prompt"]
+        assert "Voice_Profiles" not in prompt_yaml
+        assert "低沉沙哑" not in prompt_yaml
+        # 台词逐字不变，与 C 类真无声路径同口径
+        assert "你来了。" in prompt_yaml
 
     @pytest.mark.unit
     async def test_execute_video_task_strips_caller_supplied_voice_profiles_for_non_drama(self, monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #1635

## 变更

分镜路线的「无声」判据合并两条路径——C 类模型不产音（`voice_consistency=none`）与本集关闭音频（`requested_generate_audio=False`）——本集关闭音频时不再向模型描述角色声音特征，与参考路线（#1631）同口径。

判据落在两个收口点，均复用同一表达：

- 执行期：`VideoLaneResult.is_silent`（`generation_tasks.py` 的 Voice_Profiles 门控，utterances 与 legacy dialogue 两个出口共用）
- 入队期：`video_caps.resolve_project_is_silent`（智能体 SDK 入队工具，此前也只看模型档位；该路径入队时 prompt 已渲染成字符串，不会被执行期门控兜住），内部委托 `VoiceRenderSettings.is_silent`

台词渲染逐字不变：无声成片里台词文本照常下发，供应商可用作口型参考。

## 验证

- 新增/更新单测覆盖 `soft+关闭音频`、`none`、有声三类取值，utterances 与 legacy dialogue 两个出口各有无声路径断言，并逐字断言台词仍在
- `uv run python -m pytest`：7856 passed
- `uv run ruff check` / `uv run basedpyright`（0 errors）/ `uv run lint-imports` 全通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化视频静音判定：使用无声模型或关闭本集音频时，不再注入角色声音配置。
  * 静音场景仍保留台词文本，支持口型参考。
  * 有声视频继续注入项目角色声音配置。
  * 增强对历史台词格式及音频开关场景的兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->