### PR TITLE
fix(i18n): 中文模板文案与英文 key 集合漂移在构建时即报错

### DIFF
--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -1,0 +1,10 @@
+// 翻译表守卫类型：与 en 侧同构，但值放宽为 string（译文不参与字面量类型约束）。
+// zh / vi 各命名空间以 `satisfies DeepStringify<typeof enX>` 锁 key 集合，
+// 多 key / 少 key 在 typecheck 报错，含嵌套层。
+export type DeepStringify<T> = {
+  [K in keyof T]: T[K] extends string
+    ? string
+    : T[K] extends object
+      ? DeepStringify<T[K]>
+      : T[K];
+};

--- a/frontend/src/i18n/vi/templates.ts
+++ b/frontend/src/i18n/vi/templates.ts
@@ -1,12 +1,5 @@
 import type enTemplates from "@/i18n/en/templates";
-
-type DeepStringify<T> = {
-  [K in keyof T]: T[K] extends string
-    ? string
-    : T[K] extends object
-      ? DeepStringify<T[K]>
-      : T[K];
-};
+import type { DeepStringify } from "@/i18n/types";
 
 export default {
   category: {

--- a/frontend/src/i18n/zh/templates.ts
+++ b/frontend/src/i18n/zh/templates.ts
@@ -1,3 +1,13 @@
+import type enTemplates from "@/i18n/en/templates";
+
+type DeepStringify<T> = {
+  [K in keyof T]: T[K] extends string
+    ? string
+    : T[K] extends object
+      ? DeepStringify<T[K]>
+      : T[K];
+};
+
 export default {
   category: {
     custom: "自定义",
@@ -124,4 +134,4 @@ export default {
   wizard_step_style: "风格",
   next_step: "下一步",
   prev_step: "上一步",
-} as const;
+} satisfies DeepStringify<typeof enTemplates>;

--- a/frontend/src/i18n/zh/templates.ts
+++ b/frontend/src/i18n/zh/templates.ts
@@ -1,12 +1,5 @@
 import type enTemplates from "@/i18n/en/templates";
-
-type DeepStringify<T> = {
-  [K in keyof T]: T[K] extends string
-    ? string
-    : T[K] extends object
-      ? DeepStringify<T[K]>
-      : T[K];
-};
+import type { DeepStringify } from "@/i18n/types";
 
 export default {
   category: {


### PR DESCRIPTION
Closes #1573

## 问题

前端三语翻译中 `en → vi` 由 `satisfies DeepStringify<typeof enTemplates>` 在 typecheck 强制同构，`zh ↔ en` 则缺守卫。核查仓库现状后确认缺口已收窄到一处：`common`/`auth`/`dashboard`/`errors`/`assets`/`onboarding` 六个 zh 命名空间早已带 `satisfies Record<keyof typeof enX, string>`，唯独 `zh/templates.ts`（唯一含嵌套结构的命名空间）仍是裸 `as const`，新增/删除 key 的漂移无任何检查。

## 改动

- `zh/templates.ts` 结尾改为 `satisfies DeepStringify<typeof enTemplates>`，与 vi 侧同一守卫模式
- `DeepStringify` 从 zh/vi 两份逐字副本抽到 `frontend/src/i18n/types.ts` 共用

守卫经 `pnpm check` 随 CI 生效，未新增测试面。

## 验证

注入漂移后 `tsc --noEmit` 逐项确认守卫非恒真：

| 场景 | 结果 |
|---|---|
| zh 顶层多 key | TS2353 |
| zh 顶层少 key | TS1360 |
| zh 嵌套层（`category`）多 key | TS2353 |
| zh 嵌套层少 key | TS2741 |
| vi 顶层多 key（抽取共享类型后回归） | TS2353 |

质量门：`pnpm lint` 0 问题，`pnpm check` typecheck 0 error、vitest 142 files / 1654 tests 全过。

## 说明

移除 `as const` 无消费方受影响：`i18n/index.ts` 经 `import.meta.glob` 加载资源并声明为 `Record<string, string>`，不依赖字面量类型；`frontend/src/i18n` 之外无文件直接 import `zh/templates`。

另六个命名空间用的 `Record<keyof typeof enX, string>` 只对扁平结构等价于 `DeepStringify`——目前那六个确为扁平，若将来引入嵌套需换成 `DeepStringify`，否则嵌套层漂移不报错。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 统一了多语言模板的类型校验方式，提升翻译内容结构检查的一致性。
  - 优化了中文和越南语翻译模板的维护体验，减少因类型限制导致的校验问题。
  - 本次更新不改变现有界面、翻译内容或用户操作方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->