### PR TITLE
docs: 前端异步纪律与审查循环补批次复盘约定,测试替身收敛入 fakes 模块

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -65,7 +65,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/query.sh <PR_NUMBER> <子命令>
 
 GitHub code scanning 两家(quality / security)的评论并入同一批,处置口径(全部 actionable、修复与 pushback 落点)见 reviewers.md「GitHub code scanning bots」节。
 
-**修复形状**:下面两条与 `receiving-code-review` 逐条实施的要求冲突时以本节为准——逐条实施会把一批意见变成一批分散的小改动,累积下来持续降低代码的可修改性(ETC)。
+**修复形状**:下面两条与 `receiving-code-review` 逐条实施的要求冲突时以本节为准——逐条实施会把一批意见变成一批分散的小补丁,累积下来持续降低代码的可修改性(ETC);修复取「回到合理形态」的最小改动,不在现状上叠补丁。
 
 - **YAGNI**:对防御性意见(新增检查、兜底、try-except、默认值、空值分支),先确认它要防的失败路径是否真实存在,即能否指出一个具体的调用方或输入触发它。能指出就实施;不能指出就回复评论说明理由,不修改代码。两种处置都要用一句话记录这条路径:驳回的写在回复评论里,实施的写在 commit 说明里。`receiving-code-review` 的 `YAGNI Check` 一节检查的是静态未被调用的代码,这里检查的是运行时不可达的分支
 - **Duplicated Code**:先确认这批意见中有几条指向同一处逻辑或同一个根因。有两条以上时,在已有抽象内合并为一处改动

--- a/.claude/rules/frontend-async-race.md
+++ b/.claude/rules/frontend-async-race.md
@@ -17,7 +17,7 @@ paths:
 - 被 abort 方的收尾（如 loading 复位）让位给接管方：`finally` 中先查 `signal.aborted`，已作废则不修改共享状态，否则会干扰接管方正在进行的加载
 - 作废由一次性事件触发的在途请求后必须补拉：事件已被消费，那份数据不会自行再来，作废方（或接管方）在 abort 后自行发起一轮拉取补上缺口，否则界面停留在旧数据——「取消」与「补偿」成对出现
 
-参考实现：`frontend/src/hooks/useAssistantSession.ts`（init 自动选择 + `loadSession` 加载链）。
+参考实现：`frontend/src/hooks/useAssistantSession.ts`（init 自动选择 + `loadSession` 加载链）、`frontend/src/hooks/useScriptReviewDraft.ts`（采纳写入时作废在途拉取并补拉）。
 
 `cancelled` closure flag 是历史写法：只拦截所在函数自身的 await 断点，不传播到被调函数，不再新增；改动涉及处一并迁移到 AbortSignal。
 

--- a/.claude/rules/frontend-async-race.md
+++ b/.claude/rules/frontend-async-race.md
@@ -15,10 +15,15 @@ paths:
 - 非网络断点（写 store、建 SSE 连接等副作用）前复核 `signal.aborted`，覆盖 abort 发生在响应已 resolve 之后的窗口
 - 接管方轮换 controller：新一轮加载先 `abort()` 上一个 controller 再新建。取消域按数据生命周期划分，不共用——项目级数据（如会话列表、技能列表）只随项目切换作废，会话级加载随任何会话操作作废，二者混用会把慢响应的项目级数据误判过期丢弃
 - 被 abort 方的收尾（如 loading 复位）让位给接管方：`finally` 中先查 `signal.aborted`，已作废则不修改共享状态，否则会干扰接管方正在进行的加载
+- 作废由一次性事件触发的在途请求后必须补拉：事件已被消费，那份数据不会自行再来，作废方（或接管方）在 abort 后自行发起一轮拉取补上缺口，否则界面停留在旧数据——「取消」与「补偿」成对出现
 
 参考实现：`frontend/src/hooks/useAssistantSession.ts`（init 自动选择 + `loadSession` 加载链）。
 
 `cancelled` closure flag 是历史写法：只拦截所在函数自身的 await 断点，不传播到被调函数，不再新增；改动涉及处一并迁移到 AbortSignal。
+
+## hook 的函数型 option：显式依赖，不收进 ref
+
+自定义 hook 接受函数型 option（selector / 回调）时，把它原样列入内部 effect/callback 的依赖数组，并在类型与 JSDoc 上要求调用方传稳定引用（`useCallback` / 模块级函数）；不在 hook 内用 ref 存最新值来豁免依赖。显式依赖下，调用方传了不稳定引用会表现为 effect 反复重跑，当场暴露；ref 豁免则把同一错误静默吸收——行为看似正常，回调却可能闭包过期状态，无从发现。先例：`frontend/src/hooks/useScriptReviewDraft.ts`。
 
 ## 跨入口共享的刷新：store action 在途合并
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）�
 - **ruff**：line-length 120，提交前对修改的 Python 文件执行 `uv run ruff check <files> && uv run ruff format <files>`
 - **basedpyright**：standard 模式 + `reportMissingTypeStubs = false`，CI 强制 0 error，pre-push hook 跑全量扫描；本地可随时执行 `uv run basedpyright` 校验。tests/ 内 `reportOptional*` 和 `unknown*` 系列降级为 warning，避免大量使用 mock 的测试产生噪声；第三方 untyped 库（ffmpeg-python、pyJianYingDraft、volcenginesdkarkruntime、xai_sdk.chat、docx2txt/mammoth/ebooklib）通过行级 `# pyright: ignore[...]` 处理
 - **import-linter**：`uv run lint-imports` 校验 `lib.config < lib.*_backends < lib.custom_provider` 分层契约，CI backend-tests 必过步骤；新增 ignore 条目前先确认该依赖边无法就地清零（约定见 pyproject.toml）
-- **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`
+- **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`。测试替身优先复用/扩展 `tests/fakes.py`，新建 fake 入该模块；触碰含文件内私有 fake 的测试文件时顺带迁移
 - **依赖管理**：前后端新增/升级依赖一律用 `uv add` / `pnpm add`（不手写版本号到 pyproject.toml / package.json）；新增依赖后同步 `.github/dependabot.yml` 的 patterns 归入对应分组
 - **注释**：代码与测试注释只描述当下行为与约束，不写 issue/PR/Spec 编号，也不用时间性措辞（「最近」「本次」「实测」）——这些信息写在 commit message / PR 描述；修改文件时顺带清除已有的此类引用。`docs/` 下专门文档之间互引 spec 不受此限
 - **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围。前后端同仓一体发布，后端 API 不做版本化对外承诺（外部集成经 `/skill.md` 运行时拉取契约，删改 `public/skill.md.template` 引用的端点时同步更新该模板）：接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer


### PR DESCRIPTION
批次复盘经用户裁决后的文档落地:

- `.claude/rules/frontend-async-race.md`:补「作废由一次性事件触发的在途请求后必须补拉」(取消与补偿成对);新增「hook 的函数型 option:显式依赖,不收进 ref」节,先例指向 `useScriptReviewDraft`
- `.agents/skills/pr-ai-review-loop/SKILL.md`:「修复形状」节导语点明反补丁式修复——修复取「回到合理形态」的最小改动,不在现状上叠补丁
- `AGENTS.md`:pytest 条补测试替身规约(优先复用/扩展 `tests/fakes.py`,触碰私有 fake 顺带迁移)

纯文档,无行为变化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 完善形状修复规范，要求采用最小改动恢复合理形态，避免持续叠加补丁。
  * 补充异步请求取消后的补偿拉取要求，确保数据及时更新。
  * 明确函数型配置项的依赖管理规范，提升异步行为稳定性。
  * 更新测试规范，鼓励复用或扩展统一的测试替身。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->