### PR TITLE
test(设置): 同步模型列表加载失败提示文案的测试断言

### DIFF
--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -88,7 +88,7 @@ describe("MediaModelSection", () => {
     const alerts = await screen.findAllByRole("alert");
     expect(alerts.length).toBeGreaterThanOrEqual(2); // video + image 两处折叠区
     for (const alert of alerts) {
-      expect(alert).toHaveTextContent(/可选模型列表加载失败/);
+      expect(alert).toHaveTextContent(/模型列表加载失败/);
     }
     expect(screen.getAllByRole("button", { name: "重试" }).length).toBeGreaterThanOrEqual(2);
   });

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -117,7 +117,7 @@ describe("LayeredModelFields", () => {
     // 无任何细分项本应让整块折叠区消失，但错误态下仍需展示，用户才能感知失败并重试
     expect(container.querySelector("details")).not.toBeNull();
     expect(container.querySelector("details")?.open).toBe(true);
-    expect(screen.getByRole("alert")).toHaveTextContent(/可选模型列表加载失败/);
+    expect(screen.getByRole("alert")).toHaveTextContent(/模型列表加载失败/);
     expect(screen.queryByText("留空的用途沿用上方默认模型。")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -176,7 +176,7 @@ describe("ModelConfigSection", () => {
     const alerts = screen.getAllByRole("alert");
     expect(alerts).toHaveLength(2); // video + image；文本档位不取用候选数据，不参与
     for (const alert of alerts) {
-      expect(alert).toHaveTextContent(/可选模型列表加载失败/);
+      expect(alert).toHaveTextContent(/模型列表加载失败/);
     }
     const retryButtons = screen.getAllByRole("button", { name: "重试" });
     expect(retryButtons).toHaveLength(2);


### PR DESCRIPTION
## 背景

c02bdbc5「fix(设置): 精简模型列表加载失败的提示文案」把 zh/en/vi 三份 `templates.ts` 的 `model_bucket_candidates_error` 改为「模型列表加载失败」，但未同步断言旧文案的测试。main 因此变红，阻塞当前所有 PR 的 CI。

## 改动

仅同步三处过期断言（不改产品代码与文案本身）：

- `frontend/src/components/shared/LayeredModelFields.test.tsx`
- `frontend/src/components/shared/ModelConfigSection.test.tsx`
- `frontend/src/components/pages/settings/MediaModelSection.test.tsx`

全仓已搜索确认无第四处旧文案残留。

## 验证

`pnpm lint` 通过；`pnpm check` 通过（142 文件 / 1654 用例全绿）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 更新模型列表加载失败场景的预期提示文案。
  - 统一错误提示为“模型列表加载失败”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->