### PR TITLE
refactor(参考视频): 提及解析统一输出规范形，含 BOM 的名称前后端判定一致

### DIFF
--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.test.tsx
@@ -311,8 +311,8 @@ describe("ReferenceStep1PreviewPanel", () => {
   });
 
   it("dedupes a reference pill when the same asset is mentioned once in NFC and once in NFD", async () => {
-    // extractMentions 按裸字符串去重，同一资产以两种编码各出现一次会各产一条；deriveDisplayReferences
-    // 须在归一后再去重，否则预览会重复渲染同一资产的 pill / 图号，与后端落盘的单条引用不一致。
+    // extractMentions 输出规范形并按规范形去重，同一资产的两种编码收敛成一条；否则预览会重复
+    // 渲染同一资产的 pill / 图号，与后端落盘的单条引用不一致。
     const nameNfc = "Hiếu".normalize("NFC");
     const nameNfd = "Hiếu".normalize("NFD");
     expect(nameNfc).not.toBe(nameNfd);

--- a/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
+++ b/frontend/src/components/canvas/reference/ReferenceStep1PreviewPanel.tsx
@@ -20,7 +20,7 @@ import { ACCENT_BTN_CLS, ACCENT_BUTTON_STYLE, CARD_STYLE, GHOST_BTN_CLS, GHOST_B
 import { assetColor } from "@/components/canvas/reference/asset-colors";
 import { ScriptHighlight } from "@/components/shared/ScriptHighlight";
 import { toScriptLines, type MentionLookup } from "@/hooks/useShotPromptHighlight";
-import { extractMentions, formatShotHeader, normalizeAssetName } from "@/utils/reference-mentions";
+import { extractMentions, formatShotHeader } from "@/utils/reference-mentions";
 
 interface ReferenceStep1PreviewPanelProps {
   projectName: string;
@@ -82,15 +82,10 @@ function deriveDisplayReferences(text: string, lookup: MentionLookup): Reference
   const out: ReferenceResource[] = [];
   // extractMentions（非 tokenizePrompt）：规范台词行里的说话人不产参考图，与后端
   // extract_mentions 同口径——tokenizePrompt 是给高亮用的，不做这条跳过。
-  // extractMentions 按裸字符串去重，同一资产以 NFC/NFD 两种编码各出现一次时会各产一条；
-  // 后端归一后落盘只保留一条，这里须同口径按归一形式去重，否则预览多显示一张图/一个图号。
-  const seen = new Set<string>();
   for (const name of extractMentions(text)) {
-    const canonical = normalizeAssetName(name);
-    const assetKind = lookup[canonical];
-    if (!assetKind || seen.has(canonical)) continue;
-    seen.add(canonical);
-    out.push({ type: assetKind, name: canonical });
+    const assetKind = lookup[name];
+    if (!assetKind) continue;
+    out.push({ type: assetKind, name });
   }
   return out;
 }
@@ -167,7 +162,7 @@ function unitDurationTiers(
   tiers: NonNullable<ScriptReviewState["duration_tiers"]> | null,
 ): number[] | null {
   if (!tiers) return null;
-  const hasReferences = extractMentions(unit.scriptText).some((name) => Boolean(lookup[normalizeAssetName(name)]));
+  const hasReferences = extractMentions(unit.scriptText).some((name) => Boolean(lookup[name]));
   return hasReferences ? tiers.with_references : tiers.without_references;
 }
 

--- a/frontend/src/hooks/useShotPromptHighlight.test.ts
+++ b/frontend/src/hooks/useShotPromptHighlight.test.ts
@@ -134,8 +134,8 @@ describe("tokenizePrompt", () => {
 
   it("resolves a mention typed in NFD against a lookup already normalized to NFC by the caller", () => {
     // MentionLookup 的契约：caller 构建时先归一 key（见类型上方注释）。这里模拟 prompt 里的
-    // mention 文本本身是 NFD（输入法产出）——lookup 侧已是 NFC，两侧不同源，查询侧须归一
-    // 后再查，否则命中不了。
+    // mention 文本本身是 NFD（输入法产出）——lookup 侧已是 NFC，两侧不同源，靠解析器输出
+    // 规范形落到同一坐标系才命中。
     const nameNfc = "Hiếu".normalize("NFC");
     const nameNfd = "Hiếu".normalize("NFD");
     expect(nameNfc).not.toBe(nameNfd);
@@ -164,14 +164,22 @@ describe("toScriptLines shot attribution", () => {
     expect(lines.map((l) => l.shotIndex)).toEqual([1]);
   });
 
-  it("resolves a dialogue speaker typed in NFD against a lookup already normalized to NFC by the caller", () => {
+  it("emits a dialogue speaker typed in NFD as NFC and resolves it against the lookup", () => {
     const nameNfc = "Hiếu".normalize("NFC");
     const nameNfd = "Hiếu".normalize("NFD");
     expect(nameNfc).not.toBe(nameNfd);
     const lookup: MentionLookup = { [nameNfc]: "character" };
     const lines = toScriptLines(`@[${nameNfd}]：{我来了}`, lookup);
     expect(lines).toEqual([
-      { kind: "dialogue", shotIndex: 1, sourceLine: 0, speaker: nameNfd, speakerKind: "character", text: "我来了" },
+      { kind: "dialogue", shotIndex: 1, sourceLine: 0, speaker: nameNfc, speakerKind: "character", text: "我来了" },
+    ]);
+  });
+
+  it("resolves a BOM-laced speaker and renders the name without it", () => {
+    // 与后端 shot_parser 同口径：BOM 在解析入口去掉，说话人名与 lookup key 同坐标系
+    const lines = toScriptLines(`@[张${"\uFEFF"}三]：{我来了}`, LOOKUP);
+    expect(lines).toEqual([
+      { kind: "dialogue", shotIndex: 1, sourceLine: 0, speaker: "张三", speakerKind: "character", text: "我来了" },
     ]);
   });
 });

--- a/frontend/src/hooks/useShotPromptHighlight.ts
+++ b/frontend/src/hooks/useShotPromptHighlight.ts
@@ -18,6 +18,12 @@ import {
  * - _MENTION_RE:     shared via reference-mentions.MENTION_RE
  *
  * Output tokens are non-overlapping and concatenate back to the original text.
+ *
+ * 匹配跑在原始文本上——token 要逐字拼回原文覆盖在 textarea 上，源文本不能归一——只有
+ * `mentionNameFromMatch` 取出的 `name` 是规范形。据此留一处残留：BOM 落在裸提及内部
+ * （`@张<U+FEFF>三`）时 `MENTION_RE` 的裸名字符类不含 U+FEFF，高亮只认到 BOM 之前那截、
+ * 判它未登记。参考图派生走 `extractMentions`（行已归一）不受影响，两者只在编辑器着色上
+ * 不一致；包裹形 `@[名<U+FEFF>称]` 无此残留——BOM 在方括号内，名字整取后再归一。
  */
 
 /**

--- a/frontend/src/hooks/useShotPromptHighlight.ts
+++ b/frontend/src/hooks/useShotPromptHighlight.ts
@@ -7,7 +7,6 @@ import {
   matchDialogueLine,
   matchVoiceoverLine,
   mentionNameFromMatch,
-  normalizeAssetName,
   splitScriptLines,
 } from "@/utils/reference-mentions";
 
@@ -22,9 +21,9 @@ import {
  */
 
 /**
- * key 一律是归一后的资产名（callers 构建时须先 `normalizeAssetName`），查询侧
- * （`pushMentionTokens` / `toScriptLines`）同样归一后再查——mention/说话人取自 prompt
- * 原始文本，与登记侧字节形式可能不同，两侧不同源同一坐标系才能稳定命中。
+ * key 一律是归一后的资产名（callers 构建时须先 `normalizeAssetName`）。查询侧不再补归一：
+ * mention 名与说话人都出自 `reference-mentions` 的解析原语，已承诺是规范形——两侧不同源，
+ * 同一坐标系才能稳定命中。
  */
 export type MentionLookup = Record<string, "character" | "scene" | "prop">;
 
@@ -76,7 +75,7 @@ function pushMentionTokens(out: Token[], text: string, lookup: MentionLookup): v
     if (idx > lastIdx) {
       out.push({ kind: "text", text: text.slice(lastIdx, idx) });
     }
-    const name = normalizeAssetName(mentionNameFromMatch(m));
+    const name = mentionNameFromMatch(m);
     // hasOwn 而非直接下标：`toString` 等原型链属性是合法资产名，未登记时下标会取到
     // Object.prototype 上的函数并被当成已解析的类型。
     const resolved = Object.hasOwn(lookup, name) ? lookup[name] : undefined;
@@ -167,7 +166,7 @@ export function toScriptLines(text: string, lookup: MentionLookup): ScriptLine[]
         speaker: dialogue.speaker,
         // Only a registered character can be a speaker — a scene or prop name in the
         // speaker slot reads as unresolved here, matching the backend's warning.
-        speakerKind: lookup[normalizeAssetName(dialogue.speaker)] === "character" ? "character" : "unknown",
+        speakerKind: lookup[dialogue.speaker] === "character" ? "character" : "unknown",
         text: dialogue.text,
       });
       continue;

--- a/frontend/src/utils/reference-mentions.test.ts
+++ b/frontend/src/utils/reference-mentions.test.ts
@@ -56,6 +56,61 @@ describe("extractMentions", () => {
   });
 });
 
+describe("parser output is normalized", () => {
+  // 解析器承诺输出规范形（NFC + 去 BOM），与后端 shot_parser._normalize_source 同口径：
+  // 调用方拿到的名字可直接与已归一的资产表 key 判等，不再各自补归一。
+  const nameNfc = "Hiếu".normalize("NFC");
+  const nameNfd = "Hiếu".normalize("NFD");
+  const BOM = "\uFEFF";
+
+  it("has distinct NFC / NFD byte forms in the fixtures", () => {
+    expect(nameNfc).not.toBe(nameNfd);
+  });
+
+  it("emits NFC mention names regardless of the encoding written in the text", () => {
+    expect(extractMentions(`镜头1：@[${nameNfd}] 登场`)).toEqual([nameNfc]);
+  });
+
+  it("dedupes mentions across NFC / NFD spellings of the same asset", () => {
+    expect(extractMentions(`@[${nameNfc}] 与 @[${nameNfd}]`)).toEqual([nameNfc]);
+  });
+
+  it("strips BOM from inside a mention name", () => {
+    // `@[名<BOM>称]` 类粘贴产物：后端解析入口去 BOM，前端不去就会判未登记，预览与生成结果不一致
+    expect(extractMentions(`镜头1：@[张${BOM}三] 抬眼`)).toEqual(["张三"]);
+    expect(extractMentions(`${BOM}@[张三] 抬眼`)).toEqual(["张三"]);
+  });
+
+  it("reads a line as a normative dialogue line despite BOM and NFD", () => {
+    expect(matchDialogueLine(`${BOM}@[张${BOM}三]：{我${BOM}来了}`)).toEqual({
+      speaker: "张三",
+      text: "我来了",
+    });
+    expect(matchDialogueLine(`@[${nameNfd}]：{我来了}`)).toEqual({ speaker: nameNfc, text: "我来了" });
+  });
+
+  it("reads a bare braces line as voiceover despite BOM", () => {
+    expect(matchVoiceoverLine(`${BOM}{那年冬天}`)).toBe("那年冬天");
+  });
+
+  it("keeps a BOM-laced speaker slot out of mention extraction", () => {
+    // BOM 让前端判规范行、后端判描述行时，说话人是否进参考图两侧结论相反
+    expect(extractMentions(`@[张${BOM}三]：{我来了}`)).toEqual([]);
+  });
+
+  it("emits normalized script lines", () => {
+    expect(splitScriptLines(`${BOM}镜头1：中景\n@[${nameNfd}]：{我来了}`)).toEqual([
+      "镜头1：中景",
+      `@[${nameNfc}]：{我来了}`,
+    ]);
+  });
+
+  it("resolves a BOM-laced mention against the registered bucket", () => {
+    const merged = mergeReferences(`镜头1：@[张${BOM}三] 抬眼`, [], mkProject());
+    expect(merged).toEqual([{ type: "character", name: "张三" }]);
+  });
+});
+
 describe("resolveMentionType", () => {
   const project = mkProject();
 

--- a/frontend/src/utils/reference-mentions.ts
+++ b/frontend/src/utils/reference-mentions.ts
@@ -21,8 +21,35 @@ import type { AssetKind, ReferenceResource } from "@/types/reference-video";
  */
 export const MENTION_RE = /(?<!\w)@(?:\[([^\]\r\n]+)\]|([\w\u4e00-\u9fff]+))/g;
 
+/**
+ * BOM / ZWNBSP。镜像后端 `shot_parser._BOM`：正文里它没有语义，却让按字节走的判定分叉
+ * ——JS 的 `\s` 认它、Python 的 `str.strip()` 不认，带 BOM 的行在前端算规范台词行、在
+ * 后端算描述行，说话人是否进参考图两侧结论相反。
+ */
+const BOM_RE = /\uFEFF/gu;
+
+/**
+ * 书写层文本的入口归一：去掉全部 U+FEFF，并把编码形式收敛到 Unicode NFC。镜像后端
+ * `lib/reference_video/shot_parser.py::_normalize_source`——两条派生路径同口径。
+ *
+ * 两者同一性质：屏幕上看不见的字节差异，却让按字节走的判定分叉，故合并在一个入口处理。
+ * BOM 不止出现在文档开头，粘贴拼接会把它带到任意行首，而分叉是按行发生的；NFC 则是资产名
+ * 比对的坐标系（见 {@link normalizeAssetName}），正文以 NFD 书写、资产表以 NFC 登记时肉眼
+ * 同字却判不相等。
+ *
+ * 归一落在解析入口而非提取结果上：BOM 落在名字内部（`@[名<U+FEFF>称]`）时，逐名补归一修不了——
+ * 匹配已经按含 BOM 的字节做完了。
+ */
+function normalizeSource(text: string): string {
+  return text.replace(BOM_RE, "").normalize("NFC");
+}
+
+/**
+ * 从 mention 匹配取名字。归一在此完成而非交给调用方：高亮分词器（`tokenizePrompt`）要
+ * 逐字拼回原文、不能归一源文本，只有名字这一路出得来规范形。
+ */
 export function mentionNameFromMatch(match: RegExpMatchArray): string {
-  return match[1] ?? match[2] ?? "";
+  return normalizeSource(match[1] ?? match[2] ?? "");
 }
 
 /**
@@ -50,13 +77,14 @@ function hasSpokenText(text: string): boolean {
 export const LINE_BREAK_RE = /(\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029])/;
 
 /**
- * 按后端同一套换行边界切行（不保留分隔符）。
+ * 按后端同一套换行边界切行（不保留分隔符），行内容已是规范形（见 `normalizeSource`）。
  *
  * 末尾换行不产生空行、空串切出空数组——都与 `splitlines()` 一致；行中间的空行照常保留。
+ * 归一不增删换行，行数与下标（`toScriptLines` 的 `sourceLine`）与原文逐行对应。
  */
 export function splitScriptLines(text: string): string[] {
   if (text.length === 0) return [];
-  const lines = text.split(LINE_BREAK_RE).filter((_, i) => i % 2 === 0);
+  const lines = normalizeSource(text).split(LINE_BREAK_RE).filter((_, i) => i % 2 === 0);
   if (lines[lines.length - 1] === "") lines.pop();
   return lines;
 }
@@ -88,7 +116,7 @@ export function formatShotHeader(shotIndex: number): string {
 const VOICEOVER_LINE_RE = /^\s*\{([^{}]*)\}\s*$/;
 
 export function matchDialogueLine(line: string): { speaker: string; text: string } | null {
-  const m = DIALOGUE_LINE_RE.exec(line);
+  const m = DIALOGUE_LINE_RE.exec(normalizeSource(line));
   if (!m) return null;
   const speaker = m[1] ?? m[2] ?? "";
   // speaker 位全为空白不算规范行（同 shot_parser.py：dialogue utterance 必须带非空 speaker）。
@@ -97,7 +125,7 @@ export function matchDialogueLine(line: string): { speaker: string; text: string
 }
 
 export function matchVoiceoverLine(line: string): string | null {
-  const m = VOICEOVER_LINE_RE.exec(line);
+  const m = VOICEOVER_LINE_RE.exec(normalizeSource(line));
   if (!m || !hasSpokenText(m[1])) return null;
   return m[1];
 }
@@ -107,6 +135,8 @@ export function matchVoiceoverLine(line: string): string | null {
  * derivation. Mirrors `shot_parser.py:extract_mentions`, including its rule that
  * **normative dialogue lines are skipped entirely**: attaching a reference image to
  * a speaker would coax the model into drawing a character who only speaks off-screen.
+ *
+ * 名字一律是规范形，去重也按规范形——调用方直接拿去与已归一的资产表 key 判等，不再补归一。
  */
 export function extractMentions(text: string): string[] {
   const seen = new Set<string>();
@@ -171,10 +201,9 @@ export function mergeReferences(
   existing: ReferenceResource[],
   project: ProjectBuckets | null | undefined,
 ): ReferenceResource[] {
-  // mention 与既有 references 的名字都归一到比对坐标系再判等/去重——两侧字节形式可能不同
-  // （既有 references 出自后端已归一的落盘值，mention 出自 prompt 文本解析，来源不同）；
-  // 输出的 name 同样落成归一形式，与后端 `resolve_references` 的产出口径一致。
-  const mentioned = new Set(extractMentions(prompt).map(normalizeAssetName));
+  // mention 名出自解析器、已是规范形；既有 references 出自后端落盘值，来源不同故仍需归一后
+  // 再判等/去重。输出的 name 一律是规范形，与后端 `resolve_references` 的产出口径一致。
+  const mentioned = new Set(extractMentions(prompt));
   const kept: ReferenceResource[] = [];
   const keptNames = new Set<string>();
   for (const ref of existing) {


### PR DESCRIPTION
Closes #1651

## 改动

提及解析器改为承诺输出规范形（NFC + 去 U+FEFF），归一落在解析入口而非交给调用方善后，与后端 `lib/reference_video/shot_parser.py::_normalize_source` 同口径。

- `reference-mentions.ts` 新增私有 `normalizeSource()`，落在 `splitScriptLines` / `matchDialogueLine` / `matchVoiceoverLine` / `mentionNameFromMatch` 四个解析原语上——与后端把归一落在同名行级原语的做法逐一对应
- 删除三个调用方的补救归一（`pushMentionTokens` / `toScriptLines` 的说话人位、`deriveDisplayReferences`、`unitDurationTiers`、`mergeReferences` 的 mention 侧）与 `deriveDisplayReferences` 的防御性二次去重，生产代码净减
- 用户可感知的修复：`@[名﻿称]` 这类带 BOM 的粘贴产物，此前前端判未登记、后端判已登记，预览显示的参考图与实际生成结果不一致；现在两侧结论一致

## 验证

- `pnpm lint` / `pnpm check`（typecheck + 全量 vitest）：**142 文件 / 1664 用例全通过**，已 rebase 到 `origin/main`=a731c522（含模型列表文案测试的 hotfix）
- 新增 `reference-mentions.test.ts` 的 `parser output is normalized` 一节：NFC/NFD 收敛、跨编码去重、BOM 落在名字内部 / 行首 / 说话人位、`splitScriptLines` 输出规范形、带 BOM 的名字仍能解析到已登记资产
- `useShotPromptHighlight.test.ts` 原「说话人保持 NFD」断言改为断言输出 NFC，另补带 BOM 的说话人用例
- 前后端逐输入对照：11 组混用 NFC/NFD 与 BOM 的样本（含 `@张<BOM>三`、`@<BOM>张三`、`﻿{画外音}`、header 同行台词、`@[ ]：{台词}`）在 `extract_mentions` / `match_dialogue_line` / `match_voiceover_line` / 逐行剥 header 四项上前后端输出完全一致

## 两处刻意的取舍

- **不额外 `strip` 提取出的名字**。issue 把规范形写作「NFC、去 BOM、strip」，实现只做前两项：后端 `_iter_mentions` 同样不 strip 名字（`@[ ]：{台词}` 两侧都产 `[" "]`，有既有回归测试锁定），补 strip 反而新造一处前后端分叉。行级空白照旧由既有的 `\s*` / `.trim()` 处理。
- **高亮分词器 `tokenizePrompt` 仍在原始文本上匹配**。它的 token 要逐字拼回原文覆盖在 textarea 上，源文本不能归一，只有取出的 `name` 出规范形。残留：BOM 落在裸提及内部（`@张<BOM>三`）时高亮只认到 BOM 之前那截、判它未登记——参考图派生走 `extractMentions`（行已归一）不受影响，两者只在编辑器着色上不一致。已在 `useShotPromptHighlight.ts` 的函数注释里写明约束与残留形态。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化引用与脚本解析，统一处理 Unicode 字符名称，避免同名资源重复显示。
  * 修复包含 BOM/ZWNBSP 字符的说话人、旁白及提及解析问题。
  * 改善编辑器高亮与已登记角色、资源的匹配准确性。

* **Tests**
  * 补充 Unicode 归一化、BOM 清理及引用合并场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->