### PR TITLE
refactor(参考视频): 声音档收为渲染入口必填，杜绝无声项目被按有声渲染

### DIFF
--- a/lib/reference_video/prompt_render.py
+++ b/lib/reference_video/prompt_render.py
@@ -104,7 +104,7 @@ def render_unit_prompt(
     text: str,
     project: dict,
     references: list[ReferenceResource],
-    settings: VoiceRenderSettings | None = None,
+    settings: VoiceRenderSettings,
     *,
     style: str | None = None,
 ) -> RenderedUnitPrompt:
@@ -116,7 +116,9 @@ def render_unit_prompt(
     由上游持久化，本函数只消费不重算。
 
     ``settings`` 是本次渲染的声音输入档（见 :class:`~lib.reference_video.voice_settings
-    .VoiceRenderSettings`）。``requires_reference_image`` 为 True 时（backend 要求音频逐段挂在
+    .VoiceRenderSettings`），必填无兜底：这一档决定这一集听不听得到声音，缺省成任何一个方向都是
+    替调用方猜——猜有声会给无声项目注入声音特征，漏传时报错才让新调用方在接线阶段就发现。
+    ``requires_reference_image`` 为 True 时（backend 要求音频逐段挂在
     具体参考素材项上），纯画外 speaker 不绑定音频（降级 + warning）——绑定后 ``@音频N`` 编号会
     写进 prompt 文本，若随后才在 backend 层过滤会让文本承诺的绑定与实际发出的
     ``reference_audio_files`` 分叉，必须在编号生成前就排除。
@@ -127,7 +129,6 @@ def render_unit_prompt(
 
     warning 与解析预览面板同一批 ``{key, params}`` 条目，由调用方并入任务 ``result.warnings``。
     """
-    settings = settings or VoiceRenderSettings()
     shots, mentions = parse_prompt(text)
     utterances, warnings = derive_utterances(shots)
 
@@ -334,7 +335,7 @@ def render_ad_backend_prompt(
     shots: list[dict],
     entries: list[dict],
     project: dict,
-    settings: VoiceRenderSettings | None = None,
+    settings: VoiceRenderSettings,
     *,
     style: str | None = None,
 ) -> RenderedUnitPrompt:
@@ -352,14 +353,14 @@ def render_ad_backend_prompt(
     只接管第一、三段与音频接线，故调用 ``render_ad_unit_prompt`` 时传 ``style=None``。
 
     ``entries`` 是本次实际随请求发出的参考条目（已按能力上限裁剪），其顺序即 ``图片N``
-    编号——与调用方组装的 ``reference_images`` 严格等长同序。
+    编号——与调用方组装的 ``reference_images`` 严格等长同序。``settings`` 同 :func:`render_unit_prompt`
+    必填无兜底。
 
     Raises:
         ValueError: 成员镜头全无画面内容（第二段渲染为空）——同
             :func:`lib.reference_video.ad_units.render_ad_unit_prompt` 的口径，防止机器生成的
             第一/三段把空提示词撑成非空文本绕过 backend 的空值保护。
     """
-    settings = settings or VoiceRenderSettings()
     body = render_ad_unit_prompt(shots, style=None)
     if not body.strip():
         raise ValueError("reference video unit prompt is empty: all member shots have no visual content")

--- a/lib/reference_video/script_preview.py
+++ b/lib/reference_video/script_preview.py
@@ -211,14 +211,14 @@ def derive_voice_bindings(
 def build_script_preview(
     text: str,
     project: dict,
-    settings: VoiceRenderSettings | None = None,
+    settings: VoiceRenderSettings,
     *,
     max_reference_images: int | None = None,
 ) -> ScriptPreview:
     """把书写文稿派生成 shots / references / utterances + 降级可见性 warning。
 
-    ``settings`` 须与执行层（``render_unit_prompt``）拿到的同一份声音输入档同步，否则预览会
-    显示音频已绑定、实际请求却不带音频段。其中 ``requires_reference_image``（目标 backend 是否
+    ``settings`` 必填无兜底（同 ``render_unit_prompt``），须与执行层拿到的同一份声音输入档同步，
+    否则预览会显示音频已绑定、实际请求却不带音频段。其中 ``requires_reference_image``（目标 backend 是否
     要求音频逐段挂图）不涉及 IO，预览虽不碰文件系统也须一并同步，遗漏会让预览显示已绑定、
     执行时才降级，用户直到生成后才发现声音没生效。``settings.audio_ready`` 在预览侧留 None：
     预览不解析文件，按角色资产的 ``reference_audio`` 字段非空判定。
@@ -246,7 +246,7 @@ def build_script_preview(
     bindings = derive_voice_bindings(
         utterances,
         project.get(BUCKET_KEY["character"]) or {},
-        settings or VoiceRenderSettings(),
+        settings,
         speakers_with_reference_image=character_image_names,
     )
     warnings.extend(bindings.warnings)

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -567,10 +567,12 @@ class ReferenceSplitCaps(NamedTuple):
     可能合法；归属哪一套要等正文派生出 references 才知道。三者相等即该型号在当前分辨率下未声明
     生效的「参考图↔时长」联动约束，多数型号如此。
 
-    ``voice`` 是同一次能力解析派生出的声音输入档（故障回退时按 ``VoiceRenderSettings.from_caps``
-    的空 dict 口径），供声音相关的容忍 warning 消费——与时长档位同源于这一次解析，分两次查会让
-    同一份产物的档位与声音提示描述不同时刻的配置。携带值对象而非原始能力 dict：下游只需要声音那
-    几位，穿一整个 dict 过接口会把能力 key 名耦合扩散到消费侧。
+    ``voice`` 是同一次能力解析派生出的声音输入档，供声音相关的容忍 warning 消费——与时长档位同源
+    于这一次解析，分两次查会让同一份产物的档位与声音提示描述不同时刻的配置。能力解析故障回退时
+    档位相关的几位落到 ``VoiceRenderSettings`` 的字段默认，唯 ``requested_generate_audio`` 仍带着
+    本集的无声意图（该位不依赖能力接口，回退分支独立解析后写回，见
+    ``_fetch_reference_caps_with_fallback``）。携带值对象而非原始能力 dict：下游只需要声音那几位，
+    穿一整个 dict 过接口会把能力 key 名耦合扩散到消费侧。
     """
 
     default_duration: int | None

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -560,17 +560,17 @@ def normalize_drama_script_tool(ctx: ToolContext):
 
 
 class ReferenceSplitCaps(NamedTuple):
-    """rv 拆分用的视频能力：两套逐 unit 档位 + 派生上限 + 用户偏好 + 原始能力 dict。
+    """rv 拆分用的视频能力：两套逐 unit 档位 + 派生上限 + 用户偏好 + 声音输入档。
 
     ``reference_durations`` / ``text_durations`` 是带 / 不带 ``@`` 引用的 unit 各自的生效档位，
     ``durations`` 是二者的并集——schema 枚举与 prompt 候选集合取并集，因为落在任一套内的时长都
     可能合法；归属哪一套要等正文派生出 references 才知道。三者相等即该型号在当前分辨率下未声明
     生效的「参考图↔时长」联动约束，多数型号如此。
 
-    ``raw`` 是解析到的原始能力 dict（故障回退时为空 dict），供声音相关的容忍 warning 取
-    ``voice_consistency`` / ``max_reference_audio_count`` / ``requested_generate_audio`` /
-    ``model``——它们与时长档位同源于这一次解析，分两次查会让同一份产物的档位与声音提示描述
-    不同时刻的配置。
+    ``voice`` 是同一次能力解析派生出的声音输入档（故障回退时按 ``VoiceRenderSettings.from_caps``
+    的空 dict 口径），供声音相关的容忍 warning 消费——与时长档位同源于这一次解析，分两次查会让
+    同一份产物的档位与声音提示描述不同时刻的配置。携带值对象而非原始能力 dict：下游只需要声音那
+    几位，穿一整个 dict 过接口会把能力 key 名耦合扩散到消费侧。
     """
 
     default_duration: int | None
@@ -579,7 +579,7 @@ class ReferenceSplitCaps(NamedTuple):
     text_durations: list[int]
     max_duration: int
     max_refs: int | None
-    raw: dict[str, Any]
+    voice: VoiceRenderSettings
 
     def tiers_for(self, *, has_references: bool) -> list[int]:
         """该引用状态下的生效档位。"""
@@ -637,7 +637,7 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any], episode: 
         text_durations=sorted(set(without_refs)),
         max_duration=max_duration,
         max_refs=max_refs,
-        raw=caps,
+        voice=VoiceRenderSettings.from_caps(caps),
     )
 
 
@@ -750,7 +750,9 @@ _TOLERATED_VOICE_WARNINGS = (
 )
 
 
-def _reference_voice_warning_lines(unit_texts: list[str], project: dict[str, Any], caps: dict[str, Any]) -> list[str]:
+def _reference_voice_warning_lines(
+    unit_texts: list[str], project: dict[str, Any], voice: VoiceRenderSettings
+) -> list[str]:
     """逐 unit 派生声音绑定，取容忍类 warning 的渲染文本（跨 unit 去重、保持首现顺序）。
 
     逐 unit 而非把全集正文拼起来判：unit 就是一次生成调用，参考音频段数上限按调用计——拼起来
@@ -763,7 +765,7 @@ def _reference_voice_warning_lines(unit_texts: list[str], project: dict[str, Any
     段数上限」这些该让 agent 看见的提示反被吞掉。
     """
     characters = project.get(BUCKET_KEY["character"]) or {}
-    settings = replace(VoiceRenderSettings.from_caps(caps), requires_reference_image=False)
+    settings = replace(voice, requires_reference_image=False)
     seen: set[tuple[str, str]] = set()
     lines: list[str] = []
     for text in unit_texts:
@@ -941,7 +943,7 @@ async def _promote_reference_step1(ctx: ToolContext, episode: int, draft: Quaran
             "content": [{"type": "text", "text": _render_step1_conflict_report(episode, draft, conflict)}],
             "is_error": True,
         }
-    warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.raw)
+    warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.voice)
     return {
         "content": [{"type": "text", "text": _reference_result_text(step1_path, units, warning_lines, action="晋升")}]
     }
@@ -1289,7 +1291,7 @@ def split_reference_video_units_tool(ctx: ToolContext):
             with script_review.step1_write_lock(project_path, episode) as step1_path:
                 script_review.write_step1_locked(project_path, episode, {"units": raw_units})
                 clear_quarantine(project_path, episode, QUARANTINE_KIND_STEP1)
-            warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.raw)
+            warning_lines = _reference_voice_warning_lines([f["text"] for f in flat_units], project, split_caps.voice)
             return {
                 "content": [
                     {

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,6 +7,10 @@ Single-file fakes stay in their respective test modules.
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.reference_video.voice_settings import VoiceRenderSettings
 
 
 class FakeSDKClient:
@@ -188,7 +192,7 @@ def fake_reference_caps_fetcher(
     text_durations: tuple[int, ...] | None = None,
     max_duration: int = 12,
     max_refs: int | None = 3,
-    voice=None,
+    voice: VoiceRenderSettings | None = None,
 ):
     """假 ``_fetch_reference_caps_with_fallback``：返回一份 ``ReferenceSplitCaps`` 的 async 取值器。
 
@@ -197,8 +201,9 @@ def fake_reference_caps_fetcher(
     （``soft`` 有声、无参考音频）。
 
     被 monkeypatch 的目标签名带 episode 位，故取值器收两参——多数用例只关心返回值。
-    ``ReferenceSplitCaps`` 在函数体内导入：它出自 server 侧的 SDK 工具模块，本模块的其余替身不
-    依赖 server 包，不为一个替身把该依赖提到导入期。
+    运行期用到的两个类型在函数体内导入：它们出自 lib / server 侧的业务模块，本模块的其余替身不
+    依赖这两个包，不为一个替身把依赖提到导入期（签名上的标注由 ``from __future__`` 延迟求值，
+    经 ``TYPE_CHECKING`` 供类型检查器读取）。
     """
     from lib.reference_video.voice_settings import VoiceRenderSettings
     from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
@@ -211,7 +216,7 @@ def fake_reference_caps_fetcher(
             text_durations=list(durations if text_durations is None else text_durations),
             max_duration=max_duration,
             max_refs=max_refs,
-            voice=voice or VoiceRenderSettings(),
+            voice=VoiceRenderSettings() if voice is None else voice,
         )
 
     return _fetch

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -178,3 +178,40 @@ class FakeImageBackend:
             provider=self._provider,
             model=self._model,
         )
+
+
+def fake_reference_caps_fetcher(
+    *,
+    default_duration: int | None = 4,
+    durations: tuple[int, ...] = (4, 6, 8),
+    reference_durations: tuple[int, ...] | None = None,
+    text_durations: tuple[int, ...] | None = None,
+    max_duration: int = 12,
+    max_refs: int | None = 3,
+    voice=None,
+):
+    """假 ``_fetch_reference_caps_with_fallback``：返回一份 ``ReferenceSplitCaps`` 的 async 取值器。
+
+    ``reference_durations`` / ``text_durations`` 留 None 即与 ``durations`` 同集（该型号未声明
+    生效的「参考图↔时长」联动约束）；``voice`` 留 None 取 ``VoiceRenderSettings`` 的字段默认
+    （``soft`` 有声、无参考音频）。
+
+    被 monkeypatch 的目标签名带 episode 位，故取值器收两参——多数用例只关心返回值。
+    ``ReferenceSplitCaps`` 在函数体内导入：它出自 server 侧的 SDK 工具模块，本模块的其余替身不
+    依赖 server 包，不为一个替身把该依赖提到导入期。
+    """
+    from lib.reference_video.voice_settings import VoiceRenderSettings
+    from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
+
+    async def _fetch(_project, _episode=None) -> ReferenceSplitCaps:
+        return ReferenceSplitCaps(
+            default_duration=default_duration,
+            durations=list(durations),
+            reference_durations=list(durations if reference_durations is None else reference_durations),
+            text_durations=list(durations if text_durations is None else text_durations),
+            max_duration=max_duration,
+            max_refs=max_refs,
+            voice=voice or VoiceRenderSettings(),
+        )
+
+    return _fetch

--- a/tests/lib/test_reference_video_prompt_render.py
+++ b/tests/lib/test_reference_video_prompt_render.py
@@ -51,6 +51,11 @@ def _refs(*pairs):
     return [ReferenceResource(type=t, name=n) for t, n in pairs]
 
 
+#: 与声音无关的用例用的声音档：``soft`` 有声、无参考音频。渲染入口的 ``settings`` 必填，
+#: 这些用例照样要给一档，取字段默认即可。
+_SOFT = VoiceRenderSettings()
+
+
 _TEXT = "\n".join(
     [
         "镜头1：夜色下的 @[酒馆]，@[张三] 推门而入，手按 @[长剑]。",
@@ -223,12 +228,12 @@ def test_speaker_without_reference_audio_warns_and_keeps_voice_style():
 
 
 def test_voiceover_line_renders_as_offscreen_speech():
-    rendered = render_unit_prompt("镜头1：空镜。\n{多年以后他仍记得这句话。}", _project(), [])
+    rendered = render_unit_prompt("镜头1：空镜。\n{多年以后他仍记得这句话。}", _project(), [], _SOFT)
     assert "画外音说 {多年以后他仍记得这句话。}" in rendered.prompt
 
 
 def test_unregistered_speaker_line_is_sent_verbatim_with_warning():
-    rendered = render_unit_prompt("镜头1：黑场。\n@[路人]：{你好。}", _project(), [])
+    rendered = render_unit_prompt("镜头1：黑场。\n@[路人]：{你好。}", _project(), [], _SOFT)
     assert "@[路人]：{你好。}" in rendered.prompt
     assert "说 {你好。}" not in rendered.prompt
     assert {"key": WARN_UNREGISTERED_SPEAKER, "params": {"name": "路人"}} in rendered.warnings
@@ -236,7 +241,7 @@ def test_unregistered_speaker_line_is_sent_verbatim_with_warning():
 
 def test_clipped_reference_still_renders_as_subject():
     """被能力上限裁掉参考图的已登记名字仍是画面主体：渲染 <X>，不把编辑器语法发给模型。"""
-    rendered = render_unit_prompt(_TEXT, _project(), _refs(("scene", "酒馆")))
+    rendered = render_unit_prompt(_TEXT, _project(), _refs(("scene", "酒馆")), _SOFT)
     assert "@[张三]" not in rendered.prompt
     assert "@[长剑]" not in rendered.prompt
     assert "<张三> 推门而入，手按 <长剑>。" in rendered.prompt
@@ -246,19 +251,21 @@ def test_clipped_reference_still_renders_as_subject():
 
 
 def test_unregistered_mention_kept_verbatim_with_warning():
-    rendered = render_unit_prompt("镜头1：@[未知资产] 出现。", _project(), [])
+    rendered = render_unit_prompt("镜头1：@[未知资产] 出现。", _project(), [], _SOFT)
     assert "@[未知资产]" in rendered.prompt
     assert {"key": WARN_UNREGISTERED_MENTION, "params": {"name": "未知资产"}} in rendered.warnings
 
 
 def test_unclosed_brace_line_sent_verbatim_with_warning():
-    rendered = render_unit_prompt("镜头1：@[张三] 开口。\n@[张三]：{没有闭合", _project(), _refs(("character", "张三")))
+    rendered = render_unit_prompt(
+        "镜头1：@[张三] 开口。\n@[张三]：{没有闭合", _project(), _refs(("character", "张三")), _SOFT
+    )
     assert "{没有闭合" in rendered.prompt
     assert any(w["key"] == WARN_UNCLOSED_BRACE for w in rendered.warnings)
 
 
 def test_legend_and_absolute_seconds_are_gone():
-    rendered = render_unit_prompt(_TEXT, _project(), _refs(("character", "张三")), style="写实电影感")
+    rendered = render_unit_prompt(_TEXT, _project(), _refs(("character", "张三")), _SOFT, style="写实电影感")
     assert "[图" not in rendered.prompt
     assert "参考图对照" not in rendered.prompt
     assert "禁止出现：BGM、文字字幕、水印。" not in rendered.prompt
@@ -266,7 +273,7 @@ def test_legend_and_absolute_seconds_are_gone():
 
 
 def test_third_segment_anchors_style_and_constraint_packs():
-    rendered = render_unit_prompt("镜头1：空镜。", _project(), [], style="写实电影感")
+    rendered = render_unit_prompt("镜头1：空镜。", _project(), [], _SOFT, style="写实电影感")
     assert "整体视觉风格：写实电影感。" in rendered.prompt
     assert "保持无字幕" in rendered.prompt
     assert "不要生成水印" in rendered.prompt
@@ -274,12 +281,13 @@ def test_third_segment_anchors_style_and_constraint_packs():
 
 
 def test_twin_guard_only_when_two_or_more_character_images():
-    single = render_unit_prompt("镜头1：@[张三] 独行。", _project(), _refs(("character", "张三")))
+    single = render_unit_prompt("镜头1：@[张三] 独行。", _project(), _refs(("character", "张三")), _SOFT)
     assert "双胞胎" not in single.prompt
     both = render_unit_prompt(
         "镜头1：@[张三] 与 @[李四] 对峙。",
         _project(),
         _refs(("character", "张三"), ("character", "李四")),
+        _SOFT,
     )
     assert "双胞胎" in both.prompt
 

--- a/tests/lib/test_reference_video_prompt_render_ad.py
+++ b/tests/lib/test_reference_video_prompt_render_ad.py
@@ -20,6 +20,10 @@ from lib.reference_video.voice_settings import VoiceRenderSettings
 
 pytestmark = pytest.mark.unit
 
+#: 与声音无关的用例用的声音档：``soft`` 有声、无参考音频。渲染入口的 ``settings`` 必填，
+#: 这些用例照样要给一档，取字段默认即可。
+_SOFT = VoiceRenderSettings()
+
 
 def _project(**overrides):
     project = {
@@ -65,7 +69,7 @@ def test_subject_binding_uses_entry_labels_positionally():
         _entry("小美", "角色「小美」设计图"),
     ]
 
-    rendered = render_ad_backend_prompt(shots, entries, _project())
+    rendered = render_ad_backend_prompt(shots, entries, _project(), _SOFT)
 
     assert "<产品「按摩仪」标准多角度参考图>@图片1" in rendered.prompt
     assert "<角色「小美」设计图>@图片2" in rendered.prompt
@@ -163,7 +167,7 @@ def test_silent_paths_keep_shot_segment_identical_to_audible_path(silencing: dic
 def test_voiceover_text_excluded_ambiance_kept_as_prose():
     shots = [_shot("E1S1")]
 
-    rendered = render_ad_backend_prompt(shots, [], _project())
+    rendered = render_ad_backend_prompt(shots, [], _project(), _SOFT)
 
     assert "口播文案" not in rendered.prompt
     assert "环境音：环境音" in rendered.prompt
@@ -225,7 +229,7 @@ def test_legend_and_negative_tail_are_gone():
     shots = [_shot("E1S1", dialogue=[{"speaker": "小美", "line": "买它"}])]
     entries = [_entry("按摩仪", "产品「按摩仪」标准多角度参考图", kind="sheet")]
 
-    rendered = render_ad_backend_prompt(shots, entries, _project())
+    rendered = render_ad_backend_prompt(shots, entries, _project(), _SOFT)
 
     assert "[图" not in rendered.prompt
     assert "参考图对照" not in rendered.prompt
@@ -235,7 +239,7 @@ def test_legend_and_negative_tail_are_gone():
 def test_third_segment_anchors_style_and_constraint_pack():
     shots = [_shot("E1S1")]
 
-    rendered = render_ad_backend_prompt(shots, [], _project(), style="明亮写实")
+    rendered = render_ad_backend_prompt(shots, [], _project(), _SOFT, style="明亮写实")
 
     assert "整体视觉风格：明亮写实。" in rendered.prompt
     assert "保持无字幕" in rendered.prompt
@@ -245,13 +249,14 @@ def test_third_segment_anchors_style_and_constraint_pack():
 
 def test_twin_guard_only_when_two_or_more_character_images():
     shots = [_shot("E1S1")]
-    single = render_ad_backend_prompt(shots, [_entry("小美", "角色「小美」设计图")], _project())
+    single = render_ad_backend_prompt(shots, [_entry("小美", "角色「小美」设计图")], _project(), _SOFT)
     assert "双胞胎" not in single.prompt
 
     both = render_ad_backend_prompt(
         shots,
         [_entry("小美", "角色「小美」设计图"), _entry("小明", "角色「小明」设计图")],
         _project(),
+        _SOFT,
     )
     assert "双胞胎" in both.prompt
 
@@ -276,7 +281,7 @@ def test_speaker_without_reference_audio_downgrades_and_warns():
 def test_unregistered_speaker_still_renders_with_warning():
     shots = [_shot("E1S1", dialogue=[{"speaker": "路人甲", "line": "哇好厉害"}])]
 
-    rendered = render_ad_backend_prompt(shots, [], _project())
+    rendered = render_ad_backend_prompt(shots, [], _project(), _SOFT)
 
     assert "<路人甲>说 {哇好厉害}" in rendered.prompt
     assert any(w["key"] == WARN_UNREGISTERED_SPEAKER and w["params"]["name"] == "路人甲" for w in rendered.warnings)
@@ -364,7 +369,7 @@ def test_twin_guard_ignores_non_character_reference_images():
         _entry("客厅", "场景「客厅」设计图", asset_type="scene"),
     ]
 
-    rendered = render_ad_backend_prompt(shots, entries, _project())
+    rendered = render_ad_backend_prompt(shots, entries, _project(), _SOFT)
 
     assert "双胞胎" not in rendered.prompt
 
@@ -373,4 +378,4 @@ def test_all_blank_shots_raise_value_error():
     shots = [_shot("E1S1", image_prompt={"scene": ""}, video_prompt={"action": ""})]
 
     with pytest.raises(ValueError, match="no visual content"):
-        render_ad_backend_prompt(shots, [], _project())
+        render_ad_backend_prompt(shots, [], _project(), _SOFT)

--- a/tests/lib/test_reference_video_script_preview.py
+++ b/tests/lib/test_reference_video_script_preview.py
@@ -44,6 +44,10 @@ PROJECT = {
 _NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
 _NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
 
+#: 与声音无关的用例用的声音档：``soft`` 有声、无参考音频。预览入口的 ``settings`` 必填，
+#: 这些用例照样要给一档，取字段默认即可。
+_SOFT = VoiceRenderSettings()
+
 
 def keys(preview) -> list[str]:
     return [w["key"] for w in preview.warnings]
@@ -79,7 +83,7 @@ def test_dialogue_line_rejects_non_normative(line: str):
 
 def test_blank_speaker_degrades_to_warning_instead_of_raising():
     """speaker 位空白不得构造非法 Utterance——只读派生要出 warning，不能抛校验错。"""
-    preview = build_script_preview("镜头1：中景。\n@[ ]：{我来了}", PROJECT)
+    preview = build_script_preview("镜头1：中景。\n@[ ]：{我来了}", PROJECT, _SOFT)
     assert preview.utterances == []
     # 非规范行 → 台词混写 warning；空白名同时作为未登记 mention 被点名。
     assert keys(preview) == [WARN_UNREGISTERED_MENTION, WARN_DIALOGUE_INLINE]
@@ -97,7 +101,7 @@ def test_blank_braces_are_not_utterances(line: str):
 
 
 def test_blank_braces_degrade_to_warning():
-    preview = build_script_preview("镜头1：中景。\n@[张三]：{}\n{   }", PROJECT)
+    preview = build_script_preview("镜头1：中景。\n@[张三]：{}\n{   }", PROJECT, _SOFT)
     assert preview.utterances == []
     assert keys(preview) == [WARN_DIALOGUE_INLINE, WARN_DIALOGUE_INLINE]
 
@@ -107,7 +111,7 @@ def test_blank_braces_degrade_to_warning():
 
 def test_normative_lines_derive_dialogue_and_voiceover():
     text = "镜头1：@[张三] 推门进来。\n@[张三]：{我来了}\n{那年冬天格外冷}\n镜头2：@[李四] 抬眼。\n@[李四]：{你迟到了}"
-    preview = build_script_preview(text, PROJECT)
+    preview = build_script_preview(text, PROJECT, _SOFT)
     assert [(u.shot_index, u.utterance.kind, u.utterance.speaker, u.utterance.text) for u in preview.utterances] == [
         (1, "dialogue", "张三", "我来了"),
         (1, "voiceover", None, "那年冬天格外冷"),
@@ -116,14 +120,14 @@ def test_normative_lines_derive_dialogue_and_voiceover():
 
 
 def test_inline_dialogue_is_not_derived_and_warns():
-    preview = build_script_preview("镜头1：中景，@[张三] 笑着说 {我来了}。", PROJECT)
+    preview = build_script_preview("镜头1：中景，@[张三] 笑着说 {我来了}。", PROJECT, _SOFT)
     assert preview.utterances == []
     assert WARN_DIALOGUE_INLINE in keys(preview)
 
 
 def test_script_without_dialogue_symbols_derives_nothing():
     """存量文稿零迁移：没有台词符号 → utterances 自然为空、无 warning。"""
-    preview = build_script_preview("镜头1：中景，@[张三] 推门进 @[酒馆]。", PROJECT)
+    preview = build_script_preview("镜头1：中景，@[张三] 推门进 @[酒馆]。", PROJECT, _SOFT)
     assert preview.utterances == []
     assert preview.warnings == []
     assert [r.name for r in preview.references] == ["张三", "酒馆"]
@@ -134,7 +138,7 @@ def test_script_without_dialogue_symbols_derives_nothing():
 
 def test_speaker_position_is_excluded_from_references():
     text = "镜头1：@[酒馆] 内景，人声嘈杂。\n@[张三]：{我来了}"
-    preview = build_script_preview(text, PROJECT)
+    preview = build_script_preview(text, PROJECT, _SOFT)
     assert [r.name for r in preview.references] == ["酒馆"]
     # 纯画外角色没有参考图，但 utterance 照常
     assert [u.utterance.speaker for u in preview.utterances] == ["张三"]
@@ -150,7 +154,7 @@ def test_extract_mentions_skips_speaker_position():
 def test_dialogue_on_shot_header_line_derives_utterance_without_reference():
     """写在 header 同一行的台词：切分后即规范行，参考图与 utterance 两侧口径须一致。"""
     text = "镜头1：@[张三]：{我来了}"
-    preview = build_script_preview(text, PROJECT)
+    preview = build_script_preview(text, PROJECT, _SOFT)
     assert preview.references == []
     assert [(u.utterance.kind, u.utterance.speaker) for u in preview.utterances] == [("dialogue", "张三")]
     assert extract_mentions(text) == []
@@ -160,24 +164,24 @@ def test_dialogue_on_shot_header_line_derives_utterance_without_reference():
 
 
 def test_warn_unregistered_mention():
-    preview = build_script_preview("镜头1：@[王五] 推门。", PROJECT)
+    preview = build_script_preview("镜头1：@[王五] 推门。", PROJECT, _SOFT)
     assert keys(preview) == [WARN_UNREGISTERED_MENTION]
     assert preview.warnings[0]["params"] == {"name": "王五"}
 
 
 def test_warn_unclosed_brace():
-    preview = build_script_preview("镜头1：他说 {我来了。", PROJECT)
+    preview = build_script_preview("镜头1：他说 {我来了。", PROJECT, _SOFT)
     assert keys(preview) == [WARN_UNCLOSED_BRACE]
     assert preview.warnings[0]["params"]["shot"] == 1
 
 
 def test_warn_dialogue_inline():
-    preview = build_script_preview("镜头1：@[张三] 说 {我来了}。", PROJECT)
+    preview = build_script_preview("镜头1：@[张三] 说 {我来了}。", PROJECT, _SOFT)
     assert keys(preview) == [WARN_DIALOGUE_INLINE]
 
 
 def test_warn_unregistered_speaker():
-    preview = build_script_preview("镜头1：开场。\n@[王五]：{我来了}", PROJECT)
+    preview = build_script_preview("镜头1：开场。\n@[王五]：{我来了}", PROJECT, _SOFT)
     assert keys(preview) == [WARN_UNREGISTERED_SPEAKER]
     assert preview.warnings[0]["params"] == {"name": "王五"}
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -49,6 +49,7 @@ from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
     validate_and_promote_reference_draft_tool,
 )
+from tests.fakes import fake_reference_caps_fetcher
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -3267,23 +3268,6 @@ async def test_generate_video_all_ad_reference_falls_through_to_episode(
 # ---------------------------------------------------------------------------
 
 
-def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_duration=12, max_refs=3, voice=None):
-    from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
-
-    async def fake_caps(_p, _episode=None):
-        return ReferenceSplitCaps(
-            default_duration=default,
-            durations=list(durations),
-            reference_durations=list(durations if reference_durations is None else reference_durations),
-            text_durations=list(durations),
-            max_duration=max_duration,
-            max_refs=max_refs,
-            voice=voice or VoiceRenderSettings(),
-        )
-
-    return fake_caps
-
-
 @pytest.mark.unit
 async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeypatch) -> None:
     """unit 时长就是发给供应商的那个值，档位原样取自模型声明（不与任何静态区间求交）。"""
@@ -3587,7 +3571,7 @@ def _rv_step1_path(fake_ctx: ToolContext):
 async def _run_rv_split(fake_ctx: ToolContext, monkeypatch, units: list[dict], **caps_kwargs) -> dict:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _rv_caps(**caps_kwargs))
+    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(**caps_kwargs))
     monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units))
     return await _call(split_reference_video_units_tool(fake_ctx), {"episode": 1})
 
@@ -3597,7 +3581,7 @@ async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext, monkey
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     _rv_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _rv_caps())
+    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher())
 
     tool_obj = split_reference_video_units_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
@@ -3619,7 +3603,7 @@ async def test_split_reference_video_units_happy_derives_structure(fake_ctx: Too
     _rv_source(fake_ctx)
     captured: dict[str, Any] = {}
     units = [_rv_unit("镜头1：@[张三] 走向 @[村口]\n镜头2：@[张三] 停下脚步")]
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _rv_caps())
+    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher())
     monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units, captured))
 
     out = await _call(split_reference_video_units_tool(fake_ctx), {"episode": 1})
@@ -3828,7 +3812,7 @@ async def _promote(fake_ctx: ToolContext, monkeypatch, **caps_kwargs) -> dict:
 
     if not (fake_ctx.project_path / "project.json").exists():
         _rv_project(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _rv_caps(**caps_kwargs))
+    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(**caps_kwargs))
     return await _call(validate_and_promote_reference_draft_tool(fake_ctx), {"episode": 1})
 
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -23,6 +23,7 @@ from lib.reference_video.quarantine import (
     quarantine_path,
     write_quarantine,
 )
+from lib.reference_video.voice_settings import VoiceRenderSettings
 from server.agent_runtime.sdk_tools import build_arcreel_mcp_server
 from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.enqueue_assets import (
@@ -3266,7 +3267,7 @@ async def test_generate_video_all_ad_reference_falls_through_to_episode(
 # ---------------------------------------------------------------------------
 
 
-def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_duration=12, max_refs=3, caps=None):
+def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_duration=12, max_refs=3, voice=None):
     from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
 
     async def fake_caps(_p, _episode=None):
@@ -3277,7 +3278,7 @@ def _rv_caps(default=4, durations=(4, 6, 8), reference_durations=None, max_durat
             text_durations=list(durations),
             max_duration=max_duration,
             max_refs=max_refs,
-            raw=dict(caps or {}),
+            voice=voice or VoiceRenderSettings(),
         )
 
     return fake_caps
@@ -3504,7 +3505,7 @@ async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_fai
     monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
     monkeypatch.setattr(ConfigResolver, "video_generate_audio_for_project", _fake_project_audio)
     caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1)
-    assert caps.raw.get("requested_generate_audio") is False
+    assert caps.voice.requested_generate_audio is False
 
 
 @pytest.mark.unit
@@ -3526,7 +3527,7 @@ async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_fail
     monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
     monkeypatch.setattr(ConfigResolver, "video_generate_audio_for_project", _raising_project_audio)
     caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1)
-    assert caps.raw.get("requested_generate_audio") is False
+    assert caps.voice.requested_generate_audio is False
 
 
 def _rv_generator_returning(units: list[dict], captured: dict[str, Any] | None = None):
@@ -4530,7 +4531,7 @@ async def test_split_reference_video_units_surfaces_tolerated_voice_warnings(
         fake_ctx,
         monkeypatch,
         [_rv_unit("镜头1：@[张三] 起身\n@[张三]：{我来了。}")],
-        caps={"voice_consistency": "native", "max_reference_audio_count": 2, "model": "m"},
+        voice=VoiceRenderSettings(voice_consistency="native", max_reference_audio=2, model_id="m"),
     )
 
     assert out.get("is_error") is not True, out
@@ -4558,12 +4559,9 @@ async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_bac
         fake_ctx,
         monkeypatch,
         [_rv_unit("镜头1：@[张三] 起身\n@[张三]：{我来了。}\n@[李四]：{你终于来了。}")],
-        caps={
-            "voice_consistency": "native",
-            "max_reference_audio_count": 1,
-            "model": "m",
-            "reference_audio_per_image": True,
-        },
+        voice=VoiceRenderSettings(
+            voice_consistency="native", max_reference_audio=1, model_id="m", requires_reference_image=True
+        ),
     )
 
     assert out.get("is_error") is not True, out

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
+from lib.reference_video.voice_settings import VoiceRenderSettings
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import script_review as router_mod
@@ -211,7 +212,7 @@ class TestReferenceVideoRouter:
                 text_durations=[4, 6, 8],
                 max_duration=8,
                 max_refs=3,
-                raw={},
+                voice=VoiceRenderSettings(),
             )
 
         monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _fake_caps)
@@ -262,7 +263,7 @@ class TestReferenceVideoRouter:
                 text_durations=[4, 6, 8],
                 max_duration=8,
                 max_refs=3,
-                raw={},
+                voice=VoiceRenderSettings(),
             )
 
         monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _fake_caps)

--- a/tests/test_script_review_router.py
+++ b/tests/test_script_review_router.py
@@ -10,11 +10,11 @@ from fastapi.testclient import TestClient
 
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
-from lib.reference_video.voice_settings import VoiceRenderSettings
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import script_review as router_mod
 from tests.auth_deps import AUTH_DEPENDENCIES
+from tests.fakes import fake_reference_caps_fetcher
 
 
 def _drama_step1() -> dict:
@@ -204,18 +204,7 @@ class TestReferenceVideoRouter:
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text(novel, encoding="utf-8")
 
-        async def _fake_caps(_project, _episode=None):
-            return mod.ReferenceSplitCaps(
-                default_duration=4,
-                durations=[4, 6, 8],
-                reference_durations=[4, 6, 8],
-                text_durations=[4, 6, 8],
-                max_duration=8,
-                max_refs=3,
-                voice=VoiceRenderSettings(),
-            )
-
-        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _fake_caps)
+        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(max_duration=8))
 
         flat_units = [{"duration_seconds": 4, "source_text": novel, "text": "镜头1：门开了\n@[阿离]：｛我来了。｝"}]
         write_quarantine(
@@ -255,18 +244,7 @@ class TestReferenceVideoRouter:
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text("阿离站在屋檐下。", encoding="utf-8")
 
-        async def _fake_caps(_project, _episode=None):
-            return mod.ReferenceSplitCaps(
-                default_duration=4,
-                durations=[4, 6, 8],
-                reference_durations=[4, 6, 8],
-                text_durations=[4, 6, 8],
-                max_duration=8,
-                max_refs=3,
-                voice=VoiceRenderSettings(),
-            )
-
-        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", _fake_caps)
+        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(max_duration=8))
         write_quarantine(
             project_path,
             1,


### PR DESCRIPTION
Closes #1646

## 改动

无声判定已收口为 `VoiceRenderSettings.is_silent` 单一判据，但接口上还留着两扇绕过门——正是「本集关音频后仍注入声音特征」这一缺陷的同形复发通道。本次把两扇门关上，生产行为零变化。

1. **三个渲染入口的声音档收为必填**（`render_unit_prompt` / `render_ad_backend_prompt` / `build_script_preview`）：去掉 `| None = None` 与 `or VoiceRenderSettings()` 兜底。原先漏传即落到「有声」方向的字段默认，无声项目会被静默按有声渲染；收必填后新调用方漏传在接线阶段就失败。三个生产调用点本就全部显式传值。
2. **能力接口不再穿原始 dict**：`ReferenceSplitCaps.raw: dict[str, Any]` 改为 `voice: VoiceRenderSettings`。整个能力 dict 过接口只为下游取四个键，而这四键正是 `from_caps` 的输入——改携值对象后，能力 key 名的耦合从消费侧消失。
3. **测试替身收敛**：`ReferenceSplitCaps` 的三处同形内联假造点合并为 `tests/fakes.py::fake_reference_caps_fetcher`。

## 关于「dataclass 字段默认是否一并移除」

议题让评估这一条，结论是**保留**：

- 入口收必填后，`voice_consistency="soft"` / `requested_generate_audio=True` 已不可能被「调用点漏传」触达，只在有人逐字段手写值对象时生效。生产侧手写构造只有 `reference_video_tasks.py` 一处且六字段全给。
- 移除的代价全部落在约 64 处测试构造上——多数只关心其中一两位，强制补全会把「这个用例在测什么」淹没在复述里。
- `from_caps` 的空 dict 回退语义不依赖字段默认（它六个字段都显式传），其专项测试里的具体值断言在移除后照样成立，只有 `== VoiceRenderSettings()` 这一句简写要改写。

即残余风险仅限「未来新增生产构造点手写部分字段」，比刚关掉的那扇门窄得多，不值当为它付上面的代价。

## 验证

- `uv run python -m pytest`：7907 passed
- `uv run basedpyright`：0 error
- `uv run ruff check .` / `ruff format --check .` / `uv run lint-imports`：通过
- 未触碰前端，不涉及前端检查

本地审查另修正了一处注释失真：`ReferenceSplitCaps.voice` 原写「故障回退时按空 dict 口径」，而回退分支实际会独立解析并写回 `requested_generate_audio`——正是保住本集无声意图的那一位，注释按实际改正。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能变更**
  * 参考视频渲染与脚本预览现在必须明确提供声音渲染设置。
  * 声音能力配置统一使用标准设置，确保静音及声音降级提示保持一致。
* **测试**
  * 更新并扩展渲染、预览及广告生成场景的验证，覆盖多种声音配置和异常情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->