### PR TITLE
refactor(生成): 视频身份解析统一走入队钉住的执行身份

### DIFF
--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -160,24 +160,6 @@ def _payload_model_or_default(raw_model: object, provider_id: str, media_type: s
     return default_model_for_provider(provider_id, media_type)
 
 
-def _payload_pinned_pair(
-    payload: dict, cap_keys: tuple[str, ...], *, drop_unknown_provider: bool = True
-) -> tuple[str, str] | None:
-    """读 payload 里能力桶键（``<media>_provider_<cap>``）钉住的执行身份，按给定键序取第一个命中。
-
-    值是 ``ProviderModel.pair_key`` 形态的复合值。``drop_unknown_provider`` 为真时，provider
-    不可信（见 ``_trusted_payload_provider``）即视为未钉住，由调用方回退 payload 旧键与配置层；
-    调用方自带身份可用性收口（视频侧 ``_ensure_video_identity_resolvable``）时传假，让供应商已下线的
-    钉住身份走报错而非静默回退——回退等于换供应商执行。"""
-    for key in cap_keys:
-        pair = _split_pair(payload.get(key))
-        if pair is None:
-            continue
-        if not drop_unknown_provider or _trusted_payload_provider(pair[0]) is not None:
-            return pair
-    return None
-
-
 @dataclass(frozen=True)
 class _LayeredBackendKeys:
     """「默认 + 能力桶」四级解析骨架的键位声明，媒体类型无关（见 ``docs/adr/0054``）。
@@ -225,6 +207,16 @@ _VIDEO_LAYERED_KEYS: dict[str, _LayeredBackendKeys] = {
     )
     for cap in ("i2v", "r2v")
 }
+
+
+# 不定桶视频键位：与 ``_VIDEO_LAYERED_KEYS`` 同源同层，只去掉桶层（None 由骨架跳过）。供不承诺
+# 能力桶的调用方（费用估算、限流路由兜底、配置展示）解析，不施加桶键覆盖也不过能力闸。
+_VIDEO_DEFAULT_LAYERED_KEYS = _LayeredBackendKeys(
+    media_type="video",
+    parse_fallback=_DEFAULT_VIDEO_BACKEND,
+    project_default_key="video_backend",
+    global_default_key="default_video_backend",
+)
 
 
 # 音频键位。音频无能力桶，桶层留空（None）由骨架直接跳过：项目默认层用 project.json 的
@@ -278,16 +270,20 @@ def video_bucket_for_generation_mode(generation_mode: str | None) -> VideoCapabi
 def _payload_video_pinned_pair(
     payload: dict, capability: VideoCapability | None
 ) -> tuple[VideoCapability, tuple[str, str]] | None:
-    """读 payload 里入队时钉住的视频执行身份，连同命中的桶一并返回（见 ``_payload_pinned_pair``）。
+    """读 payload 里入队时钉住的视频执行身份（桶键 ``video_provider_<cap>``），连同命中的桶一并返回。
 
-    入队只为任务所属的那一个桶写键（``lib.generation_queue``），故 ``capability`` 未声明（resume
-    等不承诺桶的调用方）时按固定桶序扫两个桶键——至多命中一个，桶序不产生歧义。
+    值是 ``ProviderModel.pair_key`` 形态的复合值，写入方是 ``lib.generation_queue``。入队只为任务
+    所属的那一个桶写键，故 ``capability`` 未声明（resume 等不承诺桶的调用方）时按固定桶序扫两个
+    桶键——至多命中一个，桶序不产生歧义。
+
+    provider 不可信（见 ``_trusted_payload_provider``）不在此丢弃：视频侧身份可用性由
+    ``_ensure_video_identity_resolvable`` 收口，供应商已下线时该报错，回退等于换供应商执行。
     """
     caps: tuple[VideoCapability, ...] = (capability,) if capability is not None else get_args(VideoCapability)
     for cap in caps:
-        pinned = _payload_pinned_pair(payload, (f"video_provider_{cap}",), drop_unknown_provider=False)
-        if pinned is not None:
-            return cap, pinned
+        pair = _split_pair(payload.get(f"video_provider_{cap}"))
+        if pair is not None:
+            return cap, pair
     return None
 
 
@@ -767,8 +763,8 @@ class ConfigResolver:
     ) -> ProviderModel:
         """解析视频任务应使用的 ProviderModel。
 
-        payload 恒为最高优先级：入队时钉进能力桶键 ``video_provider_<cap>`` 的执行身份优先，
-        其次是历史任务携带的 ``video_provider``。其后按 ``capability`` 分两条路径（``docs/adr/0054``）：
+        payload 恒为最高优先级：入队时钉进能力桶键 ``video_provider_<cap>`` 的执行身份优先。
+        其后按 ``capability`` 分两条路径（``docs/adr/0054``）：
 
         - ``capability`` 给定（``"i2v"`` / ``"r2v"``）：走四级骨架 项目桶（``video_provider_<cap>``）
           > 项目默认（``video_backend``）> 全局桶（``default_video_backend_<cap>``）> 全局默认
@@ -776,10 +772,11 @@ class ConfigResolver:
           所需能力、或配置引用已不可用（模型被删 / 能力被改 / 供应商被删）时抛
           ``VideoBucketCapabilityError``，不静默换模型。payload 命中时跳过能力闸——已入队任务
           按 payload 照常执行，不回头补校验；但入队钉住的身份仍过身份可用性校验，悬空同样抛该异常。
-        - ``capability`` 为 None：project（``video_backend``）> 全局默认 的旧三级路径，无能力闸；
-          自定义 provider 的 model 不存在、已禁用或 endpoint 的 media_type 不是 video 时，收敛到
-          该 provider 默认启用的 video model（**运行时有效身份**），无可用默认则抛 ``ValueError``。
-          供不承诺能力的调用方（费用估算、限流路由兜底）使用。
+        - ``capability`` 为 None：同一骨架去掉桶层，项目默认（``video_backend``）> 全局默认
+          （``default_video_backend``）> 自动推断，无能力闸；自定义 provider 的 model 不存在、
+          已禁用或 endpoint 的 media_type 不是 video 时，收敛到该 provider 默认启用的 video
+          model（**运行时有效身份**），无可用默认则抛 ``ValueError``。供不承诺能力的调用方
+          （费用估算、限流路由兜底）使用。
 
         provider id 不做归一化。只要字面配置结果（不经收敛）请改用 ``video_backend()``。
         """
@@ -1038,10 +1035,11 @@ class ConfigResolver:
         return value
 
     async def _resolve_default_video_backend(self, svc: ConfigService, session: AsyncSession) -> tuple[str, str]:
-        raw = await svc.get_setting("default_video_backend", "")
-        if raw and "/" in raw:
-            return ConfigService._parse_backend(raw, _DEFAULT_VIDEO_BACKEND)
-        return await self._auto_resolve_backend(svc, session, "video")
+        """仅全局层解析视频默认 backend：全局默认键 > 自动推断。
+
+        走四级骨架但不带项目（project=None 跳过项目层），键位不含桶层（``_VIDEO_DEFAULT_LAYERED_KEYS``）。
+        """
+        return await self._resolve_layered_backend(svc, session, None, _VIDEO_DEFAULT_LAYERED_KEYS)
 
     async def _resolve_video_backend(
         self,
@@ -1049,24 +1047,12 @@ class ConfigResolver:
         session: AsyncSession,
         project_name: str | None,
     ) -> tuple[str, str]:
-        """三级解析当前项目应使用的 video backend。
+        """三级解析当前项目应使用的 video backend：项目默认 > 全局默认 > 自动推断。
 
-        模式对齐 `_resolve_text_backend`：项目级 > 系统设置 > 系统默认 / auto。
+        走四级骨架的不定桶键位（``_VIDEO_DEFAULT_LAYERED_KEYS``），桶层缺席由骨架跳过。
         """
         project = get_project_manager().load_project(project_name) if project_name else None
-        return await self._resolve_video_backend_from_project(svc, session, project)
-
-    async def _resolve_video_backend_from_project(
-        self,
-        svc: ConfigService,
-        session: AsyncSession,
-        project: dict | None,
-    ) -> tuple[str, str]:
-        if project is not None:
-            parsed = _parse_project_provider(project.get("video_backend"), "video")
-            if parsed is not None:
-                return parsed
-        return await self._resolve_default_video_backend(svc, session)
+        return await self._resolve_layered_backend(svc, session, project, _VIDEO_DEFAULT_LAYERED_KEYS)
 
     async def _resolve_layered_backend(
         self,
@@ -1110,15 +1096,14 @@ class ConfigResolver:
     ) -> ProviderModel:
         """payload 优先解析图片 ProviderModel，无 payload 时走四级骨架。
 
-        payload 层保留 ``payload>project>global`` 的规范骨架，接受 ``image_provider_<cap>``
-        与旧的 ``image_provider`` / ``image_model`` 键——队列里按旧格式序列化的任务据此解析。
-        payload provider 须是已知 provider（见 ``_trusted_payload_provider``），否则不予信任、
-        回退骨架（``_resolve_layered_backend``，键位见 ``_IMAGE_LAYERED_KEYS``）。
+        payload 层保留 ``payload>project>global`` 的规范骨架，接受 ``image_provider`` /
+        ``image_model`` 键——按该格式序列化的任务据此解析。图片任务不钉住执行身份（任务周期
+        短，排队期间配置漂移的窗口小），故 payload 层无能力桶键。payload provider 须是已知
+        provider（见
+        ``_trusted_payload_provider``），否则不予信任、回退骨架（``_resolve_layered_backend``，
+        键位见 ``_IMAGE_LAYERED_KEYS``）。
         """
         if payload:
-            pinned = _payload_pinned_pair(payload, (f"image_provider_{capability}",))
-            if pinned is not None:
-                return ProviderModel(*pinned)
             provider_id = _trusted_payload_provider(payload.get("image_provider"))
             if provider_id is not None:
                 model = _payload_model_or_default(payload.get("image_model"), provider_id, "image")
@@ -1137,15 +1122,12 @@ class ConfigResolver:
         payload: dict | None,
         capability: VideoCapability | None = None,
     ) -> ProviderModel:
-        """payload 优先解析视频 ProviderModel；无 payload 时按 ``capability`` 走桶骨架或旧三级。
+        """payload 优先解析视频 ProviderModel；无 payload 时按 ``capability`` 走桶骨架或不定桶骨架。
 
-        payload 层接受两种形态，均不过能力闸：入队时钉住的能力桶键（``video_provider_<cap>``
-        复合值，见 ``_payload_video_pinned_pair``）优先，原样返回、只过身份可用性
-        （``_ensure_video_identity_resolvable``），悬空即报错；其后是历史任务携带的
-        ``video_provider`` + ``video_model`` / ``video_provider_settings.model``，按运行时
-        有效身份收敛。历史形态的 payload provider 须是已知 provider（见
-        ``_trusted_payload_provider``），否则不予信任、回退配置层；钉住形态不做这层丢弃——供应商
-        已下线时回退等于换供应商执行。各层语义见 ``resolve_video_backend`` docstring。
+        payload 层只认入队时钉住的能力桶键（``video_provider_<cap>`` 复合值，见
+        ``_payload_video_pinned_pair``）：原样返回、不过能力闸，只过身份可用性
+        （``_ensure_video_identity_resolvable``），悬空即报错。钉住形态不丢弃不可信 provider——
+        供应商已下线时回退等于换供应商执行。各层语义见 ``resolve_video_backend`` docstring。
         """
         if payload:
             pinned = _payload_video_pinned_pair(payload, capability)
@@ -1154,17 +1136,10 @@ class ConfigResolver:
                 selected = ProviderModel(*pair)
                 await self._ensure_video_identity_resolvable(session, selected, pinned_capability)
                 return selected
-            provider_id = _trusted_payload_provider(payload.get("video_provider"))
-            if provider_id is not None:
-                settings = payload.get("video_provider_settings")
-                settings_model = settings.get("model") if isinstance(settings, dict) else None
-                model = _payload_model_or_default(payload.get("video_model") or settings_model, provider_id, "video")
-                if model is not None:
-                    return await self._resolve_effective_video_provider_model(
-                        session, ProviderModel(provider_id, model)
-                    )
         if capability is None:
-            provider_id, model_id = await self._resolve_video_backend_from_project(svc, session, project)
+            provider_id, model_id = await self._resolve_layered_backend(
+                svc, session, project, _VIDEO_DEFAULT_LAYERED_KEYS
+            )
             return await self._resolve_effective_video_provider_model(session, ProviderModel(provider_id, model_id))
         provider_id, model_id = await self._resolve_layered_backend(
             svc, session, project, _VIDEO_LAYERED_KEYS[capability]

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -764,12 +764,14 @@ class GenerationWorker:
     async def _process_resume_task(self, task: dict[str, Any]) -> None:
         """重启自愈入口：直接调 backend.resume_video，绕过 normal executor 流水线。
 
-        provider 锁定：把持久化的 ``task["provider_id"]`` 注入 payload 的
-        ``video_provider`` 字段，让 ``ConfigResolver`` 按持久化 provider 而非当前
-        项目配置解析 backend。否则任务提交后到重启前若项目 provider 配置切换，
-        会拿旧 ``provider_job_id`` 去新 provider 轮询，导致可恢复任务被误判失败。
-        model 侧由入队时钉进 payload 能力桶键的执行身份负责（``lib.generation_queue``），
-        解析优先级高于此处注入；这里的注入是无桶键存量任务的兜底。
+        身份锁定：视频任务的 provider 与 model 由入队时钉进 payload 能力桶键的执行身份负责
+        （``lib.generation_queue``），``ConfigResolver`` 据此按提交时的身份而非当前项目配置解析
+        backend——否则任务提交后到重启前若项目 provider 配置切换，会拿旧 ``provider_job_id``
+        去新 provider 轮询，导致可恢复任务被误判失败。
+
+        非视频媒体退到把持久化的 ``task["provider_id"]`` 注入 payload 的 ``image_provider``
+        字段（只锁 provider、锁不住 model）。孤儿扫描只把 video 交到这里，image / audio 孤儿
+        在扫描期即落 ``[restart_lost]``，该分支因而只在 media_type 为脏数据时可达。
         """
         task_id = task["task_id"]
         task_type = task.get("task_type", "unknown")
@@ -784,18 +786,16 @@ class GenerationWorker:
                 await asyncio.shield(self.queue.mark_task_cancelled(task_id, cancelled_by="user"))
             return
 
-        # 锁定持久化 provider 到 payload（resolver 优先级：payload > project > 默认）。
+        # 非视频媒体：锁定持久化 provider 到 payload（resolver 优先级：payload > project > 默认）。
+        # 视频任务的身份走入队钉住的能力桶键，不在此注入——注入只覆盖 provider、盖不住 model。
         persisted_provider_id = task.get("provider_id")
-        if persisted_provider_id:
+        is_video = task.get("media_type") == "video" or task_type in ("video", "reference_video")
+        if persisted_provider_id and not is_video:
             payload = task.get("payload")
             if payload is None:
                 payload = {}
                 task["payload"] = payload
-            is_video = task.get("media_type") == "video" or task_type in ("video", "reference_video")
-            if is_video:
-                payload["video_provider"] = persisted_provider_id
-            else:
-                payload["image_provider"] = persisted_provider_id
+            payload["image_provider"] = persisted_provider_id
 
         provider_id = await _extract_provider(task)
         logger.info(

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -283,12 +283,12 @@ class TestVideoLane:
 
     @pytest.mark.unit
     async def test_payload_overrides_project(self, session_factory, project_env, fake_assemble):
-        """payload > project：历史任务携带的 video_provider 决定实际解析身份。"""
+        """payload > project：入队钉住的桶键决定实际解析身份。"""
         ark_model = _registry_video_model("ark")
         grok_model = _registry_video_model("grok")
         ctx = await resolve_generation_context(
             "demo",
-            {"video_provider": "grok", "video_model": grok_model},
+            {"video_provider_i2v": f"grok/{grok_model}"},
             project={"video_backend": f"ark/{ark_model}"},
             video=VideoLaneRequest(),
         )

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1161,15 +1161,14 @@ class TestResolveImageBackend:
     """resolve_image_backend：payload > 项目桶 > 项目默认 > 全局桶 > 全局默认 > 自动推断。"""
 
     @pytest.mark.unit
-    async def test_payload_capability_slot_wins(self):
+    async def test_payload_capability_slot_is_not_a_payload_layer_key(self):
+        """图片任务不钉住执行身份：``image_provider_<cap>`` 只是项目层键，payload 里同名键不参与解析。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        project = {"image_provider_t2i": "ark/proj-t2i", "image_provider_i2i": "ark/proj-i2i"}
-        payload = {"image_provider_t2i": "openai/pay-t2i", "image_provider_i2i": "openai/pay-i2i"}
-        t2i = await resolver._resolve_image_provider_model(fake_svc, None, project, payload, "t2i")
-        i2i = await resolver._resolve_image_provider_model(fake_svc, None, project, payload, "i2i")
-        assert (t2i.provider_id, t2i.model_id) == ("openai", "pay-t2i")
-        assert (i2i.provider_id, i2i.model_id) == ("openai", "pay-i2i")
+        project = {"image_provider_t2i": "ark/proj-t2i"}
+        payload = {"image_provider_t2i": "openai/pay-t2i"}
+        resolved = await resolver._resolve_image_provider_model(fake_svc, None, project, payload, "t2i")
+        assert (resolved.provider_id, resolved.model_id) == ("ark", "proj-t2i")
 
     @pytest.mark.unit
     async def test_payload_legacy_fields_for_historical_tasks(self):
@@ -1376,16 +1375,7 @@ class TestLayeredBackendSkeleton:
 
 
 class TestResolveVideoBackend:
-    """resolve_video_backend：payload > project > 全局默认。"""
-
-    @pytest.mark.unit
-    async def test_payload_historical_provider_wins(self):
-        resolver = ConfigResolver.__new__(ConfigResolver)
-        fake_svc = _FakeConfigService(settings={})
-        project = {"video_backend": "grok/grok-imagine-video"}
-        payload = {"video_provider": "ark", "video_provider_settings": {"model": "seedance"}}
-        resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, payload)
-        assert (resolved.provider_id, resolved.model_id) == ("ark", "seedance")
+    """resolve_video_backend：payload 钉住键 > project > 全局默认。"""
 
     @pytest.mark.unit
     async def test_project_video_backend_when_no_payload(self):
@@ -1459,24 +1449,14 @@ class TestResolveVideoBackend:
         assert resolved.model_id == "doubao-seedance-2-0-mini-260615"  # registry 中 ark 的默认 video model
 
     @pytest.mark.unit
-    async def test_payload_legacy_provider_not_trusted_falls_through_to_project(self):
-        """in-flight 历史任务 payload 携带 legacy video_provider（如 seedance）→ 不予信任，回退已迁移的 project。"""
+    async def test_payload_without_pinned_bucket_key_falls_through_to_project(self):
+        """payload 层只认钉住的能力桶键：非桶键的 provider 字段不参与解析，一律回退配置层。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        project = {"video_backend": "ark/doubao-seedance-2-0-260128"}  # 启动期已迁移为规范名
-        payload = {"video_provider": "seedance", "video_model": "legacy"}  # legacy，不可识别
+        project = {"video_backend": "ark/doubao-seedance-2-0-260128"}
+        payload = {"video_provider": "grok", "video_provider_settings": {"model": "grok-imagine-video"}}
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, payload)
         assert (resolved.provider_id, resolved.model_id) == ("ark", "doubao-seedance-2-0-260128")
-
-    @pytest.mark.unit
-    async def test_payload_non_dict_video_provider_settings_does_not_crash(self):
-        """脏 payload：video_provider_settings 非 dict → 不抛异常，按缺 model 补该 provider 默认。"""
-        resolver = ConfigResolver.__new__(ConfigResolver)
-        fake_svc = _FakeConfigService(settings={"default_video_backend": "grok/grok-imagine-video"})
-        payload = {"video_provider": "ark", "video_provider_settings": "not-a-dict"}
-        resolved = await resolver._resolve_video_provider_model(fake_svc, None, {}, payload)
-        assert resolved.provider_id == "ark"
-        assert resolved.model_id == "doubao-seedance-2-0-mini-260615"  # 补 ark 默认 video model
 
 
 @pytest.mark.unit
@@ -1529,14 +1509,6 @@ class TestResolveVideoBackendBuckets:
         fake_svc = _FakeConfigService(settings={})
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, None, None, "i2v")
         assert resolved.provider_id == "gemini-aistudio"
-
-    async def test_payload_wins_and_skips_capability_gate(self):
-        """已入队任务按 payload 照常执行：payload 命中不过能力闸，r2v 桶下仍放行仅 i2v 的模型。"""
-        resolver = ConfigResolver.__new__(ConfigResolver)
-        fake_svc = _FakeConfigService(settings={})
-        payload = {"video_provider": "vidu", "video_model": "viduq3-pro"}
-        resolved = await resolver._resolve_video_provider_model(fake_svc, None, None, payload, "r2v")
-        assert (resolved.provider_id, resolved.model_id) == ("vidu", "viduq3-pro")
 
     async def test_missing_i2v_capability_raises_structured_error(self):
         from lib.config.resolver import VideoBucketCapabilityError
@@ -2046,11 +2018,11 @@ class TestPayloadPinnedVideoModel:
     """入队钉进 payload 能力桶键的执行身份：优先级最高，且不承诺桶的调用方（resume）也读得到。"""
 
     @pytest.mark.unit
-    async def test_pinned_bucket_key_wins_over_project_and_legacy_payload(self):
+    async def test_pinned_bucket_key_wins_over_project(self):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
         project = {"video_provider_i2v": "vidu/viduq3-pro", "video_backend": "grok/grok-imagine-video"}
-        payload = {"video_provider_i2v": "ark/doubao-seedance-2-0-260128", "video_provider": "grok"}
+        payload = {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"}
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, payload, "i2v")
         assert (resolved.provider_id, resolved.model_id) == ("ark", "doubao-seedance-2-0-260128")
 
@@ -2088,14 +2060,14 @@ class TestPayloadPinnedVideoModel:
 
     @pytest.mark.unit
     async def test_pin_of_unavailable_provider_raises_instead_of_falling_back(self):
-        """钉住的供应商已下线：报错，不回退 payload 旧键或配置层。
+        """钉住的供应商已下线：报错，不回退配置层。
 
         回退等于换供应商执行，续跑更会拿另一个 backend 去轮原供应商的 provider_job_id。
         """
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
         project = {"video_backend": "grok/grok-imagine-video"}
-        payload = {"video_provider_i2v": "seedance/legacy", "video_provider": "ark", "video_model": "seedance"}
+        payload = {"video_provider_i2v": "seedance/legacy"}
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
             await resolver._resolve_video_provider_model(fake_svc, None, project, payload, "i2v")
         assert excinfo.value.provider_id == "seedance"

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -122,9 +122,9 @@ class TestExtractProvider:
     """_extract_provider 是解析链的薄投影：按 task_type 派发，取 .provider_id。"""
 
     @pytest.mark.unit
-    async def test_video_payload_provider(self):
-        """payload 携带 video_provider → 投影直接取到（payload 层短路，无需 DB）。"""
-        task = {"payload": {"video_provider": "ark"}, "task_type": "video"}
+    async def test_video_payload_pinned_bucket_provider(self):
+        """payload 携带入队钉住的桶键 → 投影直接取到（payload 层短路，无需 DB）。"""
+        task = {"payload": {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"}, "task_type": "video"}
         assert await _extract_provider(task) == "ark"
 
     @pytest.mark.unit
@@ -242,9 +242,13 @@ class TestExtractProvider:
 
     @pytest.mark.unit
     async def test_payload_provider_takes_precedence_over_project(self, monkeypatch):
-        """payload provider 优先于项目级。"""
+        """payload 钉住的 provider 优先于项目级。"""
         _patch_pm(monkeypatch, {"video_backend": "grok/grok-imagine-video"})
-        task = {"payload": {"video_provider": "ark"}, "project_name": "demo", "task_type": "video"}
+        task = {
+            "payload": {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"},
+            "project_name": "demo",
+            "task_type": "video",
+        }
         assert await _extract_provider(task) == "ark"
 
     @pytest.mark.unit
@@ -1091,7 +1095,7 @@ class TestGenerationWorker:
                         "task_id": "vid1",
                         "task_type": "gen_video",
                         "media_type": "video",
-                        "payload": {"video_provider": "ark"},
+                        "payload": {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"},
                     },
                 ]
 
@@ -1325,7 +1329,7 @@ class TestGenerationWorker:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_handle_orphan_uses_persisted_provider_id(self, monkeypatch):
-        """task.provider_id 优先于 _extract_provider 的当前项目解析（CR round-2 N2 回归）。
+        """task.provider_id 优先于 _extract_provider 的当前项目解析。
 
         如果 task 持久化的 provider_id 是 Grok（不支持 resume），即便当前项目配置
         已切换成 Ark（支持 resume），孤儿仍应被识别为 non_resumable → [resume_unsupported]，
@@ -1342,8 +1346,8 @@ class TestGenerationWorker:
                 "provider_job_id": "stale-job",
                 "media_type": "video",
                 "task_type": "video",
-                # payload 显式写 video_provider=ark，模拟"项目已切换" → _extract_provider 会解析成 ark
-                "payload": {"video_provider": "ark"},
+                # payload 钉住桶键写 ark，模拟"项目已切换" → _extract_provider 会解析成 ark
+                "payload": {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"},
                 "project_name": "demo",
             }
         ]
@@ -1583,8 +1587,11 @@ class TestGenerationWorker:
     # ------------------------------------------------------------------
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_process_resume_task_locks_persisted_provider_to_payload(self, monkeypatch):
-        """C2 回归：persisted provider_id 应注入 payload.video_provider。"""
+    async def test_process_resume_task_keeps_pinned_video_identity(self, monkeypatch):
+        """视频任务的续跑身份由入队钉住的桶键决定，persisted provider_id 不注入 payload。
+
+        注入只覆盖 provider、盖不住 model，两者分裂即静默换模型续跑。
+        """
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
         captured_task: dict | None = None
@@ -1604,13 +1611,13 @@ class TestGenerationWorker:
             "media_type": "video",
             "provider_id": "openai",
             "provider_job_id": "openai-job",
-            "payload": {"video_provider": "gemini-aistudio"},  # payload 原本指向另一个 provider
+            "payload": {"video_provider_i2v": "gemini-aistudio/veo-3.1-fast-generate-preview"},
             "project_name": "demo",
         }
         await worker._process_resume_task(task)
         assert captured_task is not None
-        # _process_resume_task 应覆写为持久化 provider_id (openai)
-        assert captured_task["payload"]["video_provider"] == "openai"
+        # 钉住键原样交给 resume，persisted provider_id 不写进 payload
+        assert captured_task["payload"] == {"video_provider_i2v": "gemini-aistudio/veo-3.1-fast-generate-preview"}
         assert captured_job_id == "openai-job"
         assert queue.succeeded == [("resume-locked", {"ok": True})]
 


### PR DESCRIPTION
Closes #1650

## 变更

视频任务的 payload 层此前并存两种形态：入队钉住的能力桶键，以及钉住机制上线前入队的旧格式（provider + model 分列）。旧格式在自定义模型被删或禁用时会静默换用供应商当下的默认模型续跑旧任务，用户看到的成片与提交时选定的模型不符且无从归因。整条旧格式解析路径连同重启自愈里只覆盖 provider、盖不住 model 的注入一并删除，续跑与执行自此认同一个身份。

同时清理两处收尾项：

- 图片任务不钉住执行身份（周期短、排队期配置漂移窗口小），payload 层无写入方的桶键读取删除
- 不定桶的视频解析（`capability=None`）改走与分桶路径同一套分层骨架，去掉并存的手写解析

## 验证

- 前置核验：删除旧格式解析路径前确认队列无在途任务（`tasks` 表按 status 分组计数，`queued` / `running` / `cancelling` 三态全空），旧格式在途任务不存在
- 收编项行为等价性逐层核对：项目层空 dict 两侧同样落下一级；全局层空串无 `/`、条件等价；取值同源同默认；auto 推断分支不变
- `pytest` 7907 passed、`basedpyright` 0 errors、`ruff check` + `format` 干净、`lint-imports` 分层契约 KEPT
- 前端未改动

## 已知边界

无钉住桶键的视频任务（入队派生执行身份失败时不写钉住键）在重启续跑时不再有 provider 锁：若提交到重启之间项目供应商配置切换，会拿旧 `provider_job_id` 去新供应商轮询。触发需「入队派生异常 + 重启 + 期间切供应商」三者叠加。根因是执行路径只有参考生视频侧在提交前回写执行身份（`persist_execution_identity`），图生视频侧没有；补齐属本议题范围外，另记 follow-up。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **配置与行为调整**
  * 视频任务现使用已锁定的能力桶解析供应商和模型，配置优先级更加一致。
  * 视频配置仅支持能力桶复合键；图片配置继续使用独立的供应商和模型字段。
  * 视频能力配置仍会校验供应商可用性与能力匹配，非能力桶配置不执行能力校验。
* **兼容性**
  * 视频任务续跑会保留原始能力桶和模型信息，避免旧身份信息覆盖任务配置。
  * 历史视频字段不再覆盖项目配置，相关旧行为已移除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->