### PR TITLE
docs(skills): 补记 CI 重跑不含上游修复;afk 清尾立项改为直接建 issue

### DIFF
--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # AFK 团队执行流程
 
-你是 team-lead：组建团队，把一批 issue 无人值守推进到全部合并或明确搁置。你负责调度、合并、裁决、健康检查与清尾，自己不写代码；实现、本地审查、外部审查循环、补立项分别交给 /tdd、/code-review、/pr-ai-review-loop、/to-tickets。
+你是 team-lead：组建团队，把一批 issue 无人值守推进到全部合并或明确搁置。你负责调度、合并、裁决、健康检查与清尾，自己不写代码；实现、本地审查、外部审查循环分别交给 /tdd、/code-review、/pr-ai-review-loop。
 
 ## 第一步：确定批次成员
 
@@ -26,7 +26,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 1. 依赖顺序按 batch-poll 的 `blocked_by` / `ready_to_start` 排；并发槽位优先给改动域互不相交的 issue，同域或足迹重叠者靠依赖序或补位串行——冲突事前避而非事后解；`stage_hint` 已起的 issue 在计划中标明现状与接力起点（按第三步阶段表的交付物反推），随计划一并交用户确认
 2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；已被他人 assign 的 issue 视为已认领，同样跳过（batch-poll 不含 assignee，用 `gh issue view <N> --json assignees` 核对）；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
 3. 向用户展示批次计划：成员清单、依赖顺序、每个 issue 的实现路线与模型（**各附一句选择理由**，见第三步「实现路线与模型」）、跳过项及连带不启动的下游、并发上限（默认 3，用户可覆盖）
-4. **主动请求一次性前置授权**：向用户明确提出两项预批——本批所有 PR 的合并（含清尾轮立项的 PR）；清尾立项权限（对满足收尾节判据的缺陷类 follow-up，team-lead 可自行 /to-tickets 立项并在清尾轮跑到合并，被拒则清尾降级为收尾转呈）。连同流程将自动执行的动作边界（修改 triage 标签、PR 转 draft、在 Spec 发 QA 验收 comment；清尾授权之外不创建新 issue，gap 立项仍须用户中途指令）。这是本流程唯一的同步确认点；前置授权在此落入 team-lead 的 transcript，后续不再逐笔请示
+4. **主动请求一次性前置授权**：向用户明确提出两项预批——本批所有 PR 的合并（含清尾轮立项的 PR）；清尾立项权限（对满足收尾节判据的缺陷类 follow-up，team-lead 可自行立项并在清尾轮跑到合并，被拒则清尾降级为收尾转呈）。连同流程将自动执行的动作边界（修改 triage 标签、PR 转 draft、在 Spec 发 QA 验收 comment；清尾授权之外不创建新 issue，gap 立项仍须用户中途指令）。这是本流程唯一的同步确认点；前置授权在此落入 team-lead 的 transcript，后续不再逐笔请示
 5. 用户确认后建账本（首条 append，记录计划裁决与所得授权，见「账本」），进入无人值守执行，不再中途请示
 
 ## 第三步：组建团队，按依赖调度
@@ -61,7 +61,7 @@ spawn 时按 [references/spawn-prompts.md](references/spawn-prompts.md) 的模�
 1. **清尾轮（单轮）**：聚合账本与 handoff 目录的 follow-up 候选，逐条经过分拣、验证、立项，终态为应收或转呈：
    - **分拣**：应收须同时满足三条：真缺陷、在 Spec 范围内、不涉及需用户决策的业务取舍。否则转呈
    - **验证**：在 origin/main 上确认缺陷存在；不存在的项撤下，记入转呈说明
-   - **立项**：验证通过的项用 /to-tickets 立项并跑到终态，其「与用户确认拆分」一步由清尾授权代替，接力与合并纪律与批内 issue 一致。未获清尾授权则不立项，全部转呈
+   - **立项**：验证通过的项按 issue-tracker 约定直接建 issue，并跑到终态，接力与合并纪律与批内 issue 一致。未获清尾授权则不立项，全部转呈
 
    分拣结果 append 账本 `decision`；`--issues` 批次扩员后补一条带 scope 的行。轮中新增的候选转呈
 2. **在 Spec issue 发人工 QA 验收清单 comment，不关闭 Spec 本体**。清单按已合并子 issue（含清尾轮）组织：每项给 PR 链接与面向用户可感知行为的验收步骤（实际操作路径，不复读技术验收标准）；末尾列 needs-human 搁置项、跳过与未启动项、发现的缺口。纯 issue 列表批次没有共同 Spec 时，清单并入收尾汇报
@@ -109,4 +109,4 @@ bash .agents/skills/afk-team-workflow/scripts/ledger.sh <batch-id> <kind> [--iss
 
 ## 发现 Spec 落点缺口时
 
-gap 专指功能性缺口：Spec 有要求但任何子 issue 均未覆盖——"未覆盖"可能是用户拆解时的有意裁剪，故必须人工确认，不入清尾授权；批内发现的缺陷类 follow-up 不走本节，按收尾的清尾轮处置。发现 gap 时：SendUserMessage（proactive）实时提醒用户，说明缺口描述、建议与对本批次的影响，不阻塞批次继续。用户中途授权则用 /to-tickets 立项并按依赖加入批次；未获回复则相关 issue 按字面验收标准收口。append 账本 `gap`，并记入收尾转呈与 QA comment。
+gap 专指功能性缺口：Spec 有要求但任何子 issue 均未覆盖——"未覆盖"可能是用户拆解时的有意裁剪，故必须人工确认，不入清尾授权；批内发现的缺陷类 follow-up 不走本节，按收尾的清尾轮处置。发现 gap 时：SendUserMessage（proactive）实时提醒用户，说明缺口描述、建议与对本批次的影响，不阻塞批次继续。用户中途授权则直接立项并按依赖加入批次；未获回复则相关 issue 按字面验收标准收口。append 账本 `gap`，并记入收尾转呈与 QA comment。

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -11,7 +11,7 @@
 1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行，每轮动作后安排下一次唤醒
 2. **请示重定向**：其中"暂停询问用户"的场景一律改为 SendMessage 请示 team-lead，按裁决继续；等待裁决期间保持唤醒监控 PR 动态
 3. **范围边界**：修复以验收标准为界。reviewer 的改进建议超出标准时，回复评论说明范围，并按 follow-up 候选记入 handoff，不修改代码
-4. **rebase**：只在三种时机做——随下次修复 push 顺带完成（每次 push 触发全体 reviewer 重审一轮，合并也不要求分支 up-to-date，不为 main 前进单独 rebase）；每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动；CI 红且修复已合入 main 时，rebase 后 push 以获取修复（见 /pr-ai-review-loop 的「CI 红」行）
+4. **rebase**：只在三种时机做——随下次修复 push 顺带完成（push 后各家 reviewer 按 reviewers.md 的触发规则重审，合并也不要求分支 up-to-date，不为 main 前进单独 rebase）；每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动；CI 红且修复已合入 main 时，rebase 后 push 以获取修复（见 /pr-ai-review-loop 的「CI 红」行）
 
 ## 交付与退役
 

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -11,7 +11,7 @@
 1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行，每轮动作后安排下一次唤醒
 2. **请示重定向**：其中"暂停询问用户"的场景一律改为 SendMessage 请示 team-lead，按裁决继续；等待裁决期间保持唤醒监控 PR 动态
 3. **范围边界**：修复以验收标准为界。reviewer 的改进建议超出标准时，回复评论说明范围，并按 follow-up 候选记入 handoff，不修改代码
-4. **rebase**：只在两种时机做——随下次修复 push 顺带完成（每次 push 触发全体 reviewer 重审一轮，合并也不要求分支 up-to-date，不为 main 前进单独 rebase），或每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动
+4. **rebase**：只在三种时机做——随下次修复 push 顺带完成（每次 push 触发全体 reviewer 重审一轮，合并也不要求分支 up-to-date，不为 main 前进单独 rebase）；每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动；CI 红且修复已合入 main 时，rebase 后 push 以获取修复（见 /pr-ai-review-loop 的「CI 红」行）
 
 ## 交付与退役
 

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -47,7 +47,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/query.sh <PR_NUMBER> <子命令>
 
 | 缺口 | 动作 |
 |---|---|
-| `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发;修不动(重试仍红 / 根因在 main)才暂停询问 |
+| `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发。若根因是 main 上的问题且修复已合入,rebase 到最新 main 后 push 即可拿到修复——`gh run rerun` 只在原 merge-ref 上重跑,不包含 main 的新提交;修不动时才暂停询问 |
 | 某家参审 reviewer 未审当前 HEAD | 按 reviewers.md 该家「触发」规则决定等待或发触发命令 |
 | 至少一家有本轮新 actionable 评论(判定见 reviewers.md) | 进入步骤 3 |
 | `security_alerts.open_introduced` 与已认定误报在案清单(核对方式见 reviewers.md「已知误报」)的差集非空,且该差集无对应新评论 | 上一轮没修干净(bot 不重复提醒)——只把差集里的 alert 数据(number / rule / path / url)带入步骤 3,按数据修而非按评论修;已在案的部分不重复处理。前提:CodeQL 分析完成且成功(门槛 1 口径)——分析未完成时差集基于过期数据,归入下行等待 |

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -47,7 +47,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/query.sh <PR_NUMBER> <子命令>
 
 | 缺口 | 动作 |
 |---|---|
-| `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发。若根因是 main 上的问题且修复已合入,rebase 到最新 main 后 push 即可拿到修复——`gh run rerun` 只在原 merge-ref 上重跑,不包含 main 的新提交;修不动时才暂停询问 |
+| `checks_failing` 非空(CI 红) | 就地修复并 push——CI 红会阻塞 reviewer 触发。若根因是 main 上的问题且修复已合入,rebase 到最新 main 后 `git push --force-with-lease` 即可拿到修复——`gh run rerun` 只在原 merge-ref 上重跑,不包含 main 的新提交,而 rebase 改写了 commit,普通 push 会被拒;已 rebase 到最新 main 仍红即属修不动,暂停询问 |
 | 某家参审 reviewer 未审当前 HEAD | 按 reviewers.md 该家「触发」规则决定等待或发触发命令 |
 | 至少一家有本轮新 actionable 评论(判定见 reviewers.md) | 进入步骤 3 |
 | `security_alerts.open_introduced` 与已认定误报在案清单(核对方式见 reviewers.md「已知误报」)的差集非空,且该差集无对应新评论 | 上一轮没修干净(bot 不重复提醒)——只把差集里的 alert 数据(number / rule / path / url)带入步骤 3,按数据修而非按评论修;已在案的部分不重复处理。前提:CodeQL 分析完成且成功(门槛 1 口径)——分析未完成时差集基于过期数据,归入下行等待 |


### PR DESCRIPTION
## 背景

两处 afk/审查循环 skill 文档修订:

1. **CI 重跑不含上游修复**:批次执行中,PR 的 CI 因 main 上的回归变红,hotfix 合入 main 后用 `gh run rerun --failed` 重试仍红——rerun 只在原 event payload 的 merge-ref 上重跑,不包含 main 的新提交,必须 rebase + push 生成新 merge-ref。原文把「根因在 main」整体归入"修不动、暂停询问"一侧,会在最可机械解决的场景误导 looper 升级请示。
2. **清尾立项口径**:/to-tickets 面向的是把计划/Spec 拆解为 tracer-bullet 票集,不适用于清尾轮对单个缺陷类 follow-up 的立项;改为按 issue-tracker 约定直接建 issue。

## 改动

- `pr-ai-review-loop/SKILL.md`「CI 红」行:补「根因在 main 且修复已合入时 rebase 再 push」及 rerun 不含新提交的说明,暂停询问条件相应收窄
- `afk-team-workflow/references/review-looper.md` rebase 时机清单:两种扩为三种,第三种只留指针指回 SKILL.md「CI 红」行,机制表述不重复
- `afk-team-workflow/SKILL.md`:清尾立项相关三处(职责分工列表、前置授权、清尾轮步骤)不再引用 /to-tickets,改为直接建 issue;gap 节同口径改为直接立项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新 CI 失败处理流程：当失败原因已合入主分支时，先同步最新代码并重新推送，以获取新的合并检查结果。
  * 明确避免基于旧合并引用重新运行 CI 检查。
  * 简化清尾立项流程，按问题跟踪规范直接创建事项。
  * Spec 落点存在缺口时，经用户授权后直接创建事项，不再调用独立的清尾工具。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
