### PR TITLE
feat(参考视频): 广告成片可在对话里点名单元重做，不必逐个到界面上操作

### DIFF
--- a/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
@@ -68,7 +68,8 @@ ad 参考直出项目下，`scene_id` / `scene_ids` 传的是 video_unit 的 `un
 | 重新生成单个 unit | `mcp__arcreel__generate_video_scene({"script": "episode_1.json", "scene_id": "E1U2"})` |
 | 重新生成多个 unit | `mcp__arcreel__generate_video_selected({"script": "episode_1.json", "scene_ids": ["E1U2", "E1U3"]})` |
 
-一次调用完成入队、等待与结果回报。要点：
+一次调用完成入队、等待与结果回报（申请时长与剧本编排不一致时同样先走下方的时长确认，
+确认后的那次调用才入队）。要点：
 
 - **点名即强制**：已有成片一律覆盖重做，unit 是否 stale 都可以重来一次——用户对满意度不够的 unit 说「再生成一版」照此处理
 - **不重新派生分组**：分组索引原样沿用，只对点名的 unit 重做。镜头有增删导致索引悬空时工具会报错要求先重新派生（重新派生走整集生成工具）

--- a/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-video/SKILL.md
@@ -33,6 +33,8 @@ ad 剧本骨架唯一（平铺 `shots[]`，不存在 `video_units`）。项目 `
 
 镜头编辑（增删/改时长/重排）后再次调用生成工具即自动重新派生；成员与参考集未变的 unit 保留已生成的视频，不重复消耗。
 
+成员或参考集变了的 unit 同样保留旧成片（剧本编辑不作废产物），只在工具输出里以 stale 清单透出——整集生成**不会**替用户把它们重做。要更新这些 unit，点名它们重新生成（见下方「点名重新生成 unit」）。
+
 广告/短片项目的产品镜头（`products_in_shot` 非空）在视频层自动二次注入产品参考：视频后端支持在首帧请求上叠加参考输入时把产品参考随请求注入并附高保真指令，不支持时正常降级——无需手动指定，video_prompt 不必复述产品外观。
 
 > 画面比例、时长等规格由项目配置和视频模型能力决定，MCP 工具自动处理。
@@ -54,7 +56,25 @@ ad 剧本骨架唯一（平铺 `shots[]`，不存在 `video_units`）。项目 `
 
 > 所有任务一次性提交到生成队列，由 Worker 按 per-provider 并发配置自动调度。
 > 集号从 script 顶层 `episode` 或文件名推导，无需手动传。
-> `reference_video` 模式下 `scene_id` / `scene_ids` 会被忽略，转整集生成。
+> narration / drama 的 `reference_video` 项目下 `scene_id` / `scene_ids` 会被忽略，转整集生成；
+> ad 参考直出项目改为按 unit 点名，见下。
+
+### 点名重新生成 unit（ad 参考直出）
+
+ad 参考直出项目下，`scene_id` / `scene_ids` 传的是 video_unit 的 `unit_id`：
+
+| 操作 | 工具 |
+|------|------|
+| 重新生成单个 unit | `mcp__arcreel__generate_video_scene({"script": "episode_1.json", "scene_id": "E1U2"})` |
+| 重新生成多个 unit | `mcp__arcreel__generate_video_selected({"script": "episode_1.json", "scene_ids": ["E1U2", "E1U3"]})` |
+
+一次调用完成入队、等待与结果回报。要点：
+
+- **点名即强制**：已有成片一律覆盖重做，unit 是否 stale 都可以重来一次——用户对满意度不够的 unit 说「再生成一版」照此处理
+- **不重新派生分组**：分组索引原样沿用，只对点名的 unit 重做。镜头有增删导致索引悬空时工具会报错要求先重新派生（重新派生走整集生成工具）
+- stale 是产物与当前编排的比较结果，不是一个要去清除的标记：重新生成成功后它自然不再偏离，无需额外操作
+- 索引里没有的 `unit_id` 会被跳过并写进输出；一个都没命中时报错并列出索引现有的 unit_id
+- 点名重新生成没有断点可续，`resume` 会被忽略
 
 ### reference_video 模式的时长确认
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -18,7 +18,7 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 6. **sheet 过目（软门禁）**：产品生成了 `product_sheet` 时，分镜开工前（参考直出路径为首次视频生成前——sheet 直接进 unit 参考集）先请用户到产品资产页确认 sheet 与真品一致（不一致就重新生成 sheet），确认后才继续；无 sheet（仅原图）时直接开工。这是工作流约定，没有系统状态强制
 7. **镜头编排与生成**：每镜头口播文案/时长/section 可经 `patch_episode_script` 调整；镜头**顺序**调整只在 WebUI 剧本页提供（agent 侧没有重排工具，用户要求调顺序时引导其到剧本页操作，不要用逐字段互换内容模拟）。两条生成路径：
    - **storyboard 路径**：用 `generate-storyboard` / `generate-video` 逐镜头出图出视频；分镜生成后引导用户审核产品形象，不合格的重生成分镜，在产生视频费用前拦截
-   - **reference_video 路径（参考直出）**：直接调 `mcp__arcreel__generate_video_episode` 一键直出——工具自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成
+   - **reference_video 路径（参考直出）**：直接调 `mcp__arcreel__generate_video_episode` 一键直出——工具自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
 
    产品镜头（`products_in_shot` 非空）的分镜与视频生成会自动注入产品参考并附高保真指令，prompt 不必复述产品外观
 

--- a/agent_runtime_profile/CLAUDE.ad.md
+++ b/agent_runtime_profile/CLAUDE.ad.md
@@ -70,7 +70,7 @@ agent session 的当前工作目录（cwd）已绑定到当前项目根，**所�
 ### 参考直出（reference_video）的派生分组
 
 - 剧本骨架不变（仍是平铺 `shots[]`）；`generate_video_*` 工具会自动把**连续镜头**派生分组为 video_unit（每 unit ≤4 个镜头，unit 总时长受供应商单次生成上限约束），按 unit 直出视频到 `reference_videos/{unit_id}.mp4`，跳过分镜步骤
-- 分组索引持久在剧本 `reference_units` 字段（仅引用 shot_id 与参考集）——由工具派生维护，**不要手工编辑**；shots 是内容唯一真相，镜头编辑后再次生成即自动重新派生，未变化的 unit 不重复生成
+- 分组索引持久在剧本 `reference_units` 字段（仅引用 shot_id 与参考集）——由工具派生维护，**不要手工编辑**；shots 是内容唯一真相，镜头编辑后再次生成即自动重新派生。整集生成只补没有成片的 unit，已有成片的一律沿用——编排改动过的 unit 也不例外，要更新须按 `unit_id` 点名重做（见 `generate-video` skill）
 - unit 参考集从成员镜头继承：产品参考全量注入且绝对优先（有 sheet 时 sheet + 原图，无 sheet 时原图直注，自动附高保真指令），其后是角色/场景/道具 sheet；口播文案不进画面 prompt
 - **镜头时长约束**：reference_video 路径下单镜头时长为 1-15 秒自由整数（storyboard 路径则须取视频模型 `supported_durations` 成员）；越界时主动列出并建议调整，经 `patch_episode_script` 修正后再生成
 

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -737,12 +737,18 @@ def _report_residual_staleness(ctx: ToolContext, script_filename: str, unit_ids:
     stale 是产物签名与当前编排的读时比较结果，正常路径下 finalize 落新签名即自然回清；
     但生成期间剧本被改、或产物没带上签名时它会留下来。不复核就只能由智能体替系统宣布
     角标已消失，说错了用户无从察觉。复核失败不改变本次生成的成败——产物已落盘、已计费。
+
+    覆盖不到全部点名 unit 的复核一律按「无法复核」报，不按「未偏离」报：索引被并发重新
+    派生后点名的 ID 可能已不存在，此时过滤只会得到空集合，沿用空集合等于替系统宣布干净。
     """
     try:
         fresh = ctx.pm.load_script(ctx.project_name, script_filename)
-        units = [
-            u for u in (fresh.get("reference_units") or []) if isinstance(u, dict) and u.get("unit_id") in unit_ids
-        ]
+        indexed = fresh.get("reference_units") or []
+        if not isinstance(indexed, list):
+            raise ValueError(f"reference_units 必须是数组，当前为 {type(indexed).__name__}")
+        units = [u for u in indexed if isinstance(u, dict) and u.get("unit_id") in unit_ids]
+        if missing := unit_ids - {str(u["unit_id"]) for u in units}:
+            raise ValueError(f"以下 unit 已不在分组索引中：{'、'.join(sorted(missing))}")
         residual = ad_stale_unit_ids(fresh, units)
     except Exception as exc:  # noqa: BLE001
         log.append(f"⚠️  无法复核重新生成后的 stale 状态：{exc}")
@@ -1106,8 +1112,9 @@ def generate_video_all_tool(ctx: ToolContext):
 def generate_video_selected_tool(ctx: ToolContext):
     @tool(
         "generate_video_selected",
-        "生成指定多个场景的视频（独立 checkpoint，按 scene_ids 哈希）。ad 参考直出项目传 unit_id 列表即"
-        "对这些 unit 重新生成（覆盖已有成片）；其余 reference_video 项目会忽略 scene_ids 转整集生成。",
+        "生成指定多个场景的视频。storyboard 项目用按 scene_ids 哈希的独立 checkpoint，支持 resume 续传。"
+        "ad 参考直出项目传 unit_id 列表即对这些 unit 重新生成（覆盖已有成片），不落 checkpoint、不支持 resume；"
+        "其余 reference_video 项目会忽略 scene_ids 转整集生成。",
         {
             "type": "object",
             "properties": {
@@ -1120,7 +1127,10 @@ def generate_video_selected_tool(ctx: ToolContext):
                     "items": {"type": "string"},
                     "description": '场景或片段 ID 列表；ad 参考直出项目传 video_unit 的 unit_id 列表（如 ["E1U2"]）',
                 },
-                "resume": {"type": "boolean", "description": "是否从上次中断处继续"},
+                "resume": {
+                    "type": "boolean",
+                    "description": "是否从上次中断处继续；ad 参考直出项目的点名重新生成会忽略此参数",
+                },
                 "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script", "scene_ids"],

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -944,7 +944,10 @@ def generate_video_scene_tool(ctx: ToolContext):
 
             route = _resolve_reference_route(ctx, script)
             if route == "episode":
-                log.append(f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。")
+                log.append(
+                    f"⚠️  narration / drama 的 reference_video 项目暂不支持单 unit 精确选择；"
+                    f"scene_id={scene_id} 被忽略，转整集生成。"
+                )
                 return await _run_reference_episode(
                     ctx=ctx,
                     script=script,
@@ -1139,7 +1142,8 @@ def generate_video_selected_tool(ctx: ToolContext):
             route = _resolve_reference_route(ctx, script)
             if route == "episode":
                 log.append(
-                    f"⚠️  reference_video 模式暂不支持多 unit 精确选择；scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
+                    f"⚠️  narration / drama 的 reference_video 项目暂不支持多 unit 精确选择；"
+                    f"scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
                 )
                 return await _run_reference_episode(
                     ctx=ctx,

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -482,6 +482,7 @@ async def _generate_reference_units(
     episode: int,
     resume: bool,
     log: list[str],
+    checkpoint_path: Path | None,
     build_specs: Callable[[list[dict[str, Any]], list[str], list[str]], tuple[list[TaskSpec], dict[str, int]]],
     spec_for: Callable[[dict[str, Any]], TaskSpec],
     project: dict[str, Any],
@@ -506,12 +507,16 @@ async def _generate_reference_units(
     调用不产生任何任务，返回 :class:`DurationConfirmationPending` 供调用方转述给用户；
     用户同意后调用方带 ``confirm_duration=True`` 重新调用完成入队（与 Web 端
     ``duration-precheck`` 预检共用同一取档规则）。
+
+    ``checkpoint_path`` 为 None 表示本次生成不落 checkpoint：点名重新生成一律强制覆盖，
+    没有可续传的语义，写一份没有读者的进度文件只会在中断时留下垃圾，也会覆盖掉整集
+    生成留下的进度。
     """
     project_dir = ctx.project_path
-    ckpt_path = _episode_checkpoint_path(project_dir, episode)
+    ckpt_path = checkpoint_path
     completed: list[str] = []
     started_at = datetime.now(UTC).isoformat()
-    if resume:
+    if resume and ckpt_path is not None:
         ckpt = _load_checkpoint_at(ckpt_path)
         if ckpt:
             completed = ckpt.get("completed_scenes", [])
@@ -555,7 +560,9 @@ async def _generate_reference_units(
             ordered_paths=ordered_paths,
             completed=completed,
             fallback_relpath=_reference_fallback_relpath,
-            save_fn=lambda: _save_checkpoint_at(ckpt_path, completed, started_at, episode=episode),
+            save_fn=lambda: (
+                None if ckpt_path is None else _save_checkpoint_at(ckpt_path, completed, started_at, episode=episode)
+            ),
             log=log,
         )
         if failures:
@@ -564,7 +571,8 @@ async def _generate_reference_units(
     final = [p for p in ordered_paths if p is not None]
     if not final:
         raise RuntimeError("没有生成任何 video_unit")
-    _clear_checkpoint_at(ckpt_path)
+    if ckpt_path is not None:
+        _clear_checkpoint_at(ckpt_path)
     return final
 
 
@@ -598,6 +606,7 @@ async def _run_reference_episode(
         episode=episode,
         resume=resume,
         log=log,
+        checkpoint_path=_episode_checkpoint_path(ctx.project_path, episode),
         build_specs=lambda u, skip, lg: _build_reference_specs(
             units=u, script_filename=script_filename, skip_ids=skip, log=lg
         ),
@@ -642,7 +651,10 @@ async def _run_ad_reference_episode(
     # 是否重生成由用户/智能体决定（重生成 finalize 落新签名后自然回归非 stale）。
     stale_ids = ad_stale_unit_ids(script, units)
     if stale_ids:
-        log.append(f"⚠️  以下 unit 的剧本已变更但保留既有成片（stale），如需更新请重新生成：{', '.join(stale_ids)}")
+        log.append(
+            f"⚠️  以下 unit 的剧本已变更但保留既有成片（stale）：{', '.join(stale_ids)}。"
+            "如需更新，用 generate_video_selected 点名这些 unit 重新生成。"
+        )
 
     style = project.get("style")
     result = await _generate_reference_units(
@@ -651,6 +663,7 @@ async def _run_ad_reference_episode(
         episode=episode,
         resume=resume,
         log=log,
+        checkpoint_path=_episode_checkpoint_path(ctx.project_path, episode),
         build_specs=lambda u, skip, lg: _build_ad_reference_specs(
             script=script,
             units=u,
@@ -673,6 +686,123 @@ async def _run_ad_reference_episode(
     if isinstance(result, DurationConfirmationPending):
         return _duration_confirmation_response(result, log)
     header = f"参考直出生成完成，共 {len(result)} 个 unit"
+    return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
+
+
+def _select_ad_units(script: dict[str, Any], unit_ids: list[str], log: list[str]) -> list[dict[str, Any]]:
+    """按 unit_id 从持久化的分组索引里点名取 unit，重复 ID 只取一次。
+
+    索引里没有的 ID 记日志跳过（多半是镜头增删后未重新派生分组），一个都没命中才抛错：
+    错误里带上索引现有的 unit_id，智能体据此就能引导用户改口或先重新派生，不必再问一轮。
+    """
+    indexed = script.get("reference_units")
+    by_id: dict[str, dict[str, Any]] = {}
+    if isinstance(indexed, list):
+        for unit in indexed:
+            if isinstance(unit, dict) and isinstance(unit.get("unit_id"), str) and unit["unit_id"]:
+                by_id.setdefault(unit["unit_id"], unit)
+
+    selected: list[dict[str, Any]] = []
+    for unit_id in dict.fromkeys(unit_ids):
+        unit = by_id.get(unit_id)
+        if unit is None:
+            log.append(f"⚠️  unit {unit_id} 不在分组索引中，跳过")
+            continue
+        selected.append(unit)
+    if not selected:
+        known = "、".join(by_id) if by_id else "（索引为空，请先整集生成或重新派生分组）"
+        raise ValueError(f"没有匹配到任何 unit：{', '.join(unit_ids)}；索引中现有 {known}")
+    return selected
+
+
+def _assert_ad_units_generatable(
+    script: dict[str, Any], units: list[dict[str, Any]], script_filename: str, style: str | None
+) -> None:
+    """点名的 unit 逐个当场校验可入队性，不合法即抛错。
+
+    批量路径对坏 unit 是「跳过并告警」——一个坏 unit 不该中断整批；点名重新生成没有
+    批次可保全，沿用跳过会让调用以「没有生成任何 video_unit」收场，智能体转述不出原因。
+    校验走 ``_ad_reference_unit_spec``，与真正入队时同一份构造，不另立判据。
+    """
+    for unit in units:
+        try:
+            _ad_reference_unit_spec(script, unit, script_filename, style)
+        except ValueError as exc:
+            raise ValueError(f"unit {unit.get('unit_id')} 无法生成：{exc}") from exc
+
+
+def _report_residual_staleness(ctx: ToolContext, script_filename: str, unit_ids: set[str], log: list[str]) -> None:
+    """生成后按签名复核点名 unit 是否仍偏离编排，仍偏离的明说。
+
+    stale 是产物签名与当前编排的读时比较结果，正常路径下 finalize 落新签名即自然回清；
+    但生成期间剧本被改、或产物没带上签名时它会留下来。不复核就只能由智能体替系统宣布
+    角标已消失，说错了用户无从察觉。复核失败不改变本次生成的成败——产物已落盘、已计费。
+    """
+    try:
+        fresh = ctx.pm.load_script(ctx.project_name, script_filename)
+        units = [
+            u for u in (fresh.get("reference_units") or []) if isinstance(u, dict) and u.get("unit_id") in unit_ids
+        ]
+        residual = ad_stale_unit_ids(fresh, units)
+    except Exception as exc:  # noqa: BLE001
+        log.append(f"⚠️  无法复核重新生成后的 stale 状态：{exc}")
+        return
+    if residual:
+        log.append(f"⚠️  以下 unit 重新生成后仍偏离当前编排（stale），可能是生成期间剧本又被改动：{', '.join(residual)}")
+
+
+async def _run_ad_reference_units(
+    *,
+    ctx: ToolContext,
+    script_filename: str,
+    unit_ids: list[str],
+    confirm_duration: bool,
+    log: list[str],
+) -> dict[str, Any]:
+    """ad + reference_video：对点名的 unit 重新生成成片，不重新派生分组。
+
+    与 Web 端逐 unit 重新生成同口径：分组索引原样沿用（分组是纯函数，重生成单个 unit
+    时可复现），成员镜头按索引从 shots 水合。点名即强制——已有成片的 unit 一律重新
+    生成，不按现有产物复用，因此非 stale 的 unit 也能重来一次；stale 不是被谁清掉的
+    状态位，而是产物签名与当前编排的比较结果，finalize 落下新签名后自然不再偏离。
+    """
+    project = ctx.pm.load_project(ctx.project_name)
+    script = ctx.pm.load_script(ctx.project_name, script_filename)
+    episode = ProjectManager.resolve_episode_from_script(script, script_filename)
+
+    selected = _select_ad_units(script, unit_ids, log)
+    style = project.get("style")
+    style_str = style if isinstance(style, str) else None
+    _assert_ad_units_generatable(script, selected, script_filename, style_str)
+    log.append(f"重新生成 {len(selected)} 个 unit（已有成片一律覆盖）：{', '.join(u['unit_id'] for u in selected)}")
+
+    result = await _generate_reference_units(
+        ctx=ctx,
+        units=selected,
+        episode=episode,
+        resume=False,
+        log=log,
+        checkpoint_path=None,
+        build_specs=lambda u, skip, lg: _build_ad_reference_specs(
+            script=script,
+            units=u,
+            script_filename=script_filename,
+            style=style_str,
+            skip_ids=skip,
+            log=lg,
+        ),
+        spec_for=lambda u: _ad_reference_unit_spec(script, u, script_filename, style_str),
+        project=project,
+        confirm_duration=confirm_duration,
+        # 点名即强制：磁盘上的同名成片一律不复用，否则「重新生成」会变成一次空转，
+        # 而这恰是 stale unit 最需要它生效的场景。
+        reuse_existing=lambda _u: False,
+        ad_shots_for=lambda u: resolve_ad_unit_shots(script, u),
+    )
+    if isinstance(result, DurationConfirmationPending):
+        return _duration_confirmation_response(result, log)
+    _report_residual_staleness(ctx, script_filename, {u["unit_id"] for u in selected}, log)
+    header = f"参考直出重新生成完成，共 {len(result)} 个 unit"
     return {"content": [{"type": "text", "text": "\n".join([header, *log])}]}
 
 
@@ -784,7 +914,8 @@ def generate_video_episode_tool(ctx: ToolContext):
 def generate_video_scene_tool(ctx: ToolContext):
     @tool(
         "generate_video_scene",
-        "生成单个场景/片段的视频。reference_video 模式会忽略 scene_id 转为整集生成。",
+        "生成单个场景/片段的视频。ad 参考直出项目传 unit_id 即对该 unit 重新生成（覆盖已有成片）；"
+        "其余 reference_video 项目会忽略 scene_id 转为整集生成。",
         {
             "type": "object",
             "properties": {
@@ -792,13 +923,17 @@ def generate_video_scene_tool(ctx: ToolContext):
                     "type": "string",
                     "description": "剧本文件名（如 episode_1.json），必须是纯文件名，禁止任何路径分隔符",
                 },
-                "scene_id": {"type": "string", "description": "场景或片段 ID"},
+                "scene_id": {
+                    "type": "string",
+                    "description": "场景或片段 ID；ad 参考直出项目传 video_unit 的 unit_id（如 E1U2）",
+                },
                 "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
             },
             "required": ["script", "scene_id"],
         },
     )
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        log: list[str] = []
         try:
             script_filename = validate_script_filename(args["script"])
             scene_id = args["scene_id"]
@@ -809,9 +944,7 @@ def generate_video_scene_tool(ctx: ToolContext):
 
             route = _resolve_reference_route(ctx, script)
             if route == "episode":
-                log: list[str] = [
-                    f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。"
-                ]
+                log.append(f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。")
                 return await _run_reference_episode(
                     ctx=ctx,
                     script=script,
@@ -821,15 +954,12 @@ def generate_video_scene_tool(ctx: ToolContext):
                     log=log,
                 )
             if route == "ad":
-                ad_log: list[str] = [
-                    f"⚠️  reference_video 模式暂不支持单 unit 精确选择；scene_id={scene_id} 被忽略，转整集生成。"
-                ]
-                return await _run_ad_reference_episode(
+                return await _run_ad_reference_units(
                     ctx=ctx,
                     script_filename=script_filename,
-                    resume=False,
+                    unit_ids=[scene_id],
                     confirm_duration=confirm_duration,
-                    log=ad_log,
+                    log=log,
                 )
 
             items, id_field, _chars, _scenes, _props = get_storyboard_items(script)
@@ -884,7 +1014,7 @@ def generate_video_scene_tool(ctx: ToolContext):
             output_path = project_dir / rel
             return {"content": [{"type": "text", "text": f"✅ 视频已保存: {output_path}"}]}
         except Exception as exc:  # noqa: BLE001
-            return tool_error("generate_video_scene", exc)
+            return tool_error("generate_video_scene", exc, log)
 
     return _handler
 
@@ -973,7 +1103,8 @@ def generate_video_all_tool(ctx: ToolContext):
 def generate_video_selected_tool(ctx: ToolContext):
     @tool(
         "generate_video_selected",
-        "生成指定多个场景的视频（独立 checkpoint，按 scene_ids 哈希）。reference_video 模式会忽略 scene_ids 转整集生成。",
+        "生成指定多个场景的视频（独立 checkpoint，按 scene_ids 哈希）。ad 参考直出项目传 unit_id 列表即"
+        "对这些 unit 重新生成（覆盖已有成片）；其余 reference_video 项目会忽略 scene_ids 转整集生成。",
         {
             "type": "object",
             "properties": {
@@ -984,7 +1115,7 @@ def generate_video_selected_tool(ctx: ToolContext):
                 "scene_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "场景或片段 ID 列表",
+                    "description": '场景或片段 ID 列表；ad 参考直出项目传 video_unit 的 unit_id 列表（如 ["E1U2"]）',
                 },
                 "resume": {"type": "boolean", "description": "是否从上次中断处继续"},
                 "confirm_duration": _CONFIRM_DURATION_SCHEMA_PROPERTY,
@@ -1019,13 +1150,14 @@ def generate_video_selected_tool(ctx: ToolContext):
                     log=log,
                 )
             if route == "ad":
-                log.append(
-                    f"⚠️  reference_video 模式暂不支持多 unit 精确选择；scene_ids={','.join(scene_ids)} 被忽略，转整集生成。"
-                )
-                return await _run_ad_reference_episode(
+                if resume:
+                    # 点名重新生成一律覆盖已有成片，没有可续传的中断态；照单收下再无视会让
+                    # 调用方以为断点还在。
+                    log.append("⚠️  点名重新生成不支持续传，resume 已忽略。")
+                return await _run_ad_reference_units(
                     ctx=ctx,
                     script_filename=script_filename,
-                    resume=resume,
+                    unit_ids=scene_ids,
                     confirm_duration=confirm_duration,
                     log=log,
                 )

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -3263,6 +3263,259 @@ async def test_generate_video_all_ad_reference_falls_through_to_episode(
 
 
 # ---------------------------------------------------------------------------
+# ad 参考直出：点名 unit 重新生成
+# ---------------------------------------------------------------------------
+
+
+def _existing_ad_unit(
+    ctx: ToolContext, *, shot_ids: list[str], signature: str | None = "signature-of-old-orchestration"
+) -> dict[str, Any]:
+    """一个已有成片（文件也在盘）的分组索引条目；``signature`` 为 None 表示存量无签名产物。"""
+    assets: dict[str, Any] = {"video_clip": "reference_videos/E1U1.mp4", "status": "completed"}
+    if signature is not None:
+        assets["source_signature"] = signature
+    out = ctx.project_path / "reference_videos" / "E1U1.mp4"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(b"\x00")
+    return {
+        "unit_id": "E1U1",
+        "shot_ids": shot_ids,
+        "references": [{"type": "product", "name": "保温杯"}],
+        "generated_assets": assets,
+    }
+
+
+def _ad_batch(ctx: ToolContext, enqueued: list[Any], *, refresh_signature: bool = True, fail: bool = False):
+    """``batch_enqueue_and_wait`` 替身：记录 spec，成功时按 finalize 的写点更新索引条目。"""
+
+    async def fake_batch(*, project_name: str, specs: list[Any], on_success=None, on_failure=None):
+        from lib.generation_queue_client import BatchTaskResult
+        from lib.reference_video.ad_units import ad_unit_source_signature
+
+        script = ctx.pm.script_payload  # type: ignore[attr-defined]
+        by_id = {u["unit_id"]: u for u in script.get("reference_units") or []}
+        successes: list[Any] = []
+        failures: list[Any] = []
+        for spec in specs:
+            enqueued.append(spec)
+            if fail:
+                br = BatchTaskResult(
+                    resource_id=spec.resource_id, task_id="t1", status="failed", error="供应商拒绝：额度不足"
+                )
+                failures.append(br)
+                if on_failure:
+                    on_failure(br)
+                continue
+            out = ctx.project_path / "reference_videos" / f"{spec.resource_id}.mp4"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"\x01")
+            unit = by_id.get(spec.resource_id)
+            if unit is not None:
+                assets = unit.setdefault("generated_assets", {})
+                assets["video_clip"] = f"reference_videos/{spec.resource_id}.mp4"
+                assets["status"] = "completed"
+                if refresh_signature:
+                    assets["source_signature"] = ad_unit_source_signature(script, unit)
+            br = BatchTaskResult(
+                resource_id=spec.resource_id,
+                task_id="t1",
+                status="succeeded",
+                result={"file_path": f"reference_videos/{spec.resource_id}.mp4"},
+            )
+            successes.append(br)
+            if on_success:
+                on_success(br)
+        return successes, failures
+
+    return fake_batch
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_regenerates_named_stale_unit(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """点名 stale unit：不复用既有成片、照常入队，且不重新派生分组索引。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    enqueued: list[Any] = []
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, enqueued))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+    # 分组不重新派生：索引仍是点名时的成员集，prompt 也只含该成员镜头
+    script = pm.script_payload  # type: ignore[attr-defined]
+    assert script["reference_units"][0]["shot_ids"] == ["E1S1"]
+    assert "E1S2" not in enqueued[0].payload["prompt"]
+    # finalize 落新签名后不再偏离，工具不再报 stale
+    assert "stale" not in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_generate_video_scene_ad_regenerates_named_unit(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """单 unit 入口同样点名生效，不再退化成整集生成。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    enqueued: list[Any] = []
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, enqueued))
+
+    tool_obj = generate_video_scene_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1U1"})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+    assert "转整集生成" not in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_forces_non_stale_unit(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """非 stale 的 unit 被点名时同样重新生成——点名即强制，不按现有产物复用。"""
+    from lib.reference_video.ad_units import ad_unit_source_signature
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    unit = _existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1", "E1S2"], signature=None)
+    pm.script_payload["reference_units"] = [unit]  # type: ignore[attr-defined]
+    unit["generated_assets"]["source_signature"] = ad_unit_source_signature(pm.script_payload, unit)  # type: ignore[attr-defined]
+
+    enqueued: list[Any] = []
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, enqueued))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_keeps_episode_checkpoint(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """点名重新生成不落 checkpoint，也不清掉整集生成留下的断点。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+    ckpt = ad_reference_ctx.project_path / "videos" / ".checkpoint_ep1.json"
+    ckpt.parent.mkdir(parents=True, exist_ok=True)
+    ckpt.write_text(json.dumps({"completed_scenes": ["E1U9"]}), encoding="utf-8")
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, []))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"], "resume": True})
+
+    assert out.get("is_error") is not True, out
+    assert json.loads(ckpt.read_text(encoding="utf-8"))["completed_scenes"] == ["E1U9"]
+    # resume 对点名重新生成无意义，照单收下再无视会让调用方以为断点还在
+    assert "resume 已忽略" in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_unknown_unit_ids_error(ad_reference_ctx: ToolContext) -> None:
+    """全部点名 ID 都不在索引里：报错并带上索引现有的 unit_id。"""
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U7"]})
+
+    assert out["is_error"] is True
+    text = out["content"][0]["text"]
+    assert "E1U7" in text
+    assert "E1U1" in text
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_skips_unknown_and_generates_rest(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """部分点名 ID 无效时生成其余 unit，被跳过的 ID 写进输出供智能体转述。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    enqueued: list[Any] = []
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, enqueued))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1", "E1U7"]})
+
+    assert out.get("is_error") is not True, out
+    assert [s.resource_id for s in enqueued] == ["E1U1"]
+    assert "E1U7" in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_dangling_index_fails_loud(ad_reference_ctx: ToolContext) -> None:
+    """点名 unit 的成员镜头已被删：报出重新派生分组的指引，不静默跳过。"""
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S9"])]  # type: ignore[attr-defined]
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out["is_error"] is True
+    text = out["content"][0]["text"]
+    assert "E1U1" in text
+    assert "重新派生分组" in text
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_reports_failure_reason(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """生成失败时供应商给的原因随工具输出回到智能体手上。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, [], fail=True))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out["is_error"] is True
+    assert "额度不足" in out["content"][0]["text"]
+
+
+@pytest.mark.unit
+async def test_generate_video_selected_ad_reports_residual_staleness(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """产物没带上新签名时仍判 stale，工具明说而不是让智能体宣布角标已消失。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _ad_batch(ad_reference_ctx, [], refresh_signature=False))
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out.get("is_error") is not True, out
+    text = out["content"][0]["text"]
+    assert "stale" in text
+    assert "E1U1" in text
+
+
+# ---------------------------------------------------------------------------
 # split_reference_video_units
 # ---------------------------------------------------------------------------
 

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -3515,6 +3515,34 @@ async def test_generate_video_selected_ad_reports_residual_staleness(
     assert "E1U1" in text
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("mutated_index", [[], {"E1U1": {"unit_id": "E1U1"}}], ids=["vanished", "malformed"])
+async def test_generate_video_selected_ad_recheck_without_coverage_says_so(
+    ad_reference_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch, mutated_index: Any
+) -> None:
+    """复核覆盖不到点名 unit 时报「无法复核」，不把空集合当成「未偏离」宣布干净。"""
+    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+
+    pm = ad_reference_ctx.pm
+    pm.script_payload["reference_units"] = [_existing_ad_unit(ad_reference_ctx, shot_ids=["E1S1"])]  # type: ignore[attr-defined]
+
+    inner = _ad_batch(ad_reference_ctx, [])
+
+    async def fake_batch(**kwargs: Any):
+        result = await inner(**kwargs)
+        # 生成落盘后索引被并发重新派生：点名的 ID 消失 / 容器被写成非数组
+        pm.script_payload["reference_units"] = mutated_index  # type: ignore[attr-defined]
+        return result
+
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
+
+    tool_obj = generate_video_selected_tool(ad_reference_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1U1"]})
+
+    assert out.get("is_error") is not True, out
+    assert "无法复核" in out["content"][0]["text"]
+
+
 # ---------------------------------------------------------------------------
 # split_reference_video_units
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1667

## 做了什么

广告/短片的参考直出项目里，成片与剧本编排偏离（stale）或用户对某个 unit 不满意时，此前只能到界面上逐个重做。现在智能体一次工具调用即可对点名的 unit 完成入队、等待与结果回报。

入口沿用既有工具而非新增参数：`generate_video_scene` 的 `scene_id`、`generate_video_selected` 的 `scene_ids` 在 **ad + 参考直出**路线下解释为 `unit_id`——这两个字段本就是「点名」语义，只是过去在该路线下被忽略并退化成整集生成。`generate_video_episode` / `generate_video_all` 维持整集语义。

关键取舍：

- **不重新派生分组**：沿用剧本里持久化的 `reference_units` 索引，与 Web 端逐 unit 重做同口径；否则一次点名会静默改变别的 unit 的成员集
- **点名即强制**：已有成片一律覆盖，否则对 stale unit 的「重新生成」恰好会变成一次空转；非 stale unit 也因此可以重来一版
- **坏 unit 对点名 fail loud**：批量路径「跳过并告警」是为了不让一个坏 unit 中断整批，点名没有批次可保全，沿用跳过会以「没有生成任何 video_unit」收场，智能体转述不出原因
- **点名不落 checkpoint**：强制覆盖没有可续传的中断态；`resume=true` 记一行「已忽略」而非闷声吃掉
- **生成后复核 stale**：finalize 落新签名后 stale 自然回清，但生成期间剧本又被改会留下漏报窗口，复核到仍偏离就追加一行告警。复核失败只记一行，不把已落盘已计费的成功生成翻成失败

## 验证

- 全量 `pytest`：**7938 passed**
- `ruff check` / `ruff format --check`（748 files）通过
- `basedpyright`：**0 errors**
- `lint-imports`：1 kept / 0 broken
- 未跑前端检查——本分支未触碰 `frontend/`

新增 9 个用例覆盖：点名单个 / 多个 unit、强制覆盖已有成片、未命中 ID 跳过、全未命中报错并列出索引现有 ID、索引悬空 fail loud、`resume` 忽略、失败原因进入返回文本、生成后 stale 复核。

## 本地审查修复

在实现基础上另修 3 处（commit f0c6aaab）：narration / drama 分支的告警仍写「reference_video 模式暂不支持」而对智能体过度概括；SKILL.md 点名小节漏写时长确认这道闸（点名路径同样会先返回待确认清单）；`CLAUDE.ad.md` 仍称整集生成会重做变化过的 unit。

## 已知范围限制

narration / drama 的参考路线（`video_units[]`）仍是「忽略 ID 转整集」，本 PR 只覆盖 ad，两条参考路线在这一点上目前不对称。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持按 `unit_id` 点名重新生成单个或多个广告参考视频片段。
  * 点名生成会强制覆盖已有成片，并保留现有分组关系。
  * 生成完成后自动检查并更新片段的过期状态。

* **改进**
  * 成员或编排变化时保留已有成片，仅标记过期片段，不再自动整集重做。
  * 整集生成仅补齐缺失片段。
  * 对重复、无效或已删除的片段标识提供明确反馈。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->