### PR TITLE
fix(cost-estimation): 修正宫格实付在重复条目编号下被重复计入合计

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -385,29 +385,30 @@ class CostEstimationService:
                         grid_cost_per_segment[seg.get(id_key, "")] = (per_scene_cost, grid_image_unit_cost[1])
 
             # --- Grid actual cost apportionment ---
-            # Map grid_id → [scene_ids] from each segment's generated_assets
-            grid_to_scenes: dict[str, list[str]] = {}
-            for seg in raw_segments:
+            # Map grid_id → [raw_segments 下标]（按位置而非条目 ID 组织）：ADR 0053 接受
+            # 一张宫格覆盖的多个条目共用同一 ID，若按 ID 建表，同 ID 条目的下标会合并进同一
+            # 键，均摊分母被抵消，分发阶段又按 ID 命中同一份额、每个同 ID 条目各挂一次全额。
+            # 按位置索引保证分发阶段每个条目（含同 ID 条目）恰好消费一次自己的份额。
+            grid_to_indices: dict[str, list[int]] = {}
+            for idx, seg in enumerate(raw_segments):
                 gid = get_generated_assets(seg).get("grid_id")
-                sid = seg.get(id_key, "")
-                if gid and sid:
-                    grid_to_scenes.setdefault(gid, []).append(sid)
+                if gid and seg.get(id_key, ""):
+                    grid_to_indices.setdefault(gid, []).append(idx)
 
-            # Compute per-scene share of each grid's actual cost
-            grid_actual_per_scene: dict[str, CostBreakdown] = {}
-            for gid, sids in grid_to_scenes.items():
+            # Compute per-position share of each grid's actual cost，复用
+            # ``_split_cost_across`` 的余数补偿语义，使各份之和与冻结实付分文不差。
+            grid_actual_per_index: dict[int, CostBreakdown] = {}
+            for gid, indices in grid_to_indices.items():
                 grid_cost = _claim_actual(actual_by_segment, claimed_actual, gid, ("image",)).get("image", {})
                 if grid_cost:
-                    n = len(sids)
-                    per_scene: CostBreakdown = {cur: round(amt / n, 6) for cur, amt in grid_cost.items()}
-                    for sid in sids:
-                        grid_actual_per_scene[sid] = _merge_breakdowns(grid_actual_per_scene.get(sid, {}), per_scene)
+                    for idx, share in zip(indices, _split_cost_across(grid_cost, len(indices)), strict=True):
+                        grid_actual_per_index[idx] = share
 
             segments_result = []
             ep_est: dict[str, CostBreakdown] = {}
             ep_act: dict[str, CostBreakdown] = {}
 
-            for seg in raw_segments:
+            for idx, seg in enumerate(raw_segments):
                 seg_id = seg.get(id_key, "")
                 duration = seg.get("duration_seconds", 8)
 
@@ -457,8 +458,8 @@ class CostEstimationService:
 
                 seg_actual = _claim_actual(actual_by_segment, claimed_actual, seg_id)
                 act_image: CostBreakdown = seg_actual.get("image", {})
-                if seg_id in grid_actual_per_scene:
-                    act_image = _merge_breakdowns(act_image, grid_actual_per_scene[seg_id])
+                if idx in grid_actual_per_index:
+                    act_image = _merge_breakdowns(act_image, grid_actual_per_index[idx])
                 act_video: CostBreakdown = seg_actual.get("video", {})
                 act_audio: CostBreakdown = seg_actual.get("audio", {})
 

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -385,18 +385,17 @@ class CostEstimationService:
                         grid_cost_per_segment[seg.get(id_key, "")] = (per_scene_cost, grid_image_unit_cost[1])
 
             # --- Grid actual cost apportionment ---
-            # Map grid_id → [raw_segments 下标]（按位置而非条目 ID 组织）：ADR 0053 接受
-            # 一张宫格覆盖的多个条目共用同一 ID，若按 ID 建表，同 ID 条目的下标会合并进同一
-            # 键，均摊分母被抵消，分发阶段又按 ID 命中同一份额、每个同 ID 条目各挂一次全额。
-            # 按位置索引保证分发阶段每个条目（含同 ID 条目）恰好消费一次自己的份额。
+            # 均摊份额以条目在 raw_segments 中的位置为身份，而非条目 ID：ADR 0053 接受一张
+            # 宫格覆盖的多个条目共用同一 ID，位置唯一而 ID 不唯一，只有按位置组织才能让每个
+            # 条目（含同 ID 条目）恰好消费一次自己的份额。
             grid_to_indices: dict[str, list[int]] = {}
             for idx, seg in enumerate(raw_segments):
                 gid = get_generated_assets(seg).get("grid_id")
                 if gid and seg.get(id_key, ""):
                     grid_to_indices.setdefault(gid, []).append(idx)
 
-            # Compute per-position share of each grid's actual cost，复用
-            # ``_split_cost_across`` 的余数补偿语义，使各份之和与冻结实付分文不差。
+            # 逐宫格算出每个位置的份额；``_split_cost_across`` 的余数补偿保证各份之和与冻结
+            # 实付分文不差。
             grid_actual_per_index: dict[int, CostBreakdown] = {}
             for gid, indices in grid_to_indices.items():
                 grid_cost = _claim_actual(actual_by_segment, claimed_actual, gid, ("image",)).get("image", {})

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -473,6 +473,86 @@ class TestCostEstimationService:
         # But should have the cost under "image"
         assert result["project_totals"]["actual"]["image"]["USD"] == pytest.approx(0.101, abs=1e-4)
 
+    @pytest.mark.unit
+    async def test_grid_duplicate_ids_each_claim_own_share(self, db_factory):
+        """一张宫格覆盖两个共用同一 ID 的条目（ADR 0053 明确接受的受支持状态）：
+
+        两条目应各拿自己那一份均摊份额，而不是把宫格实付重复计入合计。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        grid_id = "grid_dup"
+        await _seed_call(
+            db_factory,
+            "proj-dup",
+            "image",
+            "historical-model",
+            segment_id=grid_id,
+            cost_amount=1.0,
+            currency="USD",
+        )
+
+        overrides = [
+            {"grid_id": grid_id, "grid_cell_index": 0},
+            {"grid_id": grid_id, "grid_cell_index": 1},
+        ]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "grid_storyboard": True,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, ["E1S001", "E1S001"], [6, 6], generated_assets_overrides=overrides)}
+
+        result = await service.compute(project_data, scripts, project_name="proj-dup")
+
+        segments = result["episodes"][0]["segments"]
+        assert len(segments) == 2
+        for seg in segments:
+            assert seg["segment_id"] == "E1S001"
+            assert seg["actual"]["image"]["USD"] == pytest.approx(0.5)
+
+        ep_total_image = result["episodes"][0]["totals"]["actual"].get("image", {})
+        assert ep_total_image.get("USD", 0) == pytest.approx(1.0)
+        assert result["project_totals"]["actual"]["image"]["USD"] == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    async def test_grid_actual_split_remainder_sums_exactly(self, db_factory):
+        """除不尽的宫格实付（USD 0.101 均摊 9 份）分摊后，各份之和须与冻结实付分文不差——
+
+        复用 ``_split_cost_across`` 的余数补偿语义，而非各份独立 round。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        grid_id = "grid_remainder"
+        seg_ids = [f"E1S{i:03d}" for i in range(1, 10)]  # 9 scenes
+
+        await _seed_call(
+            db_factory,
+            "proj-rem",
+            "image",
+            "historical-model",
+            segment_id=grid_id,
+            cost_amount=0.101,
+            currency="USD",
+        )
+
+        overrides = [{"grid_id": grid_id, "grid_cell_index": i} for i in range(9)]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "grid_storyboard": True,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 9, generated_assets_overrides=overrides)}
+
+        result = await service.compute(project_data, scripts, project_name="proj-rem")
+
+        per_scene_costs = [seg["actual"]["image"]["USD"] for seg in result["episodes"][0]["segments"]]
+        assert sum(per_scene_costs) == pytest.approx(0.101, abs=1e-9)
+
     @pytest.mark.integration
     async def test_claimed_key_keeps_unconsumed_cost_types_as_unassigned(self, db_factory):
         """认领粒度到 (记账 key, 类型)：宫格 key 上只消费 image，同 key 的 video 仍须计入未归属。"""

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -518,10 +518,48 @@ class TestCostEstimationService:
         assert result["project_totals"]["actual"]["image"]["USD"] == pytest.approx(1.0)
 
     @pytest.mark.unit
-    async def test_grid_actual_split_remainder_sums_exactly(self, db_factory):
-        """除不尽的宫格实付（USD 0.101 均摊 9 份）分摊后，各份之和须与冻结实付分文不差——
+    async def test_grid_duplicate_ids_across_multiple_grids(self, db_factory):
+        """同一 ID 既在一张宫格内出现 3 次、又跨到另一张宫格：每个条目只拿所属宫格的那一份。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
 
-        复用 ``_split_cost_across`` 的余数补偿语义，而非各份独立 round。"""
+        for grid_id, amount in (("grid_a", 0.9), ("grid_b", 1.0)):
+            await _seed_call(
+                db_factory,
+                "proj-multi",
+                "image",
+                "historical-model",
+                segment_id=grid_id,
+                cost_amount=amount,
+                currency="USD",
+            )
+
+        overrides = [
+            {"grid_id": "grid_a", "grid_cell_index": 0},
+            {"grid_id": "grid_a", "grid_cell_index": 1},
+            {"grid_id": "grid_a", "grid_cell_index": 2},
+            {"grid_id": "grid_b", "grid_cell_index": 0},
+            {"grid_id": "grid_b", "grid_cell_index": 1},
+        ]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "grid_storyboard": True,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        seg_ids = ["E1S001", "E1S001", "E1S001", "E1S001", "E1S002"]
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 5, generated_assets_overrides=overrides)}
+
+        result = await service.compute(project_data, scripts, project_name="proj-multi")
+
+        per_scene_costs = [seg["actual"]["image"]["USD"] for seg in result["episodes"][0]["segments"]]
+        assert per_scene_costs == pytest.approx([0.3, 0.3, 0.3, 0.5, 0.5])
+        assert result["project_totals"]["actual"]["image"]["USD"] == pytest.approx(1.9)
+
+    @pytest.mark.unit
+    async def test_grid_actual_split_remainder_sums_exactly(self, db_factory):
+        """除不尽的宫格实付（USD 0.101 均摊 9 份）分摊后，各份之和须与冻结实付分文不差。"""
         resolver = ConfigResolver(db_factory)
         service = CostEstimationService(resolver, db_factory)
 


### PR DESCRIPTION
Closes #1519

## 问题

宫格生视频路径下，一张宫格覆盖的多个剧本条目若共用同一编号，该宫格的实付会按条目数重复计入项目与集合计——一张 $1 的宫格覆盖两个同编号条目时合计得到 $2。条目编号不保证唯一是 `docs/adr/0053` 明确接受的状态，因此这是受支持输入下的错账。

同段代码还有第二个缺陷：宫格实付按覆盖条目数均摊时每份独立取整到六位小数，各份之和不等于冻结的实付（USD 0.101 均摊 9 份会少 0.000002）。

## 改动

- 宫格均摊份额改以条目在 `raw_segments` 中的**位置**为身份组织与分发，取代原先按条目编号建表。位置唯一而编号不唯一，同编号条目因此各拿自己那一份，不再共享按编号聚合后的金额。数据模型未改动。
- 均摊改为复用同文件的 `_split_cost_across()`，与参考视频 unit 分摊共用同一套余数补偿语义（前 n-1 份取整、最后一份吃余数），各份之和与冻结实付分文不差。

冻结的记账数据本身一直是正确的，重算即可恢复正确合计。

## 验证

新增三个回归用例（`tests/test_cost_estimation_service.py`）：

- `test_grid_duplicate_ids_each_claim_own_share` — 一张宫格覆盖两个同编号条目，各拿半份、合计不翻倍
- `test_grid_duplicate_ids_across_multiple_grids` — 同一编号在 grid_a 内出现 3 次并跨到 grid_b，各条目只拿所属宫格那一份（0.3/0.3/0.3/0.5/0.5），合计 1.9；旧实现在此用例下会得到 6.1
- `test_grid_actual_split_remainder_sums_exactly` — USD 0.101 均摊 9 份，和与冻结实付分文不差

质量门：`ruff check` / `ruff format` 通过；`basedpyright` 0 errors；`lint-imports` 1 kept 0 broken；`pytest -q --cov` 7932 passed，覆盖率 92%。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化宫格图片实际费用分摊，确保同一宫格中的多张图片能够分别获得准确份额。
  - 支持同一图片标识跨多个宫格时独立计算费用，避免重复或遗漏。
  - 改进无法整除金额时的余数处理，确保各图片分摊金额合计与原始实付金额完全一致。

- **Tests**
  - 新增多项费用分摊场景验证，提升计算结果的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->