### PR TITLE
fix(Agnes 视频): 修复成片下载失败与成片时长误记

### DIFF
--- a/lib/agnes_shared.py
+++ b/lib/agnes_shared.py
@@ -5,6 +5,7 @@ apihub 网关提供 OpenAI 风格端点，单 `/v1` base，Bearer 单 key 鉴权
 - AGNES_BASE_URL — 默认 base（含 `/v1`）
 - resolve_agnes_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
 - agnes_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
+- agnes_host — 归一化为 {host}（不含 `/v1`），供挂在网关根下的非 OpenAI 风格端点拼接
 - agnes_headers — Bearer 鉴权头
 """
 
@@ -23,8 +24,12 @@ def resolve_agnes_api_key(api_key: str | None = None) -> str:
     return api_key.strip()
 
 
-def _agnes_host(configured: str | None) -> str:
-    """从配置的 base_url 提取 host 段（剥除 `/v1` 后缀），缺省回落默认 host。"""
+def agnes_host(configured: str | None = None) -> str:
+    """从配置的 base_url 提取 host 段（剥除 `/v1` 后缀），缺省回落默认 host。
+
+    网关并非所有端点都挂在 `/v1` 下——成片查询 `/agnesapi` 直接挂在 host 根，需要这个不带
+    版本段的 base。
+    """
     # 先 strip 再判空：纯空白串（"   "）是真值会绕过 or，回落必须在 strip 之后，
     # 否则 base 变空串、派生出 "/v1" 这类非法相对 URL。
     base = ((configured or "").strip() or AGNES_BASE_URL).rstrip("/")
@@ -35,7 +40,7 @@ def _agnes_host(configured: str | None) -> str:
 
 def agnes_base_url(configured: str | None = None) -> str:
     """OpenAI 兼容 base：{host}/v1。"""
-    return f"{_agnes_host(configured)}{_V1_SUFFIX}"
+    return f"{agnes_host(configured)}{_V1_SUFFIX}"
 
 
 def agnes_headers(api_key: str) -> dict[str, str]:

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -174,8 +174,8 @@ def _extract_task_id(body: dict) -> str:
 def _extract_duration_seconds(final: dict, fallback: int) -> int:
     """从轮询终态取实际成片时长（顶层 ``seconds``），缺失或不可解析回落请求时长。
 
-    不读 ``usage.duration_seconds``——该字段是任务处理耗时（实测与成片时长无关，如处理
-    184 秒生成一条 8 秒成片），不是成片时长，读它会错记计费与元数据。
+    不读 ``usage.duration_seconds``——该字段是任务处理耗时，与成片时长无关，读它会错记
+    计费与元数据。
     """
     parsed = _coerce_duration(final.get("seconds"))
     if parsed is not None:

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -103,10 +103,13 @@ _FAILED_STATUSES = ("failed", "error", "cancelled", "canceled")
 # 进日志的安全标量白名单；image / extra_body 内的 base64 一律不入日志。
 _SAFE_LOG_KEYS = ("model", "height", "width", "num_frames", "frame_rate", "seed")
 
-# 完成态响应中可能承载成片 URL 的直接字段，按优先级探测。remixed_from_video_id 语义是
-# remix 来源视频 ID（非 URL 形态时不当下载地址），列在此处仅为兼容部分网关把成片 URL
-# 直接回填在该字段的行为，值形态为 URL 时才采用。
-_DIRECT_URL_FIELDS = ("url", "video_url", "remixed_from_video_id")
+# 完成态响应中可能承载成片 URL 的权威字段，按优先级探测（顶层与 metadata 同权，顶层优先）。
+_PRIMARY_URL_FIELDS = ("url", "video_url")
+
+# remix 来源视频 ID 字段。语义不是 URL（非 URL 形态时不当下载地址），列在此处仅为兼容部分
+# 网关把成片 URL 直接回填在该字段的行为；优先级低于 _PRIMARY_URL_FIELDS——顶层与 metadata
+# 的权威字段任一命中都优先于本字段，避免它抢在真正的成片 URL 前面被当下载地址。
+_COMPAT_URL_FIELD = "remixed_from_video_id"
 
 
 def _looks_like_url(value: str) -> bool:
@@ -120,21 +123,27 @@ def _looks_like_url(value: str) -> bool:
 
 
 def _first_url_field(body: dict) -> str | None:
-    """按 _DIRECT_URL_FIELDS 顺序探测响应体中形态为 URL 的字段，无命中返回 None。
+    """探测响应体中形态为 URL 的成片地址，按 _PRIMARY_URL_FIELDS 优先、_COMPAT_URL_FIELD
+    兜底的顺序；每一级顶层与 ``metadata``（网关成片查询把下载地址放在 metadata.url）同权、
+    顶层优先，无命中返回 None。
 
-    顶层无命中时下探 ``metadata``——网关成片查询把下载地址放在 ``metadata.url``。
+    _COMPAT_URL_FIELD 兜底级必须整体排在 _PRIMARY_URL_FIELDS 之后：否则顶层的兼容字段会
+    抢在 metadata 里的权威 URL 字段前面命中，误把兼容字段值当下载地址。
     """
-    for key in _DIRECT_URL_FIELDS:
-        value = body.get(key)
+    metadata = body.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+
+    for key in _PRIMARY_URL_FIELDS:
+        for source in (body, metadata):
+            value = source.get(key)
+            if isinstance(value, str) and _looks_like_url(value):
+                return value
+
+    for source in (body, metadata):
+        value = source.get(_COMPAT_URL_FIELD)
         if isinstance(value, str) and _looks_like_url(value):
             return value
 
-    metadata = body.get("metadata")
-    if isinstance(metadata, dict):
-        for key in _DIRECT_URL_FIELDS:
-            value = metadata.get(key)
-            if isinstance(value, str) and _looks_like_url(value):
-                return value
     return None
 
 

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -104,7 +104,8 @@ _FAILED_STATUSES = ("failed", "error", "cancelled", "canceled")
 _SAFE_LOG_KEYS = ("model", "height", "width", "num_frames", "frame_rate", "seed")
 
 # 完成态响应中可能承载成片 URL 的直接字段，按优先级探测。remixed_from_video_id 语义是
-# remix 来源视频 ID（非 URL 形态时不当下载地址），列在此处仅兼容旧网关曾直接回填 URL 的行为。
+# remix 来源视频 ID（非 URL 形态时不当下载地址），列在此处仅为兼容部分网关把成片 URL
+# 直接回填在该字段的行为，值形态为 URL 时才采用。
 _DIRECT_URL_FIELDS = ("url", "video_url", "remixed_from_video_id")
 
 
@@ -187,8 +188,9 @@ def _extract_task_id(body: dict) -> str:
     raise RuntimeError(f"Agnes 视频提交返回体缺少 task_id（字段: {sorted(body)}）")
 
 
-def _extract_duration_seconds(final: dict, fallback: int) -> int:
-    """从轮询终态取实际成片时长（顶层 ``seconds``），缺失或不可解析回落请求时长。
+def _extract_duration_seconds(final: dict, queried: dict | None, fallback: int) -> int:
+    """从轮询终态取实际成片时长（顶层 ``seconds``），缺失时改读 video_id 二次查询响应的
+    ``seconds``（完成态只带 video_id 时才有此响应），两处均缺失或不可解析才回落请求时长。
 
     不读 ``usage.duration_seconds``——该字段是任务处理耗时，与成片时长无关，读它会错记
     计费与元数据。
@@ -196,6 +198,10 @@ def _extract_duration_seconds(final: dict, fallback: int) -> int:
     parsed = _coerce_duration(final.get("seconds"))
     if parsed is not None:
         return parsed
+    if queried is not None:
+        parsed = _coerce_duration(queried.get("seconds"))
+        if parsed is not None:
+            return parsed
     return fallback
 
 
@@ -443,22 +449,25 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         resp.raise_for_status()
         return resp.json()
 
-    async def _resolve_video_url(self, client: httpx.AsyncClient, final: dict) -> str:
+    async def _resolve_video_url(self, client: httpx.AsyncClient, final: dict) -> tuple[str, dict | None]:
         """成片 URL 两级来源：完成态直接字段命中即用；否则用 video_id 二次查询取 URL。
+
+        命中二次查询时一并返回该查询响应体（未查询则 None），供调用方从中补解析成片时长——
+        终态响应可能不带 ``seconds``，只有二次查询响应才带。
 
         两级来源均不可用时报错信息只列字段名，不回显响应体（可能含签名 URL 等敏感字段，
         与 _safe_body_for_log 同口径）。
         """
         video_url = _first_url_field(final)
         if video_url is not None:
-            return video_url
+            return video_url, None
 
         video_id = final.get("video_id")
         if isinstance(video_id, str) and video_id:
             queried = await self._query_video(client, video_id)
             video_url = _first_url_field(queried)
             if video_url is not None:
-                return video_url
+                return video_url, queried
             raise RuntimeError(f"Agnes 任务完成但 video_id 查询响应缺少成片 URL（字段: {sorted(queried)}）")
 
         raise RuntimeError(f"Agnes 任务完成但缺少成片 URL 与 video_id（字段: {sorted(final)}）")
@@ -498,7 +507,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             ),
         )
 
-        video_url = await self._resolve_video_url(client, final)
+        video_url, queried = await self._resolve_video_url(client, final)
 
         await self._download_with_retry(video_url, request.output_path)
         logger.info("Agnes 视频下载完成: %s", request.output_path)
@@ -507,7 +516,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             video_path=request.output_path,
             provider=PROVIDER_AGNES,
             model=self._model,
-            duration_seconds=_extract_duration_seconds(final, request.duration_seconds),
+            duration_seconds=_extract_duration_seconds(final, queried, request.duration_seconds),
             video_uri=video_url,
             task_id=task_id,
             seed=request.seed,

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -2,10 +2,14 @@
 
 走 apihub 网关上的 OpenAI 风格异步端点：submit ``POST /v1/videos``（JSON）取 task_id →
 轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed``。成片 URL 分两级取：完成态响应
-自带直接 URL 字段（``url`` / ``video_url``，或 ``remixed_from_video_id`` 恰好是 URL 形态时
-兼容旧网关）即直接下载；只有 ``video_id`` 时以其向同一 ``/videos/{video_id}`` 端点二次查询，
-从查询响应取 URL。``remixed_from_video_id`` 语义是 remix 来源视频 ID，非 URL 形态时一律不当
-下载地址。状态机 ``queued → in_progress → completed / failed``。
+自带直接 URL 字段（``url`` / ``video_url`` / ``metadata.url``，或 ``remixed_from_video_id``
+恰好是 URL 形态时兼容旧网关）即直接下载；只有 ``video_id`` 时以其向网关根下的成片查询端点
+``GET /agnesapi?video_id=...`` 二次查询，从查询响应同样按上述字段取 URL。
+``remixed_from_video_id`` 语义是 remix 来源视频 ID，非 URL 形态时一律不当下载地址。
+状态机 ``queued → in_progress → completed / failed``。
+
+轮询端点 ``/v1/videos/{task_id}`` 是网关的旧版任务查询接口，仍受支持；成片结果查询归
+``/agnesapi?video_id=``（网关文档指明按 video_id 查询，不要拿 task_id 打这个端点）。
 
 能力约束：fps 固定 24；时长 1–18s（内部 ``num_frames = 最近的 8n+1``，由秒 × fps 取整对齐，
 上限 441 帧）；分辨率经 aspect_size 精确算出并显式下发 ``height`` × ``width``（不显式下发时
@@ -26,7 +30,7 @@ from urllib.parse import urlsplit
 
 import httpx
 
-from lib.agnes_shared import agnes_base_url, agnes_headers, resolve_agnes_api_key
+from lib.agnes_shared import agnes_base_url, agnes_headers, agnes_host, resolve_agnes_api_key
 from lib.aspect_size import VIDEO_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.logging_utils import format_kwargs_for_log
@@ -58,6 +62,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "agnes-video-v2.0"
 
 _VIDEOS_ENDPOINT = "/videos"
+# 成片查询端点，挂在网关根（不在 /v1 下），按 video_id 查询。
+_VIDEO_QUERY_ENDPOINT = "/agnesapi"
 
 # fps 固定 24；num_frames 必须形如 8n+1，上限 441（≈18.4s @24fps）。时长按秒 × fps 取整后
 # 对齐到最近的 8n+1。1–3s 会落到 81 帧以下（25/49/73），文档允许的合法值。
@@ -113,11 +119,21 @@ def _looks_like_url(value: str) -> bool:
 
 
 def _first_url_field(body: dict) -> str | None:
-    """按 _DIRECT_URL_FIELDS 顺序探测响应体中形态为 URL 的直接字段，无命中返回 None。"""
+    """按 _DIRECT_URL_FIELDS 顺序探测响应体中形态为 URL 的字段，无命中返回 None。
+
+    顶层无命中时下探 ``metadata``——网关成片查询把下载地址放在 ``metadata.url``。
+    """
     for key in _DIRECT_URL_FIELDS:
         value = body.get(key)
         if isinstance(value, str) and _looks_like_url(value):
             return value
+
+    metadata = body.get("metadata")
+    if isinstance(metadata, dict):
+        for key in _DIRECT_URL_FIELDS:
+            value = metadata.get(key)
+            if isinstance(value, str) and _looks_like_url(value):
+                return value
     return None
 
 
@@ -227,6 +243,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
     ) -> None:
         self._api_key = resolve_agnes_api_key(api_key)
         self._base_url = agnes_base_url(base_url)
+        self._host = agnes_host(base_url)
         self._model = model or DEFAULT_MODEL
         self._http_timeout = http_timeout
 
@@ -413,11 +430,14 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         retry_if=should_retry_poll,
     )
     async def _query_video(self, client: httpx.AsyncClient, video_id: str) -> dict:
-        """按 ``video_id`` 向同一 ``/videos/{id}`` 端点二次查询成片信息（完成态只含 video_id、
-        无直接 URL 字段时）。幂等 GET，复用轮询同一套重试判定。
+        """按 ``video_id`` 向成片查询端点二次查询（完成态只含 video_id、无直接 URL 字段时）。
+
+        该端点挂在网关根而非 ``/v1`` 下，且只认 video_id——拿 task_id 打它会排队异常。
+        幂等 GET，复用轮询同一套重试判定。
         """
         resp = await client.get(
-            f"{self._base_url}{_VIDEOS_ENDPOINT}/{video_id}",
+            f"{self._host}{_VIDEO_QUERY_ENDPOINT}",
+            params={"video_id": video_id},
             headers=agnes_headers(self._api_key),
         )
         resp.raise_for_status()

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -1,8 +1,11 @@
 """AgnesVideoBackend — Agnes 视频生成后端（裸 base64 + 异步轮询 + resume）。
 
 走 apihub 网关上的 OpenAI 风格异步端点：submit ``POST /v1/videos``（JSON）取 task_id →
-轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed`` → 从响应 ``remixed_from_video_id``
-字段取成片 mp4 URL → 下载本地。状态机 ``queued → in_progress → completed / failed``。
+轮询 ``GET /v1/videos/{task_id}`` 至 ``status=completed``。成片 URL 分两级取：完成态响应
+自带直接 URL 字段（``url`` / ``video_url``，或 ``remixed_from_video_id`` 恰好是 URL 形态时
+兼容旧网关）即直接下载；只有 ``video_id`` 时以其向同一 ``/videos/{video_id}`` 端点二次查询，
+从查询响应取 URL。``remixed_from_video_id`` 语义是 remix 来源视频 ID，非 URL 形态时一律不当
+下载地址。状态机 ``queued → in_progress → completed / failed``。
 
 能力约束：fps 固定 24；时长 1–18s（内部 ``num_frames = 最近的 8n+1``，由秒 × fps 取整对齐，
 上限 441 帧）；分辨率经 aspect_size 精确算出并显式下发 ``height`` × ``width``（不显式下发时
@@ -19,6 +22,7 @@ import base64
 import logging
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -93,6 +97,29 @@ _FAILED_STATUSES = ("failed", "error", "cancelled", "canceled")
 # 进日志的安全标量白名单；image / extra_body 内的 base64 一律不入日志。
 _SAFE_LOG_KEYS = ("model", "height", "width", "num_frames", "frame_rate", "seed")
 
+# 完成态响应中可能承载成片 URL 的直接字段，按优先级探测。remixed_from_video_id 语义是
+# remix 来源视频 ID（非 URL 形态时不当下载地址），列在此处仅兼容旧网关曾直接回填 URL 的行为。
+_DIRECT_URL_FIELDS = ("url", "video_url", "remixed_from_video_id")
+
+
+def _looks_like_url(value: str) -> bool:
+    """粗粒度 URL 形态校验：http/https scheme + 非空 netloc。用于把 remixed_from_video_id
+    这类语义不是 URL 的字段与真正的下载地址区分开，避免把 remix 来源 ID 误当 URL 下载。
+    """
+    if not value:
+        return False
+    parsed = urlsplit(value)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _first_url_field(body: dict) -> str | None:
+    """按 _DIRECT_URL_FIELDS 顺序探测响应体中形态为 URL 的直接字段，无命中返回 None。"""
+    for key in _DIRECT_URL_FIELDS:
+        value = body.get(key)
+        if isinstance(value, str) and _looks_like_url(value):
+            return value
+    return None
+
 
 def _duration_to_num_frames(duration_seconds: int) -> int:
     """秒 → num_frames：秒 × fps 取整后对齐到最近的 ``8n+1``，上限 441。"""
@@ -145,12 +172,11 @@ def _extract_task_id(body: dict) -> str:
 
 
 def _extract_duration_seconds(final: dict, fallback: int) -> int:
-    """从轮询终态取实际计费时长（``usage.duration_seconds`` 优先，回落顶层 ``seconds``，再回落请求值）。"""
-    usage = final.get("usage")
-    if isinstance(usage, dict):
-        parsed = _coerce_duration(usage.get("duration_seconds"))
-        if parsed is not None:
-            return parsed
+    """从轮询终态取实际成片时长（顶层 ``seconds``），缺失或不可解析回落请求时长。
+
+    不读 ``usage.duration_seconds``——该字段是任务处理耗时（实测与成片时长无关，如处理
+    184 秒生成一条 8 秒成片），不是成片时长，读它会错记计费与元数据。
+    """
     parsed = _coerce_duration(final.get("seconds"))
     if parsed is not None:
         return parsed
@@ -381,6 +407,42 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
         resp.raise_for_status()
         return resp.json()
 
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_poll,
+    )
+    async def _query_video(self, client: httpx.AsyncClient, video_id: str) -> dict:
+        """按 ``video_id`` 向同一 ``/videos/{id}`` 端点二次查询成片信息（完成态只含 video_id、
+        无直接 URL 字段时）。幂等 GET，复用轮询同一套重试判定。
+        """
+        resp = await client.get(
+            f"{self._base_url}{_VIDEOS_ENDPOINT}/{video_id}",
+            headers=agnes_headers(self._api_key),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _resolve_video_url(self, client: httpx.AsyncClient, final: dict) -> str:
+        """成片 URL 两级来源：完成态直接字段命中即用；否则用 video_id 二次查询取 URL。
+
+        两级来源均不可用时报错信息只列字段名，不回显响应体（可能含签名 URL 等敏感字段，
+        与 _safe_body_for_log 同口径）。
+        """
+        video_url = _first_url_field(final)
+        if video_url is not None:
+            return video_url
+
+        video_id = final.get("video_id")
+        if isinstance(video_id, str) and video_id:
+            queried = await self._query_video(client, video_id)
+            video_url = _first_url_field(queried)
+            if video_url is not None:
+                return video_url
+            raise RuntimeError(f"Agnes 任务完成但 video_id 查询响应缺少成片 URL（字段: {sorted(queried)}）")
+
+        raise RuntimeError(f"Agnes 任务完成但缺少成片 URL 与 video_id（字段: {sorted(final)}）")
+
     async def _poll_and_build(
         self,
         client: httpx.AsyncClient,
@@ -416,10 +478,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             ),
         )
 
-        video_url = final.get("remixed_from_video_id")
-        if not isinstance(video_url, str) or not video_url:
-            # 仅暴露字段名，不回显整串响应（可能含签名 URL 等敏感字段，与 _safe_body_for_log 同口径）。
-            raise RuntimeError(f"Agnes 任务完成但缺少 remixed_from_video_id 成片 URL（字段: {sorted(final)}）")
+        video_url = await self._resolve_video_url(client, final)
 
         await self._download_with_retry(video_url, request.output_path)
         logger.info("Agnes 视频下载完成: %s", request.output_path)

--- a/tests/test_agnes_shared.py
+++ b/tests/test_agnes_shared.py
@@ -8,6 +8,7 @@ from lib.agnes_shared import (
     AGNES_BASE_URL,
     agnes_base_url,
     agnes_headers,
+    agnes_host,
     resolve_agnes_api_key,
 )
 
@@ -37,6 +38,25 @@ class TestBaseUrlDerivation:
         # 纯空白 base_url 是真值会绕过 or，须 strip 后回落默认 host，
         # 不能 strip 成空串派生出 "/v1" 这类非法相对 URL
         assert agnes_base_url("   ") == AGNES_BASE_URL
+
+
+class TestHostDerivation:
+    """agnes_host 与 agnes_base_url 同源归一化，差别只在不带 /v1——网关的成片查询端点
+    /agnesapi 挂在 host 根下，拼接需要这个形态。"""
+
+    def test_default_host(self):
+        assert agnes_host(None) == "https://apihub.agnes-ai.com"
+
+    def test_strips_v1_suffix(self):
+        assert agnes_host("https://apihub.agnes-ai.com/v1") == "https://apihub.agnes-ai.com"
+        assert agnes_host("https://apihub.agnes-ai.com/v1/") == "https://apihub.agnes-ai.com"
+
+    def test_host_only_unchanged(self):
+        assert agnes_host("https://apihub.agnes-ai.com") == "https://apihub.agnes-ai.com"
+        assert agnes_host("https://relay.example.com/") == "https://relay.example.com"
+
+    def test_whitespace_falls_back_to_default(self):
+        assert agnes_host("   ") == "https://apihub.agnes-ai.com"
 
 
 class TestApiKeyResolution:

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -734,6 +734,42 @@ class TestFailureAndTimeout:
 
         assert result.video_uri == "https://cdn.agnes/from-query.mp4"
 
+    async def test_metadata_url_takes_priority_over_url_shaped_remixed_from_video_id(self, tmp_path: Path):
+        """顶层 remixed_from_video_id 是 URL 形态、metadata.url 也存在时，metadata.url
+        才是权威成片地址，remixed_from_video_id 只是兼容兜底，不得抢先命中。"""
+        create_resp = _make_response(200, {"task_id": "t-meta-priority", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-meta-priority",
+                "status": "completed",
+                "remixed_from_video_id": "https://cdn.agnes/legacy-compat.mp4",
+                "metadata": {"url": "https://cdn.agnes/authoritative.mp4"},
+            },
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://cdn.agnes/authoritative.mp4"
+        assert client.get.call_count == 1  # 顶层/metadata 已命中权威字段，未发起二次查询
+
     async def test_video_id_query_url_under_metadata_is_used(self, tmp_path: Path):
         """成片查询把下载地址放在 metadata.url：顶层无直接 URL 字段时下探 metadata 取到。"""
         create_resp = _make_response(200, {"task_id": "t-meta", "status": "queued"})

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -619,8 +619,9 @@ class TestFailureAndTimeout:
         assert result.video_uri == "https://cdn.agnes/queried.mp4"
         assert result.duration_seconds == 8
         assert result.video_path.read_bytes() == b"queried-bytes"
-        # 二次查询打到同一 /videos/{id} 端点，用 video_id 而非 task_id
-        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/v1/videos/vid-123"
+        # 二次查询打网关根下的 /agnesapi，按 video_id 传参（不带 /v1，也不用 task_id）
+        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/agnesapi"
+        assert client.get.call_args_list[1].kwargs["params"] == {"video_id": "vid-123"}
 
     async def test_completed_with_direct_url_field_skips_video_id_query(self, tmp_path: Path):
         """完成态直接带 url 字段时直接下载，不发起 video_id 二次查询。"""
@@ -728,6 +729,45 @@ class TestFailureAndTimeout:
             )
 
         assert result.video_uri == "https://cdn.agnes/from-query.mp4"
+
+    async def test_video_id_query_url_under_metadata_is_used(self, tmp_path: Path):
+        """成片查询把下载地址放在 metadata.url：顶层无直接 URL 字段时下探 metadata 取到。"""
+        create_resp = _make_response(200, {"task_id": "t-meta", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {"task_id": "t-meta", "video_id": "vid-meta", "status": "completed", "remixed_from_video_id": None},
+        )
+        query_resp = _make_response(
+            200,
+            {
+                "video_id": "vid-meta",
+                "status": "completed",
+                "seconds": "8.0",
+                "metadata": {"url": "https://platform-outputs.agnes-ai.com/videos/meta.mp4"},
+            },
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, query_resp]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"meta-bytes"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://platform-outputs.agnes-ai.com/videos/meta.mp4"
+        assert result.video_path.read_bytes() == b"meta-bytes"
 
     async def test_video_id_query_without_url_raises_descriptive_error(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t-bad-query", "status": "queued"})
@@ -930,7 +970,8 @@ class TestResume:
 
         client.post.assert_not_called()
         assert client.get.call_args_list[0].args[0].endswith("/videos/task-resume-vid")
-        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/v1/videos/vid-resume"
+        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/agnesapi"
+        assert client.get.call_args_list[1].kwargs["params"] == {"video_id": "vid-resume"}
         assert result.video_uri == "https://cdn.agnes/resume-queried.mp4"
         assert result.duration_seconds == 8
         assert (tmp_path / "out.mp4").read_bytes() == b"resume-queried"

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -42,11 +42,15 @@ def _fake_download_factory(payload: bytes = b"mp4-bytes"):
 
 
 def _completed(task_id: str = "task-1", url: str = "https://cdn.agnes/out.mp4", **extra) -> dict:
+    """完成态响应：成片 URL 落在直接字段 ``url``；``remixed_from_video_id`` 是 remix 来源，
+    普通图生/文生视频恒为 null，用 extra 显式覆盖才走旧网关兼容路径。
+    """
     body = {
         "task_id": task_id,
         "status": "completed",
         "size": "720x1280",
-        "remixed_from_video_id": url,
+        "url": url,
+        "remixed_from_video_id": None,
     }
     body.update(extra)
     return body
@@ -578,8 +582,8 @@ class TestFailureAndTimeout:
         fake_download.assert_not_called()
 
     async def test_completed_with_null_remixed_from_video_id_uses_video_id_query(self, tmp_path: Path):
-        """普通图生/文生视频完成态 remixed_from_video_id 恒为 null——不再误判为「缺少成片 URL」，
-        改按 video_id 二次查询取真正的下载地址。"""
+        """普通图生/文生视频完成态 remixed_from_video_id 恒为 null，成片地址须按 video_id
+        二次查询取得。"""
         create_resp = _make_response(200, {"task_id": "t-null-remix", "status": "queued"})
         poll_resp = _make_response(
             200,
@@ -653,6 +657,42 @@ class TestFailureAndTimeout:
 
         assert result.video_uri == "https://cdn.agnes/direct.mp4"
         assert client.get.call_count == 1  # 未发起二次查询
+
+    async def test_completed_with_url_shaped_remixed_from_video_id_downloads_directly(self, tmp_path: Path):
+        """旧网关把成片 URL 回填在 remixed_from_video_id：值是 URL 形态时仍作下载地址，
+        不发起 video_id 二次查询。"""
+        create_resp = _make_response(200, {"task_id": "t-legacy", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-legacy",
+                "video_id": "vid-should-not-be-queried",
+                "status": "completed",
+                "remixed_from_video_id": "https://cdn.agnes/legacy.mp4",
+            },
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"legacy-bytes"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://cdn.agnes/legacy.mp4"
+        assert client.get.call_count == 1
 
     async def test_remixed_from_video_id_non_url_value_not_used_as_download_url(self, tmp_path: Path):
         """remixed_from_video_id 是非 URL 形态的 remix 来源 ID 时不得当下载地址，转向 video_id 二次查询。"""
@@ -851,6 +891,49 @@ class TestResume:
         assert client.get.call_args.args[0].endswith("/videos/task-resume")
         assert result.task_id == "task-resume"
         assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
+
+    async def test_resume_completed_with_only_video_id_queries_and_downloads(self, tmp_path: Path):
+        """resume 已完成任务、完成态只带 video_id 时，与首跑共用同一套终态解析：经二次查询取回
+        成片，全程不 POST 建任务（不重复计费）。
+        """
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "task-resume-vid",
+                "video_id": "vid-resume",
+                "status": "completed",
+                "remixed_from_video_id": None,
+                "seconds": "8.0",
+            },
+        )
+        query_resp = _make_response(200, {"video_id": "vid-resume", "url": "https://cdn.agnes/resume-queried.mp4"})
+        client = _mock_client(
+            post=AsyncMock(side_effect=AssertionError("resume 不应 POST create")),
+            get=AsyncMock(side_effect=[poll_resp, query_resp]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"resume-queried"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://apihub.agnes-ai.com/v1")
+            result = await backend.resume_video(
+                "task-resume-vid",
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                ),
+            )
+
+        client.post.assert_not_called()
+        assert client.get.call_args_list[0].args[0].endswith("/videos/task-resume-vid")
+        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/v1/videos/vid-resume"
+        assert result.video_uri == "https://cdn.agnes/resume-queried.mp4"
+        assert result.duration_seconds == 8
+        assert (tmp_path / "out.mp4").read_bytes() == b"resume-queried"
 
     async def test_resume_404_raises_resume_expired_without_retry(self, tmp_path: Path):
         not_found = _make_response(404, {"error": "task not found"})

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -132,14 +132,15 @@ class TestDurationCoercion:
 
         assert _coerce_duration(value) == expected
 
-    def test_extract_duration_falls_back_when_usage_zero(self):
+    def test_extract_duration_reads_top_level_seconds_not_usage(self):
         from lib.video_backends.agnes import _extract_duration_seconds
 
-        # usage.duration_seconds=0 不应落到结果对象，回落请求时长
-        assert _extract_duration_seconds({"usage": {"duration_seconds": 0}}, fallback=5) == 5
-        # 优先 usage，其次顶层 seconds，再回落
-        assert _extract_duration_seconds({"usage": {"duration_seconds": "9.6"}}, fallback=5) == 10
+        # 顶层 seconds 是成片时长真相源；usage.duration_seconds 是任务处理耗时，不得读取
+        assert _extract_duration_seconds({"seconds": "8.0", "usage": {"duration_seconds": 184}}, fallback=5) == 8
         assert _extract_duration_seconds({"seconds": "7"}, fallback=5) == 7
+        # seconds 缺失（含非正值/不可解析）一律回落请求时长，不看 usage
+        assert _extract_duration_seconds({"usage": {"duration_seconds": 184}}, fallback=5) == 5
+        assert _extract_duration_seconds({"seconds": "0"}, fallback=5) == 5
         assert _extract_duration_seconds({}, fallback=5) == 5
 
 
@@ -551,7 +552,7 @@ class TestFailureAndTimeout:
                 )
         fake_download.assert_not_called()
 
-    async def test_completed_without_video_url_raises(self, tmp_path: Path):
+    async def test_completed_without_video_url_or_video_id_raises(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t-nourl", "status": "queued"})
         poll_resp = _make_response(200, {"task_id": "t-nourl", "status": "completed"})
         client = _mock_client(
@@ -568,7 +569,145 @@ class TestFailureAndTimeout:
             from lib.video_backends.agnes import AgnesVideoBackend
 
             backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            with pytest.raises(RuntimeError, match="remixed_from_video_id"):
+            with pytest.raises(RuntimeError, match="缺少成片 URL 与 video_id"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+        fake_download.assert_not_called()
+
+    async def test_completed_with_null_remixed_from_video_id_uses_video_id_query(self, tmp_path: Path):
+        """普通图生/文生视频完成态 remixed_from_video_id 恒为 null——不再误判为「缺少成片 URL」，
+        改按 video_id 二次查询取真正的下载地址。"""
+        create_resp = _make_response(200, {"task_id": "t-null-remix", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-null-remix",
+                "video_id": "vid-123",
+                "status": "completed",
+                "remixed_from_video_id": None,
+                "seconds": "8.0",
+            },
+        )
+        query_resp = _make_response(200, {"video_id": "vid-123", "url": "https://cdn.agnes/queried.mp4"})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, query_resp]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"queried-bytes"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://apihub.agnes-ai.com/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://cdn.agnes/queried.mp4"
+        assert result.duration_seconds == 8
+        assert result.video_path.read_bytes() == b"queried-bytes"
+        # 二次查询打到同一 /videos/{id} 端点，用 video_id 而非 task_id
+        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/v1/videos/vid-123"
+
+    async def test_completed_with_direct_url_field_skips_video_id_query(self, tmp_path: Path):
+        """完成态直接带 url 字段时直接下载，不发起 video_id 二次查询。"""
+        create_resp = _make_response(200, {"task_id": "t-direct", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-direct",
+                "video_id": "vid-should-not-be-queried",
+                "status": "completed",
+                "url": "https://cdn.agnes/direct.mp4",
+                "remixed_from_video_id": None,
+            },
+        )
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(return_value=poll_resp),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"direct-bytes"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://cdn.agnes/direct.mp4"
+        assert client.get.call_count == 1  # 未发起二次查询
+
+    async def test_remixed_from_video_id_non_url_value_not_used_as_download_url(self, tmp_path: Path):
+        """remixed_from_video_id 是非 URL 形态的 remix 来源 ID 时不得当下载地址，转向 video_id 二次查询。"""
+        create_resp = _make_response(200, {"task_id": "t-remix-id", "status": "queued"})
+        poll_resp = _make_response(
+            200,
+            {
+                "task_id": "t-remix-id",
+                "video_id": "vid-456",
+                "status": "completed",
+                "remixed_from_video_id": "src-video-abc",  # 非 URL 形态：真正的 remix 来源 ID
+            },
+        )
+        query_resp = _make_response(200, {"url": "https://cdn.agnes/from-query.mp4"})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, query_resp]),
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.video_uri == "https://cdn.agnes/from-query.mp4"
+
+    async def test_video_id_query_without_url_raises_descriptive_error(self, tmp_path: Path):
+        create_resp = _make_response(200, {"task_id": "t-bad-query", "status": "queued"})
+        poll_resp = _make_response(200, {"task_id": "t-bad-query", "video_id": "vid-789", "status": "completed"})
+        query_resp = _make_response(200, {"video_id": "vid-789", "status": "unexpected"})
+        client = _mock_client(
+            post=AsyncMock(return_value=create_resp),
+            get=AsyncMock(side_effect=[poll_resp, query_resp]),
+        )
+        fake_download = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
+            patch("lib.video_backends.agnes.download_video", fake_download),
+        ):
+            from lib.video_backends.agnes import AgnesVideoBackend
+
+            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            with pytest.raises(RuntimeError, match="video_id 查询响应缺少成片 URL"):
                 await backend.generate(
                     VideoGenerationRequest(
                         prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5

--- a/tests/test_agnes_video_backend.py
+++ b/tests/test_agnes_video_backend.py
@@ -140,12 +140,16 @@ class TestDurationCoercion:
         from lib.video_backends.agnes import _extract_duration_seconds
 
         # 顶层 seconds 是成片时长真相源；usage.duration_seconds 是任务处理耗时，不得读取
-        assert _extract_duration_seconds({"seconds": "8.0", "usage": {"duration_seconds": 184}}, fallback=5) == 8
-        assert _extract_duration_seconds({"seconds": "7"}, fallback=5) == 7
+        assert _extract_duration_seconds({"seconds": "8.0", "usage": {"duration_seconds": 184}}, None, fallback=5) == 8
+        assert _extract_duration_seconds({"seconds": "7"}, None, fallback=5) == 7
         # seconds 缺失（含非正值/不可解析）一律回落请求时长，不看 usage
-        assert _extract_duration_seconds({"usage": {"duration_seconds": 184}}, fallback=5) == 5
-        assert _extract_duration_seconds({"seconds": "0"}, fallback=5) == 5
-        assert _extract_duration_seconds({}, fallback=5) == 5
+        assert _extract_duration_seconds({"usage": {"duration_seconds": 184}}, None, fallback=5) == 5
+        assert _extract_duration_seconds({"seconds": "0"}, None, fallback=5) == 5
+        assert _extract_duration_seconds({}, None, fallback=5) == 5
+        # 终态无 seconds 时改读 video_id 二次查询响应的 seconds
+        assert _extract_duration_seconds({}, {"seconds": "8.0"}, fallback=5) == 8
+        # 终态与查询响应均无 seconds 才回落请求时长
+        assert _extract_duration_seconds({}, {}, fallback=5) == 5
 
 
 class TestTextToVideo:
@@ -768,6 +772,8 @@ class TestFailureAndTimeout:
 
         assert result.video_uri == "https://platform-outputs.agnes-ai.com/videos/meta.mp4"
         assert result.video_path.read_bytes() == b"meta-bytes"
+        # 终态响应无 seconds，时长须从二次查询响应解析，而非回落请求时长
+        assert result.duration_seconds == 8
 
     async def test_video_id_query_without_url_raises_descriptive_error(self, tmp_path: Path):
         create_resp = _make_response(200, {"task_id": "t-bad-query", "status": "queued"})


### PR DESCRIPTION
Closes #1505

## 问题

Agnes 视频任务跑完后被系统性判为失败：完成态响应固定从 `remixed_from_video_id` 取成片 URL，但该字段语义是 remix 来源视频 ID，普通图生 / 文生视频完成态恒为 `null`——已成功生成（且已计费）的整集视频全被标记失败。

同一条响应还暴露时长误记：实现优先读 `usage.duration_seconds`（任务处理耗时，实测 184 秒），而不是顶层 `seconds`（成片实际时长 8 秒），成片元数据与按秒计费一并记错。

## 改动

**成片 URL 改为两级来源**。完成态自带直接 URL 字段（`url` / `video_url` / `metadata.url`）即直接下载；只有 `video_id` 时以其向网关根下的成片查询端点 `GET /agnesapi?video_id=` 二次查询。`remixed_from_video_id` 只在值恰好是 URL 形态时才当下载地址（兼容旧网关行为），否则一律不用。

端点按 Agnes 官方文档核定：成片结果查询归 `/agnesapi?video_id=`，文档明确要求按 `video_id` 查询、不要拿 `task_id` 打该端点；`/v1/videos/{task_id}` 是保留兼容的旧版任务查询接口，继续用于轮询。为拼接这个挂在网关根（不带 `/v1`）的端点，把 `agnes_shared` 的 host 归一化提升为公开的 `agnes_host`，与 `agnes_base_url` 同源。

**成片时长改读顶层 `seconds`**，缺失或不可解析时回落请求时长，不再读 `usage.duration_seconds`。

resume 路径与首跑共用同一套 `_poll_and_build` 终态解析，不重复提交任务、不重复计费。

## 验证

- `uv run python -m pytest` — 7940 passed
- `uv run ruff check . && uv run ruff format`、`uv run basedpyright`（0 error）、`uv run lint-imports` 均通过

新增 / 调整的用例覆盖完成态各字段组合：`remixed_from_video_id` 为 null 走 video_id 二次查询、直接 `url` 字段跳过二次查询、`remixed_from_video_id` 为非 URL 值时不当下载地址、查询响应 URL 落在 `metadata.url`、两级来源均不可用时报错信息如实描述缺失字段、`seconds='8.0'` 与 `usage.duration_seconds=184` 并存时记 8 秒、`seconds` 缺失回落请求时长，以及 resume + 完成态仅含 `video_id` 的组合（即报告者走的那条链路）。

测试 fixture `_completed()` 原先把成片 URL 塞在 `remixed_from_video_id`，导致约十处既有用例走的是旧网关兼容旁路而非主路径；已改为 URL 落 `url` 字段，兼容旁路另立专用用例。

**待真实链路验证**：查询端点与 `metadata.url` 两处依据来自 Agnes 官方文档与报告者的实测记录，本地无 API key，全部测试为 mock。合并后建议由持 key 的人跑一次真实生成确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 提升视频成片结果解析能力，支持从多种返回字段中识别有效的视频地址。
  * 当仅返回视频 ID 时，系统会自动查询并获取最终视频。
  * 优化恢复任务流程，确保已完成的视频能够正常查询和下载。
  * 视频时长优先使用成片返回时长，缺失时回退至请求时长。
  * 提升不同网关地址配置下的视频提交、轮询与下载兼容性。
  * 改进网关地址识别，兼容包含或不包含 API 路径的配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->