### PR TITLE
fix(生成): 中转站供应商结构化输出改走三档降级，失败时给出可读提示

### DIFF
--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -44,9 +44,11 @@ from lib.path_safety import PathTraversalError, safe_join
 from lib.project_manager import ProjectManager, resolve_source_kind
 from lib.text_backends.base import (
     DEFAULT_MAX_OUTPUT_TOKENS,
+    StructuredOutputExhaustedError,
     TextGenerationRequest,
     TextOutputTruncatedError,
     TextTaskType,
+    truncate_for_log,
 )
 from lib.text_generator import TextGenerator
 from lib.text_metrics import count_reading_units, reading_unit_noun
@@ -606,6 +608,10 @@ class EpisodePlanner:
         结构化输出被输出上限截断时 :class:`TextOutputTruncatedError` 直接短路本循环——
         重发同一份必然再截断的请求没有意义；追加本规划器特有的杠杆提示（调小窗口字数 /
         每批集数）后转为 :class:`EpisodePlanningError` 冒泡（见 docs/adr/0044）。
+
+        后端结构化输出降级链耗尽的 :class:`StructuredOutputExhaustedError` 同样短路本循环，
+        转为 :class:`EpisodePlanningError`，让智能体拿到「供应商结构化输出能力不足」的可读
+        话术而非后端内部异常原文。
         """
         if self.generator is None:
             raise RuntimeError("TextGenerator 未初始化，请使用 EpisodePlanner.create() 工厂方法")
@@ -625,6 +631,9 @@ class EpisodePlanner:
                     f"{exc}也可调小项目设置 planning_window_chars（单批窗口字数）或 "
                     "planning_max_episodes（单批集数上限）以缩小本批输出体量后重试。"
                 ) from exc
+            except StructuredOutputExhaustedError as exc:
+                # 后端的降级链已把各档与档内重试都走完，本层再重试只是重复同一条必败路径。
+                raise EpisodePlanningError(str(exc)) from exc
             try:
                 draft = self._parse_draft(result.text, draft_model)
                 drafts = list(getattr(draft, "episodes"))
@@ -651,11 +660,13 @@ class EpisodePlanner:
         try:
             data = json.loads(text)
         except json.JSONDecodeError as exc:
+            logger.warning("分集规划输出不是合法 JSON（%s）；模型原始输出：%s", exc, truncate_for_log(response_text))
             raise _DraftRejected([f"输出不是合法 JSON：{exc}"]) from exc
         try:
             return draft_model.model_validate(data)
         except ValidationError as exc:
             issues = "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()[:5])
+            logger.warning("分集规划输出不符合 schema（%s）；模型原始输出：%s", issues, truncate_for_log(response_text))
             raise _DraftRejected([f"输出不符合 schema：{issues}"]) from exc
 
     def _effective_start(self, project: Mapping[str, Any]) -> tuple[str, int]:

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -135,7 +135,7 @@ class ArkTextBackend:
             # ark 原生 response_format 未声明 strict，复验同样用 strict=False，避免对可强转值误判违例。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:
-                from lib.text_backends.base import truncate_for_log
+                from lib.text_backends.base import merge_billed_tokens, truncate_for_log
 
                 logger.warning(
                     "原生 response_format %s，降级到带校验的 Instructor 路径；模型原始输出：%s",
@@ -143,16 +143,9 @@ class ArkTextBackend:
                     truncate_for_log(native.text),
                 )
                 result = await self._structured_fallback(request, messages)
-                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，否则会系统性漏记。
-                # 仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token。
-                if result.input_tokens is not None or native.input_tokens is not None:
-                    result.input_tokens = (result.input_tokens if result.input_tokens is not None else 0) + (
-                        native.input_tokens if native.input_tokens is not None else 0
-                    )
-                if result.output_tokens is not None or native.output_tokens is not None:
-                    result.output_tokens = (result.output_tokens if result.output_tokens is not None else 0) + (
-                        native.output_tokens if native.output_tokens is not None else 0
-                    )
+                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果。
+                result.input_tokens = merge_billed_tokens(result.input_tokens, native.input_tokens)
+                result.output_tokens = merge_billed_tokens(result.output_tokens, native.output_tokens)
                 return result
             return native
 

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -135,7 +135,13 @@ class ArkTextBackend:
             # ark 原生 response_format 未声明 strict，复验同样用 strict=False，避免对可强转值误判违例。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:
-                logger.warning("原生 response_format %s，降级到带校验的 Instructor 路径", fallback_reason)
+                from lib.text_backends.base import truncate_for_log
+
+                logger.warning(
+                    "原生 response_format %s，降级到带校验的 Instructor 路径；模型原始输出：%s",
+                    fallback_reason,
+                    truncate_for_log(native.text),
+                )
                 result = await self._structured_fallback(request, messages)
                 # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，否则会系统性漏记。
                 # 仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token。

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -219,6 +219,18 @@ class TextGenerationResult:
     output_tokens: int | None = None
 
 
+def merge_billed_tokens(kept: int | None, discarded: int | None) -> int | None:
+    """把降级路径上被丢弃的那次调用的 token 并入保留结果的计量。
+
+    降级前的调用只要拿到过 HTTP 200 就已被计费，不并账会系统性漏记用量与成本。
+    仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token——
+    「未追踪」与「零消耗」在成本口径上不是一回事。
+    """
+    if kept is None and discarded is None:
+        return None
+    return (kept or 0) + (discarded or 0)
+
+
 def resolve_schema(schema: dict | type[BaseModel]) -> dict:
     """将 response_schema 转为无 $ref 的纯 JSON Schema dict。
 

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -72,6 +72,44 @@ class TextOutputTruncatedError(NonRetryableError):
         )
 
 
+class StructuredOutputExhaustedError(NonRetryableError):
+    """结构化输出降级链已走完，模型仍未产出满足 schema 的内容。
+
+    各后端把「结构化输出能力不足」的终局失败统一收敛到本异常：Instructor 档内校验重试
+    耗尽、Gemini prompt 注入降级耗尽，都抛它而非各自的内部异常（``InstructorRetryException``、
+    裸 ``ValueError``），调用方据此给用户一句可行动的解释，而不是把 SDK 内部异常原文透出去。
+
+    继承 NonRetryableError 的理由同 :class:`TextOutputTruncatedError`：消息里嵌的失败原因
+    含模型侧动态文本，可能偶然命中 with_retry_async 的瞬态错误字符串模式。语义上也确实
+    不该重试——降级链本身已经把该试的档位与档内重试都试过了。
+    """
+
+    def __init__(self, *, provider: str, model: str, reason: str):
+        self.provider = provider
+        self.model = model
+        self.reason = reason
+        super().__init__(f"{provider}/{model} 的结构化输出能力不足：{reason}。请更换文本模型或供应商后重试。")
+
+
+# 诊断日志里模型原始输出的截断长度：够看清结构性问题（是散文还是 JSON、顶层是对象还是数组、
+# 哪个字段缺了），又不至于把整份生成内容写进日志。
+RAW_OUTPUT_LOG_LIMIT = 500
+
+
+def truncate_for_log(text: str | None, limit: int = RAW_OUTPUT_LOG_LIMIT) -> str:
+    """把模型原始输出压到可入日志的长度。
+
+    结构化输出降级与解析拒绝由「模型实际输出了什么」决定，只记摘要（字段路径、错误类型）
+    事后无法复盘，故这里刻意保留原文片段。与 :func:`summarize_validation_error` 的取舍不同：
+    后者是每次校验失败都会走的高频路径，本函数只用在 warning 级的降级 / 拒绝分支。
+    """
+    if not text:
+        return "<空>"
+    if len(text) > limit:
+        return f"{text[:limit]}…（截断，共 {len(text)} 字符）"
+    return text
+
+
 # 文本输出上限：非约束安全阀，仅防模型退化性 runaway，不是功能预算——分集规划、剧本生成、
 # drama step1 规范化三处的正常输出体量由各自 schema/内容天然约束，永远不会触碰这个高位值；
 # 只有病态超大批量，或用户配置了输出能力偏低的模型时才会命中。三处共用同一常量，调整只改

--- a/lib/text_backends/gemini.py
+++ b/lib/text_backends/gemini.py
@@ -16,6 +16,7 @@ from ..logging_utils import format_kwargs_for_log
 from ..providers import PROVIDER_GEMINI
 from ..text_utils import strip_json_code_fences
 from .base import (
+    StructuredOutputExhaustedError,
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
@@ -24,6 +25,7 @@ from .base import (
     resolve_schema,
     structured_fallback_reason,
     summarize_validation_error,
+    truncate_for_log,
 )
 
 logger = logging.getLogger(__name__)
@@ -203,8 +205,7 @@ class GeminiTextBackend:
         """异步生成文本，支持结构化输出和 vision。
 
         本方法不带重试装饰器：瞬态错误重试在 :meth:`_generate_native` 层完成。若把复验/
-        降级也包进重试范围，降级尝试的失败会连带重放已成功的原生调用（重试叠乘），且降级
-        穷尽的 ValueError 消息含模型侧动态文本，可能误中重试判定的字符串模式。
+        降级也包进重试范围，降级尝试的失败会连带重放已成功的原生调用（重试叠乘）。
         """
         native = await self._generate_native(request, structured=bool(request.response_schema))
 
@@ -215,7 +216,11 @@ class GeminiTextBackend:
             # 容忍可强转值，避免对供应商已接受的合法响应触发多余的计费降级调用。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:
-                logger.warning("原生 response_schema %s，降级到 prompt 注入路径", fallback_reason)
+                logger.warning(
+                    "原生 response_schema %s，降级到 prompt 注入路径；模型原始输出：%s",
+                    fallback_reason,
+                    truncate_for_log(native.text),
+                )
                 result = await self._prompt_json_fallback(request)
                 # 这次原生 200 调用已被计费，把它的 token 并入降级结果，否则会系统性漏记。
                 # 仅在至少一侧有计量时相加；两侧皆 None（未追踪）保持 None，不塌成字面 0 token。
@@ -325,11 +330,16 @@ class GeminiTextBackend:
                     output_tokens=total_output,
                 )
             feedback = f"\n\n上次输出不符合要求（{last_reason}），请严格按上述 JSON Schema 重新输出纯 JSON。"
-            logger.warning("prompt 注入降级输出校验未通过（%s），带反馈重试", last_reason)
+            logger.warning(
+                "prompt 注入降级输出校验未通过（%s），带反馈重试；模型原始输出：%s",
+                last_reason,
+                truncate_for_log(text),
+            )
 
-        raise ValueError(
-            f"模型 {_FALLBACK_MAX_ATTEMPTS + 1} 次尝试后仍未返回符合要求的 JSON（{last_reason}）；"
-            "当前供应商或模型可能不支持结构化输出，请更换模型或供应商后重试"
+        raise StructuredOutputExhaustedError(
+            provider=PROVIDER_GEMINI,
+            model=self._model,
+            reason=f"prompt 注入降级 {_FALLBACK_MAX_ATTEMPTS} 次尝试后输出仍不合规（{last_reason}）",
         )
 
 

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -1,4 +1,9 @@
-"""Instructor 降级支持 — 为不支持原生结构化输出的模型提供 prompt 注入 + 解析 + 重试。"""
+"""Instructor 降级支持 — 原生 json_schema 通道不可用时的结构化输出降级链。
+
+链路为 TOOLS → MD_JSON：前者用 function calling 在 wire 层传 schema，后者把 schema 注入
+prompt。只有 wire 层失败才继续降档，校验类失败即判终局（见 :func:`_is_tools_wire_failure`）。
+OpenAI 兼容与 Ark 两个 backend 共用本模块，故降级链的调整在此一处生效。
+"""
 
 from __future__ import annotations
 
@@ -6,18 +11,103 @@ import logging
 
 import instructor
 from instructor import Mode
-from instructor.core import IncompleteOutputException
+from instructor.core import IncompleteOutputException, InstructorRetryException, ResponseParsingError
+from openai import BadRequestError
 from pydantic import BaseModel
 
-from lib.text_backends.base import TextGenerationResult, TextOutputTruncatedError, TokenParam, check_truncation
+from lib.text_backends.base import (
+    StructuredOutputExhaustedError,
+    TextGenerationResult,
+    TextOutputTruncatedError,
+    TokenParam,
+    check_truncation,
+    truncate_for_log,
+)
 
 logger = logging.getLogger(__name__)
+
+# 结构化输出降级链：TOOLS 用 function calling 传 schema，是 OpenAI 兼容端点里约束最强、
+# 兼容面最广的一档；MD_JSON 纯靠 prompt 注入 schema，是最后兜底。native json_schema 档在
+# 各 backend 的 generate() 里，本模块只负责 native 之后的两档（见 docs/adr/0014）。
+_STRUCTURED_MODE_CHAIN: tuple[Mode, ...] = (Mode.TOOLS, Mode.MD_JSON)
+
+# 上游不接受 tools 参数时的错误关键字。与 openai backend 的 _SCHEMA_ERROR_KEYWORDS 同构：
+# 代理网关会把上游的参数不兼容包装成非 400 状态码，只认 BadRequestError 会漏判。
+_TOOLS_UNSUPPORTED_KEYWORDS = (
+    "tools",
+    "tool_calls",
+    "tool_choice",
+    "function_call",
+    "functions",
+)
 
 
 def _output_tokens_from_incomplete(exc: IncompleteOutputException) -> int | None:
     """尽力从截断异常携带的部分响应里取 output_tokens，取不到则 None（不阻断异常转换）。"""
     usage = getattr(getattr(exc, "last_completion", None), "usage", None)
     return getattr(usage, "completion_tokens", None) if usage else None
+
+
+def _raw_output_from_exception(exc: BaseException) -> str:
+    """尽力从 Instructor 异常里取模型这一轮的原始输出文本，取不到返回占位串。
+
+    Instructor 把最后一次（失败的）completion 挂在异常上；不同档位的响应形态不同
+    （MD_JSON 在 message.content、TOOLS 在 tool_calls 的 arguments），两处都取，
+    供降级点的诊断日志说清「模型到底输出了什么」。
+    """
+    completion = getattr(exc, "last_completion", None)
+    if completion is None:
+        for attempt in getattr(exc, "failed_attempts", None) or []:
+            completion = getattr(attempt, "completion", None)
+            if completion is not None:
+                break
+    if completion is None:
+        return "<无响应>"
+    choices = getattr(completion, "choices", None) or []
+    if not choices:
+        return "<无响应>"
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None)
+    if content:
+        return truncate_for_log(str(content))
+    tool_calls = getattr(message, "tool_calls", None) or []
+    if tool_calls:
+        return truncate_for_log(str(getattr(getattr(tool_calls[0], "function", None), "arguments", None)))
+    return "<无响应>"
+
+
+def _failure_reason(exc: BaseException) -> str:
+    """把某一档的失败压成一句可读原因，供 StructuredOutputExhaustedError 携带。"""
+    if isinstance(exc, InstructorRetryException):
+        attempts = getattr(exc, "failed_attempts", None) or []
+        last = attempts[-1].exception if attempts else None
+        detail = type(last).__name__ if last is not None else type(exc).__name__
+        return f"降级链各档重试耗尽后模型输出仍不合规（{exc.n_attempts} 次尝试，最后一次 {detail}）"
+    return f"降级链失败（{type(exc).__name__}: {exc}）"
+
+
+def _is_tools_wire_failure(exc: BaseException) -> bool:
+    """判断 TOOLS 档的失败是否属于 wire 层不兼容——只有这一类才继续降档到 MD_JSON。
+
+    两种 wire 层形态：上游直接拒收 tools 参数（API 异常，Instructor 的档内重试只覆盖解析类
+    异常，故这类异常原样冒泡），或上游收下了却不回 tool call（Instructor 解析器抛
+    ``ResponseParsingError``，属可重试解析错误，档内重试耗尽后包在
+    ``InstructorRetryException`` 里）。
+
+    校验类失败（上游确实回了 tool call，只是参数结构反复不合规）不算 wire 层：换成约束更弱的
+    MD_JSON 只会更差，直接判终局。其余异常（瞬态 5xx、连接错误等）也不算，原样冒泡交给调用方
+    的 @with_retry_async 处理，不被降档吞掉。
+    """
+    if isinstance(exc, InstructorRetryException):
+        return any(
+            isinstance(attempt.exception, ResponseParsingError)
+            for attempt in getattr(exc, "failed_attempts", None) or []
+        )
+    if isinstance(exc, TextOutputTruncatedError):
+        return False
+    if isinstance(exc, BadRequestError):
+        return True
+    return any(kw in str(exc) for kw in _TOOLS_UNSUPPORTED_KEYWORDS)
 
 
 def generate_structured_via_instructor(
@@ -134,6 +224,42 @@ def inject_json_instruction(messages: list[dict]) -> list[dict]:
     return fb_messages
 
 
+def _handle_mode_failure(
+    exc: Exception,
+    *,
+    mode: Mode,
+    next_mode: Mode | None,
+    provider: str,
+    model: str,
+) -> None:
+    """处理降级链某一档的失败：可降档则记日志后正常返回，否则抛终局异常或原样冒泡。
+
+    正常返回即「调用方应继续下一档」。
+    """
+    if isinstance(exc, TextOutputTruncatedError):
+        # 截断是可操作硬错误，重发同一份必然再截断的请求没有意义（docs/adr/0044）。
+        raise exc
+    if next_mode is not None and _is_tools_wire_failure(exc):
+        logger.warning(
+            "Instructor %s 档 wire 层不兼容（%s），降档到 %s 档；模型原始输出：%s",
+            mode.value,
+            exc,
+            next_mode.value,
+            _raw_output_from_exception(exc),
+        )
+        return
+    if not isinstance(exc, InstructorRetryException):
+        # 既非 wire 层不兼容也非档内重试耗尽（瞬态 5xx、连接错误、client 类型错误等），
+        # 原样冒泡交给调用方的 @with_retry_async 判定，不误收敛成不可重试的终局异常。
+        raise exc
+    logger.warning(
+        "Instructor %s 档重试耗尽，判定为结构化输出能力不足；模型原始输出：%s",
+        mode.value,
+        _raw_output_from_exception(exc),
+    )
+    raise StructuredOutputExhaustedError(provider=provider, model=model, reason=_failure_reason(exc)) from exc
+
+
 def instructor_fallback_sync(
     client,
     model: str,
@@ -145,22 +271,33 @@ def instructor_fallback_sync(
 ):
     """同步 Instructor 降级路径。
 
-    - response_schema 为 Pydantic 类 → instructor create_with_completion
+    - response_schema 为 Pydantic 类 → TOOLS → MD_JSON 降级链
     - response_schema 为 dict → inject JSON instruction + json_object 模式
 
     供 Ark 等同步 SDK 后端使用（调用方用 asyncio.to_thread 包装）。
-    不做重试，瞬态错误由调用方的重试循环统一处理。
+    不做瞬态重试，瞬态错误由调用方的重试循环统一处理；档内的结构化校验重试由 Instructor 自带。
     """
     if isinstance(response_schema, type):
-        json_text, input_tokens, output_tokens = generate_structured_via_instructor(
-            client=client,
-            model=model,
-            messages=messages,
-            response_model=response_schema,
-            max_tokens=max_tokens,
-            token_param=token_param,
-            provider=provider,
-        )
+        json_text: str | None = None
+        input_tokens: int | None = None
+        output_tokens: int | None = None
+        for index, mode in enumerate(_STRUCTURED_MODE_CHAIN):
+            next_mode = _STRUCTURED_MODE_CHAIN[index + 1] if index + 1 < len(_STRUCTURED_MODE_CHAIN) else None
+            try:
+                json_text, input_tokens, output_tokens = generate_structured_via_instructor(
+                    client=client,
+                    model=model,
+                    messages=messages,
+                    response_model=response_schema,
+                    mode=mode,
+                    max_tokens=max_tokens,
+                    token_param=token_param,
+                    provider=provider,
+                )
+                break
+            except Exception as exc:
+                _handle_mode_failure(exc, mode=mode, next_mode=next_mode, provider=provider, model=model)
+        assert json_text is not None  # 链内每条失败路径都抛异常，走到这里必有结果
         return TextGenerationResult(
             text=json_text,
             provider=provider,
@@ -212,24 +349,35 @@ async def instructor_fallback_async(
 ):
     """异步 Instructor 降级路径。
 
-    - response_schema 为 Pydantic 类 → instructor create_with_completion (async)
+    - response_schema 为 Pydantic 类 → TOOLS → MD_JSON 降级链 (async)
     - response_schema 为 dict → inject JSON instruction + json_object 模式 (async)
 
     供 OpenAI 等原生异步 SDK 后端使用。
-    不做重试，瞬态错误由调用方的重试循环统一处理。
+    不做瞬态重试，瞬态错误由调用方的重试循环统一处理；档内的结构化校验重试由 Instructor 自带。
     """
     from lib.text_backends.base import TextGenerationResult
 
     if isinstance(response_schema, type):
-        json_text, input_tokens, output_tokens = await generate_structured_via_instructor_async(
-            client=client,
-            model=model,
-            messages=messages,
-            response_model=response_schema,
-            max_tokens=max_tokens,
-            token_param=token_param,
-            provider=provider,
-        )
+        json_text: str | None = None
+        input_tokens: int | None = None
+        output_tokens: int | None = None
+        for index, mode in enumerate(_STRUCTURED_MODE_CHAIN):
+            next_mode = _STRUCTURED_MODE_CHAIN[index + 1] if index + 1 < len(_STRUCTURED_MODE_CHAIN) else None
+            try:
+                json_text, input_tokens, output_tokens = await generate_structured_via_instructor_async(
+                    client=client,
+                    model=model,
+                    messages=messages,
+                    response_model=response_schema,
+                    mode=mode,
+                    max_tokens=max_tokens,
+                    token_param=token_param,
+                    provider=provider,
+                )
+                break
+            except Exception as exc:
+                _handle_mode_failure(exc, mode=mode, next_mode=next_mode, provider=provider, model=model)
+        assert json_text is not None  # 链内每条失败路径都抛异常，走到这里必有结果
         return TextGenerationResult(
             text=json_text,
             provider=provider,

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -1,13 +1,14 @@
 """Instructor 降级支持 — 原生 json_schema 通道不可用时的结构化输出降级链。
 
 链路为 TOOLS → MD_JSON：前者用 function calling 在 wire 层传 schema，后者把 schema 注入
-prompt。只有 wire 层失败才继续降档，校验类失败即判终局（见 :func:`_is_tools_wire_failure`）。
+prompt。只有 wire 层失败才继续降档，校验类失败即判终局（见 :func:`_classify_mode_failure`）。
 OpenAI 兼容与 Ark 两个 backend 共用本模块，故降级链的调整在此一处生效。
 """
 
 from __future__ import annotations
 
 import logging
+from enum import Enum
 
 import instructor
 from instructor import Mode
@@ -40,6 +41,14 @@ _TOOLS_UNSUPPORTED_KEYWORDS = (
     "function_call",
     "functions",
 )
+
+
+def _mode_chain_steps() -> list[tuple[Mode, Mode | None]]:
+    """降级链的 (当前档, 下一档) 序列；下一档为 None 表示已是末档、无处可退。"""
+    return [
+        (mode, _STRUCTURED_MODE_CHAIN[index + 1] if index + 1 < len(_STRUCTURED_MODE_CHAIN) else None)
+        for index, mode in enumerate(_STRUCTURED_MODE_CHAIN)
+    ]
 
 
 def _output_tokens_from_incomplete(exc: IncompleteOutputException) -> int | None:
@@ -76,38 +85,79 @@ def _raw_output_from_exception(exc: BaseException) -> str:
     return "<无响应>"
 
 
+def _api_call_failure(exc: InstructorRetryException) -> BaseException | None:
+    """取这一档折在 API 调用上的原始异常；折在模型输出上则返回 None。
+
+    Instructor 的档内重试只把解析 / 校验类异常记进 ``failed_attempts``；API 调用本身抛的
+    异常会中断重试循环、被包进 ``InstructorRetryException``，原异常只挂在 ``__cause__`` 上。
+    因此 ``failed_attempts`` 为空即表示这一档根本没走到解析——判据必须穿过这层包装取原异常，
+    否则「上游拒收 tools 参数」永远认不出来。
+    """
+    if exc.failed_attempts:
+        return None
+    return exc.__cause__
+
+
 def _failure_reason(exc: BaseException) -> str:
     """把某一档的失败压成一句可读原因，供 StructuredOutputExhaustedError 携带。"""
+    if not isinstance(exc, InstructorRetryException):
+        return f"降级链失败（{type(exc).__name__}: {exc}）"
+    api_failure = _api_call_failure(exc)
+    if api_failure is not None:
+        return f"降级链各档传递 schema 的方式均被上游拒收（{api_failure}）"
+    last = exc.failed_attempts[-1].exception if exc.failed_attempts else None
+    detail = type(last).__name__ if last is not None else "未知原因"
+    return f"降级链各档重试耗尽后模型输出仍不合规（{exc.n_attempts} 次尝试，最后一次 {detail}）"
+
+
+def _propagated_cause(exc: Exception) -> Exception:
+    """冒泡时该抛的异常：API 调用失败抛原异常本身，其余抛原样。"""
     if isinstance(exc, InstructorRetryException):
-        attempts = getattr(exc, "failed_attempts", None) or []
-        last = attempts[-1].exception if attempts else None
-        detail = type(last).__name__ if last is not None else type(exc).__name__
-        return f"降级链各档重试耗尽后模型输出仍不合规（{exc.n_attempts} 次尝试，最后一次 {detail}）"
-    return f"降级链失败（{type(exc).__name__}: {exc}）"
+        api_failure = _api_call_failure(exc)
+        if isinstance(api_failure, Exception):
+            return api_failure
+    return exc
 
 
-def _is_tools_wire_failure(exc: BaseException) -> bool:
-    """判断 TOOLS 档的失败是否属于 wire 层不兼容——只有这一类才继续降档到 MD_JSON。
+class _ModeFailure(Enum):
+    """某一档失败后的处置。"""
 
-    两种 wire 层形态：上游直接拒收 tools 参数（API 异常，Instructor 的档内重试只覆盖解析类
-    异常，故这类异常原样冒泡），或上游收下了却不回 tool call（Instructor 解析器抛
-    ``ResponseParsingError``，属可重试解析错误，档内重试耗尽后包在
-    ``InstructorRetryException`` 里）。
+    DOWNGRADE = "downgrade"
+    """wire 层不兼容，换下一档还有机会。"""
 
-    校验类失败（上游确实回了 tool call，只是参数结构反复不合规）不算 wire 层：换成约束更弱的
-    MD_JSON 只会更差，直接判终局。其余异常（瞬态 5xx、连接错误等）也不算，原样冒泡交给调用方
-    的 @with_retry_async 处理，不被降档吞掉。
+    TERMINAL = "terminal"
+    """模型输出反复不合规，换约束更弱的档只会更差。"""
+
+    PROPAGATE = "propagate"
+    """与结构化输出能力无关，交调用方判定。"""
+
+
+def _classify_mode_failure(exc: BaseException) -> _ModeFailure:
+    """判定某一档的失败该降档、判终局，还是原样冒泡。
+
+    只有 wire 层不兼容才降档，两种形态：上游拒收 tools 参数（API 调用异常），或收下了却不回
+    tool call（解析器抛 ``ResponseParsingError``，属档内可重试解析错误）。
+
+    上游确实回了 tool call、只是参数结构反复不合规，属校验类失败，判终局。
+
+    其余一律冒泡：瞬态 5xx 与连接错误交调用方的 ``@with_retry_async`` 判定，不被降级链吞成
+    不可重试的终局异常；``TextOutputTruncatedError`` 是可操作硬错误，重发同一份必然再截断的
+    请求没有意义（见 docs/adr/0044），它自身已是 NonRetryableError，原样传给调用方即可。
     """
-    if isinstance(exc, InstructorRetryException):
-        return any(
-            isinstance(attempt.exception, ResponseParsingError)
-            for attempt in getattr(exc, "failed_attempts", None) or []
-        )
-    if isinstance(exc, TextOutputTruncatedError):
-        return False
-    if isinstance(exc, BadRequestError):
-        return True
-    return any(kw in str(exc) for kw in _TOOLS_UNSUPPORTED_KEYWORDS)
+    if not isinstance(exc, InstructorRetryException):
+        return _ModeFailure.PROPAGATE
+    api_failure = _api_call_failure(exc)
+    if api_failure is None:
+        if any(isinstance(attempt.exception, ResponseParsingError) for attempt in exc.failed_attempts or []):
+            return _ModeFailure.DOWNGRADE
+        return _ModeFailure.TERMINAL
+    if isinstance(api_failure, BadRequestError):
+        # 走到降级链说明 native 档已经跟上游握过手，模型名 / 鉴权类 400 早在那里就炸了；
+        # 此处的 400 压倒性地是参数不被接受，值得花一次 MD_JSON 调用去试。
+        return _ModeFailure.DOWNGRADE
+    if any(kw in str(api_failure) for kw in _TOOLS_UNSUPPORTED_KEYWORDS):
+        return _ModeFailure.DOWNGRADE
+    return _ModeFailure.PROPAGATE
 
 
 def generate_structured_via_instructor(
@@ -236,10 +286,12 @@ def _handle_mode_failure(
 
     正常返回即「调用方应继续下一档」。
     """
-    if isinstance(exc, TextOutputTruncatedError):
-        # 截断是可操作硬错误，重发同一份必然再截断的请求没有意义（docs/adr/0044）。
-        raise exc
-    if next_mode is not None and _is_tools_wire_failure(exc):
+    failure = _classify_mode_failure(exc)
+    if failure is _ModeFailure.PROPAGATE:
+        # 冒泡时剥掉 Instructor 的包装：调用方的 @with_retry_async 先按异常类型判瞬态
+        # （ConnectionError / TimeoutError），包着一层就只剩消息文本匹配，漏判连接类错误。
+        raise _propagated_cause(exc)
+    if failure is _ModeFailure.DOWNGRADE and next_mode is not None:
         logger.warning(
             "Instructor %s 档 wire 层不兼容（%s），降档到 %s 档；模型原始输出：%s",
             mode.value,
@@ -248,12 +300,9 @@ def _handle_mode_failure(
             _raw_output_from_exception(exc),
         )
         return
-    if not isinstance(exc, InstructorRetryException):
-        # 既非 wire 层不兼容也非档内重试耗尽（瞬态 5xx、连接错误、client 类型错误等），
-        # 原样冒泡交给调用方的 @with_retry_async 判定，不误收敛成不可重试的终局异常。
-        raise exc
+    # 校验类耗尽，或末档仍是 wire 层不兼容——降级链已无更弱的档可退。
     logger.warning(
-        "Instructor %s 档重试耗尽，判定为结构化输出能力不足；模型原始输出：%s",
+        "Instructor %s 档失败且降级链已走完，判定为结构化输出能力不足；模型原始输出：%s",
         mode.value,
         _raw_output_from_exception(exc),
     )
@@ -281,8 +330,7 @@ def instructor_fallback_sync(
         json_text: str | None = None
         input_tokens: int | None = None
         output_tokens: int | None = None
-        for index, mode in enumerate(_STRUCTURED_MODE_CHAIN):
-            next_mode = _STRUCTURED_MODE_CHAIN[index + 1] if index + 1 < len(_STRUCTURED_MODE_CHAIN) else None
+        for mode, next_mode in _mode_chain_steps():
             try:
                 json_text, input_tokens, output_tokens = generate_structured_via_instructor(
                     client=client,
@@ -355,14 +403,11 @@ async def instructor_fallback_async(
     供 OpenAI 等原生异步 SDK 后端使用。
     不做瞬态重试，瞬态错误由调用方的重试循环统一处理；档内的结构化校验重试由 Instructor 自带。
     """
-    from lib.text_backends.base import TextGenerationResult
-
     if isinstance(response_schema, type):
         json_text: str | None = None
         input_tokens: int | None = None
         output_tokens: int | None = None
-        for index, mode in enumerate(_STRUCTURED_MODE_CHAIN):
-            next_mode = _STRUCTURED_MODE_CHAIN[index + 1] if index + 1 < len(_STRUCTURED_MODE_CHAIN) else None
+        for mode, next_mode in _mode_chain_steps():
             try:
                 json_text, input_tokens, output_tokens = await generate_structured_via_instructor_async(
                     client=client,

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -13,7 +13,6 @@ from enum import Enum
 import instructor
 from instructor import Mode
 from instructor.core import IncompleteOutputException, InstructorRetryException, ResponseParsingError
-from openai import BadRequestError
 from pydantic import BaseModel
 
 from lib.text_backends.base import (
@@ -22,6 +21,7 @@ from lib.text_backends.base import (
     TextOutputTruncatedError,
     TokenParam,
     check_truncation,
+    merge_billed_tokens,
     truncate_for_log,
 )
 
@@ -32,8 +32,9 @@ logger = logging.getLogger(__name__)
 # 各 backend 的 generate() 里，本模块只负责 native 之后的两档（见 docs/adr/0014）。
 _STRUCTURED_MODE_CHAIN: tuple[Mode, ...] = (Mode.TOOLS, Mode.MD_JSON)
 
-# 上游不接受 tools 参数时的错误关键字。与 openai backend 的 _SCHEMA_ERROR_KEYWORDS 同构：
-# 代理网关会把上游的参数不兼容包装成非 400 状态码，只认 BadRequestError 会漏判。
+# 上游不接受 tools 参数时的错误关键字，匹配前把错误文本转小写（各家代理的大小写不统一）。
+# 与 openai backend 的 _SCHEMA_ERROR_KEYWORDS 同构：代理网关会把上游的参数不兼容包装成非 400
+# 状态码，只认 BadRequestError 会漏判。
 _TOOLS_UNSUPPORTED_KEYWORDS = (
     "tools",
     "tool_calls",
@@ -110,6 +111,19 @@ def _failure_reason(exc: BaseException) -> str:
     return f"降级链各档重试耗尽后模型输出仍不合规（{exc.n_attempts} 次尝试，最后一次 {detail}）"
 
 
+def _billed_usage(exc: BaseException) -> tuple[int | None, int | None]:
+    """取这一档已经计费的 token，供降档时并入最终结果。
+
+    档内重试里每次拿到 HTTP 200 的尝试都已被计费，即便响应最终没通过解析 / 校验；Instructor
+    把它们累加在 ``total_usage`` 上。上游直接拒收参数时该累加值为零，此时按「无计量」处理，
+    以免把 None 塌成字面 0 token。
+    """
+    usage = getattr(exc, "total_usage", None)
+    prompt = getattr(usage, "prompt_tokens", None) or None
+    completion = getattr(usage, "completion_tokens", None) or None
+    return prompt, completion
+
+
 def _propagated_cause(exc: Exception) -> Exception:
     """冒泡时该抛的异常：API 调用失败抛原异常本身，其余抛原样。"""
     if isinstance(exc, InstructorRetryException):
@@ -135,8 +149,14 @@ class _ModeFailure(Enum):
 def _classify_mode_failure(exc: BaseException) -> _ModeFailure:
     """判定某一档的失败该降档、判终局，还是原样冒泡。
 
-    只有 wire 层不兼容才降档，两种形态：上游拒收 tools 参数（API 调用异常），或收下了却不回
-    tool call（解析器抛 ``ResponseParsingError``，属档内可重试解析错误）。
+    只有 wire 层不兼容才降档，两种形态：上游拒收 tools 参数（API 调用异常，须由错误文本指名
+    tools / functions 才算数），或收下了却不回 tool call（解析器抛 ``ResponseParsingError``，
+    属档内可重试解析错误）。
+
+    API 调用异常一律走关键字判据，400 也不例外：无 ``STRUCTURED_OUTPUT`` 能力位的 Ark 模型
+    不经原生档直接进本链，此处的 400 同样可能是模型名无效、上下文超限或策略拒绝。把这些无差别
+    当成 tools 不兼容，既白花一次 MD_JSON 调用，又会把真实原因替换成不可重试的终局异常、
+    使调用方拿到错误的处置指引。
 
     上游确实回了 tool call、只是参数结构反复不合规，属校验类失败，判终局。
 
@@ -151,11 +171,7 @@ def _classify_mode_failure(exc: BaseException) -> _ModeFailure:
         if any(isinstance(attempt.exception, ResponseParsingError) for attempt in exc.failed_attempts or []):
             return _ModeFailure.DOWNGRADE
         return _ModeFailure.TERMINAL
-    if isinstance(api_failure, BadRequestError):
-        # 走到降级链说明 native 档已经跟上游握过手，模型名 / 鉴权类 400 早在那里就炸了；
-        # 此处的 400 压倒性地是参数不被接受，值得花一次 MD_JSON 调用去试。
-        return _ModeFailure.DOWNGRADE
-    if any(kw in str(api_failure) for kw in _TOOLS_UNSUPPORTED_KEYWORDS):
+    if any(kw in str(api_failure).lower() for kw in _TOOLS_UNSUPPORTED_KEYWORDS):
         return _ModeFailure.DOWNGRADE
     return _ModeFailure.PROPAGATE
 
@@ -281,10 +297,10 @@ def _handle_mode_failure(
     next_mode: Mode | None,
     provider: str,
     model: str,
-) -> None:
+) -> tuple[int | None, int | None]:
     """处理降级链某一档的失败：可降档则记日志后正常返回，否则抛终局异常或原样冒泡。
 
-    正常返回即「调用方应继续下一档」。
+    正常返回即「调用方应继续下一档」，返回值是这一档已计费、需并入最终结果的 token。
     """
     failure = _classify_mode_failure(exc)
     if failure is _ModeFailure.PROPAGATE:
@@ -299,7 +315,7 @@ def _handle_mode_failure(
             next_mode.value,
             _raw_output_from_exception(exc),
         )
-        return
+        return _billed_usage(exc)
     # 校验类耗尽，或末档仍是 wire 层不兼容——降级链已无更弱的档可退。
     logger.warning(
         "Instructor %s 档失败且降级链已走完，判定为结构化输出能力不足；模型原始输出：%s",
@@ -330,6 +346,8 @@ def instructor_fallback_sync(
         json_text: str | None = None
         input_tokens: int | None = None
         output_tokens: int | None = None
+        billed_input: int | None = None
+        billed_output: int | None = None
         for mode, next_mode in _mode_chain_steps():
             try:
                 json_text, input_tokens, output_tokens = generate_structured_via_instructor(
@@ -344,14 +362,18 @@ def instructor_fallback_sync(
                 )
                 break
             except Exception as exc:
-                _handle_mode_failure(exc, mode=mode, next_mode=next_mode, provider=provider, model=model)
+                discarded_input, discarded_output = _handle_mode_failure(
+                    exc, mode=mode, next_mode=next_mode, provider=provider, model=model
+                )
+                billed_input = merge_billed_tokens(billed_input, discarded_input)
+                billed_output = merge_billed_tokens(billed_output, discarded_output)
         assert json_text is not None  # 链内每条失败路径都抛异常，走到这里必有结果
         return TextGenerationResult(
             text=json_text,
             provider=provider,
             model=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
+            input_tokens=merge_billed_tokens(input_tokens, billed_input),
+            output_tokens=merge_billed_tokens(output_tokens, billed_output),
         )
 
     logger.info("response_schema 为 dict，无法使用 Instructor，回退到 json_object 模式")
@@ -407,6 +429,8 @@ async def instructor_fallback_async(
         json_text: str | None = None
         input_tokens: int | None = None
         output_tokens: int | None = None
+        billed_input: int | None = None
+        billed_output: int | None = None
         for mode, next_mode in _mode_chain_steps():
             try:
                 json_text, input_tokens, output_tokens = await generate_structured_via_instructor_async(
@@ -421,14 +445,18 @@ async def instructor_fallback_async(
                 )
                 break
             except Exception as exc:
-                _handle_mode_failure(exc, mode=mode, next_mode=next_mode, provider=provider, model=model)
+                discarded_input, discarded_output = _handle_mode_failure(
+                    exc, mode=mode, next_mode=next_mode, provider=provider, model=model
+                )
+                billed_input = merge_billed_tokens(billed_input, discarded_input)
+                billed_output = merge_billed_tokens(billed_output, discarded_output)
         assert json_text is not None  # 链内每条失败路径都抛异常，走到这里必有结果
         return TextGenerationResult(
             text=json_text,
             provider=provider,
             model=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
+            input_tokens=merge_billed_tokens(input_tokens, billed_input),
+            output_tokens=merge_billed_tokens(output_tokens, billed_output),
         )
 
     logger.info("response_schema 为 dict，无法使用 Instructor，回退到 json_object 模式")

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -9,11 +9,17 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
+from json import JSONDecodeError
 
 import instructor
 from instructor import Mode
-from instructor.core import IncompleteOutputException, InstructorRetryException, ResponseParsingError
-from pydantic import BaseModel
+from instructor.core import (
+    AsyncValidationError,
+    IncompleteOutputException,
+    InstructorRetryException,
+    ResponseParsingError,
+)
+from pydantic import BaseModel, ValidationError
 
 from lib.text_backends.base import (
     StructuredOutputExhaustedError,
@@ -41,6 +47,16 @@ _TOOLS_UNSUPPORTED_KEYWORDS = (
     "tool_choice",
     "function_call",
     "functions",
+)
+
+# 终止一档的解析 / 校验类异常，与 Instructor v2 重试循环的 _RETRYABLE_PARSE_ERRORS 同集合。
+# 判据靠「终止原因是否属这一类」区分模型输出问题与 API 调用问题，集合漂移会让区分失准，
+# 故由 TestInstructorExceptionShape 对真实 Instructor 钉住。
+_PARSE_FAILURE_TYPES: tuple[type[BaseException], ...] = (
+    ValidationError,
+    JSONDecodeError,
+    AsyncValidationError,
+    ResponseParsingError,
 )
 
 
@@ -87,16 +103,39 @@ def _raw_output_from_exception(exc: BaseException) -> str:
 
 
 def _api_call_failure(exc: InstructorRetryException) -> BaseException | None:
-    """取这一档折在 API 调用上的原始异常；折在模型输出上则返回 None。
+    """取终止这一档的原始异常；若终止在模型输出的解析 / 校验上则返回 None。
 
-    Instructor 的档内重试只把解析 / 校验类异常记进 ``failed_attempts``；API 调用本身抛的
-    异常会中断重试循环、被包进 ``InstructorRetryException``，原异常只挂在 ``__cause__`` 上。
-    因此 ``failed_attempts`` 为空即表示这一档根本没走到解析——判据必须穿过这层包装取原异常，
-    否则「上游拒收 tools 参数」永远认不出来。
+    Instructor 把终止原因挂在 ``__cause__`` 上（``raise ... from last_exception``），判据必须
+    穿过这层包装才认得出「上游拒收 tools 参数」。
+
+    只能看 ``__cause__``，不能拿 ``failed_attempts`` 是否为空当代理：解析 / 校验类失败会逐次
+    累积进 ``failed_attempts`` 且不清空，因此「先解析失败一次、再撞上代理 503」这条路径下
+    ``failed_attempts`` 非空而终止原因是 503。按前者判会把瞬态错误当成模型输出不合规，吞掉
+    调用方的重试。
     """
-    if exc.failed_attempts:
+    cause = exc.__cause__
+    if cause is None or isinstance(cause, _PARSE_FAILURE_TYPES):
         return None
-    return exc.__cause__
+    return cause
+
+
+def _tool_call_absent(exc: BaseException | None) -> bool:
+    """响应里根本没有 tool call（wire 层不兼容），而非给了 tool call 但参数不可用。
+
+    TOOLS 档下 ``ResponseParsingError`` 有三种成因：没有 tool call、tool call 的 arguments
+    缺失、arguments 不可 JSON 序列化。只有第一种说明上游这条通道不产 tool call、值得换档；
+    后两种上游确实回了 tool call，只是内容不合规，属校验类失败——换约束更弱的档只会更差。
+    按响应结构判而非按错误文案判，免得 Instructor 改文案就失效。
+    """
+    if not isinstance(exc, ResponseParsingError):
+        return False
+    choices = getattr(getattr(exc, "raw_response", None), "choices", None) or []
+    if not choices:
+        return True
+    message = getattr(choices[0], "message", None)
+    if getattr(message, "tool_calls", None):
+        return False
+    return getattr(message, "function_call", None) is None
 
 
 def _failure_reason(exc: BaseException) -> str:
@@ -150,8 +189,7 @@ def _classify_mode_failure(exc: BaseException) -> _ModeFailure:
     """判定某一档的失败该降档、判终局，还是原样冒泡。
 
     只有 wire 层不兼容才降档，两种形态：上游拒收 tools 参数（API 调用异常，须由错误文本指名
-    tools / functions 才算数），或收下了却不回 tool call（解析器抛 ``ResponseParsingError``，
-    属档内可重试解析错误）。
+    tools / functions 才算数），或收下了却不回 tool call（见 :func:`_tool_call_absent`）。
 
     API 调用异常一律走关键字判据，400 也不例外：无 ``STRUCTURED_OUTPUT`` 能力位的 Ark 模型
     不经原生档直接进本链，此处的 400 同样可能是模型名无效、上下文超限或策略拒绝。把这些无差别
@@ -168,7 +206,7 @@ def _classify_mode_failure(exc: BaseException) -> _ModeFailure:
         return _ModeFailure.PROPAGATE
     api_failure = _api_call_failure(exc)
     if api_failure is None:
-        if any(isinstance(attempt.exception, ResponseParsingError) for attempt in exc.failed_attempts or []):
+        if _tool_call_absent(exc.__cause__):
             return _ModeFailure.DOWNGRADE
         return _ModeFailure.TERMINAL
     if any(kw in str(api_failure).lower() for kw in _TOOLS_UNSUPPORTED_KEYWORDS):

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -19,6 +19,7 @@ from lib.text_backends.base import (
     check_truncation,
     resolve_schema,
     structured_fallback_reason,
+    truncate_for_log,
 )
 
 logger = logging.getLogger(__name__)
@@ -91,8 +92,9 @@ class OpenAITextBackend:
             fallback_reason = structured_fallback_reason(native.text, request.response_schema)
             if fallback_reason:
                 logger.warning(
-                    "原生 response_format %s，降级到带校验的 Instructor 路径",
+                    "原生 response_format %s，降级到带校验的 Instructor 路径；模型原始输出：%s",
                     fallback_reason,
+                    truncate_for_log(native.text),
                 )
                 result = await _instructor_fallback(
                     self._client,

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -17,6 +17,7 @@ from lib.text_backends.base import (
     TextGenerationResult,
     TokenParam,
     check_truncation,
+    merge_billed_tokens,
     resolve_schema,
     structured_fallback_reason,
     truncate_for_log,
@@ -104,13 +105,9 @@ class OpenAITextBackend:
                     provider=self._provider_name,
                     token_param=self._max_tokens_param,
                 )
-                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果，否则
-                # 记账层会系统性漏记。仅在至少一侧有计量时相加；两侧皆 None
-                # （未追踪）保持 None，不塌成字面 0 token。
-                if result.input_tokens is not None or native.input_tokens is not None:
-                    result.input_tokens = (result.input_tokens or 0) + (native.input_tokens or 0)
-                if result.output_tokens is not None or native.output_tokens is not None:
-                    result.output_tokens = (result.output_tokens or 0) + (native.output_tokens or 0)
+                # 这次原生 200 调用已被代理计费，把它的 token 并入降级结果。
+                result.input_tokens = merge_billed_tokens(result.input_tokens, native.input_tokens)
+                result.output_tokens = merge_billed_tokens(result.output_tokens, native.output_tokens)
                 return result
 
         return native

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from instructor.core import InstructorRetryException
+
 if TYPE_CHECKING:
     from lib.reference_video.voice_settings import VoiceRenderSettings
 
@@ -220,3 +222,23 @@ def fake_reference_caps_fetcher(
         )
 
     return _fetch
+
+
+def instructor_api_call_exhausted(cause: Exception) -> InstructorRetryException:
+    """构造「API 调用失败」形态的 Instructor 异常，供结构化输出降级链的判据测试使用。
+
+    Instructor 的档内重试只把解析 / 校验类异常记进 ``failed_attempts``；API 调用本身抛的异常
+    （参数被拒、瞬态 5xx、连接错误）会中断重试循环、被包成 ``InstructorRetryException``，原异常
+    只挂在 ``__cause__`` 上、``failed_attempts`` 为空。降级链的判据要认的正是这个形态，拿裸 API
+    异常做桩会测出生产里不存在的路径。形态本身由
+    ``TestInstructorExceptionShape::test_api_call_failure_arrives_wrapped`` 对真实 Instructor 钉住。
+    """
+    exc = InstructorRetryException(
+        str(cause),
+        last_completion=None,
+        n_attempts=1,
+        total_usage=0,
+        failed_attempts=[],
+    )
+    exc.__cause__ = cause
+    return exc

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -227,11 +227,11 @@ def fake_reference_caps_fetcher(
 def instructor_api_call_exhausted(cause: Exception) -> InstructorRetryException:
     """构造「API 调用失败」形态的 Instructor 异常，供结构化输出降级链的判据测试使用。
 
-    Instructor 的档内重试只把解析 / 校验类异常记进 ``failed_attempts``；API 调用本身抛的异常
-    （参数被拒、瞬态 5xx、连接错误）会中断重试循环、被包成 ``InstructorRetryException``，原异常
-    只挂在 ``__cause__`` 上、``failed_attempts`` 为空。降级链的判据要认的正是这个形态，拿裸 API
-    异常做桩会测出生产里不存在的路径。形态本身由
-    ``TestInstructorExceptionShape::test_api_call_failure_arrives_wrapped`` 对真实 Instructor 钉住。
+    API 调用本身抛的异常（参数被拒、瞬态 5xx、连接错误）会中断档内重试循环、被包成
+    ``InstructorRetryException``，原异常只挂在 ``__cause__`` 上。降级链的判据要认的正是这个
+    形态，拿裸 API 异常做桩会测出生产里不存在的路径。此处 ``failed_attempts`` 为空表示这一档
+    一次都没走到解析；先解析失败若干次再折在 API 上的混合形态由测试模块自行构造。形态本身由
+    ``TestInstructorExceptionShape`` 对真实 Instructor 钉住。
     """
     exc = InstructorRetryException(
         str(cause),

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -18,11 +18,13 @@ from lib.episode_ledger import discover_sources as _real_discover_sources
 from lib.episode_planner import (
     EpisodePlanner,
     EpisodePlanningError,
+    NarrationPlanDraft,
     PlanningConflictError,
+    _DraftRejected,
     _find_all_overlapping,
 )
 from lib.episode_reset import EpisodeResetResult, reset_episode_planning
-from lib.text_backends.base import TextGenerationResult
+from lib.text_backends.base import StructuredOutputExhaustedError, TextGenerationResult
 from lib.text_metrics import count_reading_units
 
 # 源文：三段剧情，句子互不重复，锚点可唯一定位
@@ -105,6 +107,41 @@ class TestFindAllOverlapping:
         # 空 needle 防御边界：直接返回 []，不进入逐位滑动（调用方 anchor 受 min_length=2 约束）
         assert _find_all_overlapping("abcabc", "") == []
         assert _find_all_overlapping("", "") == []
+
+
+class TestParseDraft:
+    """解析层的拒绝行为：两类失败都要变成可回传给模型的 _DraftRejected，且日志留下原始输出。"""
+
+    @pytest.mark.unit
+    def test_rejects_malformed_json_with_unescaped_quote(self, caplog):
+        """字符串里带未转义引号 → 非法 JSON，拒绝并记录原始输出。"""
+        raw = '{"episodes": [{"title": "他说"你好"", "hook": "h", "end_anchor": "锚点"}]}'
+
+        with caplog.at_level("WARNING", logger="lib.episode_planner"):
+            with pytest.raises(_DraftRejected) as exc_info:
+                EpisodePlanner._parse_draft(raw, NarrationPlanDraft)
+
+        assert "不是合法 JSON" in exc_info.value.reasons[0]
+        assert any(raw[:20] in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.unit
+    def test_rejects_bare_episode_dict_at_top_level(self, caplog):
+        """顶层是裸 episode 对象（缺 episodes wrapper）→ 结构错误，拒绝而不机械补 wrapper。"""
+        raw = json.dumps({"title": "山村少年", "hook": "h", "end_anchor": ANCHOR_EP1}, ensure_ascii=False)
+
+        with caplog.at_level("WARNING", logger="lib.episode_planner"):
+            with pytest.raises(_DraftRejected) as exc_info:
+                EpisodePlanner._parse_draft(raw, NarrationPlanDraft)
+
+        assert "不符合 schema" in exc_info.value.reasons[0]
+        assert "episodes" in exc_info.value.reasons[0]
+        assert any(ANCHOR_EP1 in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.unit
+    def test_accepts_wrapped_episodes(self):
+        raw = _plan_response([{"title": "山村少年", "hook": "h", "end_anchor": ANCHOR_EP1}])
+        draft = EpisodePlanner._parse_draft(raw, NarrationPlanDraft)
+        assert [ep.end_anchor for ep in draft.episodes] == [ANCHOR_EP1]  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class TestPlan:
@@ -615,6 +652,32 @@ class TestPlan:
 
         assert (project_dir / "project.json").read_text(encoding="utf-8") == before
         assert not list((project_dir / "source").glob("episode_*.txt"))
+
+    @pytest.mark.unit
+    async def test_plan_converts_structured_output_exhausted_to_planning_error(self, tmp_path: Path):
+        """后端结构化输出降级链耗尽：转为 EpisodePlanningError，话术指向供应商能力不足，且不在本层重试。"""
+        project_dir = _write_project(tmp_path)
+
+        class _ExhaustedGenerator(_FakeTextGenerator):
+            def __init__(self):
+                super().__init__([])
+                self.calls = 0
+
+            async def generate(self, request, project_name=None):
+                self.calls += 1
+                raise StructuredOutputExhaustedError(
+                    provider="custom-relay",
+                    model="claude-sonnet-4-6",
+                    reason="降级链各档重试耗尽后模型输出仍不合规",
+                )
+
+        fake = _ExhaustedGenerator()
+        with pytest.raises(EpisodePlanningError, match="结构化输出能力不足") as exc_info:
+            await EpisodePlanner(project_dir, generator=fake).plan()
+
+        assert fake.calls == 1
+        assert isinstance(exc_info.value.__cause__, StructuredOutputExhaustedError)
+        assert "InstructorRetryException" not in str(exc_info.value)
 
     @pytest.mark.integration
     async def test_plan_raises_planning_conflict_when_ledger_advances_during_call(self, tmp_path: Path):

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from instructor import Mode
 from openai import BadRequestError
 from pydantic import BaseModel
 
@@ -421,6 +422,61 @@ class TestInstructorFallback:
         assert result.provider == PROVIDER_OPENAI
         assert result.input_tokens == 20
         assert result.output_tokens == 10
+
+    async def test_response_format_rejected_succeeds_via_tools_mode(self):
+        """上游拒收 response_format 但支持 tools：降级链首档 TOOLS 即产出合规结构化结果。"""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=_make_bad_request_error())
+
+        instructor_result = _PersonSchema(name="Dana", age=31)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = None
+        mock_patched = AsyncMock()
+        mock_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", return_value=mock_patched) as mock_from_openai,
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            result = await backend.generate(TextGenerationRequest(prompt="Extract info", response_schema=_PersonSchema))
+
+        assert result.text == instructor_result.model_dump_json()
+        assert [call.kwargs["mode"] for call in mock_from_openai.call_args_list] == [Mode.TOOLS]
+
+    async def test_tools_mode_rejected_falls_back_to_md_json(self):
+        """上游连 tools 也不接受时降到 MD_JSON 档，两档都在同一次 generate 内完成。"""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=_make_bad_request_error())
+
+        instructor_result = _PersonSchema(name="Erin", age=27)
+        instructor_completion = MagicMock()
+        instructor_completion.usage = None
+
+        tools_patched = AsyncMock()
+        tools_patched.chat.completions.create_with_completion = AsyncMock(
+            side_effect=_make_bad_request_error("tools is not supported")
+        )
+        md_json_patched = AsyncMock()
+        md_json_patched.chat.completions.create_with_completion = AsyncMock(
+            return_value=(instructor_result, instructor_completion)
+        )
+
+        with (
+            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            patch("instructor.from_openai", side_effect=[tools_patched, md_json_patched]) as mock_from_openai,
+        ):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key")
+            result = await backend.generate(TextGenerationRequest(prompt="Extract info", response_schema=_PersonSchema))
+
+        assert result.text == instructor_result.model_dump_json()
+        assert [call.kwargs["mode"] for call in mock_from_openai.call_args_list] == [Mode.TOOLS, Mode.MD_JSON]
 
     async def test_bad_request_error_with_dict_schema_falls_back_to_plain(self):
         """原生 response_format 抛 BadRequestError 且 schema 为 dict 时，降级为无结构化输出的普通调用。"""

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -17,6 +17,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
 )
+from tests.fakes import instructor_api_call_exhausted
 
 pytestmark = pytest.mark.unit
 
@@ -458,8 +459,9 @@ class TestInstructorFallback:
         instructor_completion.usage = None
 
         tools_patched = AsyncMock()
+        # 上游拒收 tools 参数时，Instructor 会把这次 API 调用异常包起来后才交给降级链。
         tools_patched.chat.completions.create_with_completion = AsyncMock(
-            side_effect=_make_bad_request_error("tools is not supported")
+            side_effect=instructor_api_call_exhausted(_make_bad_request_error("tools is not supported"))
         )
         md_json_patched = AsyncMock()
         md_json_patched.chat.completions.create_with_completion = AsyncMock(

--- a/tests/test_text_backends/test_gemini.py
+++ b/tests/test_text_backends/test_gemini.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import BaseModel
 
 from lib.text_backends.base import (
+    StructuredOutputExhaustedError,
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
@@ -367,15 +368,27 @@ class TestStructuredFallback:
         assert result.input_tokens == 30
         assert result.output_tokens == 15
 
-    async def test_fallback_exhausted_raises_value_error(self, backend):
-        """降级重试穷尽后 fail-loud，错误消息面向用户可读（不透传 pydantic 原始串）。"""
+    async def test_fallback_exhausted_raises_structured_output_exhausted(self, backend):
+        """降级重试穷尽后收敛为 StructuredOutputExhaustedError，消息面向用户可读（不透传 pydantic 原始串）。"""
         gc = AsyncMock(side_effect=[_resp(_PROSE), _resp(_PROSE), _resp(_PROSE)])
         backend._test_client.aio.models.generate_content = gc
 
-        with pytest.raises(ValueError, match="结构化输出"):
+        with pytest.raises(StructuredOutputExhaustedError, match="结构化输出能力不足") as exc_info:
             await backend.generate(TextGenerationRequest(prompt="p", response_schema=_OverviewModel))
 
         assert gc.call_count == 3
+        assert exc_info.value.provider == "gemini"
+        assert exc_info.value.model == "gemini-3-flash-preview"
+
+    async def test_fallback_logs_raw_model_output(self, backend, caplog):
+        """降级触发点以 warning 记录模型原始输出，供事后诊断模型实际吐了什么。"""
+        gc = AsyncMock(side_effect=[_resp(_PROSE), _resp(_VALID_JSON)])
+        backend._test_client.aio.models.generate_content = gc
+
+        with caplog.at_level("WARNING", logger="lib.text_backends.gemini"):
+            await backend.generate(TextGenerationRequest(prompt="p", response_schema=_OverviewModel))
+
+        assert any(_PROSE in record.getMessage() for record in caplog.records)
 
     async def test_valid_schema_json_no_fallback(self, backend):
         """满足 schema 的合法 JSON 不触发降级（单次调用）。"""

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -476,7 +476,12 @@ class TestInstructorExceptionShape:
         assert exc_info.value.__cause__ is rejection
 
     def test_parse_failure_types_match_instructors_retryable_set(self):
-        """判据靠「终止原因是否属解析 / 校验类」区分模型问题与 API 问题，集合须与 Instructor 一致。"""
+        """判据靠「终止原因是否属解析 / 校验类」区分模型问题与 API 问题，集合须与 Instructor 一致。
+
+        `_RETRYABLE_PARSE_ERRORS` 是私有符号、不属公开契约，而 pyproject 允许 instructor>=1.14.5，
+        升级后它可能改名或搬家。此处导入失败即是该情况：到 instructor 的重试循环里重新找出这批
+        「会被记进 failed_attempts 并触发 reask」的异常类型，同步更新 `_PARSE_FAILURE_TYPES`。
+        """
         from instructor.v2.core.retry import _RETRYABLE_PARSE_ERRORS
 
         assert set(_PARSE_FAILURE_TYPES) == set(_RETRYABLE_PARSE_ERRORS)

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -33,15 +33,24 @@ def _completion(content: str) -> SimpleNamespace:
     return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None))])
 
 
-def _retry_exhausted(inner: Exception, *, content: str = "") -> InstructorRetryException:
-    """构造 Instructor 档内重试耗尽异常，failed_attempts 决定失败属 wire 层还是校验类。"""
+def _retry_exhausted(
+    inner: Exception,
+    *,
+    content: str = "",
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> InstructorRetryException:
+    """构造 Instructor 档内重试耗尽异常，failed_attempts 决定失败属 wire 层还是校验类。
+
+    prompt_tokens / completion_tokens 模拟档内那些拿到 HTTP 200、已被计费的尝试。
+    """
     from instructor.core.exceptions import FailedAttempt
 
     return InstructorRetryException(
         "retries exhausted",
         last_completion=_completion(content),
         n_attempts=3,
-        total_usage=0,
+        total_usage=SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),  # type: ignore[arg-type]
         failed_attempts=[FailedAttempt(attempt_number=1, exception=inner)],
     )
 
@@ -592,6 +601,59 @@ class TestStructuredModeChainSync:
         # 消息文本不含任何瞬态状态码模式，只有异常类型能证明它可重试。
         assert _should_retry(exc_info.value, BASE_RETRYABLE_ERRORS)
 
+    def test_non_tools_bad_request_propagates(self):
+        """与 tools 无关的 400（如上下文超限）原样冒泡：无 STRUCTURED_OUTPUT 能力位的模型
+        不经原生档直接进本链，把这类 400 当 tools 不兼容会替换掉真实的失败原因。"""
+        rejection = _bad_request("This model's maximum context length is 8192 tokens")
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[instructor_api_call_exhausted(rejection)],
+        ) as mock_gen:
+            with pytest.raises(BadRequestError):
+                self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+
+    def test_tools_rejection_matched_case_insensitively(self):
+        """代理的拒收文案大小写不统一，判据须归一后再匹配，否则降档路径形同虚设。"""
+        sample = SampleModel(name="Grace", age=31)
+        rejection = _bad_request("Tools Are Not Supported By This Endpoint")
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[instructor_api_call_exhausted(rejection), (sample.model_dump_json(), 10, 5)],
+        ) as mock_gen:
+            result = self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert result.text == sample.model_dump_json()
+
+    def test_downgrade_carries_billed_tokens_of_failed_mode(self):
+        """TOOLS 档拿到过 HTTP 200（已计费）后才降档，这部分 token 并入最终结果。"""
+        sample = SampleModel(name="Heidi", age=29)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[
+                _retry_exhausted(_no_tool_call_error(), prompt_tokens=70, completion_tokens=30),
+                (sample.model_dump_json(), 10, 5),
+            ],
+        ):
+            result = self._call()
+
+        assert result.input_tokens == 80
+        assert result.output_tokens == 35
+
+    def test_downgrade_without_usage_keeps_tokens_untracked(self):
+        """两侧皆未追踪用量时保持 None，不因并账塌成字面 0 token。"""
+        sample = SampleModel(name="Ivan", age=26)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_retry_exhausted(_no_tool_call_error()), (sample.model_dump_json(), None, None)],
+        ):
+            result = self._call()
+
+        assert result.input_tokens is None
+        assert result.output_tokens is None
+
     def test_last_mode_wire_rejection_is_terminal(self):
         """末档仍被上游拒收：无更弱的档可退，收敛为终局异常而非无限降档。"""
         with patch(
@@ -649,6 +711,20 @@ class TestStructuredModeChainAsync:
         ):
             with pytest.raises(ConnectionError):
                 await self._call()
+
+    async def test_downgrade_carries_billed_tokens_of_failed_mode(self):
+        sample = SampleModel(name="Judy", age=27)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
+            side_effect=[
+                _retry_exhausted(_no_tool_call_error(), prompt_tokens=70, completion_tokens=30),
+                (sample.model_dump_json(), 10, 5),
+            ],
+        ):
+            result = await self._call()
+
+        assert result.input_tokens == 80
+        assert result.output_tokens == 35
 
 
 class TestInstructorFallbackAsync:

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import instructor
 import pytest
 from instructor import Mode
 from instructor.core import IncompleteOutputException, InstructorRetryException, ResponseParsingError
@@ -17,6 +18,7 @@ from lib.text_backends.instructor_support import (
     instructor_fallback_async,
     instructor_fallback_sync,
 )
+from tests.fakes import instructor_api_call_exhausted
 
 pytestmark = pytest.mark.unit
 
@@ -56,13 +58,17 @@ def _no_tool_call_error() -> ResponseParsingError:
     return ResponseParsingError("No tool calls or function call found in response", mode="TOOLS")
 
 
-def _tools_rejected_error() -> BadRequestError:
-    message = "tools is not supported by this endpoint"
+def _bad_request(message: str) -> BadRequestError:
     return BadRequestError(
         message=message,
         response=httpx.Response(400, request=httpx.Request("POST", "https://proxy.example/v1/chat/completions")),
         body={"error": {"message": message}},
     )
+
+
+def _tools_rejected_error() -> InstructorRetryException:
+    """上游拒收 tools 参数：Instructor 把这次 API 调用异常包起来后才到达降级链。"""
+    return instructor_api_call_exhausted(_bad_request("tools is not supported by this endpoint"))
 
 
 class TestGenerateStructuredViaInstructor:
@@ -404,11 +410,63 @@ class TestInstructorFallbackSync:
         assert exc_info.value.model == "test-model"
 
 
+class TestInstructorExceptionShape:
+    """钉住降级链判据所依赖的 Instructor 异常形态。
+
+    判据要区分「API 调用被拒」与「模型输出不合规」，靠的是 Instructor 把前者包进
+    ``InstructorRetryException`` 且 ``failed_attempts`` 为空、原异常挂 ``__cause__``。这个形态
+    是 Instructor 的实现细节，升级依赖时可能变——本用例对真实 Instructor 校验它，形态一变即红，
+    避免降级链在无人察觉的情况下退化成「任何失败都判终局」。
+    """
+
+    def test_api_call_failure_arrives_wrapped(self):
+        from openai import OpenAI
+
+        client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
+        rejection = _bad_request("tools is not supported by this endpoint")
+        client.chat.completions.create = MagicMock(side_effect=rejection)  # type: ignore[method-assign]
+        patched = instructor.from_openai(client, mode=Mode.TOOLS)
+
+        with pytest.raises(InstructorRetryException) as exc_info:
+            patched.chat.completions.create_with_completion(
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                response_model=SampleModel,
+                max_retries=2,
+            )
+
+        assert exc_info.value.failed_attempts == []
+        assert exc_info.value.__cause__ is rejection
+
+    def test_parse_failure_is_recorded_in_failed_attempts(self):
+        """对照组：模型输出不合规时失败记进 failed_attempts，而非挂在 __cause__ 上。"""
+        from openai import OpenAI
+
+        message = SimpleNamespace(content="不是 JSON", tool_calls=None, refusal=None)
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="stop")],
+            usage=None,
+        )
+        client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
+        client.chat.completions.create = MagicMock(return_value=completion)  # type: ignore[method-assign]
+        patched = instructor.from_openai(client, mode=Mode.TOOLS)
+
+        with pytest.raises(InstructorRetryException) as exc_info:
+            patched.chat.completions.create_with_completion(
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                response_model=SampleModel,
+                max_retries=1,
+            )
+
+        assert exc_info.value.failed_attempts != []
+
+
 class TestStructuredModeChainSync:
     """TOOLS → MD_JSON 降级链（同步版）。"""
 
     @staticmethod
-    def _call(mock_gen):
+    def _call():
         return instructor_fallback_sync(
             client=MagicMock(),
             model="test-model",
@@ -428,7 +486,7 @@ class TestStructuredModeChainSync:
             "lib.text_backends.instructor_support.generate_structured_via_instructor",
             return_value=(sample.model_dump_json(), 50, 20),
         ) as mock_gen:
-            result = self._call(mock_gen)
+            result = self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
         assert result.text == sample.model_dump_json()
@@ -440,7 +498,7 @@ class TestStructuredModeChainSync:
             "lib.text_backends.instructor_support.generate_structured_via_instructor",
             side_effect=[_tools_rejected_error(), (sample.model_dump_json(), 10, 5)],
         ) as mock_gen:
-            result = self._call(mock_gen)
+            result = self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
         assert result.text == sample.model_dump_json()
@@ -452,7 +510,7 @@ class TestStructuredModeChainSync:
             "lib.text_backends.instructor_support.generate_structured_via_instructor",
             side_effect=[_retry_exhausted(_no_tool_call_error()), (sample.model_dump_json(), 10, 5)],
         ) as mock_gen:
-            result = self._call(mock_gen)
+            result = self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
         assert result.text == sample.model_dump_json()
@@ -465,7 +523,7 @@ class TestStructuredModeChainSync:
             side_effect=[exhausted],
         ) as mock_gen:
             with pytest.raises(StructuredOutputExhaustedError) as exc_info:
-                self._call(mock_gen)
+                self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
         assert exc_info.value.__cause__ is exhausted
@@ -478,7 +536,7 @@ class TestStructuredModeChainSync:
             side_effect=[_tools_rejected_error(), _retry_exhausted(_validation_error())],
         ) as mock_gen:
             with pytest.raises(StructuredOutputExhaustedError, match="结构化输出能力不足"):
-                self._call(mock_gen)
+                self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
 
@@ -486,10 +544,10 @@ class TestStructuredModeChainSync:
         """瞬态错误既不降档也不收敛为终局异常，原样冒泡交调用方的重试装饰器判定。"""
         with patch(
             "lib.text_backends.instructor_support.generate_structured_via_instructor",
-            side_effect=[ConnectionError("503 service unavailable")],
+            side_effect=[instructor_api_call_exhausted(ConnectionError("503 service unavailable"))],
         ) as mock_gen:
             with pytest.raises(ConnectionError):
-                self._call(mock_gen)
+                self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
 
@@ -500,7 +558,7 @@ class TestStructuredModeChainSync:
             side_effect=[TextOutputTruncatedError(provider="test-provider", model="test-model")],
         ) as mock_gen:
             with pytest.raises(TextOutputTruncatedError):
-                self._call(mock_gen)
+                self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
 
@@ -514,11 +572,36 @@ class TestStructuredModeChainSync:
                 _retry_exhausted(_no_tool_call_error(), content=raw),
                 (sample.model_dump_json(), 10, 5),
             ],
-        ) as mock_gen:
+        ):
             with caplog.at_level("WARNING", logger="lib.text_backends.instructor_support"):
-                self._call(mock_gen)
+                self._call()
 
         assert any(raw in record.getMessage() for record in caplog.records)
+
+    def test_transient_error_keeps_its_type_after_unwrapping(self):
+        """瞬态错误剥掉 Instructor 包装后冒泡，保住类型供调用方的重试装饰器判定。"""
+        from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry
+
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[instructor_api_call_exhausted(ConnectionError("connection reset by peer"))],
+        ):
+            with pytest.raises(ConnectionError) as exc_info:
+                self._call()
+
+        # 消息文本不含任何瞬态状态码模式，只有异常类型能证明它可重试。
+        assert _should_retry(exc_info.value, BASE_RETRYABLE_ERRORS)
+
+    def test_last_mode_wire_rejection_is_terminal(self):
+        """末档仍被上游拒收：无更弱的档可退，收敛为终局异常而非无限降档。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_tools_rejected_error(), _tools_rejected_error()],
+        ) as mock_gen:
+            with pytest.raises(StructuredOutputExhaustedError, match="被上游拒收"):
+                self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
 
 
 class TestStructuredModeChainAsync:
@@ -562,7 +645,7 @@ class TestStructuredModeChainAsync:
     async def test_transient_error_propagates_unchanged(self):
         with patch(
             "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
-            side_effect=[ConnectionError("503 service unavailable")],
+            side_effect=[instructor_api_call_exhausted(ConnectionError("503 service unavailable"))],
         ):
             with pytest.raises(ConnectionError):
                 await self._call()

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ValidationError
 
 from lib.text_backends.base import StructuredOutputExhaustedError, TextOutputTruncatedError
 from lib.text_backends.instructor_support import (
+    _PARSE_FAILURE_TYPES,
     generate_structured_via_instructor,
     generate_structured_via_instructor_async,
     instructor_fallback_async,
@@ -28,9 +29,11 @@ class SampleModel(BaseModel):
     age: int
 
 
-def _completion(content: str) -> SimpleNamespace:
-    """构造一个只带文本内容的 completion，供诊断日志断言取原始输出。"""
-    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None))])
+def _completion(content: str, *, tool_calls=None) -> SimpleNamespace:
+    """构造一个 completion，供诊断日志断言取原始输出、供判据看有无 tool call。"""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=tool_calls, function_call=None))]
+    )
 
 
 def _retry_exhausted(
@@ -39,20 +42,30 @@ def _retry_exhausted(
     content: str = "",
     prompt_tokens: int = 0,
     completion_tokens: int = 0,
+    earlier_attempts: list[Exception] | None = None,
 ) -> InstructorRetryException:
-    """构造 Instructor 档内重试耗尽异常，failed_attempts 决定失败属 wire 层还是校验类。
+    """构造 Instructor 档内重试耗尽异常，终止原因 inner 挂在 __cause__ 上（与真实形态一致）。
 
     prompt_tokens / completion_tokens 模拟档内那些拿到 HTTP 200、已被计费的尝试。
+    earlier_attempts 模拟终止前已累积的解析 / 校验失败——Instructor 不清空 failed_attempts，
+    所以它非空并不代表这一档是折在模型输出上。
     """
     from instructor.core.exceptions import FailedAttempt
 
-    return InstructorRetryException(
+    recorded = [*(earlier_attempts or []), inner]
+    exc = InstructorRetryException(
         "retries exhausted",
         last_completion=_completion(content),
         n_attempts=3,
         total_usage=SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),  # type: ignore[arg-type]
-        failed_attempts=[FailedAttempt(attempt_number=1, exception=inner)],
+        failed_attempts=[
+            FailedAttempt(attempt_number=i, exception=e)
+            for i, e in enumerate(recorded, 1)
+            if isinstance(e, _PARSE_FAILURE_TYPES)
+        ],
     )
+    exc.__cause__ = inner
+    return exc
 
 
 def _validation_error() -> ValidationError:
@@ -64,7 +77,22 @@ def _validation_error() -> ValidationError:
 
 
 def _no_tool_call_error() -> ResponseParsingError:
-    return ResponseParsingError("No tool calls or function call found in response", mode="TOOLS")
+    """上游没回 tool call：wire 层不兼容。"""
+    return ResponseParsingError(
+        "No tool calls or function call found in response",
+        mode="TOOLS",
+        raw_response=_completion(""),
+    )
+
+
+def _tool_call_args_invalid_error() -> ResponseParsingError:
+    """上游回了 tool call 但 arguments 不可用：属校验类，不是 wire 层不兼容。"""
+    tool_call = SimpleNamespace(function=SimpleNamespace(arguments=None))
+    return ResponseParsingError(
+        "Tool call arguments missing in response",
+        mode="TOOLS",
+        raw_response=_completion("", tool_calls=[tool_call]),
+    )
 
 
 def _bad_request(message: str) -> BadRequestError:
@@ -422,10 +450,10 @@ class TestInstructorFallbackSync:
 class TestInstructorExceptionShape:
     """钉住降级链判据所依赖的 Instructor 异常形态。
 
-    判据要区分「API 调用被拒」与「模型输出不合规」，靠的是 Instructor 把前者包进
-    ``InstructorRetryException`` 且 ``failed_attempts`` 为空、原异常挂 ``__cause__``。这个形态
-    是 Instructor 的实现细节，升级依赖时可能变——本用例对真实 Instructor 校验它，形态一变即红，
-    避免降级链在无人察觉的情况下退化成「任何失败都判终局」。
+    判据要区分「API 调用被拒」与「模型输出不合规」，靠的是 Instructor 把终止原因挂在
+    ``__cause__`` 上、并按类型区分解析 / 校验类与其余异常。这些都是 Instructor 的实现细节，
+    升级依赖时可能变——本组用例对真实 Instructor 校验它们，形态一变即红，避免降级链在无人
+    察觉的情况下退化成「任何失败都判终局」或「瞬态错误也降档」。
     """
 
     def test_api_call_failure_arrives_wrapped(self):
@@ -446,6 +474,41 @@ class TestInstructorExceptionShape:
 
         assert exc_info.value.failed_attempts == []
         assert exc_info.value.__cause__ is rejection
+
+    def test_parse_failure_types_match_instructors_retryable_set(self):
+        """判据靠「终止原因是否属解析 / 校验类」区分模型问题与 API 问题，集合须与 Instructor 一致。"""
+        from instructor.v2.core.retry import _RETRYABLE_PARSE_ERRORS
+
+        assert set(_PARSE_FAILURE_TYPES) == set(_RETRYABLE_PARSE_ERRORS)
+
+    def test_failed_attempts_survive_a_later_api_failure(self):
+        """解析失败一次后再撞上 API 层错误：failed_attempts 保留旧记录，终止原因只在 __cause__。
+
+        判据若拿 failed_attempts 是否为空当「折在模型输出上」的代理，这条路径会被误判。
+        """
+        from openai import OpenAI
+        from openai.types.chat import ChatCompletionMessage
+
+        bad_json = ChatCompletionMessage(role="assistant", content="不是 JSON")
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=bad_json, finish_reason="stop")],
+            usage=None,
+        )
+        outage = ConnectionError("connection reset by peer")
+        client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
+        client.chat.completions.create = MagicMock(side_effect=[completion, outage])  # type: ignore[method-assign]
+        patched = instructor.from_openai(client, mode=Mode.MD_JSON)
+
+        with pytest.raises(InstructorRetryException) as exc_info:
+            patched.chat.completions.create_with_completion(
+                model="test-model",
+                messages=[{"role": "user", "content": "test"}],
+                response_model=SampleModel,
+                max_retries=2,
+            )
+
+        assert exc_info.value.failed_attempts != []
+        assert exc_info.value.__cause__ is outage
 
     def test_parse_failure_is_recorded_in_failed_attempts(self):
         """对照组：模型输出不合规时失败记进 failed_attempts，而非挂在 __cause__ 上。"""
@@ -600,6 +663,33 @@ class TestStructuredModeChainSync:
 
         # 消息文本不含任何瞬态状态码模式，只有异常类型能证明它可重试。
         assert _should_retry(exc_info.value, BASE_RETRYABLE_ERRORS)
+
+    def test_invalid_tool_call_arguments_are_terminal(self):
+        """上游回了 tool call 但 arguments 不可用：属校验类，不降到约束更弱的 MD_JSON。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_retry_exhausted(_tool_call_args_invalid_error())],
+        ) as mock_gen:
+            with pytest.raises(StructuredOutputExhaustedError):
+                self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+
+    def test_api_failure_after_earlier_parse_failure_propagates(self):
+        """先解析失败一次、再撞上瞬态错误：终止原因是后者，原样冒泡而非当成模型输出不合规。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[
+                _retry_exhausted(
+                    ConnectionError("connection reset by peer"),
+                    earlier_attempts=[_no_tool_call_error()],
+                )
+            ],
+        ) as mock_gen:
+            with pytest.raises(ConnectionError):
+                self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
 
     def test_non_tools_bad_request_propagates(self):
         """与 tools 无关的 400（如上下文超限）原样冒泡：无 STRUCTURED_OUTPUT 能力位的模型

--- a/tests/test_text_backends/test_instructor_support.py
+++ b/tests/test_text_backends/test_instructor_support.py
@@ -3,11 +3,14 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
-from instructor.core import IncompleteOutputException
-from pydantic import BaseModel
+from instructor import Mode
+from instructor.core import IncompleteOutputException, InstructorRetryException, ResponseParsingError
+from openai import BadRequestError
+from pydantic import BaseModel, ValidationError
 
-from lib.text_backends.base import TextOutputTruncatedError
+from lib.text_backends.base import StructuredOutputExhaustedError, TextOutputTruncatedError
 from lib.text_backends.instructor_support import (
     generate_structured_via_instructor,
     generate_structured_via_instructor_async,
@@ -21,6 +24,45 @@ pytestmark = pytest.mark.unit
 class SampleModel(BaseModel):
     name: str
     age: int
+
+
+def _completion(content: str) -> SimpleNamespace:
+    """构造一个只带文本内容的 completion，供诊断日志断言取原始输出。"""
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None))])
+
+
+def _retry_exhausted(inner: Exception, *, content: str = "") -> InstructorRetryException:
+    """构造 Instructor 档内重试耗尽异常，failed_attempts 决定失败属 wire 层还是校验类。"""
+    from instructor.core.exceptions import FailedAttempt
+
+    return InstructorRetryException(
+        "retries exhausted",
+        last_completion=_completion(content),
+        n_attempts=3,
+        total_usage=0,
+        failed_attempts=[FailedAttempt(attempt_number=1, exception=inner)],
+    )
+
+
+def _validation_error() -> ValidationError:
+    try:
+        SampleModel.model_validate({"name": "Alice"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("SampleModel 缺 age 字段应当校验失败")
+
+
+def _no_tool_call_error() -> ResponseParsingError:
+    return ResponseParsingError("No tool calls or function call found in response", mode="TOOLS")
+
+
+def _tools_rejected_error() -> BadRequestError:
+    message = "tools is not supported by this endpoint"
+    return BadRequestError(
+        message=message,
+        response=httpx.Response(400, request=httpx.Request("POST", "https://proxy.example/v1/chat/completions")),
+        body={"error": {"message": message}},
+    )
 
 
 class TestGenerateStructuredViaInstructor:
@@ -360,6 +402,170 @@ class TestInstructorFallbackSync:
 
         assert exc_info.value.provider == "test-provider"
         assert exc_info.value.model == "test-model"
+
+
+class TestStructuredModeChainSync:
+    """TOOLS → MD_JSON 降级链（同步版）。"""
+
+    @staticmethod
+    def _call(mock_gen):
+        return instructor_fallback_sync(
+            client=MagicMock(),
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+            response_schema=SampleModel,
+            provider="test-provider",
+        )
+
+    @staticmethod
+    def _modes(mock_gen) -> list[Mode]:
+        return [call.kwargs["mode"] for call in mock_gen.call_args_list]
+
+    def test_chain_starts_with_tools_mode(self):
+        """首档是 TOOLS：成功即返回，不触碰约束更弱的 MD_JSON。"""
+        sample = SampleModel(name="Alice", age=30)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            return_value=(sample.model_dump_json(), 50, 20),
+        ) as mock_gen:
+            result = self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+        assert result.text == sample.model_dump_json()
+
+    def test_tools_param_rejected_falls_back_to_md_json(self):
+        """上游拒收 tools 参数（wire 层）→ 降档到 MD_JSON 并产出合规结果。"""
+        sample = SampleModel(name="Bob", age=25)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_tools_rejected_error(), (sample.model_dump_json(), 10, 5)],
+        ) as mock_gen:
+            result = self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert result.text == sample.model_dump_json()
+
+    def test_no_tool_call_in_response_falls_back_to_md_json(self):
+        """上游收下 tools 却不回 tool call（wire 层）→ 降档到 MD_JSON。"""
+        sample = SampleModel(name="Carol", age=28)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_retry_exhausted(_no_tool_call_error()), (sample.model_dump_json(), 10, 5)],
+        ) as mock_gen:
+            result = self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert result.text == sample.model_dump_json()
+
+    def test_tools_validation_exhaustion_is_terminal(self):
+        """TOOLS 档校验类耗尽不降档：上游确实回了 tool call，换更弱的档只会更差。"""
+        exhausted = _retry_exhausted(_validation_error(), content='{"name": "Alice"}')
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[exhausted],
+        ) as mock_gen:
+            with pytest.raises(StructuredOutputExhaustedError) as exc_info:
+                self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+        assert exc_info.value.__cause__ is exhausted
+        assert exc_info.value.provider == "test-provider"
+
+    def test_md_json_exhaustion_raises_structured_output_exhausted(self):
+        """末档耗尽同样收敛为终局异常，不把 InstructorRetryException 原文透出去。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[_tools_rejected_error(), _retry_exhausted(_validation_error())],
+        ) as mock_gen:
+            with pytest.raises(StructuredOutputExhaustedError, match="结构化输出能力不足"):
+                self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+
+    def test_transient_error_propagates_unchanged(self):
+        """瞬态错误既不降档也不收敛为终局异常，原样冒泡交调用方的重试装饰器判定。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[ConnectionError("503 service unavailable")],
+        ) as mock_gen:
+            with pytest.raises(ConnectionError):
+                self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+
+    def test_truncation_does_not_fall_back(self):
+        """截断是硬错误：重发同一份必然再截断的请求没有意义，不降档。"""
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[TextOutputTruncatedError(provider="test-provider", model="test-model")],
+        ) as mock_gen:
+            with pytest.raises(TextOutputTruncatedError):
+                self._call(mock_gen)
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+
+    def test_downgrade_logs_raw_model_output(self, caplog):
+        """降档触发点以 warning 记录截断后的模型原始输出。"""
+        sample = SampleModel(name="Dave", age=33)
+        raw = "抱歉，我无法按要求输出 JSON。"
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor",
+            side_effect=[
+                _retry_exhausted(_no_tool_call_error(), content=raw),
+                (sample.model_dump_json(), 10, 5),
+            ],
+        ) as mock_gen:
+            with caplog.at_level("WARNING", logger="lib.text_backends.instructor_support"):
+                self._call(mock_gen)
+
+        assert any(raw in record.getMessage() for record in caplog.records)
+
+
+class TestStructuredModeChainAsync:
+    """TOOLS → MD_JSON 降级链（异步版），与同步版同口径。"""
+
+    @staticmethod
+    async def _call():
+        return await instructor_fallback_async(
+            client=AsyncMock(),
+            model="async-model",
+            messages=[{"role": "user", "content": "test"}],
+            response_schema=SampleModel,
+            provider="async-provider",
+        )
+
+    @staticmethod
+    def _modes(mock_gen) -> list[Mode]:
+        return [call.kwargs["mode"] for call in mock_gen.call_args_list]
+
+    async def test_wire_failure_falls_back_to_md_json(self):
+        sample = SampleModel(name="Eve", age=45)
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
+            side_effect=[_tools_rejected_error(), (sample.model_dump_json(), 10, 5)],
+        ) as mock_gen:
+            result = await self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert result.text == sample.model_dump_json()
+
+    async def test_validation_exhaustion_is_terminal(self):
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
+            side_effect=[_retry_exhausted(_validation_error())],
+        ) as mock_gen:
+            with pytest.raises(StructuredOutputExhaustedError):
+                await self._call()
+
+        assert self._modes(mock_gen) == [Mode.TOOLS]
+
+    async def test_transient_error_propagates_unchanged(self):
+        with patch(
+            "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
+            side_effect=[ConnectionError("503 service unavailable")],
+        ):
+            with pytest.raises(ConnectionError):
+                await self._call()
 
 
 class TestInstructorFallbackAsync:


### PR DESCRIPTION
Closes #1465

## 背景

中转站（OpenAI 兼容代理）常常收下 `response_format: json_schema` 却不落实该约束。原先的结构化输出只有两档：native `json_schema` → Instructor `MD_JSON`，复验不合规就直接掉进约束最弱的纯 prompt 档，结构性失败率高；档内重试耗尽后抛的 `InstructorRetryException`、Gemini prompt 降级耗尽抛的裸 `ValueError`，都不被 `EpisodePlanner` 的重试循环捕获，以 SDK 内部异常原文泄漏给智能体——报告中「4 validation errors for NarrationPlanDraft」正是这么来的。

## 改动

**三档降级链**：native `json_schema` → Instructor `TOOLS` → Instructor `MD_JSON`，改在 OpenAI 与 Ark 共用的 Instructor 支持层，两个 backend 同时受益。降档只留给 wire 层不兼容（上游拒收 tools 参数、或收下了却不回 tool call）；上游确实回了 tool call 只是参数结构反复不合规，属校验类失败，换更弱的档只会更差，直接判终局。各档维持 Instructor 现有 `max_retries=2`。

**终局异常规范化**：新增 `StructuredOutputExhaustedError`（继承 `NonRetryableError`），Instructor 降级链耗尽与 Gemini prompt 降级耗尽都收敛到它，携带可读原因；`EpisodePlanner` 捕获后转为 `EpisodePlanningError`，智能体拿到的是「供应商结构化输出能力不足，请更换文本模型或供应商」而非内部异常原文。规划器层不追加重试——后端已把各档与档内重试走完。

**诊断日志**：降级触发点与规划器解析拒绝点以 warning 记录模型原始输出，截断到 500 字符。

## 审查阶段修正

本地审查发现首版判据不成立，已在 `7b302da8` 修正：

Instructor 的重试循环只把解析/校验类异常记进 `failed_attempts`；API 调用本身抛的异常会中断循环、被包进 `InstructorRetryException` 且 `failed_attempts` 为空、原异常仅挂 `__cause__`。首版判据只看 `failed_attempts`，后果是：

- 「上游拒收 tools 参数」永远判不出 wire 层失败，直接判终局，**降不到 MD_JSON**，本 PR 的主收益落空；判据里的 `BadRequestError` 与关键字分支全成死码
- 瞬态 5xx / 连接错误同样被收敛成 `StructuredOutputExhaustedError`（不可重试），**吃掉调用方 `@with_retry_async` 的重试**，相对现状是退化

改为先穿过 Instructor 的包装取原异常再三分：wire 层不兼容降档、校验类耗尽判终局、其余剥掉包装原样冒泡（保住 `ConnectionError` 等类型供重试判定）。

首版测试把桩打在 `generate_structured_via_instructor` 上、喂的是生产中不存在的裸 API 异常，因而测不出上述缺陷；已改用真实包装形态，并新增一组**对真实 Instructor 的契约测试**钉住该异常形态，依赖升级导致形态漂移时即红。

## 验证

- `uv run python -m pytest`：7965 passed
- `uv run basedpyright`：0 error
- `uv run ruff check .`、`uv run lint-imports`：通过
- 未做真实中转站联调，上游行为全部由测试替身模拟；Instructor 侧的异常形态假设由上述契约测试对真实依赖校验

## 已知边界

非 `BadRequestError` 的 wire 判据是 tools 关键字启发式匹配（沿用 openai backend `_SCHEMA_ERROR_KEYWORDS` 的同构做法）。上游若用完全不含 tools/functions 字样的措辞拒收该参数，会被判为非 wire 失败原样冒泡——退化成现状行为（可重试错误），不会更差，但拿不到降档收益。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化结构化输出处理：原生格式失败时按备用方式自动尝试，提高成功率。
  - 新增多级备用路径，全部失败后明确结束并避免无效重试。
  - 错误日志记录截断后的模型原始响应，便于排查格式或校验问题。
  - 改进同步与异步处理中的异常分类及用量统计。

- **测试**
  - 增加结构化输出降级、解析失败、异常传播及规划重试行为测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->