### PR TITLE
fix(cost-store): 切换项目后迟到的费用估算不再覆盖当前项目显示

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2210,8 +2210,13 @@ class API {
    * 获取项目费用估算。
    * @param projectName - 项目名称
    */
-  static async getCostEstimate(projectName: string): Promise<CostEstimateResponse> {
-    return this.request(`/projects/${encodeURIComponent(projectName)}/cost-estimate`);
+  static async getCostEstimate(
+    projectName: string,
+    options: { signal?: AbortSignal } = {}
+  ): Promise<CostEstimateResponse> {
+    return this.request(`/projects/${encodeURIComponent(projectName)}/cost-estimate`, {
+      signal: options.signal,
+    });
   }
 
   // ==================== Grid 图生视频 API ====================

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -60,7 +60,7 @@ export function OverviewCanvas({
 
   useEffect(() => {
     // 演示项目的费用请求交给费用 store 自身的 isDemoProject 分支跳过并失效：
-    // 那条分支会取消已排队的防抖计时器、递增 _fetchId 使在途真实请求作废、清空费用状态——
+    // 那条分支会取消已排队的防抖计时器、abort 在途的真实项目请求、清空费用状态——
     // 这里若改成对 readOnly 直接 return，反而会绕过这套失效机制，让切入只读态前
     // 真实项目已排队的防抖任务照常在之后触发，把真实费用写回全局 store。
     if (!projectName) return;

--- a/frontend/src/stores/cost-store.test.ts
+++ b/frontend/src/stores/cost-store.test.ts
@@ -89,6 +89,35 @@ describe("cost-store", () => {
     expect(fetchCostSpy).toHaveBeenCalledWith("project-b");
   });
 
+  it("does not abort the current project's in-flight request when a stale project's fetchCost fires late", async () => {
+    // project-b 的请求先发起且保持 pending（模拟仍在等待响应）。
+    useProjectsStore.setState({ currentProjectName: "project-b" });
+    let releaseB: (data: CostEstimateResponse) => void = () => {};
+    const bSignals: (AbortSignal | undefined)[] = [];
+    vi.spyOn(API, "getCostEstimate").mockImplementation((name, options) => {
+      if (name === "project-b") {
+        bSignals.push(options?.signal);
+        return new Promise<CostEstimateResponse>((resolve) => {
+          releaseB = resolve;
+        });
+      }
+      return Promise.resolve(buildResponse(name));
+    });
+
+    const bPromise = useCostStore.getState().fetchCost("project-b");
+
+    // project-a 的调用在用户已经离开之后才触发（比如某个慢 PATCH 的 .then 回调），
+    // 不应中止仍在合法进行中的 project-b 请求——这与"顶替同项目在途请求"是两回事。
+    await useCostStore.getState().fetchCost("project-a");
+    expect(bSignals[0]?.aborted).toBe(false);
+
+    releaseB(buildResponse("project-b"));
+    await bPromise;
+
+    expect(useCostStore.getState().costData?.project_name).toBe("project-b");
+    expect(useCostStore.getState().loading).toBe(false);
+  });
+
   it("aborts the in-flight request when a newer fetchCost supersedes it", async () => {
     useProjectsStore.setState({ currentProjectName: "project-a" });
     const signals: (AbortSignal | undefined)[] = [];

--- a/frontend/src/stores/cost-store.test.ts
+++ b/frontend/src/stores/cost-store.test.ts
@@ -88,4 +88,34 @@ describe("cost-store", () => {
     expect(fetchCostSpy).toHaveBeenCalledTimes(1);
     expect(fetchCostSpy).toHaveBeenCalledWith("project-b");
   });
+
+  it("aborts the in-flight request when a newer fetchCost supersedes it", async () => {
+    useProjectsStore.setState({ currentProjectName: "project-a" });
+    const signals: (AbortSignal | undefined)[] = [];
+    let releaseFirst: (data: CostEstimateResponse) => void = () => {};
+    vi.spyOn(API, "getCostEstimate")
+      .mockImplementationOnce((_name, options) => {
+        signals.push(options?.signal);
+        return new Promise<CostEstimateResponse>((resolve) => {
+          releaseFirst = resolve;
+        });
+      })
+      .mockImplementationOnce((_name, options) => {
+        signals.push(options?.signal);
+        return Promise.resolve(buildResponse("second"));
+      });
+
+    const first = useCostStore.getState().fetchCost("project-a");
+    const second = useCostStore.getState().fetchCost("project-a");
+    await second;
+
+    // 同一项目内被更晚的调用顶替：signal 要真的 abort（网络请求随之取消），
+    // 且被顶替的那次即便响应晚到也不回写 store。
+    expect(signals[0]?.aborted).toBe(true);
+    releaseFirst(buildResponse("first"));
+    await first;
+
+    expect(useCostStore.getState().costData?.project_name).toBe("second");
+    expect(useCostStore.getState().loading).toBe(false);
+  });
 });

--- a/frontend/src/stores/cost-store.test.ts
+++ b/frontend/src/stores/cost-store.test.ts
@@ -1,20 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { API } from "@/api";
 import { DEMO_PROJECT_NAME } from "@/onboarding/demo-project";
+import { useProjectsStore } from "@/stores/projects-store";
+import type { CostEstimateResponse } from "@/types";
 import { useCostStore } from "./cost-store";
+
+function buildResponse(projectName: string): CostEstimateResponse {
+  return {
+    project_name: projectName,
+    models: { image: { provider: "p", model: "m" }, video: { provider: "p", model: "m" } },
+    episodes: [],
+    project_totals: { estimate: {}, actual: {} },
+  };
+}
 
 describe("cost-store", () => {
   beforeEach(() => {
     useCostStore.setState(useCostStore.getInitialState(), true);
+    useProjectsStore.setState(useProjectsStore.getInitialState(), true);
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
   it("clears stale cost data immediately when switching to the demo project via debouncedFetch", async () => {
-    vi.spyOn(API, "getCostEstimate").mockResolvedValue({
-      project_totals: { total: 42 },
-      episodes: [],
-    } as never);
+    useProjectsStore.setState({ currentProjectName: "real-project" });
+    vi.spyOn(API, "getCostEstimate").mockResolvedValue(buildResponse("real-project"));
 
     await useCostStore.getState().fetchCost("real-project");
     expect(useCostStore.getState().costData).not.toBeNull();
@@ -26,5 +36,56 @@ describe("cost-store", () => {
     expect(useCostStore.getState().costData).toBeNull();
     expect(useCostStore.getState().loading).toBe(false);
     expect(API.getCostEstimate).not.toHaveBeenCalledWith(DEMO_PROJECT_NAME);
+  });
+
+  it("discards a late successful response whose fetchCost call fires after the user already switched projects", async () => {
+    // project-b 先完整落地：模拟用户已经切走，且 B 自己的费用请求已经完成写入。
+    useProjectsStore.setState({ currentProjectName: "project-b" });
+    vi.spyOn(API, "getCostEstimate").mockResolvedValueOnce(buildResponse("project-b"));
+    await useCostStore.getState().fetchCost("project-b");
+    expect(useCostStore.getState().costData?.project_name).toBe("project-b");
+
+    // project-a 页面里某个慢 PATCH 的 .then 回调在用户已经离开之后才触发，此时才发起
+    // fetchCost("project-a")——没有任何后续调用去 abort 它，只能靠落地时校验当前
+    // 项目名才能拦下。
+    vi.spyOn(API, "getCostEstimate").mockResolvedValueOnce(buildResponse("project-a"));
+    await useCostStore.getState().fetchCost("project-a");
+
+    expect(useCostStore.getState().costData?.project_name).toBe("project-b");
+    expect(useCostStore.getState().loading).toBe(false);
+  });
+
+  it("discards a late failed response whose fetchCost call fires after the user already switched projects, without surfacing its error", async () => {
+    useProjectsStore.setState({ currentProjectName: "project-b" });
+    vi.spyOn(API, "getCostEstimate").mockResolvedValueOnce(buildResponse("project-b"));
+    await useCostStore.getState().fetchCost("project-b");
+    expect(useCostStore.getState().costData?.project_name).toBe("project-b");
+
+    vi.spyOn(API, "getCostEstimate").mockRejectedValueOnce(new Error("boom"));
+    await useCostStore.getState().fetchCost("project-a");
+
+    // 不应该把 error 写回 store（用户早已不在那个项目上，没有意义提示一个已经离开
+    // 的项目的错误），也不应打断已经收尾的 loading。
+    expect(useCostStore.getState().error).toBeNull();
+    expect(useCostStore.getState().costData?.project_name).toBe("project-b");
+    expect(useCostStore.getState().loading).toBe(false);
+  });
+
+  it("does not clear or replace the shared debounce timer for a call from a project the user already left", () => {
+    vi.useFakeTimers();
+    useProjectsStore.setState({ currentProjectName: "project-b" });
+    const fetchCostSpy = vi.spyOn(useCostStore.getState(), "fetchCost").mockResolvedValue();
+
+    // project-b 排了一次防抖刷新。
+    useCostStore.getState().debouncedFetch("project-b");
+
+    // project-a 的调用在用户已经离开之后才触发（比如某个慢 PATCH 的 .then 回调），
+    // 不应清空/顶替 project-b 刚排的计时器。
+    useCostStore.getState().debouncedFetch("project-a");
+
+    vi.advanceTimersByTime(500);
+
+    expect(fetchCostSpy).toHaveBeenCalledTimes(1);
+    expect(fetchCostSpy).toHaveBeenCalledWith("project-b");
   });
 });

--- a/frontend/src/stores/cost-store.ts
+++ b/frontend/src/stores/cost-store.ts
@@ -102,6 +102,13 @@ export const useCostStore = create<CostState>((set, get) => ({
     // B 之后才落地（如某个慢请求的 .then 回调），清掉/顶替计时器会连带取消 B 刚排的、
     // 真正需要跑的那次刷新——响应落地时的过期检查只能丢弃 A 自己的结果，救不回被它
     // 顶掉的 B。
+    //
+    // 这一支丢弃后不补拉，靠的是「切到新项目后必有一次以 currentProjectName 为
+    // 依赖的调用」：AssetSidebar 无条件挂在工作台布局里，其刷新 effect 的依赖就是
+    // currentProjectName，项目名落地的那一帧必然补发一次。各画布的 effect 依赖的是
+    // 路由参数 projectName，会先于路由层写入 currentProjectName 触发（React 子组件
+    // effect 先于父组件），那一次调用注定被这里丢掉。新增费用刷新入口时保持这条链：
+    // 要么依赖 currentProjectName，要么确保有后续 effect 重跑。
     if (isStaleProject(projectName)) return;
     if (_debounceTimer) clearTimeout(_debounceTimer);
     _debounceTimer = setTimeout(() => {

--- a/frontend/src/stores/cost-store.ts
+++ b/frontend/src/stores/cost-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { API } from "@/api";
 import { isDemoProject } from "@/onboarding/demo-project";
+import { useProjectsStore } from "@/stores/projects-store";
 import { errMsg } from "@/utils/async";
 import type { CostEstimateResponse, SegmentCost, EpisodeCost } from "@/types";
 
@@ -37,7 +38,12 @@ function buildIndexes(data: CostEstimateResponse): {
 }
 
 let _debounceTimer: ReturnType<typeof setTimeout> | null = null;
-let _fetchId = 0;
+let _abortController: AbortController | null = null;
+
+/** 用户是否已切到别的项目——成功/失败两条路径共用同一份判断，避免各自维护出偏差。 */
+function isStaleProject(projectName: string): boolean {
+  return useProjectsStore.getState().currentProjectName !== projectName;
+}
 
 export const useCostStore = create<CostState>((set, get) => ({
   costData: null,
@@ -47,36 +53,57 @@ export const useCostStore = create<CostState>((set, get) => ({
   _episodeIndex: new Map(),
 
   fetchCost: async (projectName: string) => {
-    // 引导演示项目在后端不存在，费用估算无从计算，界面按「未估算」显示；
-    // 递增 _fetchId 使切入前尚在途的真实项目请求作废，避免其晚到响应把真实费用写回演示页
+    // 使切入前尚在途的请求作废：无论接下来走哪条分支，这次调用都取代它
+    _abortController?.abort();
+    // 引导演示项目在后端不存在，费用估算无从计算，界面按「未估算」显示
     if (isDemoProject(projectName)) {
-      _fetchId += 1;
+      _abortController = null;
       get().clear();
       return;
     }
-    const currentId = ++_fetchId;
+    const controller = new AbortController();
+    _abortController = controller;
     set({ loading: true, error: null });
     try {
-      const data = await API.getCostEstimate(projectName);
-      // 如果在请求期间又触发了新请求，丢弃旧响应
-      if (currentId !== _fetchId) return;
+      const data = await API.getCostEstimate(projectName, { signal: controller.signal });
+      // 请求期间又发起了新请求，这份响应已作废：loading 收尾交给取代它的那次调用
+      if (controller.signal.aborted) return;
+      // 用户已切到别的项目：不能用这份数据覆盖当前项目的显示（单例 costData 不分项目
+      // 存储，两个项目的 segment_id 还可能撞名），但 loading 要收尾——不会再有同 key
+      // 请求替它复位，放着不收会一直卡在加载态
+      if (isStaleProject(projectName)) {
+        set({ loading: false });
+        return;
+      }
       set({ costData: data, loading: false, ...buildIndexes(data) });
     } catch (err) {
-      if (currentId !== _fetchId) return;
+      if (controller.signal.aborted) return;
+      if (isStaleProject(projectName)) {
+        set({ loading: false });
+        return;
+      }
       set({ error: errMsg(err), loading: false });
     }
   },
 
   debouncedFetch: (projectName: string) => {
-    if (_debounceTimer) clearTimeout(_debounceTimer);
     // 演示项目立即清空，不等 500ms 防抖窗口——否则切入演示项目后的这段窗口期，
-    // UI 仍会读到上一个真实项目残留在 store 里的费用数据
+    // UI 仍会读到上一个真实项目残留在 store 里的费用数据。这一支不判过期：演示项目
+    // 本身就是当前项目，不存在「切走了还调它」的场景。
     if (isDemoProject(projectName)) {
+      if (_debounceTimer) clearTimeout(_debounceTimer);
       _debounceTimer = null;
-      _fetchId += 1;
+      _abortController?.abort();
+      _abortController = null;
       get().clear();
       return;
     }
+    // 已不是当前项目的调用不动共享的防抖计时器：debouncedFetch(A) 若在用户已切到
+    // B 之后才落地（如某个慢请求的 .then 回调），清掉/顶替计时器会连带取消 B 刚排的、
+    // 真正需要跑的那次刷新——响应落地时的过期检查只能丢弃 A 自己的结果，救不回被它
+    // 顶掉的 B。
+    if (isStaleProject(projectName)) return;
+    if (_debounceTimer) clearTimeout(_debounceTimer);
     _debounceTimer = setTimeout(() => {
       _debounceTimer = null;
       void get().fetchCost(projectName);
@@ -86,6 +113,8 @@ export const useCostStore = create<CostState>((set, get) => ({
   clear: () => {
     if (_debounceTimer) clearTimeout(_debounceTimer);
     _debounceTimer = null;
+    _abortController?.abort();
+    _abortController = null;
     set({
       costData: null,
       loading: false,

--- a/frontend/src/stores/cost-store.ts
+++ b/frontend/src/stores/cost-store.ts
@@ -53,6 +53,11 @@ export const useCostStore = create<CostState>((set, get) => ({
   _episodeIndex: new Map(),
 
   fetchCost: async (projectName: string) => {
+    // 过期调用不得中止当前项目的在途请求：debouncedFetch 的定时器在触发时不会重新
+    // 校验过期（只在排期时查过一次），public 方法也可能被直接调用，晚到执行时项目
+    // 可能已经切走——此时若仍无条件 abort，会错误中止一个不相干、真正需要跑完的
+    // 当前项目请求。直接返回，不动 loading（不是它开的，也不该由它收）。
+    if (isStaleProject(projectName)) return;
     // 使切入前尚在途的请求作废：无论接下来走哪条分支，这次调用都取代它
     _abortController?.abort();
     // 引导演示项目在后端不存在，费用估算无从计算，界面按「未估算」显示


### PR DESCRIPTION
Closes #1529

## 问题

费用 store 的 `costData` 是不分项目的全局单例，响应落地时只用一个自增计数器挡「同 store 后续又发起的请求」，不校验用户是否已经切走。项目 A 的费用请求若发起晚于项目 B（例如 A 页面里某个慢写请求的回调在用户切走后才触发刷新），它会被判定为「最新」而整份覆盖 `costData`——用户在 B 的界面上看到 A 的费用。两个项目的分镜编号还可能撞名，此时费用会精确串到错误条目上。

## 修复

- 响应落地前校验当前项目名，不匹配则丢弃数据、仅收尾 loading（成功与失败两条分支共用同一份判断）
- 防抖计时器不再被已离开项目的调用清空或顶替——否则会连带取消当前项目刚排的那次刷新
- 按前端异步竞态规则，把这段防护里的自增计数器迁移为 AbortController，费用估算接口透传 `signal`，被顶替的请求真正取消而非只丢弃结果

## 验证

- 新增 4 条回归测试：迟到成功响应不覆盖、迟到失败响应不写 error、已离开项目的调用不动共享防抖计时器、更晚的调用 abort 在途请求且晚到响应不回写
- `pnpm lint` 通过；`pnpm check`（typecheck + vitest）通过，142 个测试文件 1676 个用例全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化费用估算请求的取消机制，避免过期或重复请求覆盖当前费用数据。
  * 切换项目时立即清理旧项目费用，降低显示过时结果的风险。
  * 修复演示项目切换、防抖刷新及迟到响应处理异常。
  * 增强费用请求稳定性，确保同一项目的新请求可中止旧请求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->