### PR TITLE
fix(skills): 审查循环防 CodeRabbit 限流假阳性与 rebase 轮次重置

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -57,6 +57,8 @@ bash .agents/skills/pr-ai-review-loop/scripts/query.sh <PR_NUMBER> <子命令>
 
 **fix-up 顺延**:仅在决定是否重触发 Gemini 前,对最近的 push 批次跑 `classify_commits.sh`(SINCE_SHA 取上一批次末 commit 的 `oid`;批次边界从索引 `commits_since_pr_created` 的间隔看,首批次以 `base_oid` 为界),按 reviewers.md「通用约定」判定是否沿用 Gemini 结论。
 
+脚本在 stderr 报 `WARNING: SINCE_SHA ... is not on PR`(典型成因 rebase 改写了全部 SHA)时锚点已失效,拿到的是全量提交而非最近一批,不得按该输出判形状——rebase 同时刷新了 `committedDate`,批次边界也无从重建。此时保守处置:不顺延,按 reviewers.md 的触发规则重审 Gemini,并把锚点重设为索引 `commits_since_pr_created` 末条 `oid` 供下轮使用。「收敛兜底」#2 用本脚本取证时同样适用该告警的处置。
+
 执行完触发动作后,按「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
 
 ### 步骤 3:收集评论并实施修复

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -26,7 +26,7 @@
 
 **触发**:`coderabbit.walkthrough.is_paused == true`,且 `updated_at` 之后未发送过 `@coderabbitai resume`(从 `own_trigger_comments` 筛,最新一条 `createdAt` 早于 walkthrough 的 `updated_at`;为空视为未发送)→ 发送 `@coderabbitai resume`。其余场景 CodeRabbit 自动跟新 push,无需手动触发。
 
-**已审当前 HEAD**:`walkthrough.reviewed_current_head == true`。
+**已审当前 HEAD**:`walkthrough.reviewed_current_head == true`。CodeRabbit 限流时会把 walkthrough 改写成限流横幅,这次改写不算审查——poll 已按 `is_rate_limited` 排除,该场景下字段恒为 false。
 
 **actionable**:`walkthrough.is_ok == true` 或 `actionable_count == "0"` 时无 actionable;否则看 `inline_new_by_user["coderabbitai[bot]"]` 各行的 `cr_markers`:含 `potential_issue` / `major` / `refactor` / `verification` 任一即 actionable;仅含 nit 级 token(`nitpick` / `trivial` / `low_value` / `minor`)不算。
 
@@ -39,7 +39,7 @@
 
 **outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。索引只给出这条 review 的存在与 `is_new`、不含正文,`unacked coderabbitai[bot]` 兜底只扫 `inline_*_by_user`,同样看不见它——只靠 inline 口径会漏。发现靠 `query.sh <PR> history`(按 400 字 head 扫出该 review),全文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复只能走 PR 顶层评论,不能回 inline。
 
-**配额**:本仓库使用 CodeRabbit 免费开源方案,配额/限流受阻时等待自恢复并手动 `@coderabbitai review` 重试一次;仍失败则本 PR 停用该家,记入退出汇报。全程不询问用户,也不提议付费扩容。
+**配额**:本仓库使用 CodeRabbit 免费开源方案,限流以 `walkthrough.is_rate_limited == true` 或 `quota_alerts` 判读;受阻时等待自恢复并手动 `@coderabbitai review` 重试一次;仍失败则本 PR 停用该家,记入退出汇报。全程不询问用户,也不提议付费扩容。
 
 ## Gemini Code Assist
 

--- a/.agents/skills/pr-ai-review-loop/scripts/classify_commits.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/classify_commits.sh
@@ -7,6 +7,10 @@
 # If SINCE_SHA omitted, returns all commits on the PR. With SINCE_SHA, returns commits AFTER that SHA
 # (use to inspect just the latest push: pass the previous round's head).
 #
+# A SINCE_SHA that is not on the PR's commit list (typical cause: a rebase rewrote every SHA)
+# returns ALL commits and warns on stderr — re-anchor on the current commit list instead of
+# trusting the stale SHA.
+#
 # OUTPUT: JSON array, one object per commit:
 # [
 #   {
@@ -57,6 +61,9 @@ COMMITS_JSON=$(gh pr view "$PR" --json commits 2>/dev/null) || {
 
 # Filter to commits after SINCE_SHA if provided.
 if [[ -n "$SINCE_SHA" ]]; then
+  if [[ $(echo "$COMMITS_JSON" | jq --arg since "$SINCE_SHA" '.commits | map(.oid) | index($since)') == "null" ]]; then
+    echo "WARNING: SINCE_SHA $SINCE_SHA is not on PR $PR (branch rebased?). Returning ALL commits — re-anchor on the current commit list." >&2
+  fi
   FILTERED=$(echo "$COMMITS_JSON" | jq --arg since "$SINCE_SHA" '
     .commits as $all
     | ($all | map(.oid) | index($since)) as $idx

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -705,7 +705,11 @@ jq --arg snapshot_file "$SNAPSHOT_FILE" '
 # loosen. Within one PR the fix-round count never genuinely decreases, so carry forward the
 # max of (computed, last printed). The snapshot keeps the raw computed value.
 INDEX_FILE="${SNAPSHOT_FILE%.json}.index.json"
-PREV_ROUND=$(jq -r '.index.round_estimate // 0' "$INDEX_FILE" 2>/dev/null) || PREV_ROUND=0
+PREV_ROUND=0
+if [[ -f "$INDEX_FILE" ]]; then
+  # The fallback still covers a present-but-unparsable index; absence is the first-poll norm.
+  PREV_ROUND=$(jq -r '.index.round_estimate // 0' "$INDEX_FILE" 2>/dev/null) || PREV_ROUND=0
+fi
 if [[ "$PREV_ROUND" =~ ^[0-9]+$ ]] && (( PREV_ROUND > 0 )); then
   jq --argjson prev "$PREV_ROUND" '.round_estimate = ([.round_estimate, $prev] | max)' \
     "$WORKDIR/index.json" > "$WORKDIR/index_ratchet.json"

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -20,7 +20,7 @@
 #              carries no cross-round state: it materializes THIS poll's fetch and is fully
 #              rebuilt by re-running poll.sh. query.sh is its only intended reader.
 #   index    — last fully-printed index plus its printed_at, at <snapshot>.index.json;
-#              backs the no_change comparison and `query.sh index`.
+#              backs the no_change comparison, the round_estimate ratchet, and `query.sh index`.
 #
 # INDEX SCHEMA (stdout)
 # {
@@ -29,8 +29,11 @@
 #   "head": "<sha>",                                    # current PR head commit SHA
 #   "last_push_at": "<ISO8601>",                        # head commit committedDate — see PITFALL 1
 #   "round_estimate": <int>,                            # fix-round count: commits with committedDate > pr_created_at,
-#                                                       # clustered by >5min gaps (rebase refreshes all dates =>
-#                                                       # underestimates; heuristic only)
+#                                                       # clustered by >5min gaps; ratcheted against the last printed
+#                                                       # index so it never decreases within a PR — a rebase refreshes
+#                                                       # all dates, collapsing the clustering, and would otherwise
+#                                                       # silently reset the convergence guardrail. The snapshot keeps
+#                                                       # the raw computed value (heuristic only)
 #   "snapshot_file": "<path>",                          # full snapshot staged for query.sh
 #   "base_oid": "<sha>" | null,                         # last commit at/before PR creation — SINCE_SHA for the
 #                                                       # first fix batch (null when every commit postdates creation)
@@ -39,9 +42,10 @@
 #     "walkthrough": {                                  # CR's first comment (auto-edited each review)
 #       "id":                    <int>,                 # REST issue comment id — stable across rewrites
 #       "created_at", "updated_at",
-#       "reviewed_current_head": <bool>,                # updated_at > last_push_at
+#       "reviewed_current_head": <bool>,                # updated_at > last_push_at AND not rate-limited
 #       "is_ok":                 <bool>,                # CR explicit pass marker
 #       "is_paused":             <bool>,                # CR paused for this PR
+#       "is_rate_limited":       <bool>,                # walkthrough body IS CR's rate-limit banner — not a review
 #       "is_in_progress":        <bool>,                # CR still processing — don't declare PASS yet
 #       "actionable_count":      "<n>" | null           # parsed from "Actionable comments posted: N"
 #     },
@@ -93,7 +97,11 @@
 #
 # FLAG SEMANTICS (single source of truth — reviewers.md references these fields by name)
 #   is_new                 new this round: created_at/submittedAt > last_push_at (see PITFALL 2)
-#   reviewed_current_head  walkthrough.updated_at > last_push_at (CR rewrites its first comment each review)
+#   reviewed_current_head  walkthrough.updated_at > last_push_at AND is_rate_limited == false. CR rewrites its
+#                          first comment each review — but a rate-limit banner rewrite also advances updated_at
+#                          without reviewing anything, so it must not read as "reviewed"
+#   is_rate_limited        walkthrough body carries CR's dedicated rate-limit banner marker (same match as
+#                          quota_alerts) — the current walkthrough is a rate-limit notice, not a review
 #   is_ack                 reviewer acknowledgment of a fix or inline reply (never actionable): body carries a
 #                          <review_comment_addressed>/<review_comment_withdrawn> marker or starts with "### Summary"
 #   cr_markers             CodeRabbit tag tokens found in the first 300 chars of a body (literal match):
@@ -405,17 +413,24 @@ jq -n \
   def codex_comment_has_pass_marker:
     (. // "") | test("^\\s*Codex Review:\\s*Didn(\\x27|\\x{2019})t find any major issues\\."; "i");
 
+  def cr_rate_limited_body:
+    # CodeRabbit wraps its rate-limit banner in a dedicated HTML marker. One match backs both
+    # quota_alerts and walkthrough.is_rate_limited so the two judgments cannot drift apart.
+    (. // "") | test("<!--\\s*This is an auto-generated comment:\\s*rate limited by coderabbit\\.ai\\s*-->");
+
   def cr_walkthrough_rest:
     [$sub_a[] | select(.user.login == "coderabbitai[bot]")]
     | sort_by(.created_at)
     | first
     | if . == null then null else
         (.body // "") as $wb
+        | ($wb | cr_rate_limited_body) as $rate_limited
         | {
           id,
           created_at,
           updated_at,
-          reviewed_current_head: (.updated_at > $last_push),
+          reviewed_current_head: ((.updated_at > $last_push) and ($rate_limited | not)),
+          is_rate_limited: $rate_limited,
           is_ok:          ($wb | test("No actionable comments were generated in the recent review")),
           is_paused:      ($wb | test("(review[s]?\\s+paused|paused\\s+by\\s+coderabbit|automatic reviews are paused|paused\\s+for\\s+this\\s+PR)"; "i")),
           is_in_progress: ($wb | test("(review in progress by coderabbit|currently processing new changes)"; "i")),
@@ -488,7 +503,7 @@ jq -n \
      | select(.user.login | test("(chatgpt-codex-connector|gemini-code-assist|coderabbitai)\\[bot\\]$"))
      | (.body // "") as $qb
      | select(
-         ($qb | test("<!--\\s*This is an auto-generated comment:\\s*rate limited by coderabbit\\.ai\\s*-->"))
+         ($qb | cr_rate_limited_body)
          or ($qb[0:500] | test("you(\\x27ve|\\x{2019}ve|\\s+have)\\s+reached your[^\\n]*?limit"; "i"))
          or ($qb[0:500] | test("(usage|rate|api|daily|monthly)\\s+limit[^\\n]*?(exceeded|reached|hit|reset)"; "i"))
          or ($qb[0:500] | test("quota[^\\n]*?(exceeded|exhausted|reached|reset|limit hit)"; "i"))
@@ -684,12 +699,24 @@ jq --arg snapshot_file "$SNAPSHOT_FILE" '
     }
   ' "$SNAPSHOT_FILE" > "$WORKDIR/index.json"
 
+# ---- Round-estimate ratchet ----
+# The date-gap clustering resets after a rebase: every committedDate refreshes, all fix
+# commits collapse into one cluster, and the >=3-round convergence guardrail would quietly
+# loosen. Within one PR the fix-round count never genuinely decreases, so carry forward the
+# max of (computed, last printed). The snapshot keeps the raw computed value.
+INDEX_FILE="${SNAPSHOT_FILE%.json}.index.json"
+PREV_ROUND=$(jq -r '.index.round_estimate // 0' "$INDEX_FILE" 2>/dev/null) || PREV_ROUND=0
+if [[ "$PREV_ROUND" =~ ^[0-9]+$ ]] && (( PREV_ROUND > 0 )); then
+  jq --argjson prev "$PREV_ROUND" '.round_estimate = ([.round_estimate, $prev] | max)' \
+    "$WORKDIR/index.json" > "$WORKDIR/index_ratchet.json"
+  mv "$WORKDIR/index_ratchet.json" "$WORKDIR/index.json"
+fi
+
 # ---- Pass 3: no-change collapse + semi-compact print ----
 # Waiting rounds dominate the loop; re-printing an identical index every poll is pure
 # context waste. Compare the derived index (key-order normalized) against the last fully
 # printed one and collapse to a single no_change line on match. printed_at sticks to the
 # last full print, so unchanged_since reports how long the state has been flat.
-INDEX_FILE="${SNAPSHOT_FILE%.json}.index.json"
 NEW_NORM=$(jq -cS . "$WORKDIR/index.json")
 PREV_NORM=""
 if [[ -f "$INDEX_FILE" ]]; then

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -6,9 +6,14 @@
 # USAGE
 #   bash test_quota_alerts.sh
 #
-# Extracts the `cr_rate_limited_body` and `quota_alerts` jq defs verbatim out of
-# poll.sh (so this test always exercises the functions actually shipped, not a
-# copy that can drift) and runs them against fixture comment bodies in testdata/:
+# Extracts the `cr_rate_limited_body`, `quota_alerts` and `cr_walkthrough_rest`
+# jq defs verbatim out of poll.sh (so this test always exercises the functions
+# actually shipped, not a copy that can drift) and runs them against fixture
+# comment bodies in testdata/. `cr_walkthrough_rest` is exercised because the
+# banner match alone is not the guarantee that matters: what the loop reads is
+# the walkthrough projection, and a rate-limited body must surface there as
+# is_rate_limited=true AND reviewed_current_head=false even when updated_at is
+# newer than the last push. The fixtures:
 #   - quota_alert_pr1115_no_stack.txt / quota_alert_pr1115_review_stack.txt: real
 #     CodeRabbit rate-limit banners captured from the source PR's walkthrough
 #     comment edit history (GraphQL userContentEdits — the live GitHub body has
@@ -46,6 +51,18 @@ if [[ -z "$QUOTA_DEF" ]]; then
   echo "could not extract quota_alerts def from $POLL_SH" >&2
   exit 4
 fi
+# cr_walkthrough_rest closes on its `end;` line — the same terminator rule as above.
+WT_DEF=$(awk '/^[[:space:]]*def cr_walkthrough_rest:/{flag=1} flag{print; if (/;[[:space:]]*$/ && !/^[[:space:]]*def /) exit}' "$POLL_SH")
+if [[ -z "$WT_DEF" ]]; then
+  echo "could not extract cr_walkthrough_rest def from $POLL_SH" >&2
+  exit 4
+fi
+
+# The walkthrough fixture is stamped updated_at > LAST_PUSH on purpose: without the
+# rate-limit suppression every case would read reviewed_current_head=true, so the
+# expected false on the banner fixtures can only come from the suppression itself.
+LAST_PUSH="2026-07-13T00:30:00Z"
+WT_UPDATED_AT="2026-07-13T01:00:00Z"
 
 # name : user login : expect quota_alerts triggered : expect cr_rate_limited_body
 # (the two differ on *_no_stack-style bodies only if CodeRabbit ever drops its banner
@@ -84,10 +101,25 @@ for tc in "${CASES[@]}"; do
     \$body | cr_rate_limited_body
     ")
 
-  if [[ "$got" == "$expect" && "$got_rl" == "$expect_rl" ]]; then
-    echo "PASS $file (quota_alerts triggered=$got, is_rate_limited=$got_rl)"
+  # Rate-limited bodies must suppress reviewed_current_head; non-alert ones must not.
+  if [[ "$expect_rl" == "true" ]]; then expect_wt="true:false"; else expect_wt="false:true"; fi
+  got_wt=$(jq -rn \
+    --rawfile body "$body_file" \
+    --arg login "$login" \
+    --arg last_push "$LAST_PUSH" \
+    --arg updated_at "$WT_UPDATED_AT" \
+    "
+    [{id: 1, user: {login: \$login}, created_at: \"2026-07-13T00:00:00Z\",
+      updated_at: \$updated_at, body: \$body}] as \$sub_a
+    | $RL_DEF
+      $WT_DEF
+      (cr_walkthrough_rest | \"\\(.is_rate_limited):\\(.reviewed_current_head)\")
+    ")
+
+  if [[ "$got" == "$expect" && "$got_rl" == "$expect_rl" && "$got_wt" == "$expect_wt" ]]; then
+    echo "PASS $file (quota_alerts triggered=$got, is_rate_limited=$got_rl, walkthrough=$got_wt)"
   else
-    echo "FAIL $file: expected triggered=$expect/is_rate_limited=$expect_rl, got=$got/$got_rl" >&2
+    echo "FAIL $file: expected triggered=$expect/is_rate_limited=$expect_rl/walkthrough=$expect_wt, got=$got/$got_rl/$got_wt" >&2
     fail=1
   fi
 done

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# test_quota_alerts.sh — regression test for poll.sh's quota_alerts detection.
+# test_quota_alerts.sh — regression test for poll.sh's quota_alerts detection and
+# the CodeRabbit rate-limit banner match (cr_rate_limited_body, which also backs
+# walkthrough.is_rate_limited / reviewed_current_head suppression).
 #
 # USAGE
 #   bash test_quota_alerts.sh
 #
-# Extracts the `quota_alerts` jq def verbatim out of poll.sh (so this test always
-# exercises the function actually shipped, not a copy that can drift) and runs it
-# against fixture comment bodies in testdata/:
+# Extracts the `cr_rate_limited_body` and `quota_alerts` jq defs verbatim out of
+# poll.sh (so this test always exercises the functions actually shipped, not a
+# copy that can drift) and runs them against fixture comment bodies in testdata/:
 #   - quota_alert_pr1115_no_stack.txt / quota_alert_pr1115_review_stack.txt: real
 #     CodeRabbit rate-limit banners captured from the source PR's walkthrough
 #     comment edit history (GraphQL userContentEdits — the live GitHub body has
@@ -32,25 +34,32 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 3
 fi
 
-# Pull the def verbatim: from `def quota_alerts:` through the line ending `];`
-# that closes it.
+# Pull each def verbatim: cr_rate_limited_body ends on its single expression line
+# (`;`), quota_alerts on the line ending `];` that closes it.
+RL_DEF=$(awk '/^[[:space:]]*def cr_rate_limited_body:/{flag=1} flag{print; if (/;[[:space:]]*$/ && !/^[[:space:]]*def /) exit}' "$POLL_SH")
+if [[ -z "$RL_DEF" ]]; then
+  echo "could not extract cr_rate_limited_body def from $POLL_SH" >&2
+  exit 4
+fi
 QUOTA_DEF=$(awk '/^[[:space:]]*def quota_alerts:/{flag=1} flag{print; if (/\];[[:space:]]*$/) exit}' "$POLL_SH")
 if [[ -z "$QUOTA_DEF" ]]; then
   echo "could not extract quota_alerts def from $POLL_SH" >&2
   exit 4
 fi
 
-# name : user login : expect (true/false)
+# name : user login : expect quota_alerts triggered : expect cr_rate_limited_body
+# (the two differ on *_no_stack-style bodies only if CodeRabbit ever drops its banner
+# marker; today every marker-bearing body triggers both)
 CASES=(
-  "quota_alert_pr1115_no_stack.txt:coderabbitai[bot]:true"
-  "quota_alert_pr1115_review_stack.txt:coderabbitai[bot]:true"
-  "no_actionable_pr1115.txt:coderabbitai[bot]:false"
-  "synthetic_non_alert_mentions_limit.txt:coderabbitai[bot]:false"
+  "quota_alert_pr1115_no_stack.txt:coderabbitai[bot]:true:true"
+  "quota_alert_pr1115_review_stack.txt:coderabbitai[bot]:true:true"
+  "no_actionable_pr1115.txt:coderabbitai[bot]:false:false"
+  "synthetic_non_alert_mentions_limit.txt:coderabbitai[bot]:false:false"
 )
 
 fail=0
 for tc in "${CASES[@]}"; do
-  IFS=":" read -r file login expect <<<"$tc"
+  IFS=":" read -r file login expect expect_rl <<<"$tc"
   body_file="$TESTDATA/$file"
   if [[ ! -f "$body_file" ]]; then
     echo "FAIL $file: fixture missing at $body_file" >&2
@@ -63,14 +72,22 @@ for tc in "${CASES[@]}"; do
     --arg login "$login" \
     "
     [{user: {login: \$login}, created_at: \"2026-07-13T00:00:00Z\", body: \$body}] as \$sub_a
-    | $QUOTA_DEF
+    | $RL_DEF
+      $QUOTA_DEF
       (quota_alerts | length) > 0
     ")
 
-  if [[ "$got" == "$expect" ]]; then
-    echo "PASS $file (quota_alerts triggered=$got)"
+  got_rl=$(jq -n \
+    --rawfile body "$body_file" \
+    "
+    $RL_DEF
+    \$body | cr_rate_limited_body
+    ")
+
+  if [[ "$got" == "$expect" && "$got_rl" == "$expect_rl" ]]; then
+    echo "PASS $file (quota_alerts triggered=$got, is_rate_limited=$got_rl)"
   else
-    echo "FAIL $file: expected triggered=$expect, got=$got" >&2
+    echo "FAIL $file: expected triggered=$expect/is_rate_limited=$expect_rl, got=$got/$got_rl" >&2
     fail=1
   fi
 done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）�
 - **ruff**：line-length 120，提交前对修改的 Python 文件执行 `uv run ruff check <files> && uv run ruff format <files>`
 - **basedpyright**：standard 模式 + `reportMissingTypeStubs = false`，CI 强制 0 error，pre-push hook 跑全量扫描；本地可随时执行 `uv run basedpyright` 校验。tests/ 内 `reportOptional*` 和 `unknown*` 系列降级为 warning，避免大量使用 mock 的测试产生噪声；第三方 untyped 库（ffmpeg-python、pyJianYingDraft、volcenginesdkarkruntime、xai_sdk.chat、docx2txt/mammoth/ebooklib）通过行级 `# pyright: ignore[...]` 处理
 - **import-linter**：`uv run lint-imports` 校验 `lib.config < lib.*_backends < lib.custom_provider` 分层契约，CI backend-static 必过步骤；新增 ignore 条目前先确认该依赖边无法就地清零（约定见 pyproject.toml）
-- **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`。测试替身优先复用/扩展 `tests/fakes.py`，新建 fake 入该模块；触碰含文件内私有 fake 的测试文件时顺带迁移
+- **pytest**：`asyncio_mode = "auto"`，CI 覆盖率 ≥80%，共用 fixtures 在 `tests/conftest.py`，跨文件共用的测试替身在 `tests/fakes.py`（收录边界见其模块 docstring）
 - **依赖管理**：前后端新增/升级依赖一律用 `uv add` / `pnpm add`（不手写版本号到 pyproject.toml / package.json）；新增依赖后同步 `.github/dependabot.yml` 的 patterns 归入对应分组
 - **注释**：代码与测试注释只描述当下行为与约束，不写 issue/PR/Spec 编号，也不用时间性措辞（「最近」「本次」「实测」）——这些信息写在 commit message / PR 描述；修改文件时顺带清除已有的此类引用。`docs/` 下专门文档之间互引 spec 不受此限
 - **提交与 PR**：标题遵循 Conventional Commits（`type(scope): 摘要`，type 取值与 changelog 分类见 `CONTRIBUTING.md` / `.release-please-config.json`）。squash 合并下标题即 changelog 条目——写用户可感知的收益、范围词用产品术语，不写实现术语（status_code、内部类名等）且如实限定范围。前后端同仓一体发布，后端 API 不做版本化对外承诺（外部集成经 `/skill.md` 运行时拉取契约，删改 `public/skill.md.template` 引用的端点时同步更新该模板）：接口删改按 `fix`/`refactor` 正常分类，不加 `!` 后缀、不写 `BREAKING CHANGE:` footer


### PR DESCRIPTION
## 改动

三处均为 pr-ai-review-loop 循环在真实运行中暴露的护栏缺口，另附一处文档规约收敛：

1. **poll.sh — CodeRabbit 限流假阳性**：限流时 CodeRabbit 把 walkthrough 改写成限流横幅，`updated_at` 前移导致 `reviewed_current_head` 为 true，但实际没有发生审查——曾几乎导致未审即合并。新增 `is_rate_limited` 字段（与 `quota_alerts` 共用同一横幅标记匹配，杜绝两处判定漂移），`reviewed_current_head` 判定排除限流态。`test_quota_alerts.sh` 同步抽取新 def，四个 fixture 各加 `is_rate_limited` 断言。
2. **poll.sh — round_estimate 单调棘轮**：rebase 刷新全部 committedDate，日期聚簇坍缩成单簇，≥3 轮收敛护栏被静默重置。索引值改为与上次已打印索引取 max（单 PR 内不减）；快照保留原始计算值。
3. **classify_commits.sh — SINCE_SHA 失效响亮化**：SINCE_SHA 不在 PR 提交列表（典型成因 rebase 改写 SHA）时原先静默返回全量提交，调用方以为拿到的是增量。行为不变，但改为 stderr 告警提示重新锚定。
4. **AGENTS.md 测试替身规约**：删除与 `tests/fakes.py` docstring 矛盾的「新建 fake 一律入该模块」表述（已实际产生一条审查误报），收录边界收敛到 docstring 单一真相源。reviewers.md 同步 1 的字段口径。

## 验证

- `bash -n` 两脚本语法通过；`test_pass_marker.sh` / `test_quota_alerts.sh` 全绿
- 对 PR #1682 冒烟：`is_rate_limited=false`、`reviewed_current_head=true` 如预期；篡改存储索引 `round_estimate=7` 后重跑，棘轮取 max 保留 7；`classify_commits.sh 1682 deadbeef00` 输出告警且返回全量 3 条提交（测试残留已清理）

https://claude.ai/code/session_01H1gDD7LXUVURpN4C5hpGtf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进限流提示识别，避免误判审查状态。
  * 检测到无效起始提交时发出警告并继续处理全部提交。
  * 确保审查轮次估计值不会因轮询刷新而回退。
  * Rebase 后起始提交失效时，自动重新触发审查并调整处理锚点。

* **Tests**
  * 补充限流、配额告警及审查状态判定的验证场景。

* **Documentation**
  * 更新审查流程说明及测试替身规范。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->