### PR TITLE
docs(智能体): 修正宫格分镜图技能文档的产物路径与切割产物说明

### DIFF
--- a/agent_runtime_profile/.claude/references/generation-modes.md
+++ b/agent_runtime_profile/.claude/references/generation-modes.md
@@ -70,7 +70,7 @@ Step 8 旁白配音（仅 narration 内容模式）
 
 ```text
 projects/{name}/          # ← session cwd 已在此
-├── storyboards/          # storyboard 模式分镜图（grid_storyboard=true 时存宫格切割出的首尾帧）
+├── storyboards/          # storyboard 模式分镜图（grid_storyboard=true 时存宫格切割出的起始分镜图）
 ├── grids/                # storyboard 模式且 grid_storyboard=true（宫格大图）
 ├── reference_videos/     # reference_video 模式视频输出
 ├── videos/               # storyboard 模式视频输出

--- a/agent_runtime_profile/.claude/skills/generate-grid/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-grid/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: generate-grid
-description: 生成宫格分镜图。当用户说"生成宫格"、"宫格生图"、"宫格模式生成分镜"时使用。自动按 segment_break 分组，选择最优宫格大小，生成首尾帧链式宫格图并切割分配。
+description: 生成宫格分镜图。当用户说"生成宫格"、"宫格生图"、"宫格模式生成分镜"时使用。自动按 segment_break 分组，选择最优宫格大小，生成链式过渡帧宫格图并切割分配为各场景起始分镜图。
 ---
 
 # 生成宫格分镜图
 
-为开启宫格装配的项目生成宫格分镜图。自动按 segment_break 分组，每组生成一张宫格大图，切割后形成首尾帧链式结构。
+为开启宫格装配的项目生成宫格分镜图。自动按 segment_break 分组，每组生成一张宫格大图，切割后按链式过渡帧结构分配为各场景的起始分镜图（仍走 i2v，与逐张生成的分镜图输入契约相同）。
 
 ## 前置条件
 
@@ -23,6 +23,6 @@ description: 生成宫格分镜图。当用户说"生成宫格"、"宫格生图"
 
 ## 输出
 
-- 宫格大图保存到 `grids/grid_{id}.png`
-- 切割后的首帧/尾帧保存到 `storyboards/scene_{id}_first.png` / `scene_{id}_last.png`
-- 帧链元数据保存到 `grids/grid_{id}.json`
+- 宫格大图保存到 `grids/{grid_id}.png`（`grid_id` 自身即带 `grid_` 前缀，如 `grids/grid_a1b2c3d4e5f6.png`）
+- 帧链元数据保存到 `grids/{grid_id}.json`
+- 切割后的单元格按 `next_scene_id` 分配落盘，文件名与普通分镜图对齐为 `storyboards/scene_{id}.png`（无 first/last 后缀）

--- a/agent_runtime_profile/.claude/skills/generate-grid/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-grid/SKILL.md
@@ -11,7 +11,7 @@ description: 生成宫格分镜图。当用户说"生成宫格"、"宫格生图"
 
 - 项目 `generation_mode` 为 `"storyboard"` 且 `grid_storyboard` 为 `true`（宫格装配由用户在 Web 设置页开关，项目创建后不可经 agent 改）
 - 剧本已生成（scripts/episode_N.json 存在）
-- 角色/场景/道具设计图已生成（用作参考图）
+- 角色/场景/道具设计图（已生成的会作为参考图带入；一张都没有时退化为纯文生图，画面一致性会明显变差）
 
 ## 工具调用
 

--- a/agent_runtime_profile/CLAUDE.drama.md
+++ b/agent_runtime_profile/CLAUDE.drama.md
@@ -164,7 +164,7 @@ projects/{项目名}/      # ← session cwd 已在此，下面均为 cwd 内的
 ├── characters/        # 角色设计图
 ├── scenes/            # 场景设计图
 ├── props/             # 道具设计图
-├── storyboards/       # 分镜图片（storyboard 模式；`grid_storyboard=true` 时存宫格切割出的首尾帧）
+├── storyboards/       # 分镜图片（storyboard 模式；`grid_storyboard=true` 时存宫格切割出的起始分镜图）
 ├── grids/             # 宫格大图（storyboard 模式且 `grid_storyboard=true`）
 ├── videos/            # 生成的视频片段（storyboard 模式）
 ├── reference_videos/  # 生成的 video_unit（reference_video 模式）

--- a/agent_runtime_profile/CLAUDE.narration.md
+++ b/agent_runtime_profile/CLAUDE.narration.md
@@ -166,7 +166,7 @@ projects/{项目名}/      # ← session cwd 已在此，下面均为 cwd 内的
 ├── characters/        # 角色设计图
 ├── scenes/            # 场景设计图
 ├── props/             # 道具设计图
-├── storyboards/       # 分镜图片（storyboard 模式；`grid_storyboard=true` 时存宫格切割出的首尾帧）
+├── storyboards/       # 分镜图片（storyboard 模式；`grid_storyboard=true` 时存宫格切割出的起始分镜图）
 ├── grids/             # 宫格大图（storyboard 模式且 `grid_storyboard=true`）
 ├── videos/            # 生成的视频片段（storyboard 模式）
 ├── reference_videos/  # 生成的 video_unit（reference_video 模式）


### PR DESCRIPTION
Closes #1697

## 改动

纯文档，无代码行为变更。

**`generate-grid/SKILL.md` 输出段三处文件名按代码改准**（issue 主体）：

- 宫格大图 `grids/grid_{id}.png` → `grids/{grid_id}.png`（`grid_id` 自身即带 `grid_` 前缀，来自 `lib/grid/models.py` 的 `f"grid_{uuid.uuid4().hex[:12]}"`）
- 帧链元数据 `grids/{grid_id}.json`（`lib/grid_manager.py::_path` 默认 `.json` 后缀）
- 切割单元格 `storyboards/scene_{id}_first.png` / `_last.png` → `storyboards/scene_{id}.png`，按 `next_scene_id` 分配落盘、与普通分镜图同名

**顺带改准的过时表述**：`FrameCell.frame_type` 只有 `first`/`transition`/`placeholder`，宫格已统一走普通图生视频，不再有尾帧产物。SKILL.md 的「首尾帧链式」按 `docs/adr/0055` 的口径改写为「链式过渡帧…分配为各场景起始分镜图（仍走 i2v）」；`CLAUDE.drama.md` / `CLAUDE.narration.md` / `.claude/references/generation-modes.md` 三处目录树注释里同样的「首尾帧」一并统一——这三份是常驻注入的文档，权威性高于按需加载的 SKILL.md，不改会让智能体同时读到两种矛盾说法。

**前置条件措辞**：资产设计图原写成硬前置，实际 `execute_grid_task` 按 `_needs_i2i = bool(reference_images)` 分派，无参考图时走 t2i 照常生成，改为柔性表述并说明退化后果。

## 验证

- 三处文件名逐一对照真相源 `server/services/generation_tasks.py::execute_grid_task`、`lib/grid_manager.py`、`lib/grid/models.py` 核实
- 「前置条件」「工具调用」两段对照 `server/agent_runtime/sdk_tools/enqueue_grid.py`，参数契约（`script` / `scene_ids` / `list_only`）与宫格开关校验一致，未改动
- 全文无硬编码格数/分辨率数值，方形档位阶梯（`lib/grid/layout.py`）无需在文档侧跟随
- `pytest tests/test_profile_manifest.py tests/test_grid_executor.py` 95 passed；`ruff check .` 与 `lint-imports` 通过
- profile manifest 的 sha256 在运行期计算、不入库，无需同步


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新目录结构说明，明确 `storyboards/` 保存宫格图切割出的起始分镜图。
  * 补充宫格生成流程说明：生成链式过渡帧并按场景分配起始分镜图。
  * 支持角色、场景或道具设计图缺失时继续生成；全部缺失时可使用纯文生图。
  * 更新输出说明，记录帧链元数据，并按场景写入切割后的分镜图。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->