### PR TITLE
fix(合成): 参考生视频成片支持转场/字幕/BGM，字幕按真实语音对齐并收敛字号

### DIFF
--- a/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/compose-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-video
-description: 把已生成的视频片段按剧本顺序拼接为单集成片，可选混入 BGM 与场景间转场。当用户说"拼成片"、"合成本集视频"或"加背景音乐"时使用。
+description: 把已生成的视频片段按剧本顺序拼接为单集成片，可选混入 BGM、场景间转场与台词字幕烧录。当用户说"拼成片"、"合成本集视频"、"加背景音乐"或"加字幕"时使用。
 ---
 
 # 合成视频
@@ -9,7 +9,8 @@ description: 把已生成的视频片段按剧本顺序拼接为单集成片，�
 
 ## 适用范围（重要）
 
-- **仅 drama 模式** — 脚本读取剧本顶层 `scenes[]`；narration（`segments[]`）、ad（`shots[]`）和 reference_video（`video_units[]`）会被脚本拒绝。这些模式的成片导出请走 Web 端剪映草稿导出（ad 草稿含视频轨 + 口播文案字幕轨，导出后在剪映配音成片）
+- **支持 drama 与 reference_video 模式** — 脚本读取剧本顶层 `scenes[]`（drama）或 `video_units[]`（reference_video 路线）；narration（`segments[]`）、ad（`shots[]`）会被脚本拒绝。这些模式的成片导出请走 Web 端剪映草稿导出（ad 草稿含视频轨 + 口播文案字幕轨，导出后在剪映配音成片）
+- **字幕来源随模式** — `--subtitles` 时：drama 从场景级 `utterances`（台词 + 画外音）派生；reference_video 从 unit 的 `shots[*].text` 台词行（`@[角色]：{台词}` 对话行 / `{台词}` 画外音行，与剪映导出同口径）派生。时间轴默认先用本地 faster-whisper 语音识别把每条字幕配到真实语音边界，模型不可用时自动回退 silencedetect（开场静音偏移 + 溢出缩放，见下文）。烧录用显式样式的 ASS（字号 / 底部边距 / 描边按画布分辨率计算，长台词按宽度硬换行），不再依赖 libass 对 SRT 的默认样式
 - **单集拼接** — 一次只处理一份剧本文件，不支持多集合并
 - **不实现片头片尾 / BGM 音量调节** — 这些需求请走 Web 端剪映草稿导出
 
@@ -29,6 +30,15 @@ python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.j
 
 # 自定义输出文件名（输出固定落在 output/ 下）
 python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.json --output episode_1_final.mp4
+
+# 烧录台词字幕（剧本 utterances 派生，默认 ASR 语音识别对齐 + silencedetect 兜底，需 ffmpeg 带 libass）
+python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.json --subtitles
+
+# 不想用语音识别（更快但可能不同步）：跳过 ASR，仅 silencedetect 对齐
+python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.json --subtitles --no-asr
+
+# 完全关闭音频对齐（纯按语速估算）
+python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.json --subtitles --no-audio-align
 ```
 
 完整参数：
@@ -39,17 +49,21 @@ python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.j
 | `--output OUTPUT` | 可选 | 输出文件名；缺省按剧本 `novel.chapter` 字段生成。无论何种取值，最终都落在 `output/` 子目录内 |
 | `--music MUSIC` | 可选 | BGM 文件路径（相对项目 cwd 或绝对路径），但**必须解析后位于项目目录内** |
 | `--no-transitions` | flag | 全部用 cut 直接拼接，忽略剧本里的 `transition_to_next` |
+| `--subtitles` | flag | drama 按每场景 `utterances`、reference_video 按 unit `shots[*].text` 台词行，把台词 + 画外音烧录为画面底部字幕；时长按 `lib.speech_rate` 语速估算，与剪映导出同口径。需 ffmpeg 编译 libass（预检失败会给出安装指引） |
+| `--no-asr` | flag | 跳过 faster-whisper 语音识别对齐（回退 silencedetect；默认开启，见下方说明） |
+| `--no-audio-align` | flag | 关闭字幕音频对齐（仅按语速估算） |
 
 ## 工作流程
 
 1. **读剧本** — 通过 `ProjectManager.load_script()` 从 `scripts/` 加载（路径过滤复用 lib 内 `_safe_subpath`）
-2. **收集片段** — 按 `scenes[i].generated_assets.video_clip` 逐个解析视频文件并校验存在
+2. **收集片段** — 按 `scenes[i].generated_assets.video_clip`（drama）或 `video_units[i].generated_assets.video_clip`（reference_video）逐个解析视频文件并校验存在
 3. **拼接** — 默认走 normalize → concat（先把每段规范化为统一 H.264/AAC，再用 concat filter 编码），有 `xfade` 转场需求时按 `transition_to_next` 加滤镜
-4. **混音** — 若指定 `--music`，再做一遍 audio mix；输出文件名追加 `_with_music`
+4. **字幕** — 若指定 `--subtitles`，drama 按场景 `utterances`、reference_video 按 unit `shots[*].text` 台词行派生时间片，默认用 **faster-whisper**（本地 CPU，word-level 时间戳）把每条台词按文本相似度贪心配到真实语音边界，前后各留 0.1~0.15s 余量；配对失败或模型不可用（未安装 / 下载失败 / 转写无结果）自动回退 **silencedetect** 对齐：开场静音超过 0.3s 时整体后移（避免「人未开口字幕先出」）、估算总时长超过场景可用时长时按比例压缩、相邻字幕条间留 0.25s 留白。随后把时间片渲染为显式样式 ASS（`PlayResX/Y` 按目标分辨率、字号约画布高 6% 且超长台词自动缩档保证最多 5 行、底部边距约画布高 5.5%、描边阴影、长台词按宽度 `\N` 硬换行且任何一行都不超出画面宽度）并在 normalize 阶段烧录进画面（各片段字幕时间轴相对自身，转场 / concat 后仍与场景对齐）
+5. **混音** — 若指定 `--music`，再做一遍 audio mix（`-c:v copy`，保留已烧字幕）；输出文件名追加 `_with_music`
 
 ## 支持的转场类型
 
-按剧本字段 `scenes[i].transition_to_next` 映射：
+按剧本字段 `scenes[i].transition_to_next` / `video_units[i].transition_to_next` 映射：
 
 | 字段值 | ffmpeg 行为 |
 |---|---|
@@ -61,17 +75,25 @@ python .claude/skills/compose-video/scripts/compose_video.py scripts/episode_1.j
 ## 前置检查
 
 - [ ] 当前 cwd 是项目根（含 `project.json`）
-- [ ] 剧本 content_mode 为 drama（顶层有 `scenes[]`）
+- [ ] 剧本顶层有 `scenes[]`（drama）或 `video_units[]`（reference_video 路线）
 - [ ] 每个场景的 `generated_assets.video_clip` 都已生成
-- [ ] `ffmpeg` / `ffprobe` 都在 PATH（脚本会预检）
+- [ ] `ffmpeg` / `ffprobe` 可用（脚本预检：先查 PATH，再查 Windows 常见安装位置；缺失时给出安装指引）
 - [ ] BGM 文件存在（如指定 `--music`）
+- [ ] ffmpeg 带 libass（如指定 `--subtitles`；脚本用 `ffmpeg -filters` 预检 `subtitles` 滤镜，缺失时给出换用完整版的指引）
+- [ ] faster-whisper（可选，推荐）：`uv add faster-whisper` 后首次运行会下载 base 模型（约 140MB）；网络受限时可设 `HF_ENDPOINT=https://hf-mirror.com`。未安装 / 下载失败不影响合成，自动回退 silencedetect
+
+## Windows 环境说明
+
+- 脚本定位 ffmpeg/ffprobe 的顺序：PATH → Git for Windows / MSYS2 的 `mingw64\bin`、`usr\bin` → `C:\ffmpeg\bin`、`C:\Program Files\ffmpeg\bin` → 用户级 `%LOCALAPPDATA%\ffmpeg\bin` → winget 安装目录（`%LOCALAPPDATA%\Microsoft\WinGet\Packages`）
+- 都找不到时脚本退出并给出安装指引；Windows 推荐 `winget install --id Gyan.FFmpeg -e`
+- agent 的 Bash 工具是非登录 shell，不读 `~/.bashrc`；若在 `~/.bashrc` 里手动加过 PATH，重启 git bash 才会生效
+- faster-whisper 在 CPU 上用 int8 推理；每场景 6~12s 音频转写约数秒到十几秒，成片时长不变
 
 ## 限制 / 缺失能力
 
 下列能力**未实现**，请使用 Web 端剪映草稿导出：
 
-- narration / ad / reference_video 模式（脚本只识别 `scenes[]`）
+- narration / ad 模式（脚本只识别 `scenes[]` / `video_units[]`）
 - 多集合并 / 单集分片裁剪
 - BGM 音量调节、独立 BGM 时间轴
 - 片头片尾 intro/outro
-- 字幕渲染

--- a/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
+++ b/agent_runtime_profile/.claude/skills/compose-video/scripts/compose_video.py
@@ -3,20 +3,38 @@
 Video Composer - 使用 ffmpeg 合成最终视频
 
 Usage:
-    python compose_video.py <script_file> [--output OUTPUT] [--music MUSIC_FILE]
+    python compose_video.py <script_file> [--output OUTPUT] [--music MUSIC_FILE] [--subtitles]
 
 Example:
     python compose_video.py chapter_01_script.json --output chapter_01_final.mp4
     python compose_video.py chapter_01_script.json --music bgm.mp3
+    python compose_video.py chapter_01_script.json --subtitles
 """
 
 import argparse
+import functools
 import json
 import math
+import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
+import unicodedata
+from difflib import SequenceMatcher
 from pathlib import Path
+from typing import Any
+
+# Windows 控制台/管道默认 cp936，emoji 输出会抛 UnicodeEncodeError 打断报错；
+# 统一把 stdout/stderr 切成 UTF-8（agent 捕获的是字节流，UTF-8 无信息损失）。
+# reconfigure 本身在异常流上也可能抛错，失败时静默跳过，不让日志输出成为启动障碍。
+for _stream in (sys.stdout, sys.stderr):
+    if _stream is not None and hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
 
 
 def _find_repo_root(start: Path) -> Path:
@@ -36,9 +54,71 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from lib.project_manager import ProjectManager
+from lib.reference_video.shot_parser import match_dialogue_line, match_voiceover_line
 from lib.script_models import get_generated_assets
+from lib.speech_rate import estimate_spoken_seconds
 
-FFMPEG_TOOLS_HINT = "需要 ffmpeg 和 ffprobe 同时可用，并且都在 PATH 中"
+FFMPEG_TOOLS_HINT = "需要 ffmpeg 和 ffprobe 同时可用（脚本会自动查找 PATH 与常见安装位置）"
+
+# Windows 上 ffmpeg/ffprobe 可能只存在于 git bash（MSYS2）的 PATH 里、或装在非 PATH
+# 目录：git bash 非登录 shell 不读 ~/.bashrc，Python subprocess 也拿不到 bash 内
+# POSIX 路径转换后的目录，所以除 shutil.which 外再探测常见安装位置。
+_WINDOWS_TOOL_CANDIDATE_DIRS: tuple[Path, ...] = tuple(
+    Path(p)
+    for p in (
+        r"C:\Program Files\Git\mingw64\bin",
+        r"C:\Program Files\Git\usr\bin",
+        r"C:\msys64\mingw64\bin",
+        r"C:\msys64\usr\bin",
+        r"C:\ffmpeg\bin",
+        r"C:\Program Files\ffmpeg\bin",
+    )
+)
+
+
+def _find_tool(name: str) -> Path | None:
+    """在 PATH 与 Windows 常见安装位置定位 ffmpeg/ffprobe，找不到返回 None。"""
+    found = shutil.which(name)
+    if found is not None:
+        return Path(found)
+    if os.name != "nt":
+        return None
+    for directory in _WINDOWS_TOOL_CANDIDATE_DIRS:
+        candidate = directory / f"{name}.exe"
+        if candidate.is_file():
+            return candidate
+    # 用户级安装（%LOCALAPPDATA%\ffmpeg\bin）——无需管理员权限的常见位置
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidate = Path(local_app_data) / "ffmpeg" / "bin" / f"{name}.exe"
+        if candidate.is_file():
+            return candidate
+    # winget 安装的 Gyan.FFmpeg 落在 %LOCALAPPDATA%\Microsoft\WinGet\Packages\...
+    winget_root = Path(os.environ.get("LOCALAPPDATA", "")) / "Microsoft" / "WinGet" / "Packages"
+    if winget_root.is_dir():
+        for package_dir in winget_root.glob(f"*{name}*"):
+            for bin_dir in package_dir.glob("*/bin"):
+                candidate = bin_dir / f"{name}.exe"
+                if candidate.is_file():
+                    return candidate
+    return None
+
+
+@functools.cache
+def _resolve_ffmpeg_tools() -> tuple[Path | None, Path | None]:
+    """一次性解析 ffmpeg/ffprobe，之后所有 subprocess 调用都用解析出的绝对路径。"""
+    return _find_tool("ffmpeg"), _find_tool("ffprobe")
+
+
+def _require_tool(name: str) -> str:
+    """返回已解析的 ffmpeg/ffprobe 绝对路径；未解析到时回退裸命令名。
+
+    主流程在构建命令前已由 check_ffmpeg() 把关，真实运行总能拿到绝对路径；
+    直接调用各拼接函数（测试）时回退到旧行为，由 subprocess 自行报错。
+    """
+    ffmpeg, ffprobe = _resolve_ffmpeg_tools()
+    path = ffmpeg if name == "ffmpeg" else ffprobe
+    return str(path) if path is not None else name
 
 
 def _require_project_cwd() -> tuple[ProjectManager, str, Path]:
@@ -54,19 +134,30 @@ def _require_project_cwd() -> tuple[ProjectManager, str, Path]:
     return pm, cwd.name, cwd
 
 
-def check_ffmpeg():
-    """检查 ffmpeg / ffprobe 是否可用"""
-    try:
-        ffmpeg = subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True)
-        ffprobe = subprocess.run(["ffprobe", "-version"], capture_output=True, text=True)
-        return ffmpeg.returncode == 0 and ffprobe.returncode == 0
-    except FileNotFoundError:
-        return False
+def check_ffmpeg() -> bool:
+    """检查 ffmpeg / ffprobe 是否可用（PATH + Windows 常见安装位置）。"""
+    ffmpeg, ffprobe = _resolve_ffmpeg_tools()
+    return ffmpeg is not None and ffprobe is not None
+
+
+def _check_subtitles_support() -> bool:
+    """ffmpeg 是否带 libass（subtitles 滤镜可用）。
+
+    官方 / gyan 完整版都带；极小化静态版可能不带。结果缓存，缺失时在 --subtitles
+    前置检查里给出明确指引，而不是等滤镜报错。
+    """
+    result = subprocess.run(
+        [_require_tool("ffmpeg"), "-hide_banner", "-filters"],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    return result.returncode == 0 and "subtitles" in result.stdout
 
 
 def run_ffmpeg(cmd: list[str], error_prefix: str) -> None:
     """执行 ffmpeg / ffprobe 命令并在失败时抛出完整错误。"""
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode != 0:
         raise RuntimeError(f"{error_prefix}: {result.stderr}")
 
@@ -116,7 +207,7 @@ def get_video_duration(video_path: Path) -> float:
     """获取视频时长"""
     result = subprocess.run(
         [
-            "ffprobe",
+            _require_tool("ffprobe"),
             "-v",
             "error",
             "-show_entries",
@@ -127,6 +218,8 @@ def get_video_duration(video_path: Path) -> float:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -142,7 +235,7 @@ def probe_media(video_path: Path) -> dict[str, object]:
     """读取片段的基础媒体信息，用于统一中间片规格。"""
     result = subprocess.run(
         [
-            "ffprobe",
+            _require_tool("ffprobe"),
             "-v",
             "error",
             "-print_format",
@@ -153,6 +246,8 @@ def probe_media(video_path: Path) -> dict[str, object]:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -196,6 +291,505 @@ def probe_media(video_path: Path) -> dict[str, object]:
     }
 
 
+# 字幕音频对齐（--subtitles 默认开启，--no-audio-align 关闭）：
+# seedance 生成视频自带对白与氛围音（实测均值约 -21dB），纯按语速估算的时间轴会与
+# 实际语音错位（长台词常溢出场景、人未开口字幕先出）。silencedetect 在 -25dB / 0.3s
+# 阈值下能切出句间停顿而不会被氛围音淹没。
+_SUBTITLE_SILENCE_DB = -25
+_SUBTITLE_MIN_SILENCE = 0.3
+_SUBTITLE_LEAD_MIN = 0.3  # 开场静音超过该值才把字幕整体后移（秒）
+_SUBTITLE_GAP = 0.25  # 相邻字幕条间留白（秒），避免贴边连读
+_SUBTITLE_MIN_DISPLAY = 0.3  # 单条字幕最短展示时长（秒）
+
+_SILENCE_START_RE = re.compile(r"silence_start:\s*([0-9.]+)")
+_SILENCE_END_RE = re.compile(r"silence_end:\s*([0-9.]+)")
+_FFMPEG_DURATION_RE = re.compile(r"Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)")
+
+
+def _parse_silencedetect_output(stderr: str, duration: float) -> list[tuple[float, float]]:
+    """把 silencedetect 的 stderr 解析为有声区间列表（升序、互不重叠、末尾截断到 duration）。
+
+    silence_start / silence_end 交替出现（开头静音的起点是 0）；由静音区间反推
+    有声区间：第一个静音开始前、每个静音结束后到下一段静音开始、最后一段静音之后。
+    ffmpeg 可能只报 start 不报 end（流在静音中结束），未配对 start 按解析失败处理，
+    整体视为有声。未检测到任何静音返回 [(0, duration)]。
+    """
+    silences: list[tuple[float, float]] = []
+    open_start: float | None = None
+    for line in stderr.splitlines():
+        m = _SILENCE_START_RE.search(line)
+        if m:
+            open_start = float(m.group(1))
+            continue
+        m = _SILENCE_END_RE.search(line)
+        if m and open_start is not None:
+            end = float(m.group(1))
+            if end > open_start:
+                silences.append((open_start, end))
+            open_start = None
+
+    segments: list[tuple[float, float]] = []
+    cursor = 0.0
+    for start, end in silences:
+        start = max(start, cursor)
+        end = max(end, start)
+        if start > cursor + 1e-9:
+            segments.append((cursor, start))
+        cursor = end
+    if cursor < duration - 1e-9:
+        segments.append((cursor, duration))
+    return segments
+
+
+def _detect_voiced_segments(video_path: Path) -> tuple[list[tuple[float, float]], float | None]:
+    """对片段跑一次 silencedetect，返回 (有声区间列表, 片段时长)。
+
+    时长从同一份 stderr 的 Duration 行解析，避免额外 probe；ffmpeg 失败（无音频流 /
+    滤镜不可用）或解析不出时长时返回 ([], None)，由调用方决定回退策略。
+    """
+    result = subprocess.run(
+        [
+            _require_tool("ffmpeg"),
+            "-hide_banner",
+            "-i",
+            str(video_path.resolve()),
+            "-af",
+            f"silencedetect=noise={_SUBTITLE_SILENCE_DB:.0f}dB:d={_SUBTITLE_MIN_SILENCE}",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    if result.returncode != 0:
+        return [], None
+    m = _FFMPEG_DURATION_RE.search(result.stderr)
+    if m is None:
+        return [], None
+    hours, minutes, seconds = (float(g) for g in m.groups())
+    duration = hours * 3600 + minutes * 60 + seconds
+    return _parse_silencedetect_output(result.stderr, duration), duration
+
+
+# 语音识别字幕对齐（faster-whisper，本地 CPU 推理）：
+# seedance 视频自带对白，silencedetect 只能切有声区间、拿不到「哪句话何时开口」。
+# faster-whisper 可用时用 word-level 时间戳把剧本 utterances 逐条配对到真实语音边界
+# （按文本相似度贪心配对，未命中回退按估算时长摆放）；模型缺失 / 下载失败 / 转写
+# 无结果时自动回退到 silencedetect 对齐，绝不中断合成。
+_ASR_MODEL_SIZE = "base"  # tiny/base/small/medium；中文对白 base 在 CPU int8 下性价比最高
+_ASR_MATCH_THRESHOLD = 0.25  # 相似度低于该值视为配对失败，走估算回退
+_ASR_LEAD_PAD = 0.10  # 配对成功后字幕比语音稍早出现（秒）
+_ASR_TAIL_PAD = 0.15  # 配对成功后字幕比语音稍晚消失（秒）
+_ASR_MIN_DISPLAY = 0.3  # 单条字幕最短展示时长（秒）
+
+_ASR_MODEL: Any | None = None
+_ASR_MODEL_ERROR: Exception | None = None
+
+
+def _asr_load_model() -> Any | None:
+    """加载 faster-whisper 模型（进程内缓存）；不可用返回 None 并记录原因。
+
+    首次加载会下载模型（base 约 140MB），下载失败 / 未安装依赖均返回 None，
+    由调用方回退到 silencedetect，不抛出异常。
+    """
+    global _ASR_MODEL, _ASR_MODEL_ERROR
+    if _ASR_MODEL is not None:
+        return _ASR_MODEL
+    if _ASR_MODEL_ERROR is not None:
+        return None
+    if _ASR_MODEL is None and _ASR_MODEL_ERROR is None:
+        print("🗣️ 首次使用将加载 faster-whisper base 模型（约 140MB，仅下载一次）...")
+    try:
+        from faster_whisper import WhisperModel  # pyright: ignore[reportMissingImports]
+    except Exception as exc:  # 未安装 / 平台无 wheel
+        _ASR_MODEL_ERROR = exc
+        return None
+    try:
+        _ASR_MODEL = WhisperModel(_ASR_MODEL_SIZE, device="cpu", compute_type="int8")
+    except Exception as exc:  # 模型下载失败 / 网络不可达
+        _ASR_MODEL_ERROR = exc
+        return None
+    return _ASR_MODEL
+
+
+def _extract_audio_for_asr(video_path: Path, wav_path: Path) -> None:
+    """抽取单声道 16k PCM 供 whisper 转写；ffmpeg 失败抛异常，由调用方回退。"""
+    run_ffmpeg(
+        [
+            _require_tool("ffmpeg"),
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            str(video_path.resolve()),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-f",
+            "wav",
+            str(wav_path),
+        ],
+        "ffmpeg 抽取对白音频失败",
+    )
+
+
+def _asr_word_timestamps(video_path: Path, language: str | None) -> list[tuple[float, float, str]]:
+    """对片段做本地语音识别，返回按时间升序的 (start, end, word)。
+
+    faster-whisper 的 word_timestamps 对中文按字输出时间戳。任一步骤失败返回空列表
+    （模型不可用 / 音频抽取失败 / 转写异常），由调用方决定回退策略。
+    """
+    model = _asr_load_model()
+    if model is None:
+        return []
+    with tempfile.TemporaryDirectory(prefix="arcreel_asr_") as tmp:
+        wav_path = Path(tmp) / "audio.wav"
+        try:
+            _extract_audio_for_asr(video_path, wav_path)
+        except Exception:
+            return []
+        # vad_filter 需要 onnxruntime；缺失时退化到不带 VAD 再试一次
+        for vad in (True, False):
+            try:
+                segments, _info = model.transcribe(
+                    str(wav_path),
+                    language=language if language in ("zh", "en", "ja", "ko") else None,
+                    word_timestamps=True,
+                    vad_filter=vad,
+                )
+                words: list[tuple[float, float, str]] = []
+                for segment in segments:
+                    for word in segment.words or []:
+                        start = float(getattr(word, "start", 0.0))
+                        end = float(getattr(word, "end", start))
+                        token = str(getattr(word, "word", "")).strip()
+                        if token and end > start:
+                            words.append((start, end, token))
+                if words:
+                    return words
+            except Exception:
+                continue
+    return []
+
+
+def _norm_for_match(text: str) -> str:
+    """归一化台词文本：去空白与标点，只留中英文与数字，供相似度配对。"""
+    return re.sub(r"[\W_]+", "", text, flags=re.UNICODE)
+
+
+def _find_best_word_window(
+    target: str, words: list[tuple[float, float, str]], start_idx: int
+) -> tuple[tuple[float, float, int] | None, float]:
+    """在 words[start_idx:] 里贪心找与 target 最相似的连续窗口。
+
+    返回 (窗口 (start, end, 窗口后一位下标), 相似度)。窗口越长长度惩罚越大，
+    避免把整段语音都吞进一条字幕。
+    """
+    target_n = _norm_for_match(target)
+    if not target_n or start_idx >= len(words):
+        return None, 0.0
+    best: tuple[float, float, int] | None = None
+    best_score = 0.0
+    max_len = min(len(words) - start_idx, max(8, len(target_n) + 6))
+    for end_idx in range(start_idx + 1, start_idx + max_len + 1):
+        window = words[start_idx:end_idx]
+        text_n = _norm_for_match("".join(w[2] for w in window))
+        if not text_n:
+            continue
+        ratio = SequenceMatcher(None, target_n, text_n).ratio()
+        length_penalty = 1.0 - 0.4 * abs(len(target_n) - len(text_n)) / max(len(target_n), len(text_n), 1)
+        score = ratio * length_penalty
+        if score > best_score:
+            best_score = score
+            best = (window[0][0], window[-1][1], end_idx)
+    return best, best_score
+
+
+def _align_subtitle_spans_with_asr(
+    spans: list[dict[str, object]],
+    words: list[tuple[float, float, str]],
+    video_duration: float,
+) -> list[dict[str, object]]:
+    """用 ASR 词级时间戳把字幕逐条配到真实语音边界。
+
+    台词按顺序贪心配对：命中相似度阈值就用识别到的起止时间（前后加小段余量），
+    未命中（转写错字严重 / 该句无语音）退回按估算时长从上一句末尾顺延；整体保证
+    单调不重叠、不越出场景时长。配对有顺序约束，越过后不回头，防止后面的台词
+    把前面句子的时间抢走。
+    """
+    if not spans or not words:
+        return spans
+    aligned: list[dict[str, object]] = []
+    cursor = 0.0
+    idx = 0
+    for span in spans:
+        text = str(span["text"])
+        estimated = float(span["duration_seconds"])
+        window, score = _find_best_word_window(text, words, idx)
+        if window is not None and score >= _ASR_MATCH_THRESHOLD:
+            start, end, end_idx = window
+            start = max(start - _ASR_LEAD_PAD, cursor, 0.0)
+            end = min(end + _ASR_TAIL_PAD, video_duration)
+            if end - start < _ASR_MIN_DISPLAY:
+                end = min(start + _ASR_MIN_DISPLAY, video_duration)
+            aligned.append({"offset_seconds": start, "duration_seconds": max(end - start, 0.0), "text": text})
+            cursor = end
+            idx = end_idx
+        else:
+            start = max(cursor, 0.0)
+            duration = min(max(estimated, _ASR_MIN_DISPLAY), max(video_duration - start, 0.0))
+            aligned.append({"offset_seconds": start, "duration_seconds": duration, "text": text})
+            cursor = start + duration
+    return aligned
+
+
+def _align_subtitle_spans_to_audio(
+    spans: list[dict[str, object]],
+    video_duration: float,
+    voiced_segments: list[tuple[float, float]],
+) -> list[dict[str, object]]:
+    """把估算字幕时间轴对齐到片段的真实音频结构。
+
+    - 开场静音：第一个有声区间起点晚于 _SUBTITLE_LEAD_MIN 时整体后移，避免
+      「人还没开口字幕先出」
+    - 溢出缩放：估算总时长超过可用时长（seedance 实际语速快于估算语速，长台词常
+      溢出场景）时按比例压缩，保证每条字幕都落在场景内
+    - 条间留白：除最后一条外，每条结尾让出 _SUBTITLE_GAP 秒，避免字幕贴边连读
+    - 检测失败（voiced_segments 为空）退化为按场景时长缩放，仍优于纯估算
+    """
+    if not spans or video_duration <= 0:
+        return spans
+    lead = 0.0
+    if voiced_segments:
+        first_start = voiced_segments[0][0]
+        if first_start >= _SUBTITLE_LEAD_MIN:
+            lead = first_start
+    available = max(video_duration - lead, 0.0)
+    total_est = sum(float(span["duration_seconds"]) for span in spans)
+    if total_est <= 0:
+        return spans
+    scale = min(1.0, available / total_est)
+    aligned: list[dict[str, object]] = []
+    offset = lead
+    for index, span in enumerate(spans):
+        scaled = float(span["duration_seconds"]) * scale
+        if index == len(spans) - 1:
+            # 末条不扣留白：展示到语音/场景结束，只钳到场景时长
+            display = max(0.0, min(scaled, video_duration - offset))
+        else:
+            display = max(scaled - _SUBTITLE_GAP, min(scaled, _SUBTITLE_MIN_DISPLAY))
+        aligned.append(
+            {
+                "offset_seconds": offset,
+                "duration_seconds": display,
+                "text": span["text"],
+            }
+        )
+        offset += scaled
+    return aligned
+
+
+def _subtitle_spans_from_utterances(utterances: object, language: str | None) -> list[dict[str, object]]:
+    """从 drama 场景的有序 utterances 派生字幕时间片（与剪映导出同口径）。
+
+    dialogue 与 voiceover 都出字幕、按顺序摆放；每条时长按 ``estimate_spoken_seconds``
+    估算、offset 在场景内累加；空 / 纯空白 text、非 dict 条目、估时长为 0（纯标点）跳过
+    且不占 offset。此处不做场景时长拉伸，时间轴对齐由 ``_align_subtitle_spans_to_audio``
+    在拿到片段实际时长与有声区间后统一处理。
+    """
+    spans: list[dict[str, object]] = []
+    offset = 0.0
+    for utterance in utterances if isinstance(utterances, list) else []:
+        if not isinstance(utterance, dict):
+            continue
+        text = utterance.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        duration = estimate_spoken_seconds(text, language)
+        if duration <= 0:
+            continue
+        spans.append({"offset_seconds": offset, "duration_seconds": duration, "text": text})
+        offset += duration
+    return spans
+
+
+def _subtitle_spans_from_unit_shots(shots: object, language: str | None) -> list[dict[str, object]]:
+    """从 reference_video unit 的 ``shots[*].text`` 提取台词/画外音生成字幕时间片。
+
+    与剪映导出同口径（``lib.reference_video.shot_parser``）：整行匹配
+    ``@[角色]：{台词}``（对话）或 ``{台词}``（画外音），镜头描述行不烧字幕。
+    offset 在 unit 内累计，时长按 ``estimate_spoken_seconds`` 估算；空文本 /
+    估时长为 0 的条目跳过且不占 offset（与 ``_subtitle_spans_from_utterances`` 一致）。
+    """
+    spans: list[dict[str, object]] = []
+    offset = 0.0
+    for shot in shots if isinstance(shots, list) else []:
+        if not isinstance(shot, dict):
+            continue
+        text = shot.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        for line in text.splitlines():
+            dialogue = match_dialogue_line(line)
+            if dialogue is not None:
+                spoken = dialogue[1]
+            else:
+                spoken = match_voiceover_line(line)
+            if not isinstance(spoken, str) or not spoken.strip():
+                continue
+            duration = estimate_spoken_seconds(spoken, language)
+            if duration <= 0:
+                continue
+            spans.append({"offset_seconds": offset, "duration_seconds": duration, "text": spoken})
+            offset += duration
+    return spans
+
+
+def _format_srt_timestamp(seconds: float) -> str:
+    """秒 → SRT 时间戳（00:00:00,000）；负值钳到 0。"""
+    total_ms = max(0, int(round(seconds * 1000)))
+    hours, remainder = divmod(total_ms, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, millis = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def _subtitle_font_name() -> str:
+    """按平台挑选中文字体；libass 找不到该字体时会自动回退，不影响渲染。"""
+    if os.name == "nt":
+        return "Microsoft YaHei"
+    if sys.platform == "darwin":
+        return "PingFang SC"
+    return "Noto Sans CJK SC"
+
+
+def _subtitle_char_units(ch: str) -> float:
+    """字符显示宽度单位：东亚全角字符算 1，其余按 0.6 折算。"""
+    return 1.0 if unicodedata.east_asian_width(ch) in ("W", "F") else 0.6
+
+
+def _wrap_subtitle_text(text: str, max_units: float) -> str:
+    """按显示宽度把长台词切成 \\N 硬换行，避免 libass 自动折行溢出画面。
+
+    每行都硬性不超过 max_units：超长台词宁可多拆几行，也不让任何一行横向
+    溢出画面（行数上限由 _render_ass 按最长台词缩字号保证）。空文本原样返回。
+    """
+    text = text.strip()
+    if not text:
+        return text
+    lines: list[str] = []
+    current = ""
+    current_units = 0.0
+    for ch in text:
+        units = _subtitle_char_units(ch)
+        if current and current_units + units > max_units:
+            lines.append(current)
+            current = ch
+            current_units = units
+        else:
+            current += ch
+            current_units += units
+    if current:
+        lines.append(current)
+    return "\\N".join(lines)
+
+
+def _escape_ass_text(text: str) -> str:
+    """转义 ASS 文本里的花括号与反斜杠（防止被当成覆盖标签）。"""
+    return text.replace("\\", "\\\\").replace("{", "\\{").replace("}", "\\}")
+
+
+def _format_ass_timestamp(seconds: float) -> str:
+    """秒 → ASS 时间戳（H:MM:SS.cc 百分秒）；负值钳到 0。"""
+    total_cs = max(0, int(round(seconds * 100)))
+    hours, remainder = divmod(total_cs, 360_000)
+    minutes, remainder = divmod(remainder, 6_000)
+    secs, centis = divmod(remainder, 100)
+    return f"{hours}:{minutes:02d}:{secs:02d}.{centis:02d}"
+
+
+def _render_ass(spans: list[dict[str, object]], target_width: int, target_height: int) -> str:
+    """把字幕时间片渲染为带显式样式的 UTF-8 ASS 文本。
+
+    相比 SRT 的 libass 默认样式（字号/边距不可控，长台词会被压成贴边横幅），ASS
+    直接声明 PlayResX/Y：字号、底部边距、描边都以目标分辨率的像素为准，配合 \\N
+    硬换行保证字幕始终落在画面安全区内。字号按画布高度 6% 取整，边距按宽/高
+    5.5% 取整，均钳到合理范围。
+    """
+    margin_lr = min(max(round(target_width * 0.055), 16), 80)
+    margin_v = min(max(round(target_height * 0.055), 24), 140)
+    max_lines = 5
+    # 描边(2px)*2 + 阴影(1px) 的横向占位，按全角字宽=font_size 保守估算每行字数
+    outline_budget = 8
+    longest_units = max(
+        (sum(_subtitle_char_units(ch) for ch in str(span["text"])) for span in spans),
+        default=0.0,
+    )
+
+    def units_per_line(font_size: int) -> float:
+        return max(4.0, (target_width - 2 * margin_lr - outline_budget) / font_size)
+
+    # 字号自适应：最长台词放不进 max_lines 行时逐档缩小，保证不横向溢出
+    font_size = min(max(round(target_height * 0.06), 20), 64)
+    while longest_units > 0 and font_size > 20 and math.ceil(longest_units / units_per_line(font_size)) > max_lines:
+        font_size -= 2
+    max_units = units_per_line(font_size)
+    blocks = []
+    for span in spans:
+        start = float(span["offset_seconds"])
+        end = start + float(span["duration_seconds"])
+        text = _wrap_subtitle_text(_escape_ass_text(str(span["text"])), max_units)
+        blocks.append(f"Dialogue: 0,{_format_ass_timestamp(start)},{_format_ass_timestamp(end)},Default,,0,0,0,,{text}")
+    events = "\n".join(blocks)
+    return (
+        "[Script Info]\n"
+        "ScriptType: v4.00+\n"
+        f"PlayResX: {target_width}\n"
+        f"PlayResY: {target_height}\n"
+        "WrapStyle: 2\n"
+        "ScaledBorderAndShadow: yes\n"
+        "\n"
+        "[V4+ Styles]\n"
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, "
+        "Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        f"Style: Default,{_subtitle_font_name()},{font_size},&H00FFFFFF,&H000000FF,&H00000000,&H96000000,"
+        f"1,0,0,0,100,100,0,0,1,2,1,2,{margin_lr},{margin_lr},{margin_v},1\n"
+        "\n"
+        "[Events]\n"
+        "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        f"{events}\n"
+    )
+
+
+def _render_srt(spans: list[dict[str, object]]) -> str:
+    """把字幕时间片渲染为 UTF-8 SRT 文本（供 subtitles 滤镜读取）。"""
+    blocks = []
+    for index, span in enumerate(spans, start=1):
+        start = float(span["offset_seconds"])
+        end = start + float(span["duration_seconds"])
+        text = str(span["text"])
+        blocks.append(f"{index}\n{_format_srt_timestamp(start)} --> {_format_srt_timestamp(end)}\n{text}")
+    return "\n\n".join(blocks) + ("\n" if blocks else "")
+
+
+def _escape_subtitles_filter_path(path: Path) -> str:
+    """把字幕文件路径转成 subtitles 滤镜可用的 filename 值。
+
+    实测（ffmpeg 6.x Gyan build + libass）：反斜杠换正斜杠、冒号前加反斜杠
+    （否则盘符冒号会被当作选项分隔符），整个值用单引号包裹以保护空格 / 逗号；
+    引号内不能再反斜杠转义逗号（实测反斜杠逗号会原样传给 libass 导致文件打不开）。
+    """
+    value = str(path.resolve()).replace("\\", "/").replace(":", "\\:")
+    if "'" in value:
+        raise ValueError(f"字幕文件路径含单引号，无法安全传给 subtitles 滤镜: {value}")
+    return f"filename='{value}'"
+
+
 def normalize_clip(
     video_path: Path,
     output_path: Path,
@@ -203,6 +797,7 @@ def normalize_clip(
     target_width: int,
     target_height: int,
     target_fps: str,
+    subtitles_path: Path | None = None,
 ) -> None:
     """先把单个片段重编码为统一中间片，再做最终拼接。"""
     media = probe_media(video_path)
@@ -213,12 +808,17 @@ def normalize_clip(
         f"setsar=1,fps={target_fps},format=yuv420p,setpts=PTS-STARTPTS"
     )
 
+    if subtitles_path is not None:
+        # 字幕在统一画布上烧录：放滤镜链尾，时间轴相对本片段（setpts 已归零），
+        # 之后 concat / 转场不再重编码视频，字幕天然跟着所属场景走
+        video_filter += f",subtitles={_escape_subtitles_filter_path(subtitles_path)}"
+
     if media["has_audio"]:
         filter_complex = (
             f"[0:v]{video_filter}[vout];[0:a]aresample=48000,aformat=channel_layouts=stereo,asetpts=PTS-STARTPTS[aout]"
         )
         cmd = [
-            "ffmpeg",
+            _require_tool("ffmpeg"),
             "-y",
             "-i",
             str(video_path.resolve()),
@@ -251,7 +851,7 @@ def normalize_clip(
             f"[0:v]{video_filter}[vout];[1:a]atrim=duration={float(media['duration']):.6f},asetpts=PTS-STARTPTS[aout]"
         )
         cmd = [
-            "ffmpeg",
+            _require_tool("ffmpeg"),
             "-y",
             "-i",
             str(video_path.resolve()),
@@ -288,7 +888,11 @@ def normalize_clip(
     run_ffmpeg(cmd, "ffmpeg 规范化片段失败")
 
 
-def normalize_clips(video_paths: list[Path], temp_dir: Path) -> list[Path]:
+def normalize_clips(
+    video_paths: list[Path],
+    temp_dir: Path,
+    subtitle_spanss: list[list[dict[str, object]]] | None = None,
+) -> list[Path]:
     """将全部片段统一成可安全拼接的中间片。"""
     first = probe_media(video_paths[0])
     target_width = int(first["width"])
@@ -298,12 +902,18 @@ def normalize_clips(video_paths: list[Path], temp_dir: Path) -> list[Path]:
     normalized_paths: list[Path] = []
     for index, path in enumerate(video_paths):
         normalized_path = temp_dir / f"normalized_{index:03d}.mp4"
+        subtitles_path = None
+        if subtitle_spanss is not None and index < len(subtitle_spanss) and subtitle_spanss[index]:
+            ass_path = temp_dir / f"subtitles_{index:03d}.ass"
+            ass_path.write_text(_render_ass(subtitle_spanss[index], target_width, target_height), encoding="utf-8")
+            subtitles_path = ass_path
         normalize_clip(
             path,
             normalized_path,
             target_width=target_width,
             target_height=target_height,
             target_fps=target_fps,
+            subtitles_path=subtitles_path,
         )
         normalized_paths.append(normalized_path)
     return normalized_paths
@@ -319,7 +929,7 @@ def concatenate_final(video_paths: list[Path], output_path: Path):
         # 中间片在 normalize_clip 内已统一编码 + setpts 归零，这里只需补 +faststart
         run_ffmpeg(
             [
-                "ffmpeg",
+                _require_tool("ffmpeg"),
                 "-y",
                 "-i",
                 str(video_paths[0].resolve()),
@@ -346,7 +956,7 @@ def concatenate_final(video_paths: list[Path], output_path: Path):
     filter_complex = "".join(filter_inputs) + f"concat=n={len(video_paths)}:v=1:a=1[vout][aout]"
     run_ffmpeg(
         [
-            "ffmpeg",
+            _require_tool("ffmpeg"),
             "-y",
             *inputs,
             "-filter_complex",
@@ -375,7 +985,11 @@ def concatenate_final(video_paths: list[Path], output_path: Path):
     )
 
 
-def concatenate_simple(video_paths: list, output_path: Path):
+def concatenate_simple(
+    video_paths: list,
+    output_path: Path,
+    subtitle_spanss: list[list[dict[str, object]]] | None = None,
+):
     """
     无转场拼接
 
@@ -383,7 +997,7 @@ def concatenate_simple(video_paths: list, output_path: Path):
     避免直接 copy 原始码流时的关键帧 / 时间戳边界问题。
     """
     with tempfile.TemporaryDirectory(prefix="compose-video-") as temp_dir:
-        normalized_paths = normalize_clips(video_paths, Path(temp_dir))
+        normalized_paths = normalize_clips(video_paths, Path(temp_dir), subtitle_spanss=subtitle_spanss)
         concatenate_final(normalized_paths, output_path)
 
 
@@ -496,13 +1110,17 @@ def _build_xfade_filter_complex(
 
 
 def concatenate_with_transitions(
-    video_paths: list, transitions: list, output_path: Path, transition_duration: float = 0.5
+    video_paths: list,
+    transitions: list,
+    output_path: Path,
+    transition_duration: float = 0.5,
+    subtitle_spanss: list[list[dict[str, object]]] | None = None,
 ):
     """
     使用 xfade 滤镜实现场景间转场，cut 边界用 concat 串联以避免滤镜链断裂。
     """
     with tempfile.TemporaryDirectory(prefix="compose-video-") as temp_dir:
-        normalized_paths = normalize_clips(video_paths, Path(temp_dir))
+        normalized_paths = normalize_clips(video_paths, Path(temp_dir), subtitle_spanss=subtitle_spanss)
         if len(normalized_paths) < 2:
             concatenate_final(normalized_paths, output_path)
             return
@@ -523,7 +1141,7 @@ def concatenate_with_transitions(
             inputs.extend(["-i", str(path.resolve())])
 
         cmd = [
-            "ffmpeg",
+            _require_tool("ffmpeg"),
             "-y",
             *inputs,
             "-filter_complex",
@@ -549,7 +1167,7 @@ def concatenate_with_transitions(
             str(output_path),
         ]
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
 
         if result.returncode != 0:
             print(f"⚠️  转场效果失败，尝试简单拼接: {result.stderr[:200]}")
@@ -567,7 +1185,7 @@ def add_background_music(video_path: Path, music_path: Path, output_path: Path, 
         music_volume: 背景音乐音量 (0-1)
     """
     cmd = [
-        "ffmpeg",
+        _require_tool("ffmpeg"),
         "-y",
         "-i",
         str(video_path),
@@ -586,14 +1204,27 @@ def add_background_music(video_path: Path, music_path: Path, output_path: Path, 
         str(output_path),
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
 
     if result.returncode != 0:
         raise RuntimeError(f"添加背景音乐失败: {result.stderr}")
 
 
+def _project_source_language(pm: ProjectManager, project_name: str) -> str | None:
+    """项目源语言，决定字幕语速；缺失回退 None（用默认语速）。"""
+    project = pm.load_project(project_name)
+    value = project.get("source_language") or (project.get("overview") or {}).get("language")
+    return value if isinstance(value, str) and value.strip() else None
+
+
 def compose_video(
-    script_filename: str, output_filename: str = None, music_path: str = None, use_transitions: bool = True
+    script_filename: str,
+    output_filename: str = None,
+    music_path: str = None,
+    use_transitions: bool = True,
+    subtitles: bool = False,
+    audio_align: bool = True,
+    asr: bool = True,
 ) -> Path:
     """
     合成最终视频
@@ -603,21 +1234,43 @@ def compose_video(
         output_filename: 输出文件名
         music_path: 背景音乐文件路径
         use_transitions: 是否使用转场效果
+        subtitles: 是否把台词 / 画外音烧录为字幕（需 ffmpeg 带 libass）
+        audio_align: 是否按真实音频对齐字幕时间轴（开场静音偏移 + 溢出缩放；
+            检测失败自动回退为按场景时长缩放）
+        asr: audio_align 开启时是否先用 faster-whisper 语音识别把每条字幕配到
+            真实语音边界；模型不可用 / 转写失败自动回退到 silencedetect 对齐
 
     Returns:
         输出视频路径
     """
     pm, project_name, project_dir = _require_project_cwd()
 
+    if subtitles and not _check_subtitles_support():
+        raise RuntimeError(
+            "当前 ffmpeg 未编译 libass，无法烧录字幕（subtitles 滤镜不可用）。"
+            "请换用完整版 ffmpeg（如 gyan.dev 的 full/essentials build，或 winget install --id Gyan.FFmpeg -e）"
+        )
+
     # 加载剧本（pm.load_script 内部已用 _safe_subpath 过滤 ../ 等逃逸尝试）
     script = pm.load_script(project_name, script_filename)
 
-    # 仅支持 drama 模式（顶层 scenes[]）；narration/ad/reference_video 给友好错误
-    if "scenes" not in script:
+    # 剧本顶层骨架：drama 读 scenes[]，reference_video 路线读 video_units[]；
+    # 其余（narration/ad）给友好错误。
+    if "scenes" in script:
+        items = script["scenes"]
+        item_kind = "场景"
+        item_id_key = "scene_id"
+        subtitle_source = "utterances"
+    elif "video_units" in script:
+        items = script["video_units"]
+        item_kind = "视频单元"
+        item_id_key = "unit_id"
+        subtitle_source = "shots"
+    else:
         content_mode = script.get("content_mode") or "unknown"
         actual_keys = [k for k in ("segments", "shots", "video_units") if k in script]
         raise RuntimeError(
-            f"compose_video.py 目前仅支持 drama 模式（剧本顶层需有 scenes[]）；"
+            f"compose_video.py 仅支持 drama（顶层 scenes[]）与 reference_video（顶层 video_units[]）；"
             f"当前剧本 content_mode={content_mode}，实际结构含 {actual_keys or ['无法识别']}，"
             "请使用 Web 端剪映草稿导出"
         )
@@ -626,10 +1279,10 @@ def compose_video(
     video_paths = []
     transitions = []
 
-    for scene in script["scenes"]:
-        video_clip = get_generated_assets(scene).get("video_clip")
+    for item in items:
+        video_clip = get_generated_assets(item).get("video_clip")
         if not video_clip:
-            raise ValueError(f"场景 {scene['scene_id']} 缺少视频片段")
+            raise ValueError(f"{item_kind} {item.get(item_id_key)} 缺少视频片段")
 
         # 与 --music / output 同样的围栏：剧本里 video_clip 写成绝对路径或 ../
         # 形式时，未 resolve 的 `project_dir / video_clip` 会落到项目外（且字面
@@ -642,12 +1295,48 @@ def compose_video(
             raise FileNotFoundError(f"视频文件不存在或不是普通文件: {video_path}")
 
         video_paths.append(video_path)
-        transitions.append(scene.get("transition_to_next", "cut"))
+        transitions.append(item.get("transition_to_next", "cut"))
 
     if not video_paths:
         raise ValueError("没有可用的视频片段")
 
     print(f"📹 共 {len(video_paths)} 个视频片段")
+
+    # 字幕：按场景 utterances 派生时间片（与剪映导出同口径），与 video_paths 一一对应；
+    # 默认再按真实音频对齐时间轴（开场静音偏移 + 溢出缩放），检测失败时按场景时长缩放
+    subtitle_spanss = None
+    if subtitles:
+        language = _project_source_language(pm, project_name)
+        subtitle_spanss = []
+        asr_scenes = 0
+        for item, video_path in zip(items, video_paths):
+            if subtitle_source == "shots":
+                spans = _subtitle_spans_from_unit_shots(item.get("shots"), language)
+            else:
+                spans = _subtitle_spans_from_utterances(item.get("utterances"), language)
+            if audio_align and spans:
+                asr_words: list[tuple[float, float, str]] = []
+                if asr:
+                    asr_words = _asr_word_timestamps(video_path, language)
+                if asr_words:
+                    spans = _align_subtitle_spans_with_asr(spans, asr_words, get_video_duration(video_path))
+                    asr_scenes += 1
+                else:
+                    voiced, detected_duration = _detect_voiced_segments(video_path)
+                    duration = detected_duration if detected_duration is not None else get_video_duration(video_path)
+                    spans = _align_subtitle_spans_to_audio(spans, duration, voiced)
+            subtitle_spanss.append(spans)
+        non_empty = sum(1 for spans in subtitle_spanss if spans)
+        if audio_align:
+            if asr and non_empty > 0 and asr_scenes == non_empty:
+                align_note = "，已用 faster-whisper 语音识别按真实语音对齐时间轴"
+            elif asr:
+                align_note = "，已按真实音频对齐时间轴（faster-whisper 不可用，回退 silencedetect）"
+            else:
+                align_note = "，已按真实音频对齐时间轴"
+        else:
+            align_note = ""
+        print(f"📝 字幕：{non_empty}/{len(video_paths)} 个片段含台词，将烧录到画面底部{align_note}")
 
     # 确定输出路径：强制落在 project_dir/output/ 内，拒绝 ../ 逃逸
     if output_filename is None:
@@ -682,9 +1371,9 @@ def compose_video(
     print("🎬 正在合成视频...")
 
     if use_transitions and any(t != "cut" for t in transitions):
-        concatenate_with_transitions(video_paths, transitions, output_path)
+        concatenate_with_transitions(video_paths, transitions, output_path, subtitle_spanss=subtitle_spanss)
     else:
-        concatenate_simple(video_paths, output_path)
+        concatenate_simple(video_paths, output_path, subtitle_spanss=subtitle_spanss)
 
     print(f"✅ 视频合成完成: {output_path}")
 
@@ -705,18 +1394,37 @@ def main():
     parser.add_argument("--output", help="输出文件名")
     parser.add_argument("--music", help="背景音乐文件")
     parser.add_argument("--no-transitions", action="store_true", help="不使用转场效果")
+    parser.add_argument("--subtitles", action="store_true", help="把台词/画外音烧录为字幕")
+    parser.add_argument("--no-audio-align", action="store_true", help="字幕不按真实音频对齐（仅按语速估算）")
+    parser.add_argument(
+        "--no-asr", action="store_true", help="不使用 faster-whisper 语音识别对齐字幕（回退 silencedetect）"
+    )
 
     args = parser.parse_args()
 
     # 检查 ffmpeg / ffprobe
     if not check_ffmpeg():
         print(f"❌ 错误: {FFMPEG_TOOLS_HINT}")
-        print("   macOS 可执行: brew install ffmpeg")
+        if os.name == "nt":
+            print("   Windows 可执行: winget install --id Gyan.FFmpeg -e")
+            print("   或从 https://www.gyan.dev/ffmpeg/builds/ 下载 essentials 版，解压后把 bin 目录加入 PATH")
+            print("   安装后请重启 git bash / 终端再试")
+        else:
+            print("   macOS 可执行: brew install ffmpeg")
+            print("   Linux 可执行: sudo apt install ffmpeg")
         print("   安装后请确认 ffmpeg -version 和 ffprobe -version 都能执行")
         sys.exit(1)
 
     try:
-        output_path = compose_video(args.script, args.output, args.music, use_transitions=not args.no_transitions)
+        output_path = compose_video(
+            args.script,
+            args.output,
+            args.music,
+            use_transitions=not args.no_transitions,
+            subtitles=args.subtitles,
+            audio_align=not args.no_audio_align,
+            asr=not args.no_asr,
+        )
 
         print(f"\n🎉 最终视频: {output_path}")
         print("   单独片段保留在: videos/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "portalocker>=2.10.1",
     "pdf-oxide>=0.3.46",
     "socksio>=1.0.0",
+    "faster-whisper>=1.2.1",
+    "onnxruntime==1.20.1",
+    "ctranslate2==4.8.1",
 ]
 
 [dependency-groups]

--- a/tests/test_compose_video_filter_graph.py
+++ b/tests/test_compose_video_filter_graph.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
 import sys
 import tempfile
@@ -393,3 +394,562 @@ class TestConcatenateFinalSingleSegment:
     def test_empty_list_raises(self) -> None:
         with pytest.raises(ValueError, match="没有可用的视频片段"):
             compose_video.concatenate_final([], Path(tempfile.gettempdir()) / "unused.mp4")
+
+
+# ---------------------------------------------------------------------------
+# 字幕：utterances → spans
+# ---------------------------------------------------------------------------
+
+
+class TestSubtitleSpansFromUtterances:
+    """drama 场景 utterances → 字幕时间片（与剪映草稿导出同口径）。"""
+
+    def test_dialogue_and_voiceover_in_order(self) -> None:
+        utterances = [
+            {"kind": "dialogue", "speaker": "A", "text": "你好世界"},
+            {"kind": "voiceover", "speaker": "", "text": "这是一段旁白"},
+        ]
+        spans = compose_video._subtitle_spans_from_utterances(utterances, "zh")
+        assert [s["text"] for s in spans] == ["你好世界", "这是一段旁白"]
+        assert spans[0]["offset_seconds"] == pytest.approx(0.0)
+        assert spans[0]["duration_seconds"] == pytest.approx(0.8)  # 4 字 @ 5/秒
+        assert spans[1]["offset_seconds"] == pytest.approx(0.8)
+        assert spans[1]["duration_seconds"] == pytest.approx(1.2)  # 6 字 @ 5/秒
+
+    def test_language_changes_rate(self) -> None:
+        zh = compose_video._subtitle_spans_from_utterances([{"text": "你好世界"}], "zh")
+        en = compose_video._subtitle_spans_from_utterances([{"text": "hello world"}], "en")
+        assert zh[0]["duration_seconds"] == pytest.approx(0.8)  # 4 字 @ 5/秒
+        assert en[0]["duration_seconds"] == pytest.approx(0.8)  # 2 词 @ 2.5/秒
+
+    def test_blank_text_skipped_without_consuming_offset(self) -> None:
+        utterances = [
+            {"text": "   "},
+            {"text": ""},
+            {"text": "你好"},
+            {"text": "\n\t"},
+        ]
+        spans = compose_video._subtitle_spans_from_utterances(utterances, "zh")
+        assert len(spans) == 1
+        assert spans[0]["text"] == "你好"
+        assert spans[0]["offset_seconds"] == pytest.approx(0.0)
+
+    def test_halfwidth_punctuation_only_skipped(self) -> None:
+        """半角标点无阅读单位 → 估时 0 → 不产字幕也不占 offset。"""
+        utterances = [{"text": "?!"}, {"text": "..."}, {"text": "你好"}]
+        spans = compose_video._subtitle_spans_from_utterances(utterances, "zh")
+        assert len(spans) == 1
+        assert spans[0]["offset_seconds"] == pytest.approx(0.0)
+
+    def test_non_dict_and_non_string_entries_skipped(self) -> None:
+        utterances = ["bad", 42, None, {"text": None}, {"text": 123}, {"text": "你好"}]
+        spans = compose_video._subtitle_spans_from_utterances(utterances, "zh")
+        assert [s["text"] for s in spans] == ["你好"]
+
+    def test_non_list_input_returns_empty(self) -> None:
+        assert compose_video._subtitle_spans_from_utterances(None, "zh") == []
+        assert compose_video._subtitle_spans_from_utterances({"text": "你好"}, "zh") == []
+
+
+# ---------------------------------------------------------------------------
+# 字幕：SRT 渲染
+# ---------------------------------------------------------------------------
+
+
+class TestSrtRendering:
+    def test_timestamp_format(self) -> None:
+        assert compose_video._format_srt_timestamp(0) == "00:00:00,000"
+        assert compose_video._format_srt_timestamp(1.234) == "00:00:01,234"
+        assert compose_video._format_srt_timestamp(3661.5) == "01:01:01,500"
+        assert compose_video._format_srt_timestamp(-3) == "00:00:00,000"
+
+    def test_render_srt_structure(self) -> None:
+        spans = [
+            {"offset_seconds": 0.0, "duration_seconds": 0.8, "text": "你好"},
+            {"offset_seconds": 0.8, "duration_seconds": 1.2, "text": "这是一段旁白"},
+        ]
+        rendered = compose_video._render_srt(spans)
+        assert rendered.startswith("1\n00:00:00,000 --> 00:00:00,800\n你好")
+        assert "\n\n2\n00:00:00,800 --> 00:00:02,000\n这是一段旁白\n" in rendered
+        assert rendered.endswith("\n")
+
+    def test_render_srt_empty(self) -> None:
+        assert compose_video._render_srt([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# 字幕：subtitles 滤镜路径转义
+# ---------------------------------------------------------------------------
+
+
+class TestSubtitlesPathEscaping:
+    def test_forward_slash_relative_end(self) -> None:
+        escaped = compose_video._escape_subtitles_filter_path(Path("scripts") / "subs.srt")
+        assert escaped.startswith("filename='")
+        assert escaped.endswith("/scripts/subs.srt'")
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows 盘符路径形态")
+    def test_windows_drive_colon_escaped(self) -> None:
+        escaped = compose_video._escape_subtitles_filter_path(Path(r"C:\Users\test\subs.srt"))
+        assert escaped == "filename='C\\:/Users/test/subs.srt'"
+
+    def test_quote_in_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="单引号"):
+            compose_video._escape_subtitles_filter_path(Path(r"C:\O'Brien\subs.srt"))
+
+
+# ---------------------------------------------------------------------------
+# normalize_clip 字幕烧录
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeClipSubtitles:
+    def test_subtitles_filter_appended(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        captured: dict[str, list[str]] = {}
+
+        def fake_probe(path: Path) -> dict[str, object]:
+            return {"width": 320, "height": 240, "fps": "25/1", "duration": 2.0, "has_audio": True}
+
+        def fake_run_ffmpeg(cmd: list[str], _error_prefix: str) -> None:
+            captured["cmd"] = cmd
+
+        monkeypatch.setattr(compose_video, "probe_media", fake_probe)
+        monkeypatch.setattr(compose_video, "run_ffmpeg", fake_run_ffmpeg)
+
+        source = tmp_path / "clip.mp4"
+        source.write_bytes(b"\x00" * 16)
+        output = tmp_path / "normalized.mp4"
+        srt = tmp_path / "subs.srt"
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8")
+
+        compose_video.normalize_clip(
+            source, output, target_width=320, target_height=240, target_fps="25/1", subtitles_path=srt
+        )
+
+        filter_complex = captured["cmd"][captured["cmd"].index("-filter_complex") + 1]
+        assert "subtitles=filename='" in filter_complex
+        assert "setpts=PTS-STARTPTS,subtitles=" in filter_complex
+
+    def test_no_subtitles_keeps_plain_filter(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        captured: dict[str, list[str]] = {}
+
+        def fake_probe(path: Path) -> dict[str, object]:
+            return {"width": 320, "height": 240, "fps": "25/1", "duration": 2.0, "has_audio": True}
+
+        def fake_run_ffmpeg(cmd: list[str], _error_prefix: str) -> None:
+            captured["cmd"] = cmd
+
+        monkeypatch.setattr(compose_video, "probe_media", fake_probe)
+        monkeypatch.setattr(compose_video, "run_ffmpeg", fake_run_ffmpeg)
+
+        source = tmp_path / "clip.mp4"
+        source.write_bytes(b"\x00" * 16)
+        output = tmp_path / "normalized.mp4"
+
+        compose_video.normalize_clip(source, output, target_width=320, target_height=240, target_fps="25/1")
+
+        filter_complex = captured["cmd"][captured["cmd"].index("-filter_complex") + 1]
+        assert "subtitles=" not in filter_complex
+
+
+# ---------------------------------------------------------------------------
+# 字幕音频对齐：silencedetect 解析 + 时间轴对齐
+# ---------------------------------------------------------------------------
+
+
+class TestParseSilencedetectOutput:
+    """silencedetect stderr → 有声区间（含首/中/尾静音、无静音等形态）。"""
+
+    def test_no_silence_returns_full_segment(self) -> None:
+        assert compose_video._parse_silencedetect_output("frame=...", 10.0) == [(0.0, 10.0)]
+
+    def test_leading_and_inner_silence(self) -> None:
+        stderr = (
+            "  Duration: 00:00:12.00, start: 0.000000, bitrate: 6000 kb/s\n"
+            "[silencedetect @ 0] silence_start: 0\n"
+            "[silencedetect @ 0] silence_end: 0.64 | silence_duration: 0.64\n"
+            "[silencedetect @ 0] silence_start: 3.95\n"
+            "[silencedetect @ 0] silence_end: 4.44 | silence_duration: 0.49\n"
+        )
+        assert compose_video._parse_silencedetect_output(stderr, 12.0) == [(0.64, 3.95), (4.44, 12.0)]
+
+    def test_trailing_silence_capped_at_duration(self) -> None:
+        stderr = "silence_start: 9.05\nsilence_end: 9.37 | silence_duration: 0.32\n"
+        assert compose_video._parse_silencedetect_output(stderr, 10.08) == [(0.0, 9.05), (9.37, 10.08)]
+
+    def test_unmatched_start_treated_as_fully_voiced(self) -> None:
+        """只报 silence_start 不报 end（流在静音中结束的极端情况）→ 忽略，整体有声。"""
+        assert compose_video._parse_silencedetect_output("silence_start: 5.0", 8.0) == [(0.0, 8.0)]
+
+
+class TestDetectVoicedSegments:
+    """_detect_voiced_segments：subprocess 失败回退、Duration 从同一份 stderr 解析。"""
+
+    def test_ffmpeg_failure_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeResult:
+            returncode = 1
+            stderr = "no such file"
+
+        monkeypatch.setattr(compose_video.subprocess, "run", lambda *a, **k: FakeResult())
+        assert compose_video._detect_voiced_segments(Path("missing.mp4")) == ([], None)
+
+    def test_parses_duration_from_same_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stderr = (
+            "  Duration: 00:00:10.08, start: 0.000000, bitrate: 6610 kb/s\n"
+            "[silencedetect @ 0] silence_start: 1.69\n"
+            "[silencedetect @ 0] silence_end: 2.01 | silence_duration: 0.32\n"
+        )
+
+        fake_result = type("FakeResult", (), {"returncode": 0, "stderr": stderr})
+        monkeypatch.setattr(compose_video.subprocess, "run", lambda *a, **k: fake_result)
+        voiced, duration = compose_video._detect_voiced_segments(Path("scene.mp4"))
+        assert voiced == [(0.0, 1.69), (2.01, 10.08)]
+        assert duration == pytest.approx(10.08)
+
+    def test_cmd_uses_silencedetect_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, list[str]] = {}
+
+        class FakeResult:
+            returncode = 1
+            stderr = ""
+
+        def fake_run(cmd: list[str], **kwargs: object) -> FakeResult:
+            captured["cmd"] = cmd
+            return FakeResult()
+
+        monkeypatch.setattr(compose_video.subprocess, "run", fake_run)
+        compose_video._detect_voiced_segments(Path("scene.mp4"))
+        af = captured["cmd"][captured["cmd"].index("-af") + 1]
+        assert "silencedetect=noise=-25dB:d=0.3" in af
+
+
+class TestAlignSubtitleSpansToAudio:
+    """估算时间轴 → 音频对齐：溢出缩放、开场静音偏移、条间留白、失败回退。"""
+
+    @staticmethod
+    def _spans(durations: list[float]) -> list[dict[str, object]]:
+        out: list[dict[str, object]] = []
+        offset = 0.0
+        for index, duration in enumerate(durations):
+            out.append({"offset_seconds": offset, "duration_seconds": duration, "text": f"L{index}"})
+            offset += duration
+        return out
+
+    def test_single_span_within_scene_unchanged(self) -> None:
+        out = compose_video._align_subtitle_spans_to_audio(self._spans([2.0]), 10.0, [(0.0, 10.0)])
+        assert out[0]["offset_seconds"] == pytest.approx(0.0)
+        assert out[0]["duration_seconds"] == pytest.approx(2.0)
+
+    def test_overflow_scaled_and_gap_applied(self) -> None:
+        spans = self._spans([6.4, 3.2])
+        out = compose_video._align_subtitle_spans_to_audio(spans, 4.8, [(0.0, 4.8)])
+        # 估算 9.6s 塞进 4.8s（scale=0.5）；首条扣 0.25s 留白，末条展示到场景结束
+        assert out[0]["offset_seconds"] == pytest.approx(0.0)
+        assert out[0]["duration_seconds"] == pytest.approx(3.2 - 0.25)
+        assert out[1]["offset_seconds"] == pytest.approx(3.2)
+        assert out[1]["duration_seconds"] == pytest.approx(1.6)
+
+    def test_leading_silence_shifts_and_compresses(self) -> None:
+        spans = self._spans([5.0, 5.0])
+        out = compose_video._align_subtitle_spans_to_audio(spans, 10.0, [(2.0, 10.0)])
+        # 开场静音 2s：可用 8s，scale=0.8；offset 从 2.0 起
+        assert out[0]["offset_seconds"] == pytest.approx(2.0)
+        assert out[0]["duration_seconds"] == pytest.approx(4.0 - 0.25)
+        assert out[1]["offset_seconds"] == pytest.approx(6.0)
+        assert out[1]["duration_seconds"] == pytest.approx(4.0)
+
+    def test_small_lead_ignored(self) -> None:
+        out = compose_video._align_subtitle_spans_to_audio(self._spans([2.0]), 10.0, [(0.1, 10.0)])
+        assert out[0]["offset_seconds"] == pytest.approx(0.0)
+
+    def test_empty_voiced_falls_back_to_duration_scale(self) -> None:
+        out = compose_video._align_subtitle_spans_to_audio(self._spans([5.0]), 2.5, [])
+        assert out[0]["duration_seconds"] == pytest.approx(2.5)
+
+    def test_empty_spans_passthrough(self) -> None:
+        assert compose_video._align_subtitle_spans_to_audio([], 10.0, [(0.0, 10.0)]) == []
+
+    def test_short_span_keeps_min_display(self) -> None:
+        out = compose_video._align_subtitle_spans_to_audio(self._spans([0.2]), 10.0, [(0.0, 10.0)])
+        assert out[0]["duration_seconds"] == pytest.approx(0.2)
+
+    def test_zero_duration_video_returns_same_list(self) -> None:
+        spans = self._spans([2.0])
+        assert compose_video._align_subtitle_spans_to_audio(spans, 0.0, [(0.0, 10.0)]) is spans
+
+
+# ---------------------------------------------------------------------------
+# 字幕：ASS 渲染（显式样式 + 硬换行，替代 SRT 默认样式的贴边/溢出问题）
+# ---------------------------------------------------------------------------
+
+
+class TestWrapSubtitleText:
+    def test_wraps_cjk_at_max_units(self) -> None:
+        text = "大哥，做兄弟的和你结义之时，说什么来？"
+        wrapped = compose_video._wrap_subtitle_text(text, 12)
+        assert wrapped == "大哥，做兄弟的和你结义之\\N时，说什么来？"
+
+    def test_long_text_never_overflows_a_line(self) -> None:
+        # 20 个全角字、max_units=6：宁可多拆几行，也不让任何一行超过 max_units
+        text = "一二三四五六七八九十甲乙丙丁戊己庚辛壬癸"
+        wrapped = compose_video._wrap_subtitle_text(text, 6)
+        lines = wrapped.split("\\N")
+        assert lines == ["一二三四五六", "七八九十甲乙", "丙丁戊己庚辛", "壬癸"]
+        assert all(len(line) <= 6 for line in lines)
+
+    def test_blank_text_passthrough(self) -> None:
+        assert compose_video._wrap_subtitle_text("   ", 12) == ""
+        assert compose_video._wrap_subtitle_text("", 12) == ""
+
+    def test_narrow_chars_consume_less_units(self) -> None:
+        # 2 个全角 + 10 个半角 = 8 单位 ≤ 8 → 单行
+        wrapped = compose_video._wrap_subtitle_text("你好helloworld", 8)
+        assert "\\N" not in wrapped
+
+
+class TestEscapeAssText:
+    def test_braces_and_backslash_escaped(self) -> None:
+        assert compose_video._escape_ass_text("a{b}c\\d") == "a\\{b\\}c\\\\d"
+        assert compose_video._escape_ass_text("普通文本") == "普通文本"
+
+
+class TestFormatAssTimestamp:
+    def test_format(self) -> None:
+        assert compose_video._format_ass_timestamp(0) == "0:00:00.00"
+        assert compose_video._format_ass_timestamp(1.234) == "0:00:01.23"
+        assert compose_video._format_ass_timestamp(3661.5) == "1:01:01.50"
+        assert compose_video._format_ass_timestamp(-3) == "0:00:00.00"
+
+
+class TestRenderAss:
+    def test_structure_with_playres_and_style(self) -> None:
+        rendered = compose_video._render_ass(
+            [{"offset_seconds": 1.8, "duration_seconds": 3.2, "text": "你好"}], 720, 1280
+        )
+        assert "PlayResX: 720\nPlayResY: 1280" in rendered
+        assert "WrapStyle: 2" in rendered
+        assert "Style: Default," in rendered
+        assert "Dialogue: 0,0:00:01.80,0:00:05.00,Default,,0,0,0,,你好" in rendered
+
+    def test_style_numbers_scale_with_width(self) -> None:
+        small = compose_video._render_ass([{"offset_seconds": 0.0, "duration_seconds": 1.0, "text": "x"}], 540, 960)
+        large = compose_video._render_ass([{"offset_seconds": 0.0, "duration_seconds": 1.0, "text": "x"}], 1080, 1920)
+        small_style = next(line for line in small.splitlines() if line.startswith("Style: Default,"))
+        large_style = next(line for line in large.splitlines() if line.startswith("Style: Default,"))
+        small_font = int(small_style.split(",")[2])
+        large_font = int(large_style.split(",")[2])
+        assert small_font < large_font
+
+    def test_long_text_wrapped_with_hard_breaks(self) -> None:
+        text = "大哥，做兄弟的和你结义之时，说什么来？有福同享，有难同当！"
+        rendered = compose_video._render_ass(
+            [{"offset_seconds": 0.0, "duration_seconds": 5.0, "text": text}], 720, 1280
+        )
+        assert "\\N" in rendered
+        # 整段文本仍在同一 Dialogue 行内（ASS 硬换行不是真实换行）
+        dialogue = next(line for line in rendered.splitlines() if line.startswith("Dialogue: 0,"))
+        assert dialogue.count("\\N") >= 1
+
+    def test_long_monologue_wrapped_within_width(self) -> None:
+        text = (
+            "大哥，做兄弟的和你结义之时，说什么来？咱俩有福同享，有难同当，"
+            "不愿同年同月同日生，但愿同年同月同日死。今日大哥有难，兄弟焉能苟且偷生？"
+        )
+        rendered = compose_video._render_ass(
+            [{"offset_seconds": 0.0, "duration_seconds": 12.0, "text": text}], 720, 1280
+        )
+        style = next(line for line in rendered.splitlines() if line.startswith("Style: Default,"))
+        parts = style.split(",")
+        font_size = int(parts[2])
+        margin_lr = int(parts[19])
+        dialogue = next(line for line in rendered.splitlines() if line.startswith("Dialogue: 0,"))
+        body = dialogue.rsplit(",,", 1)[-1]
+        max_units = (720 - 2 * margin_lr - 8) / font_size
+        for line in body.split("\\N"):
+            units = sum(compose_video._subtitle_char_units(ch) for ch in line)
+            assert units <= max_units + 0.001
+        assert body.count("\\N") >= 4
+
+    def test_very_long_text_shrinks_font_to_stay_in_bounds(self) -> None:
+        text = "好" * 120
+        rendered = compose_video._render_ass(
+            [{"offset_seconds": 0.0, "duration_seconds": 30.0, "text": text}], 720, 1280
+        )
+        style = next(line for line in rendered.splitlines() if line.startswith("Style: Default,"))
+        font_size = int(style.split(",")[2])
+        dialogue = next(line for line in rendered.splitlines() if line.startswith("Dialogue: 0,"))
+        body = dialogue.rsplit(",,", 1)[-1]
+        lines = body.split("\\N")
+        assert font_size < 50
+        assert len(lines) <= 5
+
+    def test_empty_spans_renders_no_dialogue(self) -> None:
+        rendered = compose_video._render_ass([], 720, 1280)
+        assert "Dialogue:" not in rendered
+        assert "[Events]" in rendered
+
+
+# ---------------------------------------------------------------------------
+# 字幕：faster-whisper 语音识别时间戳 + 台词配对
+# ---------------------------------------------------------------------------
+
+
+class TestAsrWordTimestamps:
+    """_asr_word_timestamps：模型可用/不可用/抽取失败/转写异常四类路径。"""
+
+    @staticmethod
+    def _fake_words() -> list[tuple[float, float, str]]:
+        return [(0.1, 0.4, "你"), (0.4, 0.8, "好")]
+
+    def test_returns_words_from_fake_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeWord:
+            def __init__(self, start: float, end: float, word: str) -> None:
+                self.start, self.end, self.word = start, end, word
+
+        class FakeSegment:
+            def __init__(self, words: list[FakeWord]) -> None:
+                self.words = words
+
+        class FakeModel:
+            def transcribe(self, path: str, **kwargs: object) -> tuple[object, object]:
+                return (iter([FakeSegment([FakeWord(0.1, 0.4, "你"), FakeWord(0.4, 0.8, "好")])]), object())
+
+        monkeypatch.setattr(compose_video, "_asr_load_model", lambda: FakeModel())
+        monkeypatch.setattr(compose_video, "_extract_audio_for_asr", lambda video, wav: None)
+        assert compose_video._asr_word_timestamps(Path("scene.mp4"), "zh") == self._fake_words()
+
+    def test_model_unavailable_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(compose_video, "_asr_load_model", lambda: None)
+        assert compose_video._asr_word_timestamps(Path("scene.mp4"), "zh") == []
+
+    def test_extract_failure_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeModel:
+            def transcribe(self, path: str, **kwargs: object) -> tuple[object, object]:
+                raise AssertionError("不应走到转写")
+
+        monkeypatch.setattr(compose_video, "_asr_load_model", lambda: FakeModel())
+        monkeypatch.setattr(
+            compose_video, "_extract_audio_for_asr", lambda video, wav: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        assert compose_video._asr_word_timestamps(Path("scene.mp4"), "zh") == []
+
+    def test_transcribe_failure_falls_back_to_no_vad(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, object]] = []
+
+        class FakeModel:
+            def transcribe(self, path: str, **kwargs: object) -> tuple[object, object]:
+                calls.append(kwargs)
+                if kwargs.get("vad_filter") is True:
+                    raise RuntimeError("onnxruntime missing")
+                return (iter([]), object())
+
+        monkeypatch.setattr(compose_video, "_asr_load_model", lambda: FakeModel())
+        monkeypatch.setattr(compose_video, "_extract_audio_for_asr", lambda video, wav: None)
+        assert compose_video._asr_word_timestamps(Path("scene.mp4"), "zh") == []
+        assert [c["vad_filter"] for c in calls] == [True, False]
+
+
+class TestFindBestWordWindow:
+    def test_finds_matching_window(self) -> None:
+        words = [(0.0, 0.4, "大哥"), (0.4, 0.8, "做"), (0.8, 1.2, "兄弟"), (1.2, 1.6, "的"), (1.6, 2.0, "你")]
+        window, score = compose_video._find_best_word_window("做兄弟的和你", words, 0)
+        assert window == (0.0, 2.0, 5)
+        assert score >= compose_video._ASR_MATCH_THRESHOLD
+
+    def test_no_match_returns_none(self) -> None:
+        words = [(0.0, 0.5, "music"), (0.5, 1.0, "noise")]
+        window, score = compose_video._find_best_word_window("完全无关的台词", words, 0)
+        assert window is None
+
+    def test_empty_target_or_exhausted_index(self) -> None:
+        assert compose_video._find_best_word_window("", [(0.0, 0.5, "x")], 0) == (None, 0.0)
+        assert compose_video._find_best_word_window("台词", [(0.0, 0.5, "x")], 5) == (None, 0.0)
+
+
+class TestAlignSubtitleSpansWithAsr:
+    @staticmethod
+    def _spans(texts: list[str]) -> list[dict[str, object]]:
+        out: list[dict[str, object]] = []
+        offset = 0.0
+        for text in texts:
+            out.append({"offset_seconds": offset, "duration_seconds": 1.0, "text": text})
+            offset += 1.0
+        return out
+
+    def test_matched_spans_take_asr_boundaries_with_pads(self) -> None:
+        words = [
+            (0.1, 0.5, "大哥"),
+            (0.5, 0.9, "做"),
+            (0.9, 1.3, "兄弟"),
+            (1.3, 1.7, "的"),
+            (1.7, 2.1, "和你"),
+            (5.0, 5.4, "有福"),
+            (5.4, 5.8, "同享"),
+        ]
+        out = compose_video._align_subtitle_spans_with_asr(self._spans(["大哥做兄弟的和你", "有福同享"]), words, 10.0)
+        assert out[0]["offset_seconds"] == pytest.approx(0.0)  # 0.1-0.1 前导
+        assert out[0]["duration_seconds"] == pytest.approx(2.25)  # 2.1+0.15 尾
+        assert out[1]["offset_seconds"] == pytest.approx(4.9)
+        assert out[1]["duration_seconds"] == pytest.approx(1.05)
+
+    def test_unmatched_span_falls_back_after_cursor(self) -> None:
+        words = [(0.5, 0.9, "music"), (0.9, 1.3, "only")]
+        spans = self._spans(["完全无关的台词", "另一句"])
+        out = compose_video._align_subtitle_spans_with_asr(spans, words, 10.0)
+        # 首条未命中 → 估算 1.0s 从 0 起；次条从 1.0 起
+        assert out[0]["offset_seconds"] == pytest.approx(0.0)
+        assert out[0]["duration_seconds"] == pytest.approx(1.0)
+        assert out[1]["offset_seconds"] == pytest.approx(1.0)
+
+    def test_clamps_to_video_duration(self) -> None:
+        words = [(8.0, 8.3, "末"), (8.3, 8.6, "句"), (9.0, 9.5, "尾巴")]
+        out = compose_video._align_subtitle_spans_with_asr(self._spans(["末尾台词尾巴"]), words, 9.4)
+        end = out[0]["offset_seconds"] + out[0]["duration_seconds"]
+        assert end <= 9.4 + 1e-9
+
+    def test_empty_words_returns_same_list(self) -> None:
+        spans = self._spans(["台词"])
+        assert compose_video._align_subtitle_spans_with_asr(spans, [], 10.0) is spans
+
+    def test_monotonic_non_overlapping(self) -> None:
+        words = [(0.1, 0.4, "一"), (0.4, 0.8, "二"), (0.8, 1.2, "三"), (2.0, 2.4, "四")]
+        out = compose_video._align_subtitle_spans_with_asr(self._spans(["一二三", "四"]), words, 10.0)
+        for prev, cur in zip(out, out[1:]):
+            assert prev["offset_seconds"] + prev["duration_seconds"] <= cur["offset_seconds"] + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _subtitle_spans_from_unit_shots
+# ---------------------------------------------------------------------------
+
+
+class TestSubtitleSpansFromUnitShots:
+    def test_dialogue_and_voiceover_lines(self) -> None:
+        """整行对话/画外音提取为字幕时间片，offset 在 unit 内累计。"""
+        shots = [
+            {"text": ("中景，平视构图。@[顾家老宅·客厅]内，窗外铅灰色云层压低。\n@[苏小凤]:{这个家……怎么这么冷。}")},
+            {"text": "{风雨欲来}"},
+            {"text": "纯镜头描述行，不烧字幕。"},
+        ]
+        spans = compose_video._subtitle_spans_from_unit_shots(shots, None)
+        assert [s["text"] for s in spans] == ["这个家……怎么这么冷。", "风雨欲来"]
+        assert spans[0]["offset_seconds"] == 0
+        assert spans[1]["offset_seconds"] == pytest.approx(spans[0]["duration_seconds"])
+        assert all(s["duration_seconds"] > 0 for s in spans)
+
+    def test_no_dialogue_yields_no_spans(self) -> None:
+        shots = [{"text": "全景，固定机位，人物缓步走入。"}]
+        assert compose_video._subtitle_spans_from_unit_shots(shots, None) == []
+
+    def test_invalid_shapes_are_skipped(self) -> None:
+        shots = ["bad", None, {"text": 123}, {"no_text": True}]
+        assert compose_video._subtitle_spans_from_unit_shots(shots, None) == []
+
+    def test_dialogue_mixed_into_description_line_is_not_subtitle(self) -> None:
+        """台词与描述混在同一行不算规范台词行，与 shot_parser 语义一致。"""
+        shots = [{"text": "画面内容 @[苏小凤]:{这不是台词} 混合行"}]
+        assert compose_video._subtitle_spans_from_unit_shots(shots, None) == []
+
+    def test_empty_or_blank_lines_are_skipped(self) -> None:
+        shots = [{"text": ""}, {"text": "   "}, {"text": None}]
+        assert compose_video._subtitle_spans_from_unit_shots(shots, None) == []

--- a/tests/test_skill_script_path_guards.py
+++ b/tests/test_skill_script_path_guards.py
@@ -40,6 +40,8 @@ def _run(
         cwd=str(cwd),
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
         input=stdin,
     )
@@ -127,7 +129,7 @@ def test_compose_video_rejects_narration_mode(fake_project: Path) -> None:
     result = _run(COMPOSE_VIDEO, fake_project, "scripts/ep_narration.json")
     assert result.returncode != 0
     out = result.stdout + result.stderr
-    assert "仅支持 drama 模式" in out
+    assert "仅支持 drama（顶层 scenes[]）与 reference_video（顶层 video_units[]）" in out
     # 不能出现裸 KeyError
     assert "KeyError" not in out
 
@@ -157,7 +159,7 @@ def test_compose_video_rejects_ad_mode(fake_project: Path) -> None:
     result = _run(COMPOSE_VIDEO, fake_project, "scripts/ep_ad.json")
     assert result.returncode != 0
     out = result.stdout + result.stderr
-    assert "仅支持 drama 模式" in out
+    assert "仅支持 drama（顶层 scenes[]）与 reference_video（顶层 video_units[]）" in out
     assert "content_mode=ad" in out
     assert "剪映草稿导出" in out
     assert "KeyError" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -193,14 +193,17 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "charset-normalizer" },
     { name = "claude-agent-sdk" },
+    { name = "ctranslate2" },
     { name = "docx2txt" },
     { name = "ebooklib" },
     { name = "fastapi" },
+    { name = "faster-whisper" },
     { name = "ffmpeg-python" },
     { name = "google-genai" },
     { name = "instructor" },
     { name = "lxml" },
     { name = "mammoth" },
+    { name = "onnxruntime" },
     { name = "openai" },
     { name = "packaging" },
     { name = "pdf-oxide" },
@@ -240,14 +243,17 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "charset-normalizer", specifier = ">=3.4.6" },
     { name = "claude-agent-sdk", specifier = ">=0.1.76" },
+    { name = "ctranslate2", specifier = "==4.8.1" },
     { name = "docx2txt", specifier = ">=0.9" },
     { name = "ebooklib", specifier = ">=0.20" },
     { name = "fastapi", specifier = ">=0.138.2" },
+    { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "google-genai", specifier = ">=1.65.0" },
     { name = "instructor", specifier = ">=1.14.5" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mammoth", specifier = ">=1.12.0" },
+    { name = "onnxruntime", specifier = "==1.20.1" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pdf-oxide", specifier = ">=0.3.46" },
@@ -369,6 +375,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/4ee23a7f1609adf9b2f140c7a8ffade64a1449d89ab431d922a809eebf19/av-18.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:88dd8e35e9242662b409a6a05fd24a6775d949eb05da0ba31cab4f250eacbab5", size = 22740741, upload-time = "2026-07-02T06:37:26.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/b9f8363d07aa4521913e483f6a30c7c164973ef01de62769bf9b97049cd8/av-18.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f8f454349c402e2c8d6fa80b54eb2a3f86c00f414d2b399f01ae6dab075c6fd8", size = 18384189, upload-time = "2026-07-02T06:37:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e5/69397019aed280a72a43e97a252dee4295df1a9e608848452e5300ec4dab/av-18.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:88ce194c2201c6a6d40336adee8a5ddde46ed743eacb500e3ae9368d1c6d889e", size = 36749881, upload-time = "2026-07-02T06:37:33.096Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3a/1614d74f0d676ea6745eb59553c9ad01ca25db523cba808d522e838f4f5b/av-18.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:aa15e567a018cc94a26b0ab45da676dee70c4146ace6e92e47d30cc9689cbfbe", size = 38645927, upload-time = "2026-07-02T06:37:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3c/5f54710d69b0ea93634134f92b49c7a2a7fd27da5486a8a7e6251ac1cfb4/av-18.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:613153e48cefc91700746dde0ad0282d4677b194cba22cc771de14c78411cf8b", size = 40454783, upload-time = "2026-07-02T06:37:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/8293e6a267e0591b543abd96ae01e7e8ed228509bdb4e4644a8a8395d90f/av-18.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:30404f53ca1ea7f350ac86ff22a2c04f903014758e9b33f398c5a62de34bd84f", size = 37573117, upload-time = "2026-07-02T06:37:44.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
 ]
 
 [[package]]
@@ -552,14 +584,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -578,6 +610,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -724,6 +768,38 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/3101c3a0785253a8ef386f39744ad19c28c75b7f227e7c232aee7a5c416a/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba628835e6ad4ad399261ab6cb51bf152de563e6b122a9e8eb0c61e69f925931", size = 1270478, upload-time = "2026-07-03T12:39:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b9/e50c7558e96a054d6b1e6a6c5e729dda4a4f05584e065f2902aa5f1bc4c8/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:85ef15ce0b2172ec471975b8a30d5c5bc71e7cffcd163ad6c07ea32f1943d940", size = 11930241, upload-time = "2026-07-03T12:39:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2f/ea7a19c6d7e949b731fb034664633184bbfc7882846d107f4d790693fb76/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0030670278a73cae09dff9bca72cdd248af61f9367257f18db9b3b94fbb3a50d", size = 16883512, upload-time = "2026-07-03T12:39:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4a/21f325a9d0925d8ad24b04249adf29bf9909442967603634f7f6d4acbb79/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4242a7f8e285f922525f4cffd5b1fb43cbacc61d0611cf54832e9c447d030840", size = 39529085, upload-time = "2026-07-03T12:39:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/37da1a7500b57496a5269318c4f57962ea0c26dcac06b85222d7831acf00/ctranslate2-4.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:d52499f05a60a791aeadee28d609efa130142f376d1ea76b2b1c593bb01f8827", size = 19220784, upload-time = "2026-07-03T12:39:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/66/39111224e418400d97fd79fbc9e72329c51f91a3e7a9c9a1a182e4f88022/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b4c3246aa4a7f309109a841ca743a72cc4abad4f93c0bf7da691023323215621", size = 1271321, upload-time = "2026-07-03T12:39:37.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/89/13f827fae226eea51315729c00111f716813d7736ebb827fecb8f361fe0d/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:c989f747789e8619cbc2e06443b3674c31bc71bad0369652485bd894b627360a", size = 11930735, upload-time = "2026-07-03T12:39:39.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/94/4b73f9bbaba29df4227cc65114f11d83fe6d696ef3705cb1ade79eb118fd/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90eb0bd67b6bb183712cc3fd14bf01ec4f622cd625c5b33cc6c56be7d1c9c34", size = 16872460, upload-time = "2026-07-03T12:39:42.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/9816494d5ff0745bdf9abe5af04e57a103a416444e604cbe83a6eb0aed7b/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e3e3aef4670a6c8dcea367401675f82b49b02c18f5837221bcd7cca90b1707a8", size = 39494736, upload-time = "2026-07-03T12:39:45.733Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/dc/22a2c874ca8bb6caa7018dfefdff92dddd487db31cf169891c4c6d408091/ctranslate2-4.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:a2dcce0a57beee984a691d9daa8fc3fd389f5b6cada2644c34571011833bd5b1", size = 19477164, upload-time = "2026-07-03T12:39:48.952Z" },
+    { url = "https://files.pythonhosted.org/packages/77/39/7b8d47bf49748ba73182742683eef74b46608beb879765d9d4efc46bc345/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a28c5889585cd17ee3649dfd46d9002ddf50204173f8bff476b9f76d6585795", size = 1293935, upload-time = "2026-07-03T12:39:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/20/434e30c752c433eaef5deccd4de54775bc1f205a6fe6c9e756b737018209/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:911a5cdef8a405c1804330613a1865f616eb9c092a0e932ee4648128eb20b627", size = 11951789, upload-time = "2026-07-03T12:39:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f2/d716426220b462bbb5bb354b9c6c8d9a41285f067203c860cc79f9f19917/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84723cae6f802551bbf2438e5e4810722631a2183b89a82c31df26566b54821d", size = 16860414, upload-time = "2026-07-03T12:39:55.54Z" },
+    { url = "https://files.pythonhosted.org/packages/69/11/cdab0e7e2ad4e547f15ab227c09207569f1272abae05816900ecebb0797a/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1910752ec541980644191fa3b407bc61dee00e88070b0aed29b4cef75010b3ea", size = 39465200, upload-time = "2026-07-03T12:39:59.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/03/126e963fc3237a416f3085b8a663ebd8ab449ed6c37195b4e0b49597ba0c/ctranslate2-4.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dc9f1abef55579cc02cdc74b3a55df38491ec56d177d6e6039609d61d09ed30e", size = 19499597, upload-time = "2026-07-03T12:40:01.68Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -789,6 +865,22 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -807,6 +899,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -896,6 +996,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
 ]
 
 [[package]]
@@ -1116,6 +1225,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1150,6 +1283,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -1562,6 +1727,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1744,6 +1918,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
     { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/39/9335e0874f68f7d27103cbffc0e235e32e26759202df6085716375c078bb/onnxruntime-1.20.1-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:22b0655e2bf4f2161d52706e31f517a0e54939dc393e92577df51808a7edc8c9", size = 31007580, upload-time = "2024-11-21T00:49:07.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9d/a42a84e10f1744dd27c6f2f9280cc3fb98f869dd19b7cd042e391ee2ab61/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f56e898815963d6dc4ee1c35fc6c36506466eff6d16f3cb9848cea4e8c8172", size = 11952833, upload-time = "2024-11-21T00:49:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/2f71f5680834688a9c81becbe5c5bb996fd33eaed5c66ae0606c3b1d6a02/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb71a814f66517a65628c9e4a2bb530a6edd2cd5d87ffa0af0f6f773a027d99e", size = 13333903, upload-time = "2024-11-21T00:49:12.984Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/aabfdf91d013320aa2fc46cf43c88ca0182860ff15df872b4552254a9680/onnxruntime-1.20.1-cp312-cp312-win32.whl", hash = "sha256:bd386cc9ee5f686ee8a75ba74037750aca55183085bf1941da8efcfe12d5b120", size = 9814562, upload-time = "2024-11-21T00:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/76979e0b744307d488c79e41051117634b956612cc731f1028eb17ee7294/onnxruntime-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:19c2d843eb074f385e8bbb753a40df780511061a63f9def1b216bf53860223fb", size = 11331482, upload-time = "2024-11-21T00:49:19.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/71/c5d980ac4189589267a06f758bd6c5667d07e55656bed6c6c0580733ad07/onnxruntime-1.20.1-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:cc01437a32d0042b606f462245c8bbae269e5442797f6213e36ce61d5abdd8cc", size = 31007574, upload-time = "2024-11-21T00:49:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13bbd9489be2a6944f4a940084bfe388f1100472f38c07080a46fbd4ab96/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb44b08e017a648924dbe91b82d89b0c105b1adcfe31e90d1dc06b8677ad37be", size = 11951459, upload-time = "2024-11-21T00:49:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/4454ae122874fd52bbb8a961262de81c5f932edeb1b72217f594c700d6ef/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bda6aebdf7917c1d811f21d41633df00c58aff2bef2f598f69289c1f1dabc4b3", size = 13331620, upload-time = "2024-11-21T00:49:28.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/55/3821c5fd60b52a6c82a00bba18531793c93c4addfe64fbf061e235c5617a/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9158465745423b2b5d97ed25aa7740c7d38d2993ee2e5c3bfacb0c4145c49d8", size = 11950342, upload-time = "2024-11-21T00:49:34.164Z" },
+    { url = "https://files.pythonhosted.org/packages/14/56/fd990ca222cef4f9f4a9400567b9a15b220dee2eafffb16b2adbc55c8281/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b", size = 13337040, upload-time = "2024-11-21T00:49:37.271Z" },
 ]
 
 [[package]]
@@ -2245,6 +2445,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2554,6 +2763,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2676,12 +2894,51 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 范围

compose-video 合成技能（agent_runtime_profile/.claude/skills/compose-video）：支持 reference_video 路线成片、字幕烧录与字号收敛。不涉及数据层与服务路由。

## 变更

- compose-video 支持 video_units[]（参考生视频路线）成片，转场按剧本 transition_to_next 生效
- 字幕烧录：台词/画外音按剪映同口径派生，默认 faster-whisper 按真实语音对齐时间轴，silencedetect 兜底
- 字幕字号按画布高度 6% 收敛（720p 约 43px），超长台词自动缩档保证最多 5 行
- 混入 BGM 背景音乐，输出追加 _with_music 后缀
- 新增 faster-whisper / ctranslate2 / onnxruntime 依赖

## 验收清单

- [x] 本地已跑相关测试（tests/test_compose_video_filter_graph.py、tests/test_skill_script_path_guards.py），179 项通过
- [x] 手动验证：暴雨将至第 01 集成片转场/字幕/BGM 均生效，字幕不再遮挡画面
- [ ] CI（ruff / basedpyright / import-linter / 覆盖率）待跑

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 drama 与 reference_video 两种视频制作模式。
  * 新增字幕生成与烧录，可从对白或镜头信息生成字幕。
  * 支持语音识别对齐、静音检测及自动回退。
  * 新增字幕、关闭语音识别和关闭音频对齐等命令行选项。
  * 增强 Windows 环境兼容性，并提供相关依赖检查提示。

* **测试**
  * 补充字幕渲染、音频对齐、路径处理及异常回退场景测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->