### PR TITLE
fix(后端): Windows 下 uvicorn 强制 ProactorEventLoop，Agent SDK 子进程可用

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ frontend/ (React SPA)  →  server/ (FastAPI)  →  lib/ (核心库)
 # 后端
 # 启动开发服务器（必须用 --reload-dir 限定监视目录，否则 watchfiles 会扫描
 # node_modules / .venv / .git / .worktrees 等十几万个文件，单核 CPU 50%+）
-uv run uvicorn server.app:app --reload --reload-dir server --reload-dir lib --port 1241
+uv run uvicorn server.app:app --loop server.proactor_loop:proactor_loop_factory --reload --reload-dir server --reload-dir lib --port 1241
 
 uv run python -m pytest                              # 测试（-v 单文件 / -k 关键字 / --cov 覆盖率）
 uv run ruff check . && uv run ruff format .          # lint + format
@@ -126,6 +126,8 @@ API Key、后端选择、模型配置等通过 WebUI 配置页（`/settings`）�
 ## Windows 兼容性
 
 主开发平台是 macOS / Linux，但 server 必须能在 Windows 上完成项目创建与基础流程。涉及文件系统、子进程、tmp 路径、权限的新代码遵循：
+
+- **事件循环** — uvicorn 在 `--reload` / 多 worker 模式下 Windows 会强制 `SelectorEventLoop`（不支持 `asyncio.create_subprocess_exec`），Claude Agent SDK 起子进程会失败；启动命令里的 `--loop server.proactor_loop:proactor_loop_factory` 将其改为 `ProactorEventLoop`，不可省略
 
 - **POSIX-only `os` 常量** — `O_NOFOLLOW` / `O_DIRECT` 等用 `getattr(os, "O_NOFOLLOW", 0)`，Python 层 `is_symlink()` 兜底（例：`lib/profile_manifest.py::_project_lock`）
 - **`os.chmod(0o600)`** — 以 `if os.name == "posix":` 包裹；Windows 凭证保护交给 ACL（用户级 `%LOCALAPPDATA%`）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ uv run alembic upgrade head
 # 启动后端 (终端 1)
 # 注意：必须用 --reload-dir 限定监视目录，否则 watchfiles 会扫描
 # node_modules / .venv / .git / .worktrees 等十几万个文件，单核 CPU 50%+
-uv run uvicorn server.app:app --reload --reload-dir server --reload-dir lib --port 1241
+uv run uvicorn server.app:app --loop server.proactor_loop:proactor_loop_factory --reload --reload-dir server --reload-dir lib --port 1241
 
 # 启动前端 (终端 2)
 cd frontend && pnpm dev

--- a/README.en.md
+++ b/README.en.md
@@ -299,7 +299,7 @@ uv run alembic upgrade head
 # Note: --reload-dir is required. Without it, watchfiles scans the entire
 # project tree (node_modules / .venv / .git / .worktrees, 150k+ files),
 # pinning a CPU core at 50%+.
-uv run uvicorn server.app:app --reload --reload-dir server --reload-dir lib --port 1241
+uv run uvicorn server.app:app --loop server.proactor_loop:proactor_loop_factory --reload --reload-dir server --reload-dir lib --port 1241
 
 # Start frontend (Terminal 2)
 cd frontend && pnpm dev

--- a/server/app.py
+++ b/server/app.py
@@ -3,13 +3,19 @@
 
 启动方式:
     cd ArcReel
-    uv run uvicorn server.app:app --reload --reload-dir server --reload-dir lib --port 1241
+    uv run uvicorn server.app:app --loop server.proactor_loop:proactor_loop_factory --reload --reload-dir server --reload-dir lib --port 1241
 
 注意：必须用 --reload-dir 限定监视目录，否则 watchfiles 会扫描
 node_modules / .venv / .git / .worktrees 等十几万个文件，单核 CPU 50%+。
 """
 
 import asyncio
+import sys
+
+# Windows 上强制 ProactorEventLoop 以支持子进程启动（Claude Agent SDK 需要）
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
 import logging
 import os
 import platform
@@ -325,6 +331,7 @@ async def lifespan(app: FastAPI):
     # Windows 回退时跳过，避免无意义的文件系统调用。
     is_docker = detect_docker_environment() if sandbox_enabled else False
     logger.info("Sandbox runtime: enabled=%s docker=%s", sandbox_enabled, is_docker)
+    logger.info("Event loop: %s", type(asyncio.get_running_loop()).__name__)
 
     app.state.in_docker = is_docker
     app.state.sandbox_enabled = sandbox_enabled

--- a/server/proactor_loop.py
+++ b/server/proactor_loop.py
@@ -1,0 +1,25 @@
+"""uvicorn 自定义事件循环工厂。
+
+Windows 上 uvicorn 在 --reload / 多 worker 模式下会选用 SelectorEventLoop
+（见 uvicorn.loops.asyncio.asyncio_loop_factory），该事件循环不支持
+asyncio.create_subprocess_exec，Claude Agent SDK 启动 claude.exe 子进程时直接
+抛 NotImplementedError。这里在 Windows 上强制 ProactorEventLoop，其他平台沿用
+uvicorn auto 行为（有 uvloop 用 uvloop）。
+
+uvicorn ``--loop`` 的自定义路径约定：工厂函数直接交给 asyncio.run，必须返回
+事件循环实例（不是类）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+
+def proactor_loop_factory() -> asyncio.AbstractEventLoop:
+    """返回事件循环实例，供 uvicorn ``--loop`` 使用。"""
+    if sys.platform == "win32":
+        return asyncio.ProactorEventLoop()
+    from uvicorn.loops.auto import auto_loop_factory
+
+    return auto_loop_factory(use_subprocess=False)()


### PR DESCRIPTION
## 范围

server/app.py、新增 server/proactor_loop.py，以及 AGENTS.md / CONTRIBUTING.md / README.en.md 的启动命令。

## 变更

- 新增 server/proactor_loop.py 事件循环工厂，uvicorn --loop 在 Windows 下改用 ProactorEventLoop
- server.app 启动时按平台设置事件循环策略，并在日志记录实际事件循环类型
- 更新三处开发文档启动命令（--loop server.proactor_loop:proactor_loop_factory 不可省略）

## 验收清单

- [x] 本地 Windows 启动后端正常，日志确认事件循环为 ProactorEventLoop
- [ ] CI（ruff / basedpyright）待跑

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改善 Windows 下开发服务器的兼容性，支持热重载和多进程启动。
  * 优化子进程启动及事件循环配置，提升本地开发稳定性。

* **文档**
  * 更新开发环境启动命令及 Windows 配置说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->