### PR TITLE
feat(供应商): 方舟 Agent Plan 支持 bearer 鉴权，套餐模型收敛为 seedance 1.5 Pro

### DIFF
--- a/lib/agent_provider_catalog.py
+++ b/lib/agent_provider_catalog.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 CUSTOM_SENTINEL_ID = "__custom__"
 
@@ -28,6 +29,8 @@ class PresetProvider:
     notes_i18n_key: str | None
     api_key_pattern: str | None
     is_recommended: bool
+    # 鉴权方式：x-api-key（Anthropic 官方默认）或 bearer（方舟 Coding/Agent Plan 网关）
+    auth_scheme: Literal["x-api-key", "bearer"] = "x-api-key"
 
 
 PRESET_PROVIDERS: dict[str, PresetProvider] = {
@@ -163,13 +166,14 @@ PRESET_PROVIDERS: dict[str, PresetProvider] = {
         icon_key="Volcengine",
         messages_url="https://ark.cn-beijing.volces.com/api/coding",
         discovery_url="https://ark.cn-beijing.volces.com",
-        default_model="",
+        default_model="ark-code-latest",
         suggested_models=(),
         docs_url="https://www.volcengine.com/docs/82379/1928262",
         api_key_url="https://console.volcengine.com/ark",
         notes_i18n_key="preset_notes_ark_coding_plan",
         api_key_pattern=None,
         is_recommended=False,
+        auth_scheme="bearer",
     ),
     "ark-agent-plan": PresetProvider(
         id="ark-agent-plan",
@@ -177,13 +181,14 @@ PRESET_PROVIDERS: dict[str, PresetProvider] = {
         icon_key="Volcengine",
         messages_url="https://ark.cn-beijing.volces.com/api/plan",
         discovery_url="https://ark.cn-beijing.volces.com",
-        default_model="",
+        default_model="ark-code-latest",
         suggested_models=(),
         docs_url="https://www.volcengine.com/docs/82379/2375486",
         api_key_url="https://console.volcengine.com/ark",
         notes_i18n_key="preset_notes_ark_agent_plan",
         api_key_pattern=None,
         is_recommended=False,
+        auth_scheme="bearer",
     ),
 }
 

--- a/lib/config/anthropic_probe.py
+++ b/lib/config/anthropic_probe.py
@@ -25,6 +25,14 @@ from lib.httpx_shared import get_http_client
 logger = logging.getLogger(__name__)
 
 _ERR_TRUNCATE = 200
+AuthScheme = Literal["x-api-key", "bearer"]
+
+
+def _auth_header(*, api_key: str, auth_scheme: AuthScheme) -> dict[str, str]:
+    """按鉴权方式生成认证头；bearer 供只认 ANTHROPIC_AUTH_TOKEN 的网关使用。"""
+    if auth_scheme == "bearer":
+        return {"Authorization": f"Bearer {api_key}"}
+    return {"x-api-key": api_key}
 
 
 class DiagnosisCode(StrEnum):
@@ -68,6 +76,7 @@ async def probe_messages(
     messages_root: str,
     api_key: str,
     model: str,
+    auth_scheme: AuthScheme = "x-api-key",
     timeout_s: float = 10.0,
 ) -> ProbeResult:
     """POST {messages_root}/v1/messages 发最小请求 (max_tokens=1)。
@@ -85,7 +94,7 @@ async def probe_messages(
         "messages": [{"role": "user", "content": "ping"}],
     }
     headers = {
-        "x-api-key": api_key,
+        **_auth_header(api_key=api_key, auth_scheme=auth_scheme),
         "anthropic-version": "2023-06-01",
         "content-type": "application/json",
     }
@@ -163,13 +172,17 @@ async def probe_discovery(
     *,
     discovery_root: str | None,
     api_key: str,
+    auth_scheme: AuthScheme = "x-api-key",
     timeout_s: float = 5.0,
 ) -> ProbeResult | None:
     """GET {discovery_root}/v1/models 体检模型发现端点 (warn 级，仅供参考)。"""
     if not discovery_root:
         return None
     url = f"{discovery_root.rstrip('/')}/v1/models"
-    headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+    headers = {
+        **_auth_header(api_key=api_key, auth_scheme=auth_scheme),
+        "anthropic-version": "2023-06-01",
+    }
     started = time.perf_counter()
     try:
         resp = await _get(url=url, headers=headers, timeout_s=timeout_s)
@@ -223,11 +236,13 @@ async def run_test(
     model: str | None,
 ) -> TestConnectionResponse:
     """完整端到端测试：派生 → messages + discovery 并发 → 自定义模式自愈 → 诊断。"""
+    auth_scheme: AuthScheme = "x-api-key"
     # 1. 派生 endpoints
     if preset_id and preset_id != CUSTOM_SENTINEL_ID:
         preset = get_preset(preset_id)
         if preset is None:
             raise ValueError(f"unknown preset: {preset_id!r}")
+        auth_scheme = preset.auth_scheme
         if base_url:
             # 凭证覆盖了 preset.messages_url（如内部代理）：用 base_url 同时派生 messages
             # 和 discovery 两个 root，保持与运行时 build_anthropic_env_dict 一致。
@@ -244,7 +259,7 @@ async def run_test(
                 discovery_root=preset.discovery_url or "",
                 has_explicit_suffix=True,
             )
-        effective_model = model or preset.default_model
+        effective_model = model or preset.default_model or _DEFAULT_TEST_MODEL
     else:
         if not base_url:
             raise ValueError("base_url required for __custom__ mode")
@@ -253,8 +268,13 @@ async def run_test(
 
     # 2. messages + discovery 并发首轮：discovery 是 warn 级独立信号，串行只浪费墙钟时间
     msg, disc = await asyncio.gather(
-        probe_messages(messages_root=ep.messages_root, api_key=api_key, model=effective_model),
-        probe_discovery(discovery_root=ep.discovery_root or None, api_key=api_key),
+        probe_messages(
+            messages_root=ep.messages_root,
+            api_key=api_key,
+            model=effective_model,
+            auth_scheme=auth_scheme,
+        ),
+        probe_discovery(discovery_root=ep.discovery_root or None, api_key=api_key, auth_scheme=auth_scheme),
     )
 
     # 3. 自定义模式 + 失败 + 没显式 anthropic 后缀 + status 命中 retryable → 串行自愈
@@ -268,7 +288,12 @@ async def run_test(
         and msg.status_code in _RETRYABLE_STATUS_FOR_SELF_HEAL
     ):
         retry_root = ep.messages_root.rstrip("/") + "/anthropic"
-        retry = await probe_messages(messages_root=retry_root, api_key=api_key, model=effective_model)
+        retry = await probe_messages(
+            messages_root=retry_root,
+            api_key=api_key,
+            model=effective_model,
+            auth_scheme=auth_scheme,
+        )
         if retry.success:
             msg = retry
             final_messages_root = retry_root

--- a/lib/config/env_keys.py
+++ b/lib/config/env_keys.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # —— SDK 子进程需要的 Anthropic env keys（通过 options.env 注入）——
 ANTHROPIC_ENV_KEYS: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
@@ -48,6 +49,7 @@ OTHER_PROVIDER_ENV_KEYS: tuple[str, ...] = (
 PROVIDER_SECRET_KEYS: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
         "ARK_API_KEY",
         "XAI_API_KEY",
         "GEMINI_API_KEY",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -694,34 +694,14 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 default=True,
             ),
             # --- video ---
+            # Agent Plan 仅支持 seedance-1.5-pro 生成视频，后续 2.0 系列不在套餐内
             "doubao-seedance-1.5-pro": ModelInfo(
                 display_name="Seedance 1.5 Pro",
                 media_type="video",
                 capabilities=["generate_audio", "seed_control", "flex_tier"],
+                default=True,
                 supported_durations=list(range(4, 13)),
                 resolutions=["480p", "720p", "1080p"],
-            ),
-            "doubao-seedance-2.0": ModelInfo(
-                display_name="Seedance 2.0",
-                media_type="video",
-                capabilities=["generate_audio", "seed_control", "video_extend"],
-                supported_durations=list(range(4, 16)),
-                resolutions=["480p", "720p", "1080p"],
-            ),
-            "doubao-seedance-2.0-fast": ModelInfo(
-                display_name="Seedance 2.0 Fast",
-                media_type="video",
-                capabilities=["generate_audio", "seed_control", "video_extend"],
-                supported_durations=list(range(4, 16)),
-                resolutions=["480p", "720p"],
-            ),
-            "doubao-seedance-2.0-mini": ModelInfo(
-                display_name="Seedance 2.0 Mini",
-                media_type="video",
-                capabilities=["generate_audio", "seed_control", "video_extend"],
-                default=True,
-                supported_durations=list(range(4, 16)),
-                resolutions=["480p", "720p"],
             ),
         },
         default_base_url="https://ark.cn-beijing.volces.com/api/plan/v3",

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lib.agent_provider_catalog import CUSTOM_SENTINEL_ID, get_preset
 from lib.config.env_keys import ANTHROPIC_ENV_KEYS
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
@@ -51,6 +52,7 @@ class ProviderConfigValueError(ValueError):
 # DB setting key → environment variable name
 _ANTHROPIC_ENV_MAP: dict[str, str] = {
     "anthropic_api_key": "ANTHROPIC_API_KEY",
+    "anthropic_auth_token": "ANTHROPIC_AUTH_TOKEN",
     "anthropic_base_url": "ANTHROPIC_BASE_URL",
     "anthropic_model": "ANTHROPIC_MODEL",
     "anthropic_default_haiku_model": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
@@ -80,10 +82,16 @@ async def build_anthropic_env_dict(session: AsyncSession) -> dict[str, str]:
 
     if cred is not None:
         settings = await SystemSettingRepository(session).get_all()
+        preset = get_preset(cred.preset_id) if cred.preset_id and cred.preset_id != CUSTOM_SENTINEL_ID else None
+        auth_scheme = preset.auth_scheme if preset else "x-api-key"
+        api_key = cred.api_key or ""
         return {
-            "ANTHROPIC_API_KEY": cred.api_key or "",
+            "ANTHROPIC_API_KEY": "" if auth_scheme == "bearer" else api_key,
+            "ANTHROPIC_AUTH_TOKEN": api_key if auth_scheme == "bearer" else "",
             "ANTHROPIC_BASE_URL": cred.base_url or "",
-            "ANTHROPIC_MODEL": cred.model or settings.get("anthropic_model", "").strip(),
+            "ANTHROPIC_MODEL": cred.model
+            or (preset.default_model if preset else "")
+            or settings.get("anthropic_model", "").strip(),
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": cred.haiku_model
             or settings.get("anthropic_default_haiku_model", "").strip(),
             "ANTHROPIC_DEFAULT_SONNET_MODEL": cred.sonnet_model

--- a/lib/i18n/en/providers.py
+++ b/lib/i18n/en/providers.py
@@ -28,6 +28,6 @@ MESSAGES: dict[str, str] = {
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek official Anthropic-compat endpoint; needs sk- prefixed key.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo only accepts known model names; no public model list.",
-    "preset_notes_ark_coding_plan": "Volcengine Ark Coding Plan",
-    "preset_notes_ark_agent_plan": "Volcengine Ark Agent Plan",
+    "preset_notes_ark_coding_plan": "Volcengine Ark Coding Plan: requires the dedicated Coding Plan API Key; model can be ark-code-latest",
+    "preset_notes_ark_agent_plan": "Volcengine Ark Agent Plan: requires the dedicated Agent Plan API Key (regular Ark / Coding Plan keys won't work); model can be ark-code-latest",
 }

--- a/lib/i18n/vi/providers.py
+++ b/lib/i18n/vi/providers.py
@@ -28,6 +28,6 @@ MESSAGES: dict[str, str] = {
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "Endpoint Anthropic-compat chính thức của DeepSeek; cần API key sk-.",
     "preset_notes_xiaomi_mimo": "Xiaomi MiMo chỉ chấp nhận tên model đã biết; không có danh sách model công khai.",
-    "preset_notes_ark_coding_plan": "Gói Volcengine Ark Coding Plan",
-    "preset_notes_ark_agent_plan": "Gói Volcengine Ark Agent Plan",
+    "preset_notes_ark_coding_plan": "Gói Volcengine Ark Coding Plan: cần API Key riêng của Coding Plan; model có thể dùng ark-code-latest",
+    "preset_notes_ark_agent_plan": "Gói Volcengine Ark Agent Plan: cần API Key riêng của Agent Plan (API Key Ark thường / Coding Plan không dùng được); model có thể dùng ark-code-latest",
 }

--- a/lib/i18n/zh/providers.py
+++ b/lib/i18n/zh/providers.py
@@ -28,6 +28,6 @@ MESSAGES: dict[str, str] = {
     # Agent preset notes (lib/agent_provider_catalog.py)
     "preset_notes_deepseek": "DeepSeek 官方 Anthropic 兼容端点，需 sk- 开头的 API Key",
     "preset_notes_xiaomi_mimo": "小米 MiMo 仅支持已知模型名，未公开模型列表",
-    "preset_notes_ark_coding_plan": "火山方舟 Coding Plan 套餐",
-    "preset_notes_ark_agent_plan": "火山方舟 Agent Plan 套餐",
+    "preset_notes_ark_coding_plan": "火山方舟 Coding Plan 套餐：需使用 Coding Plan 专属 API Key，模型可填 ark-code-latest",
+    "preset_notes_ark_agent_plan": "火山方舟 Agent Plan 套餐：需使用 Agent Plan 专属 API Key（方舟普通 API Key / Coding Plan Key 不可用），模型可填 ark-code-latest",
 }

--- a/tests/config/test_anthropic_env_dict.py
+++ b/tests/config/test_anthropic_env_dict.py
@@ -20,6 +20,7 @@ async def test_active_credential_returns_full_dict(monkeypatch: pytest.MonkeyPat
         "Cred",
         (),
         dict(
+            preset_id="anthropic-official",
             api_key="sk-test",
             base_url="https://api.anthropic.com",
             model="claude-opus-4-7",
@@ -42,6 +43,7 @@ async def test_active_credential_returns_full_dict(monkeypatch: pytest.MonkeyPat
 
     result = await build_anthropic_env_dict(session)
     assert result["ANTHROPIC_API_KEY"] == "sk-test"
+    assert result["ANTHROPIC_AUTH_TOKEN"] == ""
     assert result["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
     assert result["ANTHROPIC_MODEL"] == "claude-opus-4-7"
 
@@ -107,6 +109,7 @@ async def test_function_does_not_touch_environ(monkeypatch: pytest.MonkeyPatch) 
         "Cred",
         (),
         dict(
+            preset_id="anthropic-official",
             api_key="sk-test",
             base_url="x",
             model="y",
@@ -129,3 +132,38 @@ async def test_function_does_not_touch_environ(monkeypatch: pytest.MonkeyPatch) 
 
     await build_anthropic_env_dict(session)
     assert dict(os.environ) == baseline, "build 函数禁止改 os.environ"
+
+
+@pytest.mark.asyncio
+async def test_bearer_preset_fills_auth_token_and_blanks_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ark-agent-plan 等 bearer 预设：key 注入 ANTHROPIC_AUTH_TOKEN，ANTHROPIC_API_KEY 置空。"""
+    session = AsyncMock()
+    repo_mock = AsyncMock()
+    cred = type(
+        "Cred",
+        (),
+        dict(
+            preset_id="ark-agent-plan",
+            api_key="ark-test-key",
+            base_url="https://ark.cn-beijing.volces.com/api/plan",
+            model="",
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            subagent_model=None,
+        ),
+    )()
+    repo_mock.get_active = AsyncMock(return_value=cred)
+
+    setting_repo = AsyncMock()
+    setting_repo.get_all = AsyncMock(return_value={})
+
+    monkeypatch.setattr(
+        "lib.db.repositories.agent_credential_repo.AgentCredentialRepository",
+        lambda _s: repo_mock,
+    )
+    monkeypatch.setattr("lib.config.service.SystemSettingRepository", lambda _s: setting_repo)
+
+    result = await build_anthropic_env_dict(session)
+    assert result["ANTHROPIC_AUTH_TOKEN"] == "ark-test-key"
+    assert result["ANTHROPIC_API_KEY"] == ""

--- a/tests/test_anthropic_probe.py
+++ b/tests/test_anthropic_probe.py
@@ -363,3 +363,77 @@ async def test_run_test_custom_mode_requires_base_url() -> None:
 async def test_run_test_unknown_preset_raises() -> None:
     with pytest.raises(ValueError, match="unknown preset"):
         await run_test(preset_id="bogus-preset", base_url=None, api_key="sk", model=None)
+
+
+@pytest.mark.asyncio
+async def test_probe_messages_bearer_auth_uses_authorization_header() -> None:
+    fake = httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []})
+    with patch("lib.config.anthropic_probe._post", AsyncMock(return_value=fake)) as mocked:
+        result = await probe_messages(
+            messages_root="https://ark.cn-beijing.volces.com/api/plan",
+            api_key="ark-secret",
+            model="ark-code-latest",
+            auth_scheme="bearer",
+        )
+    assert result.success is True
+    headers = mocked.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer ark-secret"
+    assert "x-api-key" not in headers
+
+
+@pytest.mark.asyncio
+async def test_probe_discovery_bearer_auth_uses_authorization_header() -> None:
+    fake = httpx.Response(200, json={"data": []})
+    with patch("lib.config.anthropic_probe._get", AsyncMock(return_value=fake)) as mocked:
+        result = await probe_discovery(
+            discovery_root="https://ark.cn-beijing.volces.com",
+            api_key="ark-secret",
+            auth_scheme="bearer",
+        )
+    assert result is not None
+    assert result.success is True
+    headers = mocked.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer ark-secret"
+    assert "x-api-key" not in headers
+
+
+@pytest.mark.asyncio
+async def test_run_test_ark_agent_plan_uses_bearer_and_default_model() -> None:
+    """ark 预设：probe 走 Bearer 头，无显式 model 时回退 preset.default_model。"""
+    captured: dict[str, object] = {}
+
+    async def fake_post(
+        *, url: str, headers: dict[str, str], payload: dict[str, object], **_kw: object
+    ) -> httpx.Response:
+        captured["messages_url"] = url
+        captured["messages_headers"] = headers
+        captured["model"] = payload.get("model")
+        return httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []})
+
+    async def fake_get(*, url: str, headers: dict[str, str], **_kw: object) -> httpx.Response:
+        captured["discovery_url"] = url
+        captured["discovery_headers"] = headers
+        return httpx.Response(200, json={"data": []})
+
+    with (
+        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
+        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
+    ):
+        resp = await run_test(
+            preset_id="ark-agent-plan",
+            base_url=None,
+            api_key="ark-secret",
+            model=None,
+        )
+
+    assert resp.overall == "ok"
+    assert captured["model"] == "ark-code-latest"
+    assert captured["messages_url"] == "https://ark.cn-beijing.volces.com/api/plan/v1/messages"
+    assert captured["discovery_url"] == "https://ark.cn-beijing.volces.com/v1/models"
+    headers = captured["messages_headers"]
+    assert isinstance(headers, dict)
+    assert headers["Authorization"] == "Bearer ark-secret"
+    assert "x-api-key" not in headers
+    discovery_headers = captured["discovery_headers"]
+    assert isinstance(discovery_headers, dict)
+    assert discovery_headers["Authorization"] == "Bearer ark-secret"

--- a/tests/test_pricing_lookup.py
+++ b/tests/test_pricing_lookup.py
@@ -140,7 +140,7 @@ class TestUnknownModelFallback:
 
     def test_agent_plan_no_pricing_falls_back_to_gemini_quietly(self, caplog):
         with caplog.at_level(logging.WARNING, logger="lib.pricing.lookup"):
-            pricing = lookup_pricing("ark-agent-plan", "doubao-seedance-2.0", "video")
+            pricing = lookup_pricing("ark-agent-plan", "doubao-seedance-1.5-pro", "video")
         # Agent Plan 模型 pricing=None → 回落 Gemini 默认视频费率，不发 WARNING
         assert isinstance(pricing, PerSecondMatrix)
         assert "veo-3.1-lite-generate-preview" in pricing.rates

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -25,7 +25,7 @@ def test_ark_agent_plan_registered() -> None:
     assert defaults_by_media == {
         "text": "doubao-seed-2.0-lite",
         "image": "doubao-seedream-5.0-lite",
-        "video": "doubao-seedance-2.0-mini",
+        "video": "doubao-seedance-1.5-pro",
     }
     for mid, m in p.models.items():
         if m.media_type == "video":
@@ -42,16 +42,8 @@ def test_ark_agent_plan_baseline_models_present() -> None:
         "doubao-seed-2.0-code",
         "doubao-seedream-5.0-lite",
         "doubao-seedance-1.5-pro",
-        "doubao-seedance-2.0",
-        "doubao-seedance-2.0-fast",
-        "doubao-seedance-2.0-mini",
     }
     assert baseline.issubset(set(p.models.keys()))
-
-
-def test_ark_agent_plan_fast_has_no_1080p() -> None:
-    p = PROVIDER_REGISTRY["ark-agent-plan"]
-    assert p.models["doubao-seedance-2.0-fast"].resolutions == ["480p", "720p"]
 
 
 def test_ark_agent_plan_model_id_format_differs_from_ark() -> None:


### PR DESCRIPTION
## 范围

lib/agent_provider_catalog.py、lib/config/*、lib/i18n/* 及对应配置测试。不涉及生成管线。

## 变更

- 预设供应商增加鉴权方式声明（x-api-key / bearer），方舟 Coding/Agent Plan 走 Authorization: Bearer
- 新增 ANTHROPIC_AUTH_TOKEN 注入，探活（probe）与配置服务按 auth_scheme 选择认证头
- 方舟 Agent Plan 默认模型 ark-code-latest；视频套餐收敛为 doubao-seedance-1.5-pro，移除不在套餐内的 2.0 系列
- 同步 zh/en/vi 供应商说明

## 验收清单

- [x] 本地已跑相关测试（test_anthropic_env_dict / test_anthropic_probe / test_provider_registry / test_pricing_lookup）
- [ ] CI（ruff / basedpyright / i18n 一致性）待跑

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持 Anthropic 使用 API Key 或 Bearer Token 两种认证方式。
  - 新增 `ANTHROPIC_AUTH_TOKEN` 环境变量支持。
  - Ark Coding Plan 与 Ark Agent Plan 默认使用 `ark-code-latest` 模型。

- **变更**
  - Ark Agent Plan 默认视频模型调整为 `doubao-seedance-1.5-pro`，移除旧版 2.0 系列模型。
  - 更新中英文预设说明，明确 API Key 要求及可用模型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->