### PR TITLE
feat(分集): step1 内容生成默认按分集 source_range 只喂本集原文切片

### DIFF
--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -24,7 +24,7 @@ from typing import Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from lib.episode_paths import episode_drafts_dir, episode_script_relpath
-from lib.path_safety import safe_exists
+from lib.path_safety import PathTraversalError, safe_exists, safe_join
 
 logger = logging.getLogger(__name__)
 
@@ -400,6 +400,41 @@ def parse_source_range(entry: Mapping[str, Any]) -> tuple[str, int, int] | None:
     ):
         return rel, start, end
     return None
+
+
+def episode_source_slice(project_dir: Path, project: Mapping[str, Any], episode: int) -> str | None:
+    """按账本 ``source_range`` 切出本集原文（归一化坐标系），无位置记录时返回 None。
+
+    供 step1 内容生成工具（normalize / split）默认只喂本集切片，避免整篇源文被重复
+    塞进每一集的 prompt。坐标校验与派生文件重写（``lib.episode_planner``）同口径：
+    源文件缺失 / 读取失败 / 坐标越界一律 fail-loud 抛 ValueError——账本坐标绑定的是
+    源文件内容，静默回退全文会让多集产出重复内容。旧式条目（无 ``source_range``）
+    由调用方自行决定回退策略，本函数返回 None 不抛错。
+    """
+    entry = next(
+        (e for e in (project.get("episodes") or []) if isinstance(e, Mapping) and e.get("episode") == episode),
+        None,
+    )
+    if entry is None:
+        return None
+    coords = parse_source_range(entry)
+    if coords is None:
+        return None
+    rel, start, end = coords
+    try:
+        path = safe_join(project_dir, rel, require_file=True)
+    except (PathTraversalError, FileNotFoundError) as exc:
+        raise ValueError(f"本集源文件不可读（{rel}）：{exc}") from exc
+    try:
+        text = normalize_source_text(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError(f"本集源文件读取失败（{rel}）：{exc}") from exc
+    if not 0 <= start <= end <= len(text):
+        raise ValueError(
+            f"第 {episode} 集原文范围越界（start={start}，end={end}，源文长度 {len(text)}）："
+            "账本坐标与源文件内容不一致，请先全量重置分集规划再重新规划"
+        )
+    return text[start:end]
 
 
 def episodes_without_source_range(project: Mapping[str, Any]) -> list[int]:

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -518,6 +518,7 @@ def build_normalize_prompt(
     source_language: str | None = None,
     episode_outline: dict | None = None,
     next_episode_outline: dict | None = None,
+    source_is_episode_slice: bool = False,
 ) -> str:
     """Step-1 规范化 prompt：源文 → 结构化分镜内容（utterances + source_text + 视觉改编描述）。
 
@@ -528,6 +529,8 @@ def build_normalize_prompt(
     ``source_kind="screenplay"`` 翻为「提取/逐字保留」：台词与画外音逐字落 utterances、视觉转写为
     scene_description；默认 ``"novel"`` 维持「改编」语义、画外音由语境判断放开。``episode_outline`` /
     ``next_episode_outline`` 来自分集账本，驱动内容覆盖故事节点、末场落地集尾钩子。
+    ``source_is_episode_slice`` 为真时 ``novel_text`` 只含本集原文切片：prompt 明确本集范围、
+    抑制模型扩展整篇（normalize 工具默认按账本 ``source_range`` 切片后置真）。
 
     ``source_language`` 供时长指引的「台词口播时长」单向下界软指引取语速（阅读单位 / 秒，来自
     ``lib.speech_rate`` 单一真相源，与保存期上界 warning、字幕派生同口径）；缺省 / 未登记回退默认语速。
@@ -547,6 +550,15 @@ def build_normalize_prompt(
     utterances_rule = _NORMALIZE_UTTERANCES_SCREENPLAY if is_screenplay else _NORMALIZE_UTTERANCES_NOVEL
     break_rule = _NORMALIZE_BREAK_RULE_SCREENPLAY if is_screenplay else _NORMALIZE_BREAK_RULE_NOVEL
     outline_block = _format_episode_outline_block(episode_outline, next_episode_outline)
+    if source_is_episode_slice:
+        source_heading = f"本集{source_heading}（仅第 {episode} 集对应段落）"
+        source_scope_note = (
+            "下方原文已按分集规划切分，只包含本集内容：仅据此段改编，不要扩展引用整篇故事或下文尚未出现的情节。\n\n"
+        )
+        episode_scope_rule = "所有分镜内容须取自上方本集原文段。 "
+    else:
+        source_scope_note = ""
+        episode_scope_rule = ""
 
     # 资产引用字段（characters_in_scene / scenes / props，须逐字等于 project.json 登记名）与
     # 说话人引用 `utterances[].speaker`（须等于 characters_in_scene 中登记的角色名）须排除在目标语言要求外——
@@ -638,13 +650,13 @@ def build_normalize_prompt(
 
 ## {source_heading}
 
-<{source_tag}>
+{source_scope_note}<{source_tag}>
 {novel_text}
 </{source_tag}>
 
 {outline_block}# 字段写作指引
 
-把源文拆为有序分镜，逐条产出结构化场景内容。当前正在生成第 {episode} 集。
+{episode_scope_rule}把源文拆为有序分镜，逐条产出结构化场景内容。当前正在生成第 {episode} 集。
 
 ## 基础字段
 
@@ -677,6 +689,7 @@ def build_narration_split_prompt(
     supported_durations: list[int],
     episode: int,
     target_language: str = "中文",
+    source_is_episode_slice: bool = False,
 ) -> str:
     """Step-1 说书片段拆分 prompt：源文 → 结构化片段表（逐字 novel_text + 时长 + 资产登记）。
 
@@ -689,6 +702,8 @@ def build_narration_split_prompt(
     ``default_duration`` 为单片段默认秒数偏好；与 ``build_normalize_prompt`` 不同，此处对漂移到
     ``supported_durations`` 之外的 default 按 None 处理（软偏好、可被内容需要覆盖），不 fail-loud——
     与 split-narration-segments subagent 的「default 非成员按 null」口径一致。
+    ``source_is_episode_slice`` 为真时 ``novel_text`` 只含本集原文切片：prompt 明确本集范围、
+    抑制模型扩展整篇（split_narration_segments 工具默认按账本 ``source_range`` 切片后置真）。
     """
     normalized_durations = sorted({int(d) for d in supported_durations})
     if not normalized_durations:
@@ -706,6 +721,17 @@ def build_narration_split_prompt(
     else:
         duration_rule = f"按朗读节奏从档位（{durations_str}）中取值（最长 {max_dur} 秒），不强制默认值"
     pacing_block = render_pacing_section("narration") + "\n\n"
+
+    if source_is_episode_slice:
+        source_heading = f"本集小说原文（仅第 {episode} 集对应段落）"
+        source_scope_note = (
+            "下方原文已按分集规划切分，只包含本集内容：仅据此段拆分，不要扩展引用整篇故事或下文尚未出现的情节。\n\n"
+        )
+        episode_scope_rule = "所有片段须取自上方本集原文段。 "
+    else:
+        source_heading = "小说原文"
+        source_scope_note = ""
+        episode_scope_rule = ""
 
     character_names = list(characters.keys())
     scene_names = list(scenes.keys())
@@ -744,15 +770,15 @@ def build_narration_split_prompt(
 {_format_names(props)}
 </props>
 
-## 小说原文
+## {source_heading}
 
-<novel>
+{source_scope_note}<novel>
 {novel_text}
 </novel>
 
 # 拆分规则
 
-当前正在生成第 {episode} 集。
+{episode_scope_rule}当前正在生成第 {episode} 集。
 
 - **novel_text**：逐字保留小说原文，不改编 / 不删减 / 不添加 / 不改标点（后期配音与透传的真相源）；
   对话片段含完整说话内容与引导语（如「他说道」）。在句号 / 问号 / 感叹号 / 省略号等标点或段落结束处拆分，

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -24,7 +24,7 @@ from lib.asset_types import BUCKET_KEY
 from lib.config.resolver import ConfigResolver
 from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
 from lib.db import async_session_factory
-from lib.episode_ledger import episode_outline_context
+from lib.episode_ledger import discover_sources, episode_outline_context, episode_source_slice
 from lib.episode_paths import (
     REFERENCE_VIDEO_STEP1_FILENAME,
     REFERENCE_VIDEO_STEP1_LEGACY_FILENAME,
@@ -145,15 +145,32 @@ def _load_novel_source(project_path: Path, source: str | None) -> str:
         source_dir = project_path / "source"
         if not source_dir.exists() or not any(source_dir.iterdir()):
             raise ValueError(f"source/ 目录为空或不存在: {source_dir}")
-        texts = [
-            f.read_text(encoding="utf-8")
-            for f in sorted(source_dir.iterdir())
-            if f.is_file() and f.suffix in (".txt", ".md", ".text")
-        ]
-        novel_text = "\n\n".join(texts)
+        # 只拼候选源文件（discover_sources 排除派生 episode_N.txt 与 _ / . 前缀文件）：
+        # 派生集文件是账本的派生物，若与主文本一起进全文，每集 prompt 都会重复整篇故事。
+        sources = discover_sources(project_path)
+        if not sources:
+            raise ValueError(f"source/ 目录下没有可用的源文本文件: {source_dir}")
+        novel_text = "\n\n".join(doc.text for doc in sources)
     if not novel_text.strip():
         raise ValueError("小说原文为空")
     return novel_text
+
+
+def _load_episode_source(
+    project_path: Path, project: dict[str, Any], episode: int, source: str | None
+) -> tuple[str, bool]:
+    """读取 step1 工具的源文：显式 ``source`` 优先，否则按账本 ``source_range`` 切本集切片。
+
+    返回 ``(文本, 是否按集切片)``。显式 ``source`` 保持整文件读取（参考视频隔离草稿等
+    既有调用路径沿用）；默认路径下账本有该集位置记录时只取本集切片，旧式条目（无
+    ``source_range``）回退读取全部候选源文。
+    """
+    if source:
+        return _load_novel_source(project_path, source), False
+    sliced = episode_source_slice(project_path, project, episode)
+    if sliced is not None:
+        return sliced, True
+    return _load_novel_source(project_path, None), False
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +463,7 @@ async def _fetch_caps_with_fallback(project: dict[str, Any], episode: int) -> tu
 def normalize_drama_script_tool(ctx: ToolContext):
     @tool(
         "normalize_drama_script",
-        "把 source/ 小说原文（或指定 source 文件）抽取为结构化分镜内容（场景边界、出场资产、"
+        "把本集小说原文（或指定 source 文件）抽取为结构化分镜内容（场景边界、出场资产、"
         "逐字口播 utterances、原文锚 source_text、视觉改编描述），保存到 "
         "drafts/episode_N/step1_normalized_script.json，供 generate_episode_script 透传消费。"
         "dry_run=true 时仅返回 prompt。",
@@ -456,7 +473,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                 "episode": {"type": "integer", "description": "剧集编号"},
                 "source": {
                     "type": "string",
-                    "description": "指定小说源文件路径（相对项目目录）；默认读取 source/ 下所有文本",
+                    "description": "指定小说源文件路径（相对项目目录）；默认按分集规划的 source_range 读取本集原文切片",
                 },
                 "dry_run": {"type": "boolean", "description": "仅显示 prompt，不调用模型"},
             },
@@ -473,7 +490,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
             project = ctx.pm.load_project(ctx.project_name)
 
             try:
-                novel_text = _load_novel_source(project_path, source)
+                novel_text, is_episode_slice = _load_episode_source(project_path, project, episode, source)
             except ValueError as exc:
                 return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
@@ -493,6 +510,7 @@ def normalize_drama_script_tool(ctx: ToolContext):
                 source_kind=project.get("source_kind") or DEFAULT_SOURCE_KIND,
                 episode_outline=episode_outline,
                 next_episode_outline=next_episode_outline,
+                source_is_episode_slice=is_episode_slice,
                 # 输出语言取项目 source_language（生成内容语言的唯一真相源）；缺省回退默认中文，
                 # 非中文项目的 step1 内容据此用目标语言产出，而非默认中文。
                 target_language=project.get("source_language") or "中文",
@@ -1479,7 +1497,7 @@ def split_narration_segments_tool(ctx: ToolContext):
                 "episode": {"type": "integer", "description": "剧集编号"},
                 "source": {
                     "type": "string",
-                    "description": "指定小说源文件路径（相对项目目录）；默认读取 source/ 下所有文本",
+                    "description": "指定小说源文件路径（相对项目目录）；默认按分集规划的 source_range 读取本集原文切片",
                 },
                 "dry_run": {"type": "boolean", "description": "仅显示 prompt，不调用模型"},
             },
@@ -1496,7 +1514,7 @@ def split_narration_segments_tool(ctx: ToolContext):
             project = ctx.pm.load_project(ctx.project_name)
 
             try:
-                novel_text = _load_novel_source(project_path, source)
+                novel_text, is_episode_slice = _load_episode_source(project_path, project, episode, source)
             except ValueError as exc:
                 return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
@@ -1519,6 +1537,7 @@ def split_narration_segments_tool(ctx: ToolContext):
                 default_duration=default_duration,
                 supported_durations=supported_durations,
                 episode=episode,
+                source_is_episode_slice=is_episode_slice,
                 # 输出语言取项目 source_language（生成内容语言的唯一真相源），与 normalize / reference 同口径。
                 target_language=project.get("source_language") or "中文",
             )

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -2548,6 +2548,63 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
 
 
 @pytest.mark.unit
+async def test_normalize_drama_script_slices_episode_source_range(fake_ctx: ToolContext, monkeypatch) -> None:
+    """默认路径按账本 source_range 切本集原文：ep2 的 prompt 只含 ep2 切片，不含 ep1 / 派生文件。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    novel = "第一集独有内容甲。第二集独有内容乙。第三集独有内容丙。"
+    (src / "novel.txt").write_text(novel, encoding="utf-8")
+    (src / "episode_2.txt").write_text("派生文件不应被读入", encoding="utf-8")
+    start2 = novel.index("第二集")
+    start3 = novel.index("第三集")
+    fake_ctx.pm.project_payload["episodes"] = [  # type: ignore[attr-defined]
+        {"episode": 1, "source_range": {"source_file": "source/novel.txt", "start": 0, "end": start2}},
+        {"episode": 2, "source_range": {"source_file": "source/novel.txt", "start": start2, "end": start3}},
+    ]
+
+    async def fake_caps(_p, _episode=None):
+        return 4, [4, 6, 8]
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    tool_obj = normalize_drama_script_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 2, "dry_run": True})
+    assert out.get("is_error") is not True, out
+    prompt_text = out["content"][0]["text"]
+    assert "第二集独有内容乙" in prompt_text
+    assert "第一集独有内容甲" not in prompt_text
+    assert "派生文件不应被读入" not in prompt_text
+    assert "本集小说原文" in prompt_text
+    assert "仅第 2 集对应段落" in prompt_text
+
+
+@pytest.mark.unit
+async def test_normalize_drama_script_fallback_excludes_derived_episode_files(
+    fake_ctx: ToolContext, monkeypatch
+) -> None:
+    """无 source_range 的旧式回退路径只拼候选源文，派生 episode_N.txt 不再与主文本一起进 prompt。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    (src / "novel.txt").write_text("从前有座山，山上有个庙。", encoding="utf-8")
+    (src / "episode_1.txt").write_text("从前有座山，山上有个庙。", encoding="utf-8")
+
+    async def fake_caps(_p, _episode=None):
+        return 4, [4, 6, 8]
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    tool_obj = normalize_drama_script_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    assert out.get("is_error") is not True, out
+    prompt_text = out["content"][0]["text"]
+    assert prompt_text.count("从前有座山，山上有个庙。") == 1
+
+
+@pytest.mark.unit
 async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: ToolContext, monkeypatch) -> None:
     """工具必须把 ctx.project_name 传给 TextGenerator.create/generate，
     否则项目级文本档位覆盖被跳过，且 usage tracking 会丢 project_name。"""
@@ -3499,6 +3556,7 @@ def _rv_source(fake_ctx: ToolContext) -> None:
     _rv_project(fake_ctx)
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
+    (src / "novel.txt").write_text(_RV_NOVEL, encoding="utf-8")
     (src / "episode_1.txt").write_text(_RV_NOVEL, encoding="utf-8")
 
 
@@ -4616,13 +4674,40 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypat
 
 
 @pytest.mark.unit
+async def test_split_narration_segments_slices_episode_source_range(fake_ctx: ToolContext, monkeypatch) -> None:
+    """narration 默认路径同样按账本 source_range 切本集原文，避免整篇重复进每集 prompt。"""
+    from server.agent_runtime.sdk_tools import text_generation as mod
+
+    project_path = fake_ctx.project_path
+    src = project_path / "source"
+    src.mkdir(parents=True)
+    novel = "第一段独有内容。第二段独有内容。第三段独有内容。"
+    (src / "novel.txt").write_text(novel, encoding="utf-8")
+    start2 = novel.index("第二段")
+    start3 = novel.index("第三段")
+    fake_ctx.pm.project_payload["episodes"] = [  # type: ignore[attr-defined]
+        {"episode": 1, "source_range": {"source_file": "source/novel.txt", "start": 0, "end": start2}},
+        {"episode": 2, "source_range": {"source_file": "source/novel.txt", "start": start2, "end": start3}},
+    ]
+
+    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    tool_obj = split_narration_segments_tool(fake_ctx)
+    out = await _call(tool_obj, {"episode": 2, "dry_run": True})
+    assert out.get("is_error") is not True, out
+    prompt_text = out["content"][0]["text"]
+    assert "第二段独有内容" in prompt_text
+    assert "第一段独有内容" not in prompt_text
+    assert "本集小说原文（仅第 2 集对应段落）" in prompt_text
+
+
+@pytest.mark.unit
 async def test_split_narration_segments_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     """happy path：结构化片段 step1 落盘；模型经文本管道按 SCRIPT 任务解析并携带 project_name 入账。"""
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
-    (src / "episode_1.txt").write_text("张三走向村口。他停下脚步，久久凝望。", encoding="utf-8")
+    (src / "novel.txt").write_text("张三走向村口。他停下脚步，久久凝望。", encoding="utf-8")
     captured: dict[str, Any] = {}
     segments = [
         _nr_segment("E1S01", 4, "张三走向村口。", characters_in_segment=["张三"], scenes=["村口"]),
@@ -4753,7 +4838,7 @@ async def _nr_source_and_call(fake_ctx: ToolContext, monkeypatch, source_text: s
 
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
-    (src / "episode_1.txt").write_text(source_text, encoding="utf-8")
+    (src / "novel.txt").write_text(source_text, encoding="utf-8")
     monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 

--- a/tests/test_episode_ledger.py
+++ b/tests/test_episode_ledger.py
@@ -10,6 +10,7 @@ import pytest
 from lib.episode_ledger import (
     compute_source_fingerprints,
     discover_sources,
+    episode_source_slice,
     episodes_without_source_range,
     mismatched_source_fingerprints,
     normalize_source_text,
@@ -210,3 +211,55 @@ class TestSourceFingerprints:
         d = _project(tmp_path)
         mismatched = mismatched_source_fingerprints({"source/novel.txt": 123}, discover_sources(d))
         assert mismatched == []
+
+
+class TestEpisodeSourceSlice:
+    """按账本 source_range 切本集原文（归一化坐标系）；无位置记录返回 None，坐标/源文件异常 fail-loud。"""
+
+    @pytest.mark.unit
+    def test_slices_normalized_text_by_source_range(self, tmp_path: Path):
+        d = _project(tmp_path)
+        project = {
+            "episodes": [{"episode": 1, "source_range": {"source_file": "source/novel.txt", "start": 0, "end": CUT_1}}]
+        }
+        assert episode_source_slice(d, project, 1) == normalize_source_text(NOVEL[:CUT_1])
+
+    @pytest.mark.unit
+    def test_crlf_source_uses_normalized_coordinates(self, tmp_path: Path):
+        d = _project(tmp_path)
+        # 直接写原始字节内容，避免 Windows write_text 把 \n 翻成 \r\n 干扰坐标
+        (d / "source" / "novel.txt").write_text("ab\r\ncd\r\nef", encoding="utf-8", newline="")
+        project = {
+            "episodes": [{"episode": 1, "source_range": {"source_file": "source/novel.txt", "start": 3, "end": 7}}]
+        }
+        # 归一化后为 "ab\ncd\nef"，[3:7] = "cd\ne"
+        assert episode_source_slice(d, project, 1) == "cd\ne"
+
+    @pytest.mark.unit
+    def test_no_entry_returns_none(self, tmp_path: Path):
+        d = _project(tmp_path)
+        assert episode_source_slice(d, {"episodes": []}, 1) is None
+
+    @pytest.mark.unit
+    def test_no_source_range_returns_none(self, tmp_path: Path):
+        d = _project(tmp_path)
+        project = {"episodes": [{"episode": 1, "title": "旧式条目"}]}
+        assert episode_source_slice(d, project, 1) is None
+
+    @pytest.mark.unit
+    def test_out_of_bounds_raises(self, tmp_path: Path):
+        d = _project(tmp_path)
+        project = {
+            "episodes": [{"episode": 1, "source_range": {"source_file": "source/novel.txt", "start": 0, "end": 9999}}]
+        }
+        with pytest.raises(ValueError):
+            episode_source_slice(d, project, 1)
+
+    @pytest.mark.unit
+    def test_missing_source_file_raises(self, tmp_path: Path):
+        d = _project(tmp_path)
+        project = {
+            "episodes": [{"episode": 1, "source_range": {"source_file": "source/gone.txt", "start": 0, "end": 5}}]
+        }
+        with pytest.raises(ValueError):
+            episode_source_slice(d, project, 1)

--- a/tests/test_prompt_builders_script.py
+++ b/tests/test_prompt_builders_script.py
@@ -260,6 +260,15 @@ class TestScreenplaySourceKind:
         assert "utterances" in prompt
         assert "source_text" in prompt
 
+    def test_normalize_episode_slice_marks_scope(self):
+        """source_is_episode_slice=True 时原文块标注本集范围，抑制模型扩展整篇。"""
+        prompt = self._normalize_prompt("novel", source_is_episode_slice=True)
+        assert "本集小说原文（仅第 1 集对应段落）" in prompt
+        assert "只包含本集内容" in prompt
+        assert "所有分镜内容须取自上方本集原文段" in prompt
+        # 非切片默认不渲染本集范围说明
+        assert "只包含本集内容" not in self._normalize_prompt("novel")
+
     def test_normalize_novel_releases_voiceover_by_context(self):
         # AC5：novel 源画外音克制放开——由语境判断产出，不再一律禁用、不预设规则白名单、不作兜底
         prompt = self._normalize_prompt("novel")
@@ -608,6 +617,13 @@ class TestBuildNarrationSplitPrompt:
         # 档位与默认偏好进 prompt
         assert "4, 6, 8" in text
         assert "默认取 4 秒" in text
+
+    def test_narration_episode_slice_marks_scope(self):
+        text = self._prompt(source_is_episode_slice=True)
+        assert "本集小说原文（仅第 1 集对应段落）" in text
+        assert "只包含本集内容" in text
+        assert "所有片段须取自上方本集原文段" in text
+        assert "只包含本集内容" not in self._prompt()
 
     def test_mirrors_narration_pacing_rules(self):
         text = self._prompt()


### PR DESCRIPTION
## 范围

lib/episode_ledger.py、lib/prompt_builders_script.py、server/agent_runtime/sdk_tools/text_generation.py 及对应测试。

## 变更

- episode_ledger 新增按账本 source_range 切本集原文的读取入口，源缺失/坐标越界 fail-loud
- normalize/split 工具默认只读本集切片，旧式无位置记录条目回退全文
- 候选源文件排除派生 episode_N.txt，避免整篇故事重复进每集 prompt
- normalize prompt 增加本集范围提示，抑制模型扩展整篇

## 验收清单

- [x] 本地已跑相关测试（test_episode_ledger / test_prompt_builders_script / test_sdk_tools），326 项通过
- [ ] CI（ruff / basedpyright）待跑

## 已知 defer

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持根据分集记录精准读取当前集的原文片段。
  - 未指定源文时，系统会优先使用当前集内容，避免误读派生文件或重复拼接全文。
  - 生成剧本和旁白分段时，会明确限制内容仅来源于当前集原文范围。

- **错误修复**
  - 缺少源文件、读取失败或范围越界时提供明确错误，不再回退读取全文。

- **测试**
  - 新增分集切片、换行格式、缺失记录、越界及提示内容范围校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->