### PR TITLE
fix(费用估算): 宫格图按项目实际分辨率档计价，同名条目各自展示正确估算

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -19,7 +19,7 @@ from lib.config.resolver import (
 from lib.cost_calculator import cost_calculator
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.db.repositories.usage_repo import PROJECT_LEVEL_SEGMENT_KEY, UsageRepository
-from lib.grid.layout import large_grid_allowed, plan_grid_chunks
+from lib.grid.layout import GRID_FALLBACK_RESOLUTION, large_grid_allowed, plan_grid_chunks
 from lib.pricing.strategies import PricingParams
 from lib.project_manager import grid_storyboard_enabled, is_reference_video_project
 from lib.reference_video import assemble_shots_text
@@ -177,9 +177,11 @@ class CostEstimationService:
             except Exception:
                 image_provider, image_model = "unknown", "unknown"
 
-            # 宫格 4×4 / 5×5 的 4K 门控：与路由入队、SDK 工具共用 ``grid_resolution`` 的取档，
-            # 估算的宫格张数才不会与实际入队张数漂移。
-            grid_allow_large = large_grid_allowed(await resolve_grid_image_resolution(r, project_data))
+            # 宫格档位：与路由入队、SDK 工具共用 ``grid_resolution`` 的取档，估算的宫格张数才
+            # 不会与实际入队张数漂移；同一档位还是宫格图的计价档，未配置时回落
+            # ``GRID_FALLBACK_RESOLUTION``（与 ``execute_grid_task`` 下发的保底档同源）。
+            grid_image_resolution = await resolve_grid_image_resolution(r, project_data)
+            grid_allow_large = large_grid_allowed(grid_image_resolution)
 
             # 视频按能力桶解析（``docs/adr/0054``），与执行扣费同一个模型：图生视频 / 宫格算
             # i2v 桶的价；参考生视频按 unit 声明的参考集逐 unit 分桶（有参考图 → r2v，无参考图
@@ -276,7 +278,11 @@ class CostEstimationService:
             try:
                 grid_image_unit_cost = cost_calculator.calculate_cost(
                     image_provider,
-                    PricingParams(call_type="image", model=image_model, resolution="2K"),
+                    PricingParams(
+                        call_type="image",
+                        model=image_model,
+                        resolution=grid_image_resolution or GRID_FALLBACK_RESOLUTION,
+                    ),
                     custom_price_input=image_price.price_input,
                     custom_price_output=image_price.price_output,
                     custom_currency=image_price.currency,
@@ -374,21 +380,26 @@ class CostEstimationService:
                 logger.warning("费用估算跳过脏脚本 %s: %s", script_file, exc)
                 raw_segments, id_key = [], "segment_id"
 
-            # Grid 模式：预计算每个 segment 的图片分摊费用
-            grid_cost_per_segment: dict[str, tuple[float, str]] = {}
+            # Grid 模式：预计算每个 segment 的图片分摊费用。份额以条目在 ``raw_segments`` 中的
+            # 位置为身份，与下方实付均摊同口径（理由见该处）；分组由
+            # ``group_scenes_by_segment_break`` 按顺序切出、连续且不重不漏，故位置即组内序号
+            # 加上前序各组的长度。
+            grid_cost_per_index: dict[int, tuple[float, str]] = {}
             if grid_enabled and grid_image_unit_cost:
-                groups = group_scenes_by_segment_break(raw_segments, id_key)
-                for group in groups:
+                group_offset = 0
+                for group in group_scenes_by_segment_break(raw_segments, id_key):
                     n = len(group)
                     # 宫格张数与实际入队同源（plan_grid_chunks）：超上限分组按切块后的
                     # 张数计费，避免估算与执行漂移。
                     plans = plan_grid_chunks(group, aspect_ratio, allow_large_grid=grid_allow_large)
-                    if not plans:
-                        continue
-                    grid_count = len(plans)
-                    per_scene_cost = round(grid_image_unit_cost[0] * grid_count / n, 6)
-                    for seg in group:
-                        grid_cost_per_segment[seg.get(id_key, "")] = (per_scene_cost, grid_image_unit_cost[1])
+                    if plans:
+                        per_scene_cost = round(grid_image_unit_cost[0] * len(plans) / n, 6)
+                        for offset_in_group in range(n):
+                            grid_cost_per_index[group_offset + offset_in_group] = (
+                                per_scene_cost,
+                                grid_image_unit_cost[1],
+                            )
+                    group_offset += n
 
             # --- Grid actual cost apportionment ---
             # 均摊份额以条目在 raw_segments 中的位置为身份，而非条目 ID：ADR 0053 接受一张
@@ -421,8 +432,8 @@ class CostEstimationService:
                 est_video: CostBreakdown = {}
                 est_audio: CostBreakdown = {}
 
-                if grid_enabled and seg_id in grid_cost_per_segment:
-                    cost_amount, cost_currency = grid_cost_per_segment[seg_id]
+                if grid_enabled and idx in grid_cost_per_index:
+                    cost_amount, cost_currency = grid_cost_per_index[idx]
                     _add_cost(est_image, cost_amount, cost_currency)
                 elif image_unit_cost:
                     _add_cost(est_image, image_unit_cost[0], image_unit_cost[1])

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -713,8 +713,31 @@ class TestCostEstimationService:
     @pytest.mark.unit
     async def test_grid_estimate_count_follows_4k_gate(self, db_factory, monkeypatch):
         """估算的宫格张数按 4K 门控走同一条阶梯：12 场景一组，4K 下一张 4×4 装下，
-        非 4K 下封顶 3×3 要切两张，估算总价相应翻倍。"""
+        非 4K 下封顶 3×3 要切两张，估算总价相应翻倍。
+
+        用按张定价（与分辨率无关）的自定义供应商，把张数变化与单价随档位变化的影响隔开。
+        """
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
         from server.services import cost_estimation as ce
+
+        async with db_factory() as session:
+            await CustomProviderRepository(session).create_provider(
+                display_name="Custom",
+                discovery_format="openai",
+                base_url="https://api.example.com",
+                api_key="k",
+                models=[
+                    {
+                        "model_id": "img",
+                        "display_name": "Img",
+                        "endpoint": "openai-images",
+                        "price_unit": "image",
+                        "price_input": 0.09,
+                        "currency": "USD",
+                    },
+                ],
+            )
+            await session.commit()
 
         seg_ids = [f"E1S{i:03d}" for i in range(1, 13)]
         project_data = {
@@ -722,6 +745,7 @@ class TestCostEstimationService:
             "content_mode": "narration",
             "generation_mode": "storyboard",
             "grid_storyboard": True,
+            "image_provider_t2i": "custom-1/img",
             "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
         }
         scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 12)}
@@ -740,6 +764,75 @@ class TestCostEstimationService:
         # 未配置分辨率（None）与 2K 同样落在门控内
         assert await _estimated_image_total("2K") == pytest.approx(total_4k * 2, rel=1e-4)  # 每条份额各自 round(…, 6)
         assert await _estimated_image_total(None) == pytest.approx(total_4k * 2, rel=1e-4)  # 每条份额各自 round(…, 6)
+
+    @pytest.mark.unit
+    async def test_grid_estimate_prices_at_resolved_resolution(self, db_factory, monkeypatch):
+        """宫格图按执行期生效的分辨率档计价：4K 项目按 4K 单价，未配置回落保底档。
+
+        9 场景在任何档位下都只切一张 grid_9，张数不变，差异只来自单价。
+        """
+        from lib.grid.layout import GRID_FALLBACK_RESOLUTION
+        from server.services import cost_estimation as ce
+
+        seg_ids = [f"E1S{i:03d}" for i in range(1, 10)]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "grid_storyboard": True,
+            # 显式钉住按分辨率分档定价的型号：测试要验的是「计价档随解析结果走」，
+            # 不该依赖全局默认图片模型恰好是分档定价的
+            "image_provider_t2i": "gemini-aistudio/gemini-3.1-flash-image-preview",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 9)}
+
+        async def _estimated_image_total(resolution: str | None) -> float:
+            async def _resolution(_r, _project):
+                return resolution
+
+            monkeypatch.setattr(ce, "resolve_grid_image_resolution", _resolution)
+            service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+            result = await service.compute(project_data, scripts, project_name="proj")
+            return sum(seg["estimate"]["image"]["USD"] for seg in result["episodes"][0]["segments"])
+
+        total_2k = await _estimated_image_total("2K")
+        total_4k = await _estimated_image_total("4K")
+        assert total_2k > 0
+        # 该型号 4K 单价高于 2K，估算须随之上浮而非恒按 2K
+        assert total_4k > total_2k
+        # 未配置分辨率时按保底档计价，与执行期下发的档位同源
+        assert await _estimated_image_total(None) == pytest.approx(
+            await _estimated_image_total(GRID_FALLBACK_RESOLUTION)
+        )
+
+    @pytest.mark.unit
+    async def test_grid_estimate_duplicate_ids_across_groups_each_correct(self, db_factory):
+        """同 ID 条目落在不同分组时各自展示本组的均摊估算，不被后写的分组覆盖。"""
+        resolver = ConfigResolver(db_factory)
+        service = CostEstimationService(resolver, db_factory)
+
+        # 前 9 条一组（grid_9，每条摊 1/9 张），第 10 条 segment_break 另起一组（grid_4，独占一张）
+        seg_ids = [f"E1S{i:03d}" for i in range(1, 9)] + ["DUP", "DUP"]
+        script = _make_script(1, seg_ids, [6] * 10)
+        script["segments"][9]["segment_break"] = True
+
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            "grid_storyboard": True,
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+
+        result = await service.compute(project_data, {"ep1.json": script}, project_name="proj")
+        segments = result["episodes"][0]["segments"]
+
+        unit = segments[9]["estimate"]["image"]["USD"]  # 独占一张宫格 → 满张单价
+        assert unit > 0
+        # 含末位与第 10 条同名的第 9 条：按 ID 建 key 时它会被后写的第二组覆盖成满张单价
+        for seg in segments[:9]:
+            assert seg["estimate"]["image"]["USD"] == pytest.approx(round(unit / 9, 6))
 
     @pytest.mark.unit
     async def test_project_level_actual_split_by_asset_type(self, db_factory):


### PR DESCRIPTION
## 问题

宫格图片估算固定按 2K 档取价，而 4K 项目实际按 4K 档生成，估算系统性偏低——正好覆盖 4K 门控（大宫格档位）引入的用户群。同函数内 4K 门控已同源取档，只有计价档没跟上。

同函数的估算均摊表按条目 ID 建 key，而 40 行之下的实付均摊按位置索引组织（一张宫格覆盖的多个条目可共用同一 ID，位置唯一而 ID 不唯一）。同 ID 条目跨 segment_break 分组时，后写的分组覆盖前写，对应条目展示错误的每场景估算。

## 改动

- 计价档复用同函数已解析的 `resolve_grid_image_resolution` 结果，未配置时回落 `GRID_FALLBACK_RESOLUTION`，与 `execute_grid_task` 下发的档位逐字同源；4K 门控与计价共用一次解析
- 估算均摊表改按条目在 `raw_segments` 中的位置建 key，与实付均摊同口径。分组由 `group_scenes_by_segment_break` 按顺序切出、连续不重不漏，故位置 = 组内序号 + 前序各组长度，用一个偏移量累加即可；跳过的分组同样推进偏移量

影响面：仅估算展示，实付与冻结账不变。

## 验证

- 新增 `test_grid_estimate_prices_at_resolved_resolution`（9 场景恒 1 张，隔离张数变量：4K 总价 > 2K，未配置等于保底档）与 `test_grid_estimate_duplicate_ids_across_groups_each_correct`（两组末条同名，各自拿 1/9 张与满张）；二者在 revert 实现后均转红
- 既有 `test_grid_estimate_count_follows_4k_gate` 的「2K 总价 = 4K 总价 × 2」建立在单价与分辨率无关的旧行为上，改用按张定价的自定义供应商，把「张数随门控变化」与「单价随档位变化」两个变量隔开，测试意图更纯
- 全量 `pytest` 8068 passed、`ruff`、`basedpyright` 0 error、`lint-imports` 契约通过

Closes #1718


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 宫格图片估价现在会根据实际分辨率计算，不再固定按 2K 计价。
  - 未配置分辨率时，将自动使用默认分辨率，确保估价结果稳定。
  - 优化宫格费用分摊逻辑，即使存在重复条目标识，也能按实际位置准确分摊费用。
- **测试**
  - 新增不同分辨率、默认配置及重复条目标识场景的费用估算验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->