### PR TITLE
test(生成): merge_billed_tokens 补四象限单测并上移 ark 局部导入

### DIFF
--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -15,6 +15,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
     TextGenerationResult,
+    merge_billed_tokens,
 )
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,7 @@ class ArkTextBackend:
             # ark 原生 response_format 未声明 strict，复验同样用 strict=False，避免对可强转值误判违例。
             fallback_reason = structured_fallback_reason(native.text, request.response_schema, strict=False)
             if fallback_reason:
-                from lib.text_backends.base import merge_billed_tokens, truncate_for_log
+                from lib.text_backends.base import truncate_for_log
 
                 logger.warning(
                     "原生 response_format %s，降级到带校验的 Instructor 路径；模型原始输出：%s",

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -275,6 +275,30 @@ class TestStructuredFallbackReason:
         assert structured_fallback_reason("", None) is None
 
 
+class TestMergeBilledTokens:
+    """降级路径的原生调用计量并账：仅在至少一侧有值时相加，两侧皆 None 保持 None。"""
+
+    def test_both_sides_have_values(self):
+        from lib.text_backends.base import merge_billed_tokens
+
+        assert merge_billed_tokens(100, 50) == 150
+
+    def test_only_native_has_value(self):
+        from lib.text_backends.base import merge_billed_tokens
+
+        assert merge_billed_tokens(None, 50) == 50
+
+    def test_only_fallback_has_value(self):
+        from lib.text_backends.base import merge_billed_tokens
+
+        assert merge_billed_tokens(100, None) == 100
+
+    def test_both_none_stays_none(self):
+        from lib.text_backends.base import merge_billed_tokens
+
+        assert merge_billed_tokens(None, None) is None
+
+
 class TestIsValidJson:
     def test_valid(self):
         from lib.text_backends.base import is_valid_json


### PR DESCRIPTION
## 背景与范围

issue #970 的主体收敛（`merge_billed_tokens` 上移到 `lib/text_backends/base.py`，openai / ark 复用）在先前工作中已经合入 main。本 PR 只补齐剩余的两处验收缺口，范围收窄经裁决确认：

- 补 `TestMergeBilledTokens` 四象限单测：两侧皆有值 / 仅原生已计费侧有 / 仅保留结果侧有 / 两侧皆 None（保持 None，不塌成字面 0 token）。
- 把 `ark.py` 中对 `merge_billed_tokens` 的函数内导入上移到模块顶层的 base import 块。

零行为变更。

## 验证

- `uv run ruff check` / `ruff format --check`：通过
- `uv run python -m pytest tests/test_text_backends/`：178 passed
- `uv run basedpyright`：0 errors
- `uv run lint-imports`：1 contract kept
- 以上均在 rebase 到最新 main（12aa4404）之后重新执行通过

Closes #970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 增加了计费令牌合并逻辑的测试，覆盖双方有值、单方有值及双方为空等情况。
* **重构**
  * 优化了内部导入方式，不改变现有运行行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->