### PR TITLE
feat(视频): 阿里百炼新增 HappyHorse 1.1 三模态并设为默认视频模型

### DIFF
--- a/docs/dashscope-docs/README.md
+++ b/docs/dashscope-docs/README.md
@@ -8,16 +8,16 @@
 - [千问-文生图.md](./千问-文生图.md) — `qwen-image-2.0-pro` / `qwen-image-2.0`(融合 T2I+I2I)+ 经典 `qwen-image-max/plus/image` 系列
 - [千问-图像编辑.md](./千问-图像编辑.md) — `qwen-image-edit-max` / `qwen-image-edit-plus` / `qwen-image-edit` 编辑专用模型
 - [万相2.7-图像.md](./万相2.7-图像.md) — `wan2.7-image` / `wan2.7-image-pro`:T2I/编辑/组图/交互式编辑(bbox)/思考模式/4K
-- [参考生视频-HappyHorse.md](./参考生视频-HappyHorse.md) — `happyhorse-1.0-r2v` 请求/响应 schema、参数约束
+- [参考生视频-HappyHorse.md](./参考生视频-HappyHorse.md) — HappyHorse 1.0 / 1.1 全系 t2v / i2v / r2v 请求/响应 schema、参数约束、版本差异
 - [参考生视频-wan2.7.md](./参考生视频-wan2.7.md) — `wan2.7-r2v` 请求/响应 schema、参数约束、与 wan2.6 差异
 - [语音合成-TTS模型.md](./语音合成-TTS模型.md) — Qwen3-TTS / CosyVoice 全系列：模型选型、定价、48 音色、声音复刻/设计 API、Instruct 指令控制
 - [阿里百炼费用参考.md](./阿里百炼费用参考.md) — 文本/图像/视频全模型定价（CNY，已核实)
 
 ## 数据来源
 
-- HappyHorse R2V / Wan2.7 R2V API schema:阿里云 Model Studio 官方 API 参考(2026-05 截止)
+- HappyHorse / Wan2.7 R2V API schema:阿里云 Model Studio 官方 API 参考;HappyHorse 1.1 三模态与定价另见 `docs/research/happyhorse-1.1-dashscope-research.md` 的一手引用
 - 文本/图像/视频定价:百炼控制台模型市场页面截图,已逐项核对
-- 未在本目录覆盖的字段(如 i2v 首尾帧、t2v 文生视频)按官方文档惯例与 R2V schema 同构,实现时按需扩充
+- 未在本目录覆盖的模型与字段(如 HappyHorse 视频编辑)按官方文档惯例与同系列 schema 同构,实现时按需扩充
 
 ## 维护约定
 

--- a/docs/dashscope-docs/README.md
+++ b/docs/dashscope-docs/README.md
@@ -17,7 +17,7 @@
 
 - HappyHorse / Wan2.7 R2V API schema:阿里云 Model Studio 官方 API 参考;HappyHorse 1.1 三模态与定价另见 `docs/research/happyhorse-1.1-dashscope-research.md` 的一手引用
 - 文本/图像/视频定价:百炼控制台模型市场页面截图,已逐项核对
-- 未在本目录覆盖的模型与字段(如 HappyHorse 视频编辑)按官方文档惯例与同系列 schema 同构,实现时按需扩充
+- 未在本目录覆盖的模型与字段(如 HappyHorse 视频编辑)一律以该模型自己的官方 API 参考为准;同系列的 schema 不保证同构(视频编辑要 1 个 `video` + 0~5 张参考图,r2v 要 1~9 张参考图),收录前不要按同系列推断扩散
 
 ## 维护约定
 

--- a/docs/dashscope-docs/参考生视频-HappyHorse.md
+++ b/docs/dashscope-docs/参考生视频-HappyHorse.md
@@ -1,8 +1,8 @@
-# HappyHorse 参考生视频（happyhorse-1.0-r2v）
+# HappyHorse 视频系列（1.0 / 1.1 的 t2v / i2v / r2v）
 
-HappyHorse 参考生视频支持传入**多张参考图像**,通过**文本提示词**描述场景,将图像中的主体角色融合生成一段流畅视频。
+HappyHorse 是阿里自研的原生多模态视频生成系列,音画联合生成(输出恒带音轨,无音频开关参数)。1.0 与 1.1 两代并行在售,各含文生视频(t2v)、图生视频(i2v)、参考生视频(r2v)三个模态。
 
-通用 API 模式(异步、Headers、轮询)详见 [API 概览.md](./API%20概览.md)。本文只列模型独有 schema。
+通用 API 模式(异步、Headers、轮询)详见 [API 概览.md](./API%20概览.md)。本文以参考生视频的完整 schema 为主线,t2v / i2v 的差异集中在文末[同系列模态](#同系列模态t2v--i2v)一节。1.1 相对 1.0 的差异见[版本差异](#版本差异11-vs-10)。
 
 ## 步骤 1:创建任务
 
@@ -14,7 +14,7 @@ POST /api/v1/services/aigc/video-generation/video-synthesis
 
 ```json
 {
-  "model": "happyhorse-1.0-r2v",
+  "model": "happyhorse-1.1-r2v",
   "input": {
     "prompt": "[Image 1]中身着红色旗袍的女性,镜头先以侧面中景勾勒...",
     "media": [
@@ -33,7 +33,7 @@ POST /api/v1/services/aigc/video-generation/video-synthesis
 
 ### `model`
 
-固定值 `happyhorse-1.0-r2v`。
+`happyhorse-1.1-r2v` 或 `happyhorse-1.0-r2v`。
 
 ### `input.prompt`（必选)
 
@@ -61,7 +61,7 @@ POST /api/v1/services/aigc/video-generation/video-synthesis
 
 | 参数 | 类型 | 默认 | 取值 | 说明 |
 |------|------|------|------|------|
-| `resolution` | string | `1080P` | `720P` / `1080P` | 分辨率档位 |
+| `resolution` | string | `1080P` | `480P` / `720P` / `1080P` | 分辨率档位。官方参数表为 1.1 / 1.0 合并呈现,480P 的版本归属见[版本差异](#版本差异11-vs-10) |
 | `ratio` | string | `16:9` | `16:9` / `9:16` / `3:4` / `4:3` / `4:5` / `5:4` / `1:1` / `9:21` / `21:9` | 宽高比 |
 | `duration` | integer | `5` | `3 ~ 15` 整数(秒) | 视频时长,按秒计费 |
 | `watermark` | bool | `true` | `true` / `false` | 右下角水印,文案固定 "Happy Horse" |
@@ -109,18 +109,31 @@ GET /api/v1/tasks/{task_id}
 | `SR` | int | 输出分辨率档位(如 720) |
 | `ratio` | string | 输出宽高比 |
 
+## 同系列模态（t2v / i2v）
+
+三个模态共用同一异步端点与 `parameters` 表(`resolution` / `duration` / `watermark` / `seed`),差异只在输入形态与 `ratio`:
+
+| 模态 | model id | 输入 | `ratio` |
+|------|----------|------|---------|
+| 文生视频 | `happyhorse-1.1-t2v` / `happyhorse-1.0-t2v` | 仅 `input.prompt` | 支持,9 档(默认 `16:9`) |
+| 图生视频 | `happyhorse-1.1-i2v` / `happyhorse-1.0-i2v` | 首帧图(`media` 中 `first_frame`) | **不支持**,宽高比自动跟随首帧 |
+| 参考生视频 | `happyhorse-1.1-r2v` / `happyhorse-1.0-r2v` | 参考图 1~9 张 | 支持,同 t2v |
+
+图生视频首帧图约束:JPEG / JPG / PNG / WEBP;宽高均 ≥ 300 px;宽高比 1:2.5 ~ 2.5:1;≤ 20 MB。全系**无尾帧**能力,首尾帧场景走 wan2.7 系列(见 [参考生视频-wan2.7.md](./参考生视频-wan2.7.md))。
+
+## 版本差异（1.1 vs 1.0）
+
+- 分辨率:官方参数表把 1.1 / 1.0 合并呈现为 `480P` / `720P` / `1080P`,未按版本区分;1.0 早期资料只出现 `720P` / `1080P`,**480P 是否 1.0 通用未能确认**
+- 定价(元/秒,刊例价):1.1 为 480P 0.45 / 720P 0.9 / 1080P 1.2;1.0 为 720P 0.9 / 1080P 1.6。详见 [阿里百炼费用参考.md](./阿里百炼费用参考.md)
+- 1.1 指令遵循更严格、参考图还原度与口型同步精度提升、出片更快(来源为阿里云开发者社区通稿,非 API 参考);两代时长档位相同(3~15s)
+- 1.0 全系仍在售,无官方停售公告
+
 ## ArcReel 集成要点
 
-- **R2V 单镜头参考图上限 = 9**(`max_reference_images: 9`)
-- **resolutions**:`["720P", "1080P"]`
-- **supported_durations**:`[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]`
-- **capabilities**:`["reference_images", "generate_audio"]`(音频恒开,无开关参数)
-- **水印**:`watermark=false` 关闭,默认会带 "Happy Horse" 水印 — ArcReel 应在 backend 默认传 `false`
-
-## 同系列模型(待官方扩充)
-
-HappyHorse 系列除 R2V 外,根据 PRD 还规划:
-- `happyhorse-1.0-t2v`(文生视频 + 音频)
-- `happyhorse-1.0-i2v`(图生视频 + 音频)
-
-这两个的 schema 阿里官方文档另列,字段大体同构(`input.prompt` + `parameters.resolution/duration` 等),实现时按官方文档为准。
+- **R2V 单镜头参考图上限 = 9**(`max_reference_images: 9`),t2v / i2v 无参考图槽位
+- **能力位归 backend**:i2v 声明 `first_frame=True`,t2v / r2v 为 `False`(视频能力位不入 `ModelInfo.capabilities`,见 `docs/adr/0054`)
+- **resolutions**:1.1 `["480p", "720p", "1080p"]`;1.0 `["720p", "1080p"]`(480P 对 1.0 未确权,registry 不替官方补写)
+- **supported_durations**:`[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]`(两代同)
+- **音频**:恒开、无开关参数,由恒有声例外表判定有音轨
+- **水印**:官方默认 `watermark=true`(右下角 "Happy Horse"),ArcReel backend 构造 payload 时显式传 `false`
+- **默认视频模型**:`happyhorse-1.1-i2v`

--- a/docs/dashscope-docs/阿里百炼费用参考.md
+++ b/docs/dashscope-docs/阿里百炼费用参考.md
@@ -60,7 +60,22 @@
 
 单位:**元 / 秒**(按输出视频时长计费;wan2.7-r2v 含输入视频时长)
 
-### HappyHorse 系列
+### HappyHorse 1.1 系列
+
+统一定价(刊例价):
+
+| 分辨率 | 单价(元/秒) |
+|--------|------------|
+| 480P | 0.45 |
+| 720P | 0.9 |
+| 1080P | 1.2 |
+
+适用模型:
+- `happyhorse-1.1-t2v`(文生视频)
+- `happyhorse-1.1-i2v`(图生视频)
+- `happyhorse-1.1-r2v`(参考生视频)
+
+### HappyHorse 1.0 系列
 
 统一定价:
 
@@ -112,12 +127,12 @@
 在 `lib/config/registry.py::PROVIDER_REGISTRY["dashscope"]` 中:
 - 文本:用 `_dashscope_text_pricing` → `PerToken`,`currency="CNY"`
 - 图像:用 `_dashscope_image_pricing` → `PerImageFlat`,`currency="CNY"`
-- 视频:用 `_dashscope_video_pricing` → `PerSecondMatrix`,`dimensions="resolution_only"`,键 `("720P", None)` / `("1080P", None)`,`currency="CNY"`
+- 视频:用 `_dashscope_video_pricing` → `PerSecondMatrix`,`dimensions="resolution_only"`,键为该模型登记的各分辨率档(如 `("720p", None)`),`currency="CNY"`
 
 视频的 `dimensions="resolution_only"` 而非 `"resolution_audio"`,因为 HappyHorse / Wan2.7 音频**恒开**,价格不随音频开关变化。
 
 ## 数据来源
 
 - 文本 / 图像 / 视频价格:百炼控制台 → 模型市场 → 各模型详情页 → 模型价格区(按需切换"千 tokens" / "百万 tokens")
-- 截至 2026-05-30 核对
+- 截至 2026-05-30 核对;HappyHorse 1.1 系列价格另按 `docs/research/happyhorse-1.1-dashscope-research.md` §2.5 的一手引用核实(720P / 1080P 见阿里云开发者社区通稿,480P 取自控制台价格表)
 - 阿里官方可能调整定价,如有变动以控制台为准并回写本文档

--- a/docs/research/happyhorse-1.1-dashscope-research.md
+++ b/docs/research/happyhorse-1.1-dashscope-research.md
@@ -92,7 +92,7 @@
 
 官方多模态接入文档给出的视频调用为:
 
-```
+```http
 POST https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis
 GET  https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1/tasks/{task_id}
 ```

--- a/docs/research/happyhorse-1.1-dashscope-research.md
+++ b/docs/research/happyhorse-1.1-dashscope-research.md
@@ -21,7 +21,7 @@
 | 首尾帧 | **无 1.1 变体** | — | — | 官方首尾帧场景推荐 `wan2.7-i2v-2026-04-25` | — |
 | 视频编辑 | `happyhorse-1.0-video-edit`(仅 1.0,无 1.1) | 720P / 1080P(默认) | 输出 3–15s(输入视频 3–60s) | 视频 + 0–5 张参考图 + 文本指令,风格转换/局部替换 | 未能确认 |
 
-促销:1.1 全系曾有限时 6 折(2026-06-22 至 2026-07-06,720P 0.54 / 1080P 0.72 元/秒),同期 1.0 享 8 折;当前是否仍在折扣期未能确认。新用户免费额度:10 秒视频生成。
+促销:1.1 全系曾有限时 6 折(2026-06-22 至 2026-07-06,720P 0.54 / 1080P 0.72 元/秒),同期 1.0 享 8 折;该促销期已结束,是否续期或另有新促销未能确认。新用户免费额度:10 秒视频生成。
 
 ## 2. 各项详述与引用
 
@@ -141,7 +141,7 @@ GET  https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1/tasks/{task_id}
 - `lib/custom_provider/duration_presets.py` 的 `happyhorse` 正则(3–15)与 `lib/custom_provider/endpoints.py` 的 `"happyhorse"` 子串路由(dashscope-async-video)天然覆盖 1.1,无需改动
 - 首尾帧需求不要落在 happyhorse 上(全系无尾帧);官方首尾帧推荐 `wan2.7-i2v-2026-04-25`
 - Token Plan 接入:视频走原生异步路径且 schema 同构,理论上现有 `DashScopeVideoBackend` 换 `base_url`(`https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1`)+ `sk-sp-` Key 即可复用;但额度用尽是 429 硬阻断而非转按量,若接入需把该错误映射成用户可读的配额提示,且仅北京地域可用
-- `docs/dashscope-docs/参考生视频-HappyHorse.md` 现为 1.0 快照(且写「同系列 t2v/i2v 待官方扩充」),若实施 1.1 接入应按维护约定回写该目录
+- `docs/dashscope-docs/参考生视频-HappyHorse.md` 已按维护约定回写为 HappyHorse 全系文档(1.0/1.1 × t2v/i2v/r2v),r2v 完整 schema 为主线,t2v/i2v 差异与版本差异各成一节
 
 ## 来源清单
 

--- a/docs/research/happyhorse-1.1-dashscope-research.md
+++ b/docs/research/happyhorse-1.1-dashscope-research.md
@@ -1,0 +1,165 @@
+# HappyHorse 1.1（阿里云百炼 DashScope）视频生成系列调研
+
+调研日期:2026-08-08。来源限定为阿里云一手渠道:`help.aliyun.com` 官方文档(最高权威)与 `developer.aliyun.com` 阿里云开发者社区官方文章(用于定价通稿与版本对比,权威性次之)。查不到的项标注「未能确认」。
+
+## 0. 「happyhorse」是不是别名?
+
+**结论:不是别名,是阿里云自研的真实公开系列,置信度高。**
+
+- `help.aliyun.com` 官方 API 参考直接以 `happyhorse-1.1-t2v` / `happyhorse-1.1-i2v` / `happyhorse-1.1-r2v` / `happyhorse-1.0-*` 为 model id 建文档页(见下文各节来源)。
+- 阿里云开发者社区介绍:HappyHorse(快乐小马)为阿里自研原生多模态视频生成模型(ATH 创新事业部),2026-04-27 开启灰测,15B 参数、单流 Transformer、音画联合生成;水印文案固定 "Happy Horse"。来源:<https://developer.aliyun.com/article/1731571>、<https://developer.aliyun.com/article/1731726>
+- 本仓库 `lib/config/registry.py` 登记的 `happyhorse-1.0-{i2v,t2v,r2v}`(720P ¥0.9/s、1080P ¥1.6/s、3–15s、r2v 9 张参考图)与官方文档逐项吻合,即 registry 内的 id 就是官方 id,无需「真实系列」映射。
+- 该系列发布晚于常见模型知识截止时间,公开检索需以 2026 年 4 月后的资料为准。
+
+## 1. 结论摘要表
+
+| 模态 | model id | 分辨率档位 | 时长 | 能力位 | 定价(元/秒,刊例) |
+|------|----------|-----------|------|--------|------------------|
+| 文生视频 | `happyhorse-1.1-t2v` | 480P / 720P / 1080P(默认) | 3–15s 整数,默认 5 | 无首帧;音画同步出声;ratio 9 档 | 480P 0.45 / 720P 0.9 / 1080P 1.2 |
+| 图生视频(首帧) | `happyhorse-1.1-i2v` | 480P / 720P / 1080P(默认) | 3–15s 整数,默认 5 | 首帧 ✓、尾帧 ✗;宽高比随首帧,无 ratio 参数;音画同步出声 | 同上 |
+| 参考生视频 | `happyhorse-1.1-r2v` | 480P / 720P / 1080P(默认) | 3–15s 整数,默认 5 | 参考图 1–9 张;无首帧;音画同步出声 | 同上 |
+| 首尾帧 | **无 1.1 变体** | — | — | 官方首尾帧场景推荐 `wan2.7-i2v-2026-04-25` | — |
+| 视频编辑 | `happyhorse-1.0-video-edit`(仅 1.0,无 1.1) | 720P / 1080P(默认) | 输出 3–15s(输入视频 3–60s) | 视频 + 0–5 张参考图 + 文本指令,风格转换/局部替换 | 未能确认 |
+
+促销:1.1 全系曾有限时 6 折(2026-06-22 至 2026-07-06,720P 0.54 / 1080P 0.72 元/秒),同期 1.0 享 8 折;当前是否仍在折扣期未能确认。新用户免费额度:10 秒视频生成。
+
+## 2. 各项详述与引用
+
+### 2.1 文生视频 `happyhorse-1.1-t2v`
+
+来源:<https://help.aliyun.com/zh/model-studio/happyhorse-text-to-video-api-reference>
+
+- 同页并列 `happyhorse-1.1-t2v` 与 `happyhorse-1.0-t2v` 两个 model id。
+- `resolution`:480P / 720P / 1080P(默认 1080P)。注意:参数表为 1.1/1.0 合并呈现,480P 是否两版通用未能确认(1.1 上线通稿只宣传 720P/1080P)。
+- `duration`:「[3, 15] 之间的整数,默认值为 5」。
+- `ratio`:16:9(默认)、9:16、1:1、4:3、3:4、4:5、5:4、9:21、21:9。
+- prompt:「长度不超过 5000 个非中文字符或 2500 个中文字符,超过部分将自动截断」——与 wan2.7 相同的静默截断行为。
+- `watermark`:默认 `true`,水印在右下角,文案固定 "Happy Horse";传 `false` 关闭。
+- 音频:API 参数表**无音频开关**;官方视频模型总览将文生视频描述为「通过文本生成有声视频」,1.1 功能通稿称「音画同步」原生联合生成 → 推断音频恒开、无开关(与 1.0 口径一致)。来源:<https://help.aliyun.com/zh/model-studio/video-generate-edit-model/>、<https://developer.aliyun.com/article/1749474>
+- 可用地域:华北2(北京)、新加坡、日本(东京)、德国(法兰克福)、美国(弗吉尼亚)。
+
+### 2.2 图生视频 `happyhorse-1.1-i2v`
+
+来源:<https://help.aliyun.com/zh/model-studio/happyhorse-image-to-video-api-reference>
+
+- 首帧 ✓、尾帧 ✗(1.1 与 1.0 均不支持尾帧;文档页标题即「图生视频-基于首帧」)。
+- 「图生视频的宽高比自动跟随输入首帧图像」,「不支持 ratio 参数」。
+- 输入图约束:JPEG/JPG/PNG/WEBP;宽高均 ≥300px;宽高比 1:2.5–2.5:1;≤20MB。
+- 分辨率/时长/prompt/watermark 同 t2v。
+
+### 2.3 参考生视频 `happyhorse-1.1-r2v`
+
+来源:<https://help.aliyun.com/zh/model-studio/happyhorse-reference-to-video-api-reference>
+
+- 参考图「1~9 张」(1.1 与 1.0 上限相同)。
+- `input.media` 元素 `{type: "reference_image", url}`;prompt 用 `[Image N]` 指代参考图。
+- 分辨率 480P/720P/1080P(默认 1080P)、时长 3–15s。
+- 无首帧输入(与 wan2.7-r2v 的「首帧 + 参考图」形态不同)。
+
+### 2.4 视频编辑 `happyhorse-1.0-video-edit`
+
+来源:<https://help.aliyun.com/zh/model-studio/happyhorse-video-edit-api-reference>
+
+- **仅 1.0**,无 1.1 变体。输入视频 MP4/MOV(建议 H.264)、3–60s、长边 ≤4096px、短边 ≥360px、≤100MB、>8fps;参考图 0–5 张;输出 3–15s,720P / 1080P(默认)。定价未能确认。
+
+### 2.5 定价与免费额度
+
+- **1.1 刊例价:480P ¥0.45/秒、720P ¥0.9/秒、1080P ¥1.2/秒**,t2v/i2v/r2v 同价(按输出秒数计费)。720P/1080P 来源:<https://developer.aliyun.com/article/1750051>(「720P at 0.9 yuan/second and 1080P at 1.2 yuan/second」),与 6 折促销价 0.54/0.72 反推一致;480P 为维护者自百炼控制台价格表核实(help.aliyun 模型大全页为动态渲染,公开页未抓到)。
+- 限时 6 折(2026-06-22 至 2026-07-06):720P ¥0.54/秒、1080P ¥0.72/秒。来源:<https://developer.aliyun.com/article/1743014>、<https://developer.aliyun.com/article/1742909>
+- **1.0 刊例价:720P ¥0.9/秒、1080P ¥1.6/秒**(与本仓库 registry 现值一致)。来源:<https://developer.aliyun.com/article/1731470>
+- 免费额度:「免费领取 HappyHorse 免费 10 秒视频生成」。来源:<https://developer.aliyun.com/article/1743014>
+
+### 2.6 与 1.0 的差异
+
+来源:<https://developer.aliyun.com/article/1742909>(阿里云开发者社区功能详解)
+
+- 1080P 单价下调:¥1.6/s → ¥1.2/s(720P 持平 ¥0.9/s)。
+- 指令遵循更严格、参考图还原度更高(会如实渲染文字/边框)、口型同步精度提升、内容安全阈值放宽、出片更快(1080P 15s 约 12 分钟 vs 1.0 约 14 分钟)。
+- 档位:两版同为 3–15s;API 参考现列 480P 档(1.0 早期资料仅 720P/1080P,480P 归属版本未能确认)。
+- **弃用计划:未能确认**。截至调研日,1.0 全系仍在官方 API 参考与 Token Plan 文档中在售(且曾与 1.1 同期享 8 折促销),未检索到官方停售/下线公告。
+
+## 3. Token Plan(Token 套餐)覆盖与调用路径
+
+来源:<https://help.aliyun.com/zh/model-studio/token-plan-overview>、<https://help.aliyun.com/zh/model-studio/token-plan-multimodal-gen>、<https://help.aliyun.com/zh/model-studio/token-plan-personal-overview>、<https://help.aliyun.com/zh/model-studio/token-plan-faq>
+
+### 覆盖型号
+
+- 官方个人版文档明确列出套餐内视频模型:`happyhorse-1.1-i2v` / `happyhorse-1.1-t2v` / `happyhorse-1.1-r2v`(个人版与团队版对视频模型「双版本通用」)。
+- 多模态接入文档以 `happyhorse-1.1-t2v` 为默认模型,并给出 `happyhorse-1.0-t2v`、`happyhorse-1.1-r2v` 的调用示例 → 1.0 系列亦可在套餐内调用;完整清单以控制台模型列表页为准。
+- 万相(wan)视频系列:未见于套餐官方文档的视频示例,是否在套餐内**未能确认**(FAQ 提及 `wan2.7-image` 图像模型属套餐范围)。
+
+### 调用路径:DashScope 原生异步路径,非 compatible-mode
+
+官方多模态接入文档给出的视频调用为:
+
+```
+POST https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis
+GET  https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1/tasks/{task_id}
+```
+
+即**与标准 DashScope 完全同构的原生异步两步式**(含 `X-DashScope-Async: enable` header),只是换域名 + 换套餐 Key。文本对话才走 `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`(OpenAI 协议,另兼容 Anthropic 协议)。
+
+### 套餐域名 vs 标准 dashscope.aliyuncs.com 的差异
+
+| 维度 | 标准 DashScope | Token Plan |
+|------|----------------|-----------|
+| 域名 | `dashscope.aliyuncs.com` | `token-plan.cn-beijing.maas.aliyuncs.com`(仅华北2-北京) |
+| API Key | 普通百炼 Key | 专属 Key,`sk-sp-` 前缀;个人版/团队版 Key 独立、不可混用 |
+| 路径 | 原生 `/api/v1/...` + `/compatible-mode/v1` | 同样两类路径均支持;视频走原生异步路径 |
+| 计费 | 按量计费 | Credits 统一抵扣;**额度用尽直接阻断(429 Allocated quota exceeded),不回落按量计费** |
+| 混用后果 | — | 套餐 Key 打到 `dashscope.aliyuncs.com` 或反向混用 → `401 InvalidApiKey`(FAQ 明确「误用了百炼通用 Base URL」是 401 常见原因);不会静默转按量 |
+| 额度周期 | — | 团队版坐席月度额度(25k/100k/250k Credits)到期重置不结转;个人版滚动窗口(7 天限额,窗口内未用完不结转) |
+
+视频模型的 Credits 换算率(每秒/每档位扣多少 Credits):**未能确认**,官方文档未披露,以控制台为准。
+
+## 4. 对 ArcReel registry/backend 的增补建议
+
+对照 ADR 0018(fail-loud:`supported_durations` 未登记即拒绝,无隐性 fallback):
+
+### `lib/config/registry.py`(DashScope 供应商 video 段)
+
+新增三条,字段与 1.0 条目同构:
+
+- `happyhorse-1.1-t2v` / `happyhorse-1.1-i2v` / `happyhorse-1.1-r2v`
+  - `supported_durations = list(range(3, 16))`(官方 3–15s 整数,须显式登记)
+  - `resolutions = ["480p", "720p", "1080p"]`
+  - `pricing = _dashscope_video_pricing(..., {"480p": 0.45, "720p": 0.9, "1080p": 1.2})`(刊例价,480P 为控制台核实价;促销价不入 registry)
+  - 建议将 `default=True` 从 `happyhorse-1.0-i2v` 移到 `happyhorse-1.1-i2v`(1080P 更便宜且官方总览以 1.1 为推荐系列),同步改 `lib/video_backends/dashscope.py::DEFAULT_MODEL`
+- 保留 1.0 三条(仍在售、无弃用公告);`happyhorse-1.0-video-edit` 与 ArcReel 现有流水线无对应能力形态,暂不登记
+
+### `lib/video_backends/dashscope.py::_MODEL_PROFILES`
+
+- `"happyhorse-1.1-t2v": VideoCapabilities(first_frame=False)`
+- `"happyhorse-1.1-i2v": VideoCapabilities(first_frame=True)`
+- `"happyhorse-1.1-r2v": VideoCapabilities(first_frame=False, max_reference_images=9)`
+- key 之间互不为子串的不变式仍成立(`happyhorse-1.0-*` 与 `happyhorse-1.1-*` 无包含关系),`_profile_for_model` 的子串容忍逻辑不需要改
+- 可考虑给 happyhorse 全系补 `max_prompt_chars`(官方:非中文 5000 / 中文 2500,超限静默截断照常计费——与 wan2.7 同类陷阱,现只有 wan2.7 有付费前 gate)。注意 happyhorse 的上限是按中英文区分的双阈值,现有单一 `max_prompt_chars` 字段表达不了中文 2500 的档,需要先扩字段或按保守值 2500 登记
+- watermark:1.1 默认仍为 `true`(文案 "Happy Horse"),backend 构造 payload 时须继续显式传 `watermark: false`(与 1.0 同口径)
+
+### 周边
+
+- `lib/custom_provider/duration_presets.py` 的 `happyhorse` 正则(3–15)与 `lib/custom_provider/endpoints.py` 的 `"happyhorse"` 子串路由(dashscope-async-video)天然覆盖 1.1,无需改动
+- 首尾帧需求不要落在 happyhorse 上(全系无尾帧);官方首尾帧推荐 `wan2.7-i2v-2026-04-25`
+- Token Plan 接入:视频走原生异步路径且 schema 同构,理论上现有 `DashScopeVideoBackend` 换 `base_url`(`https://token-plan.cn-beijing.maas.aliyuncs.com/api/v1`)+ `sk-sp-` Key 即可复用;但额度用尽是 429 硬阻断而非转按量,若接入需把该错误映射成用户可读的配额提示,且仅北京地域可用
+- `docs/dashscope-docs/参考生视频-HappyHorse.md` 现为 1.0 快照(且写「同系列 t2v/i2v 待官方扩充」),若实施 1.1 接入应按维护约定回写该目录
+
+## 来源清单
+
+官方文档(help.aliyun.com):
+
+- 文生视频 API:<https://help.aliyun.com/zh/model-studio/happyhorse-text-to-video-api-reference>
+- 图生视频(首帧)API:<https://help.aliyun.com/zh/model-studio/happyhorse-image-to-video-api-reference>
+- 参考生视频 API:<https://help.aliyun.com/zh/model-studio/happyhorse-reference-to-video-api-reference>
+- 视频编辑 API:<https://help.aliyun.com/zh/model-studio/happyhorse-video-edit-api-reference>
+- 视频生成与编辑总览:<https://help.aliyun.com/zh/model-studio/video-generate-edit-model/>
+- 模型大全:<https://help.aliyun.com/zh/model-studio/models>(动态页,价格未抓取到)
+- Token Plan 概述 / 个人版 / 多模态接入 / FAQ:<https://help.aliyun.com/zh/model-studio/token-plan-overview>、<https://help.aliyun.com/zh/model-studio/token-plan-personal-overview>、<https://help.aliyun.com/zh/model-studio/token-plan-multimodal-gen>、<https://help.aliyun.com/zh/model-studio/token-plan-faq>
+
+阿里云开发者社区(定价通稿与版本对比):
+
+- 1.0 定价:<https://developer.aliyun.com/article/1731470>
+- 系列介绍:<https://developer.aliyun.com/article/1731571>、<https://developer.aliyun.com/article/1731726>
+- 1.1 价格拆解(6 折 0.54/0.72):<https://developer.aliyun.com/article/1743014>
+- 1.1 功能详解/成本指南(促销窗口、1.0 对比):<https://developer.aliyun.com/article/1742909>
+- 1.1 功能介绍(音画同步、档位):<https://developer.aliyun.com/article/1749474>
+- Token Plan 解析(1.1 刊例价 0.9/1.2):<https://developer.aliyun.com/article/1750051>

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -1054,12 +1054,37 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 pricing=_dashscope_image_pricing("wan2.7-image-pro", 0.5),
             ),
             # --- video ---
+            # HappyHorse 1.1 系列：480P ¥0.45/s，720P ¥0.9/s，1080P ¥1.2/s（音频恒开）。
+            "happyhorse-1.1-i2v": ModelInfo(
+                display_name="HappyHorse 1.1 图生视频",
+                media_type="video",
+                capabilities=[],
+                default=True,
+                supported_durations=list(range(3, 16)),
+                resolutions=["480p", "720p", "1080p"],
+                pricing=_dashscope_video_pricing("happyhorse-1.1-i2v", {"480p": 0.45, "720p": 0.9, "1080p": 1.2}),
+            ),
+            "happyhorse-1.1-t2v": ModelInfo(
+                display_name="HappyHorse 1.1 文生视频",
+                media_type="video",
+                capabilities=[],
+                supported_durations=list(range(3, 16)),
+                resolutions=["480p", "720p", "1080p"],
+                pricing=_dashscope_video_pricing("happyhorse-1.1-t2v", {"480p": 0.45, "720p": 0.9, "1080p": 1.2}),
+            ),
+            "happyhorse-1.1-r2v": ModelInfo(
+                display_name="HappyHorse 1.1 参考生视频",
+                media_type="video",
+                capabilities=[],
+                supported_durations=list(range(3, 16)),
+                resolutions=["480p", "720p", "1080p"],
+                pricing=_dashscope_video_pricing("happyhorse-1.1-r2v", {"480p": 0.45, "720p": 0.9, "1080p": 1.2}),
+            ),
             # HappyHorse 1.0 系列：720P ¥0.9/s，1080P ¥1.6/s（音频恒开）。
             "happyhorse-1.0-i2v": ModelInfo(
                 display_name="HappyHorse 1.0 图生视频",
                 media_type="video",
                 capabilities=[],
-                default=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.0-i2v", {"720p": 0.9, "1080p": 1.6}),

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -1,8 +1,8 @@
 """DashScopeVideoBackend — 阿里百炼 HappyHorse / 万相视频生成后端（异步两步式）。
 
 走原生 video-generation/video-synthesis 异步端点：submit 取 task_id → 轮询
-GET /tasks/{id} 至 SUCCEEDED → 下载 video_url。覆盖 happyhorse-1.0 与 wan2.7
-系列的 t2v / i2v / r2v。schema 依据 docs/dashscope-docs/ 一手核实快照。
+GET /tasks/{id} 至 SUCCEEDED → 下载 video_url。覆盖 happyhorse-1.0 / happyhorse-1.1
+与 wan2.7 系列的 t2v / i2v / r2v。schema 依据 docs/dashscope-docs/ 一手核实快照。
 
 注：t2v/i2v 起始帧用 media[{type:"first_frame"}]（first_frame type 在 r2v media
 枚举中确权）；尾帧 / 续写字段在一手 docs 未确权，不臆造，故 i2v 仅声明首帧能力。
@@ -86,7 +86,7 @@ def _read_reference_audio_or_none(path: Path) -> str | None:
         return None
 
 
-DEFAULT_MODEL = "happyhorse-1.0-i2v"
+DEFAULT_MODEL = "happyhorse-1.1-i2v"
 
 _VIDEO_ENDPOINT = "/services/aigc/video-generation/video-synthesis"
 
@@ -104,6 +104,9 @@ _WAN27_MAX_PROMPT_CHARS = 5000
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
 _MODEL_PROFILES: dict[str, VideoCapabilities] = {
+    "happyhorse-1.1-t2v": VideoCapabilities(first_frame=False),
+    "happyhorse-1.1-i2v": VideoCapabilities(first_frame=True),
+    "happyhorse-1.1-r2v": VideoCapabilities(first_frame=False, max_reference_images=9),
     "happyhorse-1.0-t2v": VideoCapabilities(first_frame=False),
     "happyhorse-1.0-i2v": VideoCapabilities(first_frame=True),
     "happyhorse-1.0-r2v": VideoCapabilities(first_frame=False, max_reference_images=9),
@@ -141,7 +144,7 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
         return _DEFAULT_PROFILE
     if normalized in _MODEL_PROFILES:
         return _MODEL_PROFILES[normalized]
-    # 各 profile key（happyhorse-1.0-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
+    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
     for known, profile in _MODEL_PROFILES.items():
         if known in normalized:
             return profile

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -294,6 +294,9 @@ class TestModelHasAudioTrack:
         """DashScope 视频全家族恒有声：_build_payload 不下传音频开关，故不声明 token，
         由恒有声例外表判定有音轨。"""
         for model_id in (
+            "happyhorse-1.1-i2v",
+            "happyhorse-1.1-t2v",
+            "happyhorse-1.1-r2v",
             "happyhorse-1.0-i2v",
             "happyhorse-1.0-t2v",
             "happyhorse-1.0-r2v",

--- a/tests/test_config_registry_models.py
+++ b/tests/test_config_registry_models.py
@@ -146,6 +146,20 @@ class TestProviderRegistry:
             meta = PROVIDER_REGISTRY[provider_id]
             assert "text" in meta.media_types, f"{provider_id} missing 'text'"
 
+    def test_dashscope_video_models_include_happyhorse_11(self):
+        meta = PROVIDER_REGISTRY["dashscope"]
+        video_models = {mid: m for mid, m in meta.models.items() if m.media_type == "video"}
+        for mid in ("happyhorse-1.1-t2v", "happyhorse-1.1-i2v", "happyhorse-1.1-r2v"):
+            assert mid in video_models
+            # supported_durations 未登记即 fail loud（ADR 0018），三模态均为 3–15s 整数
+            assert video_models[mid].supported_durations == list(range(3, 16))
+            assert video_models[mid].resolutions == ["480p", "720p", "1080p"]
+        # 默认视频模型是 1.1-i2v；1.0 三条仍在售，保留登记但非默认
+        assert video_models["happyhorse-1.1-i2v"].default is True
+        assert video_models["happyhorse-1.0-i2v"].default is False
+        for mid in ("happyhorse-1.0-t2v", "happyhorse-1.0-i2v", "happyhorse-1.0-r2v"):
+            assert video_models[mid].resolutions == ["720p", "1080p"]
+
     def test_ark_video_models_include_seedance_2(self):
         meta = PROVIDER_REGISTRY["ark"]
         video_models = {mid: m for mid, m in meta.models.items() if m.media_type == "video"}

--- a/tests/test_dashscope_integration.py
+++ b/tests/test_dashscope_integration.py
@@ -83,6 +83,18 @@ class TestLookupPricing:
         assert a720 == pytest.approx(4.5)
         assert a1080 == pytest.approx(8.0)
 
+    @pytest.mark.parametrize("model", ["happyhorse-1.1-t2v", "happyhorse-1.1-i2v", "happyhorse-1.1-r2v"])
+    def test_happyhorse_11_pricing_covers_three_resolutions(self, model: str):
+        """三档分辨率都要有价：任一档缺键会让该档的用量记账断链。"""
+        p = lookup_pricing(PROVIDER_DASHSCOPE, model, "video")
+        for resolution, expected in (("480p", 4.5), ("720p", 9.0), ("1080p", 12.0)):
+            amount, cur = calculate_pricing(
+                p,
+                PricingParams(call_type="video", model=model, resolution=resolution, duration_seconds=10),
+            )
+            assert cur == "CNY"
+            assert amount == pytest.approx(expected)
+
     def test_wan_video_cny(self):
         p = lookup_pricing(PROVIDER_DASHSCOPE, "wan2.7-r2v", "video")
         amount, cur = calculate_pricing(

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -102,6 +102,31 @@ class TestCapabilities:
         assert vc.first_frame is False
 
     @pytest.mark.unit
+    def test_happyhorse_11_caps(self):
+        """1.1 三模态各自登记能力档：t2v 无首帧（未登记会回落默认档的 first_frame=True，
+        被误判进 i2v 桶），i2v 有首帧无参考图，r2v 参考图 9 张且无首帧。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        t2v = DashScopeVideoBackend.video_capabilities_for_model("happyhorse-1.1-t2v")
+        assert t2v.first_frame is False
+        assert t2v.max_reference_images == 0
+
+        i2v = DashScopeVideoBackend.video_capabilities_for_model("happyhorse-1.1-i2v")
+        assert i2v.first_frame is True
+        assert i2v.max_reference_images == 0
+
+        r2v = DashScopeVideoBackend.video_capabilities_for_model("happyhorse-1.1-r2v")
+        assert r2v.first_frame is False
+        assert r2v.max_reference_images == 9
+
+    @pytest.mark.unit
+    def test_default_model_is_happyhorse_11_i2v(self):
+        from lib.video_backends.dashscope import DEFAULT_MODEL, DashScopeVideoBackend
+
+        assert DEFAULT_MODEL == "happyhorse-1.1-i2v"
+        assert DashScopeVideoBackend(api_key="sk").model == "happyhorse-1.1-i2v"
+
+    @pytest.mark.unit
     def test_wan_r2v_caps(self):
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -396,6 +421,27 @@ class TestFirstFrameAndTextOnly:
             await b.generate(VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="1080p"))
         assert "media" not in post.call_args.kwargs["json"]["input"]
         assert post.call_args.kwargs["json"]["parameters"]["resolution"] == "1080P"
+
+    @pytest.mark.unit
+    async def test_happyhorse_11_i2v_payload(self, tmp_path: Path):
+        """1.1 与 1.0 同口径：水印显式关（官方默认开），480P 档位透传为大写。"""
+        post = AsyncMock(return_value=_resp(_submit()))
+        get = AsyncMock(return_value=_resp(_succeeded()))
+        client = _client(post=post, get=get)
+        start = _ref(tmp_path, "start.png")
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3:
+            from lib.video_backends.dashscope import DashScopeVideoBackend
+
+            b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.1-i2v")
+            await b.generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", start_image=start, resolution="480p")
+            )
+        params = post.call_args.kwargs["json"]["parameters"]
+        assert post.call_args.kwargs["json"]["model"] == "happyhorse-1.1-i2v"
+        assert params["watermark"] is False
+        assert params["resolution"] == "480P"
+        assert post.call_args.kwargs["json"]["input"]["media"][0]["type"] == "first_frame"
 
 
 class TestPollingAndFailures:


### PR DESCRIPTION
Closes #1700

阿里百炼（DashScope）视频模型注册表补齐 HappyHorse 1.1 系列，用户在「模型选择」里可以直接选到 `happyhorse-1.1-t2v` / `happyhorse-1.1-i2v` / `happyhorse-1.1-r2v`，默认视频模型从 1.0-i2v 切到 1.1-i2v。1.0 三条仍在售，保留登记。

## 改动

- **registry**：1.1 三模态各登记 3–15s 整数时长（fail-loud 约定要求显式登记）、480p/720p/1080p 三档分辨率、刊例价 480P ¥0.45 / 720P ¥0.9 / 1080P ¥1.2 每秒（三模态同价）；`default=True` 从 `happyhorse-1.0-i2v` 移到 `happyhorse-1.1-i2v`
- **video backend**：`_MODEL_PROFILES` 补三条能力档（t2v 无首帧、i2v 有首帧、r2v 无首帧且参考图上限 9）。t2v 若不登记会回落默认档的 `first_frame=True`，被误判进 i2v 能力桶；`DEFAULT_MODEL` 同步切至 1.1-i2v
- **文档镜像**：`docs/dashscope-docs/参考生视频-HappyHorse.md` 由 1.0-r2v 单模态快照改写为 HappyHorse 全系文档（r2v 完整 schema 为主线，t2v/i2v 差异与版本差异各成一节）；费用参考页补 1.1 价目
- **调研笔记**：`docs/research/happyhorse-1.1-dashscope-research.md` 是本次的数据契约（对应 issue 评论中给出的 `docs/happyhorse-1.1-research` 分支，内容逐字一致），随实现一并落地

480P 只登记给 1.1：官方 API 参考页把 1.1/1.0 参数表合并呈现，480P 对 1.0 的版本归属未能确认，registry 不替官方补写未确权档位，镜像里也按未确权标注。

## 验证

rebase 到 `12aa4404` 后在该基点完整跑过：

- `uv run python -m pytest` — 8075 passed
- `uv run ruff check . && uv run ruff format --check .` — 全绿
- `uv run basedpyright` — 0 errors
- `uv run lint-imports` — 契约 KEPT

新增单测覆盖：三型号的时长/分辨率登记与默认标记迁移、三档分辨率的 pricing 查询（任一档缺键会让该档用量记账断链）、1.1 三模态能力档归属、1.1-i2v 请求 payload 显式关水印且 480P 档位大写透传、恒有声判定含 1.1。前端未改动。

## 不在本 PR 范围

`max_prompt_chars` 中英文双阈值建模、`happyhorse-1.0-video-edit`、Token 套餐 429 配额错误的可读映射（#1428）、预设供应商的模型发现与手动录入（#1701）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 HappyHorse 1.1 文生视频、图生视频和参考生视频模型。
  - 支持 3–15 秒视频及 480P、720P、1080P 分辨率。
  - 支持首帧、参考图、音频和水印等配置。

- **优化**
  - DashScope 默认视频模型升级为 HappyHorse 1.1 图生视频。
  - 完善不同模型与分辨率的价格计算及费用说明。

- **文档**
  - 更新模型索引、官方 API 资料、版本对比和 ArcReel 集成指南。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->