### PR TITLE
fix(费用估算): 分镜图按项目实际分辨率档计价

### DIFF
--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -28,7 +28,7 @@ from lib.reference_video.units import reference_unit_video_bucket
 from lib.script_editor import ScriptEditError
 from lib.script_models import get_generated_assets
 from lib.storyboard_sequence import get_storyboard_items, group_scenes_by_segment_break
-from server.services.grid_resolution import resolve_grid_image_resolution
+from server.services.grid_resolution import resolve_image_resolution
 from server.services.reference_video_tasks import (
     ProjectDurationContext,
     precheck_unit,
@@ -50,7 +50,8 @@ _VIDEO_BUCKETS: tuple[VideoCapability, ...] = ("i2v", "r2v")
 
 #: 普通分镜图取不到分辨率档时的计价档。执行侧此路径把 ``None`` 原样下发给 backend、由其自行定档
 #: （不像宫格有 ``GRID_FALLBACK_RESOLUTION`` 这一确定的保底档），估价无从同源，只能取最低档保守
-#: 计价——宁可低估未配置供应商的项目，也不拿高档单价虚报。
+#: 计价——宁可低估未配置供应商的项目，也不拿高档单价虚报。取值与分档策略自身的缺省档一致（见
+#: ``lib.pricing.strategies``），显式写出是为了让估价侧的保底口径可读、不随策略层缺省漂移。
 _IMAGE_PRICING_FALLBACK_RESOLUTION = "1K"
 
 
@@ -186,8 +187,10 @@ class CostEstimationService:
             # 张数才不会与实际入队张数漂移；同一档位又是两路分镜图的计价档——宫格图未配置时回落
             # ``GRID_FALLBACK_RESOLUTION``（与 ``execute_grid_task`` 下发的保底档同源），普通
             # 分镜图未配置时回落 ``_IMAGE_PRICING_FALLBACK_RESOLUTION``。解析在两路之前，宫格
-            # 与非宫格项目共用这一次 IO。
-            image_resolution = await resolve_grid_image_resolution(r, project_data)
+            # 与非宫格项目共用这一次 IO。计价与执行取的是同一个 T2I 槽、同一套项目配置，但身份
+            # 键不同（此处 registry ``model_id``，执行侧构造后的 backend 型号），两者分叉的供应
+            # 商上估价档位可能与实际渲染档位不一致。
+            image_resolution = await resolve_image_resolution(r, project_data)
             grid_allow_large = large_grid_allowed(image_resolution)
 
             # 视频按能力桶解析（``docs/adr/0054``），与执行扣费同一个模型：图生视频 / 宫格算

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -48,6 +48,11 @@ ACTUAL_COST_TYPES = ("image", "video", "audio")
 #: 路线与镜头分支判断该解析哪个桶的复杂度——桶只有两个，代价有界。
 _VIDEO_BUCKETS: tuple[VideoCapability, ...] = ("i2v", "r2v")
 
+#: 普通分镜图取不到分辨率档时的计价档。执行侧此路径把 ``None`` 原样下发给 backend、由其自行定档
+#: （不像宫格有 ``GRID_FALLBACK_RESOLUTION`` 这一确定的保底档），估价无从同源，只能取最低档保守
+#: 计价——宁可低估未配置供应商的项目，也不拿高档单价虚报。
+_IMAGE_PRICING_FALLBACK_RESOLUTION = "1K"
+
 
 @dataclass(frozen=True)
 class _VideoPricing:
@@ -177,11 +182,13 @@ class CostEstimationService:
             except Exception:
                 image_provider, image_model = "unknown", "unknown"
 
-            # 宫格档位：与路由入队、SDK 工具共用 ``grid_resolution`` 的取档，估算的宫格张数才
-            # 不会与实际入队张数漂移；同一档位还是宫格图的计价档，未配置时回落
-            # ``GRID_FALLBACK_RESOLUTION``（与 ``execute_grid_task`` 下发的保底档同源）。
-            grid_image_resolution = await resolve_grid_image_resolution(r, project_data)
-            grid_allow_large = large_grid_allowed(grid_image_resolution)
+            # T2I 槽分辨率档：与路由入队、SDK 工具共用 ``grid_resolution`` 的取档，估算的宫格
+            # 张数才不会与实际入队张数漂移；同一档位又是两路分镜图的计价档——宫格图未配置时回落
+            # ``GRID_FALLBACK_RESOLUTION``（与 ``execute_grid_task`` 下发的保底档同源），普通
+            # 分镜图未配置时回落 ``_IMAGE_PRICING_FALLBACK_RESOLUTION``。解析在两路之前，宫格
+            # 与非宫格项目共用这一次 IO。
+            image_resolution = await resolve_grid_image_resolution(r, project_data)
+            grid_allow_large = large_grid_allowed(image_resolution)
 
             # 视频按能力桶解析（``docs/adr/0054``），与执行扣费同一个模型：图生视频 / 宫格算
             # i2v 桶的价；参考生视频按 unit 声明的参考集逐 unit 分桶（有参考图 → r2v，无参考图
@@ -266,7 +273,11 @@ class CostEstimationService:
         try:
             image_unit_cost = cost_calculator.calculate_cost(
                 image_provider,
-                PricingParams(call_type="image", model=image_model, resolution="1K"),
+                PricingParams(
+                    call_type="image",
+                    model=image_model,
+                    resolution=image_resolution or _IMAGE_PRICING_FALLBACK_RESOLUTION,
+                ),
                 custom_price_input=image_price.price_input,
                 custom_price_output=image_price.price_output,
                 custom_currency=image_price.currency,
@@ -281,7 +292,7 @@ class CostEstimationService:
                     PricingParams(
                         call_type="image",
                         model=image_model,
-                        resolution=grid_image_resolution or GRID_FALLBACK_RESOLUTION,
+                        resolution=image_resolution or GRID_FALLBACK_RESOLUTION,
                     ),
                     custom_price_input=image_price.price_input,
                     custom_price_output=image_price.price_output,

--- a/server/services/grid_resolution.py
+++ b/server/services/grid_resolution.py
@@ -1,8 +1,8 @@
-"""宫格档位门控用的图像分辨率解析。
+"""T2I 槽图像分辨率解析，及其上的宫格档位门控。
 
 4×4 / 5×5 档只在图像分辨率档为 4K 时放行（见 ``lib.grid.layout.large_grid_allowed``）。
 判定必须与实际入队、费用估算共用同一份解析，否则前端预览、估价与真正生成的宫格张数会漂移，
-故三条路径都经本模块取档。
+故三条路径都经本模块取档；同一次解析还是费用估算里两路分镜图（宫格 / 普通）的计价档来源。
 """
 
 from __future__ import annotations
@@ -15,13 +15,14 @@ from lib.grid.layout import large_grid_allowed
 logger = logging.getLogger(__name__)
 
 
-async def resolve_grid_image_resolution(r: ConfigResolver, project: dict) -> str | None:
-    """宫格图执行期生效的图像分辨率档；``None`` 表示未配置（由调用方按保底档处理）。
+async def resolve_image_resolution(r: ConfigResolver, project: dict) -> str | None:
+    """项目 T2I 槽生效的图像分辨率档；``None`` 表示未配置（由调用方按各自保底档处理）。
 
-    以 T2I 槽解析身份，与费用估算的图片计价同源；``execute_grid_task`` 在有参考图时走 I2I 槽，
-    两槽解析到不同型号时门控与实际渲染可能取到不同档位——门控须在入队时就定档，那时还没有
-    参考图收集结果，取正交能力槽中代表宫格主路径的 T2I。同理这里取 registry 身份
-    ``model_id``（与估价一致）而非构造后的 backend 身份，避免为一次门控判定构造 backend。
+    以 T2I 槽解析身份：``execute_grid_task`` 在有参考图时走 I2I 槽，两槽解析到不同型号时门控与
+    实际渲染可能取到不同档位——门控须在入队时就定档，那时还没有参考图收集结果，取正交能力槽中
+    代表宫格主路径的 T2I。这里取 registry 身份 ``model_id`` 而非构造后的 backend 身份，避免为
+    一次门控判定构造 backend；执行侧按 backend 身份取档，两者在型号身份分叉的供应商上可能落到
+    不同档位。
 
     解析失败（未配置图像供应商等）按未配置处理：门控是收紧方向，取不到档位即不放行大宫格。
     这条降级会让已配置 4K 的项目静默退回 3×3，故留一条 warning 便于排查。
@@ -30,7 +31,7 @@ async def resolve_grid_image_resolution(r: ConfigResolver, project: dict) -> str
         resolved = await r.resolve_image_backend(project, None, capability="t2i")
         return await r.resolve_resolution(project, resolved.provider_id, resolved.model_id or "")
     except Exception as exc:
-        logger.warning("宫格档位门控取不到图像分辨率档，按未配置收紧: %s", exc)
+        logger.warning("取不到 T2I 图像分辨率档，宫格门控按未配置收紧、计价按保底档: %s", exc)
         return None
 
 
@@ -38,13 +39,13 @@ async def resolve_large_grid_allowed(project: dict) -> bool:
     """自开 session 的门控入口，供路由与 SDK 工具使用。
 
     已持有 :class:`ConfigResolver` session 的调用方（费用估算）改用
-    :func:`resolve_grid_image_resolution` + ``large_grid_allowed``，不额外开 session。
+    :func:`resolve_image_resolution` + ``large_grid_allowed``，不额外开 session。
     """
     from lib.db import async_session_factory
 
     resolver = ConfigResolver(async_session_factory)
     async with resolver.session() as r:
-        return large_grid_allowed(await resolve_grid_image_resolution(r, project))
+        return large_grid_allowed(await resolve_image_resolution(r, project))
 
 
-__all__ = ["resolve_grid_image_resolution", "resolve_large_grid_allowed"]
+__all__ = ["resolve_image_resolution", "resolve_large_grid_allowed"]

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -807,6 +807,38 @@ class TestCostEstimationService:
         )
 
     @pytest.mark.unit
+    async def test_plain_storyboard_estimate_prices_at_resolved_resolution(self, db_factory, monkeypatch):
+        """普通（非宫格）分镜图同样按执行期生效的分辨率档计价，未配置时按保底档 1K。"""
+        from server.services import cost_estimation as ce
+
+        seg_ids = [f"E1S{i:03d}" for i in range(1, 4)]
+        project_data = {
+            "title": "Test",
+            "content_mode": "narration",
+            "generation_mode": "storyboard",
+            # 按分辨率分档定价的型号，档位差异才可观测
+            "image_provider_t2i": "gemini-aistudio/gemini-3.1-flash-image-preview",
+            "episodes": [{"episode": 1, "title": "Ep1", "script_file": "ep1.json"}],
+        }
+        scripts = {"ep1.json": _make_script(1, seg_ids, [6] * 3)}
+
+        async def _estimated_image_total(resolution: str | None) -> float:
+            async def _resolution(_r, _project):
+                return resolution
+
+            monkeypatch.setattr(ce, "resolve_grid_image_resolution", _resolution)
+            service = CostEstimationService(ConfigResolver(db_factory), db_factory)
+            result = await service.compute(project_data, scripts, project_name="proj")
+            return sum(seg["estimate"]["image"]["USD"] for seg in result["episodes"][0]["segments"])
+
+        total_1k = await _estimated_image_total("1K")
+        assert total_1k > 0
+        # 4K 档单价高于 1K，估算须随之上浮而非恒按 1K
+        assert await _estimated_image_total("4K") > total_1k
+        # 解析失败（未配置图像供应商）按保底档计价，不抛错
+        assert await _estimated_image_total(None) == pytest.approx(total_1k)
+
+    @pytest.mark.unit
     async def test_grid_estimate_duplicate_ids_across_groups_each_correct(self, db_factory):
         """同 ID 条目落在不同分组时各自展示本组的均摊估算，不被后写的分组覆盖。"""
         resolver = ConfigResolver(db_factory)

--- a/tests/test_cost_estimation_service.py
+++ b/tests/test_cost_estimation_service.py
@@ -754,7 +754,7 @@ class TestCostEstimationService:
             async def _resolution(_r, _project):
                 return resolution
 
-            monkeypatch.setattr(ce, "resolve_grid_image_resolution", _resolution)
+            monkeypatch.setattr(ce, "resolve_image_resolution", _resolution)
             service = CostEstimationService(ConfigResolver(db_factory), db_factory)
             result = await service.compute(project_data, scripts, project_name="proj")
             return sum(seg["estimate"]["image"]["USD"] for seg in result["episodes"][0]["segments"])
@@ -791,7 +791,7 @@ class TestCostEstimationService:
             async def _resolution(_r, _project):
                 return resolution
 
-            monkeypatch.setattr(ce, "resolve_grid_image_resolution", _resolution)
+            monkeypatch.setattr(ce, "resolve_image_resolution", _resolution)
             service = CostEstimationService(ConfigResolver(db_factory), db_factory)
             result = await service.compute(project_data, scripts, project_name="proj")
             return sum(seg["estimate"]["image"]["USD"] for seg in result["episodes"][0]["segments"])
@@ -808,8 +808,9 @@ class TestCostEstimationService:
 
     @pytest.mark.unit
     async def test_plain_storyboard_estimate_prices_at_resolved_resolution(self, db_factory, monkeypatch):
-        """普通（非宫格）分镜图同样按执行期生效的分辨率档计价，未配置时按保底档 1K。"""
+        """普通（非宫格）分镜图同样按执行期生效的分辨率档计价，未配置时按保底档。"""
         from server.services import cost_estimation as ce
+        from server.services.cost_estimation import _IMAGE_PRICING_FALLBACK_RESOLUTION
 
         seg_ids = [f"E1S{i:03d}" for i in range(1, 4)]
         project_data = {
@@ -826,17 +827,17 @@ class TestCostEstimationService:
             async def _resolution(_r, _project):
                 return resolution
 
-            monkeypatch.setattr(ce, "resolve_grid_image_resolution", _resolution)
+            monkeypatch.setattr(ce, "resolve_image_resolution", _resolution)
             service = CostEstimationService(ConfigResolver(db_factory), db_factory)
             result = await service.compute(project_data, scripts, project_name="proj")
             return sum(seg["estimate"]["image"]["USD"] for seg in result["episodes"][0]["segments"])
 
-        total_1k = await _estimated_image_total("1K")
-        assert total_1k > 0
-        # 4K 档单价高于 1K，估算须随之上浮而非恒按 1K
-        assert await _estimated_image_total("4K") > total_1k
+        total_fallback = await _estimated_image_total(_IMAGE_PRICING_FALLBACK_RESOLUTION)
+        assert total_fallback > 0
+        # 该型号 4K 单价高于保底档，估算须随之上浮而非恒按保底档
+        assert await _estimated_image_total("4K") > total_fallback
         # 解析失败（未配置图像供应商）按保底档计价，不抛错
-        assert await _estimated_image_total(None) == pytest.approx(total_1k)
+        assert await _estimated_image_total(None) == pytest.approx(total_fallback)
 
     @pytest.mark.unit
     async def test_grid_estimate_duplicate_ids_across_groups_each_correct(self, db_factory):

--- a/tests/test_grid_resolution.py
+++ b/tests/test_grid_resolution.py
@@ -6,7 +6,7 @@ import pytest
 
 from lib.config.resolver import ConfigResolver
 from lib.grid.layout import large_grid_allowed
-from server.services.grid_resolution import resolve_grid_image_resolution
+from server.services.grid_resolution import resolve_image_resolution
 
 pytestmark = pytest.mark.unit
 
@@ -38,7 +38,7 @@ def _as_resolver(fake: _FakeResolver) -> ConfigResolver:
 
 async def test_reads_resolution_of_the_t2i_slot():
     resolver = _FakeResolver("4K")
-    assert await resolve_grid_image_resolution(_as_resolver(resolver), {}) == "4K"
+    assert await resolve_image_resolution(_as_resolver(resolver), {}) == "4K"
     assert resolver.asked_capability == "t2i"
     assert resolver.asked_identity == ("gemini", "img-model")
 
@@ -46,13 +46,13 @@ async def test_reads_resolution_of_the_t2i_slot():
 @pytest.mark.parametrize("resolution", ["4K", "2K", None])
 async def test_resolution_drives_the_gate(resolution: str | None):
     resolver = _FakeResolver(resolution)
-    resolved = await resolve_grid_image_resolution(_as_resolver(resolver), {})
+    resolved = await resolve_image_resolution(_as_resolver(resolver), {})
     assert large_grid_allowed(resolved) is (resolution == "4K")
 
 
 async def test_resolution_failure_blocks_large_grid():
     # 解析不出图像供应商时按未配置处理：门控是收紧方向，不放行大宫格
     resolver = _FakeResolver(raises=True)
-    resolved = await resolve_grid_image_resolution(_as_resolver(resolver), {})
+    resolved = await resolve_image_resolution(_as_resolver(resolver), {})
     assert resolved is None
     assert large_grid_allowed(resolved) is False


### PR DESCRIPTION
## 变更

费用估算里普通（非宫格）分镜图的计价档不再硬编码 1K，改用与宫格侧同一次 T2I 槽分辨率解析结果；配置 2K/4K 图像档的项目估价不再系统性偏低。解析失败时按保底档 `1K` 计价（与分档策略自身缺省档一致），不抛错。

取档函数随之正名 `resolve_grid_image_resolution` → `resolve_image_resolution`：它现在同时服务宫格档位门控与两路分镜图计价，原名与 warning 文案只提宫格，非宫格项目读到会误导。

## 说明

issue 正文提到「非宫格项目当前不触发该解析，需把解析上提到两路共用的位置」——该前提与现状不符：`compute` 里这次解析本就在 `grid_enabled` 分支之前无条件执行，宫格与非宫格项目共用同一次 IO。本 PR 只做复用，未新增解析或提前量。

估价按 registry `model_id` 取档，执行侧按构造后的 backend 型号取档，两者在型号身份分叉的供应商上仍可能落到不同档位——沿用宫格侧既有口径，已在注释中写明，未在本 PR 内收敛。

## 验证

- `uv run python -m pytest` 全量 8069 passed
- `uv run ruff check/format`、`uv run basedpyright`（0 errors）、`uv run lint-imports` 均通过
- 新增测试覆盖：非宫格项目 4K 档估价高于保底档、解析失败回落保底档不抛错；宫格侧既有测试不回归

Closes #1723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 统一普通分镜图与宫格图的图像分辨率识别和计价规则。
  * 普通分镜图新增“1K”默认计价档，未配置或解析异常时仍可完成估价。
  * 宫格图继续沿用独立的默认分辨率规则，并在无法解析时执行更严格的校验。
* **测试**
  * 增加并完善不同分辨率、默认档位及异常场景下的费用估算验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->