### PR TITLE
refactor(供应商): 恒有声按视频型号声明，同门型号可各自不同

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ pnpm build       # 生产构建，含 typecheck
 
 ### 供应商能力数据
 
-生成模型供应商的能力数据按字段划分真相源：视频能力位与各类上限归对应 backend（`VideoCapabilities`，与请求构造同源，见 `docs/adr/0054`）；图片能力位归 `PROVIDER_REGISTRY` 的 `ModelInfo.capabilities`（自定义供应商归 endpoint 声明）；其余能力数字与默认 model 归 `PROVIDER_REGISTRY`，`supported_durations` 未登记即 fail loud、无隐性 fallback（见 `docs/adr/0018`；仅时长联动约束在未登记型号上有 backend 兜底常量），自定义模型改读 DB 声明。自定义供应商（`custom-` 前缀）与智能体供应商预设的其余字段（不含图片能力位）不适用上述按 `PROVIDER_REGISTRY` 划分的真相源。prompt 模板与智能体运行配置（`agent_runtime_profile/`）不硬编码具体数值，占位符由编排层注入（供应商 API 文档镜像保留原始数值）；配置界面此类字段不预填。陷阱：个别 backend（如 vidu 的执行期分辨率白名单）独立于 registry，改 registry 分辨率声明时须同步核对对应 backend，否则用户可选但 backend 不认的档位会被静默替换为兜底档位。
+生成模型供应商的能力数据按字段划分真相源：视频能力位与各类上限归对应 backend（`VideoCapabilities`，与请求构造同源，见 `docs/adr/0054`）；图片能力位归 `PROVIDER_REGISTRY` 的 `ModelInfo.capabilities`（自定义供应商归 endpoint 声明）；视频音轨的两位描述（开关可控性、恒有声）不属于上述归 backend 的视频能力位，按型号声明在 `ModelInfo` 上；其余能力数字与默认 model 归 `PROVIDER_REGISTRY`，`supported_durations` 未登记即 fail loud、无隐性 fallback（见 `docs/adr/0018`；仅时长联动约束在未登记型号上有 backend 兜底常量），自定义模型改读 DB 声明。自定义供应商（`custom-` 前缀）与智能体供应商预设的其余字段（不含图片能力位）不适用上述按 `PROVIDER_REGISTRY` 划分的真相源。prompt 模板与智能体运行配置（`agent_runtime_profile/`）不硬编码具体数值，占位符由编排层注入（供应商 API 文档镜像保留原始数值）；配置界面此类字段不预填。陷阱：个别 backend（如 vidu 的执行期分辨率白名单）独立于 registry，改 registry 分辨率声明时须同步核对对应 backend，否则用户可选但 backend 不认的档位会被静默替换为兜底档位。
 
 ### 内容模式 (content_mode) 与生成模式 (generation_mode)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -213,7 +213,7 @@ _Avoid_: 用 voice 指代 audio 媒体类型本身；把音色与「声音复刻
 _Avoid_: 与「旁白配音」混为一谈——旁白是成片素材，试听样本只是选音色的中间产物。
 
 **声音一致性档位（voice consistency）**：
-视频模型在跨片段保持人物音色上能做到什么程度的三级标识，由「模型有无音轨」×「项目生成路线」二维派生，全仓库唯一派生点是 `lib/config/resolver.py::derive_voice_consistency`。路线创建即定不可变，同一项目内档位不随剧集或剧本变化。`native`＝参考路线直传参考音频、音色由音频本身锁定；`soft`＝有音轨但只能靠文字描述引导音色；`none`＝真无声，不承载任何声音语义。soft/none 之分不看 `generate_audio` token 是否声明——该 token 语义是「开关可控」而非「有无音轨」，恒有声但开关不可控的供应商（AI Studio Veo、Grok）经 `model_has_audio_track` 单独识别为有音轨。音轨的另一位描述是**开关可控性**（`model_audio_switch_controllable`，即 token 的字面语义）：设置界面按它决定音频开关是否可交互，恒有声与恒无声两类模型的开关置灰并展示成片的实际音轨状态；存量配置里的「关闭」由入队前预检显式拒绝（判据单一真相源 `server/services/video_caps.py::resolve_audio_switch_conflict`，WebUI 与智能体两条提交路径各自包一层出口），保证无声判据只在开关真正可控时才可能为假。
+视频模型在跨片段保持人物音色上能做到什么程度的三级标识，由「模型有无音轨」×「项目生成路线」二维派生，全仓库唯一派生点是 `lib/config/resolver.py::derive_voice_consistency`。路线创建即定不可变，同一项目内档位不随剧集或剧本变化。`native`＝参考路线直传参考音频、音色由音频本身锁定；`soft`＝有音轨但只能靠文字描述引导音色；`none`＝真无声，不承载任何声音语义。soft/none 之分不看 `generate_audio` token 是否声明——该 token 语义是「开关可控」而非「有无音轨」，恒有声但开关不可控的型号另由 `ModelInfo.audio_always_on` 逐型号声明，经 `model_has_audio_track` 与 token 合成为有音轨。恒有声按型号而非按供应商声明：同一供应商名下可以部分型号恒有声、部分型号可开关或无声。音轨的另一位描述是**开关可控性**（`model_audio_switch_controllable`，即 token 的字面语义）：设置界面按它决定音频开关是否可交互，恒有声与恒无声两类模型的开关置灰并展示成片的实际音轨状态；存量配置里的「关闭」由入队前预检显式拒绝（判据单一真相源 `server/services/video_caps.py::resolve_audio_switch_conflict`，WebUI 与智能体两条提交路径各自包一层出口），保证无声判据只在开关真正可控时才可能为假。
 _Avoid_: 用 `generate_audio` 的真假直接代指有无音轨；把「开关可控」与「有音轨」当同一位读。
 
 **声音描述声明段（Voice_Profiles）**：

--- a/docs/dashscope-docs/参考生视频-HappyHorse.md
+++ b/docs/dashscope-docs/参考生视频-HappyHorse.md
@@ -134,6 +134,6 @@ GET /api/v1/tasks/{task_id}
 - **能力位归 backend**:i2v 声明 `first_frame=True`,t2v / r2v 为 `False`(视频能力位不入 `ModelInfo.capabilities`,见 `docs/adr/0054`)
 - **resolutions**:1.1 `["480p", "720p", "1080p"]`;1.0 `["720p", "1080p"]`(480P 对 1.0 未确权,registry 不替官方补写)
 - **supported_durations**:`[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]`(两代同)
-- **音频**:恒开、无开关参数,由恒有声例外表判定有音轨
+- **音频**:恒开、无开关参数,registry 逐型号声明 `audio_always_on=True` 判定有音轨
 - **水印**:官方默认 `watermark=true`(右下角 "Happy Horse"),ArcReel backend 构造 payload 时显式传 `false`
 - **默认视频模型**:`happyhorse-1.1-i2v`

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -31,7 +31,7 @@ ModelCapability = Literal[
     "vision",  # 消费点：文本解析的 vision 闸（lib/config/resolver.py）
     "text_to_image",  # 消费点：图片能力桶判定（lib/capability_buckets.py）
     "image_to_image",  # 消费点：同上
-    "generate_audio",  # 消费点：音轨开关判定（model_has_audio_track，语义见其上方注）
+    "generate_audio",  # 消费点：音轨开关判定（语义见 model_audio_switch_controllable 的 docstring）
     "text_to_speech",
 ]
 

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -73,10 +73,12 @@ def model_has_audio_track(provider_id: str, model_info: ModelInfo) -> bool:
     """该视频 model 生成的成片是否带音轨（不等于「音轨开关可控」，见 generate_audio token 语义注）。
 
     两个来源合成：`generate_audio` token 表达「开关可控」，故声明了 token 即有音轨；恒有声型号
-    （请求参数无法关闭音轨）不声明 token——声明了会误导调用方以为开关生效——改由 `audio_always_on`
-    表达。voice_consistency 派生与前端能力线渲染共用本函数，不各自维护一份漂移的判断。
+    （请求参数无法关闭音轨）不声明 token——声明了会误导调用方以为开关生效——其有音轨由
+    `audio_always_on` 表达。voice_consistency 派生与前端能力线渲染共用本函数，不各自维护一份
+    漂移的判断。
 
-    `provider_id` 保留在签名里供调用方按 (provider, model) 定位模型，当前判定不读它。
+    `provider_id` 不参与判定，保留在签名里与 :func:`model_audio_always_on` 对齐——两者同为
+    (provider, model) 对上的音轨查询，签名一致省得调用方逐个记哪个要传 provider。
     """
     if model_info.media_type != "video":
         return False
@@ -897,7 +899,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
             # --- video ---
             # Sora 2 原生含对话音轨，但请求参数里没有音轨开关，故不声明 generate_audio token，
-            # 有音轨改由 audio_always_on 表达。
+            # 有音轨由 audio_always_on 表达。
             "sora-2": ModelInfo(
                 display_name="Sora 2",
                 media_type="video",

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -46,6 +46,11 @@ class ModelInfo:
     # 补一份视频输入模式或参考图上限声明即引入第二份手写来源，由
     # tests/test_video_backend_capabilities.py::TestVideoCapabilitySingleSourceOfTruth 拦下。
     capabilities: list[ModelCapability]
+    # 视频模型恒有声：成片必然带音轨，且请求参数里没有可下发的音轨开关。与 generate_audio
+    # token 互斥——token 表达「开关可控」，本位表达「不可控且恒开」，两者同时声明自相矛盾。
+    # 恒有声按型号声明而非按供应商：同一供应商名下可以部分型号恒有声、部分型号可开关或无声。
+    # 仅视频模型可置 True；两条约束由 tests/test_config_registry.py 的注册表守卫锁定。
+    audio_always_on: bool = False
     default: bool = False
     supported_durations: list[int] = field(default_factory=list)
     duration_resolution_constraints: dict[str, list[int]] = field(default_factory=dict)
@@ -64,19 +69,18 @@ class ModelInfo:
     api_model_name: str | None = None
 
 
-#: `generate_audio` token 语义是「音轨开关可控」，不是「有无音轨」——AI Studio 的 Veo、
-#: Grok Imagine、DashScope 视频全家族与 OpenAI 的 Sora 恒有声但请求参数无法关闭该开关，故
-#: registry 不为其声明该 token（声明了会误导调用方以为开关生效）。`model_has_audio_track`
-#: 据此在 token 判定之外单列这几家例外，供 voice_consistency 派生与前端能力线渲染共用，
-#: 防止两处各自维护一份漂移的判断。
-_ALWAYS_AUDIBLE_WITHOUT_TOKEN_PROVIDERS = frozenset({"gemini-aistudio", "grok", "dashscope", "openai"})
-
-
 def model_has_audio_track(provider_id: str, model_info: ModelInfo) -> bool:
-    """该视频 model 生成的成片是否带音轨（不等于「音轨开关可控」，见上方 token 语义注）。"""
+    """该视频 model 生成的成片是否带音轨（不等于「音轨开关可控」，见 generate_audio token 语义注）。
+
+    两个来源合成：`generate_audio` token 表达「开关可控」，故声明了 token 即有音轨；恒有声型号
+    （请求参数无法关闭音轨）不声明 token——声明了会误导调用方以为开关生效——改由 `audio_always_on`
+    表达。voice_consistency 派生与前端能力线渲染共用本函数，不各自维护一份漂移的判断。
+
+    `provider_id` 保留在签名里供调用方按 (provider, model) 定位模型，当前判定不读它。
+    """
     if model_info.media_type != "video":
         return False
-    return "generate_audio" in model_info.capabilities or provider_id in _ALWAYS_AUDIBLE_WITHOUT_TOKEN_PROVIDERS
+    return "generate_audio" in model_info.capabilities or model_info.audio_always_on
 
 
 def model_audio_switch_controllable(model_info: ModelInfo) -> bool:
@@ -444,6 +448,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Veo 3.1",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
@@ -454,6 +459,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Veo 3.1 Fast",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8], "4k": [8]},
                 reference_image_durations=[8],
@@ -464,6 +470,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Veo 3.1 Lite",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 default=True,
                 supported_durations=[4, 6, 8],
                 duration_resolution_constraints={"1080p": [8]},
@@ -811,6 +818,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Grok Imagine Video",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 default=True,
                 supported_durations=list(range(1, 16)),
                 resolutions=["480p", "720p"],
@@ -889,11 +897,12 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
             ),
             # --- video ---
             # Sora 2 原生含对话音轨，但请求参数里没有音轨开关，故不声明 generate_audio token，
-            # 有音轨改由 _ALWAYS_AUDIBLE_WITHOUT_TOKEN_PROVIDERS 表达。
+            # 有音轨改由 audio_always_on 表达。
             "sora-2": ModelInfo(
                 display_name="Sora 2",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 default=True,
                 supported_durations=[4, 8, 12],
                 resolutions=["720p"],
@@ -903,6 +912,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="Sora 2 Pro",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=[4, 8, 12],
                 resolutions=["720p", "1080p"],
                 pricing=_sora_video_pricing("sora-2-pro", {"720p": 0.30, "1024p": 0.50, "1080p": 0.70}),
@@ -1077,6 +1087,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.1 图生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 default=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["480p", "720p", "1080p"],
@@ -1086,6 +1097,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.1 文生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["480p", "720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.1-t2v", {"480p": 0.45, "720p": 0.9, "1080p": 1.2}),
@@ -1094,6 +1106,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.1 参考生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["480p", "720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.1-r2v", {"480p": 0.45, "720p": 0.9, "1080p": 1.2}),
@@ -1103,6 +1116,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.0 图生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.0-i2v", {"720p": 0.9, "1080p": 1.6}),
@@ -1111,6 +1125,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.0 文生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.0-t2v", {"720p": 0.9, "1080p": 1.6}),
@@ -1119,6 +1134,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="HappyHorse 1.0 参考生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(3, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("happyhorse-1.0-r2v", {"720p": 0.9, "1080p": 1.6}),
@@ -1128,6 +1144,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="万相 2.7 图生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("wan2.7-i2v", {"720p": 0.6, "1080p": 1.0}),
@@ -1136,6 +1153,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="万相 2.7 文生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("wan2.7-t2v", {"720p": 0.6, "1080p": 1.0}),
@@ -1144,6 +1162,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 display_name="万相 2.7 参考生视频",
                 media_type="video",
                 capabilities=[],
+                audio_always_on=True,
                 supported_durations=list(range(2, 16)),
                 resolutions=["720p", "1080p"],
                 pricing=_dashscope_video_pricing("wan2.7-r2v", {"720p": 0.6, "1080p": 1.0}),

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -412,7 +412,7 @@ def derive_voice_consistency(
 
     native 蕴含有音轨：generation_mode 非参考生视频时一律降格 soft，不降到 none。soft/none
     之分不看 ``generate_audio`` token 是否声明——该 token 语义是「开关可控」而非「有无音轨」，
-    恒有声但开关不可控的 provider 经 ``model_has_audio_track`` 单独识别为有音轨。
+    恒有声但开关不可控的型号经 ``model_has_audio_track`` 单独识别为有音轨。
     """
     if reference_audio_mode == "direct" and generation_mode == "reference_video":
         return "native"

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -953,7 +953,7 @@ async def execute_video_task(
     # 的 item 无 utterances 字段，payload.dialogue 原样透传；SDK 路径 prompt 已是渲染好的字符串、跳过。
     if isinstance(item, dict) and isinstance(prompt, dict) and content_mode == "drama":
         # 无声（C 类模型不产音、或本集关闭音频）传 characters=None 即不注入 Voice_Profiles；
-        # 有音轨模型（含恒有声、开关不可控的 gemini-aistudio/grok）机械派生角色声音风格。
+        # 有音轨模型（含恒有声、开关不可控的型号）机械派生角色声音风格。
         # 两条无声路径同口径，判据落在 VideoLaneResult.is_silent。台词不受影响、照常下发。
         voice_characters = None if ctx.video.is_silent else (project.get("characters") or {})
         if "utterances" in item:

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -299,7 +299,7 @@ class TestModelHasAudioTrack:
 
     def test_dashscope_video_always_audible_without_token(self):
         """DashScope 视频全家族恒有声：_build_payload 不下传音频开关，故不声明 token，
-        由恒有声例外表判定有音轨。"""
+        由各型号的 audio_always_on 判定有音轨。"""
         for model_id in (
             "happyhorse-1.1-i2v",
             "happyhorse-1.1-t2v",
@@ -316,13 +316,13 @@ class TestModelHasAudioTrack:
             assert model_has_audio_track("dashscope", model) is True
 
     def test_dashscope_image_model_not_audible(self):
-        """恒有声例外表是 provider 级，但图像 model 仍恒 False——不因同 provider 被误判。"""
+        """同一供应商名下的图像 model 恒 False——不因同门视频型号恒有声被误判。"""
         model = self._model("dashscope", "wan2.7-image")
         assert model.media_type != "video"
         assert model_has_audio_track("dashscope", model) is False
 
     def test_sora_always_audible_without_token(self):
-        """Sora 原生含对话音轨，但请求参数里没有音轨开关：不声明 token，由恒有声例外表判定有音轨。"""
+        """Sora 原生含对话音轨，但请求参数里没有音轨开关：不声明 token，由 audio_always_on 判定有音轨。"""
         for model_id in ("sora-2", "sora-2-pro"):
             model = self._model("openai", model_id)
             assert "generate_audio" not in model.capabilities
@@ -345,7 +345,7 @@ class TestModelHasAudioTrack:
             assert model_has_audio_track("kling", model) is False
 
     def test_minimax_true_silent(self):
-        """MiniMax 未声明 token 且不在恒有声例外表内——真无声模型。"""
+        """MiniMax 既未声明 token 也未声明 audio_always_on——真无声模型。"""
         model = self._model("minimax", "MiniMax-Hailuo-2.3")
         assert model_has_audio_track("minimax", model) is False
 
@@ -355,7 +355,7 @@ class TestModelHasAudioTrack:
         assert model_has_audio_track("agnes", model) is False
 
     def test_non_video_model_always_false(self):
-        """非视频 model（如文本模型）音轨判定无意义，恒 False，即便所属 provider 在恒有声例外表内。"""
+        """非视频 model（如文本模型）音轨判定无意义，恒 False，即便同门视频型号恒有声。"""
         model = self._model("gemini-aistudio", "gemini-3-flash-preview")
         assert model.media_type != "video"
         assert model_has_audio_track("gemini-aistudio", model) is False
@@ -398,3 +398,88 @@ class TestAudioSwitchControllable:
         model = self._model("dashscope", "wan2.7-image")
         assert model_audio_switch_controllable(model) is False
         assert model_audio_always_on("dashscope", model) is False
+
+
+#: 全部内置视频 model 的音轨立场逐条钉死：controllable = 开关可控；always_on = 恒有声、开关不可控；
+#: silent = 无音轨。新增视频型号必须在此登记，登记时即被迫表态其音轨立场——漏声明 audio_always_on
+#: 的恒有声新型号会以 silent 落到这张表上，与作者的登记意图对不上而在 CI 暴露。
+_VIDEO_AUDIO_STANCES: dict[tuple[str, str], str] = {
+    ("agnes", "agnes-video-v2.0"): "silent",
+    ("ark", "doubao-seedance-1-5-pro-251215"): "controllable",
+    ("ark", "doubao-seedance-2-0-260128"): "controllable",
+    ("ark", "doubao-seedance-2-0-fast-260128"): "controllable",
+    ("ark", "doubao-seedance-2-0-mini-260615"): "controllable",
+    ("ark-agent-plan", "doubao-seedance-1.5-pro"): "controllable",
+    ("ark-agent-plan", "doubao-seedance-2.0"): "controllable",
+    ("ark-agent-plan", "doubao-seedance-2.0-fast"): "controllable",
+    ("ark-agent-plan", "doubao-seedance-2.0-mini"): "controllable",
+    ("dashscope", "happyhorse-1.0-i2v"): "always_on",
+    ("dashscope", "happyhorse-1.0-r2v"): "always_on",
+    ("dashscope", "happyhorse-1.0-t2v"): "always_on",
+    ("dashscope", "happyhorse-1.1-i2v"): "always_on",
+    ("dashscope", "happyhorse-1.1-r2v"): "always_on",
+    ("dashscope", "happyhorse-1.1-t2v"): "always_on",
+    ("dashscope", "wan2.7-i2v"): "always_on",
+    ("dashscope", "wan2.7-r2v"): "always_on",
+    ("dashscope", "wan2.7-t2v"): "always_on",
+    ("gemini-aistudio", "veo-3.1-fast-generate-preview"): "always_on",
+    ("gemini-aistudio", "veo-3.1-generate-preview"): "always_on",
+    ("gemini-aistudio", "veo-3.1-lite-generate-preview"): "always_on",
+    ("gemini-vertex", "veo-3.1-fast-generate-001"): "controllable",
+    ("gemini-vertex", "veo-3.1-generate-001"): "controllable",
+    ("grok", "grok-imagine-video"): "always_on",
+    ("kling", "kling-v2-5-turbo"): "silent",
+    ("kling", "kling-v2-6"): "controllable",
+    ("kling", "kling-v3"): "controllable",
+    ("kling", "kling-v3-omni"): "controllable",
+    ("kling", "kling-video-o1"): "silent",
+    ("minimax", "MiniMax-Hailuo-2.3"): "silent",
+    ("minimax", "MiniMax-Hailuo-2.3-Fast"): "silent",
+    ("minimax", "S2V-01"): "silent",
+    ("openai", "sora-2"): "always_on",
+    ("openai", "sora-2-pro"): "always_on",
+    ("vidu", "vidu2.0"): "silent",
+    ("vidu", "viduq3"): "controllable",
+    ("vidu", "viduq3-pro"): "controllable",
+    ("vidu", "viduq3-turbo"): "controllable",
+}
+
+
+@pytest.mark.unit
+class TestVideoAudioStanceRegistry:
+    """注册表级守卫：音轨声明的形态一致性，与三个派生查询在全部视频 model 上的取值。"""
+
+    def test_every_video_model_matches_declared_stance(self):
+        """派生查询在全部内置视频 model 上的取值逐条与上表相等（整表相等，非子集）。"""
+        actual: dict[tuple[str, str], str] = {}
+        for provider_id, meta in PROVIDER_REGISTRY.items():
+            for model_id, model in meta.models.items():
+                if model.media_type != "video":
+                    continue
+                if model_audio_always_on(provider_id, model):
+                    stance = "always_on"
+                elif model_audio_switch_controllable(model):
+                    stance = "controllable"
+                else:
+                    stance = "silent"
+                assert model_has_audio_track(provider_id, model) is (stance != "silent")
+                actual[(provider_id, model_id)] = stance
+        assert actual == _VIDEO_AUDIO_STANCES
+
+    def test_always_on_declared_only_on_video_models(self):
+        """audio_always_on 只对视频 model 有意义；图像 / 文本 / 音频 model 上的声明无消费方。"""
+        for provider_id, meta in PROVIDER_REGISTRY.items():
+            for model_id, model in meta.models.items():
+                if model.media_type == "video":
+                    continue
+                assert not model.audio_always_on, f"{provider_id}/{model_id} 非视频 model 不得声明 audio_always_on"
+
+    def test_always_on_never_coexists_with_generate_audio_token(self):
+        """两位声明互斥：token 表达开关可控，audio_always_on 表达不可控且恒开，同时声明自相矛盾。"""
+        for provider_id, meta in PROVIDER_REGISTRY.items():
+            for model_id, model in meta.models.items():
+                if not model.audio_always_on:
+                    continue
+                assert "generate_audio" not in model.capabilities, (
+                    f"{provider_id}/{model_id} 同时声明了 generate_audio 与 audio_always_on"
+                )


### PR DESCRIPTION
「恒有声」（成片必然带音轨、请求参数里没有开关）的声明粒度从供应商级收编到型号级：原先按供应商整家判定，现由 `ModelInfo.audio_always_on` 逐型号声明。同一供应商名下从此可以部分型号恒有声、部分型号可开关或无声。

纯 prefactor，全站行为零变化：派生查询（有无音轨 / 开关是否可控 / 是否恒有声）的签名与语义不变，四家原供应商级声明覆盖的 15 个视频型号逐条迁移为型号级声明。

Closes #1755

## 验证

- 迁移等价性独立复核：基于 `origin/main` 的旧代码重算全部 38 个内置视频型号的音轨三态（恒有声 / 可控 / 无声），与本分支守卫表 `_VIDEO_AUDIO_STANCES` 整表相同，无一条漂移。
- 新增注册表守卫 `TestVideoAudioStanceRegistry`：三态整表相等（非子集，新增视频型号必须登记、登记即被迫表态）、`audio_always_on` 仅限视频型号、与 `generate_audio` token 互斥。
- 质量门全绿：`ruff check` / `ruff format --check` / `basedpyright`（0 error）/ `lint-imports`（契约 KEPT）/ `pytest` 全量 8245 passed、1 skipped。
- 文档同步核对：`CLAUDE.md`（symlink 至 `AGENTS.md`）「供应商能力数据」段补写音轨两位描述的真相源归属；`CONTEXT.md` 声音一致性档位段、`resolver.py` docstring、`generation_tasks.py` 注释与 DashScope 文档镜像中会因粒度变化而失实的表述一并修正。

## 审查发现

本地审查两轴（Standards / Spec）无阻断项。已修：`model_has_audio_track` 中保留 `provider_id` 形参的理由写得不成立（调用方本就持有 provider_id），改为如实说明是与 `model_audio_always_on` 保持签名对齐；两处「改由 ... 表达」的补丁式措辞改为陈述现状。

已知薄弱点：守卫表挡的是「漏表态」，挡不住「表态错误」——若作者把恒有声型号同时登记成 `silent` 且不声明 `audio_always_on`，两边自洽、测试通过。真值仍以供应商文档为准。

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 视频模型的音轨能力改为按型号识别，准确区分恒有声、可控制音频和无音轨模式。
  - 声音一致性档位会依据具体模型的音频能力进行判定。
- **文档**
  - 更新相关能力说明，明确不同视频模型的音轨属性及判定规则。
- **测试**
  - 补充并完善视频模型音轨能力的覆盖验证，确保配置保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->