### PR TITLE
chore(视频): 预留「首帧任务比例跟随首帧图」的模型能力声明与统一施加

### DIFF
--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -608,7 +608,12 @@ class MediaGenerator:
 
         # 能力校验与槽位组装先于记账括号：能力不被支持时硬失败要"不扣费"，
         # 在括号内抛虽也不结算，却会留一条 failed ApiCall 行；两者均无副作用，前置最干净。
-        from lib.video_frame_slots import gate_video_request, plan_frame_slots, resolve_video_capabilities
+        from lib.video_frame_slots import (
+            gate_video_request,
+            plan_frame_slots,
+            resolve_first_frame_aspect_ratio,
+            resolve_video_capabilities,
+        )
 
         # prompt 长度校验对每个请求都适用（不像尾帧/参考图/参考音频那样可选），故能力查询不再
         # 按可选路径惰性触发。查询是纯读后端声明的同步调用，没有 I/O 开销。
@@ -642,6 +647,13 @@ class MediaGenerator:
             start_image=start_image,
             end_image=end_image,
             reference_images=reference_images,
+        )
+        # 仅声明 first_frame_ratio_adaptive_only 的后端受影响；下发值与调用方持有的原始
+        # aspect_ratio（记账、分镜图生成沿用）分离，不回写覆盖上游变量。
+        request_aspect_ratio = resolve_first_frame_aspect_ratio(
+            caps=video_caps,
+            aspect_ratio=aspect_ratio,
+            has_first_frame=slot_plan.start_index is not None,
         )
 
         if self._config is not None:
@@ -703,7 +715,7 @@ class MediaGenerator:
                     VideoGenerationRequest(
                         prompt=prompt,
                         output_path=output_path,
-                        aspect_ratio=aspect_ratio,
+                        aspect_ratio=request_aspect_ratio,
                         duration_seconds=duration_int,
                         resolution=resolution,
                         start_image=start_arg,

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -445,6 +445,13 @@ class VideoCapabilities:
     为字符数（中英文同权），与各家文档一致。超限的典型失败模式是静默截断而非报错：供应商照常
     扣费、成片与意图不符、用户无从知情，正是 :func:`lib.video_frame_slots.gate_video_request`
     要在付费前堵住的降级。
+
+    ``first_frame_ratio_adaptive_only``：该模型的首帧（image-to-video）任务是否只接受
+    "adaptive" 比例——声明为 True 时，实际下发给该后端的 ``VideoGenerationRequest.aspect_ratio``
+    在带首帧的请求上恒为字面量 ``"adaptive"``，由
+    :func:`lib.video_frame_slots.resolve_first_frame_aspect_ratio` 统一施加，不进各 backend
+    的 payload 组装各写一套。不带首帧的请求（纯文生 / 仅参考图）不受影响。用户的比例意图仍完整
+    作用于分镜图生成——这里改写的只是视频请求实际下发的值，不改调用方持有的原始 ``aspect_ratio``。
     """
 
     first_frame: bool = True
@@ -455,6 +462,7 @@ class VideoCapabilities:
     max_reference_audio_total_seconds: float | None = None
     reference_audio_per_image: bool = False
     max_prompt_chars: int | None = None
+    first_frame_ratio_adaptive_only: bool = False
 
 
 @dataclass

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -447,11 +447,19 @@ class VideoCapabilities:
     要在付费前堵住的降级。
 
     ``first_frame_ratio_adaptive_only``：该模型的首帧（image-to-video）任务是否只接受
-    "adaptive" 比例——声明为 True 时，实际下发给该后端的 ``VideoGenerationRequest.aspect_ratio``
-    在带首帧的请求上恒为字面量 ``"adaptive"``，由
-    :func:`lib.video_frame_slots.resolve_first_frame_aspect_ratio` 统一施加，不进各 backend
-    的 payload 组装各写一套。不带首帧的请求（纯文生 / 仅参考图）不受影响。用户的比例意图仍完整
-    作用于分镜图生成——这里改写的只是视频请求实际下发的值，不改调用方持有的原始 ``aspect_ratio``。
+    "adaptive" 比例。声明为 True 时，:func:`lib.video_frame_slots.resolve_first_frame_aspect_ratio`
+    把带首帧的生成请求的 ``VideoGenerationRequest.aspect_ratio`` 改写为字面量 ``"adaptive"``；
+    不带首帧的请求（纯文生 / 仅参考图）与续接已发起 job 的 resume 路径不受影响。该字面量是供应商
+    侧的取值，只对认得它的 backend 有意义，故本位只由这类 backend 声明——别处（如
+    :func:`lib.aspect_size.parse_aspect_ratio`）解析不了它，会按非法值回退默认比例。
+
+    「首帧在场时用户比例不适用」这一情形另有 backend 各自的表达方式：dashscope 与 vidu 在
+    payload 组装期直接不下发 ratio（上游忽略或拒收）。三者形状相近而取值策略不同（省略 vs 改写
+    为 adaptive），未收敛到同一开关；本位表达的是"改写为 adaptive"这一支。
+
+    用户的比例意图仍完整作用于分镜图生成——首帧图本就按该比例生成，"跟随首帧"与用户所选比例
+    等价；改写只影响视频请求实际下发的值，不改调用方持有的原始 ``aspect_ratio``（记账、版本
+    元数据沿用后者）。
     """
 
     first_frame: bool = True

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -30,7 +30,8 @@ __all__ = [
     "resolve_video_capabilities",
 ]
 
-# 供应商 SDK 接受的字面量，表示"跟随首帧图片自身比例"而非用户指定的固定比例。
+# 供应商侧字面量，表示"跟随首帧图片自身比例"而非用户指定的固定比例。仅对声明
+# ``first_frame_ratio_adaptive_only`` 的 backend 有意义，通用比例解析器认不得它。
 FIRST_FRAME_ADAPTIVE_RATIO = "adaptive"
 
 
@@ -76,6 +77,10 @@ def resolve_first_frame_aspect_ratio(
     :data:`FIRST_FRAME_ADAPTIVE_RATIO`——调用方原始持有的 ``aspect_ratio``（用户比例意图，仍
     完整作用于分镜图生成）不受影响，本函数只决定实际下发给该次视频请求的值。``caps`` 为 None
     或未声明该约束、或本次请求不带首帧（纯文生 / 仅参考图）时原样返回 ``aspect_ratio``。
+
+    ``has_first_frame`` 由调用方按"本次请求实际会不会带首帧"传入，而不是按入参是否非空——
+    :func:`plan_frame_slots` 只让 ``str`` / ``Path`` 文件源进槽位，判定须与真正下发的
+    ``VideoGenerationRequest.start_image`` 一致，否则约束会与实际请求脱节。
     """
     if caps is not None and caps.first_frame_ratio_adaptive_only and has_first_frame:
         return FIRST_FRAME_ADAPTIVE_RATIO

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -76,9 +76,9 @@ def resolve_first_frame_aspect_ratio(
     声明该约束的后端在带首帧（image-to-video）的请求上只接受
     :data:`FIRST_FRAME_ADAPTIVE_RATIO`——调用方原始持有的 ``aspect_ratio``（用户比例意图，仍
     完整作用于分镜图生成）不受影响，本函数只决定实际下发给该次视频请求的值。``caps`` 为 None
-    或未声明该约束、或本次请求不带首帧（纯文生 / 仅参考图）时原样返回 ``aspect_ratio``。
+    或未声明该约束、或实际下发的请求不带首帧（纯文生 / 仅参考图）时原样返回 ``aspect_ratio``。
 
-    ``has_first_frame`` 由调用方按"本次请求实际会不会带首帧"传入，而不是按入参是否非空——
+    ``has_first_frame`` 由调用方按"实际下发的请求是否带首帧"传入，而不是按入参是否非空——
     :func:`plan_frame_slots` 只让 ``str`` / ``Path`` 文件源进槽位，判定须与真正下发的
     ``VideoGenerationRequest.start_image`` 一致，否则约束会与实际请求脱节。
     """

--- a/lib/video_frame_slots.py
+++ b/lib/video_frame_slots.py
@@ -21,12 +21,17 @@ if TYPE_CHECKING:
     from lib.reference_compression import ReferenceSpec
 
 __all__ = [
+    "FIRST_FRAME_ADAPTIVE_RATIO",
     "FrameSlotPlan",
     "VideoCapabilityProbe",
     "gate_video_request",
     "plan_frame_slots",
+    "resolve_first_frame_aspect_ratio",
     "resolve_video_capabilities",
 ]
+
+# 供应商 SDK 接受的字面量，表示"跟随首帧图片自身比例"而非用户指定的固定比例。
+FIRST_FRAME_ADAPTIVE_RATIO = "adaptive"
 
 
 class VideoCapabilityProbe(Protocol):
@@ -57,6 +62,24 @@ def resolve_video_capabilities(
     if tier_aware is not None:
         return tier_aware(service_tier, resolution=resolution)
     return backend.video_capabilities
+
+
+def resolve_first_frame_aspect_ratio(
+    *,
+    caps: VideoCapabilities | None,
+    aspect_ratio: str,
+    has_first_frame: bool,
+) -> str:
+    """按 ``caps.first_frame_ratio_adaptive_only`` 施加首帧任务的 ratio 覆盖。
+
+    声明该约束的后端在带首帧（image-to-video）的请求上只接受
+    :data:`FIRST_FRAME_ADAPTIVE_RATIO`——调用方原始持有的 ``aspect_ratio``（用户比例意图，仍
+    完整作用于分镜图生成）不受影响，本函数只决定实际下发给该次视频请求的值。``caps`` 为 None
+    或未声明该约束、或本次请求不带首帧（纯文生 / 仅参考图）时原样返回 ``aspect_ratio``。
+    """
+    if caps is not None and caps.first_frame_ratio_adaptive_only and has_first_frame:
+        return FIRST_FRAME_ADAPTIVE_RATIO
+    return aspect_ratio
 
 
 @dataclass(frozen=True)

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -163,6 +163,7 @@ class TestModelListExposesCapabilities:
             "max_reference_audio_total_seconds": expected.max_reference_audio_total_seconds,
             "reference_audio_per_image": expected.reference_audio_per_image,
             "max_prompt_chars": expected.max_prompt_chars,
+            "first_frame_ratio_adaptive_only": expected.first_frame_ratio_adaptive_only,
         }
 
     @pytest.mark.integration

--- a/tests/test_capability_overrides_api.py
+++ b/tests/test_capability_overrides_api.py
@@ -143,6 +143,7 @@ class TestModelListExposesCapabilities:
             "max_reference_audio_total_seconds": None,
             "reference_audio_per_image": False,
             "max_prompt_chars": None,
+            "first_frame_ratio_adaptive_only": False,
         }
         assert models[0]["capability_overrides"] is None
 

--- a/tests/test_custom_provider_capabilities.py
+++ b/tests/test_custom_provider_capabilities.py
@@ -30,6 +30,7 @@ class TestOverrideFieldSchema:
             "max_reference_audio_total_seconds",
             "reference_audio_per_image",
             "max_prompt_chars",
+            "first_frame_ratio_adaptive_only",
         }
         assert CAPABILITY_OVERRIDE_FIELDS["last_frame"] is bool
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_images"] is int
@@ -38,6 +39,7 @@ class TestOverrideFieldSchema:
         assert CAPABILITY_OVERRIDE_FIELDS["max_reference_audio_total_seconds"] == (float | None)
         assert CAPABILITY_OVERRIDE_FIELDS["max_prompt_chars"] == (int | None)
         assert CAPABILITY_OVERRIDE_FIELDS["reference_audio_per_image"] is bool
+        assert CAPABILITY_OVERRIDE_FIELDS["first_frame_ratio_adaptive_only"] is bool
 
 
 class TestOptionalDimensionSchema:

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -967,3 +967,87 @@ class TestReferenceCompressionSeam:
         await gen.generate_video_async(prompt="x" * 10, resource_type="videos", resource_id="E1S01")
 
         assert gen.ledger.outcomes
+
+
+@pytest.mark.unit
+class TestFirstFrameRatioAdaptiveOnly:
+    """VideoCapabilities.first_frame_ratio_adaptive_only 的共享施加逻辑。
+
+    覆盖点见 lib.video_frame_slots.resolve_first_frame_aspect_ratio 的调用点
+    （lib.media_generator.MediaGenerator.generate_video_async）：本仓库现无消费方声明该约束，
+    这里用能力白名单测试缝（伪造 backend 声明）覆盖首个消费方接入前的施加逻辑正确性。
+    """
+
+    async def test_first_frame_task_forced_to_adaptive(self, tmp_path):
+        from lib.video_backends.base import VideoCapabilities
+
+        gen = _build_generator(tmp_path)
+        backend = _FakeVideoBackend(video_capabilities=VideoCapabilities(first_frame_ratio_adaptive_only=True))
+        gen._video_backend = backend
+
+        start = _solid_png(tmp_path, "start.png", 100, 100)
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            start_image=str(start),
+            aspect_ratio="16:9",
+        )
+
+        assert backend.calls[-1].aspect_ratio == "adaptive"
+
+    async def test_no_first_frame_task_keeps_user_ratio(self, tmp_path):
+        """未带首帧（纯文生 / 仅参考图）不受该约束影响，原样透传用户比例。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        gen = _build_generator(tmp_path)
+        backend = _FakeVideoBackend(video_capabilities=VideoCapabilities(first_frame_ratio_adaptive_only=True))
+        gen._video_backend = backend
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            aspect_ratio="16:9",
+        )
+
+        assert backend.calls[-1].aspect_ratio == "16:9"
+
+    async def test_default_capability_leaves_existing_model_payload_unchanged(self, tmp_path):
+        """默认 False（现有模型未声明该约束）：首帧任务的请求 payload 保持原样。"""
+        gen = _build_generator(tmp_path)
+        backend = _FakeVideoBackend()  # video_capabilities=None，等同未声明
+        gen._video_backend = backend
+
+        start = _solid_png(tmp_path, "start.png", 100, 100)
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            start_image=str(start),
+            aspect_ratio="16:9",
+        )
+
+        assert backend.calls[-1].aspect_ratio == "16:9"
+
+    async def test_ledger_records_user_intent_not_adaptive_override(self, tmp_path):
+        """记账沿用用户原始比例意图，与下发给 backend 的实际值分离。"""
+        from lib.video_backends.base import VideoCapabilities
+
+        gen = _build_generator(tmp_path)
+        backend = _FakeVideoBackend(video_capabilities=VideoCapabilities(first_frame_ratio_adaptive_only=True))
+        gen._video_backend = backend
+
+        start = _solid_png(tmp_path, "start.png", 100, 100)
+
+        await gen.generate_video_async(
+            prompt="p",
+            resource_type="videos",
+            resource_id="E1S01",
+            start_image=str(start),
+            aspect_ratio="16:9",
+        )
+
+        assert gen.ledger.started[-1]["aspect_ratio"] == "16:9"

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -974,8 +974,8 @@ class TestFirstFrameRatioAdaptiveOnly:
     """VideoCapabilities.first_frame_ratio_adaptive_only 的共享施加逻辑。
 
     覆盖点见 lib.video_frame_slots.resolve_first_frame_aspect_ratio 的调用点
-    （lib.media_generator.MediaGenerator.generate_video_async）：本仓库现无消费方声明该约束，
-    这里用能力白名单测试缝（伪造 backend 声明）覆盖首个消费方接入前的施加逻辑正确性。
+    （lib.media_generator.MediaGenerator.generate_video_async）。本仓库无 backend 声明该约束，
+    故用能力白名单测试缝（伪造 backend 声明）覆盖施加逻辑。
     """
 
     async def test_first_frame_task_forced_to_adaptive(self, tmp_path):

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -974,8 +974,8 @@ class TestFirstFrameRatioAdaptiveOnly:
     """VideoCapabilities.first_frame_ratio_adaptive_only 的共享施加逻辑。
 
     覆盖点见 lib.video_frame_slots.resolve_first_frame_aspect_ratio 的调用点
-    （lib.media_generator.MediaGenerator.generate_video_async）。本仓库无 backend 声明该约束，
-    故用能力白名单测试缝（伪造 backend 声明）覆盖施加逻辑。
+    （lib.media_generator.MediaGenerator.generate_video_async）。用能力白名单测试缝
+    （伪造 backend 声明该约束）覆盖施加逻辑，不依赖真实 backend 是否已声明该字段。
     """
 
     async def test_first_frame_task_forced_to_adaptive(self, tmp_path):

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -14,6 +14,12 @@ class TestVideoCapabilities:
         assert caps.max_reference_images == 0
         assert caps.reference_audio_mode is ReferenceAudioMode.NONE
         assert caps.max_reference_audio_count == 0
+        assert caps.first_frame_ratio_adaptive_only is False
+
+    @pytest.mark.unit
+    def test_first_frame_ratio_adaptive_only_declared(self):
+        caps = VideoCapabilities(first_frame_ratio_adaptive_only=True)
+        assert caps.first_frame_ratio_adaptive_only is True
 
     @pytest.mark.unit
     def test_first_last(self):

--- a/tests/test_video_frame_slots.py
+++ b/tests/test_video_frame_slots.py
@@ -6,7 +6,13 @@ import pytest
 
 from lib.reference_compression import RefRole
 from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, VideoCapabilityError
-from lib.video_frame_slots import gate_video_request, plan_frame_slots, resolve_video_capabilities
+from lib.video_frame_slots import (
+    FIRST_FRAME_ADAPTIVE_RATIO,
+    gate_video_request,
+    plan_frame_slots,
+    resolve_first_frame_aspect_ratio,
+    resolve_video_capabilities,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -301,3 +307,33 @@ class TestGateAndAssemblySeparation:
         plan = plan_frame_slots(start_image=Path("start.png"), end_image=Path("end.png"))
 
         assert (plan.start_index, plan.end_index) == (0, 1)
+
+
+class TestResolveFirstFrameAspectRatio:
+    CAPS_ADAPTIVE_ONLY = VideoCapabilities(first_frame_ratio_adaptive_only=True)
+
+    def test_declared_constraint_with_first_frame_forces_adaptive(self):
+        ratio = resolve_first_frame_aspect_ratio(
+            caps=self.CAPS_ADAPTIVE_ONLY, aspect_ratio="9:16", has_first_frame=True
+        )
+
+        assert ratio == FIRST_FRAME_ADAPTIVE_RATIO
+
+    def test_declared_constraint_without_first_frame_passes_through(self):
+        """无首帧（纯文生 / 仅参考图）不受该约束影响，原样透传用户比例。"""
+        ratio = resolve_first_frame_aspect_ratio(
+            caps=self.CAPS_ADAPTIVE_ONLY, aspect_ratio="9:16", has_first_frame=False
+        )
+
+        assert ratio == "9:16"
+
+    def test_default_caps_unaffected(self):
+        """默认 False：既有模型请求 payload 不变。"""
+        ratio = resolve_first_frame_aspect_ratio(caps=CAPS_WITH_LAST_FRAME, aspect_ratio="16:9", has_first_frame=True)
+
+        assert ratio == "16:9"
+
+    def test_none_caps_passes_through(self):
+        ratio = resolve_first_frame_aspect_ratio(caps=None, aspect_ratio="1:1", has_first_frame=True)
+
+        assert ratio == "1:1"


### PR DESCRIPTION
Closes #1756

Spec #1753 的机制前置票。给视频模型能力声明加一位「首帧任务只接受自适应比例」，并把施加逻辑收在一处共享函数里，供后续 Seedance 2.5 / MiniMax H3 接入时复用。

## 改了什么

- `VideoCapabilities` 新增 `first_frame_ratio_adaptive_only: bool = False`
- `lib/video_frame_slots.py` 新增纯函数 `resolve_first_frame_aspect_ratio`，与同文件既有的 `gate_video_request` / `plan_frame_slots` / `resolve_video_capabilities` 并列；唯一消费点是 `MediaGenerator.generate_video_async`
- 下发值与调用方持有的原始 `aspect_ratio` 分离：记账与版本元数据仍记用户原始比例意图，改写只作用于实际下发给 backend 的请求

本仓库当前无任何 backend 声明该位，所以没有模型的请求 payload 发生变化；前端无改动。

## 验证

- 全量 `uv run python -m pytest`：8251 passed, 1 skipped
- `uv run basedpyright`：0 errors
- `uv run lint-imports`：契约 KEPT
- `uv run ruff check` / `ruff format --check`：通过
- 施加逻辑本身经能力白名单测试缝（伪造 backend 声明）覆盖：首帧任务改写为 adaptive、无首帧透传、默认能力位不改 payload、记账保留用户原始比例

核实过施加点的判定条件：`slot_plan.start_index is not None` 与实际下发的 `VideoGenerationRequest.start_image` 是否有值严格等价（`start_arg` 只由 `compressed[start_index].path` 一条路径赋值，PIL.Image 与 None 都不入槽位），不存在首帧任务静默逃逸约束的缺口。

## 审查中修正的点

原能力位说明称该约束「不进各 backend 的 payload 组装各写一套」，但 `dashscope.py` 与 `vidu.py` 已在组装期以「首帧在场即不下发 ratio」表达同一情形。说明改为如实描述三处关系与取值策略差异（省略 vs 改写为 adaptive），并标注 `"adaptive"` 是供应商侧字面量、通用比例解析器认不得它。三者是否收敛为同一开关留作后续设计，未在本票扩大范围。

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 根据视频后端能力和首帧情况，自动调整视频请求的宽高比。
  * 对仅支持首帧自适应比例的场景使用“自适应”比例。
  * 保留用户原始宽高比，用于记录和版本元数据。

* **测试**
  * 补充首帧、无首帧及不同能力配置下的比例处理验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->