### PR TITLE
feat(供应商): ark 支持自定义 base_url

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -553,7 +553,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         display_name="火山方舟",
         description="字节跳动火山方舟 AI 平台，支持 Seedance 视频生成和 Seedream 图片生成，具备音频生成和种子控制能力。",
         required_keys=["api_key"],
-        optional_keys=["video_max_workers", "image_max_workers"],
+        optional_keys=["base_url", "video_max_workers", "image_max_workers"],
         secret_keys=["api_key"],
         models={
             # --- text ---

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -553,7 +553,7 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
         display_name="火山方舟",
         description="字节跳动火山方舟 AI 平台，支持 Seedance 视频生成和 Seedream 图片生成，具备音频生成和种子控制能力。",
         required_keys=["api_key"],
-        optional_keys=["base_url", "video_max_workers", "image_max_workers"],
+        optional_keys=["base_url", "image_max_workers", "video_max_workers"],
         secret_keys=["api_key"],
         models={
             # --- text ---

--- a/tests/test_providers_api.py
+++ b/tests/test_providers_api.py
@@ -399,7 +399,7 @@ class TestGetProviderConfig:
             ("openai", True),
             ("vidu", True),
             ("dashscope", True),
-            ("ark", False),
+            ("ark", True),
             ("grok", False),
             ("gemini-vertex", False),
         ],


### PR DESCRIPTION
经中转 / 代理接入火山方舟的用户，现在可以在设置页给 ark 供应商填写自定义 base_url；填写后 ark 的文本、图片、视频请求都发往该端点，未填写时行为与现状完全一致。

改动是一处声明式字段变更：ark 在 registry 的 `optional_keys` 增加 `base_url`。请求构造层此前就已透传 base_url、registry 也已声明 `default_base_url`，唯一缺口是该可选项未登记，导致设置页不渲染输入框、也没有写入路径。前端与 backend 构造代码零改动。

## 验证

- 两轴代码审查（standards / spec）均无阻塞发现
- 实证走查确认 ark 的 text / image / video 三条构造路径统一经 `_resolve_base_url`（用户值 > registry 默认），无绕过 base_url 的硬编码端点；连接测试端点同样透传
- 既有测试已锁定「配置后请求发往覆盖端点」与「未配置回落官方端点」两种情形，覆盖 text / image / video 三侧
- 质量门全绿：ruff check + format、basedpyright（0 error）、lint-imports、pytest 8242 passed / 1 skipped

## 已知取舍

- `ark-agent-plan` 未同步获得该可选项：它是套餐制供应商、默认端点独立，超出本 issue 字面范围
- ark 对填入的 base_url 原样透传，不像 dashscope 那样做 host 派生与后缀剥离；中转用户填错格式时由对端报错

Closes #1757

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Ark 供应商现支持通过可选配置项设置自定义 Base URL。
  * 保留原有的并发配置能力。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->