### PR TITLE
feat(视频): 接入 MiniMax H3 并设为 MiniMax 视频默认模型

### DIFF
--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -351,6 +351,9 @@ def _minimax_video_per_second_pricing(model_id: str, rates: dict[str, float]) ->
         default_model=model_id,
         dimensions="resolution_only",
         currency="CNY",
+        # H3 未显式指定分辨率（Auto）时，_build_v2_payload 实际下发 768P（无 720P 档位），
+        # 结算须跟随同一默认，否则回落 720P 会因该档不存在而落空至 0。
+        default_resolution="768p",
     )
 
 

--- a/lib/config/registry.py
+++ b/lib/config/registry.py
@@ -343,6 +343,17 @@ def _minimax_video_pricing(model_id: str, buckets: dict[tuple[str, int], float])
     return PerVideoBucket(rates={model_id: buckets}, default_model=model_id, currency="CNY")
 
 
+# MiniMax 视频按秒 × 分辨率计费（元/秒，CNY）。H3 时长连续取 4–15 秒，离散档表达会退化成
+# 逐秒枚举，故与海螺系列的 (分辨率, 时长) 档价分开走每秒矩阵。
+def _minimax_video_per_second_pricing(model_id: str, rates: dict[str, float]) -> PerSecondMatrix:
+    return PerSecondMatrix(
+        rates={model_id: {(res, None): rate for res, rate in rates.items()}},
+        default_model=model_id,
+        dimensions="resolution_only",
+        currency="CNY",
+    )
+
+
 # 可灵 Kling 视频「质量档 × 是否有声」¥/s 矩阵（官方一手核实，CNY，1 积分 = ¥1）。
 # 全部 video 模型共享同一档位矩阵（官方按维度组合定价、不分模型）：4K 档仅 v3/v3-omni 可达、
 # 有声档仅 v2-6 / v3 / v3-omni 可达；turbo 与 video-o1 仅触达 std/pro 无声档。
@@ -1214,13 +1225,30 @@ PROVIDER_REGISTRY: dict[str, ProviderMeta] = {
                 pricing=_minimax_image_pricing("image-01", 0.025),
             ),
             # --- video ---
+            # H3：多模态 v2 端点（content[] 数组），768P/2K × 4–15 秒任意整数，两档分辨率
+            # 时长范围一致故无 duration_resolution_constraints。原生立体声、请求无音轨开关，
+            # 故 audio_always_on。能力与取值出处：
+            # https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md
+            # 定价出处：https://platform.minimaxi.com/docs/guides/pricing-paygo.md
+            # （768P 0.50 元/秒、2K 0.80 元/秒）。同页另有输入素材附加费——参考图前 5 张免费、
+            # 第 6 张起 0.20 元/张——未计入本策略：附加费按输入张数而非输出秒数计，
+            # PerSecondMatrix 无该维度，估价会低于实际账单。
+            "MiniMax-H3": ModelInfo(
+                display_name="MiniMax H3",
+                media_type="video",
+                capabilities=[],
+                audio_always_on=True,
+                default=True,
+                supported_durations=list(range(4, 16)),
+                resolutions=["768p", "2k"],
+                pricing=_minimax_video_per_second_pricing("MiniMax-H3", {"768p": 0.50, "2k": 0.80}),
+            ),
             # 1080P 仅 6s（10s 仅 768P）；细粒度越界由 MiniMaxVideoBackend 抛 VideoCapabilityError，
             # duration_resolution_constraints 同步给前端做下拉门控。
             "MiniMax-Hailuo-2.3": ModelInfo(
                 display_name="MiniMax Hailuo 2.3",
                 media_type="video",
                 capabilities=[],
-                default=True,
                 supported_durations=[6, 10],
                 resolutions=["768p", "1080p"],
                 duration_resolution_constraints={"1080p": [6]},

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -566,10 +566,11 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     if "wan2." in lowered and not is_image:
         return "dashscope-async-video"
 
-    # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V → 两步 file_id 视频端点；
-    # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 不被 _VIDEO_PATTERN 覆盖，
-    # image-01 含 "image" 否则会被通用图像家族抢走。
-    if "hailuo" in lowered or "s2v" in lowered:
+    # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
+    # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 与 h3 均不被 _VIDEO_PATTERN 覆盖，
+    # image-01 含 "image" 否则会被通用图像家族抢走。匹配 "minimax-h3" 而非裸 "h3"——后者过短，
+    # 容易撞上其它厂商恰好含 h3 子串的型号 id。
+    if "hailuo" in lowered or "s2v" in lowered or "minimax-h3" in lowered:
         return "minimax-video"
     if "image-01" in lowered:
         return "minimax-image"

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -318,7 +318,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "Model {model} has reference images that are missing or unreadable; generation aborted: {names}; check the reference image paths",
     "video_reference_images_unsupported": "Model {model} does not support multi-subject reference images; remove the reference images or switch to a model that supports reference-to-video",
     "video_reference_images_exceeded": "Model {model} supports at most {limit} reference images but received {count}; reduce the number of reference images",
-    "video_reference_images_with_frames_unsupported": "Model {model} cannot combine reference images with a first/last frame; use one or the other",
+    "video_reference_images_with_frames_unsupported": "Model {model} cannot combine reference images/audio with a first/last frame; use one or the other",
     "video_start_image_unreadable": "The first-frame image for model {model} is unreadable; generation aborted: {name}; check the first-frame image path",
     "video_end_image_unreadable": "The last-frame image for model {model} is unreadable; generation aborted: {name}; check the last-frame image path",
     "video_end_image_requires_start_image": "Model {model} does not support a standalone last frame; also provide a first frame (first+last keyframes) or remove the last frame",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -320,7 +320,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "Mô hình {model} có ảnh tham chiếu bị thiếu hoặc không đọc được; đã hủy tạo: {names}; hãy kiểm tra đường dẫn ảnh tham chiếu",
     "video_reference_images_unsupported": "Mô hình {model} không hỗ trợ ảnh tham chiếu đa chủ thể; hãy bỏ ảnh tham chiếu hoặc chuyển sang mô hình có hỗ trợ tạo video từ ảnh tham chiếu",
     "video_reference_images_exceeded": "Mô hình {model} hỗ trợ tối đa {limit} ảnh tham chiếu nhưng nhận được {count}; hãy giảm số lượng ảnh tham chiếu",
-    "video_reference_images_with_frames_unsupported": "Mô hình {model} không thể dùng ảnh tham chiếu cùng với khung hình đầu/cuối; hãy chọn một trong hai",
+    "video_reference_images_with_frames_unsupported": "Mô hình {model} không thể dùng ảnh/âm thanh tham chiếu cùng với khung hình đầu/cuối; hãy chọn một trong hai",
     "video_start_image_unreadable": "Ảnh khung hình đầu của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình đầu",
     "video_end_image_unreadable": "Ảnh khung hình cuối của mô hình {model} không đọc được; đã hủy tạo: {name}; hãy kiểm tra đường dẫn ảnh khung hình cuối",
     "video_end_image_requires_start_image": "Mô hình {model} không hỗ trợ khung hình cuối độc lập; hãy cung cấp thêm khung hình đầu (chế độ khung đầu+cuối) hoặc bỏ khung hình cuối",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -274,7 +274,7 @@ MESSAGES = {
     "video_reference_images_unreadable": "模型 {model} 有参考图缺失或无法读取，已中止生成：{names}；请检查参考图路径",
     "video_reference_images_unsupported": "模型 {model} 不支持多图主体参考；请移除参考图，或换一个支持参考生视频的模型",
     "video_reference_images_exceeded": "模型 {model} 最多支持 {limit} 张参考图，收到 {count} 张；请减少参考图数量",
-    "video_reference_images_with_frames_unsupported": "模型 {model} 的参考图不能与首帧/尾帧叠加使用；请二选一",
+    "video_reference_images_with_frames_unsupported": "模型 {model} 的参考图/参考音频不能与首帧/尾帧叠加使用；请二选一",
     "video_start_image_unreadable": "模型 {model} 的首帧图无法读取，已中止生成：{name}；请检查首帧图路径",
     "video_end_image_unreadable": "模型 {model} 的尾帧图无法读取，已中止生成：{name}；请检查尾帧图路径",
     "video_end_image_requires_start_image": "模型 {model} 不支持单独的尾帧；请同时提供首帧（首尾帧模式），或移除尾帧",

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -6,11 +6,13 @@
 - MINIMAX_INTL_BASE_URL — 国际站 base，供配置覆盖参考
 - resolve_minimax_api_key — Bearer API Key 解析（缺失即 raise，不走 env fallback）
 - minimax_text_base_url / minimax_video_base_url — 归一化为 {host}/v1，容忍用户填 host 或带 `/v1` 后缀
+- minimax_video_v2_base_url — 多模态视频端点 base {host}/v2（H3）
 - minimax_headers — Bearer 鉴权头
 - extract_image_url / extract_image_base64 — 单步 image_generation 响应取首图
 - minimax_failure_reason — 图像响应 base_resp.status_code 非零时的错误描述
 - safe_body_for_log — 日志白名单视图（剥 base64/URL/prompt）
 - 视频两步取 URL 状态机：submit→轮询 query 至 status=Success 取 file_id→files/retrieve 取 download_url
+- v2 视频单步取 URL 状态机：submit→轮询 query 至 task.status=succeeded 直接取 task.content.url
 """
 
 from __future__ import annotations
@@ -24,11 +26,22 @@ MINIMAX_INTL_BASE_URL = "https://api.minimax.io/v1"
 
 # 单一已知路径后缀，归一化 host 时剥除以容忍用户填入完整 base。
 _V1_SUFFIX = "/v1"
+# v2 视频端点（H3）与 v1 同 host 不同前缀，见 minimax_video_v2_base_url。
+_V2_SUFFIX = "/v2"
 
 # 视频异步任务终态：Success/Fail；中间态 Preparing/Queueing/Processing 继续轮询。
 MINIMAX_STATUS_SUCCESS = "Success"
 MINIMAX_STATUS_FAIL = "Fail"
 _TERMINAL_VIDEO_STATES = frozenset({MINIMAX_STATUS_SUCCESS, MINIMAX_STATUS_FAIL})
+
+# v2 任务状态取值与 v1 完全不同（小写、多出取消态），且成功响应直接给下载 URL、无 file_id
+# 取回步骤，故两套状态机各自独立，不在 v1 判定里加分支。
+MINIMAX_V2_STATUS_SUCCEEDED = "succeeded"
+MINIMAX_V2_STATUS_FAILED = "failed"
+MINIMAX_V2_STATUS_CANCELLED = "cancelled"
+_TERMINAL_V2_VIDEO_STATES = frozenset(
+    {MINIMAX_V2_STATUS_SUCCEEDED, MINIMAX_V2_STATUS_FAILED, MINIMAX_V2_STATUS_CANCELLED}
+)
 
 # 轮询间隔（秒）：海螺视频生成通常数十秒至数分钟，10s 一次平衡时延与请求量。
 MINIMAX_VIDEO_POLL_INTERVAL_SECONDS = 10.0
@@ -67,6 +80,11 @@ def minimax_text_base_url(configured: str | None = None) -> str:
 def minimax_video_base_url(configured: str | None = None) -> str:
     """原生视频端点 base：{host}/v1。与文本共用单一 /v1 base，仅命名区分用途。"""
     return f"{_minimax_host(configured)}{_V1_SUFFIX}"
+
+
+def minimax_video_v2_base_url(configured: str | None = None) -> str:
+    """多模态视频端点 base：{host}/v2。与 /v1 同 host，供 H3 的 content[] 端点使用。"""
+    return f"{_minimax_host(configured)}{_V2_SUFFIX}"
 
 
 def minimax_headers(api_key: str) -> dict[str, str]:
@@ -224,3 +242,37 @@ def extract_minimax_download_url(retrieve_payload: dict) -> str:
         reason = _base_resp_error(retrieve_payload)
         raise RuntimeError(reason or f"MiniMax files/retrieve 响应缺少 download_url: {retrieve_payload}")
     return url
+
+
+# ── v2 视频任务状态机工具（单步取 URL） ───────────────────────────────────────
+
+
+def minimax_v2_video_status(payload: dict) -> str | None:
+    """查询响应 task.status（queued/running/succeeded/failed/cancelled）。"""
+    return _as_dict(payload.get("task")).get("status")
+
+
+def is_minimax_v2_video_terminal(payload: dict) -> bool:
+    """succeeded / failed / cancelled 为终态；queued / running（含未知）继续轮询。"""
+    return minimax_v2_video_status(payload) in _TERMINAL_V2_VIDEO_STATES
+
+
+def minimax_v2_video_failure_reason(payload: dict) -> str | None:
+    """status=failed/cancelled 或顶层 base_resp 硬错误 → 错误描述；否则 None。
+
+    取消态一并按失败处理：任务不会再产出视频，继续轮询只会等到超时。
+    """
+    status = minimax_v2_video_status(payload)
+    if status in (MINIMAX_V2_STATUS_FAILED, MINIMAX_V2_STATUS_CANCELLED):
+        task = _as_dict(payload.get("task"))
+        detail = task.get("error") or task.get("status_msg") or ""
+        return f"MiniMax 视频任务{status} task_id={task.get('id')}: {detail}".strip()
+    return _base_resp_error(payload)
+
+
+def extract_minimax_v2_download_url(query_payload: dict) -> str:
+    """从 status=succeeded 的查询响应提取 task.content.url（限时下载地址）。"""
+    url = _as_dict(_as_dict(query_payload.get("task")).get("content")).get("url")
+    if not url:
+        raise RuntimeError(f"MiniMax 视频任务完成但缺少 content.url: {query_payload}")
+    return str(url)

--- a/lib/pricing/strategies.py
+++ b/lib/pricing/strategies.py
@@ -130,8 +130,9 @@ def _per_second_matrix(pricing: PerSecondMatrix, params: PricingParams) -> tuple
         )
         per_second = model_costs.get((resolution, params.generate_audio), fallback)
     elif pricing.dimensions == "resolution_only":
-        resolution = (params.resolution or "720p").lower()
-        per_second = model_costs.get((resolution, None), model_costs.get(("720p", None), 0.0))
+        default_resolution = pricing.default_resolution.lower()
+        resolution = (params.resolution or default_resolution).lower()
+        per_second = model_costs.get((resolution, None), model_costs.get((default_resolution, None), 0.0))
     else:  # flat
         per_second = model_costs.get(("", None), 0.0)
     return duration * per_second, pricing.currency

--- a/lib/pricing/types.py
+++ b/lib/pricing/types.py
@@ -72,7 +72,9 @@ class PerSecondMatrix:
 
     ``dimensions``：
     - ``resolution_audio`` — 键 ``(分辨率小写, 是否生成音频)``，缺失回落 ``("1080p", True)``。
-    - ``resolution_only`` — 键 ``(分辨率, None)``，缺失回落 ``("720p", None)`` 再回落 0.0。
+    - ``resolution_only`` — 键 ``(分辨率, None)``，缺失回落 ``(default_resolution, None)`` 再回落 0.0。
+      ``default_resolution`` 须与该模型在分辨率未显式指定（Auto）时实际下发的分辨率一致——
+      两者不一致会让 Auto 请求按错误档位结算，量级上可能是漏计费。
     - ``flat`` — 单一费率，键 ``("", None)``，与分辨率/音频无关。
     """
 
@@ -80,6 +82,7 @@ class PerSecondMatrix:
     default_model: str
     dimensions: Literal["resolution_audio", "resolution_only", "flat"]
     currency: str
+    default_resolution: str = "720p"
     kind: Literal["per_second_matrix"] = "per_second_matrix"
 
 

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -23,6 +23,7 @@ import base64
 import logging
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -334,12 +335,16 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         duration = request.duration_seconds
         resolutions, durations = self._v2_output_specs()
         if resolution not in resolutions or duration not in durations:
+            # v2 的分辨率与时长是两个独立集合（不像 v1 按分辨率给时长），越界可能来自任一维度；
+            # supported 一并列出两维，避免「该分辨率下不支持 Ns」读成分辨率本身合法。
+            supported_resolutions = ", ".join(sorted(r.upper() for r in resolutions))
+            supported_durations = ", ".join(f"{d}s" for d in sorted(durations))
             raise VideoCapabilityError(
                 "video_resolution_duration_unsupported",
                 model=self._model,
                 resolution=resolution.upper(),
                 duration=duration,
-                supported=", ".join(f"{d}s" for d in sorted(durations)),
+                supported=f"{supported_resolutions} × {supported_durations}",
             )
 
         start_image = self._existing_path(request.start_image)
@@ -444,11 +449,12 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         return extract_minimax_video_task_id(resp.json())
 
     async def _poll_query(self, client: httpx.AsyncClient, task_id: str) -> dict:
-        # v2 把 task_id 放路径段，v1 放 query string。
+        # v2 把 task_id 放路径段，v1 放 query string。task_id 来自上游响应/持久化记录，
+        # 非本地生成的受控值，编码后再拼入路径段，避免被改写指向非预期端点。
         url = f"{self._base_url}{_QUERY_ENDPOINT}"
         params = None if self._is_v2 else {"task_id": task_id}
         if self._is_v2:
-            url = f"{url}/{task_id}"
+            url = f"{url}/{quote(task_id, safe='')}"
         resp = await client.get(url, params=params, headers=minimax_headers(self._api_key))
         resp.raise_for_status()
         return resp.json()

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -1,20 +1,28 @@
-"""MiniMaxVideoBackend — MiniMax（海螺）Hailuo 视频生成后端（异步两步取 URL）。
+"""MiniMaxVideoBackend — MiniMax（海螺）视频生成后端，两代 API 并存。
 
-走原生视频端点，轮询而非 callback：submit POST /video_generation 取 task_id →
-轮询 GET /query/video_generation?task_id= 至 status=Success 取 file_id →
-GET /files/retrieve?file_id= 取 download_url → 下载本地。覆盖 MiniMax-Hailuo-2.3
+v1（海螺系列）两步取 URL：submit POST /v1/video_generation 取 task_id →
+轮询 GET /v1/query/video_generation?task_id= 至 status=Success 取 file_id →
+GET /v1/files/retrieve?file_id= 取 download_url → 下载本地。覆盖 MiniMax-Hailuo-2.3
 （t2v+i2v）、MiniMax-Hailuo-2.3-Fast（仅 i2v，约半价）与 S2V-01（单脸参考生视频 R2V）。
+
+v2（MiniMax-H3）单步取 URL：submit POST /v2/video_generation 取 task_id →
+轮询 GET /v2/query/video_generation/{task_id} 至 task.status=succeeded 直接取
+task.content.url。请求体是多模态 content[] 数组，条目按 role 区分首帧/尾帧/参考图/参考音频，
+一次请求覆盖 t2v、i2v（首尾帧）与 r2v（参考图 + 参考音频）三条路径。
 
 能力约束：Hailuo resolution ∈ {768P, 1080P}，1080P 仅 6s（10s 仅 768P）；越界抛
 VideoCapabilityError，Fast 仅图生视频、无首帧的文生视频请求被能力拒绝。S2V-01 走单脸
 subject_reference（reference_images[0]→{"type":"character","image":[...]}），固定输出、
-不传 resolution/duration，无参考图即 fail-loud。
+不传 resolution/duration，无参考图即 fail-loud。H3 resolution ∈ {768P, 2K}、时长 4–15 秒任意整数，
+首尾帧与参考素材互斥（官方口径「图生视频与多模态参考生视频互斥」）。
 """
 
 from __future__ import annotations
 
+import base64
 import logging
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -23,12 +31,17 @@ from lib.minimax_shared import (
     MINIMAX_VIDEO_POLL_INTERVAL_SECONDS,
     extract_minimax_download_url,
     extract_minimax_file_id,
+    extract_minimax_v2_download_url,
     extract_minimax_video_task_id,
     image_to_data_uri,
+    is_minimax_v2_video_terminal,
     is_minimax_video_terminal,
     minimax_headers,
+    minimax_v2_video_failure_reason,
+    minimax_v2_video_status,
     minimax_video_base_url,
     minimax_video_failure_reason,
+    minimax_video_v2_base_url,
     resolve_minimax_api_key,
 )
 from lib.providers import PROVIDER_MINIMAX
@@ -41,6 +54,7 @@ from lib.retry import (
 )
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
+    ReferenceAudioMode,
     VideoCapabilities,
     VideoCapabilityError,
     VideoGenerationRequest,
@@ -55,13 +69,15 @@ from lib.video_backends.base import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
-
 _HAILUO = "MiniMax-Hailuo-2.3"
 _HAILUO_FAST = "MiniMax-Hailuo-2.3-Fast"
 # S2V-01：单张人脸驱动的角色一致性参考生视频（R2V），走 subject_reference 单脸字段，
 # 不接受 first_frame_image / resolution / duration（固定输出）。
 _S2V = "S2V-01"
+# MiniMax-H3：多模态 content[] 端点（v2），唯一走 v2 分支的型号。
+_H3 = "MiniMax-H3"
+
+DEFAULT_MODEL = _H3
 
 _SUBMIT_ENDPOINT = "/video_generation"
 _QUERY_ENDPOINT = "/query/video_generation"
@@ -76,10 +92,25 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 _NO_TEXT_TO_VIDEO_MODELS: frozenset[str] = frozenset({_HAILUO_FAST, _S2V})
 
 # (分辨率小写 → 允许的时长集合)：1080P 仅 6s，768P 支持 6s/10s（两代 Hailuo 同此矩阵）。
+# 仅 v1 分支适用——H3 两档分辨率共用同一段连续时长，见 _H3_RESOLUTIONS / _H3_DURATIONS。
 _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
 
-# 进日志的安全标量白名单；first_frame_image / subject_reference（base64）一律不入日志。
-_SAFE_LOG_KEYS: frozenset[str] = frozenset({"model", "resolution", "duration"})
+# H3 输出规格与输入上限，出处均为官方《创建视频生成任务 (V2)》
+# https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md
+_H3_RESOLUTIONS: frozenset[str] = frozenset({"768p", "2k"})
+_H3_DURATIONS: frozenset[int] = frozenset(range(4, 16))
+_H3_MAX_REFERENCE_IMAGES = 9
+_H3_MAX_REFERENCE_AUDIO = 3
+_H3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
+_H3_MAX_PROMPT_CHARS = 7000
+
+# 参考音频的 data URI MIME：官方接受 wav / mp3，要求 `data:audio/<格式>;base64,<内容>` 且格式小写。
+# 与 ark 侧的同名表各存一份——各家对 mp3 的接受口径不同（此处按官方写法 audio/mp3），
+# 合并成共享表会让其中一家收到没验证过的 MIME。
+_REFERENCE_AUDIO_MIME_TYPES: dict[str, str] = {".wav": "audio/wav", ".mp3": "audio/mp3"}
+
+# 进日志的安全标量白名单；first_frame_image / subject_reference / content[]（base64）一律不入日志。
+_SAFE_LOG_KEYS: frozenset[str] = frozenset({"model", "resolution", "duration", "ratio"})
 
 
 def _supports_text_to_video(model: str | None) -> bool:
@@ -87,16 +118,58 @@ def _supports_text_to_video(model: str | None) -> bool:
 
 
 def _safe_body_for_log(body: dict) -> dict:
-    """安全日志视图：白名单标量 + prompt 截断；first_frame_image 仅标记是否存在。"""
+    """安全日志视图：白名单标量 + prompt 截断；素材字段一律折叠，不展开 base64。
+
+    v2 的 content[] 里图片与音频都是 base64 data URI，按条目类型折叠成计数后再入日志
+    （对齐 CodeQL clear-text-logging 约束），其中的 text 条目即 prompt，按同一规则截断。
+    """
     safe = {k: v for k, v in body.items() if k in _SAFE_LOG_KEYS}
-    if "prompt" in body:
-        prompt = body["prompt"] or ""
-        safe["prompt"] = prompt[:120] + ("…" if len(prompt) > 120 else "")
+    prompt = body.get("prompt")
+    content = body.get("content")
+    if isinstance(content, list):
+        counts: dict[str, int] = {}
+        for item in content:
+            kind = item.get("type", "unknown") if isinstance(item, dict) else "unknown"
+            counts[kind] = counts.get(kind, 0) + 1
+        safe["content"] = "<" + ", ".join(f"{n} {kind}" for kind, n in sorted(counts.items())) + ">"
+        prompt = next(
+            (item.get("text") for item in content if isinstance(item, dict) and item.get("type") == "text"), None
+        )
+    if prompt is not None or "prompt" in body:
+        text = prompt or ""
+        safe["prompt"] = text[:120] + ("…" if len(text) > 120 else "")
     if body.get("first_frame_image"):
         safe["first_frame_image"] = "<data_uri>"
     if body.get("subject_reference"):
         safe["subject_reference"] = "<character_ref>"
     return safe
+
+
+def _image_content_item(data_uri: str, *, role: str) -> dict[str, Any]:
+    """图片 data URI → v2 content[] 条目。"""
+    return {"type": "image_url", "image_url": {"url": data_uri}, "role": role}
+
+
+def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
+    """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
+
+    与参考图的处理同为 fail-loud：prompt 里的「音频N」按 content 数组中音频条目的出现顺序
+    编号，跳过一段会让其后所有编号整体前移，把某个角色的音色安到另一个角色头上——错得无声
+    无息，且照常扣费。
+    """
+    mime = _REFERENCE_AUDIO_MIME_TYPES.get(path.suffix.lower())
+    if mime is None:
+        raise VideoCapabilityError(
+            "video_reference_audio_format_unsupported",
+            model=model,
+            name=path.name,
+            supported=", ".join(sorted(_REFERENCE_AUDIO_MIME_TYPES)),
+        )
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise VideoCapabilityError("video_reference_audio_unreadable", model=model, names=path.name) from exc
+    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
 class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
@@ -111,8 +184,11 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         http_timeout: float = 60.0,
     ) -> None:
         self._api_key = resolve_minimax_api_key(api_key)
-        self._base_url = minimax_video_base_url(base_url)
         self._model = model or DEFAULT_MODEL
+        # v2 是整条链路的分支（base、提交体、轮询响应形状、取件方式全不同），不是单点差异，
+        # 故在构造期定好走哪一代，后续各步按此派发。
+        self._is_v2 = self._model == _H3
+        self._base_url = minimax_video_v2_base_url(base_url) if self._is_v2 else minimax_video_base_url(base_url)
         self._http_timeout = http_timeout
         self._supports_text_to_video = _supports_text_to_video(self._model)
 
@@ -130,9 +206,25 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
 
         S2V-01 仅接受单张人脸参考、不接受首帧图，故 first_frame=False + max_reference_images=1。
         Hailuo 系列首批不建模尾帧/参考图。
+
+        H3 的 content[] 数组按 role 同时承载首帧、尾帧、参考图与参考音频，各维度上限取官方
+        《创建视频生成任务 (V2)》声明值。首帧任务只接受 ratio=adaptive（官方 ratio 枚举含
+        adaptive，图生视频示例即用它），故声明 first_frame_ratio_adaptive_only。
         """
         if model == _S2V:
             return VideoCapabilities(first_frame=False, max_reference_images=1)
+        if model == _H3:
+            return VideoCapabilities(
+                first_frame=True,
+                last_frame=True,
+                max_reference_images=_H3_MAX_REFERENCE_IMAGES,
+                reference_audio_mode=ReferenceAudioMode.DIRECT,
+                # 段数与总时长两个维度独立声明：3 段各 10 秒都在单段合法区间内，合计已超 15 秒。
+                max_reference_audio_count=_H3_MAX_REFERENCE_AUDIO,
+                max_reference_audio_total_seconds=_H3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS,
+                max_prompt_chars=_H3_MAX_PROMPT_CHARS,
+                first_frame_ratio_adaptive_only=True,
+            )
         return VideoCapabilities(first_frame=True)
 
     @property
@@ -161,7 +253,10 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
     # ── request building ────────────────────────────────────────────────
 
     def _build_payload(self, request: VideoGenerationRequest) -> dict:
-        # S2V-01 走单脸 subject_reference 路径：不取首帧、不传 resolution/duration（固定输出）。
+        # H3 走 v2 多模态 content[] 端点；S2V-01 走单脸 subject_reference 路径：
+        # 不取首帧、不传 resolution/duration（固定输出）。
+        if self._is_v2:
+            return self._build_v2_payload(request)
         if self._model == _S2V:
             return self._build_s2v_payload(request)
 
@@ -226,6 +321,91 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
             "subject_reference": [{"type": "character", "image": [data_uri]}],
         }
 
+    def _build_v2_payload(self, request: VideoGenerationRequest) -> dict:
+        """H3：把首帧/尾帧/参考图/参考音频按 role 摊进多模态 content[] 数组。
+
+        prompt 恒为首条 text 条目（官方要求所有场景都带一个非空 text）；素材条目顺序即
+        prompt 中「音频N」等指认编号的依据，故任何一段素材缺失都 fail-loud，不静默跳过。
+        """
+        resolution = (request.resolution or "768p").lower()
+        duration = request.duration_seconds
+        if resolution not in _H3_RESOLUTIONS or duration not in _H3_DURATIONS:
+            raise VideoCapabilityError(
+                "video_resolution_duration_unsupported",
+                model=self._model,
+                resolution=resolution.upper(),
+                duration=duration,
+                supported=", ".join(f"{d}s" for d in sorted(_H3_DURATIONS)),
+            )
+
+        start_image = self._existing_path(request.start_image)
+        end_image = self._existing_path(request.end_image)
+        references = [Path(r) for r in (request.reference_images or []) if r]
+        # 官方口径：图生视频与多模态参考生视频互斥。混合请求会被上游 400 拒绝，
+        # 在此提前拦下，避免把一次注定失败的请求发出去。
+        if references and (start_image is not None or end_image is not None):
+            raise VideoCapabilityError("video_reference_images_with_frames_unsupported", model=self._model)
+        if end_image is not None and start_image is None:
+            raise VideoCapabilityError("video_end_image_requires_start_image", model=self._model)
+
+        content: list[dict[str, Any]] = [{"type": "text", "text": request.prompt}]
+        if start_image is not None:
+            uri = self._image_data_uri(start_image)
+            if uri is None:
+                raise VideoCapabilityError("video_start_image_unreadable", model=self._model, name=start_image.name)
+            content.append(_image_content_item(uri, role="first_frame"))
+        if end_image is not None:
+            uri = self._image_data_uri(end_image)
+            if uri is None:
+                raise VideoCapabilityError("video_end_image_unreadable", model=self._model, name=end_image.name)
+            content.append(_image_content_item(uri, role="last_frame"))
+        for reference in references:
+            uri = self._image_data_uri(reference)
+            if uri is None:
+                raise VideoCapabilityError("video_reference_images_unreadable", model=self._model, names=reference.name)
+            content.append(_image_content_item(uri, role="reference_image"))
+        for audio_path in request.reference_audio_files or []:
+            content.append(
+                {
+                    "type": "audio_url",
+                    "audio_url": {"url": _reference_audio_to_data_uri(Path(audio_path), model=self._model)},
+                    "role": "reference_audio",
+                }
+            )
+
+        return {
+            "model": self._model,
+            "content": content,
+            "resolution": resolution.upper(),
+            "duration": duration,
+            "ratio": request.aspect_ratio,
+        }
+
+    @staticmethod
+    def _existing_path(value: Path | str | None) -> Path | None:
+        """把首/尾帧入参归一化为 Path；未声明该槽位返回 None。
+
+        与 `plan_frame_slots` 的槽位口径一致：只有 str/Path 才构成槽位声明，其余类型视为未声明。
+        文件存在性不在此判定——声明了却读不到要 fail-loud 报出具体槽位，由各自的 unreadable 码承载。
+        """
+        if isinstance(value, (str, Path)) and str(value):
+            return Path(value)
+        return None
+
+    @staticmethod
+    def _image_data_uri(path: Path) -> str | None:
+        """图片 → data URI；缺失或不可读返回 None，由调用方按所属槽位抛对应的 unreadable 码。
+
+        错误码留在调用方而非集中到本函数：槽位与码一一对应，字面量码才能被
+        `tests/test_task_failure_capability.py` 的漂移守卫静态扫到。
+        """
+        if not path.is_file():
+            return None
+        try:
+            return image_to_data_uri(path)
+        except OSError:
+            return None
+
     # ── HTTP submit / poll / retrieve / download ────────────────────────
 
     @with_retry_async(
@@ -248,11 +428,12 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         return extract_minimax_video_task_id(resp.json())
 
     async def _poll_query(self, client: httpx.AsyncClient, task_id: str) -> dict:
-        resp = await client.get(
-            f"{self._base_url}{_QUERY_ENDPOINT}",
-            params={"task_id": task_id},
-            headers=minimax_headers(self._api_key),
-        )
+        # v2 把 task_id 放路径段，v1 放 query string。
+        url = f"{self._base_url}{_QUERY_ENDPOINT}"
+        params = None if self._is_v2 else {"task_id": task_id}
+        if self._is_v2:
+            url = f"{url}/{task_id}"
+        resp = await client.get(url, params=params, headers=minimax_headers(self._api_key))
         resp.raise_for_status()
         return resp.json()
 
@@ -277,21 +458,28 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         task_id: str,
         request: VideoGenerationRequest,
     ) -> VideoGenerationResult:
+        is_v2 = self._is_v2
         final = await poll_with_retry(
             poll_fn=lambda: self._poll_query(client, task_id),
-            is_done=is_minimax_video_terminal,
-            is_failed=minimax_video_failure_reason,
+            is_done=is_minimax_v2_video_terminal if is_v2 else is_minimax_video_terminal,
+            is_failed=minimax_v2_video_failure_reason if is_v2 else minimax_video_failure_reason,
             poll_interval=MINIMAX_VIDEO_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
             retry_if=should_retry_poll,
             label="MiniMax",
             on_progress=lambda v, elapsed: logger.info(
-                "MiniMax 视频生成中... status=%s elapsed=%ds", v.get("status"), int(elapsed)
+                "MiniMax 视频生成中... status=%s elapsed=%ds",
+                minimax_v2_video_status(v) if is_v2 else v.get("status"),
+                int(elapsed),
             ),
         )
 
-        file_id = extract_minimax_file_id(final)
-        download_url = await self._retrieve_download_url(client, file_id)
+        if is_v2:
+            # v2 查询响应直接带限时下载地址，没有 file_id → files/retrieve 这一步。
+            download_url = extract_minimax_v2_download_url(final)
+        else:
+            file_id = extract_minimax_file_id(final)
+            download_url = await self._retrieve_download_url(client, file_id)
         await self._download_with_retry(download_url, request.output_path)
         logger.info("MiniMax 视频下载完成: %s", request.output_path)
 

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -100,9 +100,7 @@ _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
 # H3 输入上限，出处为官方《创建视频生成任务 (V2)》
 # https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md
 # 输出规格（分辨率档、时长）不在此处声明：registry 的 resolutions / supported_durations 是其
-# 真相源，下方兜底常量（同一出处：768P/2K、4–15 秒任意整数）仅在型号未登记时生效。
-_H3_FALLBACK_RESOLUTIONS: frozenset[str] = frozenset({"768p", "2k"})
-_H3_FALLBACK_DURATIONS: frozenset[int] = frozenset(range(4, 16))
+# 唯一真相源，_v2_output_specs 缺失该条目时 fail loud，不设兜底常量。
 _H3_MAX_REFERENCE_IMAGES = 9
 _H3_MAX_REFERENCE_AUDIO = 3
 _H3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
@@ -407,13 +405,15 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         registry 是这两项的真相源，前端下拉门控读的也是它——两处若各写一份，改档位时必然漂移。
         本方法只在 `_is_v2`（即 `_is_h3_model` 判真）时被调用，故一律按 canonical 名 `_H3`
         查 registry——self._model 可能是中转站发现的大小写/命名空间变体，字面值不一定与
-        registry key 一致，用它直接查会把已注册的 H3 误判成未登记而回落兜底常量，让变体悄悄
-        脱离 registry 声明的时长/分辨率范围（与 `_is_h3_model` 判定和 `video_capabilities_for_model`
-        走同一枚 canonical 名，避免第三处再长出不一致）。回落只在 registry 意外缺失该条目时触发。
+        registry key 一致，用它直接查会把已注册的 H3 误判成未登记（与 `_is_h3_model` 判定和
+        `video_capabilities_for_model` 走同一枚 canonical 名，避免第三处再长出不一致）。
+        查询的是固定的 canonical 名而非可变的型号名，缺失只可能是 registry 条目被误删/改名，
+        不是「型号未登记」的正常场景，故 fail loud 而非回落兜底常量——静默兜底会让这类配置
+        错误在越界请求实际打到供应商前都不可见。
         """
         info = model_info_for(PROVIDER_MINIMAX, _H3)
         if info is None:
-            return _H3_FALLBACK_RESOLUTIONS, _H3_FALLBACK_DURATIONS
+            raise RuntimeError(f"registry 缺少 {PROVIDER_MINIMAX}/{_H3} 条目，无法确定 H3 输出规格")
         return frozenset(r.lower() for r in info.resolutions), frozenset(info.supported_durations)
 
     @staticmethod

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -405,10 +405,13 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         """本模型允许的（分辨率档，时长集合），取自 registry 声明。
 
         registry 是这两项的真相源，前端下拉门控读的也是它——两处若各写一份，改档位时必然漂移。
-        只有型号未登记（中转站自定义命名）才回落兜底常量；已登记但声明为空即视为不放行，
-        与 gemini backend 同口径：空声明是配置事实，不该被兜底悄悄补全。
+        本方法只在 `_is_v2`（即 `_is_h3_model` 判真）时被调用，故一律按 canonical 名 `_H3`
+        查 registry——self._model 可能是中转站发现的大小写/命名空间变体，字面值不一定与
+        registry key 一致，用它直接查会把已注册的 H3 误判成未登记而回落兜底常量，让变体悄悄
+        脱离 registry 声明的时长/分辨率范围（与 `_is_h3_model` 判定和 `video_capabilities_for_model`
+        走同一枚 canonical 名，避免第三处再长出不一致）。回落只在 registry 意外缺失该条目时触发。
         """
-        info = model_info_for(PROVIDER_MINIMAX, self._model)
+        info = model_info_for(PROVIDER_MINIMAX, _H3)
         if info is None:
             return _H3_FALLBACK_RESOLUTIONS, _H3_FALLBACK_DURATIONS
         return frozenset(r.lower() for r in info.resolutions), frozenset(info.supported_durations)

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -121,6 +121,17 @@ def _supports_text_to_video(model: str | None) -> bool:
     return (model or "").strip() not in _NO_TEXT_TO_VIDEO_MODELS
 
 
+def _is_h3_model(model: str | None) -> bool:
+    """H3 判定：大小写不敏感、容忍命名空间前缀（如中转站可能把型号存成 "proxy/minimax-h3"）。
+
+    与 ``lib.custom_provider.endpoints.infer_endpoint`` 发现 H3 原生 token 时用的
+    ``"minimax-h3" in lowered`` 同一判定口径（不能互相 import，两处各存一份字面量，改
+    其一须同改另一处）。发现与派发若用不同谓词，会出现"发现路由到 minimax-video，
+    派发却因大小写/命名空间不匹配落回 v1"的裂缝。
+    """
+    return "minimax-h3" in (model or "").lower()
+
+
 def _safe_body_for_log(body: dict) -> dict:
     """安全日志视图：白名单标量 + prompt 截断；素材字段一律折叠，不展开 base64。
 
@@ -191,7 +202,7 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         self._model = model or DEFAULT_MODEL
         # v2 是整条链路的分支（base、提交体、轮询响应形状、取件方式全不同），不是单点差异，
         # 故在构造期定好走哪一代，后续各步按此派发。
-        self._is_v2 = self._model == _H3
+        self._is_v2 = _is_h3_model(self._model)
         self._base_url = minimax_video_v2_base_url(base_url) if self._is_v2 else minimax_video_base_url(base_url)
         self._http_timeout = http_timeout
         self._supports_text_to_video = _supports_text_to_video(self._model)
@@ -217,7 +228,7 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         """
         if model == _S2V:
             return VideoCapabilities(first_frame=False, max_reference_images=1)
-        if model == _H3:
+        if _is_h3_model(model):
             return VideoCapabilities(
                 first_frame=True,
                 last_frame=True,

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -350,9 +350,9 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         start_image = self._existing_path(request.start_image)
         end_image = self._existing_path(request.end_image)
         references = [Path(r) for r in (request.reference_images or []) if r]
-        # 官方口径：图生视频与多模态参考生视频互斥。混合请求会被上游 400 拒绝，
-        # 在此提前拦下，避免把一次注定失败的请求发出去。
-        if references and (start_image is not None or end_image is not None):
+        # 官方口径：图生视频与多模态参考生视频互斥，参考音频同属参考生视频维度。混合请求会
+        # 被上游 400 拒绝，在此提前拦下，避免把一次注定失败的请求发出去。
+        if (references or request.reference_audio_files) and (start_image is not None or end_image is not None):
             raise VideoCapabilityError("video_reference_images_with_frames_unsupported", model=self._model)
         if end_image is not None and start_image is None:
             raise VideoCapabilityError("video_end_image_requires_start_image", model=self._model)

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import httpx
 
+from lib.config.registry import model_info_for
 from lib.logging_utils import format_kwargs_for_log
 from lib.minimax_shared import (
     MINIMAX_VIDEO_POLL_INTERVAL_SECONDS,
@@ -92,13 +93,15 @@ _POLL_TIMEOUT_PER_SECOND = 60.0
 _NO_TEXT_TO_VIDEO_MODELS: frozenset[str] = frozenset({_HAILUO_FAST, _S2V})
 
 # (分辨率小写 → 允许的时长集合)：1080P 仅 6s，768P 支持 6s/10s（两代 Hailuo 同此矩阵）。
-# 仅 v1 分支适用——H3 两档分辨率共用同一段连续时长，见 _H3_RESOLUTIONS / _H3_DURATIONS。
+# 仅 v1 分支适用——H3 无跨维约束，两档分辨率共用同一段连续时长，直接读 registry 声明。
 _RESOLUTION_DURATIONS: dict[str, set[int]] = {"768p": {6, 10}, "1080p": {6}}
 
-# H3 输出规格与输入上限，出处均为官方《创建视频生成任务 (V2)》
+# H3 输入上限，出处为官方《创建视频生成任务 (V2)》
 # https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md
-_H3_RESOLUTIONS: frozenset[str] = frozenset({"768p", "2k"})
-_H3_DURATIONS: frozenset[int] = frozenset(range(4, 16))
+# 输出规格（分辨率档、时长）不在此处声明：registry 的 resolutions / supported_durations 是其
+# 真相源，下方兜底常量（同一出处：768P/2K、4–15 秒任意整数）仅在型号未登记时生效。
+_H3_FALLBACK_RESOLUTIONS: frozenset[str] = frozenset({"768p", "2k"})
+_H3_FALLBACK_DURATIONS: frozenset[int] = frozenset(range(4, 16))
 _H3_MAX_REFERENCE_IMAGES = 9
 _H3_MAX_REFERENCE_AUDIO = 3
 _H3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
@@ -173,7 +176,7 @@ def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
 
 
 class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
-    """MiniMax 海螺视频后端（异步两步取 URL，轮询）。"""
+    """MiniMax 视频后端（异步轮询）；走 v1 还是 v2 在构造期按 model 定下，各步据此派发。"""
 
     def __init__(
         self,
@@ -329,13 +332,14 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
         """
         resolution = (request.resolution or "768p").lower()
         duration = request.duration_seconds
-        if resolution not in _H3_RESOLUTIONS or duration not in _H3_DURATIONS:
+        resolutions, durations = self._v2_output_specs()
+        if resolution not in resolutions or duration not in durations:
             raise VideoCapabilityError(
                 "video_resolution_duration_unsupported",
                 model=self._model,
                 resolution=resolution.upper(),
                 duration=duration,
-                supported=", ".join(f"{d}s" for d in sorted(_H3_DURATIONS)),
+                supported=", ".join(f"{d}s" for d in sorted(durations)),
             )
 
         start_image = self._existing_path(request.start_image)
@@ -380,6 +384,18 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
             "duration": duration,
             "ratio": request.aspect_ratio,
         }
+
+    def _v2_output_specs(self) -> tuple[frozenset[str], frozenset[int]]:
+        """本模型允许的（分辨率档，时长集合），取自 registry 声明。
+
+        registry 是这两项的真相源，前端下拉门控读的也是它——两处若各写一份，改档位时必然漂移。
+        只有型号未登记（中转站自定义命名）才回落兜底常量；已登记但声明为空即视为不放行，
+        与 gemini backend 同口径：空声明是配置事实，不该被兜底悄悄补全。
+        """
+        info = model_info_for(PROVIDER_MINIMAX, self._model)
+        if info is None:
+            return _H3_FALLBACK_RESOLUTIONS, _H3_FALLBACK_DURATIONS
+        return frozenset(r.lower() for r in info.resolutions), frozenset(info.supported_durations)
 
     @staticmethod
     def _existing_path(value: Path | str | None) -> Path | None:

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -433,6 +433,7 @@ _VIDEO_AUDIO_STANCES: dict[tuple[str, str], str] = {
     ("kling", "kling-v3"): "controllable",
     ("kling", "kling-v3-omni"): "controllable",
     ("kling", "kling-video-o1"): "silent",
+    ("minimax", "MiniMax-H3"): "always_on",
     ("minimax", "MiniMax-Hailuo-2.3"): "silent",
     ("minimax", "MiniMax-Hailuo-2.3-Fast"): "silent",
     ("minimax", "S2V-01"): "silent",

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -78,6 +78,16 @@ class TestVideoCost:
         assert video(8, "1080p", False, model=preview) == pytest.approx(1.6)
         assert video(8, "1080p", True, model=fast_preview) == pytest.approx(0.96)
 
+    def test_minimax_h3_resolution_omitted_settles_at_768p(self):
+        # H3 项目留 Auto（resolution=None）时，_build_v2_payload 实际下发 768P；结算须跟随
+        # 同一默认（0.50 元/s），而非 resolution_only 的通用 720P 回落——H3 未登记 720P 档，
+        # 落空会把 resolution=None 的调用错误结算为 ¥0（见 default_resolution 声明）。
+        amount, currency = _cost("minimax", "video", duration_seconds=8, resolution=None, model="MiniMax-H3")
+        assert currency == "CNY"
+        assert amount == pytest.approx(4.0)
+        amount_2k, _ = _cost("minimax", "video", duration_seconds=8, resolution="2k", model="MiniMax-H3")
+        assert amount_2k == pytest.approx(6.4)
+
     def test_singleton_instance(self):
         assert isinstance(cost_calculator, CostCalculator)
 

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -302,6 +302,8 @@ class TestInferEndpoint:
             ("minimax-s2v-01", "openai", "minimax-video"),
             ("MiniMax-H3", "openai", "minimax-video"),  # H3 同样不在通用视频 pattern，须显式路由
             ("minimax-h3", "openai", "minimax-video"),
+            ("h3", "openai", "openai-chat"),  # 裸 "h3" 不应匹配——防止退化成过于宽松的子串
+            ("other-vendor-h3", "openai", "openai-chat"),  # 其它厂商恰好含 h3 子串同样不应误路由
             ("image-01", "openai", "minimax-image"),  # image-01 含 "image" 否则会被推到通用图像家族
             ("minimax/image-01", "openai", "minimax-image"),
             ("S2V-01", "google", "minimax-video"),  # minimax 路由不分 discovery_format

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -300,6 +300,8 @@ class TestInferEndpoint:
             ),  # 海螺 token → minimax-video（前 minimax endpoint 时代默认 openai-video）
             ("S2V-01", "openai", "minimax-video"),  # s2v 不在通用视频 pattern，须显式路由
             ("minimax-s2v-01", "openai", "minimax-video"),
+            ("MiniMax-H3", "openai", "minimax-video"),  # H3 同样不在通用视频 pattern，须显式路由
+            ("minimax-h3", "openai", "minimax-video"),
             ("image-01", "openai", "minimax-image"),  # image-01 含 "image" 否则会被推到通用图像家族
             ("minimax/image-01", "openai", "minimax-image"),
             ("S2V-01", "google", "minimax-video"),  # minimax 路由不分 discovery_format

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -154,6 +154,20 @@ class TestLookupPricing:
         assert cur == "CNY"
         assert amount == pytest.approx(expected)
 
+    @pytest.mark.parametrize(
+        ("resolution", "duration", "expected"),
+        [("768p", 4, 2.0), ("768p", 15, 7.5), ("2k", 5, 4.0), ("2k", 15, 12.0)],
+    )
+    def test_h3_per_second_by_resolution(self, resolution, duration, expected):
+        # H3 按秒 × 分辨率计价（768P 0.50、2K 0.80 元/秒）；键写错会静默回落到 0，故两档都钉死。
+        p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-H3", "video")
+        amount, cur = calculate_pricing(
+            p,
+            PricingParams(call_type="video", model="MiniMax-H3", resolution=resolution, duration_seconds=duration),
+        )
+        assert cur == "CNY"
+        assert amount == pytest.approx(expected)
+
     def test_video_unmet_bucket_falls_back_nearest_cny(self):
         # 1080p 仅 6s 档；请求 1080p 10s 未命中 → 同分辨率最近档 (1080p,6)=3.5
         p = lookup_pricing(PROVIDER_MINIMAX, "MiniMax-Hailuo-2.3", "video")
@@ -178,6 +192,17 @@ class TestVideoRegistry:
         from lib.config.registry import PROVIDER_REGISTRY
 
         models = PROVIDER_REGISTRY[PROVIDER_MINIMAX].models
+        h3 = models["MiniMax-H3"]
+        assert h3.media_type == "video"
+        # H3 是 minimax 视频默认，海螺 2.3 仍可选回。
+        assert h3.default is True
+        assert models["MiniMax-Hailuo-2.3"].default is False
+        assert h3.supported_durations == list(range(4, 16))
+        assert h3.resolutions == ["768p", "2k"]
+        # 两档分辨率共用同一段时长，无需 duration_resolution_constraints 门控。
+        assert h3.duration_resolution_constraints == {}
+        assert h3.audio_always_on is True
+
         hailuo = models["MiniMax-Hailuo-2.3"]
         assert hailuo.media_type == "video"
         assert hailuo.supported_durations == [6, 10]

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -352,15 +352,18 @@ class TestH3V2Payload:
             )
         assert exc.value.code == "video_reference_images_with_frames_unsupported"
 
-    def test_frames_and_reference_audio_are_mutually_exclusive(self, tmp_path):
-        # 参考音频同属参考生视频维度，与首/尾帧混合同样应在本地被拒，而非发出注定被上游
-        # 拒绝的请求（官方口径：图生视频与多模态参考生视频互斥）。
+    @pytest.mark.parametrize("frame_field", ["start_image", "end_image"])
+    def test_frames_and_reference_audio_are_mutually_exclusive(self, tmp_path, frame_field):
+        # 参考音频同属参考生视频维度，与首/尾帧（任一）混合同样应在本地被拒，而非发出注定
+        # 被上游拒绝的请求（官方口径：图生视频与多模态参考生视频互斥）。end_image 单独给出时
+        # 互斥校验先于「尾帧须配首帧」校验命中，两个帧字段都要覆盖，回归才捕得到。
+        frame = _png(tmp_path / f"{frame_field}.png")
         with pytest.raises(VideoCapabilityError) as exc:
             _h3()._build_payload(
                 _request(
                     tmp_path,
-                    start_image=_png(tmp_path / "f.png"),
                     reference_audio_files=[_wav(tmp_path / "a.wav")],
+                    **{frame_field: frame},
                 )
             )
         assert exc.value.code == "video_reference_images_with_frames_unsupported"

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -330,14 +331,19 @@ class TestH3V2Payload:
         assert payload["ratio"] == "adaptive"
 
     def test_r2v_reference_images_and_audio_keep_order(self, tmp_path):
+        # role/type 断言之外逐项比对 data URI：素材顺序即 prompt 里「音频N」等指认编号的依据，
+        # 集合/全量断言不会捕获反转，需按内容钉死输入与条目的对应关系。
         refs = [_png(tmp_path / f"ref{i}.png") for i in range(3)]
         audios = [_wav(tmp_path / f"a{i}.wav") for i in range(2)]
         payload = _h3()._build_payload(_request(tmp_path, reference_images=refs, reference_audio_files=audios))
         items = payload["content"]
         assert [item["type"] for item in items] == ["text"] + ["image_url"] * 3 + ["audio_url"] * 2
-        assert {item.get("role") for item in items[1:4]} == {"reference_image"}
-        assert all(item["role"] == "reference_audio" for item in items[4:])
-        assert items[4]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+        assert [item["role"] for item in items[1:4]] == ["reference_image"] * 3
+        assert [item["role"] for item in items[4:]] == ["reference_audio"] * 2
+        expected_images = [f"data:image/png;base64,{base64.b64encode(p.read_bytes()).decode()}" for p in refs]
+        assert [item["image_url"]["url"] for item in items[1:4]] == expected_images
+        expected_audios = [f"data:audio/wav;base64,{base64.b64encode(p.read_bytes()).decode()}" for p in audios]
+        assert [item["audio_url"]["url"] for item in items[4:]] == expected_audios
 
     def test_frames_and_references_are_mutually_exclusive(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -115,6 +115,18 @@ class TestConstructionAndCapabilities:
         assert "content" in payload  # v2 payload 形态，v1 是扁平 dict 无此键
         assert b.video_capabilities.max_reference_images == 9
 
+    @pytest.mark.parametrize("model", ["minimax-h3", "MINIMAX-H3", "proxy/minimax-h3"])
+    def test_h3_output_specs_use_canonical_registry_lookup(self, model):
+        # self._model 可能是大小写/命名空间变体，字面值查 registry 会 miss；_v2_output_specs
+        # 须归一化到 canonical "MiniMax-H3" 再查，否则变体会悄悄回落到硬编码兜底常量，脱离
+        # registry 声明的时长/分辨率范围（即便当前兜底常量与 registry 声明恰好同值，也不能
+        # 依赖这种巧合——registry 改动时兜底不会跟着变）。
+        with patch("lib.video_backends.minimax.model_info_for") as mock_lookup:
+            mock_lookup.return_value = None
+            b = _backend(model)
+            b._v2_output_specs()
+        assert mock_lookup.call_args.args[1] == "MiniMax-H3"
+
 
 class TestPayloadAndCapabilityGating:
     def test_fast_t2v_rejected(self, tmp_path):

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -352,6 +352,19 @@ class TestH3V2Payload:
             )
         assert exc.value.code == "video_reference_images_with_frames_unsupported"
 
+    def test_frames_and_reference_audio_are_mutually_exclusive(self, tmp_path):
+        # 参考音频同属参考生视频维度，与首/尾帧混合同样应在本地被拒，而非发出注定被上游
+        # 拒绝的请求（官方口径：图生视频与多模态参考生视频互斥）。
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(
+                _request(
+                    tmp_path,
+                    start_image=_png(tmp_path / "f.png"),
+                    reference_audio_files=[_wav(tmp_path / "a.wav")],
+                )
+            )
+        assert exc.value.code == "video_reference_images_with_frames_unsupported"
+
     def test_last_frame_without_first_frame_rejected(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             _h3()._build_payload(_request(tmp_path, end_image=_png(tmp_path / "l.png")))

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from lib.config.registry import model_info_for
 from lib.providers import PROVIDER_MINIMAX
 from lib.video_backends.base import ReferenceAudioMode, VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.minimax import MiniMaxVideoBackend, _safe_body_for_log
@@ -118,14 +119,32 @@ class TestConstructionAndCapabilities:
     @pytest.mark.parametrize("model", ["minimax-h3", "MINIMAX-H3", "proxy/minimax-h3"])
     def test_h3_output_specs_use_canonical_registry_lookup(self, model):
         # self._model 可能是大小写/命名空间变体，字面值查 registry 会 miss；_v2_output_specs
-        # 须归一化到 canonical "MiniMax-H3" 再查，否则变体会悄悄回落到硬编码兜底常量，脱离
-        # registry 声明的时长/分辨率范围（即便当前兜底常量与 registry 声明恰好同值，也不能
-        # 依赖这种巧合——registry 改动时兜底不会跟着变）。
+        # 须归一化到 canonical "MiniMax-H3" 再查，返回值须与 registry 实际声明一致（正向断言，
+        # 不止是"没崩"）。
+        b = _backend(model)
+        resolutions, durations = b._v2_output_specs()
+        registry_info = model_info_for(PROVIDER_MINIMAX, "MiniMax-H3")
+        assert registry_info is not None
+        assert resolutions == frozenset(r.lower() for r in registry_info.resolutions)
+        assert durations == frozenset(registry_info.supported_durations)
+
+    @pytest.mark.parametrize("model", ["minimax-h3", "MINIMAX-H3", "proxy/minimax-h3"])
+    def test_h3_output_specs_query_uses_canonical_name(self, model):
+        # 直接断言查询参数已归一化为 canonical 名，不依赖兜底值与 registry 声明恰好相等这种
+        # 巧合。
         with patch("lib.video_backends.minimax.model_info_for") as mock_lookup:
-            mock_lookup.return_value = None
+            mock_lookup.return_value = MagicMock(resolutions=["768p"], supported_durations=[6])
             b = _backend(model)
             b._v2_output_specs()
         assert mock_lookup.call_args.args[1] == "MiniMax-H3"
+
+    def test_h3_output_specs_missing_registry_entry_fails_loud(self):
+        # 本方法只查固定的 canonical 名，缺失只可能是 registry 条目被误删/改名——这类配置
+        # 错误必须 fail loud，不能悄悄回落到硬编码常量掩盖过去。
+        with patch("lib.video_backends.minimax.model_info_for", return_value=None):
+            b = _backend("MiniMax-H3")
+            with pytest.raises(RuntimeError, match="registry"):
+                b._v2_output_specs()
 
 
 class TestPayloadAndCapabilityGating:

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -357,6 +357,15 @@ class TestH3V2Payload:
             _h3()._build_payload(_request(tmp_path, resolution=resolution, duration_seconds=duration))
         assert exc.value.code == "video_resolution_duration_unsupported"
 
+    def test_output_specs_follow_registry_declaration(self, tmp_path):
+        # 分辨率档与时长的真相源在 registry：改声明即改放行范围，backend 不另存一份。
+        stub = MagicMock(resolutions=["4k"], supported_durations=[7])
+        with patch("lib.video_backends.minimax.model_info_for", return_value=stub):
+            assert _h3()._build_payload(_request(tmp_path, resolution="4k", duration_seconds=7))["duration"] == 7
+            with pytest.raises(VideoCapabilityError) as exc:
+                _h3()._build_payload(_request(tmp_path, resolution="768p", duration_seconds=6))
+        assert exc.value.code == "video_resolution_duration_unsupported"
+
     def test_unreadable_first_frame_raises(self, tmp_path):
         with pytest.raises(VideoCapabilityError) as exc:
             _h3()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -105,6 +105,16 @@ class TestConstructionAndCapabilities:
         with pytest.raises(ValueError):
             MiniMaxVideoBackend(api_key=None)
 
+    @pytest.mark.parametrize("model", ["minimax-h3", "MINIMAX-H3", "proxy/minimax-h3"])
+    def test_h3_dispatch_case_and_namespace_insensitive(self, tmp_path, model):
+        # 中转站发现层（infer_endpoint）按大小写不敏感的 "minimax-h3" 子串把这些变体路由到
+        # minimax-video；派发/能力声明须用同一判定，否则会出现"发现路由对了，派发却落回
+        # v1"的裂缝——本用例锁定两处用的是同一谓词。
+        b = _backend(model)
+        payload = b._build_payload(_request(tmp_path))
+        assert "content" in payload  # v2 payload 形态，v1 是扁平 dict 无此键
+        assert b.video_capabilities.max_reference_images == 9
+
 
 class TestPayloadAndCapabilityGating:
     def test_fast_t2v_rejected(self, tmp_path):

--- a/tests/test_minimax_video_backend.py
+++ b/tests/test_minimax_video_backend.py
@@ -8,8 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lib.providers import PROVIDER_MINIMAX
-from lib.video_backends.base import VideoCapabilityError, VideoGenerationRequest
-from lib.video_backends.minimax import MiniMaxVideoBackend
+from lib.video_backends.base import ReferenceAudioMode, VideoCapabilityError, VideoGenerationRequest
+from lib.video_backends.minimax import MiniMaxVideoBackend, _safe_body_for_log
+from lib.video_frame_slots import resolve_first_frame_aspect_ratio
 
 pytestmark = pytest.mark.unit
 
@@ -52,8 +53,31 @@ def _client(*, post=None, get=None) -> AsyncMock:
     return c
 
 
+def _v2_query(status: str, *, url: str = "", error: str = "") -> dict:
+    task: dict = {"id": "h3-task", "model": "MiniMax-H3", "status": status}
+    if url:
+        task["content"] = {"url": url}
+    if error:
+        task["error"] = error
+    return {"task": task}
+
+
 def _backend(model: str = "MiniMax-Hailuo-2.3") -> MiniMaxVideoBackend:
     return MiniMaxVideoBackend(api_key="sk-test", model=model)
+
+
+def _h3() -> MiniMaxVideoBackend:
+    return _backend("MiniMax-H3")
+
+
+def _png(path: Path) -> Path:
+    path.write_bytes(b"\x89PNG\r\n")
+    return path
+
+
+def _wav(path: Path) -> Path:
+    path.write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+    return path
 
 
 def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
@@ -71,7 +95,7 @@ class TestConstructionAndCapabilities:
     def test_name_and_default_model(self):
         b = MiniMaxVideoBackend(api_key="k")
         assert b.name == PROVIDER_MINIMAX
-        assert b.model == "MiniMax-Hailuo-2.3"
+        assert b.model == "MiniMax-H3"
 
     def test_video_capabilities_first_frame(self):
         assert _backend().video_capabilities.first_frame is True
@@ -251,6 +275,179 @@ class TestGenerateHappyPath:
         persist.assert_awaited_once()
         assert persist.await_args is not None
         assert persist.await_args.args[1] == "task-x"
+
+
+class TestH3V2Capabilities:
+    """H3 走 v2 多模态端点：能力声明按官方《创建视频生成任务 (V2)》逐维度锁定。"""
+
+    def test_declared_capabilities(self):
+        caps = MiniMaxVideoBackend.video_capabilities_for_model("MiniMax-H3")
+        assert caps.first_frame is True
+        assert caps.last_frame is True
+        assert caps.max_reference_images == 9
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        assert caps.max_reference_audio_count == 3
+        assert caps.max_reference_audio_total_seconds == 15.0
+        assert caps.max_prompt_chars == 7000
+        assert caps.first_frame_ratio_adaptive_only is True
+
+    def test_first_frame_ratio_resolves_to_adaptive(self):
+        """不只断言声明位为真：走共享施加逻辑核实首帧任务实际拿到 adaptive。"""
+        caps = MiniMaxVideoBackend.video_capabilities_for_model("MiniMax-H3")
+        assert resolve_first_frame_aspect_ratio(caps=caps, aspect_ratio="16:9", has_first_frame=True) == "adaptive"
+        assert resolve_first_frame_aspect_ratio(caps=caps, aspect_ratio="16:9", has_first_frame=False) == "16:9"
+
+    def test_hailuo_capabilities_unchanged(self):
+        caps = MiniMaxVideoBackend.video_capabilities_for_model("MiniMax-Hailuo-2.3")
+        assert caps.first_frame is True
+        assert caps.last_frame is False
+        assert caps.max_reference_images == 0
+        assert caps.first_frame_ratio_adaptive_only is False
+
+    def test_base_url_uses_v2(self):
+        assert _h3()._base_url.endswith("/v2")
+        assert _backend()._base_url.endswith("/v1")
+
+
+class TestH3V2Payload:
+    def test_t2v_single_text_item(self, tmp_path):
+        payload = _h3()._build_payload(_request(tmp_path, resolution="2k", duration_seconds=15, aspect_ratio="16:9"))
+        assert payload["model"] == "MiniMax-H3"
+        assert payload["resolution"] == "2K"
+        assert payload["duration"] == 15
+        assert payload["ratio"] == "16:9"
+        assert payload["content"] == [{"type": "text", "text": "a cat"}]
+
+    def test_i2v_first_and_last_frame_roles(self, tmp_path):
+        first = _png(tmp_path / "first.png")
+        last = _png(tmp_path / "last.png")
+        payload = _h3()._build_payload(
+            _request(tmp_path, start_image=first, end_image=last, aspect_ratio="adaptive", duration_seconds=4)
+        )
+        roles = [item.get("role") for item in payload["content"]]
+        assert roles == [None, "first_frame", "last_frame"]
+        assert payload["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert payload["ratio"] == "adaptive"
+
+    def test_r2v_reference_images_and_audio_keep_order(self, tmp_path):
+        refs = [_png(tmp_path / f"ref{i}.png") for i in range(3)]
+        audios = [_wav(tmp_path / f"a{i}.wav") for i in range(2)]
+        payload = _h3()._build_payload(_request(tmp_path, reference_images=refs, reference_audio_files=audios))
+        items = payload["content"]
+        assert [item["type"] for item in items] == ["text"] + ["image_url"] * 3 + ["audio_url"] * 2
+        assert {item.get("role") for item in items[1:4]} == {"reference_image"}
+        assert all(item["role"] == "reference_audio" for item in items[4:])
+        assert items[4]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+
+    def test_frames_and_references_are_mutually_exclusive(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(
+                _request(tmp_path, start_image=_png(tmp_path / "f.png"), reference_images=[_png(tmp_path / "r.png")])
+            )
+        assert exc.value.code == "video_reference_images_with_frames_unsupported"
+
+    def test_last_frame_without_first_frame_rejected(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(_request(tmp_path, end_image=_png(tmp_path / "l.png")))
+        assert exc.value.code == "video_end_image_requires_start_image"
+
+    @pytest.mark.parametrize(("resolution", "duration"), [("1080p", 6), ("768p", 3), ("2k", 16)])
+    def test_out_of_range_specs_rejected(self, tmp_path, resolution, duration):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(_request(tmp_path, resolution=resolution, duration_seconds=duration))
+        assert exc.value.code == "video_resolution_duration_unsupported"
+
+    def test_unreadable_first_frame_raises(self, tmp_path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(_request(tmp_path, start_image=tmp_path / "nope.png"))
+        assert exc.value.code == "video_start_image_unreadable"
+
+    def test_unsupported_audio_format_raises(self, tmp_path):
+        bad = tmp_path / "a.ogg"
+        bad.write_bytes(b"OggS")
+        with pytest.raises(VideoCapabilityError) as exc:
+            _h3()._build_payload(_request(tmp_path, reference_audio_files=[bad]))
+        assert exc.value.code == "video_reference_audio_format_unsupported"
+
+    def test_safe_log_view_folds_content(self, tmp_path):
+        payload = _h3()._build_payload(_request(tmp_path, start_image=_png(tmp_path / "f.png")))
+        view = _safe_body_for_log(payload)
+        assert view["content"] == "<1 image_url, 1 text>"
+        assert view["prompt"] == "a cat"
+        assert "base64" not in str(view)
+
+
+class TestH3V2Generate:
+    async def test_single_step_url_extraction(self, tmp_path):
+        captured: dict = {}
+
+        async def _post(url, json, headers):
+            captured["url"] = url
+            captured["json"] = json
+            return _resp(_submit("h3-task"))
+
+        async def _get(url, params=None, headers=None):
+            captured["query_url"] = url
+            captured["query_params"] = params
+            return _resp(_v2_query("succeeded", url="https://x/h3.mp4"))
+
+        client = _client(post=AsyncMock(side_effect=_post), get=AsyncMock(side_effect=_get))
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
+        ):
+            result = await _h3().generate(_request(tmp_path, duration_seconds=5))
+
+        assert captured["url"].endswith("/v2/video_generation")
+        # v2 把 task_id 放路径段，且成功响应直接带下载地址，无 files/retrieve 这一步。
+        assert captured["query_url"].endswith("/v2/query/video_generation/h3-task")
+        assert captured["query_params"] is None
+        assert result.video_uri == "https://x/h3.mp4"
+        assert result.task_id == "h3-task"
+        dl.assert_awaited_once()
+
+    async def test_running_status_keeps_polling(self, tmp_path):
+        get = AsyncMock(side_effect=[_resp(_v2_query("running")), _resp(_v2_query("succeeded", url="https://x/o.mp4"))])
+        client = _client(post=AsyncMock(return_value=_resp(_submit())), get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        ):
+            result = await _h3().generate(_request(tmp_path))
+        assert get.await_count == 2
+        assert result.video_uri == "https://x/o.mp4"
+
+    @pytest.mark.parametrize("status", ["failed", "cancelled"])
+    async def test_terminal_failure_statuses_raise(self, tmp_path, status):
+        client = _client(
+            post=AsyncMock(return_value=_resp(_submit())),
+            get=AsyncMock(return_value=_resp(_v2_query(status, error="quota exhausted"))),
+        )
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="quota exhausted"):
+                await _h3().generate(_request(tmp_path))
+
+    async def test_resume_polls_v2_endpoint(self, tmp_path):
+        post = AsyncMock()  # must NOT be called
+        get = AsyncMock(return_value=_resp(_v2_query("succeeded", url="https://x/r2.mp4")))
+        client = _client(post=post, get=get)
+        with (
+            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        ):
+            result = await _h3().resume_video("h3-resume", _request(tmp_path))
+
+        post.assert_not_called()
+        assert get.await_args is not None
+        assert get.await_args.args[0].endswith("/v2/query/video_generation/h3-resume")
+        assert result.video_uri == "https://x/r2.mp4"
 
 
 class TestResume:

--- a/tests/test_pricing_strategies.py
+++ b/tests/test_pricing_strategies.py
@@ -269,6 +269,19 @@ class TestPerSecondMatrix:
         )
         assert amount == pytest.approx(2.80)
 
+    def test_resolution_only_custom_default_resolution_used_for_fallback(self):
+        # 该模型未显式指定分辨率时实际下发的档位若不是通用 720p（如 MiniMax H3 是 768p），
+        # 回落须跟随 default_resolution，否则会落进不存在的 720p 档而结算为 0。
+        pricing = PerSecondMatrix(
+            rates={"h3": {("768p", None): 0.50, ("2k", None): 0.80}},
+            default_model="h3",
+            dimensions="resolution_only",
+            currency="CNY",
+            default_resolution="768p",
+        )
+        amount, _ = calculate_pricing(pricing, PricingParams(call_type="video", model="h3", duration_seconds=8))
+        assert amount == pytest.approx(4.0)
+
     def test_flat_ignores_resolution(self):
         amount, _ = calculate_pricing(
             self.flat,

--- a/tests/test_video_backend_capabilities.py
+++ b/tests/test_video_backend_capabilities.py
@@ -129,6 +129,19 @@ class TestVideoCapabilitiesForModel:
         assert ViduVideoBackend.video_capabilities_for_model("viduq3-turbo").max_reference_images == 7
 
     @pytest.mark.unit
+    def test_minimax_h3_declares_multimodal_limits(self):
+        from lib.video_backends.base import ReferenceAudioMode
+        from lib.video_backends.minimax import MiniMaxVideoBackend
+
+        caps = MiniMaxVideoBackend.video_capabilities_for_model("MiniMax-H3")
+        assert caps.max_reference_images == 9
+        assert caps.last_frame is True
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        assert caps.max_reference_audio_count == 3
+        assert caps.max_prompt_chars == 7000
+        assert caps.first_frame_ratio_adaptive_only is True
+
+    @pytest.mark.unit
     def test_v2_returns_four(self):
         from lib.video_backends.v2_video_generations import V2VideoGenerationsBackend
 


### PR DESCRIPTION
Closes #1759

MiniMax 视频新增 `MiniMax-H3` 并设为该供应商的视频默认模型，Hailuo 2.3 仍可选回。H3 走 MiniMax 新一代 video_generation 端点，请求体是多模态 `content[]` 数组，条目按 role 区分首帧 / 尾帧 / 参考图 / 参考音频，一次请求同时覆盖分镜（i2v）与参考（r2v）两条路线；既有 Hailuo / S2V-01 型号继续走原端点，行为不变。

- registry 登记 768P / 2K 两档、4–15 秒任意整数时长，按秒计价（768P 0.50 元/s，2K 0.80 元/s）。参考图第 6 张起的每张 0.20 元附加费按输入张数计，逐秒矩阵无该维度，未计入估价并在 registry 行内注明
- H3 恒有声：无音频开关 token，按 model 级恒有声声明，音频开关对其不生效
- 能力声明：首帧 + 尾帧、参考图上限 9、参考音频 3 段且合计 15 秒、prompt 上限 7000 字符
- 带首帧的生成请求比例恒为 adaptive，走既有的统一施加路径；参考路线保留用户所选比例
- 能力数字与定价的官方出处写在行内注释，未建文档镜像；前端与 i18n 零改动

## 验证

- `uv run python -m pytest`：8280 passed, 1 skipped
- `uv run basedpyright`：0 errors
- `uv run ruff check . && uv run ruff format .`、`uv run lint-imports`：均通过
- 请求构造、v2 轮询响应形状、能力白名单、registry 守卫均有测试锁定；前端未改动，未跑前端门

## 本地审查修复

- 分辨率档与时长原在 backend 另存一份常量，与 registry 的 `resolutions` / `supported_durations` 重复。改为读 registry 声明（未登记型号才回落兜底常量），与 gemini backend 同口径，并补一条测试锁定「改 registry 即改放行范围」
- 修正与实现不符的类 docstring

## 已知限制

未做真实 API 联调：端点路径、`content[]` 角色名、查询响应字段均按官方文档写并由 mock 锁定形状。`ratio` 取值未做落枚举校验——该字段只可能由共享的首帧比例解析给出。

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 MiniMax H3 视频生成模型并设为默认。
  * 支持文生视频、首尾帧、参考图及参考音频生成。
  * 支持 768p/2K、4–15 秒视频和始终启用音轨。
  * 新增任务状态查询、失败处理及结果下载。

* **改进**
  * 未指定分辨率时默认按 768p 计费。
  * 增强输入校验、素材兼容性检查及安全日志保护。
  * 明确提示参考素材不能与首尾帧同时使用，并保留原有模型支持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->