### PR TITLE
feat(助手): 分支出的会话可再次改写，并记录它从哪条消息分叉而来

### DIFF
--- a/alembic/versions/9c41ad2f7be5_add_agent_session_fork_lineage.py
+++ b/alembic/versions/9c41ad2f7be5_add_agent_session_fork_lineage.py
@@ -1,0 +1,30 @@
+"""add agent session fork lineage
+
+Revision ID: 9c41ad2f7be5
+Revises: 538db5c3ec76
+Create Date: 2026-08-11 09:12:04.118273
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "9c41ad2f7be5"
+down_revision: str | Sequence[str] | None = "538db5c3ec76"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agent_sessions", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("fork_parent_session_id", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("fork_anchor_uuid", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agent_sessions", schema=None) as batch_op:
+        batch_op.drop_column("fork_anchor_uuid")
+        batch_op.drop_column("fork_parent_session_id")

--- a/docs/adr/0058-session-branch-prefix-fork.md
+++ b/docs/adr/0058-session-branch-prefix-fork.md
@@ -4,7 +4,7 @@ status: accepted
 
 # 消息改写由应用层前缀分叉实现，不依赖 SDK 原生 fork
 
-消息改写要求「回到某条历史用户消息发出前，用改写后的内容重新发出」，即从会话中间点分叉并丢弃其后内容。Claude Agent SDK 不提供这个能力：`fork_session` 只能从会话末尾复制**整史**分叉，`rewind_files` 只回退文件、明确不回退对话（官方文档原话 "It does not rewind the conversation itself"）；「从指定消息处 resume/fork」是上游已知但未实现的 feature request。Claude Code CLI 的 `/rewind` 能回退对话，但那是 CLI 在应用层截断重放自己 transcript 的内部功能，未经 SDK 下放。
+消息改写要求「回到某条历史用户消息发出前，用改写后的内容重新发出」，即从会话中间点分叉并丢弃其后内容。Claude Agent SDK 的 `fork_session` 接近但不够用：它接受 `up_to_message_id` 在指定消息处截断，但 `_build_fork_lines` 会滤掉全部 `isSidechain` 条目、并给每条消息重新分配 uuid——subagent 子时间线整段丢失，同一条历史消息在原会话与分支里也不再同名。`rewind_files` 只回退文件、明确不回退对话（官方文档原话 "It does not rewind the conversation itself"）。Claude Code CLI 的 `/rewind` 能回退对话，但那是 CLI 在应用层截断重放自己 transcript 的内部功能，未经 SDK 下放。
 
 决定在 ArcReel 应用层自实现**前缀分叉**：把改写点之前的 transcript 前缀（含 subagent 子路径）从 DB 镜像（`agent_session_entries`）复制到新 session_id 下，以 `resume=新id` 启动新 SessionActor，改写后的消息作为新会话首个输入。这与 CLI 内部实现 `/rewind` 的思路同构——在自己持有的 transcript 存储上操作，区别只是 CLI 截 jsonl、我们复制 DB 行。
 
@@ -12,16 +12,29 @@ status: accepted
 
 - **分叉点固定在用户消息边界**。前一轮次必然完整收尾，tool_use/tool_result 配对与 sidechain 完整性由此保证；会话存在未决问答卡片时禁止改写，恰好避开前一轮次存在悬空 tool_use 的时刻。
 - **封装为单一服务入口**。「以拼装出的前缀供 SDK resume」是非官方用法，风险与知识都收敛在这一处，调用方不感知前缀是怎么拼出来的。
-- **前置依赖**：SDK 侧用户消息 uuid 目前在回显去重时被丢弃，需持久化 ArcReel 用户消息 id ↔ SDK entry 的映射，改写锚点才能定位到 transcript 中的截断位置。
+- **条目 uuid 随前缀原样复制**，不重映射。唯一索引与物化目录都以 session_id 分域，跨会话同 uuid 不照面；同一条历史消息在所有分支里保持同名，跨分支对齐与分支的分支因此都不需要额外的身份簿记。
+
+## 锚点身份
+
+改写锚点由前端给出的是事件日志条目的 uuid，而截断要落在 transcript 条目上，两者分属两个 uuid 域。绝大多数条目上这两个域同名：懒生成时用户条目直接取 transcript 条目的 uuid，前缀复制又保留 uuid，因此恒等关系在分支的分支上递归成立。唯一的例外是活跃路径——POST 受理时就要给出条目身份，那时 SDK 还没分配 uuid，只能先 mint 一个 `user-<hex>`，事后由回显认领配对落进映射表 `agent_session_user_message_links`。
+
+解析因此分两段，收敛在 `EventLogService.resolve_user_message_anchor` 一处：映射表优先，未命中时校验该 uuid 在事件日志里对应的是主线 plain user 条目（无 subtype、无 parent_tool_use_id），通过即按恒等性采用。回退不校验 transcript 存在性——映射缺失的活跃路径条目会走到这里并返回一个 transcript 查无此条的 uuid，由前缀分叉在切片时拒绝。同理，transcript 把工具回执也写成 `type:"user"` 条目，混排文本的那种从条目类型上与真用户消息无从区分，由前缀分叉按「载有 tool_result」拒绝——否则配对的 tool_use 会悬在前缀末尾。两道校验分工明确，两条解析路径共同受益。
 
 ## 明确不采用
 
-- **SDK 原生 `fork_session` + prompt 覆盖**（唯一的官方姿势）：末尾分叉带走全部历史，被否定的错误分支仍在 agent 上下文里吃 token、继续污染后续生成——与「回到发出前」的语义直接矛盾，纠偏效果退化为追加指令。
+- **SDK 原生 `fork_session` + prompt 覆盖**（唯一的官方姿势）：即使用 `up_to_message_id` 截断，丢 sidechain 与重映射 uuid 两条也已否掉它——前者让分支失去 subagent 历史，后者让跨分支对齐无从谈起；而不带截断的整史分叉更是让被否定的错误分支继续在上下文里吃 token、污染后续生成，纠偏效果退化为追加指令。
 - **原地截断原会话**：删除编辑点之后的 transcript 行与事件日志行、同 session_id resume。破坏事件日志的 append-only 根基（`docs/adr/0048`），前端增量投影器与 SSE `Last-Event-ID` 续传语义连带失效，且被弃分支的备份要另行实现。前缀分叉下这些问题不存在：原会话数据整体不动即是备份，新会话事件日志按 `docs/adr/0048` 既有的重放重建机制从 transcript 懒生成。
 - **等待上游实现**：中间点分叉在上游长期处于 feature request 状态，无时间表；纠偏能力是弱模型场景的现实痛点，不适合无限期挂起。
 
+## 发布靠补偿，不靠事务
+
+一次分叉要落三样东西：新会话的 transcript 前缀、新会话的元数据行、原会话的 superseded 指针。它们跨 transcript 镜像与会话元数据两处存储，各自提交，没有共享的事务边界——store 的每次 append 就是一次提交，且 transcript 行不依赖元数据行就能被会话枚举看见。因此发布不是原子的，中途失败由服务整体撤回：清指针、删新会话 transcript（连子代理子路径）、删新会话元数据行，三步各自容错，清理自身的失败只记日志、不掩盖原始错误。把 `create` 与 `mark_superseded` 收进同一个事务不改变这个性质，只是把窗口挪到 transcript 一侧。
+
+可容忍的窗口边界：撤回之前的那一瞬，新会话行可能已经存在而指针尚未落定。此时它是一个空转的会话——没有 actor、没有输入。要让它造成实际损害，需要「会话列表恰好轮询到这一瞬」叠加「用户当场删除这个刚看见的会话」，与仓库既有的并发取舍同族（单用户本地部署）。指针本身则用条件更新守护：`WHERE superseded_by IS NULL` 保证同一会话不会被两次分叉各写一次，重复分叉在这一步失败并触发整体撤回。
+
 ## Consequences
 
-- 原会话标记 superseded 并记录指向新会话的指针，会话列表过滤隐藏，数据完整保留；闲置驱逐照常。
+- 原会话标记 superseded 并记录指向新会话的指针，会话列表过滤隐藏，数据完整保留；闲置驱逐照常。删除链中某个分支时，指向它的前身改指它自己的后继，前身不会带着一个指向不存在会话的指针永久留在列表之外。
+- `superseded_by` 表达的是替换式 UX——一个会话只呈现一条时间线，被取代者退场。分叉血统另存 `fork_parent_session_id` + `fork_anchor_uuid`（transcript 域），在 branch 时刻写入即不再变化：前者是可被删除接手改写的呈现投影，后者是不可变的事实。将来若要把分支呈现成树，放开单子约束加表现层工作即可，数据层不必迁移。
 - 改写不回退文件与项目数据副作用。SDK 的 `enable_file_checkpointing` + `rewind_files` 可作后续增强，但其盲区（Bash 写入不追踪、项目数据经任务队列/DB 落盘）决定了它最多是部分回滚，不改变本决策。
 - 事件日志与前端投影契约零改动：截断语义完全由「新会话」表达，append-only、前缀不变、SSE 续传三个既有约定原样成立。

--- a/lib/agent_session_store/prefix_fork.py
+++ b/lib/agent_session_store/prefix_fork.py
@@ -104,8 +104,23 @@ def _prefix_before_anchor(entries: list[dict], anchor_uuid: str) -> list[dict]:
             continue
         if _entry_type(entry) != "user":
             raise InvalidAnchorError(f"anchor {anchor_uuid} is a {_entry_type(entry)!r} entry, not a user message")
+        if _carries_tool_result(entry):
+            # transcript 把工具回执也写成 type:"user" 的条目，其中混排文本的那种
+            # 从条目类型上与真用户消息无从区分。以它作锚点会把配对的 tool_use
+            # 留在前缀末尾悬空，因此按非法锚点拒绝。
+            raise InvalidAnchorError(f"anchor {anchor_uuid} carries tool results, not a plain user message")
         return entries[:index]
     raise InvalidAnchorError(f"anchor {anchor_uuid} is not on the main timeline of session")
+
+
+def _carries_tool_result(entry: dict[str, Any]) -> bool:
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return False
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(isinstance(block, dict) and block.get("type") == "tool_result" for block in content)
 
 
 def _matches_subagent(subpath: str, wanted_leaves: set[str]) -> bool:

--- a/lib/db/models/session.py
+++ b/lib/db/models/session.py
@@ -20,6 +20,11 @@ class AgentSession(TimestampMixin, UserOwnedMixin, Base):
     # 指针即标记，不占用 status——status 承载生命周期，闲置驱逐与启动期
     # interrupt 都按它运转。
     superseded_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    # 分叉血统：本会话是从哪个会话的哪条消息处分叉出来的，建行时写入即不再变化。
+    # fork_anchor_uuid 取 transcript 域——锚点消息本身不随前缀复制、只留在原会话，
+    # 而同一条历史消息在所有分支里的 transcript uuid 相同，跨分支对齐由此免费。
+    fork_parent_session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    fork_anchor_uuid: Mapped[str | None] = mapped_column(String, nullable=True)
 
     __table_args__ = (
         Index("idx_agent_sessions_project", "project_name", "updated_at"),

--- a/lib/db/repositories/session_repo.py
+++ b/lib/db/repositories/session_repo.py
@@ -21,6 +21,8 @@ def _row_to_dict(row: AgentSession) -> dict[str, Any]:
         "title": row.title or "",
         "status": row.status,
         "superseded_by": row.superseded_by,
+        "fork_parent_session_id": row.fork_parent_session_id,
+        "fork_anchor_uuid": row.fork_anchor_uuid,
         "created_at": dt_to_iso(row.created_at),
         "updated_at": dt_to_iso(row.updated_at),
     }
@@ -28,7 +30,14 @@ def _row_to_dict(row: AgentSession) -> dict[str, Any]:
 
 class SessionRepository(BaseRepository):
     async def create(
-        self, project_name: str, sdk_session_id: str, title: str = "", user_id: str = DEFAULT_USER_ID
+        self,
+        project_name: str,
+        sdk_session_id: str,
+        title: str = "",
+        user_id: str = DEFAULT_USER_ID,
+        *,
+        fork_parent_session_id: str | None = None,
+        fork_anchor_uuid: str | None = None,
     ) -> dict[str, Any]:
         now = utc_now()
         row = AgentSession(
@@ -37,6 +46,8 @@ class SessionRepository(BaseRepository):
             project_name=project_name,
             title=title,
             status="idle",
+            fork_parent_session_id=fork_parent_session_id,
+            fork_anchor_uuid=fork_anchor_uuid,
             created_at=now,
             updated_at=now,
             user_id=user_id,

--- a/server/agent_runtime/event_log.py
+++ b/server/agent_runtime/event_log.py
@@ -901,3 +901,35 @@ class EventLogService:
     ) -> list[dict[str, Any]]:
         await self.ensure_backfilled(session_id, project_cwd)
         return await self._store.list_after(session_id, after_seq)
+
+    async def resolve_user_message_anchor(
+        self,
+        session_id: str,
+        entry_uuid: str,
+        project_cwd: Path | str | None,
+    ) -> str | None:
+        """把事件日志里的用户条目 uuid 解析为 transcript 域的 entry uuid。
+
+        两段：身份映射表优先，未命中时按恒等性回退。映射表是活跃路径的唯一
+        通路——POST 受理时 mint 的 ``user-<hex>`` 先于 SDK 分配 uuid，两个域
+        天然不同名，只能靠映射对上。其余条目的两域 uuid 本就相同：懒生成时
+        用户条目直接取 transcript 条目的 uuid，前缀分叉复制时 uuid 原样保留，
+        因此分支的分支同样成立。
+
+        回退只接受主线 plain user 条目（无 subtype、无 parent_tool_use_id）：
+        问答回复、tool_result、skill 注入等条目的 uuid 都是派生或定型产物，
+        作锚点没有意义。返回的 uuid 未经 transcript 存在性校验——映射缺失的
+        活跃路径条目会走到这里并返回一个 transcript 查无此条的 uuid，由前缀
+        分叉在切片时 fail loud，不静默改切别处。
+        """
+        linked = await self._store.find_user_message_link(session_id, entry_uuid)
+        if linked is not None:
+            return linked
+        await self.ensure_backfilled(session_id, project_cwd)
+        for entry in await self._store.list_after(session_id):
+            if entry.get("uuid") != entry_uuid:
+                continue
+            if entry.get("type") != ENTRY_TYPE_USER or entry.get("subtype") or entry.get("parent_tool_use_id"):
+                return None
+            return entry_uuid
+        return None

--- a/server/agent_runtime/models.py
+++ b/server/agent_runtime/models.py
@@ -51,5 +51,9 @@ class SessionMeta(BaseModel):
     status: SessionStatus = "idle"
     superseded_by: str | None = None
     """非空表示本会话已被分支会话取代，值为新会话的 sdk_session_id。"""
+    fork_parent_session_id: str | None = None
+    """非空表示本会话由分叉产生，值为被分叉会话的 sdk_session_id。"""
+    fork_anchor_uuid: str | None = None
+    """分叉锚点在 transcript 域的 entry uuid，与 fork_parent_session_id 同时写入。"""
     created_at: datetime
     updated_at: datetime

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -75,7 +75,7 @@ class AssistantService:
         self.session_branch = SessionBranchService(
             store=self._session_store,
             meta_store=self.meta_store,
-            event_log_store=self.event_log_store,
+            event_log=self.event_log,
             resolve_project_cwd=self._resolve_project_cwd_safe,
         )
         self._startup_lock = asyncio.Lock()

--- a/server/agent_runtime/session_branch.py
+++ b/server/agent_runtime/session_branch.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 from lib.agent_session_store import make_project_key
 from lib.agent_session_store.prefix_fork import InvalidAnchorError, SessionStoreLike, copy_session_prefix
-from server.agent_runtime.event_log import EventLogStore
+from server.agent_runtime.event_log import EventLogService
 from server.agent_runtime.session_store import SessionMetaStore
 
 logger = logging.getLogger(__name__)
@@ -46,20 +46,20 @@ class SessionBranchService:
         *,
         store: SessionStoreLike | None,
         meta_store: SessionMetaStore,
-        event_log_store: EventLogStore,
+        event_log: EventLogService,
         resolve_project_cwd: Callable[[str], Path | None],
     ) -> None:
         self._store = store
         self._meta_store = meta_store
-        self._event_log_store = event_log_store
+        self._event_log = event_log
         self._resolve_project_cwd = resolve_project_cwd
 
     async def branch(self, session_id: str, anchor_user_entry_uuid: str) -> BranchedSession:
         """从 ``anchor_user_entry_uuid`` 处分叉 ``session_id``，返回新会话。
 
-        ``anchor_user_entry_uuid`` 是事件日志里那条用户条目的 uuid；它到
-        transcript 条目的映射由身份映射表给出，查不到即拒绝——锚点必须是本会话
-        自己的用户消息。
+        ``anchor_user_entry_uuid`` 是事件日志里那条用户条目的 uuid，由事件日志
+        解析成 transcript 域的锚点；解析不出即拒绝——锚点必须是本会话自己的
+        一条用户消息。本服务不感知两个 uuid 域的差异。
         """
         store = self._store
         if store is None:
@@ -75,7 +75,7 @@ class SessionBranchService:
         if project_cwd is None:
             raise SessionBranchError(f"project {meta.project_name} of session {session_id} is unavailable")
 
-        anchor_uuid = await self._event_log_store.find_user_message_link(session_id, anchor_user_entry_uuid)
+        anchor_uuid = await self._event_log.resolve_user_message_anchor(session_id, anchor_user_entry_uuid, project_cwd)
         if anchor_uuid is None:
             raise SessionBranchError(f"anchor {anchor_user_entry_uuid} is not a user message of session {session_id}")
 
@@ -94,8 +94,15 @@ class SessionBranchService:
                 anchor_uuid=anchor_uuid,
                 new_session_id=new_session_id,
             )
-            # 先建新会话行再落指针，指针任何时刻都指向已存在的会话。
-            await self._meta_store.create(meta.project_name, new_session_id)
+            # 先建新会话行再落指针，指针任何时刻都指向已存在的会话。分叉血统随
+            # 建行落库：它是 branch 时刻的不可变事实，与 superseded_by 表达的
+            # 「原会话被谁取代」互为反向，后者可被删除接手改写，前者不会。
+            await self._meta_store.create(
+                meta.project_name,
+                new_session_id,
+                fork_parent_session_id=session_id,
+                fork_anchor_uuid=anchor_uuid,
+            )
             if not await self._meta_store.mark_superseded(session_id, new_session_id):
                 raise SessionBranchError(f"session {session_id} has already been superseded by another branch")
         except InvalidAnchorError as exc:

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -747,7 +747,9 @@ class SessionManager:
             # seq 0 缺失的会话开头永远无法呈现。与常规受理路径同语义——
             # 失败显式回报（调用方收到异常）、状态回写 error、会话不再后台
             # 续跑。先清理再回写状态：inbox 处理 result 时 _finalize_turn
-            # 会写终态，清理完成后写入的 error 才不会被并发覆盖。
+            # 会写终态，清理完成后写入的 error 才不会被并发覆盖。直接清空而不走
+            # _drain_pending_user_echoes：受理失败的消息不会有回放副本抵达，
+            # 这里的残留不是认领失败。
             managed.pending_user_echoes.clear()
             managed.cancel_pending_questions("initial user entry persist failed")
             # 提前置内存态为 error：_cleanup_on_error 取消 _process_task 时，
@@ -1031,6 +1033,8 @@ class SessionManager:
             await managed.send_query(prompt, sdk_session_id=session_id)
         except Exception as exc:
             logger.error("会话消息处理失败: %s", redact_diagnostic_text(exc))
+            # 同受理失败路径：投递没成功，回放副本不会来，残留不算认领失败，
+            # 因此不走 _drain_pending_user_echoes。
             managed.pending_user_echoes.clear()
             if log_entry is not None:
                 # 补偿删除受理条目：投递失败即受理失败，条目残留会让同幂等键

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -653,6 +653,10 @@ class SessionManager:
             finish naturally), then belt-and-suspenders cancels the processor
             in case it is stuck elsewhere.
             """
+            # 新会话没建起来，SDK 不会回放刚登记的那条用户消息，登记不是认领
+            # 失败。在漏斗里清掉，_drain_pending_user_echoes 的告警语义便按构造
+            # 成立，不依赖拆解途中各处状态写入的先后。
+            managed.pending_user_echoes.clear()
             self.sessions.pop(temp_id, None)
             # sdk_session_id 就绪后 key swap 已把会话挂到正式 id 下，两个键都清。
             self.sessions.pop(managed.session_id, None)

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -653,10 +653,6 @@ class SessionManager:
             finish naturally), then belt-and-suspenders cancels the processor
             in case it is stuck elsewhere.
             """
-            # 新会话没建起来，SDK 不会回放刚登记的那条用户消息，登记不是认领
-            # 失败。在漏斗里清掉，_drain_pending_user_echoes 的告警语义便按构造
-            # 成立，不依赖拆解途中各处状态写入的先后。
-            managed.pending_user_echoes.clear()
             self.sessions.pop(temp_id, None)
             # sdk_session_id 就绪后 key swap 已把会话挂到正式 id 下，两个键都清。
             self.sessions.pop(managed.session_id, None)
@@ -670,6 +666,10 @@ class SessionManager:
             if managed._process_task is not None and not managed._process_task.done():
                 managed._process_task.cancel()
                 await asyncio.gather(managed._process_task, return_exceptions=True)
+            # 清理排在断开与 inbox 消化之后：actor 在断开前仍可能回放刚登记的这条
+            # 消息，提前清掉会让回放认不出自己是副本，从而二次写入事件日志。走到
+            # 这里已无回放可言，残留的登记也就不是认领失败，直接清空不记账。
+            managed.pending_user_echoes.clear()
             startup_stderr.stop()
 
         # 登记待回放的用户消息标识：SDK 会回放刚发送消息的副本，写入点凭此
@@ -751,10 +751,8 @@ class SessionManager:
             # seq 0 缺失的会话开头永远无法呈现。与常规受理路径同语义——
             # 失败显式回报（调用方收到异常）、状态回写 error、会话不再后台
             # 续跑。先清理再回写状态：inbox 处理 result 时 _finalize_turn
-            # 会写终态，清理完成后写入的 error 才不会被并发覆盖。直接清空而不走
-            # _drain_pending_user_echoes：受理失败的消息不会有回放副本抵达，
-            # 这里的残留不是认领失败。
-            managed.pending_user_echoes.clear()
+            # 会写终态，清理完成后写入的 error 才不会被并发覆盖。回显登记留给
+            # _cleanup_on_error 在断开之后清，此刻 actor 仍可能回放。
             managed.cancel_pending_questions("initial user entry persist failed")
             # 提前置内存态为 error：_cleanup_on_error 取消 _process_task 时，
             # _process_inbox 的 CancelledError 分支会依据 status == "running"

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1297,6 +1297,11 @@ class SessionManager:
             # send_message 已把 DB 写成 running；缺少此步 get_or_connect 恢复
             # 后会拒绝新消息（SessionStatus == "running"）。
             if managed.resolved_sdk_id is not None:
+                # 关停同样终结轮次：inbox 已排空，此刻还在队列里的登记不会再被认领，
+                # 与 _mark_session_terminal 同口径记账，否则同一种中断会因走关停路径
+                # 还是走 inbox 取消路径而报或不报。限定在 SDK 已就绪的会话上，启动
+                # 失败与投递失败那两条路径此前已各自清空，不会流到这里。
+                self._drain_pending_user_echoes(managed, "session evicted")
                 if managed.status == "running":
                     managed.status = "interrupted"
                 if managed.status in ("interrupted", "error"):

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -361,6 +361,8 @@ class SessionManager:
         )
         self.meta_store = meta_store
         self.sessions: dict[str, ManagedSession] = {}
+        # 轮次终结时仍未被认领的回显登记累计数，见 _drain_pending_user_echoes。
+        self.unclaimed_user_echoes = 0
         self._disconnecting: set[str] = set()
         self._session_actor_shutdown_timeout: float = 15.0  # total budget for send_disconnect + cancel fallback
         self._connect_locks: dict[str, asyncio.Lock] = {}
@@ -1090,9 +1092,32 @@ class SessionManager:
                 interrupt_requested=managed.interrupt_requested,
             )
 
+    def _drain_pending_user_echoes(self, managed: ManagedSession, reason: str) -> None:
+        """清空回显登记队列；轮次终结时仍有残留即认领失败，记一条告警。
+
+        观测点在轮次终结处而非逐条比对处：登记与回放一一对应，轮次结束时队列
+        必然已被排空，残留只可能是文本比对没认上，或回放根本没到。逐条告警做不
+        到——单看一条消息无从判定它「是回放副本却没认上」。残留的后果是同一条
+        用户消息在事件日志里重复落库，以及其身份映射缺失（改写锚点随后走恒等
+        回退，锚点若是活跃路径 mint 的 id 则解析失败）。
+        """
+        residue = len(managed.pending_user_echoes)
+        if residue:
+            self.unclaimed_user_echoes += residue
+            logger.warning(
+                "user echo replays went unclaimed at turn end",
+                extra={
+                    "session_id": managed.session_id,
+                    "residue": residue,
+                    "unclaimed_total": self.unclaimed_user_echoes,
+                    "reason": reason,
+                },
+            )
+        managed.pending_user_echoes.clear()
+
     async def _finalize_turn(self, managed: ManagedSession, result_msg: dict[str, Any]) -> None:
         """Settle session state after a result message completes a turn."""
-        managed.pending_user_echoes.clear()
+        self._drain_pending_user_echoes(managed, "turn finalized")
         managed.cancel_pending_questions("session completed")
         explicit = str(result_msg.get("session_status") or "").strip()
         final_status: SessionStatus = (
@@ -1154,7 +1179,7 @@ class SessionManager:
 
     async def _mark_session_terminal(self, managed: ManagedSession, status: SessionStatus, reason: str) -> None:
         """Set terminal status on abnormal consumer exit."""
-        managed.pending_user_echoes.clear()
+        self._drain_pending_user_echoes(managed, reason)
         managed.cancel_pending_questions(reason)
         managed.status = status
         managed.last_activity = time.monotonic()

--- a/server/agent_runtime/session_store.py
+++ b/server/agent_runtime/session_store.py
@@ -19,6 +19,8 @@ def _dict_to_session(d: dict) -> SessionMeta:
         title=d.get("title") or "",
         status=d["status"],
         superseded_by=d.get("superseded_by"),
+        fork_parent_session_id=d.get("fork_parent_session_id"),
+        fork_anchor_uuid=d.get("fork_anchor_uuid"),
         created_at=d["created_at"],
         updated_at=d["updated_at"],
     )
@@ -30,11 +32,23 @@ class SessionMetaStore:
     def __init__(self, *, session_factory=None):
         self._session_factory = session_factory or safe_session_factory
 
-    async def create(self, project_name: str, sdk_session_id: str) -> SessionMeta:
+    async def create(
+        self,
+        project_name: str,
+        sdk_session_id: str,
+        *,
+        fork_parent_session_id: str | None = None,
+        fork_anchor_uuid: str | None = None,
+    ) -> SessionMeta:
 
         async with self._session_factory() as session:
             repo = SessionRepository(session)
-            d = await repo.create(project_name=project_name, sdk_session_id=sdk_session_id)
+            d = await repo.create(
+                project_name=project_name,
+                sdk_session_id=sdk_session_id,
+                fork_parent_session_id=fork_parent_session_id,
+                fork_anchor_uuid=fork_anchor_uuid,
+            )
         return _dict_to_session(d)
 
     async def get(self, session_id: str) -> SessionMeta | None:

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -1298,3 +1298,84 @@ class TestSubagentBackfillMerge:
         assert len(skill_entries) == 1
         assert skill_entries[0]["skill_name"] == "commit"
         assert skill_entries[0]["parent_tool_use_id"] == "tu-agent"
+
+
+class TestResolveUserMessageAnchor:
+    """锚点解析两段化：身份映射优先，未命中按恒等性回退。"""
+
+    async def test_mapping_wins_and_needs_no_transcript(self, log_store: EventLogStore):
+        """活跃路径 mint 的条目 id 与 SDK uuid 天然不同名，只能靠映射对上。"""
+        adapter = _FakeAdapter([{"type": "user", "content": "hi", "uuid": "sdk-1"}])
+        service = EventLogService(log_store, adapter)
+        await log_store.record_user_message_link("s1", "user-abc", "sdk-1")
+
+        assert await service.resolve_user_message_anchor("s1", "user-abc", None) == "sdk-1"
+        assert adapter.read_count == 0
+
+    async def test_falls_back_to_identity_for_a_plain_user_entry(self, log_store: EventLogStore):
+        """无映射的历史用户条目：两个域的 uuid 本就相同，取自身即可。"""
+        adapter = _FakeAdapter(
+            [
+                {"type": "user", "content": "hi", "uuid": "t1"},
+                {"type": "assistant", "content": [{"type": "text", "text": "在"}], "uuid": "a1"},
+            ]
+        )
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "t1", None) == "t1"
+
+    async def test_assistant_entry_is_refused(self, log_store: EventLogStore):
+        adapter = _FakeAdapter([{"type": "assistant", "content": [{"type": "text", "text": "在"}], "uuid": "a1"}])
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "a1", None) is None
+
+    async def test_typed_user_subtypes_are_refused(self, log_store: EventLogStore):
+        """问答回复带 subtype、uuid 也是派生的；作锚点没有意义。"""
+        adapter = _FakeAdapter(
+            [
+                {
+                    "type": "assistant",
+                    "uuid": "a1",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu-q",
+                            "name": "AskUserQuestion",
+                            "input": {"questions": [{"question": "继续吗?"}]},
+                        }
+                    ],
+                },
+                {
+                    "type": "user",
+                    "uuid": "u-ans",
+                    "content": [{"type": "tool_result", "tool_use_id": "tu-q", "content": "answered"}],
+                },
+            ]
+        )
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "u-ans-tr0", None) is None
+        assert await service.resolve_user_message_anchor("s1", "u-ans", None) is None
+
+    async def test_subagent_entry_is_refused(self, log_store: EventLogStore):
+        """子时间线里的用户条目带 parent_tool_use_id，不在主线上。"""
+        adapter = _FakeAdapter(
+            [
+                {
+                    "type": "assistant",
+                    "uuid": "a1",
+                    "content": [{"type": "tool_use", "id": "tu-agent", "name": "Task", "input": {}}],
+                }
+            ],
+            {"tu-agent": [{"type": "user", "content": "子任务输入", "uuid": "sub-u1"}]},
+        )
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "sub-u1", None) is None
+
+    async def test_unknown_uuid_yields_nothing(self, log_store: EventLogStore):
+        adapter = _FakeAdapter([{"type": "user", "content": "hi", "uuid": "t1"}])
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "user-never-seen", None) is None

--- a/tests/agent_runtime/test_event_log.py
+++ b/tests/agent_runtime/test_event_log.py
@@ -1358,6 +1358,23 @@ class TestResolveUserMessageAnchor:
         assert await service.resolve_user_message_anchor("s1", "u-ans-tr0", None) is None
         assert await service.resolve_user_message_anchor("s1", "u-ans", None) is None
 
+    async def test_system_shaped_pseudo_user_entries_are_refused(self, log_store: EventLogStore):
+        """transcript 侧的 interrupt 回显与 skill 注入都是 type:"user"，定型后成
+        system 条目：前者原样留用 uuid、后者带 -skill 后缀，两种形状都不作锚点。"""
+        adapter = _FakeAdapter(
+            [
+                {"type": "user", "content": "开始", "uuid": "u1"},
+                {"type": "user", "content": "[Request interrupted by user]", "uuid": "i1"},
+                {"type": "user", "content": "Base directory for this skill: /x/skills/demo", "uuid": "k1"},
+            ]
+        )
+        service = EventLogService(log_store, adapter)
+
+        assert await service.resolve_user_message_anchor("s1", "i1", None) is None
+        assert await service.resolve_user_message_anchor("s1", "k1", None) is None
+        assert await service.resolve_user_message_anchor("s1", "k1-skill0", None) is None
+        assert await service.resolve_user_message_anchor("s1", "u1", None) == "u1"
+
     async def test_subagent_entry_is_refused(self, log_store: EventLogStore):
         """子时间线里的用户条目带 parent_tool_use_id，不在主线上。"""
         adapter = _FakeAdapter(

--- a/tests/agent_runtime/test_session_branch.py
+++ b/tests/agent_runtime/test_session_branch.py
@@ -46,7 +46,7 @@ async def branching(session_factory, tmp_path):
     service = SessionBranchService(
         store=store,
         meta_store=meta_store,
-        event_log_store=log_store,
+        event_log=EventLogService(log_store, SdkTranscriptAdapter(store=store)),
         resolve_project_cwd=lambda _name: tmp_path,
     )
 
@@ -299,7 +299,7 @@ async def test_failure_midway_through_copying_leaves_no_trace_of_the_new_session
     service = SessionBranchService(
         store=_StoreFailingAfterMainWrite(store),
         meta_store=meta_store,
-        event_log_store=log_store,
+        event_log=EventLogService(log_store, SdkTranscriptAdapter(store=store)),
         resolve_project_cwd=lambda _name: tmp_path,
     )
 
@@ -322,7 +322,7 @@ async def test_pointer_is_withdrawn_when_the_caller_is_cancelled_after_it_commit
     service = SessionBranchService(
         store=store,
         meta_store=meta_store,
-        event_log_store=log_store,
+        event_log=EventLogService(log_store, SdkTranscriptAdapter(store=store)),
         resolve_project_cwd=lambda _name: tmp_path,
     )
 
@@ -341,12 +341,163 @@ async def test_branching_requires_the_db_transcript_store(session_factory, tmp_p
     service = SessionBranchService(
         store=None,
         meta_store=SessionMetaStore(session_factory=session_factory),
-        event_log_store=EventLogStore(session_factory=session_factory),
+        event_log=EventLogService(EventLogStore(session_factory=session_factory), SdkTranscriptAdapter(store=None)),
         resolve_project_cwd=lambda _name: tmp_path,
     )
 
     with pytest.raises(SessionBranchError):
         await service.branch(str(uuid4()), SECOND_USER_ENTRY)
+
+
+async def _seed_three_rounds(store, meta_store, project_key):
+    """三轮对话的原会话，只有末轮用户消息建了身份映射。
+
+    前两轮模拟「早于映射表的历史」：分支会话拿到的前缀条目同样没有映射行，
+    正是恒等回退要服务的那一类锚点。
+    """
+    session_id = str(uuid4())
+    await meta_store.create(PROJECT_NAME, session_id)
+    uuids = [f"m{i}-{uuid4().hex[:8]}" for i in range(6)]
+    parents: list[str | None] = [None, *uuids[:-1]]
+    await store.append(
+        {"project_key": project_key, "session_id": session_id},
+        [
+            _entry(uuid, parent, "user" if index % 2 == 0 else "assistant", session_id, f"第{index}条")
+            for index, (uuid, parent) in enumerate(zip(uuids, parents, strict=True))
+        ],
+    )
+    return session_id, uuids
+
+
+async def test_a_prefix_message_without_a_mapping_row_can_still_be_rewritten(branching):
+    """AC：分支会话的前缀历史消息没有映射行，靠恒等性仍能作锚点再分叉。"""
+    service, meta_store, store, log_store, _, tmp_path = branching
+    project_key = make_project_key(tmp_path)
+    origin, uuids = await _seed_three_rounds(store, meta_store, project_key)
+    await log_store.record_user_message_link(origin, "user-third", uuids[4])
+
+    branched = await service.branch(origin, "user-third")
+    # 分支会话的前缀是前两轮，其中第二条用户消息在新会话里没有任何映射行。
+    again = await service.branch(branched.session_id, uuids[2])
+
+    assert again.resumable is True
+    copied = await store.load({"project_key": project_key, "session_id": again.session_id})
+    assert copied is not None
+    assert [e["type"] for e in copied] == ["user", "assistant"]
+
+
+async def test_rewriting_recurses_through_branches_of_branches(branching):
+    """AC：分支的分支同样可再改写——uuid 随前缀复制原样保留，恒等性递归成立。"""
+    service, meta_store, store, log_store, _, tmp_path = branching
+    project_key = make_project_key(tmp_path)
+    origin, uuids = await _seed_three_rounds(store, meta_store, project_key)
+    await log_store.record_user_message_link(origin, "user-third", uuids[4])
+
+    first = await service.branch(origin, "user-third")
+    second = await service.branch(first.session_id, uuids[2])
+    third = await service.branch(second.session_id, uuids[0])
+
+    assert third.session_id not in {origin, first.session_id, second.session_id}
+    # 锚点是整段历史的第一条，前缀为空——新会话就是全新会话。
+    assert third.resumable is False
+
+
+async def test_a_continued_branch_message_is_anchored_through_the_mapping(branching):
+    """续写进分支会话的新消息走映射表这一段，与前缀历史消息两类锚点并存。"""
+    service, _, store, log_store, session_id, tmp_path = branching
+    project_key = make_project_key(tmp_path)
+    branched = await service.branch(session_id, SECOND_USER_ENTRY)
+    copied = await store.load({"project_key": project_key, "session_id": branched.session_id})
+    assert copied is not None
+    continued = f"m-cont-{uuid4().hex[:8]}"
+    await store.append(
+        {"project_key": project_key, "session_id": branched.session_id},
+        [_entry(continued, copied[-1]["uuid"], "user", branched.session_id, "继续")],
+    )
+    await log_store.record_user_message_link(branched.session_id, "user-in-branch", continued)
+
+    again = await service.branch(branched.session_id, "user-in-branch")
+
+    assert again.resumable is True
+
+
+async def test_branch_records_where_it_forked_from(branching):
+    """分叉血统在 branch 时刻写入：父会话 + transcript 域的锚点 uuid。"""
+    service, meta_store, store, _, session_id, tmp_path = branching
+    main = await store.load({"project_key": make_project_key(tmp_path), "session_id": session_id})
+    assert main is not None
+    anchor_uuid = [e["uuid"] for e in main if e["type"] == "user"][1]
+
+    branched = await service.branch(session_id, SECOND_USER_ENTRY)
+
+    meta = await meta_store.get(branched.session_id)
+    assert meta is not None
+    assert meta.fork_parent_session_id == session_id
+    assert meta.fork_anchor_uuid == anchor_uuid
+    origin = await meta_store.get(session_id)
+    assert origin is not None
+    assert origin.fork_parent_session_id is None, "原会话不是分叉产物"
+
+
+async def test_a_tool_result_carrying_entry_is_refused_as_an_anchor(branching):
+    """transcript 把工具回执也写成 type:"user"；混排 tool_result 的条目作锚会悬空前一轮 tool_use。"""
+    service, meta_store, store, _, _, tmp_path = branching
+    project_key = make_project_key(tmp_path)
+    session_id = str(uuid4())
+    await meta_store.create(PROJECT_NAME, session_id)
+    u1, a1, mixed = (f"m{i}-{uuid4().hex[:8]}" for i in range(3))
+    await store.append(
+        {"project_key": project_key, "session_id": session_id},
+        [
+            _entry(u1, None, "user", session_id, "跑一下"),
+            _entry(a1, u1, "assistant", session_id, "好"),
+            {
+                **_entry(mixed, a1, "user", session_id, ""),
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "done"},
+                        {"type": "text", "text": "顺带说一句"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    sessions_before = {row["session_id"] for row in await store.list_sessions(project_key)}
+
+    with pytest.raises(SessionBranchError):
+        await service.branch(session_id, mixed)
+
+    assert {row["session_id"] for row in await store.list_sessions(project_key)} == sessions_before
+
+
+async def test_an_identity_anchor_that_transcript_never_saw_fails_loud(branching):
+    """活跃路径条目丢了映射行：恒等回退放行，由前缀切片拒绝，不静默切错位置。"""
+    service, meta_store, store, log_store, _, tmp_path = branching
+    project_key = make_project_key(tmp_path)
+    session_id = str(uuid4())
+    await meta_store.create(PROJECT_NAME, session_id)
+    u1, a1 = (f"m{i}-{uuid4().hex[:8]}" for i in range(2))
+    await store.append(
+        {"project_key": project_key, "session_id": session_id},
+        [
+            _entry(u1, None, "user", session_id, "你好"),
+            _entry(a1, u1, "assistant", session_id, "在"),
+        ],
+    )
+    # 事件日志里有这条主线用户条目，transcript 里没有——mint 出来的 id 本该由
+    # 回显认领落进映射表，认领失败就是这个形态。
+    ghost = f"user-{uuid4().hex[:8]}"
+    await log_store.append(session_id, [{"type": "user", "uuid": ghost, "content": "改我"}])
+
+    sessions_before = {row["session_id"] for row in await store.list_sessions(project_key)}
+
+    # 拒绝来自前缀切片（"not on the main timeline"），不是恒等回退自己拦下的。
+    with pytest.raises(SessionBranchError, match="main timeline"):
+        await service.branch(session_id, ghost)
+
+    assert {row["session_id"] for row in await store.list_sessions(project_key)} == sessions_before
 
 
 async def test_new_session_event_log_is_rebuilt_from_the_copied_transcript(branching):

--- a/tests/agent_session_store/test_prefix_fork.py
+++ b/tests/agent_session_store/test_prefix_fork.py
@@ -288,3 +288,32 @@ async def test_assistant_entry_is_not_a_valid_anchor(seeded):
 
     with pytest.raises(InvalidAnchorError):
         await _copy(seeded, anchor=assistant_uuid)
+
+
+async def test_an_entry_carrying_tool_results_is_not_a_valid_anchor(seeded):
+    """工具回执也写成 type:"user"；以它作锚点会把配对的 tool_use 留在前缀末尾悬空。"""
+    store, project_key, session_id, _, _ = seeded
+    main = await store.load({"project_key": project_key, "session_id": session_id})
+    assert main is not None
+    mixed_uuid = f"mixed-{uuid4().hex[:8]}"
+    await store.append(
+        {"project_key": project_key, "session_id": session_id},
+        [
+            _entry(
+                mixed_uuid,
+                main[-1]["uuid"],
+                "user",
+                session_id,
+                message={
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_x", "content": "ok"},
+                        {"type": "text", "text": "顺带说一句"},
+                    ],
+                },
+            )
+        ],
+    )
+
+    with pytest.raises(InvalidAnchorError):
+        await _copy(seeded, anchor=mixed_uuid)

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -1,11 +1,12 @@
 """Unit tests for SessionManager user-input and user-echo behavior."""
 
 import asyncio
+import logging
 
 import pytest
 
 from server.agent_runtime.event_log import REPLAYED_USER_ECHO_ENTRY_UUID_KEY, REPLAYED_USER_ECHO_KEY
-from server.agent_runtime.message_serialization import match_user_echo, message_to_dict
+from server.agent_runtime.message_serialization import PendingUserEcho, match_user_echo, message_to_dict
 from server.agent_runtime.session_manager import SDK_AVAILABLE
 from tests.fakes import build_managed_with_actor
 
@@ -134,6 +135,36 @@ class TestSessionManagerUserInput:
                 await asyncio.sleep(0.01)
 
             assert managed.status == "completed"
+        finally:
+            await _finish(managed)
+
+    async def test_unclaimed_echo_replays_are_reported_once_at_turn_end(self, session_manager, meta_store, caplog):
+        """回显没被认领 = 该消息会重复落库且缺身份映射；轮次终结时一次性报出残留数。"""
+        messages = [{"type": "result", "subtype": "success", "is_error": False, "uuid": "r1"}]
+        meta, managed, _client = await _seed(session_manager, meta_store, messages=messages)
+        try:
+            managed.pending_user_echoes.extend([PendingUserEcho(dedup_key="从未被回放", entry_uuid="user-a")] * 2)
+
+            with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+                await session_manager._finalize_turn(managed, {"type": "result", "subtype": "success"})
+
+            assert managed.pending_user_echoes == []
+            assert session_manager.unclaimed_user_echoes == 2
+            unclaimed = [r for r in caplog.records if "unclaimed" in r.getMessage()]
+            assert len(unclaimed) == 1, "一次 drain 只报一条，不逐条刷屏"
+            assert getattr(unclaimed[0], "residue") == 2
+        finally:
+            await _finish(managed)
+
+    async def test_a_fully_claimed_turn_reports_nothing(self, session_manager, meta_store, caplog):
+        messages = [{"type": "result", "subtype": "success", "is_error": False, "uuid": "r1"}]
+        meta, managed, _client = await _seed(session_manager, meta_store, messages=messages)
+        try:
+            with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+                await session_manager._mark_session_terminal(managed, "interrupted", "user interrupt")
+
+            assert session_manager.unclaimed_user_echoes == 0
+            assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
         finally:
             await _finish(managed)
 

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -152,14 +153,26 @@ class TestSessionManagerUserInput:
             assert session_manager.unclaimed_user_echoes == 2
             unclaimed = [r for r in caplog.records if "unclaimed" in r.getMessage()]
             assert len(unclaimed) == 1, "一次 drain 只报一条，不逐条刷屏"
-            assert getattr(unclaimed[0], "residue") == 2
+            record = unclaimed[0]
+            assert getattr(record, "residue") == 2
+            assert getattr(record, "session_id") == managed.session_id
+            assert getattr(record, "unclaimed_total") == 2
+            assert getattr(record, "reason") == "turn finalized"
         finally:
             await _finish(managed)
 
     async def test_a_fully_claimed_turn_reports_nothing(self, session_manager, meta_store, caplog):
+        """登记被回放副本认领后队列自然排空，终结时无残留可报。"""
         messages = [{"type": "result", "subtype": "success", "is_error": False, "uuid": "r1"}]
         meta, managed, _client = await _seed(session_manager, meta_store, messages=messages)
         try:
+            managed.pending_user_echoes.append(PendingUserEcho(dedup_key="你好", entry_uuid="user-a"))
+            claimed = match_user_echo(
+                managed.pending_user_echoes,
+                {"type": "user", "content": "你好"},
+            )
+            assert claimed is not None and managed.pending_user_echoes == []
+
             with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
                 await session_manager._mark_session_terminal(managed, "interrupted", "user interrupt")
 
@@ -167,6 +180,43 @@ class TestSessionManagerUserInput:
             assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
         finally:
             await _finish(managed)
+
+    async def test_failed_new_session_startup_does_not_count_as_unclaimed(
+        self, session_manager, meta_store, monkeypatch, caplog
+    ):
+        """新会话没建起来，回放副本不会抵达：启动失败不计入认领失败、不产生告警。"""
+
+        class _FakeActor:
+            def __init__(self, *_, on_message=None, client_factory=None):
+                self.task = None
+
+            async def start(self):
+                return None
+
+            def add_done_callback(self, _cb):
+                pass
+
+            async def enqueue(self, cmd):
+                cmd.error = RuntimeError("SDK 拒绝了这次投递")
+                cmd.sent.set()
+                cmd.done.set()
+
+            async def wait(self):
+                return None
+
+        async def fake_env():
+            return {"ANTHROPIC_API_KEY": "sk"}
+
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
+        monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+        monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+            with pytest.raises(Exception):
+                await session_manager.send_new_session("demo", "你好")
+
+        assert session_manager.unclaimed_user_echoes == 0
+        assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
 
     async def test_ask_user_question_waits_for_answer_and_merges_answers(self, session_manager, meta_store):
         if not SDK_AVAILABLE:

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -181,6 +181,20 @@ class TestSessionManagerUserInput:
         finally:
             await _finish(managed)
 
+    async def test_closing_a_running_session_reports_echo_residue(self, session_manager, meta_store, caplog):
+        """关停打断进行中的轮次也是轮次终结点，残留照样记账，不因关停路径而漏报。"""
+        meta, managed, _client = await _seed(session_manager, meta_store, status="running", block_forever=True)
+        managed.status = "running"
+        managed.pending_user_echoes.append(PendingUserEcho(dedup_key="没等到回放", entry_uuid="user-a"))
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+            await session_manager.close_session(meta.id)
+
+        assert session_manager.unclaimed_user_echoes == 1
+        unclaimed = [r for r in caplog.records if "unclaimed" in r.getMessage()]
+        assert len(unclaimed) == 1
+        assert getattr(unclaimed[0], "reason") == "session evicted"
+
     async def test_failed_new_session_startup_does_not_count_as_unclaimed(
         self, session_manager, meta_store, monkeypatch, caplog
     ):

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -8,7 +8,7 @@ import pytest
 
 from server.agent_runtime.event_log import REPLAYED_USER_ECHO_ENTRY_UUID_KEY, REPLAYED_USER_ECHO_KEY
 from server.agent_runtime.message_serialization import PendingUserEcho, match_user_echo, message_to_dict
-from server.agent_runtime.session_manager import SDK_AVAILABLE
+from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError
 from tests.fakes import build_managed_with_actor
 
 pytestmark = pytest.mark.unit
@@ -191,14 +191,20 @@ class TestSessionManagerUserInput:
             await session_manager.close_session(meta.id)
 
         assert session_manager.unclaimed_user_echoes == 1
+        assert managed.pending_user_echoes == [], "记账之后队列要排空，不能只计数"
         unclaimed = [r for r in caplog.records if "unclaimed" in r.getMessage()]
         assert len(unclaimed) == 1
         assert getattr(unclaimed[0], "reason") == "session evicted"
 
     async def test_failed_new_session_startup_does_not_count_as_unclaimed(
-        self, session_manager, meta_store, monkeypatch, caplog
+        self, session_manager, meta_store, monkeypatch, caplog, tmp_path
     ):
         """新会话没建起来，回放副本不会抵达：启动失败不计入认领失败、不产生告警。"""
+        proj_dir = tmp_path / "projects" / "demo"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
+
+        seen_commands: list[str] = []
 
         class _FakeActor:
             def __init__(self, *_, on_message=None, client_factory=None):
@@ -211,7 +217,9 @@ class TestSessionManagerUserInput:
                 pass
 
             async def enqueue(self, cmd):
-                cmd.error = RuntimeError("SDK 拒绝了这次投递")
+                seen_commands.append(cmd.type)
+                if cmd.type == "query":
+                    cmd.error = RuntimeError("SDK 拒绝了这次投递")
                 cmd.sent.set()
                 cmd.done.set()
 
@@ -226,9 +234,10 @@ class TestSessionManagerUserInput:
         monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
 
         with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
-            with pytest.raises(Exception):
+            with pytest.raises(AgentStartupError, match="SDK 拒绝了这次投递"):
                 await session_manager.send_new_session("demo", "你好")
 
+        assert "query" in seen_commands, "投递失败要发生在 query 命令上，而非更早的装配阶段"
         assert session_manager.unclaimed_user_echoes == 0
         assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
 


### PR DESCRIPTION
Closes #1754

从消息改写分叉出来的会话，此前无法再次被改写：锚点解析只认身份映射表，而分支会话的前缀消息没有映射行。本 PR 把解析收敛成 `EventLogService.resolve_user_message_anchor` 一处两段式——映射表优先，未命中时按两域 uuid 的恒等关系回退，因此分支的分支也递归成立。同时把「从哪个会话的哪条消息分叉而来」落成会话元数据的两列不可变事实。

## 改动

- **锚点解析两段化**：`resolve_user_message_anchor(session_id, entry_uuid, project_cwd)` 内部自行 `ensure_backfilled`，「须先 backfill」的隐式前置契约从接口上消失；`SessionBranchService.branch()` 只消费该方法，不再感知两个 uuid 域的差异。恒等回退只接受主线 plain user 条目（无 subtype、无 parent_tool_use_id），问答回复、tool_result、skill 注入、子时间线条目结构性拒绝。
- **分叉血统落列**：`fork_parent_session_id` + `fork_anchor_uuid`（transcript 域）随建行写入。迁移 `9c41ad2f7be5` 纯增两列。`superseded_by` 保留，定位为替换式 UX 的投影——前者可被删除接手改写，后者是 branch 时刻的不可变事实。
- **配套加固**：`prefix_fork` 拒绝载有 tool_result 的锚点条目（否则配对的 tool_use 会悬在前缀末尾）；轮次终结清队时 `pending_user_echoes` 残留非空即 warning + 计数，观测回显认领失败。

## ADR 修订与行为改动同票

ADR 0058 的三处修订随实现一并提交，因为它们都是本 PR 改动后的现状表述，分开提会让文档与代码之间出现一个说法不一致的窗口：

- `fork_session`「只能末尾整史分叉」的依据在当前 SDK 上已不成立——它接受 `up_to_message_id`，真正的阻断点是 `_build_fork_lines` 滤掉全部 `isSidechain` 条目并重新分配 uuid（已在 `.venv` 内 SDK 源码核对）。决策结论不变，只是依据换成经得起核对的那条。
- 新增「锚点身份」一节，记录两域身份现状、映射表收敛为「仅因受理身份先于 SDK 分配 uuid」、以及恒等回退与前缀分叉两道校验的分工。
- Consequences 补 lineage 与 `superseded_by` 的投影定位。

另含「发布靠补偿，不靠事务」一节，是 PR #1751 评审口径的固化。

## 验证

- 全量 `pytest`：8300 passed, 1 skipped
- `ruff check` / `ruff format` / `basedpyright`（0 error）/ `lint-imports`（1 kept）全过
- 迁移在真实 SQLite 上从零 `alembic upgrade head` 跑通，`downgrade -1` → `upgrade head` 往返正常，`alembic heads` 单头
- 新增覆盖：无映射前缀消息可再改写、三层分支的分支递归、mixed 锚点在 service 与 prefix_fork 两层各拒一次、interrupt 回显与 skill 注入条目作锚被拒、lineage 写入断言、echo 残留告警正反用例

## 本地审查记录

- `SessionMeta` 新增两字段会出现在 `/api/v1/assistant/sessions` 响应里（恒为 null，除非该会话是分叉产物）。已确认前端无 zod/strict schema 校验会话 meta，不会拒绝未知字段。
- 分叉血统目前只写不读，无读取方——设计定稿明确的「数据层不挡路、不预建 UI 语义」。
- 恒等回退用全量事件日志线性扫描定位 uuid（uuid 存在 JSON payload 内，无列可点查）。单用户部署下无实害，若日后成为热路径再考虑加列，记为 follow-up 候选。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持从指定消息锚点创建会话分支，并保留来源会话及分支位置。
  * 新增会话分支关系信息，便于追踪会话来源。
* **错误修复**
  * 拒绝无效分支锚点，包括包含工具回执、幽灵消息或非主线消息的条目。
  * 改进用户消息锚点解析，提升历史消息分支的可靠性。
  * 清理未被认领的用户回放并记录告警，避免残留状态影响后续会话。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->