### PR TITLE
fix(供应商): 自定义供应商识别 MiniMax H3 与万相 3.0，时长档位与调用地址不再推错

### DIFF
--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -39,9 +39,15 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     (re.compile(r"vidu", re.I), list(range(1, 17))),
     # PixVerse V5/V5.5/V5.6/V6（1-15 任意）
     (re.compile(r"pixverse|^v[56](\.\d+)?$", re.I), list(range(1, 16))),
+    # MiniMax H3（4-15 任意；与下面的 hailuo 条目无 token 重叠，按 MiniMax 家族就近排列）。
+    # 出处：lib/config/registry.py MiniMax-H3 的 supported_durations。
+    (re.compile(r"minimax-h3", re.I), list(range(4, 16))),
     # MiniMax Hailuo（固定 6）
     (re.compile(r"hailuo", re.I), [6]),
-    # Wan
+    # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
+    # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
+    (re.compile(r"wan-?3", re.I), list(range(2, 31))),
+    # Wan（其余系列）
     (re.compile(r"wan-?\d", re.I), [4, 5]),
     # Pika
     (re.compile(r"pika", re.I), [3, 5, 10]),

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -540,9 +540,10 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
-    1) 阿里百炼视频 → happyhorse / wan2.x（非 image）走 "dashscope-async-video"（原生异步端点）。
-       happyhorse 不在 _VIDEO_PATTERN 须显式；wan2.x 视频抢在通用 is_video 前拦截。图像不自动推
-       dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image 落到既有图像家族推断。
+    1) 阿里百炼视频 → happyhorse / wan2.x / wan3.0（非 image）走 "dashscope-async-video"（原生异步
+       端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；wan2.x / wan3.0 视频抢在通用 is_video 前拦截。
+       图像不自动推 dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image / wan3.0-video-image
+       落到既有图像家族推断。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -559,11 +560,13 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
+    # 万相带版本号的 id（视频与图像变体都含该 token），下面路由与 is_video 排除各用一次
+    is_wan_versioned = "wan2." in lowered or "wan3." in lowered
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if "happyhorse" in lowered:
         return "dashscope-async-video"
-    if "wan2." in lowered and not is_image:
+    if is_wan_versioned and not is_image:
         return "dashscope-async-video"
 
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
@@ -586,8 +589,9 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
             return "kling-video"
         return "kling-image" if is_image else "kling-video"
 
-    # wan2.x-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到图像家族推断
-    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not ("wan2." in lowered and is_image)
+    # wan2.x-image / wan3.0-video-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到
+    # 图像家族推断
+    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not (is_wan_versioned and is_image)
 
     if "imagen" in lowered:
         return "gemini-image"

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -46,13 +46,17 @@ _TERMINAL_V2_VIDEO_STATES = frozenset(
 # 轮询间隔（秒）：海螺视频生成通常数十秒至数分钟，10s 一次平衡时延与请求量。
 MINIMAX_VIDEO_POLL_INTERVAL_SECONDS = 10.0
 
-# 图片后缀 → MIME（first_frame_image 接受 data URI）。
+# 图片后缀 → MIME（first_frame_image 接受 data URI）。本表为 MiniMax 视频系列共用，取各型号
+# 受理格式的并集，heic/heif 仅 H3 受理（出处：
+# https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md）。
 _IMAGE_MIME_TYPES: dict[str, str] = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
     ".gif": "image/gif",
     ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
 }
 
 

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -279,6 +279,14 @@ class TestInferEndpoint:
             ("viduq3-turbo", "openai", "vidu-video"),
             ("viduq3-i2v", "openai", "vidu-video"),
             ("proxy/viduq3-turbo", "openai", "vidu-video"),
+            # ── 阿里百炼 wan2.x / wan3.0 → dashscope-async-video（image 变体不受影响）──
+            ("wan2.7-i2v", "openai", "dashscope-async-video"),
+            ("wan2.7-t2v", "openai", "dashscope-async-video"),
+            ("wan3.0-video", "openai", "dashscope-async-video"),
+            ("Wan3.0-Video", "openai", "dashscope-async-video"),  # 大小写不敏感
+            ("proxy/wan3.0-video", "openai", "dashscope-async-video"),
+            ("wan2.7-image", "openai", "openai-images"),  # image 变体不受影响
+            ("wan3.0-video-image", "openai", "openai-images"),  # 含 image 语义不受影响
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -55,8 +55,15 @@ pytestmark = pytest.mark.unit
         ("MiniMax-Hailuo-2.3-Fast", [6]),
         # 不带 hailuo 的 minimax id 不再命中固定 6，落回默认（裸 minimax token 已移除）
         ("minimax-abab-6.5", DEFAULT_FALLBACK),
+        # MiniMax H3（含大小写/前缀变体，不落入 hailuo 的固定 6 预设）
+        ("minimax-h3", list(range(4, 16))),
+        ("MiniMax-H3", list(range(4, 16))),
+        ("proxy-minimax-h3-turbo", list(range(4, 16))),
         # Wan
         ("wan-2.1", [4, 5]),
+        # 万相 3.0（不落入通用 Wan 的 [4, 5] 预设）
+        ("wan3.0-video", list(range(2, 31))),
+        ("Wan3.0-Video", list(range(2, 31))),
         # Pika
         ("pika-2.0", [3, 5, 10]),
         # 未知模型 → fallback

--- a/tests/test_minimax_shared.py
+++ b/tests/test_minimax_shared.py
@@ -256,3 +256,13 @@ class TestImageToDataUri:
         img = tmp_path / "x.jpg"
         img.write_bytes(b"\xff\xd8\xff")
         assert image_to_data_uri(img).startswith("data:image/jpeg;base64,")
+
+    def test_heic_mime(self, tmp_path):
+        img = tmp_path / "x.heic"
+        img.write_bytes(b"\x00\x00\x00\x18ftypheic")
+        assert image_to_data_uri(img).startswith("data:image/heic;base64,")
+
+    def test_heif_mime(self, tmp_path):
+        img = tmp_path / "x.heif"
+        img.write_bytes(b"\x00\x00\x00\x18ftypmif1")
+        assert image_to_data_uri(img).startswith("data:image/heif;base64,")


### PR DESCRIPTION
Closes #1769

## 问题

MiniMax H3 与万相 3.0 在内建供应商下已可用，但自定义供应商（中转站）自动发现模型时有三处未同步：

1. H3 匹配不到任何时长预设，落到默认档 `[4, 8]`，而能力声明是 4-15 秒
2. `wan3.0-video` 被通用万相规则当成 2.x，只给 4/5 秒两档，而能力声明是 2-30 秒
3. `wan3.0-video` 不被识别为百炼视频，没有路由到异步视频地址，用户每次都要手动改回

另外 MiniMax 视频的参考图若为 heic/heif，会被错标成 PNG 上传（H3 官方接受这两种格式；ArcReel 自产资产不受影响，仅用户外部参考图受影响）。

## 改动

- `lib/custom_provider/duration_presets.py`：新增 H3（4-15）与万相 3.0（2-30）两条预设，取值出处以行内注释指向 `lib/config/registry.py` 对应型号的 `supported_durations`；万相 3.0 排在通用万相规则之前，否则会被 `wan-?\d` 抢走
- `lib/custom_provider/endpoints.py`：`infer_endpoint` 的百炼视频拦截与图像家族排除同时认 `wan2.` / `wan3.`，两处共用一个局部判定
- `lib/minimax_shared.py`：图片 MIME 表补 `.heic` / `.heif`

## 验证

- 三处各配回归测试：时长预设覆盖 `minimax-h3` / `MiniMax-H3` / `proxy-minimax-h3-turbo` 与 `wan3.0-video` / `Wan3.0-Video`；端点推断覆盖 `wan2.7-i2v` / `wan3.0-video` / `proxy/wan3.0-video`，并锁定 `wan2.7-image` / `wan3.0-video-image` 仍落图像家族；MIME 覆盖 `.heic` / `.heif`
- 质量门：`pytest` 全量 8400 passed / 1 skipped、`ruff check` + `format` 干净、`basedpyright` 0 error、`lint-imports` 契约 KEPT

## 范围

不动内建供应商路径，也不重构 `duration_presets` / `infer_endpoint` 机制本身。

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 MiniMax H3 视频生成的 4–15 秒时长选项。
  * 优化 Wan 2/3 视频模型的识别与路由，支持不同大小写及代理前缀。
  * 支持 HEIC 和 HEIF 图片格式转换为 Data URI。

* **Bug 修复**
  * 改进包含图像语义的 Wan 模型判定，避免误路由至视频端点。

* **测试**
  * 新增上述模型路由、时长预设及图片格式转换的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->