### PR TITLE
fix(视频): 百炼视频任务在途改域名后仍能续跑，不再误判为任务过期

### DIFF
--- a/lib/db/models/task.py
+++ b/lib/db/models/task.py
@@ -33,8 +33,9 @@ class Task(UserOwnedMixin, Base):
     cancelled_by: Mapped[str | None] = mapped_column(String)
     provider_id: Mapped[str | None] = mapped_column(String)
     provider_job_id: Mapped[str | None] = mapped_column(String)
-    # 自定义供应商提交该 job 时模型行的 endpoint（内置供应商无 endpoint 维度，恒 NULL）。
-    # 与 provider_job_id 同一次写入落地：续跑据此判定协议是否已被换掉。
+    # 提交该 job 时实际使用的执行端点，与 provider_job_id 同一次写入落地：自定义供应商记模型行
+    # 的 endpoint 标识（续跑据此判定协议是否已被换掉），提交域名随用户配置变化的内置供应商记实际
+    # 请求域名（续跑据此回放原域名轮询）。两类取值各由对应续跑分支消费，互不比对。
     provider_endpoint: Mapped[str | None] = mapped_column(String)
     queued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/lib/db/models/task.py
+++ b/lib/db/models/task.py
@@ -35,7 +35,8 @@ class Task(UserOwnedMixin, Base):
     provider_job_id: Mapped[str | None] = mapped_column(String)
     # 提交该 job 时实际使用的执行端点，与 provider_job_id 同一次写入落地：自定义供应商记模型行
     # 的 endpoint 标识（续跑据此判定协议是否已被换掉），提交域名随用户配置变化的内置供应商记实际
-    # 请求域名（续跑据此回放原域名轮询）。两类取值各由对应续跑分支消费，互不比对。
+    # 请求域名（续跑据此回放原域名轮询）。常态下两类取值各由对应续跑分支消费；内置供应商提交
+    # 后在途改成自定义供应商时，比对闸会拿落库的域名与当下 endpoint 标识比较并拒绝接续。
     provider_endpoint: Mapped[str | None] = mapped_column(String)
     queued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -121,7 +121,7 @@ def _task_to_dict(row: Task) -> dict[str, Any]:
 class TaskRepository(BaseRepository):
     def __init__(self, session: AsyncSession):
         super().__init__(session)
-        # 本次会话内落地的任务终态，供上层（GenerationQueue）在事务提交后发布项目事件。
+        # 该 session 内落地的任务终态，供上层（GenerationQueue）在事务提交后发布项目事件。
         # 在此收集而非各终态方法各自记账：所有终态迁移（含级联失败/级联取消、批量取消
         # 队列）都经 _record_terminal_event 收口，一处挂钩即全覆盖。
         self.terminal_events: list[dict[str, Any]] = []
@@ -763,8 +763,8 @@ class TaskRepository(BaseRepository):
 
         参考视频执行层按 model 能力取档后申请的秒数可能偏离入队时的剧本原值；
         resume 路径读的正是这个字段（见 ``server.services.resume_executor``），
-        不写回会让 resume 时按剧本原值重新申请，与本次执行实际申请的秒数不一致。
-        task 不存在时静默跳过（不影响本次生成结果，仅是 resume 元数据，不必 fail-fast
+        不写回会让 resume 时按剧本原值重新申请，与该任务执行时实际申请的秒数不一致。
+        task 不存在时静默跳过（不影响该任务的生成结果，仅是 resume 元数据，不必 fail-fast
         阻断执行）。
         """
         await self._merge_payload_field(task_id, "duration_seconds", duration_seconds, raise_if_missing=False)

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -704,9 +704,10 @@ class TaskRepository(BaseRepository):
     async def persist_provider_job_id(self, task_id: str, job_id: str, *, endpoint: str | None = None) -> None:
         """单独事务持久化 provider_job_id；不带 WHERE 状态守卫（worker 内调用，确定是 running）。
 
-        ``endpoint`` 是自定义供应商提交本 job 时模型行的 endpoint（内置供应商传 None）。与
-        job_id 同一次 UPDATE 落地：两者必须同时可见，否则续跑会拿到 job_id 却判不出协议是否
-        已被换掉。None 时不写该列——保留既有值比清空更安全（清空等于放弃比对）。
+        ``endpoint`` 是提交本 job 时实际使用的执行端点，按供应商类型有两种取值：自定义供应商
+        传模型行的 endpoint 标识，提交域名随用户配置变化的内置供应商传实际请求域名。与 job_id
+        同一次 UPDATE 落地：两者必须同时可见，否则续跑会拿到 job_id 却判不出协议是否已被换掉、
+        也无从回放原域名。None 时不写该列——保留既有值比清空更安全（清空等于放弃比对）。
 
         失败抛异常，由 worker finally 兜底 mark_failed（ADR 0007 fail-fast：未持久化的
         submit 视为整笔失败，避免「幽灵任务」继续在 provider 端跑而 DB 已忘）。

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -778,7 +778,7 @@ class MediaGenerator:
           / resume_failed 按 call_id 精准翻 pending → success/failed；不透传则 logger.warning 不阻断。
         - resume 成功后总是 add_version 记录新版本：无论 versions.json 是否已有历史版本，
           backend.resume_video 都会下载新视频并覆盖 output_path，必须 bump 一个新版本号
-          让 versions.json 与磁盘文件一致；否则会漏记本次重新生成的视频，回滚记录失真。
+          让 versions.json 与磁盘文件一致；否则会漏记该次 resume 产出的视频，回滚记录失真。
         - prompt / start_image / reference_images 仅用于日志/版本元数据，不影响 provider 端结果。
         - ``submitted_base_url`` 是具名参数而非 version_metadata：它是提交时域名的回放值、
           只喂给 backend 轮询，落进版本元数据会污染 versions.json。

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -767,6 +767,7 @@ class MediaGenerator:
         resolution: str | None = None,
         task_id: str | None = None,
         api_call_id: int | None = None,
+        submitted_base_url: str | None = None,
         **version_metadata,
     ) -> tuple[Path, int, Any, str | None]:
         """接续 provider 上已发起的 video job：调 backend.resume_video 而非 generate。
@@ -779,6 +780,8 @@ class MediaGenerator:
           backend.resume_video 都会下载新视频并覆盖 output_path，必须 bump 一个新版本号
           让 versions.json 与磁盘文件一致；否则会漏记本次重新生成的视频，回滚记录失真。
         - prompt / start_image / reference_images 仅用于日志/版本元数据，不影响 provider 端结果。
+        - ``submitted_base_url`` 是具名参数而非 version_metadata：它是提交时域名的回放值、
+          只喂给 backend 轮询，落进版本元数据会污染 versions.json。
 
         Returns: (output_path, version_number, video_ref, video_uri) 四元组。
         """
@@ -818,6 +821,7 @@ class MediaGenerator:
             task_id=task_id,
             service_tier=version_metadata.get("service_tier", "default"),
             seed=version_metadata.get("seed"),
+            submitted_base_url=submitted_base_url,
         )
 
         try:

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -387,7 +387,7 @@ async def download_video(url: str, output_path: Path, *, timeout: int = 120) -> 
                 await resp.aread()
             resp.raise_for_status()
             # 异步流式读取所有 chunk，然后一次 to_thread 完成整段写入，
-            # 避免对每个 64KB 分片调度一次线程池任务（评审反馈 #279）。
+            # 避免对每个 64KB 分片调度一次线程池任务。
             chunks: list[bytes] = []
             async for chunk in resp.aiter_bytes(chunk_size=65536):
                 chunks.append(chunk)

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -49,7 +49,7 @@ async def _persist_with_retry(task_id: str, job_id: str, endpoint: str | None) -
 async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str, endpoint: str | None = None) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    Caller 显式传 task_id；``endpoint`` 记本次提交实际使用的执行端点，与 job_id 同一次写入
+    Caller 显式传 task_id；``endpoint`` 记提交该 job 实际使用的执行端点，与 job_id 同一次写入
     落地供续跑消费，按供应商类型有两种取值：自定义供应商记 endpoint 标识（协议维度，续跑据
     此判定协议是否已被换掉），内置供应商记实际请求域名（连接维度，续跑据此回放原域名轮询）。
     DB 瞬态错误最多重试 3 次，业务异常立即抛。重试用尽抛异常，由 worker finally 兜底
@@ -92,7 +92,7 @@ class ProviderJobIdPersistenceMixin:
     ) -> None:
         """submit 成功后立即调：worker 路径写回 job_id，非 worker 路径（task_id=None）跳过。
 
-        同时写回本次执行所用的端点：``request.execution_endpoint`` 优先——自定义供应商的包装层
+        同时写回该 job 执行所用的端点：``request.execution_endpoint`` 优先——自定义供应商的包装层
         在转发前注入 endpoint 标识，该标识是续跑比对协议的依据，不能被下游 backend 的域名顶掉；
         它缺席（内置供应商路径）时落到 ``endpoint``，由提交域名随用户配置变化的 backend 传入实际
         请求域名，供续跑回放。持久化失败抛出（DB 瞬态错误已在 ``persist_provider_job_id`` 内重试

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -49,9 +49,11 @@ async def _persist_with_retry(task_id: str, job_id: str, endpoint: str | None) -
 async def persist_provider_job_id(task_id: str, job_id: str, *, provider: str, endpoint: str | None = None) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    Caller 显式传 task_id；``endpoint`` 仅自定义供应商有值（内置供应商无 endpoint 维度），
-    与 job_id 同一次写入落地，供续跑判定协议是否已被换掉。DB 瞬态错误最多重试 3 次，业务
-    异常立即抛。重试用尽抛异常，由 worker finally 兜底 mark_failed（fail-fast）。
+    Caller 显式传 task_id；``endpoint`` 记本次提交实际使用的执行端点，与 job_id 同一次写入
+    落地供续跑消费，按供应商类型有两种取值：自定义供应商记 endpoint 标识（协议维度，续跑据
+    此判定协议是否已被换掉），内置供应商记实际请求域名（连接维度，续跑据此回放原域名轮询）。
+    DB 瞬态错误最多重试 3 次，业务异常立即抛。重试用尽抛异常，由 worker finally 兜底
+    mark_failed（fail-fast）。
     """
     try:
         await _persist_with_retry(task_id, job_id, endpoint)
@@ -80,16 +82,30 @@ class ProviderJobIdPersistenceMixin:
     （``gemini``）不同，自动取 name 会改写持久化日志的 provider 字段。
     """
 
-    async def _persist_provider_job_id(self, request: VideoGenerationRequest, job_id: str, *, provider: str) -> None:
+    async def _persist_provider_job_id(
+        self,
+        request: VideoGenerationRequest,
+        job_id: str,
+        *,
+        provider: str,
+        endpoint: str | None = None,
+    ) -> None:
         """submit 成功后立即调：worker 路径写回 job_id，非 worker 路径（task_id=None）跳过。
 
-        同时写回 ``request.execution_endpoint``——自定义供应商的包装层在转发前注入本次执行所用
-        的 endpoint，内置供应商恒 None。持久化失败抛出（DB 瞬态错误已在 ``persist_provider_job_id``
-        内重试 3 次），由 worker finally 兜底 mark_failed —— 保持现有 fail-fast 语义（ADR 0007）。
+        同时写回本次执行所用的端点：``request.execution_endpoint`` 优先——自定义供应商的包装层
+        在转发前注入 endpoint 标识，该标识是续跑比对协议的依据，不能被下游 backend 的域名顶掉；
+        它缺席（内置供应商路径）时落到 ``endpoint``，由提交域名随用户配置变化的 backend 传入实际
+        请求域名，供续跑回放。持久化失败抛出（DB 瞬态错误已在 ``persist_provider_job_id`` 内重试
+        3 次），由 worker finally 兜底 mark_failed —— 保持现有 fail-fast 语义（ADR 0007）。
         """
         if request.task_id is None:
             return
-        await persist_provider_job_id(request.task_id, job_id, provider=provider, endpoint=request.execution_endpoint)
+        await persist_provider_job_id(
+            request.task_id,
+            job_id,
+            provider=provider,
+            endpoint=request.execution_endpoint or endpoint,
+        )
 
 
 @with_retry_async(
@@ -508,6 +524,11 @@ class VideoGenerationRequest:
     # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的 endpoint，
     # 与 job_id 一并持久化供续跑比对。内置供应商无 endpoint 维度，保持 None。
     execution_endpoint: str | None = None
+
+    # 续跑路径专用：提交本 job 时实际使用的请求域名，由 resume_executor 从持久化列回放。
+    # backend 轮询时优先用它而非当下配置解析出的域名——域名是连接维度而非协议维度，
+    # 用户在途改配置后按新域名轮旧 job 会查无（404）而被误判成过期。提交路径恒 None。
+    submitted_base_url: str | None = None
 
     # Seedance 特有
     service_tier: str = "default"

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -254,7 +254,11 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         async with httpx.AsyncClient(timeout=self._http_timeout) as client:
             task_id = await self._create_task(client, payload)
             logger.info("DashScope 视频任务已创建: task_id=%s model=%s", task_id, self._model)
-            await self._persist_provider_job_id(request, task_id, provider=PROVIDER_DASHSCOPE)
+            # 一并写回实际提交域名（wan3.0 走独立 maas 域名，且两者都随用户配置可变）：
+            # 续跑据此回放原域名，不然改配置后轮询会打到查不到该任务的主机。
+            await self._persist_provider_job_id(
+                request, task_id, provider=PROVIDER_DASHSCOPE, endpoint=self._request_base_url
+            )
             return await self._poll_and_build(client, task_id, request, is_resume=False)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
@@ -475,9 +479,9 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         )
         return extract_task_id(resp.json())
 
-    async def _poll_once(self, client: httpx.AsyncClient, task_id: str) -> dict:
+    async def _poll_once(self, client: httpx.AsyncClient, task_id: str, base_url: str) -> dict:
         resp = await client.get(
-            f"{self._request_base_url}/tasks/{task_id}",
+            f"{base_url}/tasks/{task_id}",
             headers=dashscope_headers(self._api_key),
         )
         resp.raise_for_status()
@@ -491,12 +495,16 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
         *,
         is_resume: bool,
     ) -> VideoGenerationResult:
+        # 续跑轮询回放提交时的域名：任务 id 只在创建它的 endpoint 上可查，用户在途改 base_url
+        # 后按当下配置解析出的新域名去轮旧任务会 404，被下方的 404 分支误判成过期。
+        base_url = request.submitted_base_url or self._request_base_url
+
         # resume 路径下 GET 返回 404（task 完全不存在）直接转 ResumeExpiredError，
         # 不走 poll_with_retry 重试。task_id 24h 过期表现为 200 + task_status=UNKNOWN，
         # 由下方 is_dashscope_expired 兜底（终态返回后判定）。
         async def _gated_poll() -> dict:
             try:
-                return await self._poll_once(client, task_id)
+                return await self._poll_once(client, task_id, base_url)
             except httpx.HTTPStatusError as exc:
                 if is_resume and exc.response.status_code == 404:
                     raise ResumeExpiredError(job_id=task_id, provider=PROVIDER_DASHSCOPE) from exc

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -438,7 +438,7 @@ class DashScopeVideoBackend(ProviderJobIdPersistenceMixin):
             valid = len(audio_files) <= len(reference_items)
         if not valid:
             # 与 gate 的 video_reference_audio_exceeded 分成两个 code：那条的 limit 是模型的
-            # 能力上限（减角色数就能过），这条的上限是本次请求实际有几个可挂载的参考素材
+            # 能力上限（减角色数就能过），这条的上限是该请求实际有几个可挂载的参考素材
             # （加参考图也能过）。共用一个 code 会让文案给出与实际卡点不符的处置建议。
             raise VideoCapabilityError(
                 "video_reference_audio_slots_insufficient",

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -61,7 +61,7 @@ def _submitted_base_url(task: dict[str, Any], current_endpoint: str | None) -> s
     if current_endpoint:
         return None
     submitted = task.get("provider_endpoint")
-    if isinstance(submitted, str) and submitted.startswith(("http://", "https://")):
+    if isinstance(submitted, str) and submitted.lower().startswith(("http://", "https://")):
         return submitted
     return None
 

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -34,7 +34,8 @@ def _ensure_endpoint_unchanged(task: dict[str, Any], current_endpoint: str | Non
     新协议 backend 拿到旧协议下创建的 job id：轻则报错指向新协议、用户无法归因，重则轮询
     响应被误读、任务被标失败而远端 job 仍在跑仍在计费。
 
-    两侧任一为空即跳过：内置供应商无 endpoint 维度，本列未持久化的存量任务同样无从比对，
+    两侧任一为空即跳过：内置供应商无 endpoint 维度（其持久化值是请求域名，走
+    ``_submitted_base_url`` 那条消费分支），本列未持久化的存量任务同样无从比对，
     行为与现状一致。
     """
     submitted_endpoint = task.get("provider_endpoint")
@@ -46,6 +47,22 @@ def _ensure_endpoint_unchanged(task: dict[str, Any], current_endpoint: str | Non
         submitted_endpoint=str(submitted_endpoint),
         current_endpoint=current_endpoint,
     )
+
+
+def _submitted_base_url(task: dict[str, Any], current_endpoint: str | None) -> str | None:
+    """内置供应商提交本 job 时的请求域名，供 backend 回放轮询；无从判定时 None。
+
+    ``provider_endpoint`` 一列按供应商类型承载两种取值，此处只取内置那种：``current_endpoint``
+    非空即当下是自定义供应商，其持久化值是 endpoint 标识、归比对闸消费。域名形态再确认一次，
+    是为了拦住「任务由自定义供应商提交、在途把模型行改成内置供应商」这类跨类切换——此时列里
+    躺着的是 endpoint 标识，拿它拼 URL 只会把 404（可归因为任务过期）换成更难归因的连接错误。
+    """
+    if current_endpoint is not None:
+        return None
+    submitted = task.get("provider_endpoint")
+    if isinstance(submitted, str) and submitted.startswith(("http://", "https://")):
+        return submitted
+    return None
 
 
 async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dict[str, Any]:
@@ -138,6 +155,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
             resolution=resolution,
             task_id=task_id,
             api_call_id=api_call_id,
+            submitted_base_url=_submitted_base_url(task, ctx.video.endpoint),
             seed=seed,
             service_tier=service_tier,
             **optional_kwargs,

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -53,11 +53,12 @@ def _submitted_base_url(task: dict[str, Any], current_endpoint: str | None) -> s
     """内置供应商提交本 job 时的请求域名，供 backend 回放轮询；无从判定时 None。
 
     ``provider_endpoint`` 一列按供应商类型承载两种取值，此处只取内置那种：``current_endpoint``
-    非空即当下是自定义供应商，其持久化值是 endpoint 标识、归比对闸消费。域名形态再确认一次，
-    是为了拦住「任务由自定义供应商提交、在途把模型行改成内置供应商」这类跨类切换——此时列里
-    躺着的是 endpoint 标识，拿它拼 URL 只会把 404（可归因为任务过期）换成更难归因的连接错误。
+    非空即当下是自定义供应商，其持久化值是 endpoint 标识、归比对闸消费。空值口径与
+    ``_ensure_endpoint_unchanged`` 一致取 falsy，否则空串会让两条分支都不生效。域名形态再确认
+    一次，是为了拦住「任务由自定义供应商提交、在途把模型行改成内置供应商」这类跨类切换——此时
+    列里躺着的是 endpoint 标识，拿它拼 URL 只会把 404（可归因为任务过期）换成更难归因的连接错误。
     """
-    if current_endpoint is not None:
+    if current_endpoint:
         return None
     submitted = task.get("provider_endpoint")
     if isinstance(submitted, str) and submitted.startswith(("http://", "https://")):

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -1014,7 +1014,7 @@ class TestWan3:
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
         assert await b._create_task(client, {}) == "t-wan3"
-        await b._poll_once(client, "t-wan3")
+        await b._poll_once(client, "t-wan3", b._request_base_url)
         from lib.video_backends.dashscope import _VIDEO_ENDPOINT
 
         assert post.await_args.args[0] == f"https://maas-cn-hangzhou.example.com/ws-123/api/v1{_VIDEO_ENDPOINT}"
@@ -1032,3 +1032,42 @@ class TestWan3:
 
         b = DashScopeVideoBackend(api_key="sk", model="wan2.7-i2v", wan3_base_url="https://maas.example.com/api/v1")
         assert b._request_base_url == b._base_url
+
+    @pytest.mark.unit
+    async def test_submit_persists_actual_base_url(self, tmp_path: Path):
+        """提交时把实际使用的域名与 job_id 一并落库——续跑要靠它回放。"""
+        post = AsyncMock(return_value=_resp(_submit("t-wan3")))
+        get = AsyncMock(return_value=_resp(_succeeded()))
+        client = _client(post=post, get=get)
+        persist = AsyncMock()
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3, patch("lib.video_backends.base.persist_provider_job_id", persist):
+            b = self._backend(wan3_base_url="https://maas-a.example.com/ws-1/api/v1")
+            await b.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", resolution="720p", task_id="db-task-1"
+                )
+            )
+
+        assert persist.call_args.kwargs["endpoint"] == "https://maas-a.example.com/ws-1/api/v1"
+
+    @pytest.mark.unit
+    async def test_resume_polls_submitted_base_url_after_config_change(self, tmp_path: Path):
+        """在途改 wan3_base_url 后续跑：轮询仍打提交时的域名，而非当下配置解析出的域名。"""
+        get = AsyncMock(return_value=_resp(_succeeded()))
+        client = _client(post=AsyncMock(), get=get)
+        p1, p2, p3 = _patches(client, AsyncMock())
+        with p1, p2, p3:
+            # 配置已被改成 B，提交时用的是 A
+            b = self._backend(wan3_base_url="https://maas-b.example.com/ws-2/api/v1")
+            await b.resume_video(
+                "t-wan3",
+                VideoGenerationRequest(
+                    prompt="p",
+                    output_path=tmp_path / "o.mp4",
+                    resolution="720p",
+                    submitted_base_url="https://maas-a.example.com/ws-1/api/v1",
+                ),
+            )
+
+        assert get.await_args.args[0] == "https://maas-a.example.com/ws-1/api/v1/tasks/t-wan3"

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -553,3 +553,26 @@ async def test_resume_passes_billed_duration_to_finalize(tmp_path):
     assert len(gen.ledger.resumed) == 1
     call = gen.ledger.resumed[0]
     assert call["result"].duration_seconds == 15, "backend 结果对象必须递交，实际计费时长由 ledger 分发透传"
+
+
+@pytest.mark.asyncio
+async def test_resume_forwards_submitted_base_url_to_request(tmp_path):
+    """提交时的域名装进递交 backend 的 request，且不落进版本元数据。
+
+    它是喂给 backend 轮询的回放值，混进 versions.json 会把一个连接参数写成版本属性。
+    """
+    gen = _build_generator(tmp_path)
+    backend = gen._video_backend
+
+    await gen.resume_video_async(
+        job_id="provider-job-1",
+        resource_type="videos",
+        resource_id="E1S01",
+        task_id="T-1",
+        api_call_id=42,
+        submitted_base_url="https://maas-a.example.com/ws-1/api/v1",
+    )
+
+    _, request = backend.calls[0]
+    assert request.submitted_base_url == "https://maas-a.example.com/ws-1/api/v1"
+    assert all("submitted_base_url" not in kwargs for kwargs in gen.versions.add_calls)

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -390,3 +390,51 @@ async def test_resume_proceeds_for_builtin_provider_without_endpoint(monkeypatch
     await execute_resume_video_task(video_task, job_id="openai-job-1")
 
     assert len(fake_gen.resume_calls) == 1
+
+
+# ── 提交域名回放 ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_submitted_base_url_for_builtin(monkeypatch, fake_pm, video_task):
+    """内置供应商：持久化的提交域名透传给 backend，改配置后续跑仍轮原主机。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
+
+    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "https://maas-a.example.com/ws-1/api/v1"}
+    await execute_resume_video_task(task, job_id="dashscope-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] == "https://maas-a.example.com/ws-1/api/v1"
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_replay_endpoint_id_for_custom(monkeypatch, fake_pm, video_task):
+    """自定义供应商：列里是 endpoint 标识、归比对闸消费，不当域名回放。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="openai-video")
+
+    task = {**video_task, "provider_id": "custom-7", "provider_endpoint": "openai-video"}
+    await execute_resume_video_task(task, job_id="custom-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_resume_ignores_endpoint_id_left_by_provider_switch(monkeypatch, fake_pm, video_task):
+    """任务由自定义供应商提交、模型行在途被改成内置供应商：列里的标识不当域名用。
+
+    拿 endpoint 标识拼 URL 只会把可归因的 404 换成更难归因的连接错误。
+    """
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
+
+    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "openai-video"}
+    await execute_resume_video_task(task, job_id="dashscope-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] is None

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -410,6 +410,20 @@ async def test_resume_replays_submitted_base_url_for_builtin(monkeypatch, fake_p
 
 
 @pytest.mark.asyncio
+async def test_resume_replays_submitted_base_url_with_uppercase_scheme(monkeypatch, fake_pm, video_task):
+    """域名形态判别不区分 scheme 大小写：用户填的 base_url 原样落库，大写 scheme 同样是域名。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
+
+    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "HTTPS://maas-a.example.com/ws-1/api/v1"}
+    await execute_resume_video_task(task, job_id="dashscope-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] == "HTTPS://maas-a.example.com/ws-1/api/v1"
+
+
+@pytest.mark.asyncio
 async def test_resume_does_not_replay_endpoint_id_for_custom(monkeypatch, fake_pm, video_task):
     """自定义供应商：列里是 endpoint 标识、归比对闸消费，不当域名回放。"""
     from server.services.resume_executor import execute_resume_video_task

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -438,3 +438,23 @@ async def test_resume_ignores_endpoint_id_left_by_provider_switch(monkeypatch, f
     await execute_resume_video_task(task, job_id="dashscope-job-1")
 
     assert fake_gen.resume_calls[0]["submitted_base_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_resume_fails_when_builtin_task_switched_to_custom_provider(monkeypatch, fake_pm, video_task):
+    """任务由内置供应商提交（列里是域名）、模型行在途被改成自定义供应商：比对闸拦下。
+
+    域名与 endpoint 标识必然不等，闸门据此判定协议已被换掉。内置任务的该列有值后这条路径
+    才可达，语义上也确实换了协议——宁可显式失败，也不拿新协议 backend 轮旧 job。
+    """
+    from lib.video_backends.base import ResumeEndpointChangedError
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="dashscope-async-video")
+
+    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "https://maas-a.example.com/ws-1/api/v1"}
+    with pytest.raises(ResumeEndpointChangedError):
+        await execute_resume_video_task(task, job_id="dashscope-job-1")
+
+    assert fake_gen.resume_calls == []

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -581,6 +581,34 @@ class TestProviderJobIdPersistenceMixin:
             await self._backend()._persist_provider_job_id(request, "job-1", provider="ark")
         persist.assert_awaited_once_with("local-task-1", "job-1", provider="ark", endpoint="openai-video")
 
+    async def test_worker_path_persists_backend_endpoint_when_builtin(self):
+        """内置供应商由 backend 传入实际请求域名 → 落库供续跑回放。"""
+        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+            await self._backend()._persist_provider_job_id(
+                self._request(task_id="local-task-1"),
+                "job-1",
+                provider="dashscope",
+                endpoint="https://maas.example.com/api/v1",
+            )
+        persist.assert_awaited_once_with(
+            "local-task-1", "job-1", provider="dashscope", endpoint="https://maas.example.com/api/v1"
+        )
+
+    async def test_execution_endpoint_wins_over_backend_endpoint(self):
+        """自定义供应商注入的 endpoint 标识优先于下游 backend 的域名。
+
+        列里躺着标识才能让续跑比对协议是否被换掉；被下游域名顶掉会让比对闸永远比不出差异。
+        """
+        request = self._request(task_id="local-task-1")
+        request.execution_endpoint = "dashscope-async-video"
+        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+            await self._backend()._persist_provider_job_id(
+                request, "job-1", provider="dashscope", endpoint="https://maas.example.com/api/v1"
+            )
+        persist.assert_awaited_once_with(
+            "local-task-1", "job-1", provider="dashscope", endpoint="dashscope-async-video"
+        )
+
     async def test_non_worker_path_skips_persist(self):
         """非 worker 路径（grid / 直生 / 测试，task_id=None）跳过持久化，不触碰 DB。"""
         with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:


### PR DESCRIPTION
Closes #1770

## 问题

百炼（含万相 3.0）的提交域名随用户配置变化，但提交时只把 job_id 落库、没记下当时实际用的域名。用户在任务进行中改了域名配置再触发续跑，轮询会按新配置打到另一台主机，查不到该任务而失败——远端任务其实仍在跑。

## 改动

提交时把实际使用的域名与 job_id 一并写进 `tasks.provider_endpoint`，续跑时回放该域名轮询。

`provider_endpoint` 这一列现在按供应商类型承载两种取值：自定义供应商记模型行的 endpoint 标识（续跑据此判定协议是否被换掉），提交域名随配置变化的内置供应商记实际请求域名（续跑据此回放）。两类取值各由对应的续跑分支消费，互不比对；持久化优先级固定为「自定义注入的标识赢」，保证既有的协议比对闸不被下游域名顶掉。

回放值走 `resume_video_async` 的具名参数而非版本元数据，避免一个连接参数被写成版本属性落进 versions.json。

自定义供应商的端点记录与换端点续跑显式报错的行为不变，既有测试一行未改。

顺带的行为变化：内置供应商的任务在途被改到自定义供应商时，协议比对闸现在会显式失败而不是放行——该列对内置任务有值后这条路径才可达，语义上确实换了协议，宁可 fail loud 也不拿新协议 backend 轮旧 job。已补测试锁定。

## 验证

- 全量质量门通过：`ruff check` / `ruff format --check` / `basedpyright` 0 error / `lint-imports` 契约 KEPT / `pytest` 8409 passed, 1 skipped
- 回归测试覆盖三层：backend 层断言改配置后续跑的实际轮询 URL 仍是提交时的域名；`resume_video_async` 层断言回放值装进 request 且不落进版本元数据；executor 层断言按供应商类型正确取舍回放值（含自定义→内置、内置→自定义两条跨类切换）
- 存量任务该列为 NULL，续跑仍按当下配置解析域名，行为与改动前一致

## 已知范围裁剪

- 只接线 dashscope。同类暴露面（ark / openai / kling / minimax / agnes / gemini-aistudio / newapi / v2_video_generations 等 `base_url` 可配且支持续跑的内置供应商）seam 已通用，各自只需在提交处传入实际域名、轮询处取回放值，留作 follow-up；vidu 未继承该 mixin，需单独确认
- 自定义供应商委托 dashscope 协议时，落库的是 endpoint 标识而非域名，故其改 base_url 后续跑的同根因问题仍在——这是「自定义供应商行为不变」这条约束下的取舍

https://claude.ai/code/session_01SiGE4gFBFeGBEsbn9wW9dR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 视频任务续跑时优先使用提交时保存的请求域名，配置变更后仍可向正确地址轮询。
  * 完善端点记录，区分自定义供应商端点标识与内置供应商实际请求域名。
  * 增强供应商切换时的续跑校验，避免使用不匹配的端点恢复任务。

* **测试**
  * 新增端点持久化、域名回放及配置变更后任务续跑的覆盖测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->