### PR TITLE
chore(skills): optimize unattended review loops

### DIFF
--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -25,13 +25,13 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 
 1. 依赖顺序按 batch-poll 的 `blocked_by` / `ready_to_start` 排；并发槽位优先给改动域互不相交的 issue，同域或足迹重叠者靠依赖序或补位串行——冲突事前避而非事后解；`stage_hint` 已起的 issue 在计划中标明现状与接力起点（按第三步阶段表的交付物反推），随计划一并交用户确认
 2. 分流：`ready-for-agent` 进批次；`ready-for-human` 跳过——它与下游被阻塞链都不启动；已被他人 assign 的 issue 视为已认领，同样跳过（batch-poll 不含 assignee，用 `gh issue view <N> --json assignees` 核对）；无标签的读正文判断归类（batch-poll 的 `ready_to_start` 只算依赖与未起，triage 由你定）
-3. 向用户展示批次计划：成员清单、依赖顺序、每个 issue 的实现路线与模型（**各附一句选择理由**，见第三步「实现路线与模型」）、跳过项及连带不启动的下游、并发上限（默认 3，用户可覆盖）
+3. 向用户展示批次计划：成员清单、依赖顺序、每个 issue 的实现路线与模型（**各附一句选择理由**，见第三步「实现路线与模型」）、跳过项及连带不启动的下游、实现 / 本地审查并发上限（默认 3）与 AI 审查循环软上限（默认 6）；两者均可由用户覆盖
 4. **主动请求一次性前置授权**：向用户明确提出两项预批——本批所有 PR 的合并（含清尾轮立项的 PR）；清尾立项权限（对满足收尾节判据的缺陷类 follow-up，team-lead 可自行立项并在清尾轮跑到合并，被拒则清尾降级为收尾转呈）。连同流程将自动执行的动作边界（修改 triage 标签、PR 转 draft、在 Spec 发 QA 验收 comment；清尾授权之外不创建新 issue，gap 立项仍须用户中途指令）。这是本流程唯一的同步确认点；前置授权在此落入 team-lead 的 transcript，后续不再逐笔请示
 5. 用户确认后建账本（首条 append，记录计划裁决与所得授权，见「账本」），进入无人值守执行，不再中途请示
 
 ## 第三步：组建团队，按依赖调度
 
-TeamCreate 建团队。并发上限指同时进行的 issue 数（处于任一阶段都算）：并发越高，每次合并引发的重审与并发请示越多。
+TeamCreate 建团队。并发上限只计算同时处于**实现 / 本地审查**阶段的 issue；进入 AI 审查循环即释放该槽位。AI 审查循环另设软上限 6，team-lead 可在批次计划中覆盖。
 
 issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assign 给自己（`gh issue edit <N> --add-assignee @me`）。worktree 一律从最新 main 创建，不做跨分支依赖；blocker 被搁置时下游不启动，归入收尾清单。
 
@@ -89,8 +89,6 @@ teammate 的一切暂停请示先到你这里。分四类处置：
 批次执行期间保持 ScheduleWakeup 定时唤醒（约 30 分钟一次）。每次唤醒跑一遍 batch-poll 取全批次远端快照（各 issue `stage_hint`、PR `updatedAt` / `mergeable`、`conflicting` / `merge_candidate`），结合 teammate 的 task 状态与最近一次汇报判断进展——batch-poll 不判定 teammate 存活状态。长时间无进展且无合理等待理由（等待 reviewer 响应属合理）→ SendMessage 询问；无回应则判定该 teammate 已失效，按 spawn-prompts.md 的替补附言 spawn 替补接管。
 
 codex 实现任务的进展改用 companion `status`（`--cwd` 指向对应 worktree）判定：长时间无进展 → `cancel` 后重发 task 作替补——现场可信用 `--resume-last` 接续，不可信则删 worktree 重建后 fresh 重跑。
-
-teammate 的 idle 通知不是事件：常规 idle（无伴随请示或交付消息）一律不动作、不输出、不为此提前跑 batch-poll——looper 的 idle 是轮询循环的常态，实现与本地审查阶段的失效也只在定时健康检查中判定（idle 通知与交付消息可能乱序，即时反应易误判）。
 
 ## 账本
 

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -8,7 +8,7 @@
 
 先用 EnterWorktree 的 `path` 接管该 worktree——修复要在此工作树 push；`gh issue view <N> --comments` 读验收标准，它是本轮循环中所有修复的范围边界，三家 reviewer 只看 diff、读不到这份标准；读 handoff 的「实现」段（环境备案）与「本地审查」段（跳过项及理由，作为 pushback 依据）；若为替补接管，另读已追加的「审查循环」段以继承前任的 pushback 与故障记录，避免重复处理已驳回意见。随后按下列纪律驱动循环：
 
-1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行；每轮 poll 与决策后用 `Monitor` 运行该 skill 的 `scripts/wait.sh` 主动等待，命令返回后继续下一轮。`ScheduleWakeup` 在 in-process teammate 上不可用；不得结束回合被动等待探活
+1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行；每轮 poll 与决策后用 `Monitor` 运行该 skill 的 `scripts/wait.sh` 主动等待，命令返回后继续下一轮；不得结束回合被动等待探活
 2. **请示重定向**：其中"暂停询问用户"的场景一律改为 SendMessage 请示 team-lead，按裁决继续；等待裁决期间保持唤醒监控 PR 动态
 3. **范围边界**：修复以验收标准为界。reviewer 的改进建议超出标准时，回复评论说明范围，并按 follow-up 候选记入 handoff，不修改代码
 4. **rebase**：只在三种时机做——随下次修复 push 顺带完成（push 后各家 reviewer 按 reviewers.md 的触发规则重审，合并也不要求分支 up-to-date，不为 main 前进单独 rebase）；每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动；CI 红且修复已合入 main 时，rebase 后 push 以获取修复（见 /pr-ai-review-loop 的「CI 红」行）

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -8,7 +8,7 @@
 
 先用 EnterWorktree 的 `path` 接管该 worktree——修复要在此工作树 push；`gh issue view <N> --comments` 读验收标准，它是本轮循环中所有修复的范围边界，三家 reviewer 只看 diff、读不到这份标准；读 handoff 的「实现」段（环境备案）与「本地审查」段（跳过项及理由，作为 pushback 依据）；若为替补接管，另读已追加的「审查循环」段以继承前任的 pushback 与故障记录，避免重复处理已驳回意见。随后按下列纪律驱动循环：
 
-1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行，每轮动作后安排下一次唤醒
+1. 用 Skill 工具调用 /pr-ai-review-loop，按其全部纪律执行；每轮 poll 与决策后用 `Monitor` 运行该 skill 的 `scripts/wait.sh` 主动等待，命令返回后继续下一轮。`ScheduleWakeup` 在 in-process teammate 上不可用；不得结束回合被动等待探活
 2. **请示重定向**：其中"暂停询问用户"的场景一律改为 SendMessage 请示 team-lead，按裁决继续；等待裁决期间保持唤醒监控 PR 动态
 3. **范围边界**：修复以验收标准为界。reviewer 的改进建议超出标准时，回复评论说明范围，并按 follow-up 候选记入 handoff，不修改代码
 4. **rebase**：只在三种时机做——随下次修复 push 顺带完成（push 后各家 reviewer 按 reviewers.md 的触发规则重审，合并也不要求分支 up-to-date，不为 main 前进单独 rebase）；每轮 poll 自检发现 CONFLICTING 时立即解冲突：rebase 到最新 main，按功能意图保留本 PR 的全部改动；CI 红且修复已合入 main 时，rebase 后 push 以获取修复（见 /pr-ai-review-loop 的「CI 红」行）

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -59,7 +59,7 @@ bash .agents/skills/pr-ai-review-loop/scripts/query.sh <PR_NUMBER> <子命令>
 
 脚本在 stderr 报 `WARNING: SINCE_SHA ... is not on PR`(典型成因 rebase 改写了全部 SHA)时锚点已失效,拿到的是全量提交而非最近一批,不得按该输出判形状——rebase 同时刷新了 `committedDate`,批次边界也无从重建。此时保守处置:不顺延,按 reviewers.md 的触发规则重审 Gemini,并把锚点重设为索引 `commits_since_pr_created` 末条 `oid` 供下轮使用。「收敛兜底」#2 用本脚本取证时同样适用该告警的处置。
 
-执行完触发动作后,按「轮询节奏」表选择延迟,调用 `ScheduleWakeup`。
+执行完触发动作后,按「轮询节奏」进入主动等待。
 
 ### 步骤 3:收集评论并实施修复
 
@@ -78,13 +78,13 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 ## 轮询节奏
 
-每轮 poll 与决策完成后,调用 `ScheduleWakeup` 安排下一次唤醒,唤醒 prompt 写明 skill 名与 PR 号;唤醒后按已加载的本文继续步骤 1,无需重新调用 Skill 工具。延迟取值:
+每轮 poll 与决策完成后,立即用 `Monitor` 运行 `bash .agents/skills/pr-ai-review-loop/scripts/wait.sh <PR_NUMBER> --max <延迟秒数>`,`timeout_ms` 设为比 `--max` 多 30 秒;命令返回后继续步骤 1。`ScheduleWakeup` 在 in-process teammate 上不可用。每轮都由 `wait.sh` 保持主动等待,不得结束回合被动等待外部探活。延迟取值:
 
 | 场景 | 延迟 | 备注 |
 |---|---|---|
 | 新 HEAD 后首次 poll | 360s | reviewer cold-start |
 | 其余等待(触发命令后、reviewer 响应中、仅剩 CodeQL 分析未完成) | 180s | |
-| 超过 30 分钟无响应 | 暂停并询问用户,不再 ScheduleWakeup | 见「故障处理」 |
+| 超过 30 分钟无响应 | 暂停并询问用户,不再等待 | 见「故障处理」 |
 
 ## 收敛兜底
 

--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -78,7 +78,7 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 ## 轮询节奏
 
-每轮 poll 与决策完成后,立即用 `Monitor` 运行 `bash .agents/skills/pr-ai-review-loop/scripts/wait.sh <PR_NUMBER> --max <延迟秒数>`,`timeout_ms` 设为比 `--max` 多 30 秒;命令返回后继续步骤 1。`ScheduleWakeup` 在 in-process teammate 上不可用。每轮都由 `wait.sh` 保持主动等待,不得结束回合被动等待外部探活。延迟取值:
+每轮 poll 与决策完成后,立即用 `Monitor` 运行 `bash .agents/skills/pr-ai-review-loop/scripts/wait.sh <PR_NUMBER> --max <延迟秒数>`,`timeout_ms` 设为比 `--max` 多 30 秒;命令返回后继续步骤 1。每轮都由 `wait.sh` 保持主动等待,不得结束回合被动等待外部探活。延迟取值:
 
 | 场景 | 延迟 | 备注 |
 |---|---|---|

--- a/.agents/skills/pr-ai-review-loop/references/reviewers.md
+++ b/.agents/skills/pr-ai-review-loop/references/reviewers.md
@@ -6,7 +6,7 @@
 
 - **本轮新评论**:索引中 `is_new == true` 的条目(inline 走 `inline_new_by_user`,评论走 `comments_new`)。口径与陷阱见 poll.sh PITFALL 2 与 6
 - **Acknowledgment 例外**:`is_ack == true` 的条目是 reviewer 对上一次修复或 inline 回复的确认,一律**不算** actionable;review state 为 `APPROVED` 也不算
-- **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
+- **flag 以正文为准**:索引 flags(`is_ack` / `cr_markers` / `has_pass_marker` / `has_outside_diff` / `has_body_finding` / `severity_alt`)是脚本解析结果,预览观感与 flag 冲突时用 `query.sh details` 取全文核实,以正文为准
 - **unacked 兜底假阳性**:终核 unacked 非空时逐条核对,对应修复已落地或回复为在案 pushback 的不算遗漏。快照不含非 bot 的 inline 回复,核对回复串用 `gh api --paginate repos/<owner>/<repo>/pulls/<pr>/comments` 按 `in_reply_to_id` 关联
 - **fix-up 顺延(仅 Gemini)**:Gemini 对上一已审 HEAD 已通过,且其后的 push 全为 fix-up 形状(nit、format、typo、单字段调整、小 bug 修复)时,沿用该通过结论参与目标判定,不触发重审;CodeRabbit 与 Codex 均以实际审过最终 HEAD 为目标状态。**「上一已审 HEAD」指 Gemini 最近一次实际审过的 commit,不是最近一次通过的 commit**——若最近审的 HEAD 未通过,或 `query.sh unacked gemini-code-assist[bot]` 仍有未解决评论,均不得顺延
 - **触发去重**:同一 HEAD 上每种触发命令只发一次。在 `own_trigger_comments` 中按 `command` 字段取该命令最大 `createdAt`,晚于 `last_push_at` 即视为本轮已触发,跳过(`@coderabbitai resume` 例外:以 CodeRabbit 节的 `updated_at` 口径为准)。发触发命令时只写命令本身,且命令必须在评论最开头(匹配细则见 poll.sh PITFALL 4)
@@ -28,9 +28,9 @@
 
 **已审当前 HEAD**:`walkthrough.reviewed_current_head == true`。CodeRabbit 限流时会把 walkthrough 改写成限流横幅,这次改写不算审查——poll 已按 `is_rate_limited` 排除,该场景下字段恒为 false。
 
-**actionable**:`walkthrough.is_ok == true` 或 `actionable_count == "0"` 时无 actionable;否则看 `inline_new_by_user["coderabbitai[bot]"]` 各行的 `cr_markers`:含 `potential_issue` / `major` / `refactor` / `verification` 任一即 actionable;仅含 nit 级 token(`nitpick` / `trivial` / `low_value` / `minor`)不算。**残留例外**:增量重审回复 `Already reviewed` 时 `is_ok` / `actionable_count` 是上一轮残留——跳过这条短路,直接按本轮 inline 的 `cr_markers` 判。
+**actionable**:本轮新 `coderabbit.reviews` 任一行 `has_outside_diff == true` 即 actionable;用该行 `id` 经 `query.sh details` 取正文。无此形状时,`walkthrough.is_ok == true` 或 `actionable_count == "0"` 表示无 actionable;否则看 `inline_new_by_user["coderabbitai[bot]"]` 各行的 `cr_markers`:含 `potential_issue` / `major` / `refactor` / `verification` 任一即 actionable;仅含 nit 级 token(`nitpick` / `trivial` / `low_value` / `minor`)不算。**残留例外**:增量重审回复 `Already reviewed` 时 `is_ok` / `actionable_count` 是上一轮残留——跳过这条短路,直接按本轮 review 的 `has_outside_diff` 与 inline 的 `cr_markers` 判。
 
-**通过**:前置条件——`reviewed_current_head == true` **且** `is_in_progress == false` **且** `is_paused == false`(paused 时 `is_ok` 等字段可能是上一轮残留,需先经触发规则 resume 后再判)。前置之上满足任一:
+**通过**:前置条件——`reviewed_current_head == true` **且** `is_in_progress == false` **且** `is_paused == false`(paused 时 `is_ok` 等字段可能是上一轮残留,需先经触发规则 resume 后再判)。前置之上先确认本轮新 review 均为 `has_outside_diff == false`,再满足任一:
 
 - `walkthrough.is_ok == true`
 - `actionable_count == "0"`
@@ -39,17 +39,17 @@
 
 增量重审回复 `Already reviewed` 时前两条不可用(上一轮残留),凭本轮 inline 的后两条判。
 
-**outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。索引只给出这条 review 的存在与 `is_new`、不含正文,`unacked coderabbitai[bot]` 兜底只扫 `inline_*_by_user`,同样看不见它——只靠 inline 口径会漏。发现靠 `query.sh <PR> history`(按 400 字 head 扫出该 review),全文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复只能走 PR 顶层评论,不能回 inline。
+**outside diff range 意见**:CodeRabbit 对 diff 之外代码的建议内嵌在 review body(`coderabbit.reviews` 一行,source `coderabbit_review`)里,没有独立 inline comment id。`poll.sh` 以 `has_outside_diff` 把该形状送入上述 actionable 判定,正文用 `query.sh <PR> details <该 review 的 id>` 取;因无 inline 锚点,回复走 PR 顶层评论。
 
 **配额**:本仓库使用 CodeRabbit 免费开源方案,限流以 `walkthrough.is_rate_limited == true` 或 `quota_alerts` 判读;受阻时等待自恢复并手动 `@coderabbitai review` 重试一次;仍失败则本 PR 停用该家,记入退出汇报。全程不询问用户,也不提议付费扩容。
 
 ## Gemini Code Assist
 
-**触发**(按 `pr_created_at` 与 `gemini.reviews` 判别,均受触发去重约束):
+**触发**(按 `pr_created_at` 与 `gemini.reviews` + `reviews_history.total` 判别,均受触发去重约束):
 
-- `gemini.reviews` 完全为空,`pr_created_at` 距今**不足 5 分钟** → cold-start 窗口内,等待——此时抢跑触发既耗 quota,也容易引入第一次未提及的边缘建议
-- `gemini.reviews` 完全为空,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 顺延限制**——否则 Gemini 永远不会审本 PR。阈值宽松不必精确——误发代价只是一次受去重约束的额外触发
-- `gemini.reviews` 非空但无 `reviewed_current_head == true` 条目 → 发送 `/gemini review`(受 fix-up 顺延限制)
+- `gemini.reviews` 为空且 `reviews_history.total == 0`,`pr_created_at` 距今**不足 5 分钟** → cold-start 窗口内,等待——此时抢跑触发既耗 quota,也容易引入第一次未提及的边缘建议
+- `gemini.reviews` 为空且 `reviews_history.total == 0`,`pr_created_at` 距今**已超 5 分钟** → cold-start fallback:自动 review 未在窗口内出现(可能失败或被跳过),发送 `/gemini review`。**此行不受 fix-up 顺延限制**——否则 Gemini 永远不会审本 PR。阈值宽松不必精确——误发代价只是一次受去重约束的额外触发
+- 已有 review(`gemini.reviews` 非空或 `reviews_history.total > 0`)但无 `reviewed_current_head == true` 条目 → 发送 `/gemini review`(受 fix-up 顺延限制)
 
 **已审当前 HEAD**:`gemini.reviews` 至少一条 `reviewed_current_head == true`。
 
@@ -71,7 +71,7 @@
 
 **触发**(受通用触发去重约束):
 
-- `codex.has_started == true`,或已有 review / `+1` / inline → 等待
+- `codex.has_started == true`,或已有 review(`codex.reviews` 非空或 `reviews_history.total > 0`) / `+1` / inline → 等待
 - 从无上述信号,`pr_created_at` 距今不足 5 分钟 → cold-start 窗口内等待
 - 从无上述信号,已超过 5 分钟,且本轮尚无 `@codex review` → 发送一次 `@codex review`
 - 已有 `@codex review` 但尚无结果 → 评论上的 Codex `👀` 会令 `codex.has_started == true`;未出现时同样等待,30 分钟后按故障处理
@@ -90,9 +90,9 @@ PR reaction 是当前审查状态:新 push 启动审查时,Codex 会把上一轮
 
 `poll.sh` 优先用 REST review 的 `commit_id` 判当前 HEAD,缺失时解析 body 的 `Reviewed commit`,再缺失才按 review 提交时间回退;顶层通过评论同样先解析 `Reviewed commit`,缺失时按评论创建时间回退。
 
-**actionable**:本轮非 ack inline 的 `P0 Badge` / `P1 Badge` 一律 actionable;兼容旧 payload 时,P2/P3 按 `receiving-code-review` 的纪律核实。判定为非 actionable 并记录 pushback 的 P2/P3 不再阻塞通过。
+**actionable**:本轮新 `codex.reviews` 任一行 `has_body_finding == true` 即进入处置,用该行 `id` 经 `query.sh details` 取正文;本轮非 ack inline 的 `P0 Badge` / `P1 Badge` 同样 actionable。两种投递面的 P2/P3 均按 `receiving-code-review` 的纪律核实;判定为非 actionable 并记录 pushback 后不再阻塞通过。
 
-**通过**:满足四种已审信号之一,且本轮无未解决的 actionable inline。
+**通过**:满足四种已审信号之一,且本轮无未解决的 actionable inline 或 review-body finding。
 
 ## GitHub code scanning bots(Code Quality + Advanced Security)
 

--- a/.agents/skills/pr-ai-review-loop/scripts/poll.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/poll.sh
@@ -24,6 +24,15 @@
 #   seen     — per-PR ledger of every comment/review id observed by any earlier poll, at
 #              <snapshot>.seen.json; backs the straggler half of is_new (see PITFALL 6).
 #
+# WHY THE INDEX/SNAPSHOT LAYERS EXIST
+#   The looper's context budget is a first-class limit, alongside wall-clock time. Repeatedly
+#   injecting review bodies causes attention drift; once the looper loses the thread, the
+#   whole review loop must be handed to a fresh agent. Preserve these invariants:
+#   1. stdout is the smallest decision index: new body-bearing entries expose id, flags,
+#      and a 120-character preview; old entries collapse to counts; bodies never appear.
+#   2. the full text lives only in the snapshot and query.sh retrieves it by id on demand.
+#   3. a derived index identical to the previous full print collapses to `no_change`.
+#
 # INDEX SCHEMA (stdout)
 # {
 #   "pr": <int>,
@@ -53,19 +62,23 @@
 #       "is_in_progress":        <bool>,                # CR still processing — don't declare PASS yet
 #       "actionable_count":      "<n>" | null           # parsed from "Actionable comments posted: N"
 #     },
-#     "reviews":          [{id, submittedAt, state, is_new}],
+#     "reviews":          [{id, submittedAt, state, has_outside_diff, is_new, preview}],
+#     "reviews_history":  {total, last_submitted_at},
 #     "comments_new":     [{id, createdAt, preview}],   # this-round new non-walkthrough comments
 #     "comments_history": {total, last_created_at}      # older ones collapsed to counts ({total: 0} when empty)
 #   },
 #   "gemini": {
-#     "reviews":          [{id, submittedAt, state, reviewed_current_head, has_pass_marker, is_new}],
+#     "reviews":          [{id, submittedAt, state, reviewed_current_head, has_pass_marker, is_new, preview}],
 #                                                       # body NEVER inlined — query.sh gemini-latest-body
+#     "reviews_history":  {total, last_submitted_at},
 #     "comments_new":     [{id, createdAt, preview}],
 #     "comments_history": {total, last_created_at}
 #   },
 #   "codex": {
 #     "has_started":      <bool>,                       # Codex has acknowledged with eyes or a clean-pass comment
-#     "reviews":          [{id, submittedAt, state, reviewed_commit, reviewed_current_head, is_new}],
+#     "reviews":          [{id, submittedAt, state, reviewed_commit, reviewed_current_head,
+#                            has_body_finding, is_new, preview}],
+#     "reviews_history":  {total, last_submitted_at},
 #     "comments_new":     [{id, createdAt, reviewed_commit, reviewed_current_head,
 #                            has_pass_marker, preview}], # top-level clean-pass compatibility path
 #     "comments_history": {total, last_created_at},
@@ -126,6 +139,10 @@
 #                          is empty aside from the "## Code Review" heading (any case). Gemini-only; an unmatched
 #                          summary is treated as still actionable (safe default — no silent pass).
 #   has_started            Codex has posted eyes on the PR or an @codex review trigger comment
+#   has_outside_diff       CodeRabbit review body carries one or more "Outside diff range
+#                          comments" that could not be posted as inline comments
+#   has_body_finding       Codex review body itself carries a P0-P3 finding badge; this shape
+#                          has no guaranteed inline copy
 #   preview                first 120 chars of body after stripping HTML comments and markdown images, whitespace
 #                          collapsed — the eyeball safety net for flag misparses (flag vs preview conflict => fetch
 #                          full body via query.sh details and trust the body)
@@ -453,10 +470,16 @@ jq -n \
   def codex_comment_has_pass_marker:
     (. // "") | test("^\\s*Codex Review:\\s*Didn(\\x27|\\x{2019})t find any major issues\\."; "i");
 
+  def codex_body_has_finding:
+    (. // "") | test("!\\[P[0-3] Badge\\]"; "i");
+
   def cr_rate_limited_body:
     # CodeRabbit wraps its rate-limit banner in a dedicated HTML marker. One match backs both
     # quota_alerts and walkthrough.is_rate_limited so the two judgments cannot drift apart.
     (. // "") | test("<!--\\s*This is an auto-generated comment:\\s*rate limited by coderabbit\\.ai\\s*-->");
+
+  def has_outside_diff_body:
+    (. // "") | test("Outside diff range comments \\([1-9][0-9]*\\)"; "i");
 
   def cr_walkthrough_rest:
     [$sub_a[] | select(.user.login == "coderabbitai[bot]")]
@@ -505,7 +528,8 @@ jq -n \
        end) as $reviewed_current_head
     | {id, submittedAt, state, reviewed_commit: $reviewed_commit,
        reviewed_current_head: $reviewed_current_head,
-       is_new: fresh(.submittedAt; .id), body};
+       has_body_finding: ($rb | codex_body_has_finding),
+       is_new: fresh(.submittedAt; .id), preview: ($rb | mk_preview), body};
 
   def codex_comment_row:
     (.body // "") as $cb
@@ -587,7 +611,8 @@ jq -n \
          | map({id, createdAt, is_new: fresh(.createdAt; .id), preview: (.body | mk_preview), body})),
       reviews:
         [$main.reviews[] | select(.author.login == "coderabbitai")
-         | {id, submittedAt, state, is_new: fresh(.submittedAt; .id), body}]
+         | {id, submittedAt, state, has_outside_diff: (.body | has_outside_diff_body),
+            is_new: fresh(.submittedAt; .id), preview: (.body | mk_preview), body}]
     },
 
     gemini: {
@@ -600,7 +625,8 @@ jq -n \
                then (.submittedAt > $last_push)
                else ($reviewed_commit | codex_commit_is_current_head)
                end),
-            has_pass_marker: (.body | has_pass_marker_body), body}],
+            has_pass_marker: (.body | has_pass_marker_body),
+            preview: (.body | mk_preview), body}],
       comments:
         [$main.comments[] | select(.author.login == "gemini-code-assist")
          | {id, createdAt, is_new: fresh(.createdAt; .id), preview: (.body | mk_preview), body}]
@@ -675,6 +701,10 @@ mv "$WORKDIR/snapshot.json" "$SNAPSHOT_FILE"
 # reach stdout — query.sh reads them from the snapshot on demand.
 jq --arg snapshot_file "$SNAPSHOT_FILE" '
   def prune_hist: if .total == 0 then {total} else . end;
+  def review_history:
+    [.[] | select(.is_new | not)]
+    | {total: length, last_submitted_at: (map(.submittedAt) | max // null)}
+    | prune_hist;
   . as $s
   | ($s.pr_created_at) as $created
   | {
@@ -689,7 +719,10 @@ jq --arg snapshot_file "$SNAPSHOT_FILE" '
 
       coderabbit: {
         walkthrough: ($s.coderabbit.walkthrough | if . == null then null else del(.body) end),
-        reviews:     [$s.coderabbit.reviews[] | {id, submittedAt, state, is_new}],
+        reviews:
+          [$s.coderabbit.reviews[] | select(.is_new)
+           | {id, submittedAt, state, has_outside_diff, is_new, preview}],
+        reviews_history: ($s.coderabbit.reviews | review_history),
         comments_new:
           [$s.coderabbit.other_comments[] | select(.is_new) | {id, createdAt, preview}],
         comments_history:
@@ -699,7 +732,10 @@ jq --arg snapshot_file "$SNAPSHOT_FILE" '
       },
 
       gemini: {
-        reviews: [$s.gemini.reviews[] | {id, submittedAt, state, reviewed_current_head, has_pass_marker, is_new}],
+        reviews:
+          [$s.gemini.reviews[] | select(.is_new)
+           | {id, submittedAt, state, reviewed_current_head, has_pass_marker, is_new, preview}],
+        reviews_history: ($s.gemini.reviews | review_history),
         comments_new:
           [$s.gemini.comments[] | select(.is_new) | {id, createdAt, preview}],
         comments_history:
@@ -715,8 +751,10 @@ jq --arg snapshot_file "$SNAPSHOT_FILE" '
            or (any($s.own_trigger_comments[];
                    .command == "@codex review" and .has_codex_eyes))),
         reviews:
-          [$s.codex.reviews[]
-           | {id, submittedAt, state, reviewed_commit, reviewed_current_head, is_new}],
+          [$s.codex.reviews[] | select(.is_new)
+           | {id, submittedAt, state, reviewed_commit, reviewed_current_head,
+              has_body_finding, is_new, preview}],
+        reviews_history: ($s.codex.reviews | review_history),
         comments_new:
           [$s.codex.comments[] | select(.is_new)
            | {id, createdAt, reviewed_commit, reviewed_current_head, has_pass_marker, preview}],

--- a/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_quota_alerts.sh
@@ -111,7 +111,10 @@ for tc in "${CASES[@]}"; do
     "
     [{id: 1, user: {login: \$login}, created_at: \"2026-07-13T00:00:00Z\",
       updated_at: \$updated_at, body: \$body}] as \$sub_a
-    | $RL_DEF
+    | {reviews: [], headRefOid: \"test-head\"} as \$main
+    | {} as \$review_commit_by_id
+    | def codex_commit_is_current_head: false;
+      $RL_DEF
       $WT_DEF
       (cr_walkthrough_rest | \"\\(.is_rate_limited):\\(.reviewed_current_head)\")
     ")

--- a/.agents/skills/pr-ai-review-loop/scripts/test_review_body_flags.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_review_body_flags.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression tests for actionable findings delivered only in reviewer bodies.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+POLL_SH="$SCRIPT_DIR/poll.sh"
+TESTDATA="$SCRIPT_DIR/testdata"
+
+fail=0
+CASES=(
+  "has_outside_diff_body|coderabbit_outside_diff_pr1767.txt|true"
+  "has_outside_diff_body|coderabbit_inline_review_pr1767.txt|false"
+  "codex_body_has_finding|codex_body_finding_pr1727.txt|true"
+  "codex_body_has_finding|codex_generic_review_pr1727.txt|false"
+)
+
+for tc in "${CASES[@]}"; do
+  IFS='|' read -r function fixture expected <<<"$tc"
+  definition=$(awk -v target="$function" '
+    $0 ~ "^[[:space:]]*def " target ":" {flag=1}
+    flag {print; if (/;[[:space:]]*$/) exit}
+  ' "$POLL_SH")
+  if [[ -z "$definition" ]]; then
+    echo "FAIL $fixture: could not extract $function from $POLL_SH" >&2
+    fail=1
+    continue
+  fi
+
+  got=$(jq -n --rawfile body "$TESTDATA/$fixture" "$definition (\$body | $function)")
+  if [[ "$got" == "$expected" ]]; then
+    echo "PASS $fixture ($function=$got)"
+  else
+    echo "FAIL $fixture: expected $expected, got $got" >&2
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+WAIT_SH="$SCRIPT_DIR/wait.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir "$TMP_ROOT/bin"
+mkdir "$TMP_ROOT/tmp"
+export TMPDIR="$TMP_ROOT/tmp"
+cat > "$TMP_ROOT/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$WAIT_TEST_ROOT/gh-args"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf '%s\n' 'ArcReel/ArcReel'
+elif [[ "$*" == *'reviews(first:100'* ]]; then
+  count_file="$WAIT_TEST_ROOT/review-count"
+  count=0
+  [[ ! -f "$count_file" ]] || count=$(<"$count_file")
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$count_file"
+  if [[ "${WAIT_TEST_MODE:-change}" == "http_error" && "$count" -gt 1 ]]; then
+    echo "HTTP ${WAIT_TEST_HTTP_CODE:-500}: probe failed" >&2
+    exit 1
+  elif (( count == 1 )) || [[ "${WAIT_TEST_MODE:-change}" == "flat" ]]; then
+    submitted_at='2026-08-11T00:00:00Z'
+  else
+    submitted_at='2026-08-11T00:01:00Z'
+  fi
+  printf '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"submittedAt":"%s"}]}}}}}\n' "$submitted_at"
+else
+  printf '{"data":{"repository":{"pullRequest":{"headRefOid":"%s","comments":{"nodes":[{"updatedAt":"2026-08-11T00:00:00Z"}]}}}}}\n' "${WAIT_TEST_HEAD:-abc}"
+fi
+EOF
+chmod +x "$TMP_ROOT/bin/gh"
+
+cat > "$TMP_ROOT/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >> "$WAIT_TEST_ROOT/sleeps"
+EOF
+chmod +x "$TMP_ROOT/bin/sleep"
+
+WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 180
+
+[[ "$(<"$TMP_ROOT/review-count")" == "2" ]] || fail "expected baseline plus one changed probe"
+[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected one 60-second probe interval"
+grep -q 'headRefOid' "$TMP_ROOT/gh-args" || fail "probe did not request the head SHA"
+grep -q 'submittedAt' "$TMP_ROOT/gh-args" || fail "probe did not request review submitted_at"
+grep -q 'updatedAt' "$TMP_ROOT/gh-args" || fail "probe did not request comment updated_at"
+
+echo "PASS: wait exits early when a probe signal changes"
+
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 125
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,5" ]] || fail "expected 60-second probes capped at --max"
+echo "PASS: wait respects the maximum delay"
+
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/tmp/pr-ai-review-loop-$(id -u)/wait-ArcReel-ArcReel-1767.head"
+WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
+  || fail "expected the first wait on a head to default to 360 seconds"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60" ]] \
+  || fail "expected later waits on the same head to default to 180 seconds"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+WAIT_TEST_MODE=flat WAIT_TEST_HEAD=def WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
+  || fail "expected a changed head to restore the 360-second default"
+echo "PASS: wait defaults to 360 seconds on a new head and 180 seconds thereafter"
+
+for code in 403 429; do
+  rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+  WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE="$code" WAIT_TEST_ROOT="$TMP_ROOT" \
+    PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 180
+  [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,120" ]] \
+    || fail "expected HTTP $code to degrade to sleep-only mode"
+done
+echo "PASS: rate-limit responses degrade to sleep-only mode"
+
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+if WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE=500 WAIT_TEST_ROOT="$TMP_ROOT" \
+  PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 180 >"$TMP_ROOT/error.out" 2>"$TMP_ROOT/error.err"; then
+  fail "expected a non-rate-limit GitHub error to fail"
+fi
+grep -q '^WAIT_ERROR:' "$TMP_ROOT/error.err" || fail "expected a loud WAIT_ERROR prefix"
+echo "PASS: non-rate-limit probe errors fail loudly"

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -30,12 +30,23 @@ elif [[ "$*" == *'reviews(first:100'* ]]; then
   if [[ "${WAIT_TEST_MODE:-change}" == "http_error" && "$count" -gt 1 ]]; then
     echo "HTTP ${WAIT_TEST_HTTP_CODE:-500}: probe failed" >&2
     exit 1
-  elif (( count == 1 )) || [[ "${WAIT_TEST_MODE:-change}" == "flat" ]]; then
+  elif (( count == 1 )) || [[ "${WAIT_TEST_MODE:-change}" =~ ^(flat|reaction_change)$ ]]; then
     submitted_at='2026-08-11T00:00:00Z'
   else
     submitted_at='2026-08-11T00:01:00Z'
   fi
   printf '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"submittedAt":"%s"}]}}}}}\n' "$submitted_at"
+elif [[ "$*" == *'/issues/1767/reactions'* ]]; then
+  count_file="$WAIT_TEST_ROOT/reaction-count"
+  count=0
+  [[ ! -f "$count_file" ]] || count=$(<"$count_file")
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$count_file"
+  content=eyes
+  if [[ "${WAIT_TEST_MODE:-change}" == "reaction_change" && "$count" -gt 1 ]]; then
+    content='+1'
+  fi
+  printf '[{"content":"%s","user":{"login":"chatgpt-codex-connector[bot]"}}]\n' "$content"
 else
   printf '{"data":{"repository":{"pullRequest":{"headRefOid":"%s","comments":{"nodes":[{"updatedAt":"2026-08-11T00:00:00Z"}]}}}}}\n' "${WAIT_TEST_HEAD:-abc}"
 fi
@@ -59,28 +70,35 @@ grep -q 'updatedAt' "$TMP_ROOT/gh-args" || fail "probe did not request comment u
 
 echo "PASS: wait exits early when a probe signal changes"
 
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
+WAIT_TEST_MODE=reaction_change WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
+  bash "$WAIT_SH" 1767 --max 180
+[[ "$(<"$TMP_ROOT/reaction-count")" == "2" ]] || fail "expected two Codex reaction probes"
+[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected reaction-only completion after one interval"
+echo "PASS: wait exits early when the Codex PR reaction changes"
+
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
 WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 125
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,5" ]] || fail "expected 60-second probes capped at --max"
 echo "PASS: wait respects the maximum delay"
 
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
 rm -f "$TMP_ROOT/tmp/pr-ai-review-loop-$(id -u)/wait-ArcReel-ArcReel-1767.head"
 WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
   || fail "expected the first wait on a head to default to 360 seconds"
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
 WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60" ]] \
   || fail "expected later waits on the same head to default to 180 seconds"
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
 WAIT_TEST_MODE=flat WAIT_TEST_HEAD=def WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
   || fail "expected a changed head to restore the 360-second default"
 echo "PASS: wait defaults to 360 seconds on a new head and 180 seconds thereafter"
 
 for code in 403 429; do
-  rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+  rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
   WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE="$code" WAIT_TEST_ROOT="$TMP_ROOT" \
     PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 180
   [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,120" ]] \
@@ -88,7 +106,7 @@ for code in 403 429; do
 done
 echo "PASS: rate-limit responses degrade to sleep-only mode"
 
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/sleeps"
+rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
 if WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE=500 WAIT_TEST_ROOT="$TMP_ROOT" \
   PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" 1767 --max 180 >"$TMP_ROOT/error.out" 2>"$TMP_ROOT/error.err"; then
   fail "expected a non-rate-limit GitHub error to fail"

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/coderabbit_inline_review_pr1767.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/coderabbit_inline_review_pr1767.txt
@@ -1,0 +1,5 @@
+**Actionable comments posted: 1**
+
+Inline comments:
+In `@lib/video_backends/ark.py`:
+- Around line 120-126: Use exact registered model names.

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/coderabbit_outside_diff_pr1767.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/coderabbit_outside_diff_pr1767.txt
@@ -1,0 +1,10 @@
+> [!CAUTION]
+> Some comments are outside the diff and can’t be posted inline due to platform limitations.
+>
+> <details>
+> <summary>⚠️ Outside diff range comments (2)</summary>
+> </details>
+
+Outside diff comments:
+In `@lib/config/registry.py`:
+- Around line 1012-1014: Remove time-sensitive wording.

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/codex_body_finding_pr1727.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/codex_body_finding_pr1727.txt
@@ -1,0 +1,6 @@
+### 💡 Codex Review
+
+https://github.com/ArcReel/ArcReel/blob/example/server/agent_runtime/sdk_tools/enqueue_grid.py#L219-L222
+**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Split SDK grids as each generation completes**
+
+Run each wait-and-split sequence independently so completed grids are finalized immediately.

--- a/.agents/skills/pr-ai-review-loop/scripts/testdata/codex_generic_review_pr1727.txt
+++ b/.agents/skills/pr-ai-review-loop/scripts/testdata/codex_generic_review_pr1727.txt
@@ -1,0 +1,5 @@
+### 💡 Codex Review
+
+Here are some automated review suggestions for this pull request.
+
+**Reviewed commit:** `70788b4345`

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# wait.sh — wait for one lightweight PR-state change, or until the polling delay expires.
+#
+# USAGE
+#   bash wait.sh <PR_NUMBER> [--max <seconds>]
+#
+# Without --max, the first wait observed for a HEAD is 360 seconds and later waits on the
+# same HEAD are 180 seconds.
+#
+# The probe reads only the PR head SHA, review submittedAt values, and issue-comment
+# updatedAt values. Any change returns immediately. GitHub 403/429 responses switch the
+# remainder of this wait to sleep-only mode; other errors fail loudly with WAIT_ERROR.
+
+set -euo pipefail
+
+usage() {
+  echo "WAIT_ERROR: Usage: bash wait.sh <PR_NUMBER> [--max <seconds>]" >&2
+  exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+PR="$1"
+shift
+MAX_WAIT=""
+
+if [[ $# -gt 0 ]]; then
+  [[ $# -eq 2 && "$1" == "--max" ]] || usage
+  MAX_WAIT="$2"
+fi
+
+[[ "$PR" =~ ^[0-9]+$ ]] || usage
+[[ -z "$MAX_WAIT" || ("$MAX_WAIT" =~ ^[0-9]+$ && "$MAX_WAIT" -gt 0) ]] || usage
+
+command -v gh >/dev/null 2>&1 || {
+  echo "WAIT_ERROR: gh CLI not found on PATH" >&2
+  exit 3
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "WAIT_ERROR: jq not found on PATH" >&2
+  exit 3
+}
+
+REPO_SLUG=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>&1) || {
+  if grep -Eq '(^|[^0-9])(403|429)([^0-9]|$)' <<<"$REPO_SLUG"; then
+    sleep "${MAX_WAIT:-180}"
+    exit 0
+  fi
+  echo "WAIT_ERROR: gh repo view failed" >&2
+  echo "$REPO_SLUG" >&2
+  exit 4
+}
+OWNER=${REPO_SLUG%%/*}
+REPO=${REPO_SLUG#*/}
+[[ "$REPO_SLUG" == */* && -n "$OWNER" && -n "$REPO" ]] || {
+  echo "WAIT_ERROR: gh repo view returned an invalid repository slug: $REPO_SLUG" >&2
+  exit 4
+}
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/pr-ai-review-wait.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+RATE_LIMITED=75
+
+# GraphQL variable names are literals consumed by GitHub, not shell expansions.
+# shellcheck disable=SC2016
+REVIEWS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviews(first:100,after:$endCursor){nodes{submittedAt}pageInfo{hasNextPage endCursor}}}}}'
+# shellcheck disable=SC2016
+COMMENTS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){headRefOid comments(first:100,after:$endCursor){nodes{updatedAt}pageInfo{hasNextPage endCursor}}}}}'
+
+is_rate_limited() {
+  grep -Eq '(^|[^0-9])(403|429)([^0-9]|$)' "$1"
+}
+
+probe() {
+  local reviews_json comments_json
+
+  if ! reviews_json=$(gh api graphql --paginate \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+    -f query="$REVIEWS_QUERY" 2>"$WORKDIR/probe.err"); then
+    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
+    return 1
+  fi
+  if ! comments_json=$(gh api graphql --paginate \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+    -f query="$COMMENTS_QUERY" 2>"$WORKDIR/probe.err"); then
+    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
+    return 1
+  fi
+
+  jq -n \
+    --slurpfile reviews <(printf '%s\n' "$reviews_json") \
+    --slurpfile comments <(printf '%s\n' "$comments_json") \
+    '{
+      head: $comments[0].data.repository.pullRequest.headRefOid,
+      review_submitted_at:
+        ([$reviews[].data.repository.pullRequest.reviews.nodes[]?.submittedAt] | max // null),
+      comment_updated_at:
+        ([$comments[].data.repository.pullRequest.comments.nodes[]?.updatedAt] | max // null)
+    }'
+}
+
+BASELINE_FILE="$WORKDIR/baseline.json"
+if probe > "$BASELINE_FILE"; then
+  :
+else
+  status=$?
+  if [[ "$status" -eq "$RATE_LIMITED" ]]; then
+    sleep "${MAX_WAIT:-180}"
+    exit 0
+  fi
+  echo "WAIT_ERROR: GitHub probe failed" >&2
+  cat "$WORKDIR/probe.err" >&2
+  exit 5
+fi
+
+CURRENT_HEAD=$(jq -er '.head' "$BASELINE_FILE") || {
+  echo "WAIT_ERROR: GitHub probe returned no head SHA" >&2
+  exit 5
+}
+STATE_DIR="${TMPDIR:-/tmp}/pr-ai-review-loop-$(id -u)"
+if [[ -L "$STATE_DIR" ]]; then
+  echo "WAIT_ERROR: state dir is a symlink: $STATE_DIR" >&2
+  exit 4
+fi
+if ! mkdir "$STATE_DIR" 2>/dev/null; then
+  if [[ -L "$STATE_DIR" || ! -d "$STATE_DIR" || ! -O "$STATE_DIR" ]]; then
+    echo "WAIT_ERROR: state dir is missing or not owned by the current user: $STATE_DIR" >&2
+    exit 4
+  fi
+fi
+chmod 700 "$STATE_DIR"
+HEAD_STATE="$STATE_DIR/wait-${OWNER}-${REPO}-${PR}.head"
+PREVIOUS_HEAD=""
+[[ ! -f "$HEAD_STATE" ]] || PREVIOUS_HEAD=$(<"$HEAD_STATE")
+if [[ -z "$MAX_WAIT" ]]; then
+  if [[ "$PREVIOUS_HEAD" == "$CURRENT_HEAD" ]]; then
+    MAX_WAIT=180
+  else
+    MAX_WAIT=360
+  fi
+fi
+printf '%s\n' "$CURRENT_HEAD" > "$WORKDIR/head-state"
+mv "$WORKDIR/head-state" "$HEAD_STATE"
+
+elapsed=0
+while (( elapsed < MAX_WAIT )); do
+  interval=60
+  remaining=$((MAX_WAIT - elapsed))
+  (( remaining >= interval )) || interval=$remaining
+  sleep "$interval"
+  elapsed=$((elapsed + interval))
+
+  CURRENT_FILE="$WORKDIR/current.json"
+  if probe > "$CURRENT_FILE"; then
+    :
+  else
+    status=$?
+    if [[ "$status" -eq "$RATE_LIMITED" ]]; then
+      remaining=$((MAX_WAIT - elapsed))
+      (( remaining == 0 )) || sleep "$remaining"
+      exit 0
+    fi
+    echo "WAIT_ERROR: GitHub probe failed" >&2
+    cat "$WORKDIR/probe.err" >&2
+    exit 5
+  fi
+
+  if ! cmp -s "$BASELINE_FILE" "$CURRENT_FILE"; then
+    exit 0
+  fi
+done

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -7,9 +7,10 @@
 # Without --max, the first wait observed for a HEAD is 360 seconds and later waits on the
 # same HEAD are 180 seconds.
 #
-# The probe reads only the PR head SHA, review submittedAt values, and issue-comment
-# updatedAt values. Any change returns immediately. GitHub 403/429 responses switch the
-# remainder of this wait to sleep-only mode; other errors fail loudly with WAIT_ERROR.
+# The probe reads only the PR head SHA, review submittedAt values, issue-comment
+# updatedAt values, and Codex PR reactions. Any change returns immediately. GitHub
+# 403/429 responses switch the remainder of this wait to sleep-only mode; other errors
+# fail loudly with WAIT_ERROR.
 
 set -euo pipefail
 
@@ -71,7 +72,7 @@ is_rate_limited() {
 }
 
 probe() {
-  local reviews_json comments_json
+  local reviews_json comments_json reactions_json
 
   if ! reviews_json=$(gh api graphql --paginate \
     -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
@@ -85,16 +86,27 @@ probe() {
     is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
     return 1
   fi
+  if ! reactions_json=$(gh api "repos/${REPO_SLUG}/issues/${PR}/reactions" --paginate \
+    2>"$WORKDIR/probe.err"); then
+    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
+    return 1
+  fi
 
   jq -n \
     --slurpfile reviews <(printf '%s\n' "$reviews_json") \
     --slurpfile comments <(printf '%s\n' "$comments_json") \
+    --slurpfile reactions <(printf '%s\n' "$reactions_json") \
     '{
       head: $comments[0].data.repository.pullRequest.headRefOid,
       review_submitted_at:
         ([$reviews[].data.repository.pullRequest.reviews.nodes[]?.submittedAt] | max // null),
       comment_updated_at:
-        ([$comments[].data.repository.pullRequest.comments.nodes[]?.updatedAt] | max // null)
+        ([$comments[].data.repository.pullRequest.comments.nodes[]?.updatedAt] | max // null),
+      codex_reactions:
+        ([$reactions[][]
+          | select(.user.login == "chatgpt-codex-connector[bot]")
+          | .content]
+         | sort)
     }'
 }
 


### PR DESCRIPTION
## Summary

- replace unavailable in-process `ScheduleWakeup` polling with a lightweight, state-aware `wait.sh`
- release implementation concurrency slots once issues enter AI review, with a separate review soft limit
- detect CodeRabbit outside-diff and Codex body-only findings in the minimal review index
- document the index/snapshot context-budget invariants and fold historical review rows

## Why

In-process review-loop teammates could no longer schedule their own wakeups. Their idle notifications were intentionally ignored by the team lead, leaving review loops dormant until an unrelated health check. Review-body findings could also bypass the actionable decision path because they had no inline anchor.

## Impact

Review loops regain an autonomous 60-second probe cadence while preserving the 360/180-second cold-start policy. Review waiting no longer consumes implementation capacity, and body-only findings are surfaced without injecting full review bodies into agent context.

## Validation

- `bash -n .agents/skills/pr-ai-review-loop/scripts/*.sh`
- `shellcheck` on changed and added shell scripts
- `test_wait.sh`
- `test_review_body_flags.sh`
- `test_pass_marker.sh`
- `test_quota_alerts.sh`
- real GitHub smoke tests for `wait.sh` and `poll.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化 AI 审查流程：主动等待变更并及时继续处理。
  * 改进审查结果识别，覆盖正文、行内及差异范围外评论。
  * 新增本轮审查意见预览与统计，并优化并发额度管理。

* **错误修复**
  * 改进限流及服务异常时的等待与降级处理，提升稳定性。

* **测试**
  * 补充等待机制、审查意见识别及多种审查场景的回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->