### PR TITLE
feat(视频): 统一视频单元发声归属

### DIFF
--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -400,7 +400,7 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
                         )
                     )
                     continue
-                empty_speaker = _EMPTY_SPEAKER_LINE.match(line)
+                empty_speaker = _EMPTY_SPEAKER_LINE.match(line.replace("\ufeff", ""))
                 if empty_speaker is not None:
                     spoken = empty_speaker.group(1)
                     if not spoken.strip():

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -159,6 +159,7 @@ class SpeechComposition:
 
 
 _EMPTY_SPEAKER_LINE = re.compile(r"^\s*@\[\s*\]\s*[:：]\s*\{([^{}]+)\}\s*$")
+_MISSING = object()
 
 
 def _empty_speaker_problem(unit_id: str, location: SpeechFieldLocation) -> SpeechProblem:
@@ -201,6 +202,52 @@ def _initial_problems(source: Mapping[str, object], unit_id: str, id_field: str)
     return problems
 
 
+def _append_structured_entry(
+    entries: list[SpeechInputUtterance],
+    problems: list[SpeechProblem],
+    unit_id: str,
+    *,
+    text: object,
+    speaker: object,
+    speaker_required: bool,
+    text_location: SpeechFieldLocation,
+    speaker_location: SpeechFieldLocation,
+) -> None:
+    """Translate one structured utterance without assigning its final owner."""
+
+    if not isinstance(text, str) or not text.strip():
+        problems.append(_parse_problem(unit_id, text_location))
+        return
+    if speaker is not None and not isinstance(speaker, str):
+        problems.append(_parse_problem(unit_id, speaker_location))
+        return
+    named_speaker = speaker.strip() if isinstance(speaker, str) else ""
+    if not speaker_required and named_speaker:
+        problems.append(_parse_problem(unit_id, speaker_location))
+        return
+    entries.append(
+        SpeechInputUtterance(
+            speaker=named_speaker or None,
+            speaker_required=speaker_required,
+            text=text,
+            location=speaker_location if speaker_required and not named_speaker else text_location,
+        )
+    )
+
+
+def _character_reference_names(raw_references: object) -> set[str]:
+    if not isinstance(raw_references, list):
+        return set()
+    return {
+        name.strip()
+        for reference in raw_references
+        if isinstance(reference, Mapping)
+        and reference.get("type") == "character"
+        and isinstance((name := reference.get("name")), str)
+        and name.strip()
+    }
+
+
 def adapt_narration_segment(segment: Mapping[str, object]) -> SpeechUnitSnapshot:
     """Translate a narration segment without persisting a duplicate utterance."""
 
@@ -230,35 +277,27 @@ def adapt_drama_scene(scene: Mapping[str, object]) -> SpeechUnitSnapshot:
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     entries: list[SpeechInputUtterance] = []
     problems = _initial_problems(scene, normalized_unit_id, "scene_id")
-    raw_entries = scene.get("utterances")
+    raw_entries = scene.get("utterances", _MISSING)
     if isinstance(raw_entries, list):
         for index, raw in enumerate(raw_entries):
             if not isinstance(raw, Mapping):
+                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index))))
                 continue
-            text = raw.get("text")
-            speaker = raw.get("speaker")
-            if not isinstance(text, str) or not text.strip():
-                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index, "text"))))
-                continue
-            if speaker is not None and not isinstance(speaker, str):
-                problems.append(
-                    _parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index, "speaker")))
-                )
-                continue
-            named_speaker = speaker.strip() if isinstance(speaker, str) else ""
             kind = raw.get("kind")
-            character_attributed = bool(named_speaker) or kind == "dialogue" or isinstance(speaker, str)
-            entries.append(
-                SpeechInputUtterance(
-                    speaker=named_speaker or None,
-                    speaker_required=character_attributed,
-                    text=text,
-                    location=SpeechFieldLocation(
-                        ("utterances", index, "speaker" if character_attributed and not named_speaker else "text")
-                    ),
-                )
+            if kind not in {"dialogue", "voiceover"}:
+                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index, "kind"))))
+                continue
+            _append_structured_entry(
+                entries,
+                problems,
+                normalized_unit_id,
+                text=raw.get("text"),
+                speaker=raw.get("speaker"),
+                speaker_required=kind == "dialogue",
+                text_location=SpeechFieldLocation(("utterances", index, "text")),
+                speaker_location=SpeechFieldLocation(("utterances", index, "speaker")),
             )
-    elif raw_entries is not None:
+    elif raw_entries is not _MISSING:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances",))))
     return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
 
@@ -270,8 +309,8 @@ def adapt_ad_shot(shot: Mapping[str, object]) -> SpeechUnitSnapshot:
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     entries: list[SpeechInputUtterance] = []
     problems = _initial_problems(shot, normalized_unit_id, "shot_id")
-    video_prompt = shot.get("video_prompt")
-    if video_prompt is not None and not isinstance(video_prompt, Mapping):
+    video_prompt = shot.get("video_prompt", _MISSING)
+    if not isinstance(video_prompt, Mapping):
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt",))))
     dialogue = video_prompt.get("dialogue") if isinstance(video_prompt, Mapping) else None
     if isinstance(dialogue, list):
@@ -281,30 +320,19 @@ def adapt_ad_shot(shot: Mapping[str, object]) -> SpeechUnitSnapshot:
                     _parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue", index)))
                 )
                 continue
-            speaker = raw.get("speaker")
-            text = raw.get("line")
-            if not isinstance(text, str) or not text.strip():
-                problems.append(
-                    _parse_problem(
-                        normalized_unit_id,
-                        SpeechFieldLocation(("video_prompt", "dialogue", index, "line")),
-                    )
-                )
-                continue
-            named_speaker = speaker.strip() if isinstance(speaker, str) else ""
-            entries.append(
-                SpeechInputUtterance(
-                    speaker=named_speaker or None,
-                    speaker_required=True,
-                    text=text,
-                    location=SpeechFieldLocation(
-                        ("video_prompt", "dialogue", index, "speaker" if not named_speaker else "line")
-                    ),
-                )
+            _append_structured_entry(
+                entries,
+                problems,
+                normalized_unit_id,
+                text=raw.get("line"),
+                speaker=raw.get("speaker"),
+                speaker_required=True,
+                text_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "line")),
+                speaker_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "speaker")),
             )
     elif dialogue is not None:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue"))))
-    voiceover = shot.get("voiceover_text")
+    voiceover = shot.get("voiceover_text", _MISSING)
     if isinstance(voiceover, str) and voiceover.strip():
         entries.append(
             SpeechInputUtterance(
@@ -314,7 +342,9 @@ def adapt_ad_shot(shot: Mapping[str, object]) -> SpeechUnitSnapshot:
                 location=SpeechFieldLocation(("voiceover_text",)),
             )
         )
-    elif voiceover is not None and not isinstance(voiceover, str):
+    elif voiceover is not _MISSING and not isinstance(voiceover, str):
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("voiceover_text",))))
+    elif voiceover is _MISSING:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("voiceover_text",))))
     return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
 
@@ -326,6 +356,7 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     entries: list[SpeechInputUtterance] = []
     problems = _initial_problems(unit, normalized_unit_id, "unit_id")
+    character_names = _character_reference_names(unit.get("references"))
     shots = unit.get("shots")
     if isinstance(shots, list) and shots:
         for shot_index, shot in enumerate(shots):
@@ -374,7 +405,7 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
                     or "}" in line
                     or "｛" in line
                     or "｝" in line
-                    or leading_mention_before_colon(line) is not None
+                    or (leading_mention_before_colon(line) or "") in character_names
                     or find_malformed_mention(line) is not None
                 ):
                     problems.append(_parse_problem(normalized_unit_id, location))

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -236,14 +236,14 @@ def _append_structured_entry(
     )
 
 
-def _character_reference_names(raw_references: object) -> set[str]:
+def _non_character_reference_names(raw_references: object) -> set[str]:
     if not isinstance(raw_references, list):
         return set()
     return {
         normalize_asset_name(name.strip())
         for reference in raw_references
         if isinstance(reference, Mapping)
-        and reference.get("type") == "character"
+        and reference.get("type") in {"scene", "prop"}
         and isinstance((name := reference.get("name")), str)
         and name.strip()
     }
@@ -364,7 +364,7 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     entries: list[SpeechInputUtterance] = []
     problems = _initial_problems(unit, normalized_unit_id, "unit_id")
-    character_names = _character_reference_names(unit.get("references"))
+    non_character_names = _non_character_reference_names(unit.get("references"))
     shots = unit.get("shots")
     if isinstance(shots, list) and shots:
         for shot_index, shot in enumerate(shots):
@@ -408,12 +408,16 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
                         )
                     )
                     continue
+                leading_name = leading_mention_before_colon(line)
                 if (
                     "{" in line
                     or "}" in line
                     or "｛" in line
                     or "｝" in line
-                    or (leading_mention_before_colon(line) or "") in character_names
+                    or (
+                        leading_name is not None
+                        and normalize_asset_name(leading_name.strip()) not in non_character_names
+                    )
                     or find_malformed_mention(line) is not None
                 ):
                     problems.append(_parse_problem(normalized_unit_id, location))

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -368,7 +368,10 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
     shots = unit.get("shots")
     if isinstance(shots, list) and shots:
         for shot_index, shot in enumerate(shots):
-            text = shot.get("text") if isinstance(shot, Mapping) else None
+            if not isinstance(shot, Mapping):
+                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("shots", shot_index))))
+                continue
+            text = shot.get("text")
             if not isinstance(text, str):
                 problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("shots", shot_index, "text"))))
                 continue
@@ -399,11 +402,15 @@ def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
                     continue
                 empty_speaker = _EMPTY_SPEAKER_LINE.match(line)
                 if empty_speaker is not None:
+                    spoken = empty_speaker.group(1)
+                    if not spoken.strip():
+                        problems.append(_parse_problem(normalized_unit_id, location))
+                        continue
                     entries.append(
                         SpeechInputUtterance(
                             speaker=None,
                             speaker_required=True,
-                            text=empty_speaker.group(1),
+                            text=spoken,
                             location=location,
                         )
                     )

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -223,6 +223,9 @@ def _append_structured_entry(
         problems.append(_parse_problem(unit_id, speaker_location))
         return
     named_speaker = speaker.strip() if isinstance(speaker, str) else ""
+    if not speaker_required and named_speaker:
+        problems.append(_parse_problem(unit_id, speaker_location))
+        return
     entries.append(
         SpeechInputUtterance(
             speaker=named_speaker or None,

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
+from lib.asset_types import normalize_asset_name
 from lib.reference_video.shot_parser import (
     find_malformed_mention,
     leading_mention_before_colon,
@@ -222,9 +223,6 @@ def _append_structured_entry(
         problems.append(_parse_problem(unit_id, speaker_location))
         return
     named_speaker = speaker.strip() if isinstance(speaker, str) else ""
-    if not speaker_required and named_speaker:
-        problems.append(_parse_problem(unit_id, speaker_location))
-        return
     entries.append(
         SpeechInputUtterance(
             speaker=named_speaker or None,
@@ -239,13 +237,42 @@ def _character_reference_names(raw_references: object) -> set[str]:
     if not isinstance(raw_references, list):
         return set()
     return {
-        name.strip()
+        normalize_asset_name(name.strip())
         for reference in raw_references
         if isinstance(reference, Mapping)
         and reference.get("type") == "character"
         and isinstance((name := reference.get("name")), str)
         and name.strip()
     }
+
+
+def _append_video_prompt_dialogue(
+    entries: list[SpeechInputUtterance],
+    problems: list[SpeechProblem],
+    unit_id: str,
+    video_prompt: object,
+) -> None:
+    if not isinstance(video_prompt, Mapping):
+        problems.append(_parse_problem(unit_id, SpeechFieldLocation(("video_prompt",))))
+        return
+    dialogue = video_prompt.get("dialogue")
+    if isinstance(dialogue, list):
+        for index, raw in enumerate(dialogue):
+            if not isinstance(raw, Mapping):
+                problems.append(_parse_problem(unit_id, SpeechFieldLocation(("video_prompt", "dialogue", index))))
+                continue
+            _append_structured_entry(
+                entries,
+                problems,
+                unit_id,
+                text=raw.get("line"),
+                speaker=raw.get("speaker"),
+                speaker_required=True,
+                text_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "line")),
+                speaker_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "speaker")),
+            )
+    elif dialogue is not None:
+        problems.append(_parse_problem(unit_id, SpeechFieldLocation(("video_prompt", "dialogue"))))
 
 
 def adapt_narration_segment(segment: Mapping[str, object]) -> SpeechUnitSnapshot:
@@ -255,19 +282,20 @@ def adapt_narration_segment(segment: Mapping[str, object]) -> SpeechUnitSnapshot
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     text = segment.get("novel_text")
     problems = _initial_problems(segment, normalized_unit_id, "segment_id")
-    entries = ()
+    entries: list[SpeechInputUtterance] = []
+    _append_video_prompt_dialogue(entries, problems, normalized_unit_id, segment.get("video_prompt", _MISSING))
     if isinstance(text, str) and text.strip():
-        entries = (
+        entries.append(
             SpeechInputUtterance(
                 speaker=None,
                 speaker_required=False,
                 text=text,
                 location=SpeechFieldLocation(("novel_text",)),
-            ),
+            )
         )
     else:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("novel_text",))))
-    return SpeechUnitSnapshot(normalized_unit_id, entries, tuple(problems))
+    return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
 
 
 def adapt_drama_scene(scene: Mapping[str, object]) -> SpeechUnitSnapshot:
@@ -297,7 +325,7 @@ def adapt_drama_scene(scene: Mapping[str, object]) -> SpeechUnitSnapshot:
                 text_location=SpeechFieldLocation(("utterances", index, "text")),
                 speaker_location=SpeechFieldLocation(("utterances", index, "speaker")),
             )
-    elif raw_entries is not _MISSING:
+    else:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances",))))
     return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
 
@@ -309,42 +337,19 @@ def adapt_ad_shot(shot: Mapping[str, object]) -> SpeechUnitSnapshot:
     normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
     entries: list[SpeechInputUtterance] = []
     problems = _initial_problems(shot, normalized_unit_id, "shot_id")
-    video_prompt = shot.get("video_prompt", _MISSING)
-    if not isinstance(video_prompt, Mapping):
-        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt",))))
-    dialogue = video_prompt.get("dialogue") if isinstance(video_prompt, Mapping) else None
-    if isinstance(dialogue, list):
-        for index, raw in enumerate(dialogue):
-            if not isinstance(raw, Mapping):
-                problems.append(
-                    _parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue", index)))
-                )
-                continue
-            _append_structured_entry(
-                entries,
-                problems,
-                normalized_unit_id,
-                text=raw.get("line"),
-                speaker=raw.get("speaker"),
-                speaker_required=True,
-                text_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "line")),
-                speaker_location=SpeechFieldLocation(("video_prompt", "dialogue", index, "speaker")),
-            )
-    elif dialogue is not None:
-        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue"))))
+    _append_video_prompt_dialogue(entries, problems, normalized_unit_id, shot.get("video_prompt", _MISSING))
     voiceover = shot.get("voiceover_text", _MISSING)
-    if isinstance(voiceover, str) and voiceover.strip():
-        entries.append(
-            SpeechInputUtterance(
-                speaker=None,
-                speaker_required=False,
-                text=voiceover,
-                location=SpeechFieldLocation(("voiceover_text",)),
+    if isinstance(voiceover, str):
+        if voiceover.strip():
+            entries.append(
+                SpeechInputUtterance(
+                    speaker=None,
+                    speaker_required=False,
+                    text=voiceover,
+                    location=SpeechFieldLocation(("voiceover_text",)),
+                )
             )
-        )
-    elif voiceover is not _MISSING and not isinstance(voiceover, str):
-        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("voiceover_text",))))
-    elif voiceover is _MISSING:
+    else:
         problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("voiceover_text",))))
     return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
 

--- a/lib/speech_composition/__init__.py
+++ b/lib/speech_composition/__init__.py
@@ -1,0 +1,403 @@
+"""Unified speech ownership for video generation units."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from lib.reference_video.shot_parser import (
+    find_malformed_mention,
+    leading_mention_before_colon,
+    match_dialogue_line,
+    match_voiceover_line,
+)
+
+
+class SpeechOwner(StrEnum):
+    """The entity responsible for delivering one utterance."""
+
+    CHARACTER = "character"
+    NARRATOR = "narrator"
+
+
+class SpeechMode(StrEnum):
+    """The exclusive speech ownership mechanically derived for one video unit."""
+
+    CHARACTER_SPEECH = "character_speech"
+    NARRATOR_VOICEOVER = "narrator_voiceover"
+    SILENT = "silent"
+
+
+class SpeechProblemCode(StrEnum):
+    """Stable problem codes shared by Web and Agent adapters."""
+
+    MIXED_SPEECH = "mixed_speech"
+    NEEDS_REPLAN = "needs_replan"
+    PARSE_FAILED = "parse_failed"
+    EMPTY_SPEAKER = "empty_speaker"
+
+
+class SpeechProblemReason(StrEnum):
+    """Closed reasons that explain why preparation is unsafe."""
+
+    CHARACTER_AND_NARRATOR_MIXED = "character_and_narrator_mixed"
+    UNIT_MARKED_NEEDS_REPLAN = "unit_marked_needs_replan"
+    SPEECH_INPUT_UNPARSEABLE = "speech_input_unparseable"
+    CHARACTER_SPEAKER_EMPTY = "character_speaker_empty"
+
+
+class SpeechProblemAction(StrEnum):
+    """Closed next actions for repairing a speech problem."""
+
+    REPLAN_UNIT = "replan_unit"
+    FIX_INPUT = "fix_input"
+    ASSIGN_SPEAKER = "assign_speaker"
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechFieldLocation:
+    """A source field position; ``line`` is zero-based when present."""
+
+    path: tuple[str | int, ...]
+    line: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechProblem:
+    """A machine-readable blocker with unit and source-field locations."""
+
+    code: SpeechProblemCode
+    unit_id: str
+    locations: tuple[SpeechFieldLocation, ...]
+    reason: SpeechProblemReason
+    action: SpeechProblemAction
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechInputUtterance:
+    """Structure-only utterance translated by an input adapter."""
+
+    text: str
+    speaker: str | None
+    speaker_required: bool
+    location: SpeechFieldLocation
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechUtterance:
+    """One ordered piece of spoken content with mechanically derived ownership."""
+
+    owner: SpeechOwner
+    text: str
+    speaker: str | None
+    location: SpeechFieldLocation
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechUnitSnapshot:
+    """Content-skeleton-neutral input consumed by :class:`SpeechComposition`."""
+
+    unit_id: str
+    entries: tuple[SpeechInputUtterance, ...]
+    problems: tuple[SpeechProblem, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechPreparation:
+    """Speech ownership result for one video generation unit."""
+
+    unit_id: str
+    mode: SpeechMode | None
+    utterances: tuple[SpeechUtterance, ...]
+    problems: tuple[SpeechProblem, ...] = ()
+
+
+class SpeechComposition:
+    """Derive unit-wide speech facts from a content-neutral snapshot."""
+
+    @staticmethod
+    def prepare(snapshot: SpeechUnitSnapshot) -> SpeechPreparation:
+        problems = list(snapshot.problems)
+        utterances: list[SpeechUtterance] = []
+        for entry in snapshot.entries:
+            speaker = entry.speaker.strip() if isinstance(entry.speaker, str) else ""
+            if entry.speaker_required and not speaker:
+                problems.append(_empty_speaker_problem(snapshot.unit_id, entry.location))
+            owner = SpeechOwner.CHARACTER if speaker or entry.speaker_required else SpeechOwner.NARRATOR
+            utterances.append(
+                SpeechUtterance(
+                    owner=owner,
+                    text=entry.text,
+                    speaker=speaker or None,
+                    location=entry.location,
+                )
+            )
+
+        owners = {entry.owner for entry in utterances}
+        if owners == {SpeechOwner.CHARACTER, SpeechOwner.NARRATOR}:
+            problems.append(
+                SpeechProblem(
+                    code=SpeechProblemCode.MIXED_SPEECH,
+                    unit_id=snapshot.unit_id,
+                    locations=tuple(entry.location for entry in utterances),
+                    reason=SpeechProblemReason.CHARACTER_AND_NARRATOR_MIXED,
+                    action=SpeechProblemAction.REPLAN_UNIT,
+                )
+            )
+
+        if problems:
+            mode = None
+        elif owners == {SpeechOwner.CHARACTER}:
+            mode = SpeechMode.CHARACTER_SPEECH
+        elif owners == {SpeechOwner.NARRATOR}:
+            mode = SpeechMode.NARRATOR_VOICEOVER
+        else:
+            mode = SpeechMode.SILENT
+        return SpeechPreparation(snapshot.unit_id, mode, tuple(utterances), tuple(problems))
+
+
+_EMPTY_SPEAKER_LINE = re.compile(r"^\s*@\[\s*\]\s*[:：]\s*\{([^{}]+)\}\s*$")
+
+
+def _empty_speaker_problem(unit_id: str, location: SpeechFieldLocation) -> SpeechProblem:
+    return SpeechProblem(
+        code=SpeechProblemCode.EMPTY_SPEAKER,
+        unit_id=unit_id,
+        locations=(location,),
+        reason=SpeechProblemReason.CHARACTER_SPEAKER_EMPTY,
+        action=SpeechProblemAction.ASSIGN_SPEAKER,
+    )
+
+
+def _parse_problem(unit_id: str, location: SpeechFieldLocation) -> SpeechProblem:
+    return SpeechProblem(
+        code=SpeechProblemCode.PARSE_FAILED,
+        unit_id=unit_id,
+        locations=(location,),
+        reason=SpeechProblemReason.SPEECH_INPUT_UNPARSEABLE,
+        action=SpeechProblemAction.FIX_INPUT,
+    )
+
+
+def _initial_problems(source: Mapping[str, object], unit_id: str, id_field: str) -> list[SpeechProblem]:
+    problems: list[SpeechProblem] = []
+    if not unit_id.strip():
+        problems.append(_parse_problem(unit_id, SpeechFieldLocation((id_field,))))
+    needs_replan = source.get("needs_replan")
+    if needs_replan is True:
+        problems.append(
+            SpeechProblem(
+                code=SpeechProblemCode.NEEDS_REPLAN,
+                unit_id=unit_id,
+                locations=(SpeechFieldLocation(("needs_replan",)),),
+                reason=SpeechProblemReason.UNIT_MARKED_NEEDS_REPLAN,
+                action=SpeechProblemAction.REPLAN_UNIT,
+            )
+        )
+    elif needs_replan is not None and not isinstance(needs_replan, bool):
+        problems.append(_parse_problem(unit_id, SpeechFieldLocation(("needs_replan",))))
+    return problems
+
+
+def adapt_narration_segment(segment: Mapping[str, object]) -> SpeechUnitSnapshot:
+    """Translate a narration segment without persisting a duplicate utterance."""
+
+    unit_id = segment.get("segment_id")
+    normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
+    text = segment.get("novel_text")
+    problems = _initial_problems(segment, normalized_unit_id, "segment_id")
+    entries = ()
+    if isinstance(text, str) and text.strip():
+        entries = (
+            SpeechInputUtterance(
+                speaker=None,
+                speaker_required=False,
+                text=text,
+                location=SpeechFieldLocation(("novel_text",)),
+            ),
+        )
+    else:
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("novel_text",))))
+    return SpeechUnitSnapshot(normalized_unit_id, entries, tuple(problems))
+
+
+def adapt_drama_scene(scene: Mapping[str, object]) -> SpeechUnitSnapshot:
+    """Translate the ordered spoken-content list of a drama scene."""
+
+    unit_id = scene.get("scene_id")
+    normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
+    entries: list[SpeechInputUtterance] = []
+    problems = _initial_problems(scene, normalized_unit_id, "scene_id")
+    raw_entries = scene.get("utterances")
+    if isinstance(raw_entries, list):
+        for index, raw in enumerate(raw_entries):
+            if not isinstance(raw, Mapping):
+                continue
+            text = raw.get("text")
+            speaker = raw.get("speaker")
+            if not isinstance(text, str) or not text.strip():
+                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index, "text"))))
+                continue
+            if speaker is not None and not isinstance(speaker, str):
+                problems.append(
+                    _parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances", index, "speaker")))
+                )
+                continue
+            named_speaker = speaker.strip() if isinstance(speaker, str) else ""
+            kind = raw.get("kind")
+            character_attributed = bool(named_speaker) or kind == "dialogue" or isinstance(speaker, str)
+            entries.append(
+                SpeechInputUtterance(
+                    speaker=named_speaker or None,
+                    speaker_required=character_attributed,
+                    text=text,
+                    location=SpeechFieldLocation(
+                        ("utterances", index, "speaker" if character_attributed and not named_speaker else "text")
+                    ),
+                )
+            )
+    elif raw_entries is not None:
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("utterances",))))
+    return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
+
+
+def adapt_ad_shot(shot: Mapping[str, object]) -> SpeechUnitSnapshot:
+    """Translate an ad storyboard shot's dialogue and voiceover fields."""
+
+    unit_id = shot.get("shot_id")
+    normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
+    entries: list[SpeechInputUtterance] = []
+    problems = _initial_problems(shot, normalized_unit_id, "shot_id")
+    video_prompt = shot.get("video_prompt")
+    if video_prompt is not None and not isinstance(video_prompt, Mapping):
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt",))))
+    dialogue = video_prompt.get("dialogue") if isinstance(video_prompt, Mapping) else None
+    if isinstance(dialogue, list):
+        for index, raw in enumerate(dialogue):
+            if not isinstance(raw, Mapping):
+                problems.append(
+                    _parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue", index)))
+                )
+                continue
+            speaker = raw.get("speaker")
+            text = raw.get("line")
+            if not isinstance(text, str) or not text.strip():
+                problems.append(
+                    _parse_problem(
+                        normalized_unit_id,
+                        SpeechFieldLocation(("video_prompt", "dialogue", index, "line")),
+                    )
+                )
+                continue
+            named_speaker = speaker.strip() if isinstance(speaker, str) else ""
+            entries.append(
+                SpeechInputUtterance(
+                    speaker=named_speaker or None,
+                    speaker_required=True,
+                    text=text,
+                    location=SpeechFieldLocation(
+                        ("video_prompt", "dialogue", index, "speaker" if not named_speaker else "line")
+                    ),
+                )
+            )
+    elif dialogue is not None:
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("video_prompt", "dialogue"))))
+    voiceover = shot.get("voiceover_text")
+    if isinstance(voiceover, str) and voiceover.strip():
+        entries.append(
+            SpeechInputUtterance(
+                speaker=None,
+                speaker_required=False,
+                text=voiceover,
+                location=SpeechFieldLocation(("voiceover_text",)),
+            )
+        )
+    elif voiceover is not None and not isinstance(voiceover, str):
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("voiceover_text",))))
+    return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
+
+
+def adapt_video_unit(unit: Mapping[str, object]) -> SpeechUnitSnapshot:
+    """Translate utterance lines from a self-contained reference-video unit."""
+
+    unit_id = unit.get("unit_id")
+    normalized_unit_id = unit_id if isinstance(unit_id, str) else ""
+    entries: list[SpeechInputUtterance] = []
+    problems = _initial_problems(unit, normalized_unit_id, "unit_id")
+    shots = unit.get("shots")
+    if isinstance(shots, list) and shots:
+        for shot_index, shot in enumerate(shots):
+            text = shot.get("text") if isinstance(shot, Mapping) else None
+            if not isinstance(text, str):
+                problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("shots", shot_index, "text"))))
+                continue
+            for line_index, line in enumerate(text.splitlines()):
+                location = SpeechFieldLocation(("shots", shot_index, "text"), line_index)
+                dialogue = match_dialogue_line(line)
+                if dialogue is not None:
+                    speaker, spoken = dialogue
+                    entries.append(
+                        SpeechInputUtterance(
+                            speaker=speaker,
+                            speaker_required=True,
+                            text=spoken,
+                            location=location,
+                        )
+                    )
+                    continue
+                voiceover = match_voiceover_line(line)
+                if voiceover is not None:
+                    entries.append(
+                        SpeechInputUtterance(
+                            speaker=None,
+                            speaker_required=False,
+                            text=voiceover,
+                            location=location,
+                        )
+                    )
+                    continue
+                empty_speaker = _EMPTY_SPEAKER_LINE.match(line)
+                if empty_speaker is not None:
+                    entries.append(
+                        SpeechInputUtterance(
+                            speaker=None,
+                            speaker_required=True,
+                            text=empty_speaker.group(1),
+                            location=location,
+                        )
+                    )
+                    continue
+                if (
+                    "{" in line
+                    or "}" in line
+                    or "｛" in line
+                    or "｝" in line
+                    or leading_mention_before_colon(line) is not None
+                    or find_malformed_mention(line) is not None
+                ):
+                    problems.append(_parse_problem(normalized_unit_id, location))
+    else:
+        problems.append(_parse_problem(normalized_unit_id, SpeechFieldLocation(("shots",))))
+    return SpeechUnitSnapshot(normalized_unit_id, tuple(entries), tuple(problems))
+
+
+__all__ = [
+    "SpeechComposition",
+    "SpeechFieldLocation",
+    "SpeechInputUtterance",
+    "SpeechMode",
+    "SpeechOwner",
+    "SpeechPreparation",
+    "SpeechProblem",
+    "SpeechProblemAction",
+    "SpeechProblemCode",
+    "SpeechProblemReason",
+    "SpeechUnitSnapshot",
+    "SpeechUtterance",
+    "adapt_ad_shot",
+    "adapt_drama_scene",
+    "adapt_narration_segment",
+    "adapt_video_unit",
+]

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -331,6 +331,22 @@ def test_drama_voiceover_with_speaker_is_a_parse_blocker() -> None:
     ]
 
 
+@pytest.mark.parametrize("blank_speaker", ["", "  "])
+def test_drama_voiceover_with_blank_speaker_is_narrator_voiceover(blank_speaker) -> None:
+    result = SpeechComposition.prepare(
+        adapt_drama_scene(
+            {
+                "scene_id": "E1S07",
+                "utterances": [{"kind": "voiceover", "speaker": blank_speaker, "text": "大门缓缓合拢。"}],
+            }
+        )
+    )
+
+    assert result.mode is SpeechMode.NARRATOR_VOICEOVER
+    assert [(entry.owner, entry.speaker) for entry in result.utterances] == [(SpeechOwner.NARRATOR, None)]
+    assert result.problems == ()
+
+
 def test_reference_video_adapter_preserves_cross_shot_utterance_order() -> None:
     snapshot = adapt_video_unit(
         {
@@ -443,6 +459,10 @@ def test_damaged_unit_identity_and_container_are_reported_together() -> None:
             adapt_video_unit({"unit_id": "E1U08", "shots": []}),
             SpeechFieldLocation(("shots",)),
         ),
+        (
+            adapt_video_unit({"unit_id": "E1U08", "shots": [7]}),
+            SpeechFieldLocation(("shots", 0)),
+        ),
     ],
 )
 def test_unusable_speech_shapes_never_degrade_to_a_valid_mode(snapshot, expected_location) -> None:
@@ -488,6 +508,10 @@ def test_unusable_speech_shapes_never_degrade_to_a_valid_mode(snapshot, expected
         (
             adapt_ad_shot({"shot_id": "E1S09", "video_prompt": {"dialogue": []}}),
             SpeechFieldLocation(("voiceover_text",)),
+        ),
+        (
+            adapt_video_unit({"unit_id": "E1U09", "shots": [{"text": "@[ ]：{   }"}]}),
+            SpeechFieldLocation(("shots", 0, "text"), line=0),
         ),
     ],
 )

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -367,14 +367,28 @@ def test_reference_video_adapter_allows_asset_headings_without_guessing_their_ty
     assert result.problems == ()
 
 
-def test_reference_video_adapter_rejects_malformed_dialogue_for_a_declared_character() -> None:
-    snapshot = adapt_video_unit(
+@pytest.mark.parametrize(
+    "source",
+    [
         {
             "unit_id": "E1U09",
             "shots": [{"text": "@[阿离]：快走。"}],
             "references": [{"type": "character", "name": "阿离"}],
-        }
-    )
+        },
+        {
+            "unit_id": "E1U09",
+            "shots": [{"text": "@[阿离]：快走。"}],
+            "references": [],
+        },
+        {
+            "unit_id": "E1U09",
+            "shots": [{"text": "@[ ]：快走。"}],
+            "references": [],
+        },
+    ],
+)
+def test_reference_video_adapter_rejects_malformed_dialogue(source) -> None:
+    snapshot = adapt_video_unit(source)
 
     result = SpeechComposition.prepare(snapshot)
 
@@ -384,21 +398,19 @@ def test_reference_video_adapter_rejects_malformed_dialogue_for_a_declared_chara
     ]
 
 
-def test_reference_video_adapter_normalizes_character_names_before_matching() -> None:
+def test_reference_video_adapter_normalizes_asset_headings_before_matching() -> None:
     snapshot = adapt_video_unit(
         {
             "unit_id": "E1U10",
-            "shots": [{"text": "@[Caf\u00e9]：hello"}],
-            "references": [{"type": "character", "name": "Cafe\u0301"}],
+            "shots": [{"text": "@[Caf\u00e9]：木门被风吹开。"}],
+            "references": [{"type": "scene", "name": "Cafe\u0301"}],
         }
     )
 
     result = SpeechComposition.prepare(snapshot)
 
-    assert result.mode is None
-    assert [(problem.code, problem.locations) for problem in result.problems] == [
-        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("shots", 0, "text"), line=0),))
-    ]
+    assert result.mode is SpeechMode.SILENT
+    assert result.problems == ()
 
 
 def test_damaged_unit_identity_and_container_are_reported_together() -> None:

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -1,0 +1,302 @@
+import pytest
+
+from lib.speech_composition import (
+    SpeechComposition,
+    SpeechFieldLocation,
+    SpeechMode,
+    SpeechOwner,
+    SpeechProblemAction,
+    SpeechProblemCode,
+    SpeechProblemReason,
+    adapt_ad_shot,
+    adapt_drama_scene,
+    adapt_narration_segment,
+    adapt_video_unit,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_narration_novel_text_is_materialized_as_narrator_voiceover() -> None:
+    source = {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。"}
+
+    result = SpeechComposition.prepare(adapt_narration_segment(source))
+
+    assert result.mode is SpeechMode.NARRATOR_VOICEOVER
+    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.NARRATOR, None, "“别走。”她仍在心里重复。")
+    ]
+    assert result.problems == ()
+    assert source == {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。"}
+
+
+@pytest.mark.parametrize(
+    ("adapter", "source"),
+    [
+        (adapt_narration_segment, {"segment_id": "E1S01", "novel_text": "风吹过旷野。"}),
+        (
+            adapt_drama_scene,
+            {
+                "scene_id": "E1S01",
+                "utterances": [{"kind": "voiceover", "speaker": None, "text": "风吹过旷野。"}],
+            },
+        ),
+        (adapt_ad_shot, {"shot_id": "E1S01", "voiceover_text": "风吹过旷野。", "video_prompt": {}}),
+        (adapt_video_unit, {"unit_id": "E1S01", "shots": [{"text": "{风吹过旷野。}"}]}),
+    ],
+)
+def test_narrator_voiceover_has_the_same_result_through_every_skeleton(adapter, source) -> None:
+    result = SpeechComposition.prepare(adapter(source))
+
+    assert result.mode is SpeechMode.NARRATOR_VOICEOVER
+    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.NARRATOR, None, "风吹过旷野。")
+    ]
+    assert result.problems == ()
+
+
+def test_character_performance_styles_keep_character_ownership_and_order() -> None:
+    scene = {
+        "scene_id": "E2S03",
+        "utterances": [
+            {"kind": "dialogue", "speaker": "阿离", "text": "跟紧我。"},
+            {"kind": "inner_monologue", "speaker": "阿离", "text": "不能让他看出害怕。"},
+            {"kind": "character_voiceover", "speaker": "阿离", "text": "那是我们最后一次见面。"},
+        ],
+    }
+
+    result = SpeechComposition.prepare(adapt_drama_scene(scene))
+
+    assert result.mode is SpeechMode.CHARACTER_SPEECH
+    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.CHARACTER, "阿离", "跟紧我。"),
+        (SpeechOwner.CHARACTER, "阿离", "不能让他看出害怕。"),
+        (SpeechOwner.CHARACTER, "阿离", "那是我们最后一次见面。"),
+    ]
+    assert result.problems == ()
+
+
+def test_mixed_speech_returns_a_closed_located_problem_without_rewriting_content() -> None:
+    source = {
+        "scene_id": "E1S04",
+        "utterances": [
+            {"kind": "dialogue", "speaker": "阿离", "text": "快走。"},
+            {"kind": "voiceover", "speaker": None, "text": "大门在她身后合拢。"},
+        ],
+    }
+
+    result = SpeechComposition.prepare(adapt_drama_scene(source))
+
+    assert result.mode is None
+    assert [(entry.owner, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.CHARACTER, "快走。"),
+        (SpeechOwner.NARRATOR, "大门在她身后合拢。"),
+    ]
+    assert len(result.problems) == 1
+    problem = result.problems[0]
+    assert problem.code is SpeechProblemCode.MIXED_SPEECH
+    assert problem.unit_id == "E1S04"
+    assert problem.locations == (
+        SpeechFieldLocation(("utterances", 0, "text")),
+        SpeechFieldLocation(("utterances", 1, "text")),
+    )
+    assert problem.reason is SpeechProblemReason.CHARACTER_AND_NARRATOR_MIXED
+    assert problem.action is SpeechProblemAction.REPLAN_UNIT
+    assert source["utterances"] == [
+        {"kind": "dialogue", "speaker": "阿离", "text": "快走。"},
+        {"kind": "voiceover", "speaker": None, "text": "大门在她身后合拢。"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "expected_location"),
+    [
+        (
+            adapt_drama_scene(
+                {
+                    "scene_id": "E1S02",
+                    "utterances": [{"kind": "dialogue", "speaker": "  ", "text": "快走。"}],
+                }
+            ),
+            SpeechFieldLocation(("utterances", 0, "speaker")),
+        ),
+        (
+            adapt_ad_shot(
+                {
+                    "shot_id": "E1S02",
+                    "video_prompt": {"dialogue": [{"speaker": None, "line": "快走。"}]},
+                    "voiceover_text": "",
+                }
+            ),
+            SpeechFieldLocation(("video_prompt", "dialogue", 0, "speaker")),
+        ),
+        (
+            adapt_video_unit({"unit_id": "E1S02", "shots": [{"text": "空镜。\n@[ ]：{快走。}"}]}),
+            SpeechFieldLocation(("shots", 0, "text"), line=1),
+        ),
+    ],
+)
+def test_empty_character_speaker_is_a_structured_blocker(snapshot, expected_location) -> None:
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert len(result.problems) == 1
+    problem = result.problems[0]
+    assert problem.code is SpeechProblemCode.EMPTY_SPEAKER
+    assert problem.unit_id == "E1S02"
+    assert problem.locations == (expected_location,)
+    assert problem.reason is SpeechProblemReason.CHARACTER_SPEAKER_EMPTY
+    assert problem.action is SpeechProblemAction.ASSIGN_SPEAKER
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "expected_location"),
+    [
+        (
+            adapt_narration_segment({"segment_id": "E1S03", "novel_text": 42}),
+            SpeechFieldLocation(("novel_text",)),
+        ),
+        (
+            adapt_drama_scene(
+                {
+                    "scene_id": "E1S03",
+                    "utterances": [{"kind": "dialogue", "speaker": "阿离", "text": 42}],
+                }
+            ),
+            SpeechFieldLocation(("utterances", 0, "text")),
+        ),
+        (
+            adapt_ad_shot({"shot_id": "E1S03", "video_prompt": {"dialogue": "坏结构"}, "voiceover_text": ""}),
+            SpeechFieldLocation(("video_prompt", "dialogue")),
+        ),
+        (
+            adapt_video_unit({"unit_id": "E1S03", "shots": [{"text": "空镜。\n@[阿离]：快走。"}]}),
+            SpeechFieldLocation(("shots", 0, "text"), line=1),
+        ),
+    ],
+)
+def test_damaged_input_returns_a_located_parse_problem(snapshot, expected_location) -> None:
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert len(result.problems) == 1
+    problem = result.problems[0]
+    assert problem.code is SpeechProblemCode.PARSE_FAILED
+    assert problem.unit_id == "E1S03"
+    assert problem.locations == (expected_location,)
+    assert problem.reason is SpeechProblemReason.SPEECH_INPUT_UNPARSEABLE
+    assert problem.action is SpeechProblemAction.FIX_INPUT
+
+
+def test_needs_replan_is_a_closed_problem_even_when_speech_is_otherwise_valid() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U04",
+            "needs_replan": True,
+            "shots": [{"text": "门缓缓打开。\n{多年以后，他仍记得这一幕。}"}],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert len(result.problems) == 1
+    problem = result.problems[0]
+    assert problem.code is SpeechProblemCode.NEEDS_REPLAN
+    assert problem.unit_id == "E1U04"
+    assert problem.locations == (SpeechFieldLocation(("needs_replan",)),)
+    assert problem.reason is SpeechProblemReason.UNIT_MARKED_NEEDS_REPLAN
+    assert problem.action is SpeechProblemAction.REPLAN_UNIT
+
+
+def test_persisted_speech_mode_cannot_override_mechanical_derivation() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U05",
+            "speech_mode": "silent",
+            "shots": [{"text": "@[阿离] 站在门边。\n@[阿离]：{我回来了。}"}],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is SpeechMode.CHARACTER_SPEECH
+    assert result.problems == ()
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        adapt_drama_scene({"scene_id": "E1S06", "utterances": []}),
+        adapt_ad_shot({"shot_id": "E1S06", "voiceover_text": "", "video_prompt": {"dialogue": []}}),
+        adapt_video_unit({"unit_id": "E1S06", "shots": [{"text": "空镜，风吹过树梢。"}, {"text": "门缓缓合上。"}]}),
+    ],
+)
+def test_units_without_spoken_content_are_silent(snapshot) -> None:
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is SpeechMode.SILENT
+    assert result.utterances == ()
+    assert result.problems == ()
+
+
+def test_reference_video_adapter_preserves_cross_shot_utterance_order() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U07",
+            "shots": [
+                {"text": "@[阿离] 推门。\n@[阿离]：{有人吗？}\n@[阿离]：{我进来了。}"},
+                {"text": "@[守卫] 抬头。\n@[守卫]：{站住。}"},
+            ],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert [entry.text for entry in result.utterances] == ["有人吗？", "我进来了。", "站住。"]
+    assert [entry.location for entry in result.utterances] == [
+        SpeechFieldLocation(("shots", 0, "text"), line=1),
+        SpeechFieldLocation(("shots", 0, "text"), line=2),
+        SpeechFieldLocation(("shots", 1, "text"), line=1),
+    ]
+
+
+def test_damaged_unit_identity_and_container_are_reported_together() -> None:
+    result = SpeechComposition.prepare(adapt_video_unit({"unit_id": " ", "shots": "not-a-list"}))
+
+    assert result.mode is None
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("unit_id",)),)),
+        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("shots",)),)),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "expected_location"),
+    [
+        (
+            adapt_drama_scene(
+                {
+                    "scene_id": "E1S08",
+                    "utterances": [{"kind": "dialogue", "speaker": 7, "text": "快走。"}],
+                }
+            ),
+            SpeechFieldLocation(("utterances", 0, "speaker")),
+        ),
+        (
+            adapt_ad_shot({"shot_id": "E1S08", "video_prompt": "bad", "voiceover_text": ""}),
+            SpeechFieldLocation(("video_prompt",)),
+        ),
+        (
+            adapt_video_unit({"unit_id": "E1U08", "shots": []}),
+            SpeechFieldLocation(("shots",)),
+        ),
+    ],
+)
+def test_unusable_speech_shapes_never_degrade_to_a_valid_mode(snapshot, expected_location) -> None:
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (expected_location,))
+    ]

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -314,7 +314,7 @@ def test_units_without_spoken_content_are_silent(snapshot) -> None:
     assert result.problems == ()
 
 
-def test_drama_character_voiceover_is_character_speech() -> None:
+def test_drama_voiceover_with_speaker_is_a_parse_blocker() -> None:
     result = SpeechComposition.prepare(
         adapt_drama_scene(
             {
@@ -324,11 +324,11 @@ def test_drama_character_voiceover_is_character_speech() -> None:
         )
     )
 
-    assert result.mode is SpeechMode.CHARACTER_SPEECH
-    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
-        (SpeechOwner.CHARACTER, "阿离", "我不能让他发现。")
+    assert result.mode is None
+    assert result.utterances == ()
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("utterances", 0, "speaker")),))
     ]
-    assert result.problems == ()
 
 
 def test_reference_video_adapter_preserves_cross_shot_utterance_order() -> None:

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.unit
 
 
 def test_narration_novel_text_is_materialized_as_narrator_voiceover() -> None:
-    source = {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。"}
+    source = {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。", "video_prompt": {}}
 
     result = SpeechComposition.prepare(adapt_narration_segment(source))
 
@@ -29,13 +29,32 @@ def test_narration_novel_text_is_materialized_as_narrator_voiceover() -> None:
         (SpeechOwner.NARRATOR, None, "“别走。”她仍在心里重复。")
     ]
     assert result.problems == ()
-    assert source == {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。"}
+    assert source == {"segment_id": "E1S01", "novel_text": "“别走。”她仍在心里重复。", "video_prompt": {}}
+
+
+def test_narration_dialogue_and_novel_text_are_reported_as_mixed_speech() -> None:
+    result = SpeechComposition.prepare(
+        adapt_narration_segment(
+            {
+                "segment_id": "E1S02",
+                "novel_text": "雨夜里，她想起了那句警告。",
+                "video_prompt": {"dialogue": [{"speaker": "阿离", "line": "别回头。"}]},
+            }
+        )
+    )
+
+    assert result.mode is None
+    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.CHARACTER, "阿离", "别回头。"),
+        (SpeechOwner.NARRATOR, None, "雨夜里，她想起了那句警告。"),
+    ]
+    assert [problem.code for problem in result.problems] == [SpeechProblemCode.MIXED_SPEECH]
 
 
 @pytest.mark.parametrize(
     ("adapter", "source"),
     [
-        (adapt_narration_segment, {"segment_id": "E1S01", "novel_text": "风吹过旷野。"}),
+        (adapt_narration_segment, {"segment_id": "E1S01", "novel_text": "风吹过旷野。", "video_prompt": {}}),
         (
             adapt_drama_scene,
             {
@@ -208,7 +227,7 @@ def test_empty_character_speaker_is_a_structured_blocker(snapshot, expected_loca
     ("snapshot", "expected_location"),
     [
         (
-            adapt_narration_segment({"segment_id": "E1S03", "novel_text": 42}),
+            adapt_narration_segment({"segment_id": "E1S03", "novel_text": 42, "video_prompt": {}}),
             SpeechFieldLocation(("novel_text",)),
         ),
         (
@@ -295,6 +314,23 @@ def test_units_without_spoken_content_are_silent(snapshot) -> None:
     assert result.problems == ()
 
 
+def test_drama_character_voiceover_is_character_speech() -> None:
+    result = SpeechComposition.prepare(
+        adapt_drama_scene(
+            {
+                "scene_id": "E1S06",
+                "utterances": [{"kind": "voiceover", "speaker": "阿离", "text": "我不能让他发现。"}],
+            }
+        )
+    )
+
+    assert result.mode is SpeechMode.CHARACTER_SPEECH
+    assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
+        (SpeechOwner.CHARACTER, "阿离", "我不能让他发现。")
+    ]
+    assert result.problems == ()
+
+
 def test_reference_video_adapter_preserves_cross_shot_utterance_order() -> None:
     snapshot = adapt_video_unit(
         {
@@ -337,6 +373,23 @@ def test_reference_video_adapter_rejects_malformed_dialogue_for_a_declared_chara
             "unit_id": "E1U09",
             "shots": [{"text": "@[阿离]：快走。"}],
             "references": [{"type": "character", "name": "阿离"}],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("shots", 0, "text"), line=0),))
+    ]
+
+
+def test_reference_video_adapter_normalizes_character_names_before_matching() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U10",
+            "shots": [{"text": "@[Caf\u00e9]：hello"}],
+            "references": [{"type": "character", "name": "Cafe\u0301"}],
         }
     )
 
@@ -392,6 +445,10 @@ def test_unusable_speech_shapes_never_degrade_to_a_valid_mode(snapshot, expected
 @pytest.mark.parametrize(
     ("snapshot", "expected_location"),
     [
+        (
+            adapt_drama_scene({"scene_id": "E1S09"}),
+            SpeechFieldLocation(("utterances",)),
+        ),
         (
             adapt_drama_scene({"scene_id": "E1S09", "utterances": [7]}),
             SpeechFieldLocation(("utterances", 0)),

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from lib.speech_composition import (
@@ -55,37 +57,96 @@ def test_narrator_voiceover_has_the_same_result_through_every_skeleton(adapter, 
     assert result.problems == ()
 
 
-def test_character_performance_styles_keep_character_ownership_and_order() -> None:
-    scene = {
-        "scene_id": "E2S03",
-        "utterances": [
-            {"kind": "dialogue", "speaker": "阿离", "text": "跟紧我。"},
-            {"kind": "inner_monologue", "speaker": "阿离", "text": "不能让他看出害怕。"},
-            {"kind": "character_voiceover", "speaker": "阿离", "text": "那是我们最后一次见面。"},
-        ],
-    }
-
-    result = SpeechComposition.prepare(adapt_drama_scene(scene))
+@pytest.mark.parametrize(
+    ("adapter", "source"),
+    [
+        (
+            adapt_drama_scene,
+            {
+                "scene_id": "E2S03",
+                "utterances": [
+                    {"kind": "dialogue", "speaker": "阿离", "text": "跟紧我。"},
+                    {"kind": "dialogue", "speaker": "阿离", "text": "不能让他看出害怕。"},
+                ],
+            },
+        ),
+        (
+            adapt_ad_shot,
+            {
+                "shot_id": "E2S03",
+                "video_prompt": {
+                    "dialogue": [
+                        {"speaker": "阿离", "line": "跟紧我。"},
+                        {"speaker": "阿离", "line": "不能让他看出害怕。"},
+                    ]
+                },
+                "voiceover_text": "",
+            },
+        ),
+        (
+            adapt_video_unit,
+            {
+                "unit_id": "E2S03",
+                "shots": [{"text": "@[阿离]：{跟紧我。}\n@[阿离]：{不能让他看出害怕。}"}],
+            },
+        ),
+    ],
+)
+def test_character_speech_keeps_the_same_ownership_and_order_through_applicable_skeletons(adapter, source) -> None:
+    result = SpeechComposition.prepare(adapter(source))
 
     assert result.mode is SpeechMode.CHARACTER_SPEECH
     assert [(entry.owner, entry.speaker, entry.text) for entry in result.utterances] == [
         (SpeechOwner.CHARACTER, "阿离", "跟紧我。"),
         (SpeechOwner.CHARACTER, "阿离", "不能让他看出害怕。"),
-        (SpeechOwner.CHARACTER, "阿离", "那是我们最后一次见面。"),
     ]
     assert result.problems == ()
 
 
-def test_mixed_speech_returns_a_closed_located_problem_without_rewriting_content() -> None:
-    source = {
-        "scene_id": "E1S04",
-        "utterances": [
-            {"kind": "dialogue", "speaker": "阿离", "text": "快走。"},
-            {"kind": "voiceover", "speaker": None, "text": "大门在她身后合拢。"},
-        ],
-    }
-
-    result = SpeechComposition.prepare(adapt_drama_scene(source))
+@pytest.mark.parametrize(
+    ("adapter", "source", "expected_locations"),
+    [
+        (
+            adapt_drama_scene,
+            {
+                "scene_id": "E1S04",
+                "utterances": [
+                    {"kind": "dialogue", "speaker": "阿离", "text": "快走。"},
+                    {"kind": "voiceover", "speaker": None, "text": "大门在她身后合拢。"},
+                ],
+            },
+            (
+                SpeechFieldLocation(("utterances", 0, "text")),
+                SpeechFieldLocation(("utterances", 1, "text")),
+            ),
+        ),
+        (
+            adapt_ad_shot,
+            {
+                "shot_id": "E1S04",
+                "video_prompt": {"dialogue": [{"speaker": "阿离", "line": "快走。"}]},
+                "voiceover_text": "大门在她身后合拢。",
+            },
+            (
+                SpeechFieldLocation(("video_prompt", "dialogue", 0, "line")),
+                SpeechFieldLocation(("voiceover_text",)),
+            ),
+        ),
+        (
+            adapt_video_unit,
+            {"unit_id": "E1S04", "shots": [{"text": "@[阿离]：{快走。}\n{大门在她身后合拢。}"}]},
+            (
+                SpeechFieldLocation(("shots", 0, "text"), line=0),
+                SpeechFieldLocation(("shots", 0, "text"), line=1),
+            ),
+        ),
+    ],
+)
+def test_mixed_speech_returns_a_closed_located_problem_without_rewriting_content(
+    adapter, source, expected_locations
+) -> None:
+    original = deepcopy(source)
+    result = SpeechComposition.prepare(adapter(source))
 
     assert result.mode is None
     assert [(entry.owner, entry.text) for entry in result.utterances] == [
@@ -96,16 +157,10 @@ def test_mixed_speech_returns_a_closed_located_problem_without_rewriting_content
     problem = result.problems[0]
     assert problem.code is SpeechProblemCode.MIXED_SPEECH
     assert problem.unit_id == "E1S04"
-    assert problem.locations == (
-        SpeechFieldLocation(("utterances", 0, "text")),
-        SpeechFieldLocation(("utterances", 1, "text")),
-    )
+    assert problem.locations == expected_locations
     assert problem.reason is SpeechProblemReason.CHARACTER_AND_NARRATOR_MIXED
     assert problem.action is SpeechProblemAction.REPLAN_UNIT
-    assert source["utterances"] == [
-        {"kind": "dialogue", "speaker": "阿离", "text": "快走。"},
-        {"kind": "voiceover", "speaker": None, "text": "大门在她身后合拢。"},
-    ]
+    assert source == original
 
 
 @pytest.mark.parametrize(
@@ -170,7 +225,7 @@ def test_empty_character_speaker_is_a_structured_blocker(snapshot, expected_loca
             SpeechFieldLocation(("video_prompt", "dialogue")),
         ),
         (
-            adapt_video_unit({"unit_id": "E1S03", "shots": [{"text": "空镜。\n@[阿离]：快走。"}]}),
+            adapt_video_unit({"unit_id": "E1S03", "shots": [{"text": "空镜。\n@[阿离]：{快走。"}]}),
             SpeechFieldLocation(("shots", 0, "text"), line=1),
         ),
     ],
@@ -261,6 +316,38 @@ def test_reference_video_adapter_preserves_cross_shot_utterance_order() -> None:
     ]
 
 
+def test_reference_video_adapter_allows_asset_headings_without_guessing_their_type() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U08",
+            "shots": [{"text": "@[酒馆]：木门被风吹开。"}],
+            "references": [{"type": "scene", "name": "酒馆"}],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is SpeechMode.SILENT
+    assert result.problems == ()
+
+
+def test_reference_video_adapter_rejects_malformed_dialogue_for_a_declared_character() -> None:
+    snapshot = adapt_video_unit(
+        {
+            "unit_id": "E1U09",
+            "shots": [{"text": "@[阿离]：快走。"}],
+            "references": [{"type": "character", "name": "阿离"}],
+        }
+    )
+
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (SpeechFieldLocation(("shots", 0, "text"), line=0),))
+    ]
+
+
 def test_damaged_unit_identity_and_container_are_reported_together() -> None:
     result = SpeechComposition.prepare(adapt_video_unit({"unit_id": " ", "shots": "not-a-list"}))
 
@@ -294,6 +381,48 @@ def test_damaged_unit_identity_and_container_are_reported_together() -> None:
     ],
 )
 def test_unusable_speech_shapes_never_degrade_to_a_valid_mode(snapshot, expected_location) -> None:
+    result = SpeechComposition.prepare(snapshot)
+
+    assert result.mode is None
+    assert [(problem.code, problem.locations) for problem in result.problems] == [
+        (SpeechProblemCode.PARSE_FAILED, (expected_location,))
+    ]
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "expected_location"),
+    [
+        (
+            adapt_drama_scene({"scene_id": "E1S09", "utterances": [7]}),
+            SpeechFieldLocation(("utterances", 0)),
+        ),
+        (
+            adapt_drama_scene(
+                {"scene_id": "E1S09", "utterances": [{"kind": "unknown", "speaker": None, "text": "风声。"}]}
+            ),
+            SpeechFieldLocation(("utterances", 0, "kind")),
+        ),
+        (
+            adapt_ad_shot(
+                {
+                    "shot_id": "E1S09",
+                    "video_prompt": {"dialogue": [{"speaker": 7, "line": "快走。"}]},
+                    "voiceover_text": "",
+                }
+            ),
+            SpeechFieldLocation(("video_prompt", "dialogue", 0, "speaker")),
+        ),
+        (
+            adapt_ad_shot({"shot_id": "E1S09", "voiceover_text": "风声。"}),
+            SpeechFieldLocation(("video_prompt",)),
+        ),
+        (
+            adapt_ad_shot({"shot_id": "E1S09", "video_prompt": {"dialogue": []}}),
+            SpeechFieldLocation(("voiceover_text",)),
+        ),
+    ],
+)
+def test_damaged_structured_speech_fields_are_parse_blockers(snapshot, expected_location) -> None:
     result = SpeechComposition.prepare(snapshot)
 
     assert result.mode is None

--- a/tests/test_speech_composition.py
+++ b/tests/test_speech_composition.py
@@ -208,6 +208,10 @@ def test_mixed_speech_returns_a_closed_located_problem_without_rewriting_content
             adapt_video_unit({"unit_id": "E1S02", "shots": [{"text": "空镜。\n@[ ]：{快走。}"}]}),
             SpeechFieldLocation(("shots", 0, "text"), line=1),
         ),
+        (
+            adapt_video_unit({"unit_id": "E1S02", "shots": [{"text": "空镜。\n\ufeff@[ ]：{快走。}"}]}),
+            SpeechFieldLocation(("shots", 0, "text"), line=1),
+        ),
     ],
 )
 def test_empty_character_speaker_is_a_structured_blocker(snapshot, expected_location) -> None:


### PR DESCRIPTION
## 范围

建立跨说书、剧集、广告分镜与参考视频单元的统一发声归属 seam；本 PR 不接管 TTS、视频供应商、任务队列、迁移、版本或调用方接入。

## 变更

- 新增 SpeechComposition 公开准备接口，机械派生人物发声、叙述旁白或无人声，并返回封闭、可机检的问题模型
- 新增四类内容骨架适配器，保留发声顺序和源字段定位；说书 novel_text 在边界物化为叙述旁白
- 阻止损坏的 drama/ad 发声结构静默降级为有效模式，并区分 reference 文稿中的合法资产标题与损坏人物台词
- 扩充接口级行为矩阵，覆盖人物、旁白、无人声、混合、损坏输入、顺序和输入不改写

## 验收清单

- [x] 本地已跑相关测试：./.venv/bin/python -m pytest（8477 passed，1 skipped）
- [x] 手动验证了损坏 drama/ad 快照、合法场景标题和损坏人物台词的结构化结果
- [x] 新增面向用户文案已加 zh/en 翻译（不适用：无新增用户文案）
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求

## 验证

- ./.venv/bin/ruff check . && ./.venv/bin/ruff format --check .
- ./.venv/bin/basedpyright（0 errors）
- ./.venv/bin/lint-imports（1 contract kept）

## 已知 defer

无

Closes #1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增统一的语音准备流程，识别角色对白、旁白、静音及混合语音。
  * 支持从叙述片段、戏剧场景、广告镜头和参考视频单元生成语音内容，并保持对白顺序。
  * 提供结构化问题反馈，明确标注问题位置、原因及处理建议。
  * 支持检测空说话者、损坏输入、内容冲突及需要重新规划的情况。

* **测试**
  * 新增覆盖语音归属、顺序、静音模式、输入一致性及异常场景的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->