### PR TITLE
feat(workflow): 建立产物清单与内容来源依据

### DIFF
--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -1,0 +1,648 @@
+"""Project-local artifact identity, provenance, and manifest storage."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import contextlib
+import errno
+import hashlib
+import json
+import math
+import os
+import re
+import tempfile
+import threading
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Protocol, Self
+
+import portalocker
+
+_KEY_PREFIX = "artifact-key-v1:"
+_ASSET_TYPES = frozenset({"character", "scene", "prop", "product"})
+MANIFEST_FILENAME = ".arcreel_artifacts.json"
+LOCK_FILENAME = ".artifact_manifest.lock"
+MANIFEST_SCHEMA_VERSION = 1
+HASH_ALGORITHM = "sha256-v1"
+LOCK_TIMEOUT_SECONDS = 10.0
+_DIGEST_RE = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
+_RESERVED_ARTIFACT_PATHS = frozenset({MANIFEST_FILENAME, LOCK_FILENAME})
+
+
+class ArtifactKind(StrEnum):
+    """Kinds supported by the project artifact manifest schema."""
+
+    ASSET_SHEET = "asset-sheet"
+    EPISODE_STEP1 = "episode-step1"
+    EPISODE_SCRIPT = "episode-script"
+    EPISODE_GRID = "episode-grid"
+    EPISODE_STORYBOARD = "episode-storyboard"
+    EPISODE_VIDEO = "episode-video"
+    EPISODE_AUDIO = "episode-audio"
+
+
+class ArtifactStatus(StrEnum):
+    """Currency of a formal artifact relative to its current direct-input basis."""
+
+    CURRENT = "current"
+    STALE = "stale"
+    MISSING = "missing"
+    BLOCKED = "blocked"
+
+
+class ArtifactManifestError(RuntimeError):
+    """Manifest storage cannot be read or safely updated."""
+
+
+class ArtifactRegistrationError(ArtifactManifestError):
+    """A basis cannot be registered before its formal artifact is safely present."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactBlocker:
+    code: str
+    path: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactComparison:
+    status: ArtifactStatus
+    artifact_path: str
+    blocker: ArtifactBlocker | None = None
+
+    @property
+    def usable(self) -> bool:
+        return self.status in {ArtifactStatus.CURRENT, ArtifactStatus.STALE}
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactManifestEntry:
+    artifact_path: str
+    basis_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactObservation:
+    artifact_path: str
+    present: bool
+    blocker: ArtifactBlocker | None = None
+
+
+class ArtifactManifestAdapter(Protocol):
+    """Storage seam used by the artifact manifest domain module."""
+
+    def inspect_artifact(self, artifact_path: str) -> ArtifactObservation: ...
+
+    def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None: ...
+
+    def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool: ...
+
+
+class ArtifactManifest:
+    """Register and compare canonical artifact bases through one storage seam."""
+
+    def __init__(self, adapter: ArtifactManifestAdapter) -> None:
+        self._adapter = adapter
+
+    def register(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> bool:
+        observation = self._adapter.inspect_artifact(artifact_path)
+        if observation.blocker is not None:
+            raise ArtifactRegistrationError(observation.blocker.detail)
+        if not observation.present:
+            raise ArtifactRegistrationError(f"artifact is not present: {observation.artifact_path}")
+        return self._adapter.put_entry(
+            key,
+            ArtifactManifestEntry(
+                artifact_path=observation.artifact_path,
+                basis_digest=basis.digest,
+            ),
+        )
+
+    def compare(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> ArtifactComparison:
+        observation = self._adapter.inspect_artifact(artifact_path)
+        if observation.blocker is not None:
+            return ArtifactComparison(
+                status=ArtifactStatus.BLOCKED,
+                artifact_path=observation.artifact_path,
+                blocker=observation.blocker,
+            )
+        if not observation.present:
+            return ArtifactComparison(status=ArtifactStatus.MISSING, artifact_path=observation.artifact_path)
+        try:
+            entry = self._adapter.get_entry(key)
+        except ArtifactManifestError as exc:
+            blocker = ArtifactBlocker(
+                code="manifest_unreadable",
+                path=observation.artifact_path,
+                detail=str(exc),
+            )
+            return ArtifactComparison(
+                status=ArtifactStatus.BLOCKED,
+                artifact_path=observation.artifact_path,
+                blocker=blocker,
+            )
+        if entry is None:
+            return ArtifactComparison(status=ArtifactStatus.MISSING, artifact_path=observation.artifact_path)
+        status = (
+            ArtifactStatus.CURRENT
+            if entry.artifact_path == observation.artifact_path and entry.basis_digest == basis.digest
+            else ArtifactStatus.STALE
+        )
+        return ArtifactComparison(status=status, artifact_path=observation.artifact_path)
+
+
+class InMemoryArtifactManifestAdapter:
+    """Thread-safe in-memory adapter for isolated domain tests and ephemeral callers."""
+
+    def __init__(self, *, artifacts: set[str] | None = None) -> None:
+        self._lock = threading.RLock()
+        self._entries: dict[str, ArtifactManifestEntry] = {}
+        self._artifacts = {_normalize_relative_path(path) for path in artifacts or set()}
+        self._blockers: dict[str, ArtifactBlocker] = {}
+
+    def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
+        try:
+            normalized = _normalize_relative_path(artifact_path)
+        except ValueError as exc:
+            blocker = ArtifactBlocker(code="artifact_path_invalid", path=str(artifact_path), detail=str(exc))
+            return ArtifactObservation(artifact_path=str(artifact_path), present=False, blocker=blocker)
+        with self._lock:
+            blocker = self._blockers.get(normalized)
+            return ArtifactObservation(
+                artifact_path=normalized,
+                present=normalized in self._artifacts and blocker is None,
+                blocker=blocker,
+            )
+
+    def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
+        with self._lock:
+            return self._entries.get(key.encode())
+
+    def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool:
+        with self._lock:
+            encoded = key.encode()
+            if self._entries.get(encoded) == entry:
+                return False
+            self._entries[encoded] = entry
+            return True
+
+    def remove_artifact(self, artifact_path: str) -> None:
+        normalized = _normalize_relative_path(artifact_path)
+        with self._lock:
+            self._artifacts.discard(normalized)
+            self._blockers.pop(normalized, None)
+
+    def block_artifact(self, artifact_path: str, *, code: str, detail: str) -> None:
+        normalized = _normalize_relative_path(artifact_path)
+        with self._lock:
+            self._artifacts.discard(normalized)
+            self._blockers[normalized] = ArtifactBlocker(code=code, path=normalized, detail=detail)
+
+
+class ProjectArtifactManifestAdapter:
+    """Safe project-directory adapter backed by a versioned JSON manifest."""
+
+    def __init__(self, project_dir: Path) -> None:
+        if _is_linkish(project_dir):
+            raise ArtifactManifestError(f"project directory is a symlink or junction: {project_dir}")
+        try:
+            resolved = project_dir.resolve(strict=True)
+        except OSError as exc:
+            raise ArtifactManifestError(f"project directory is unavailable: {project_dir}") from exc
+        if not resolved.is_dir():
+            raise ArtifactManifestError(f"project path is not a directory: {resolved}")
+        self._project_dir = resolved
+
+    def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
+        try:
+            normalized = _normalize_relative_path(artifact_path)
+        except ValueError as exc:
+            blocker = ArtifactBlocker(code="artifact_path_invalid", path=str(artifact_path), detail=str(exc))
+            return ArtifactObservation(artifact_path=str(artifact_path), present=False, blocker=blocker)
+        path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
+        cursor = self._project_dir
+        for part in PurePosixPath(normalized).parts:
+            cursor = cursor / part
+            if _is_linkish(cursor):
+                blocker = ArtifactBlocker(
+                    code="artifact_symlink",
+                    path=normalized,
+                    detail=f"artifact path contains a symlink or junction: {normalized}",
+                )
+                return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
+            if not cursor.exists():
+                return ArtifactObservation(artifact_path=normalized, present=False)
+        if not path.is_file():
+            blocker = ArtifactBlocker(
+                code="artifact_not_regular_file",
+                path=normalized,
+                detail=f"artifact path is not a regular file: {normalized}",
+            )
+            return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(path, flags)
+            try:
+                os.read(fd, 1)
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            blocker = ArtifactBlocker(
+                code="artifact_unreadable",
+                path=normalized,
+                detail=f"artifact is unreadable: {normalized}: {exc}",
+            )
+            return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
+        return ArtifactObservation(artifact_path=normalized, present=True)
+
+    def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
+        with self._locked():
+            entries, _ = self._load_unlocked()
+            return entries.get(key.encode())
+
+    def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool:
+        with self._locked():
+            entries, original_bytes = self._load_unlocked()
+            encoded = key.encode()
+            if entries.get(encoded) == entry and original_bytes is not None:
+                return False
+            entries[encoded] = entry
+            new_bytes = _serialize_manifest(entries)
+            if original_bytes == new_bytes:
+                return False
+            self._atomic_replace(new_bytes)
+            return True
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        lock_path = self._project_dir / LOCK_FILENAME
+        if _is_linkish(lock_path):
+            raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
+        flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
+            raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
+        handle = os.fdopen(fd, "wb")
+        deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+        try:
+            while True:
+                try:
+                    portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                    break
+                except (portalocker.AlreadyLocked, portalocker.LockException) as exc:
+                    if time.monotonic() >= deadline:
+                        raise ArtifactManifestError(f"timed out acquiring manifest lock: {lock_path}") from exc
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                portalocker.unlock(handle)
+        finally:
+            handle.close()
+
+    def _load_unlocked(self) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
+        path = self._project_dir / MANIFEST_FILENAME
+        if _is_linkish(path):
+            raise ArtifactManifestError(f"artifact manifest is a symlink or junction: {path}")
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(path, flags)
+        except FileNotFoundError:
+            return {}, None
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise ArtifactManifestError(f"artifact manifest is a symlink: {path}") from exc
+            raise ArtifactManifestError(f"cannot open artifact manifest: {path}: {exc}") from exc
+        try:
+            with os.fdopen(fd, "rb") as handle:
+                raw = handle.read()
+        except OSError as exc:
+            raise ArtifactManifestError(f"cannot read artifact manifest: {path}: {exc}") from exc
+        return _parse_manifest(raw), raw
+
+    def _atomic_replace(self, content: bytes) -> None:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f"{MANIFEST_FILENAME}.",
+            suffix=".tmp",
+            dir=self._project_dir,
+        )
+        try:
+            if os.name == "posix":
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, self._project_dir / MANIFEST_FILENAME)
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise ArtifactManifestError(f"cannot replace artifact manifest: {exc}") from exc
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class ArtifactBasis:
+    """Canonical, immutable evidence describing an artifact's direct inputs."""
+
+    kind: str
+    kind_version: int
+    _normalized: bytes
+    digest: str
+
+    def __init__(self, kind: str, *, kind_version: int, inputs: Mapping[str, object]) -> None:
+        if not kind:
+            raise ValueError("basis kind must be a non-empty string")
+        if type(kind_version) is not int or kind_version < 1:
+            raise ValueError("basis kind_version must be a positive integer")
+        normalized_inputs = _normalize_json(inputs)
+        payload = {
+            "inputs": normalized_inputs,
+            "kind": kind,
+            "kind_version": kind_version,
+        }
+        normalized = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "kind_version", kind_version)
+        object.__setattr__(self, "_normalized", normalized)
+        object.__setattr__(self, "digest", f"sha256-v1:{hashlib.sha256(normalized).hexdigest()}")
+
+    @classmethod
+    def build(cls, kind: str, *, kind_version: int, inputs: Mapping[str, object]) -> Self:
+        return cls(kind, kind_version=kind_version, inputs=inputs)
+
+    def normalized_bytes(self) -> bytes:
+        return self._normalized
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactKey:
+    """Typed artifact identity with a canonical reversible wire representation."""
+
+    kind: ArtifactKind
+    components: tuple[str | int, ...]
+
+    def __post_init__(self) -> None:
+        valid = False
+        if self.kind is ArtifactKind.ASSET_SHEET and len(self.components) == 2:
+            asset_type, asset_id = self.components
+            valid = (
+                isinstance(asset_type, str)
+                and asset_type in _ASSET_TYPES
+                and isinstance(asset_id, str)
+                and bool(asset_id)
+            )
+        elif self.kind in {ArtifactKind.EPISODE_STEP1, ArtifactKind.EPISODE_SCRIPT} and len(self.components) == 1:
+            episode = self.components[0]
+            valid = type(episode) is int and episode > 0
+        elif (
+            self.kind
+            in {
+                ArtifactKind.EPISODE_GRID,
+                ArtifactKind.EPISODE_STORYBOARD,
+                ArtifactKind.EPISODE_VIDEO,
+                ArtifactKind.EPISODE_AUDIO,
+            }
+            and len(self.components) == 2
+        ):
+            episode, resource_id = self.components
+            valid = type(episode) is int and episode > 0 and isinstance(resource_id, str) and bool(resource_id)
+        if not valid:
+            raise ValueError(f"artifact key components do not match {self.kind!r}: {self.components!r}")
+
+    @classmethod
+    def asset_sheet(cls, asset_type: str, asset_id: str) -> Self:
+        if asset_type not in _ASSET_TYPES:
+            raise ValueError(f"unsupported asset type: {asset_type!r}")
+        return cls(ArtifactKind.ASSET_SHEET, (asset_type, _non_empty("asset_id", asset_id)))
+
+    @classmethod
+    def episode_step1(cls, episode: int) -> Self:
+        return cls(ArtifactKind.EPISODE_STEP1, (_episode_number(episode),))
+
+    @classmethod
+    def episode_script(cls, episode: int) -> Self:
+        return cls(ArtifactKind.EPISODE_SCRIPT, (_episode_number(episode),))
+
+    @classmethod
+    def episode_grid(cls, episode: int, group_id: str) -> Self:
+        return cls(ArtifactKind.EPISODE_GRID, (_episode_number(episode), _non_empty("group_id", group_id)))
+
+    @classmethod
+    def episode_storyboard(cls, episode: int, resource_id: str) -> Self:
+        return cls(
+            ArtifactKind.EPISODE_STORYBOARD,
+            (_episode_number(episode), _non_empty("resource_id", resource_id)),
+        )
+
+    @classmethod
+    def episode_video(cls, episode: int, resource_id: str) -> Self:
+        return cls(
+            ArtifactKind.EPISODE_VIDEO,
+            (_episode_number(episode), _non_empty("resource_id", resource_id)),
+        )
+
+    @classmethod
+    def episode_audio(cls, episode: int, segment_id: str) -> Self:
+        return cls(
+            ArtifactKind.EPISODE_AUDIO,
+            (_episode_number(episode), _non_empty("segment_id", segment_id)),
+        )
+
+    def encode(self) -> str:
+        payload = json.dumps(
+            [self.kind.value, *self.components],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        token = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+        return _KEY_PREFIX + token
+
+    @classmethod
+    def decode(cls, value: str) -> Self:
+        if not value.startswith(_KEY_PREFIX):
+            raise ValueError("artifact key has an unsupported encoding")
+        token = value.removeprefix(_KEY_PREFIX)
+        try:
+            raw = base64.b64decode(token + "=" * (-len(token) % 4), altchars=b"-_", validate=True)
+            payload = json.loads(raw.decode("utf-8"))
+        except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("artifact key is malformed") from exc
+        if not isinstance(payload, list) or not payload or not isinstance(payload[0], str):
+            raise ValueError("artifact key payload is malformed")
+        key = cls._from_parts(payload[0], payload[1:])
+        if key.encode() != value:
+            raise ValueError("artifact key is not canonical")
+        return key
+
+    @classmethod
+    def _from_parts(cls, kind_value: str, parts: list[object]) -> Self:
+        try:
+            kind = ArtifactKind(kind_value)
+        except ValueError as exc:
+            raise ValueError(f"unsupported artifact kind: {kind_value!r}") from exc
+        if kind is ArtifactKind.ASSET_SHEET and len(parts) == 2:
+            asset_type, asset_id = parts
+            if isinstance(asset_type, str) and isinstance(asset_id, str):
+                return cls.asset_sheet(asset_type, asset_id)
+        elif kind in {ArtifactKind.EPISODE_STEP1, ArtifactKind.EPISODE_SCRIPT} and len(parts) == 1:
+            episode = parts[0]
+            if type(episode) is int:
+                builder = cls.episode_step1 if kind is ArtifactKind.EPISODE_STEP1 else cls.episode_script
+                return builder(episode)
+        elif (
+            kind
+            in {
+                ArtifactKind.EPISODE_GRID,
+                ArtifactKind.EPISODE_STORYBOARD,
+                ArtifactKind.EPISODE_VIDEO,
+                ArtifactKind.EPISODE_AUDIO,
+            }
+            and len(parts) == 2
+        ):
+            episode, resource_id = parts
+            if type(episode) is int and isinstance(resource_id, str):
+                builders = {
+                    ArtifactKind.EPISODE_GRID: cls.episode_grid,
+                    ArtifactKind.EPISODE_STORYBOARD: cls.episode_storyboard,
+                    ArtifactKind.EPISODE_VIDEO: cls.episode_video,
+                    ArtifactKind.EPISODE_AUDIO: cls.episode_audio,
+                }
+                return builders[kind](episode, resource_id)
+        raise ValueError("artifact key payload does not match its kind")
+
+
+def _episode_number(value: int) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"episode must be a positive integer, got {value!r}")
+    return value
+
+
+def _non_empty(field: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _normalize_json(value: object) -> object:
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if type(value) is int:
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("artifact basis does not permit non-finite numbers")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, object] = {}
+        for raw_key, raw_value in value.items():
+            if not isinstance(raw_key, str):
+                raise ValueError("artifact basis object keys must be strings")
+            normalized[raw_key] = _normalize_json(raw_value)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_normalize_json(item) for item in value]
+    raise ValueError(f"artifact basis contains a non-JSON value: {type(value).__name__}")
+
+
+def _normalize_relative_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
+        raise ValueError(f"artifact path must be a non-empty project-relative POSIX path: {value!r}")
+    raw_parts = value.split("/")
+    path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        path.is_absolute()
+        or windows_path.drive
+        or windows_path.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+    ):
+        raise ValueError(f"artifact path must be a canonical project-relative POSIX path: {value!r}")
+    normalized = path.as_posix()
+    if normalized in {".", ""}:
+        raise ValueError(f"artifact path must name a file: {value!r}")
+    if normalized in _RESERVED_ARTIFACT_PATHS:
+        raise ValueError(f"runtime-owned path cannot be registered as an artifact: {value!r}")
+    return normalized
+
+
+def _serialize_manifest(entries: Mapping[str, ArtifactManifestEntry]) -> bytes:
+    payload = {
+        "entries": {
+            key: {
+                "artifact_path": entry.artifact_path,
+                "basis_digest": entry.basis_digest,
+            }
+            for key, entry in sorted(entries.items())
+        },
+        "hash_algorithm": HASH_ALGORITHM,
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8") + b"\n"
+
+
+def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ArtifactManifestError(f"artifact manifest is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(payload, dict) or set(payload) != {"entries", "hash_algorithm", "schema_version"}:
+        raise ArtifactManifestError("artifact manifest has an invalid top-level schema")
+    if payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
+        raise ArtifactManifestError(f"unsupported artifact manifest schema_version: {payload['schema_version']!r}")
+    if payload["hash_algorithm"] != HASH_ALGORITHM:
+        raise ArtifactManifestError(f"unsupported artifact manifest hash_algorithm: {payload['hash_algorithm']!r}")
+    raw_entries = payload["entries"]
+    if not isinstance(raw_entries, dict):
+        raise ArtifactManifestError("artifact manifest entries must be an object")
+    entries: dict[str, ArtifactManifestEntry] = {}
+    for encoded_key, raw_entry in raw_entries.items():
+        if not isinstance(encoded_key, str):
+            raise ArtifactManifestError("artifact manifest entry keys must be strings")
+        try:
+            ArtifactKey.decode(encoded_key)
+        except ValueError as exc:
+            raise ArtifactManifestError(f"artifact manifest contains an invalid key: {encoded_key!r}") from exc
+        if not isinstance(raw_entry, dict) or set(raw_entry) != {"artifact_path", "basis_digest"}:
+            raise ArtifactManifestError(f"artifact manifest entry has an invalid schema: {encoded_key}")
+        artifact_path = raw_entry["artifact_path"]
+        basis_digest = raw_entry["basis_digest"]
+        try:
+            normalized_path = _normalize_relative_path(artifact_path)
+        except (TypeError, ValueError) as exc:
+            raise ArtifactManifestError(f"artifact manifest entry has an invalid path: {encoded_key}") from exc
+        if normalized_path != artifact_path:
+            raise ArtifactManifestError(f"artifact manifest entry path is not canonical: {encoded_key}")
+        if not isinstance(basis_digest, str) or _DIGEST_RE.fullmatch(basis_digest) is None:
+            raise ArtifactManifestError(f"artifact manifest entry has an invalid basis digest: {encoded_key}")
+        entries[encoded_key] = ArtifactManifestEntry(
+            artifact_path=normalized_path,
+            basis_digest=basis_digest,
+        )
+    return entries
+
+
+def _is_linkish(path: Path) -> bool:
+    return path.is_symlink() or path.is_junction()

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -329,8 +329,15 @@ class ProjectArtifactManifestAdapter:
                     )
                 stack.callback(os.close, next_fd)
                 if expected_parent_identity is not None:
-                    opened_parent_stat = os.fstat(next_fd)
-                    current_parent_stat = cursor.stat(follow_symlinks=False)
+                    try:
+                        opened_parent_stat = os.fstat(next_fd)
+                        current_parent_stat = cursor.stat(follow_symlinks=False)
+                    except OSError as exc:
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_unreadable",
+                            f"artifact parent changed while it was being opened: {normalized}: {exc}",
+                        )
                     if (
                         _is_linkish(cursor)
                         or not stat.S_ISDIR(opened_parent_stat.st_mode)
@@ -521,7 +528,7 @@ class ProjectArtifactManifestAdapter:
         lock_path = self._project_dir / LOCK_FILENAME
         with contextlib.ExitStack() as root_stack:
             root_fd: int | None = None
-            portable_lock_identity: tuple[int, int] | None = None
+            checked_lock_identity: tuple[int, int] | None = None
             try:
                 if os.name == "posix":
                     root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
@@ -536,9 +543,8 @@ class ProjectArtifactManifestAdapter:
                     self._assert_open_project_root_identity(root_fd)
                 else:
                     root_stack.enter_context(self._guard_portable_project_root())
-                    portable_lock_identity = self._runtime_file_identity(lock_path, "manifest lock")
-                if root_fd is not None and not _O_NOFOLLOW and _is_linkish(lock_path):
-                    raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
+                if root_fd is None or not _O_NOFOLLOW:
+                    checked_lock_identity = self._runtime_file_identity(lock_path, "manifest lock")
                 flags = os.O_WRONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
                 try:
                     if root_fd is not None:
@@ -553,11 +559,11 @@ class ProjectArtifactManifestAdapter:
                         raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
                     raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
                 try:
-                    if root_fd is None:
+                    if root_fd is None or not _O_NOFOLLOW:
                         self._assert_open_runtime_file_identity(
                             lock_path,
                             fd,
-                            portable_lock_identity,
+                            checked_lock_identity,
                             "manifest lock",
                         )
                     elif not stat.S_ISREG(os.fstat(fd).st_mode):

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import base64
 import binascii
 import contextlib
+import ctypes
+import ctypes.wintypes as wintypes
 import errno
 import hashlib
 import json
@@ -417,13 +419,15 @@ class ProjectArtifactManifestAdapter:
                     root_stack.enter_context(self._guard_portable_project_root())
                 if root_fd is None and _is_linkish(lock_path):
                     raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
-                flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+                flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
                 try:
-                    fd = (
-                        os.open(LOCK_FILENAME, flags, 0o600, dir_fd=root_fd)
-                        if root_fd is not None
-                        else os.open(lock_path, flags, 0o600)
-                    )
+                    if root_fd is not None:
+                        try:
+                            fd = os.open(LOCK_FILENAME, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=root_fd)
+                        except FileExistsError:
+                            fd = os.open(LOCK_FILENAME, flags, dir_fd=root_fd)
+                    else:
+                        fd = os.open(lock_path, flags | os.O_CREAT, 0o600)
                 except OSError as exc:
                     if exc.errno == errno.ELOOP:
                         raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
@@ -826,9 +830,6 @@ def _is_linkish(path: Path) -> bool:
 
 
 def _open_windows_directory_handle(path: Path) -> int:
-    import ctypes
-    from ctypes import wintypes
-
     kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
     create_file = kernel32.CreateFileW
     create_file.argtypes = [
@@ -857,9 +858,6 @@ def _open_windows_directory_handle(path: Path) -> int:
 
 
 def _close_windows_handle(handle: int) -> None:
-    import ctypes
-    from ctypes import wintypes
-
     kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
     close_handle = kernel32.CloseHandle
     close_handle.argtypes = [wintypes.HANDLE]

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -298,12 +298,25 @@ class ProjectArtifactManifestAdapter:
             cursor = self._project_dir
             for part in parts[:-1]:
                 cursor /= part
+                expected_parent_identity: tuple[int, int] | None = None
                 if not _O_NOFOLLOW and _is_linkish(cursor):
                     return self._artifact_blocked(
                         normalized,
                         "artifact_symlink",
                         f"artifact path contains a symlink or junction: {normalized}",
                     )
+                if not _O_NOFOLLOW:
+                    try:
+                        parent_stat = cursor.stat(follow_symlinks=False)
+                    except FileNotFoundError:
+                        return ArtifactObservation(artifact_path=normalized, present=False)
+                    except OSError as exc:
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_unreadable",
+                            f"artifact parent cannot be inspected safely: {normalized}: {exc}",
+                        )
+                    expected_parent_identity = (parent_stat.st_dev, parent_stat.st_ino)
                 try:
                     next_fd = os.open(part, directory_flags, dir_fd=directory_fd)
                 except FileNotFoundError:
@@ -315,14 +328,41 @@ class ProjectArtifactManifestAdapter:
                         f"artifact parent cannot be opened safely: {normalized}: {exc}",
                     )
                 stack.callback(os.close, next_fd)
+                if expected_parent_identity is not None:
+                    opened_parent_stat = os.fstat(next_fd)
+                    current_parent_stat = cursor.stat(follow_symlinks=False)
+                    if (
+                        _is_linkish(cursor)
+                        or not stat.S_ISDIR(opened_parent_stat.st_mode)
+                        or (opened_parent_stat.st_dev, opened_parent_stat.st_ino) != expected_parent_identity
+                        or (current_parent_stat.st_dev, current_parent_stat.st_ino) != expected_parent_identity
+                    ):
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_symlink",
+                            f"artifact parent changed while it was being opened: {normalized}",
+                        )
                 directory_fd = next_fd
             final_path = cursor / parts[-1]
+            expected_file_identity: tuple[int, int] | None = None
             if not _O_NOFOLLOW and _is_linkish(final_path):
                 return self._artifact_blocked(
                     normalized,
                     "artifact_symlink",
                     f"artifact path contains a symlink or junction: {normalized}",
                 )
+            if not _O_NOFOLLOW:
+                try:
+                    file_stat = final_path.stat(follow_symlinks=False)
+                except FileNotFoundError:
+                    return ArtifactObservation(artifact_path=normalized, present=False)
+                except OSError as exc:
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_unreadable",
+                        f"artifact cannot be inspected safely: {normalized}: {exc}",
+                    )
+                expected_file_identity = (file_stat.st_dev, file_stat.st_ino)
             try:
                 fd = os.open(parts[-1], file_flags, dir_fd=directory_fd)
             except FileNotFoundError:
@@ -335,13 +375,26 @@ class ProjectArtifactManifestAdapter:
                 )
             stack.callback(os.close, fd)
             try:
-                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                opened_file_stat = os.fstat(fd)
+                if not stat.S_ISREG(opened_file_stat.st_mode):
                     return self._artifact_blocked(
                         normalized,
                         "artifact_not_regular_file",
                         f"artifact path is not a regular file: {normalized}",
                     )
                 os.read(fd, 1)
+                if expected_file_identity is not None:
+                    current_file_stat = final_path.stat(follow_symlinks=False)
+                    if (
+                        _is_linkish(final_path)
+                        or (opened_file_stat.st_dev, opened_file_stat.st_ino) != expected_file_identity
+                        or (current_file_stat.st_dev, current_file_stat.st_ino) != expected_file_identity
+                    ):
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_symlink",
+                            f"artifact changed while it was being opened: {normalized}",
+                        )
             except OSError as exc:
                 return self._artifact_blocked(
                     normalized,
@@ -483,7 +536,7 @@ class ProjectArtifactManifestAdapter:
                     self._assert_open_project_root_identity(root_fd)
                 else:
                     root_stack.enter_context(self._guard_portable_project_root())
-                    portable_lock_identity = self._portable_runtime_file_identity(lock_path, "manifest lock")
+                    portable_lock_identity = self._runtime_file_identity(lock_path, "manifest lock")
                 if root_fd is not None and not _O_NOFOLLOW and _is_linkish(lock_path):
                     raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
                 flags = os.O_WRONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
@@ -501,7 +554,7 @@ class ProjectArtifactManifestAdapter:
                     raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
                 try:
                     if root_fd is None:
-                        self._assert_open_portable_runtime_file_identity(
+                        self._assert_open_runtime_file_identity(
                             lock_path,
                             fd,
                             portable_lock_identity,
@@ -564,7 +617,7 @@ class ProjectArtifactManifestAdapter:
             raise ArtifactManifestError(f"project directory changed after adapter initialization: {self._project_dir}")
 
     @staticmethod
-    def _portable_runtime_file_identity(path: Path, label: str) -> tuple[int, int] | None:
+    def _runtime_file_identity(path: Path, label: str) -> tuple[int, int] | None:
         if _is_linkish(path):
             raise ArtifactManifestError(f"{label} is a symlink or junction: {path}")
         try:
@@ -577,7 +630,7 @@ class ProjectArtifactManifestAdapter:
             raise ArtifactManifestError(f"{label} is not a regular file: {path}")
         return file_stat.st_dev, file_stat.st_ino
 
-    def _assert_open_portable_runtime_file_identity(
+    def _assert_open_runtime_file_identity(
         self,
         path: Path,
         fd: int,
@@ -588,7 +641,7 @@ class ProjectArtifactManifestAdapter:
             opened_stat = os.fstat(fd)
         except OSError as exc:
             raise ArtifactManifestError(f"opened {label} is unavailable: {path}: {exc}") from exc
-        current_identity = self._portable_runtime_file_identity(path, label)
+        current_identity = self._runtime_file_identity(path, label)
         opened_identity = (opened_stat.st_dev, opened_stat.st_ino)
         if (
             not stat.S_ISREG(opened_stat.st_mode)
@@ -600,13 +653,11 @@ class ProjectArtifactManifestAdapter:
 
     def _load_unlocked(self, root_fd: int | None) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
-        portable_manifest_identity: tuple[int, int] | None = None
-        if root_fd is None:
-            portable_manifest_identity = self._portable_runtime_file_identity(path, "artifact manifest")
-            if portable_manifest_identity is None:
+        checked_manifest_identity: tuple[int, int] | None = None
+        if root_fd is None or not _O_NOFOLLOW:
+            checked_manifest_identity = self._runtime_file_identity(path, "artifact manifest")
+            if checked_manifest_identity is None:
                 return {}, None
-        elif not _O_NOFOLLOW and _is_linkish(path):
-            raise ArtifactManifestError(f"artifact manifest is a symlink or junction: {path}")
         flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
         try:
             fd = os.open(MANIFEST_FILENAME, flags, dir_fd=root_fd) if root_fd is not None else os.open(path, flags)
@@ -617,11 +668,11 @@ class ProjectArtifactManifestAdapter:
                 raise ArtifactManifestError(f"artifact manifest is a symlink: {path}") from exc
             raise ArtifactManifestError(f"cannot open artifact manifest: {path}: {exc}") from exc
         try:
-            if root_fd is None:
-                self._assert_open_portable_runtime_file_identity(
+            if root_fd is None or not _O_NOFOLLOW:
+                self._assert_open_runtime_file_identity(
                     path,
                     fd,
-                    portable_manifest_identity,
+                    checked_manifest_identity,
                     "artifact manifest",
                 )
             elif not stat.S_ISREG(os.fstat(fd).st_mode):

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -11,6 +11,7 @@ import json
 import math
 import os
 import re
+import secrets
 import stat
 import tempfile
 import threading
@@ -337,13 +338,13 @@ class ProjectArtifactManifestAdapter:
         )
 
     def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
-        with self._locked():
-            entries, _ = self._load_unlocked()
+        with self._locked() as root_fd:
+            entries, _ = self._load_unlocked(root_fd)
             return entries.get(key.encode())
 
     def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool:
-        with self._locked():
-            entries, original_bytes = self._load_unlocked()
+        with self._locked() as root_fd:
+            entries, original_bytes = self._load_unlocked(root_fd)
             encoded = key.encode()
             if entries.get(encoded) == entry and original_bytes is not None:
                 return False
@@ -351,48 +352,72 @@ class ProjectArtifactManifestAdapter:
             new_bytes = _serialize_manifest(entries)
             if original_bytes == new_bytes:
                 return False
-            self._atomic_replace(new_bytes)
+            self._atomic_replace(new_bytes, root_fd)
             return True
 
     @contextmanager
-    def _locked(self) -> Iterator[None]:
-        if _is_linkish(self._project_dir):
+    def _locked(self) -> Iterator[int | None]:
+        root_fd: int | None = None
+        if os.name == "posix":
+            root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                root_fd = os.open(self._project_dir, root_flags)
+            except OSError as exc:
+                raise ArtifactManifestError(
+                    f"project directory cannot be opened safely: {self._project_dir}: {exc}"
+                ) from exc
+        elif _is_linkish(self._project_dir):
             raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
         lock_path = self._project_dir / LOCK_FILENAME
-        if _is_linkish(lock_path):
-            raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
-        flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
         try:
-            fd = os.open(lock_path, flags, 0o600)
-        except OSError as exc:
-            if exc.errno == errno.ELOOP:
-                raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
-            raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
-        handle = os.fdopen(fd, "wb")
-        deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
-        try:
-            while True:
-                try:
-                    portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
-                    break
-                except (portalocker.AlreadyLocked, portalocker.LockException) as exc:
-                    if time.monotonic() >= deadline:
-                        raise ArtifactManifestError(f"timed out acquiring manifest lock: {lock_path}") from exc
-                    time.sleep(0.05)
+            if root_fd is None and _is_linkish(lock_path):
+                raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
+            flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
             try:
-                yield
+                fd = (
+                    os.open(LOCK_FILENAME, flags, 0o600, dir_fd=root_fd)
+                    if root_fd is not None
+                    else os.open(lock_path, flags, 0o600)
+                )
+            except OSError as exc:
+                if exc.errno == errno.ELOOP:
+                    raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
+                raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
+            try:
+                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    raise ArtifactManifestError(f"manifest lock is not a regular file: {lock_path}")
+                handle = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+            try:
+                while True:
+                    try:
+                        portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                        break
+                    except (portalocker.AlreadyLocked, portalocker.LockException) as exc:
+                        if time.monotonic() >= deadline:
+                            raise ArtifactManifestError(f"timed out acquiring manifest lock: {lock_path}") from exc
+                        time.sleep(0.05)
+                try:
+                    yield root_fd
+                finally:
+                    portalocker.unlock(handle)
             finally:
-                portalocker.unlock(handle)
+                handle.close()
         finally:
-            handle.close()
+            if root_fd is not None:
+                os.close(root_fd)
 
-    def _load_unlocked(self) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
+    def _load_unlocked(self, root_fd: int | None) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
-        if _is_linkish(path):
+        if root_fd is None and _is_linkish(path):
             raise ArtifactManifestError(f"artifact manifest is a symlink or junction: {path}")
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         try:
-            fd = os.open(path, flags)
+            fd = os.open(MANIFEST_FILENAME, flags, dir_fd=root_fd) if root_fd is not None else os.open(path, flags)
         except FileNotFoundError:
             return {}, None
         except OSError as exc:
@@ -400,25 +425,36 @@ class ProjectArtifactManifestAdapter:
                 raise ArtifactManifestError(f"artifact manifest is a symlink: {path}") from exc
             raise ArtifactManifestError(f"cannot open artifact manifest: {path}: {exc}") from exc
         try:
-            with os.fdopen(fd, "rb") as handle:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise ArtifactManifestError(f"artifact manifest is not a regular file: {path}")
+            handle = os.fdopen(fd, "rb")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        try:
+            with handle:
                 raw = handle.read()
         except OSError as exc:
             raise ArtifactManifestError(f"cannot read artifact manifest: {path}: {exc}") from exc
         return _parse_manifest(raw), raw
 
-    def _atomic_replace(self, content: bytes) -> None:
-        fd, tmp_name = tempfile.mkstemp(
-            prefix=f"{MANIFEST_FILENAME}.",
-            suffix=".tmp",
-            dir=self._project_dir,
-        )
+    def _atomic_replace(self, content: bytes, root_fd: int | None) -> None:
+        if root_fd is None:
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f"{MANIFEST_FILENAME}.",
+                suffix=".tmp",
+                dir=self._project_dir,
+            )
+        else:
+            fd, tmp_name = _create_temporary_file(root_fd)
         try:
             handle = os.fdopen(fd, "wb")
         except BaseException:
             with contextlib.suppress(OSError):
                 os.close(fd)
             with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
+                _unlink_temporary_file(tmp_name, root_fd)
             raise
         try:
             with handle:
@@ -427,14 +463,17 @@ class ProjectArtifactManifestAdapter:
                 handle.write(content)
                 handle.flush()
                 os.fsync(handle.fileno())
-            os.replace(tmp_name, self._project_dir / MANIFEST_FILENAME)
+            if root_fd is None:
+                os.replace(tmp_name, self._project_dir / MANIFEST_FILENAME)
+            else:
+                os.replace(tmp_name, MANIFEST_FILENAME, src_dir_fd=root_fd, dst_dir_fd=root_fd)
         except OSError as exc:
             with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
+                _unlink_temporary_file(tmp_name, root_fd)
             raise ArtifactManifestError(f"cannot replace artifact manifest: {exc}") from exc
         except BaseException:
             with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
+                _unlink_temporary_file(tmp_name, root_fd)
             raise
 
 
@@ -702,3 +741,23 @@ def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
 
 def _is_linkish(path: Path) -> bool:
     return path.is_symlink() or path.is_junction()
+
+
+def _create_temporary_file(root_fd: int) -> tuple[int, str]:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+    for _ in range(100):
+        tmp_name = f"{MANIFEST_FILENAME}.{secrets.token_hex(8)}.tmp"
+        try:
+            return os.open(tmp_name, flags, 0o600, dir_fd=root_fd), tmp_name
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise ArtifactManifestError(f"cannot create temporary artifact manifest: {exc}") from exc
+    raise ArtifactManifestError("cannot allocate a unique temporary artifact manifest")
+
+
+def _unlink_temporary_file(tmp_name: str, root_fd: int | None) -> None:
+    if root_fd is None:
+        os.unlink(tmp_name)
+    else:
+        os.unlink(tmp_name, dir_fd=root_fd)

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -328,6 +328,13 @@ class ProjectArtifactManifestAdapter:
                 "artifact_symlink",
                 f"project directory is a symlink or junction: {self._project_dir}",
             )
+        try:
+            with self._guard_portable_project_root():
+                return self._inspect_artifact_portable_guarded(normalized)
+        except ArtifactManifestError as exc:
+            return self._artifact_blocked(normalized, "artifact_unreadable", str(exc))
+
+    def _inspect_artifact_portable_guarded(self, normalized: str) -> ArtifactObservation:
         path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
         cursor = self._project_dir
         checked_components: list[tuple[Path, tuple[int, int], int]] = []

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -866,6 +866,10 @@ def _normalize_json(value: object) -> object:
 def _normalize_relative_path(value: object) -> str:
     if not isinstance(value, str) or not value or "\x00" in value or "\\" in value:
         raise ValueError(f"artifact path must be a non-empty project-relative POSIX path: {value!r}")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"artifact path must be valid UTF-8: {value!r}") from exc
     raw_parts = value.split("/")
     path = PurePosixPath(value)
     windows_path = PureWindowsPath(value)
@@ -875,6 +879,7 @@ def _normalize_relative_path(value: object) -> str:
         or windows_path.is_absolute()
         or any(part in {"", ".", ".."} for part in raw_parts)
         or any(part.rstrip(" .") != part for part in raw_parts)
+        or any(":" in part for part in raw_parts)
     ):
         raise ValueError(f"artifact path must be a canonical project-relative POSIX path: {value!r}")
     normalized = path.as_posix()

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -432,6 +432,7 @@ class ProjectArtifactManifestAdapter:
         lock_path = self._project_dir / LOCK_FILENAME
         with contextlib.ExitStack() as root_stack:
             root_fd: int | None = None
+            portable_lock_identity: tuple[int, int] | None = None
             try:
                 if os.name == "posix":
                     root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
@@ -446,7 +447,8 @@ class ProjectArtifactManifestAdapter:
                     self._assert_open_project_root_identity(root_fd)
                 else:
                     root_stack.enter_context(self._guard_portable_project_root())
-                if (root_fd is None or not _O_NOFOLLOW) and _is_linkish(lock_path):
+                    portable_lock_identity = self._portable_runtime_file_identity(lock_path, "manifest lock")
+                if root_fd is not None and not _O_NOFOLLOW and _is_linkish(lock_path):
                     raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
                 flags = os.O_WRONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
                 try:
@@ -462,7 +464,14 @@ class ProjectArtifactManifestAdapter:
                         raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
                     raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
                 try:
-                    if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    if root_fd is None:
+                        self._assert_open_portable_runtime_file_identity(
+                            lock_path,
+                            fd,
+                            portable_lock_identity,
+                            "manifest lock",
+                        )
+                    elif not stat.S_ISREG(os.fstat(fd).st_mode):
                         raise ArtifactManifestError(f"manifest lock is not a regular file: {lock_path}")
                     handle = os.fdopen(fd, "wb")
                 except BaseException:
@@ -518,9 +527,49 @@ class ProjectArtifactManifestAdapter:
         if not stat.S_ISDIR(root_stat.st_mode) or (root_stat.st_dev, root_stat.st_ino) != self._project_identity:
             raise ArtifactManifestError(f"project directory changed after adapter initialization: {self._project_dir}")
 
+    @staticmethod
+    def _portable_runtime_file_identity(path: Path, label: str) -> tuple[int, int] | None:
+        if _is_linkish(path):
+            raise ArtifactManifestError(f"{label} is a symlink or junction: {path}")
+        try:
+            file_stat = path.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise ArtifactManifestError(f"{label} is unavailable: {path}: {exc}") from exc
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ArtifactManifestError(f"{label} is not a regular file: {path}")
+        return file_stat.st_dev, file_stat.st_ino
+
+    def _assert_open_portable_runtime_file_identity(
+        self,
+        path: Path,
+        fd: int,
+        expected_identity: tuple[int, int] | None,
+        label: str,
+    ) -> None:
+        try:
+            opened_stat = os.fstat(fd)
+        except OSError as exc:
+            raise ArtifactManifestError(f"opened {label} is unavailable: {path}: {exc}") from exc
+        current_identity = self._portable_runtime_file_identity(path, label)
+        opened_identity = (opened_stat.st_dev, opened_stat.st_ino)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or current_identity is None
+            or current_identity != opened_identity
+            or (expected_identity is not None and current_identity != expected_identity)
+        ):
+            raise ArtifactManifestError(f"{label} changed while it was being opened: {path}")
+
     def _load_unlocked(self, root_fd: int | None) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
-        if (root_fd is None or not _O_NOFOLLOW) and _is_linkish(path):
+        portable_manifest_identity: tuple[int, int] | None = None
+        if root_fd is None:
+            portable_manifest_identity = self._portable_runtime_file_identity(path, "artifact manifest")
+            if portable_manifest_identity is None:
+                return {}, None
+        elif not _O_NOFOLLOW and _is_linkish(path):
             raise ArtifactManifestError(f"artifact manifest is a symlink or junction: {path}")
         flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
         try:
@@ -532,7 +581,14 @@ class ProjectArtifactManifestAdapter:
                 raise ArtifactManifestError(f"artifact manifest is a symlink: {path}") from exc
             raise ArtifactManifestError(f"cannot open artifact manifest: {path}: {exc}") from exc
         try:
-            if not stat.S_ISREG(os.fstat(fd).st_mode):
+            if root_fd is None:
+                self._assert_open_portable_runtime_file_identity(
+                    path,
+                    fd,
+                    portable_manifest_identity,
+                    "artifact manifest",
+                )
+            elif not stat.S_ISREG(os.fstat(fd).st_mode):
                 raise ArtifactManifestError(f"artifact manifest is not a regular file: {path}")
             handle = os.fdopen(fd, "rb")
         except BaseException:
@@ -717,7 +773,7 @@ class ArtifactKey:
         try:
             raw = base64.b64decode(token + "=" * (-len(token) % 4), altchars=b"-_", validate=True)
             payload = json.loads(raw.decode("utf-8"))
-        except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        except (binascii.Error, UnicodeDecodeError, ValueError, RecursionError) as exc:
             raise ValueError("artifact key is malformed") from exc
         if not isinstance(payload, list) or not payload or not isinstance(payload[0], str):
             raise ValueError("artifact key payload is malformed")
@@ -782,6 +838,7 @@ def _normalize_relative_path(value: object) -> str:
         or windows_path.drive
         or windows_path.is_absolute()
         or any(part in {"", ".", ".."} for part in raw_parts)
+        or any(part.rstrip(" .") != part for part in raw_parts)
     ):
         raise ValueError(f"artifact path must be a canonical project-relative POSIX path: {value!r}")
     normalized = path.as_posix()
@@ -813,7 +870,7 @@ def _serialize_manifest(entries: Mapping[str, ArtifactManifestEntry]) -> bytes:
 def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
     try:
         payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, ValueError) as exc:
         raise ArtifactManifestError(f"artifact manifest is not valid UTF-8 JSON: {exc}") from exc
     except RecursionError as exc:
         raise ArtifactManifestError("artifact manifest exceeds the JSON nesting limit") from exc

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -25,7 +25,7 @@ from typing import Protocol, Self, cast
 
 import portalocker
 
-from lib.asset_types import ASSET_TYPES
+from lib.asset_types import ASSET_TYPES, normalize_asset_name
 
 _KEY_PREFIX = "artifact-key-v1:"
 MANIFEST_FILENAME = ".arcreel_artifacts.json"
@@ -569,12 +569,14 @@ class ArtifactKey:
         valid = False
         if self.kind is ArtifactKind.ASSET_SHEET and len(self.components) == 2:
             asset_type, asset_id = self.components
-            valid = (
+            if (
                 isinstance(asset_type, str)
                 and asset_type in ASSET_TYPES
                 and isinstance(asset_id, str)
                 and bool(asset_id)
-            )
+            ):
+                object.__setattr__(self, "components", (asset_type, normalize_asset_name(asset_id)))
+                valid = True
         elif self.kind in {ArtifactKind.EPISODE_STEP1, ArtifactKind.EPISODE_SCRIPT} and len(self.components) == 1:
             episode = self.components[0]
             valid = type(episode) is int and episode > 0
@@ -741,7 +743,7 @@ def _serialize_manifest(entries: Mapping[str, ArtifactManifestEntry]) -> bytes:
 
 def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
     try:
-        payload = json.loads(raw.decode("utf-8"))
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ArtifactManifestError(f"artifact manifest is not valid UTF-8 JSON: {exc}") from exc
     if not isinstance(payload, dict) or set(payload) != {"entries", "hash_algorithm", "schema_version"}:
@@ -778,6 +780,15 @@ def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
             basis_digest=basis_digest,
         )
     return entries
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ArtifactManifestError(f"artifact manifest contains a duplicate field: {key!r}")
+        payload[key] = value
+    return payload
 
 
 def _is_linkish(path: Path) -> bool:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -99,11 +99,14 @@ class ArtifactObservation:
 class ArtifactManifestAdapter(Protocol):
     """Storage seam used by the artifact manifest domain module."""
 
-    def inspect_artifact(self, artifact_path: str) -> ArtifactObservation: ...
+    def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
+        raise NotImplementedError
 
-    def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None: ...
+    def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
+        raise NotImplementedError
 
-    def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool: ...
+    def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool:
+        raise NotImplementedError
 
 
 class ArtifactManifest:
@@ -234,7 +237,7 @@ class ProjectArtifactManifestAdapter:
     def _inspect_artifact_posix(self, normalized: str) -> ArtifactObservation:
         parts = PurePosixPath(normalized).parts
         directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         try:
             root_fd = os.open(self._project_dir, directory_flags)
         except OSError as exc:
@@ -283,6 +286,12 @@ class ProjectArtifactManifestAdapter:
         return ArtifactObservation(artifact_path=normalized, present=True)
 
     def _inspect_artifact_portable(self, normalized: str) -> ArtifactObservation:
+        if _is_linkish(self._project_dir):
+            return self._artifact_blocked(
+                normalized,
+                "artifact_symlink",
+                f"project directory is a symlink or junction: {self._project_dir}",
+            )
         path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
         cursor = self._project_dir
         for part in PurePosixPath(normalized).parts:
@@ -347,6 +356,8 @@ class ProjectArtifactManifestAdapter:
 
     @contextmanager
     def _locked(self) -> Iterator[None]:
+        if _is_linkish(self._project_dir):
+            raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
         lock_path = self._project_dir / LOCK_FILENAME
         if _is_linkish(lock_path):
             raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
@@ -402,22 +413,26 @@ class ProjectArtifactManifestAdapter:
             dir=self._project_dir,
         )
         try:
-            if os.name == "posix":
-                os.fchmod(fd, 0o600)
-            with os.fdopen(fd, "wb") as handle:
+            handle = os.fdopen(fd, "wb")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+        try:
+            with handle:
+                if os.name == "posix":
+                    os.fchmod(handle.fileno(), 0o600)
                 handle.write(content)
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp_name, self._project_dir / MANIFEST_FILENAME)
         except OSError as exc:
             with contextlib.suppress(OSError):
-                os.close(fd)
-            with contextlib.suppress(OSError):
                 os.unlink(tmp_name)
             raise ArtifactManifestError(f"cannot replace artifact manifest: {exc}") from exc
         except BaseException:
-            with contextlib.suppress(OSError):
-                os.close(fd)
             with contextlib.suppress(OSError):
                 os.unlink(tmp_name)
             raise

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -11,6 +11,7 @@ import json
 import math
 import os
 import re
+import stat
 import tempfile
 import threading
 import time
@@ -19,12 +20,13 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Protocol, Self
+from typing import Protocol, Self, cast
 
 import portalocker
 
+from lib.asset_types import ASSET_TYPES
+
 _KEY_PREFIX = "artifact-key-v1:"
-_ASSET_TYPES = frozenset({"character", "scene", "prop", "product"})
 MANIFEST_FILENAME = ".arcreel_artifacts.json"
 LOCK_FILENAME = ".artifact_manifest.lock"
 MANIFEST_SCHEMA_VERSION = 1
@@ -225,6 +227,62 @@ class ProjectArtifactManifestAdapter:
         except ValueError as exc:
             blocker = ArtifactBlocker(code="artifact_path_invalid", path=str(artifact_path), detail=str(exc))
             return ArtifactObservation(artifact_path=str(artifact_path), present=False, blocker=blocker)
+        if os.name == "posix":
+            return self._inspect_artifact_posix(normalized)
+        return self._inspect_artifact_portable(normalized)
+
+    def _inspect_artifact_posix(self, normalized: str) -> ArtifactObservation:
+        parts = PurePosixPath(normalized).parts
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            root_fd = os.open(self._project_dir, directory_flags)
+        except OSError as exc:
+            return self._artifact_blocked(normalized, "artifact_unreadable", f"project directory is unreadable: {exc}")
+        with contextlib.ExitStack() as stack:
+            stack.callback(os.close, root_fd)
+            directory_fd = root_fd
+            for part in parts[:-1]:
+                try:
+                    next_fd = os.open(part, directory_flags, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    return ArtifactObservation(artifact_path=normalized, present=False)
+                except OSError as exc:
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_symlink" if exc.errno in {errno.ELOOP, errno.ENOTDIR} else "artifact_unreadable",
+                        f"artifact parent cannot be opened safely: {normalized}: {exc}",
+                    )
+                stack.callback(os.close, next_fd)
+                directory_fd = next_fd
+            try:
+                fd = os.open(parts[-1], file_flags, dir_fd=directory_fd)
+            except FileNotFoundError:
+                return ArtifactObservation(artifact_path=normalized, present=False)
+            except OSError as exc:
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_symlink" if exc.errno == errno.ELOOP else "artifact_unreadable",
+                    f"artifact cannot be opened safely: {normalized}: {exc}",
+                )
+            stack.callback(os.close, fd)
+            try:
+                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_not_regular_file",
+                        f"artifact path is not a regular file: {normalized}",
+                    )
+                os.read(fd, 1)
+            except OSError as exc:
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_unreadable",
+                    f"artifact is unreadable: {normalized}: {exc}",
+                )
+        return ArtifactObservation(artifact_path=normalized, present=True)
+
+    def _inspect_artifact_portable(self, normalized: str) -> ArtifactObservation:
         path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
         cursor = self._project_dir
         for part in PurePosixPath(normalized).parts:
@@ -260,6 +318,14 @@ class ProjectArtifactManifestAdapter:
             )
             return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
         return ArtifactObservation(artifact_path=normalized, present=True)
+
+    @staticmethod
+    def _artifact_blocked(normalized: str, code: str, detail: str) -> ArtifactObservation:
+        return ArtifactObservation(
+            artifact_path=normalized,
+            present=False,
+            blocker=ArtifactBlocker(code=code, path=normalized, detail=detail),
+        )
 
     def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
         with self._locked():
@@ -410,7 +476,7 @@ class ArtifactKey:
             asset_type, asset_id = self.components
             valid = (
                 isinstance(asset_type, str)
-                and asset_type in _ASSET_TYPES
+                and asset_type in ASSET_TYPES
                 and isinstance(asset_id, str)
                 and bool(asset_id)
             )
@@ -434,7 +500,7 @@ class ArtifactKey:
 
     @classmethod
     def asset_sheet(cls, asset_type: str, asset_id: str) -> Self:
-        if asset_type not in _ASSET_TYPES:
+        if asset_type not in ASSET_TYPES:
             raise ValueError(f"unsupported asset type: {asset_type!r}")
         return cls(ArtifactKind.ASSET_SHEET, (asset_type, _non_empty("asset_id", asset_id)))
 
@@ -503,35 +569,10 @@ class ArtifactKey:
             kind = ArtifactKind(kind_value)
         except ValueError as exc:
             raise ValueError(f"unsupported artifact kind: {kind_value!r}") from exc
-        if kind is ArtifactKind.ASSET_SHEET and len(parts) == 2:
-            asset_type, asset_id = parts
-            if isinstance(asset_type, str) and isinstance(asset_id, str):
-                return cls.asset_sheet(asset_type, asset_id)
-        elif kind in {ArtifactKind.EPISODE_STEP1, ArtifactKind.EPISODE_SCRIPT} and len(parts) == 1:
-            episode = parts[0]
-            if type(episode) is int:
-                builder = cls.episode_step1 if kind is ArtifactKind.EPISODE_STEP1 else cls.episode_script
-                return builder(episode)
-        elif (
-            kind
-            in {
-                ArtifactKind.EPISODE_GRID,
-                ArtifactKind.EPISODE_STORYBOARD,
-                ArtifactKind.EPISODE_VIDEO,
-                ArtifactKind.EPISODE_AUDIO,
-            }
-            and len(parts) == 2
-        ):
-            episode, resource_id = parts
-            if type(episode) is int and isinstance(resource_id, str):
-                builders = {
-                    ArtifactKind.EPISODE_GRID: cls.episode_grid,
-                    ArtifactKind.EPISODE_STORYBOARD: cls.episode_storyboard,
-                    ArtifactKind.EPISODE_VIDEO: cls.episode_video,
-                    ArtifactKind.EPISODE_AUDIO: cls.episode_audio,
-                }
-                return builders[kind](episode, resource_id)
-        raise ValueError("artifact key payload does not match its kind")
+        try:
+            return cls(kind, cast(tuple[str | int, ...], tuple(parts)))
+        except ValueError as exc:
+            raise ValueError("artifact key payload does not match its kind") from exc
 
 
 def _episode_number(value: int) -> int:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -219,17 +219,46 @@ class ProjectArtifactManifestAdapter:
     """Safe project-directory adapter backed by a versioned JSON manifest."""
 
     def __init__(self, project_dir: Path) -> None:
-        if _is_linkish(project_dir):
-            raise ArtifactManifestError(f"project directory is a symlink or junction: {project_dir}")
+        root_fd: int | None = None
+        windows_handle: int | None = None
         try:
+            initial_stat = project_dir.stat(follow_symlinks=False)
+            if _is_linkish(project_dir):
+                raise ArtifactManifestError(f"project directory is a symlink or junction: {project_dir}")
+            if not stat.S_ISDIR(initial_stat.st_mode):
+                raise ArtifactManifestError(f"project path is not a directory: {project_dir}")
+            initial_identity = (initial_stat.st_dev, initial_stat.st_ino)
+            opened_identity: tuple[int, int] | None = None
+            if os.name == "posix":
+                root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+                root_fd = os.open(project_dir, root_flags)
+                opened_stat = os.fstat(root_fd)
+                opened_identity = (opened_stat.st_dev, opened_stat.st_ino)
+            elif os.name == "nt":
+                windows_handle = _open_windows_directory_handle(project_dir)
             resolved = project_dir.resolve(strict=True)
+            current_stat = project_dir.stat(follow_symlinks=False)
+            resolved_stat = resolved.stat(follow_symlinks=False)
         except OSError as exc:
             raise ArtifactManifestError(f"project directory is unavailable: {project_dir}") from exc
-        if not resolved.is_dir():
-            raise ArtifactManifestError(f"project path is not a directory: {resolved}")
+        finally:
+            if root_fd is not None:
+                os.close(root_fd)
+            if windows_handle is not None:
+                _close_windows_handle(windows_handle)
+        current_identity = (current_stat.st_dev, current_stat.st_ino)
+        resolved_identity = (resolved_stat.st_dev, resolved_stat.st_ino)
+        if (
+            _is_linkish(project_dir)
+            or not stat.S_ISDIR(current_stat.st_mode)
+            or not stat.S_ISDIR(resolved_stat.st_mode)
+            or current_identity != initial_identity
+            or resolved_identity != initial_identity
+            or (opened_identity is not None and opened_identity != initial_identity)
+        ):
+            raise ArtifactManifestError(f"project directory changed during adapter initialization: {project_dir}")
         self._project_dir = resolved
-        root_stat = resolved.stat(follow_symlinks=False)
-        self._project_identity = (root_stat.st_dev, root_stat.st_ino)
+        self._project_identity = initial_identity
 
     def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
         try:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -38,6 +38,7 @@ LOCK_TIMEOUT_SECONDS = 10.0
 _DIGEST_RE = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
 _RESERVED_ARTIFACT_PATHS = frozenset({MANIFEST_FILENAME, LOCK_FILENAME})
 _WINDOWS_RESERVED_ARTIFACT_PATHS = frozenset(path.casefold() for path in _RESERVED_ARTIFACT_PATHS)
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
 class ArtifactKind(StrEnum):
@@ -242,9 +243,15 @@ class ProjectArtifactManifestAdapter:
 
     def _inspect_artifact_posix(self, normalized: str) -> ArtifactObservation:
         parts = PurePosixPath(normalized).parts
-        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+        file_flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
         with contextlib.ExitStack() as stack:
+            if not _O_NOFOLLOW and _is_linkish(self._project_dir):
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_symlink",
+                    f"project directory is a symlink or junction: {self._project_dir}",
+                )
             try:
                 root_fd = os.open(self._project_dir, directory_flags)
             except OSError as exc:
@@ -254,8 +261,20 @@ class ProjectArtifactManifestAdapter:
                     f"project directory is unreadable: {exc}",
                 )
             stack.callback(os.close, root_fd)
+            try:
+                self._assert_open_project_root_identity(root_fd)
+            except ArtifactManifestError as exc:
+                return self._artifact_blocked(normalized, "artifact_unreadable", str(exc))
             directory_fd = root_fd
+            cursor = self._project_dir
             for part in parts[:-1]:
+                cursor /= part
+                if not _O_NOFOLLOW and _is_linkish(cursor):
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_symlink",
+                        f"artifact path contains a symlink or junction: {normalized}",
+                    )
                 try:
                     next_fd = os.open(part, directory_flags, dir_fd=directory_fd)
                 except FileNotFoundError:
@@ -268,6 +287,13 @@ class ProjectArtifactManifestAdapter:
                     )
                 stack.callback(os.close, next_fd)
                 directory_fd = next_fd
+            final_path = cursor / parts[-1]
+            if not _O_NOFOLLOW and _is_linkish(final_path):
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_symlink",
+                    f"artifact path contains a symlink or junction: {normalized}",
+                )
             try:
                 fd = os.open(parts[-1], file_flags, dir_fd=directory_fd)
             except FileNotFoundError:
@@ -332,7 +358,7 @@ class ProjectArtifactManifestAdapter:
                 detail=f"artifact path is not a regular file: {normalized}",
             )
             return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | _O_NOFOLLOW
         try:
             fd = os.open(path, flags)
             try:
@@ -408,18 +434,21 @@ class ProjectArtifactManifestAdapter:
             root_fd: int | None = None
             try:
                 if os.name == "posix":
-                    root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+                    root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+                    if not _O_NOFOLLOW and _is_linkish(self._project_dir):
+                        raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
                     try:
                         root_fd = os.open(self._project_dir, root_flags)
                     except OSError as exc:
                         raise ArtifactManifestError(
                             f"project directory cannot be opened safely: {self._project_dir}: {exc}"
                         ) from exc
+                    self._assert_open_project_root_identity(root_fd)
                 else:
                     root_stack.enter_context(self._guard_portable_project_root())
-                if root_fd is None and _is_linkish(lock_path):
+                if (root_fd is None or not _O_NOFOLLOW) and _is_linkish(lock_path):
                     raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
-                flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+                flags = os.O_WRONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
                 try:
                     if root_fd is not None:
                         try:
@@ -481,11 +510,19 @@ class ProjectArtifactManifestAdapter:
         if not stat.S_ISDIR(root_stat.st_mode) or (root_stat.st_dev, root_stat.st_ino) != self._project_identity:
             raise ArtifactManifestError(f"project directory changed after adapter initialization: {self._project_dir}")
 
+    def _assert_open_project_root_identity(self, root_fd: int) -> None:
+        try:
+            root_stat = os.fstat(root_fd)
+        except OSError as exc:
+            raise ArtifactManifestError(f"opened project directory is unavailable: {self._project_dir}: {exc}") from exc
+        if not stat.S_ISDIR(root_stat.st_mode) or (root_stat.st_dev, root_stat.st_ino) != self._project_identity:
+            raise ArtifactManifestError(f"project directory changed after adapter initialization: {self._project_dir}")
+
     def _load_unlocked(self, root_fd: int | None) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
-        if root_fd is None and _is_linkish(path):
+        if (root_fd is None or not _O_NOFOLLOW) and _is_linkish(path):
             raise ArtifactManifestError(f"artifact manifest is a symlink or junction: {path}")
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
         try:
             fd = os.open(MANIFEST_FILENAME, flags, dir_fd=root_fd) if root_fd is not None else os.open(path, flags)
         except FileNotFoundError:
@@ -866,7 +903,7 @@ def _close_windows_handle(handle: int) -> None:
 
 
 def _create_temporary_file(root_fd: int) -> tuple[int, str]:
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
     for _ in range(100):
         tmp_name = f"{MANIFEST_FILENAME}.{secrets.token_hex(8)}.tmp"
         try:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -35,6 +35,7 @@ HASH_ALGORITHM = "sha256-v1"
 LOCK_TIMEOUT_SECONDS = 10.0
 _DIGEST_RE = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
 _RESERVED_ARTIFACT_PATHS = frozenset({MANIFEST_FILENAME, LOCK_FILENAME})
+_WINDOWS_RESERVED_ARTIFACT_PATHS = frozenset(path.casefold() for path in _RESERVED_ARTIFACT_PATHS)
 
 
 class ArtifactKind(StrEnum):
@@ -224,6 +225,8 @@ class ProjectArtifactManifestAdapter:
         if not resolved.is_dir():
             raise ArtifactManifestError(f"project path is not a directory: {resolved}")
         self._project_dir = resolved
+        root_stat = resolved.stat(follow_symlinks=False)
+        self._project_identity = (root_stat.st_dev, root_stat.st_ino)
 
     def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
         try:
@@ -399,58 +402,80 @@ class ProjectArtifactManifestAdapter:
     @contextmanager
     def _locked(self) -> Iterator[int | None]:
         lock_path = self._project_dir / LOCK_FILENAME
-        root_fd: int | None = None
-        try:
-            if os.name == "posix":
-                root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-                try:
-                    root_fd = os.open(self._project_dir, root_flags)
-                except OSError as exc:
-                    raise ArtifactManifestError(
-                        f"project directory cannot be opened safely: {self._project_dir}: {exc}"
-                    ) from exc
-            elif _is_linkish(self._project_dir):
-                raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
-            if root_fd is None and _is_linkish(lock_path):
-                raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
-            flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        with contextlib.ExitStack() as root_stack:
+            root_fd: int | None = None
             try:
-                fd = (
-                    os.open(LOCK_FILENAME, flags, 0o600, dir_fd=root_fd)
-                    if root_fd is not None
-                    else os.open(lock_path, flags, 0o600)
-                )
-            except OSError as exc:
-                if exc.errno == errno.ELOOP:
-                    raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
-                raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
-            try:
-                if not stat.S_ISREG(os.fstat(fd).st_mode):
-                    raise ArtifactManifestError(f"manifest lock is not a regular file: {lock_path}")
-                handle = os.fdopen(fd, "wb")
-            except BaseException:
-                with contextlib.suppress(OSError):
-                    os.close(fd)
-                raise
-            deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
-            try:
-                while True:
+                if os.name == "posix":
+                    root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
                     try:
-                        portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
-                        break
-                    except (portalocker.AlreadyLocked, portalocker.LockException) as exc:
-                        if time.monotonic() >= deadline:
-                            raise ArtifactManifestError(f"timed out acquiring manifest lock: {lock_path}") from exc
-                        time.sleep(0.05)
+                        root_fd = os.open(self._project_dir, root_flags)
+                    except OSError as exc:
+                        raise ArtifactManifestError(
+                            f"project directory cannot be opened safely: {self._project_dir}: {exc}"
+                        ) from exc
+                else:
+                    root_stack.enter_context(self._guard_portable_project_root())
+                if root_fd is None and _is_linkish(lock_path):
+                    raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
+                flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
                 try:
-                    yield root_fd
+                    fd = (
+                        os.open(LOCK_FILENAME, flags, 0o600, dir_fd=root_fd)
+                        if root_fd is not None
+                        else os.open(lock_path, flags, 0o600)
+                    )
+                except OSError as exc:
+                    if exc.errno == errno.ELOOP:
+                        raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
+                    raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
+                try:
+                    if not stat.S_ISREG(os.fstat(fd).st_mode):
+                        raise ArtifactManifestError(f"manifest lock is not a regular file: {lock_path}")
+                    handle = os.fdopen(fd, "wb")
+                except BaseException:
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
+                    raise
+                deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+                try:
+                    while True:
+                        try:
+                            portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                            break
+                        except (portalocker.AlreadyLocked, portalocker.LockException) as exc:
+                            if time.monotonic() >= deadline:
+                                raise ArtifactManifestError(f"timed out acquiring manifest lock: {lock_path}") from exc
+                            time.sleep(0.05)
+                    try:
+                        yield root_fd
+                    finally:
+                        portalocker.unlock(handle)
                 finally:
-                    portalocker.unlock(handle)
+                    handle.close()
             finally:
-                handle.close()
+                if root_fd is not None:
+                    os.close(root_fd)
+
+    @contextmanager
+    def _guard_portable_project_root(self) -> Iterator[None]:
+        windows_handle = _open_windows_directory_handle(self._project_dir) if os.name == "nt" else None
+        try:
+            self._assert_portable_project_root_identity()
+            yield
+            self._assert_portable_project_root_identity()
         finally:
-            if root_fd is not None:
-                os.close(root_fd)
+            if windows_handle is not None:
+                _close_windows_handle(windows_handle)
+
+    def _assert_portable_project_root_identity(self) -> None:
+        if _is_linkish(self._project_dir):
+            raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
+        try:
+            root_stat = self._project_dir.stat(follow_symlinks=False)
+        except OSError as exc:
+            raise ArtifactManifestError(f"project directory is unavailable: {self._project_dir}: {exc}") from exc
+        if not stat.S_ISDIR(root_stat.st_mode) or (root_stat.st_dev, root_stat.st_ino) != self._project_identity:
+            raise ArtifactManifestError(f"project directory changed after adapter initialization: {self._project_dir}")
 
     def _load_unlocked(self, root_fd: int | None) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
@@ -721,7 +746,10 @@ def _normalize_relative_path(value: object) -> str:
     normalized = path.as_posix()
     if normalized in {".", ""}:
         raise ValueError(f"artifact path must name a file: {value!r}")
-    if normalized in _RESERVED_ARTIFACT_PATHS:
+    windows_alias = normalized.rstrip(" .").casefold()
+    if normalized in _RESERVED_ARTIFACT_PATHS or (
+        len(path.parts) == 1 and windows_alias in _WINDOWS_RESERVED_ARTIFACT_PATHS
+    ):
         raise ValueError(f"runtime-owned path cannot be registered as an artifact: {value!r}")
     return normalized
 
@@ -746,6 +774,8 @@ def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
         payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ArtifactManifestError(f"artifact manifest is not valid UTF-8 JSON: {exc}") from exc
+    except RecursionError as exc:
+        raise ArtifactManifestError("artifact manifest exceeds the JSON nesting limit") from exc
     if not isinstance(payload, dict) or set(payload) != {"entries", "hash_algorithm", "schema_version"}:
         raise ArtifactManifestError("artifact manifest has an invalid top-level schema")
     if type(payload["schema_version"]) is not int or payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
@@ -793,6 +823,48 @@ def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, ob
 
 def _is_linkish(path: Path) -> bool:
     return path.is_symlink() or path.is_junction()
+
+
+def _open_windows_directory_handle(path: Path) -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        0,
+        0x00000001 | 0x00000002,
+        None,
+        3,
+        0x02000000 | 0x00200000,
+        None,
+    )
+    if handle == wintypes.HANDLE(-1).value:
+        error_code = ctypes.get_last_error()
+        raise ArtifactManifestError(f"project directory cannot be held safely: {path}: winerror {error_code}")
+    return cast(int, handle)
+
+
+def _close_windows_handle(handle: int) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    close_handle(handle)
 
 
 def _create_temporary_file(root_fd: int) -> tuple[int, str]:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -239,11 +239,15 @@ class ProjectArtifactManifestAdapter:
         parts = PurePosixPath(normalized).parts
         directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-        try:
-            root_fd = os.open(self._project_dir, directory_flags)
-        except OSError as exc:
-            return self._artifact_blocked(normalized, "artifact_unreadable", f"project directory is unreadable: {exc}")
         with contextlib.ExitStack() as stack:
+            try:
+                root_fd = os.open(self._project_dir, directory_flags)
+            except OSError as exc:
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_unreadable",
+                    f"project directory is unreadable: {exc}",
+                )
             stack.callback(os.close, root_fd)
             directory_fd = root_fd
             for part in parts[:-1]:
@@ -295,6 +299,7 @@ class ProjectArtifactManifestAdapter:
             )
         path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
         cursor = self._project_dir
+        checked_components: list[tuple[Path, tuple[int, int], int]] = []
         for part in PurePosixPath(normalized).parts:
             cursor = cursor / part
             if _is_linkish(cursor):
@@ -304,9 +309,18 @@ class ProjectArtifactManifestAdapter:
                     detail=f"artifact path contains a symlink or junction: {normalized}",
                 )
                 return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
-            if not cursor.exists():
+            try:
+                component_stat = cursor.stat(follow_symlinks=False)
+            except FileNotFoundError:
                 return ArtifactObservation(artifact_path=normalized, present=False)
-        if not path.is_file():
+            except OSError as exc:
+                return self._artifact_blocked(
+                    normalized,
+                    "artifact_unreadable",
+                    f"artifact path cannot be inspected safely: {normalized}: {exc}",
+                )
+            checked_components.append((cursor, (component_stat.st_dev, component_stat.st_ino), component_stat.st_mode))
+        if not stat.S_ISREG(checked_components[-1][2]):
             blocker = ArtifactBlocker(
                 code="artifact_not_regular_file",
                 path=normalized,
@@ -317,7 +331,34 @@ class ProjectArtifactManifestAdapter:
         try:
             fd = os.open(path, flags)
             try:
+                opened_stat = os.fstat(fd)
+                if not stat.S_ISREG(opened_stat.st_mode):
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_not_regular_file",
+                        f"artifact path is not a regular file: {normalized}",
+                    )
                 os.read(fd, 1)
+                if (opened_stat.st_dev, opened_stat.st_ino) != checked_components[-1][1]:
+                    return self._artifact_blocked(
+                        normalized,
+                        "artifact_symlink",
+                        f"artifact path changed while it was being inspected: {normalized}",
+                    )
+                for checked_path, expected_identity, _ in checked_components:
+                    if _is_linkish(checked_path):
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_symlink",
+                            f"artifact path contains a symlink or junction: {normalized}",
+                        )
+                    current_stat = checked_path.stat(follow_symlinks=False)
+                    if (current_stat.st_dev, current_stat.st_ino) != expected_identity:
+                        return self._artifact_blocked(
+                            normalized,
+                            "artifact_symlink",
+                            f"artifact path changed while it was being inspected: {normalized}",
+                        )
             finally:
                 os.close(fd)
         except OSError as exc:
@@ -357,19 +398,19 @@ class ProjectArtifactManifestAdapter:
 
     @contextmanager
     def _locked(self) -> Iterator[int | None]:
-        root_fd: int | None = None
-        if os.name == "posix":
-            root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-            try:
-                root_fd = os.open(self._project_dir, root_flags)
-            except OSError as exc:
-                raise ArtifactManifestError(
-                    f"project directory cannot be opened safely: {self._project_dir}: {exc}"
-                ) from exc
-        elif _is_linkish(self._project_dir):
-            raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
         lock_path = self._project_dir / LOCK_FILENAME
+        root_fd: int | None = None
         try:
+            if os.name == "posix":
+                root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+                try:
+                    root_fd = os.open(self._project_dir, root_flags)
+                except OSError as exc:
+                    raise ArtifactManifestError(
+                        f"project directory cannot be opened safely: {self._project_dir}: {exc}"
+                    ) from exc
+            elif _is_linkish(self._project_dir):
+                raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
             if root_fd is None and _is_linkish(lock_path):
                 raise ArtifactManifestError(f"manifest lock is a symlink or junction: {lock_path}")
             flags = os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
@@ -705,7 +746,7 @@ def _parse_manifest(raw: bytes) -> dict[str, ArtifactManifestEntry]:
         raise ArtifactManifestError(f"artifact manifest is not valid UTF-8 JSON: {exc}") from exc
     if not isinstance(payload, dict) or set(payload) != {"entries", "hash_algorithm", "schema_version"}:
         raise ArtifactManifestError("artifact manifest has an invalid top-level schema")
-    if payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
+    if type(payload["schema_version"]) is not int or payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
         raise ArtifactManifestError(f"unsupported artifact manifest schema_version: {payload['schema_version']!r}")
     if payload["hash_algorithm"] != HASH_ALGORITHM:
         raise ArtifactManifestError(f"unsupported artifact manifest hash_algorithm: {payload['hash_algorithm']!r}")

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -1,8 +1,8 @@
 """Canonical direct-input bases for structured content artifacts.
 
 These builders intentionally accept the full project mapping but project only formal
-content semantics. Execution configuration belongs to a future explicit generation,
-not to the currency of an existing structured artifact.
+content semantics. Execution configuration does not participate in the currency of an
+existing structured artifact.
 """
 
 from __future__ import annotations

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -20,7 +20,8 @@ def build_step1_basis(source_content: object, *, project: Mapping[str, object]) 
     """Describe the formal source inputs consumed by one episode's step1 artifact."""
 
     content_mode, generation_mode = _content_axes(project)
-    source_kind = project.get("source_kind", "novel")
+    raw_source_kind = project.get("source_kind")
+    source_kind = "novel" if raw_source_kind is None else raw_source_kind
     if not isinstance(source_kind, str) or source_kind not in _SOURCE_KINDS:
         raise ValueError(f"unsupported source_kind: {source_kind!r}")
     source_language = project.get("source_language")

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -1,0 +1,64 @@
+"""Canonical direct-input bases for structured content artifacts.
+
+These builders intentionally accept the full project mapping but project only formal
+content semantics. Execution configuration belongs to a future explicit generation,
+not to the currency of an existing structured artifact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from lib.artifact_manifest import ArtifactBasis
+
+_STRUCTURED_CONTENT_MODES = frozenset({"narration", "drama"})
+_GENERATION_MODES = frozenset({"storyboard", "reference_video"})
+_SOURCE_KINDS = frozenset({"novel", "screenplay"})
+
+
+def build_step1_basis(source_content: object, *, project: Mapping[str, object]) -> ArtifactBasis:
+    """Describe the formal source inputs consumed by one episode's step1 artifact."""
+
+    content_mode, generation_mode = _content_axes(project)
+    source_kind = project.get("source_kind", "novel")
+    if not isinstance(source_kind, str) or source_kind not in _SOURCE_KINDS:
+        raise ValueError(f"unsupported source_kind: {source_kind!r}")
+    source_language = project.get("source_language")
+    if source_language is not None and (not isinstance(source_language, str) or not source_language):
+        raise ValueError(f"source_language must be a non-empty string or null, got {source_language!r}")
+    return ArtifactBasis.build(
+        "structured-content/step1",
+        kind_version=1,
+        inputs={
+            "content_mode": content_mode,
+            "generation_mode": generation_mode,
+            "source_content": source_content,
+            "source_kind": source_kind,
+            "source_language": source_language,
+        },
+    )
+
+
+def build_episode_script_basis(step1_content: object, *, project: Mapping[str, object]) -> ArtifactBasis:
+    """Describe the formal step1 input consumed by one episode's script artifact."""
+
+    content_mode, generation_mode = _content_axes(project)
+    return ArtifactBasis.build(
+        "structured-content/episode-script",
+        kind_version=1,
+        inputs={
+            "content_mode": content_mode,
+            "generation_mode": generation_mode,
+            "step1_content": step1_content,
+        },
+    )
+
+
+def _content_axes(project: Mapping[str, object]) -> tuple[str, str]:
+    content_mode = project.get("content_mode")
+    if not isinstance(content_mode, str) or content_mode not in _STRUCTURED_CONTENT_MODES:
+        raise ValueError(f"structured content basis does not support content_mode: {content_mode!r}")
+    generation_mode = project.get("generation_mode")
+    if not isinstance(generation_mode, str) or generation_mode not in _GENERATION_MODES:
+        raise ValueError(f"unsupported generation_mode: {generation_mode!r}")
+    return content_mode, generation_mode

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -14,6 +14,7 @@ from lib.artifact_manifest import ArtifactBasis
 _STRUCTURED_CONTENT_MODES = frozenset({"narration", "drama"})
 _GENERATION_MODES = frozenset({"storyboard", "reference_video"})
 _SOURCE_KINDS = frozenset({"novel", "screenplay"})
+_DEFAULT_SOURCE_LANGUAGE = "中文"
 
 
 def build_step1_basis(source_content: object, *, project: Mapping[str, object]) -> ArtifactBasis:
@@ -24,8 +25,11 @@ def build_step1_basis(source_content: object, *, project: Mapping[str, object]) 
     source_kind = "novel" if raw_source_kind is None else raw_source_kind
     if not isinstance(source_kind, str) or source_kind not in _SOURCE_KINDS:
         raise ValueError(f"unsupported source_kind: {source_kind!r}")
-    source_language = project.get("source_language")
-    if source_language is not None and (not isinstance(source_language, str) or not source_language):
+    raw_source_language = project.get("source_language")
+    source_language = (
+        _DEFAULT_SOURCE_LANGUAGE if raw_source_language is None or raw_source_language == "" else raw_source_language
+    )
+    if not isinstance(source_language, str):
         raise ValueError(f"source_language must be a non-empty string or null, got {source_language!r}")
     return ArtifactBasis.build(
         "structured-content/step1",

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -26,9 +26,7 @@ def build_step1_basis(source_content: object, *, project: Mapping[str, object]) 
     if not isinstance(source_kind, str) or source_kind not in _SOURCE_KINDS:
         raise ValueError(f"unsupported source_kind: {source_kind!r}")
     raw_source_language = project.get("source_language")
-    source_language = (
-        _DEFAULT_SOURCE_LANGUAGE if raw_source_language is None or raw_source_language == "" else raw_source_language
-    )
+    source_language = raw_source_language or _DEFAULT_SOURCE_LANGUAGE
     if not isinstance(source_language, str):
         raise ValueError(f"source_language must be a non-empty string or null, got {source_language!r}")
     return ArtifactBasis.build(

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -99,13 +99,35 @@ def test_manifest_blocks_windows_drive_like_artifact_path() -> None:
     assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"
 
 
-@pytest.mark.parametrize("artifact_path", [".. /outside.json", ". /episode.json", "scripts /episode.json"])
+@pytest.mark.parametrize(
+    "artifact_path",
+    [
+        ".. /outside.json",
+        ". /episode.json",
+        "scripts /episode.json",
+        ".arcreel_artifacts.json::$DATA",
+        "episode.json:preview",
+    ],
+)
 def test_manifest_blocks_windows_normalized_artifact_path_components(artifact_path: str) -> None:
     manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
 
     comparison = manifest.compare(
         ArtifactKey.episode_script(1),
         artifact_path=artifact_path,
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"
+
+
+def test_manifest_blocks_non_utf8_artifact_path() -> None:
+    manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="bad_\udcff.json",
         basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
     )
 

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -99,6 +99,20 @@ def test_manifest_blocks_windows_drive_like_artifact_path() -> None:
     assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"
 
 
+@pytest.mark.parametrize("artifact_path", [".. /outside.json", ". /episode.json", "scripts /episode.json"])
+def test_manifest_blocks_windows_normalized_artifact_path_components(artifact_path: str) -> None:
+    manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path=artifact_path,
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"
+
+
 @pytest.mark.parametrize(
     "artifact_path",
     [".ARCREEL_ARTIFACTS.JSON", ".arcreel_artifacts.json.", ".artifact_manifest.lock "],

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unicodedata
+
 import pytest
 
 from lib.artifact_manifest import (
@@ -39,6 +41,20 @@ def test_artifact_key_round_trips_without_display_string_parsing(key: ArtifactKe
 def test_artifact_key_rejects_direct_construction_that_cannot_round_trip() -> None:
     with pytest.raises(ValueError, match="components"):
         ArtifactKey(ArtifactKind.EPISODE_SCRIPT, ("localized episode label",))
+
+
+def test_asset_sheet_key_uses_the_asset_name_equality_coordinate() -> None:
+    nfc_name = unicodedata.normalize("NFC", "Hiếu")
+    nfd_name = unicodedata.normalize("NFD", nfc_name)
+
+    canonical = ArtifactKey.asset_sheet("character", nfc_name)
+    from_nfd_factory = ArtifactKey.asset_sheet("character", nfd_name)
+    from_nfd_constructor = ArtifactKey(ArtifactKind.ASSET_SHEET, ("character", nfd_name))
+
+    assert nfc_name != nfd_name
+    assert from_nfd_factory == canonical
+    assert from_nfd_constructor == canonical
+    assert ArtifactKey.decode(canonical.encode()) == canonical
 
 
 def test_manifest_compares_registered_basis_without_mutating_the_artifact() -> None:

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactKey,
+    ArtifactKind,
+    ArtifactManifest,
+    ArtifactStatus,
+    InMemoryArtifactManifestAdapter,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ArtifactKey.asset_sheet("character", "阿黎:/%"),
+        ArtifactKey.asset_sheet("scene", "屋顶"),
+        ArtifactKey.asset_sheet("prop", "钥匙"),
+        ArtifactKey.asset_sheet("product", "咖啡豆"),
+        ArtifactKey.episode_step1(12),
+        ArtifactKey.episode_script(12),
+        ArtifactKey.episode_grid(12, "group:/一"),
+        ArtifactKey.episode_storyboard(12, "E12S03:/"),
+        ArtifactKey.episode_video(12, "unit:/3"),
+        ArtifactKey.episode_audio(12, "segment:/3"),
+    ],
+)
+def test_artifact_key_round_trips_without_display_string_parsing(key: ArtifactKey) -> None:
+    encoded = key.encode()
+
+    assert encoded.startswith("artifact-key-v1:")
+    assert ArtifactKey.decode(encoded) == key
+
+
+def test_artifact_key_rejects_direct_construction_that_cannot_round_trip() -> None:
+    with pytest.raises(ValueError, match="components"):
+        ArtifactKey(ArtifactKind.EPISODE_SCRIPT, ("localized episode label",))
+
+
+def test_manifest_compares_registered_basis_without_mutating_the_artifact() -> None:
+    path = "scripts/episode_1.json"
+    adapter = InMemoryArtifactManifestAdapter(artifacts={path})
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_script(1)
+    original_basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "original"})
+    changed_basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "changed"})
+
+    assert manifest.compare(key, artifact_path=path, basis=original_basis).status is ArtifactStatus.MISSING
+    assert manifest.register(key, artifact_path=path, basis=original_basis)
+
+    current = manifest.compare(key, artifact_path=path, basis=original_basis)
+    stale = manifest.compare(key, artifact_path=path, basis=changed_basis)
+    adapter.remove_artifact(path)
+    missing = manifest.compare(key, artifact_path=path, basis=original_basis)
+    adapter.block_artifact(path, code="artifact_symlink", detail="artifact path is a symlink")
+    blocked = manifest.compare(key, artifact_path=path, basis=original_basis)
+
+    assert current.status is ArtifactStatus.CURRENT
+    assert current.usable
+    assert stale.status is ArtifactStatus.STALE
+    assert stale.usable
+    assert missing.status is ArtifactStatus.MISSING
+    assert not missing.usable
+    assert blocked.status is ArtifactStatus.BLOCKED
+    assert blocked.blocker is not None
+    assert blocked.blocker.code == "artifact_symlink"
+    assert not blocked.usable
+
+
+def test_manifest_blocks_windows_drive_like_artifact_path() -> None:
+    manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="C:/outside.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -97,3 +97,20 @@ def test_manifest_blocks_windows_drive_like_artifact_path() -> None:
 
     assert comparison.status is ArtifactStatus.BLOCKED
     assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"
+
+
+@pytest.mark.parametrize(
+    "artifact_path",
+    [".ARCREEL_ARTIFACTS.JSON", ".arcreel_artifacts.json.", ".artifact_manifest.lock "],
+)
+def test_manifest_blocks_windows_aliases_of_runtime_paths(artifact_path: str) -> None:
+    manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path=artifact_path,
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_path_invalid"

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -339,6 +339,44 @@ def test_project_adapter_blocks_file_symlink_swap_without_no_follow(
     assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="Python identity checks backstop platforms without O_NOFOLLOW")
+def test_project_adapter_blocks_parent_vanishing_during_fallback_revalidation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    original_open = os.open
+    moved_scripts = project / "removed-scripts"
+    moved = False
+
+    def move_parent_after_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal moved
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not moved and dir_fd is not None and os.fsdecode(path) == "scripts":
+            scripts.rename(moved_scripts)
+            moved = True
+        return fd
+
+    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
+    monkeypatch.setattr("lib.artifact_manifest.os.open", move_parent_after_open)
+
+    observation = adapter.inspect_artifact("scripts/episode.json")
+
+    assert moved
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_unreadable"
+
+
 @pytest.mark.skipif(os.name != "posix", reason="FIFO inspection uses POSIX nonblocking file flags")
 def test_project_adapter_rejects_fifo_without_blocking(tmp_path: Path) -> None:
     project = tmp_path / "project"
@@ -735,6 +773,49 @@ def test_project_adapter_rejects_manifest_symlink_swap_without_no_follow(
 
     monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     monkeypatch.setattr("lib.artifact_manifest.os.open", swap_manifest_then_open)
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert swapped
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Python identity checks backstop platforms without O_NOFOLLOW")
+def test_project_adapter_rejects_lock_symlink_swap_without_no_follow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
+    assert manifest.register(key, artifact_path="episode.json", basis=basis)
+    lock_path = project / LOCK_FILENAME
+    outside = tmp_path / "outside.lock"
+    outside.write_bytes(b"")
+    original_open = os.open
+    swapped = False
+
+    def swap_lock_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if not swapped and dir_fd is not None and os.fsdecode(path) == LOCK_FILENAME:
+            lock_path.rename(project / "original-lock")
+            lock_path.symlink_to(outside)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_lock_then_open)
 
     comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -300,6 +300,45 @@ def test_project_adapter_blocks_parent_replaced_by_symlink_during_open(
     assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="Python identity checks backstop platforms without O_NOFOLLOW")
+def test_project_adapter_blocks_file_symlink_swap_without_no_follow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "episode.json"
+    artifact.write_text("inside", encoding="utf-8")
+    outside = tmp_path / "outside.json"
+    outside.write_text("outside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    original_open = os.open
+    swapped = False
+
+    def swap_file_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if not swapped and dir_fd is not None and os.fsdecode(path) == "episode.json":
+            artifact.rename(project / "original-episode.json")
+            artifact.symlink_to(outside)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_file_then_open)
+
+    observation = adapter.inspect_artifact("episode.json")
+
+    assert swapped
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
+
+
 @pytest.mark.skipif(os.name != "posix", reason="FIFO inspection uses POSIX nonblocking file flags")
 def test_project_adapter_rejects_fifo_without_blocking(tmp_path: Path) -> None:
     project = tmp_path / "project"
@@ -659,6 +698,49 @@ def test_project_adapter_rejects_portable_manifest_symlink_swap(
         adapter._load_unlocked(None)
 
     assert swapped
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Python identity checks backstop platforms without O_NOFOLLOW")
+def test_project_adapter_rejects_manifest_symlink_swap_without_no_follow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
+    assert manifest.register(key, artifact_path="episode.json", basis=basis)
+    manifest_path = project / MANIFEST_FILENAME
+    outside = tmp_path / "outside.json"
+    outside.write_bytes(manifest_path.read_bytes())
+    original_open = os.open
+    swapped = False
+
+    def swap_manifest_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if not swapped and dir_fd is not None and os.fsdecode(path) == MANIFEST_FILENAME:
+            manifest_path.rename(project / "original-manifest.json")
+            manifest_path.symlink_to(outside)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_manifest_then_open)
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert swapped
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
 
 
 def test_project_adapter_revalidates_portable_manifest_identity(tmp_path: Path) -> None:

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -162,6 +163,53 @@ def test_project_adapter_blocks_escape_and_symlink_artifact_paths(tmp_path: Path
     with pytest.raises(ArtifactRegistrationError):
         manifest.register(key, artifact_path="linked-file.json", basis=basis)
     assert outside.read_text(encoding="utf-8") == '{"secret":true}'
+
+
+@pytest.mark.skipif(os.name != "posix", reason="dir_fd traversal is the POSIX symlink-race defense")
+def test_project_adapter_blocks_parent_replaced_by_symlink_during_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "episode.json").write_text("inside", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "episode.json").write_text("outside", encoding="utf-8")
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    original_open = os.open
+    swapped = False
+
+    def swap_parent_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        path_text = os.fsdecode(path)
+        opens_parent_by_fd = dir_fd is not None and path_text == "scripts"
+        opens_final_by_path = Path(path_text) == scripts / "episode.json"
+        if not swapped and (opens_parent_by_fd or opens_final_by_path):
+            scripts.rename(project / "original-scripts")
+            scripts.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_parent_then_open)
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="scripts/episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert swapped
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_symlink"
+    assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
 
 
 @pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, ".artifact_manifest.lock"])

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -406,6 +406,10 @@ def test_project_adapter_rejects_replaced_portable_project_root_identity(tmp_pat
     project.rename(tmp_path / "original-project")
     project.mkdir()
 
+    observation = adapter._inspect_artifact_portable("missing.json")
+
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_unreadable"
     with pytest.raises(ArtifactManifestError, match="changed after adapter initialization"):
         adapter._assert_portable_project_root_identity()
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -337,7 +337,7 @@ def test_project_adapter_rejects_swapped_portable_parent(
 
     def swap_parent_then_open(path: str | bytes | Path, flags: int, mode: int = 0o777) -> int:
         nonlocal swapped
-        if not swapped and Path(path) == scripts / "episode.json":
+        if not swapped and Path(os.fsdecode(path)) == scripts / "episode.json":
             scripts.rename(moved_scripts)
             scripts.symlink_to(outside, target_is_directory=True)
             swapped = True
@@ -442,6 +442,44 @@ def test_project_adapter_reports_invalid_manifest_schema_version_as_blocked_with
     manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
     key = ArtifactKey.episode_script(1)
     basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    with pytest.raises(ArtifactManifestError):
+        manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert manifest_path.read_bytes() == malformed
+
+
+@pytest.mark.parametrize("duplicate_location", ["top-level", "entry"])
+def test_project_adapter_reports_duplicate_manifest_fields_as_blocked_without_reset(
+    tmp_path: Path,
+    duplicate_location: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+    encoded_key = key.encode()
+    entry = json.dumps(
+        {"artifact_path": "episode.json", "basis_digest": basis.digest},
+        separators=(",", ":"),
+    )
+    if duplicate_location == "top-level":
+        malformed_text = (
+            f'{{"entries":{{}},"hash_algorithm":"{HASH_ALGORITHM}","schema_version":999,"schema_version":1}}'
+        )
+    else:
+        malformed_text = (
+            f'{{"entries":{{"{encoded_key}":{entry},"{encoded_key}":{entry}}},'
+            f'"hash_algorithm":"{HASH_ALGORITHM}","schema_version":1}}'
+        )
+    malformed = malformed_text.encode("utf-8")
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_path.write_bytes(malformed)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
 
     comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -8,10 +8,13 @@ from pathlib import Path
 import pytest
 
 from lib.artifact_manifest import (
+    HASH_ALGORITHM,
+    LOCK_FILENAME,
     MANIFEST_FILENAME,
     ArtifactBasis,
     ArtifactKey,
     ArtifactManifest,
+    ArtifactManifestEntry,
     ArtifactManifestError,
     ArtifactRegistrationError,
     ArtifactStatus,
@@ -212,7 +215,52 @@ def test_project_adapter_blocks_parent_replaced_by_symlink_during_open(
     assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
 
 
-@pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, ".artifact_manifest.lock"])
+@pytest.mark.skipif(os.name != "posix", reason="FIFO inspection uses POSIX nonblocking file flags")
+def test_project_adapter_rejects_fifo_without_blocking(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    os.mkfifo(project / "artifact.fifo")
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="artifact.fifo",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "artifact_not_regular_file"
+
+
+def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    moved_project = tmp_path / "moved-project"
+    project.rename(moved_project)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "episode.json").write_text("outside", encoding="utf-8")
+    project.symlink_to(outside, target_is_directory=True)
+
+    observation = adapter._inspect_artifact_portable("episode.json")
+
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
+    with pytest.raises(ArtifactManifestError, match="project directory is a symlink or junction"):
+        adapter.put_entry(
+            ArtifactKey.episode_script(1),
+            ArtifactManifestEntry(
+                artifact_path="episode.json",
+                basis_digest=ArtifactBasis.build("test/script", kind_version=1, inputs={}).digest,
+            ),
+        )
+    assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
+    assert not (outside / MANIFEST_FILENAME).exists()
+
+
+@pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, LOCK_FILENAME])
 def test_project_adapter_refuses_runtime_file_symlinks(tmp_path: Path, runtime_path: str) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -238,7 +286,10 @@ def test_project_adapter_reports_malformed_manifest_as_blocked_without_reset(tmp
     project = tmp_path / "project"
     project.mkdir()
     (project / "episode.json").write_text("{}", encoding="utf-8")
-    malformed = b'{"schema_version":999,"entries":{}}'
+    malformed = json.dumps(
+        {"entries": {}, "hash_algorithm": HASH_ALGORITHM, "schema_version": 999},
+        separators=(",", ":"),
+    ).encode()
     manifest_path = project / MANIFEST_FILENAME
     manifest_path.write_bytes(malformed)
     manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -216,7 +216,14 @@ def test_project_adapter_replace_failure_preserves_manifest_and_cleans_temp_file
     )
 
 
-def test_project_adapter_blocks_escape_and_symlink_artifact_paths(tmp_path: Path) -> None:
+@pytest.mark.parametrize("force_python_link_fallback", [False, True])
+def test_project_adapter_blocks_escape_and_symlink_artifact_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    force_python_link_fallback: bool,
+) -> None:
+    if force_python_link_fallback:
+        monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     project = tmp_path / "project"
     project.mkdir()
     outside = tmp_path / "outside.json"
@@ -309,6 +316,37 @@ def test_project_adapter_rejects_fifo_without_blocking(tmp_path: Path) -> None:
     assert comparison.blocker is not None and comparison.blocker.code == "artifact_not_regular_file"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="descriptor traversal is the POSIX storage path")
+def test_project_adapter_reports_missing_posix_artifact_components(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    adapter = ProjectArtifactManifestAdapter(project)
+
+    assert not adapter.inspect_artifact("missing/episode.json").present
+    assert not adapter.inspect_artifact("episode.json").present
+
+
+@pytest.mark.skipif(os.name != "posix", reason="descriptor reads are the POSIX artifact inspection path")
+def test_project_adapter_reports_posix_artifact_read_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+
+    def fail_read(_fd: int, _length: int) -> bytes:
+        raise OSError("read failed")
+
+    monkeypatch.setattr("lib.artifact_manifest.os.read", fail_read)
+
+    observation = adapter.inspect_artifact("episode.json")
+
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_unreadable"
+
+
 @pytest.mark.skipif(os.name != "posix", reason="runtime FIFO inspection uses POSIX nonblocking file flags")
 @pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, LOCK_FILENAME])
 def test_project_adapter_rejects_runtime_fifo_without_blocking(tmp_path: Path, runtime_path: str) -> None:
@@ -369,6 +407,63 @@ def test_project_adapter_rejects_replaced_portable_project_root_identity(tmp_pat
 
     with pytest.raises(ArtifactManifestError, match="changed after adapter initialization"):
         adapter._assert_portable_project_root_identity()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="opened directory identity is the POSIX replacement defense")
+def test_project_adapter_rejects_replaced_posix_project_root_identity(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    project.rename(tmp_path / "original-project")
+    project.mkdir()
+    (project / "episode.json").write_text("replacement", encoding="utf-8")
+
+    observation = adapter.inspect_artifact("episode.json")
+
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_unreadable"
+    with pytest.raises(ArtifactManifestError, match="changed after adapter initialization"):
+        adapter.put_entry(
+            ArtifactKey.episode_script(1),
+            ArtifactManifestEntry(
+                artifact_path="episode.json",
+                basis_digest=ArtifactBasis.build("test/script", kind_version=1, inputs={}).digest,
+            ),
+        )
+    assert not (project / MANIFEST_FILENAME).exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="opened directory identity is the POSIX replacement defense")
+def test_project_adapter_reports_unavailable_opened_posix_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    adapter = ProjectArtifactManifestAdapter(project)
+
+    with pytest.raises(ArtifactManifestError, match="opened project directory is unavailable"):
+        adapter._assert_open_project_root_identity(-1)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Python link checks backstop platforms without O_NOFOLLOW")
+def test_project_adapter_rejects_replaced_posix_project_root_symlink_without_no_follow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    original_project = tmp_path / "original-project"
+    project.rename(original_project)
+    project.symlink_to(original_project, target_is_directory=True)
+    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
+
+    observation = adapter.inspect_artifact("episode.json")
+
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
+    with pytest.raises(ArtifactManifestError, match="project directory is a symlink"):
+        adapter.get_entry(ArtifactKey.episode_script(1))
 
 
 def test_project_adapter_rejects_swapped_portable_parent(
@@ -462,7 +557,15 @@ def test_project_adapter_keeps_manifest_write_on_opened_root_during_swap(
 
 
 @pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, LOCK_FILENAME])
-def test_project_adapter_refuses_runtime_file_symlinks(tmp_path: Path, runtime_path: str) -> None:
+@pytest.mark.parametrize("force_python_link_fallback", [False, True])
+def test_project_adapter_refuses_runtime_file_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_path: str,
+    force_python_link_fallback: bool,
+) -> None:
+    if force_python_link_fallback:
+        monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     project = tmp_path / "project"
     project.mkdir()
     artifact = project / "episode.json"

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -120,9 +120,24 @@ def test_project_adapter_replace_failure_preserves_manifest_and_cleans_temp_file
     assert manifest.register(first_key, artifact_path="scripts/episode_1.json", basis=basis)
     manifest_path = project / MANIFEST_FILENAME
     original_bytes = manifest_path.read_bytes()
+    original_replace = os.replace
 
-    def fail_replace(_source: str, _destination: Path) -> None:
-        raise OSError("injected replace failure")
+    def fail_replace(
+        source: str | bytes | Path,
+        destination: str | bytes | Path,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        is_anchored_manifest = (
+            os.fsdecode(destination) == MANIFEST_FILENAME and src_dir_fd is not None and dst_dir_fd == src_dir_fd
+        )
+        if is_anchored_manifest or Path(os.fsdecode(destination)) == manifest_path:
+            raise OSError("injected replace failure")
+        if src_dir_fd is None and dst_dir_fd is None:
+            original_replace(source, destination)
+        else:
+            original_replace(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
     monkeypatch.setattr("lib.artifact_manifest.os.replace", fail_replace)
 
@@ -232,6 +247,25 @@ def test_project_adapter_rejects_fifo_without_blocking(tmp_path: Path) -> None:
     assert comparison.blocker is not None and comparison.blocker.code == "artifact_not_regular_file"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="runtime FIFO inspection uses POSIX nonblocking file flags")
+@pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, LOCK_FILENAME])
+def test_project_adapter_rejects_runtime_fifo_without_blocking(tmp_path: Path, runtime_path: str) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    os.mkfifo(project / runtime_path)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+
+
 def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -248,7 +282,7 @@ def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) 
 
     assert not observation.present
     assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
-    with pytest.raises(ArtifactManifestError, match="project directory is a symlink or junction"):
+    with pytest.raises(ArtifactManifestError, match="project directory"):
         adapter.put_entry(
             ArtifactKey.episode_script(1),
             ArtifactManifestEntry(
@@ -258,6 +292,56 @@ def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) 
         )
     assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
     assert not (outside / MANIFEST_FILENAME).exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="dir_fd anchors manifest storage to the opened POSIX root")
+def test_project_adapter_keeps_manifest_write_on_opened_root_during_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    original_identity = project.stat()
+    original_open = os.open
+    moved_project = tmp_path / "moved-project"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    swapped = False
+
+    def swap_root_then_open_lock(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        opens_target_lock = (
+            dir_fd is not None
+            and os.fsdecode(path) == LOCK_FILENAME
+            and os.fstat(dir_fd).st_dev == original_identity.st_dev
+            and os.fstat(dir_fd).st_ino == original_identity.st_ino
+        )
+        if not swapped and opens_target_lock:
+            project.rename(moved_project)
+            project.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_root_then_open_lock)
+
+    assert ArtifactManifest(adapter).register(
+        ArtifactKey.episode_script(1),
+        artifact_path="episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+    )
+
+    assert swapped
+    assert (moved_project / MANIFEST_FILENAME).is_file()
+    assert not (outside / MANIFEST_FILENAME).exists()
+    assert not (outside / LOCK_FILENAME).exists()
 
 
 @pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, LOCK_FILENAME])

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -439,6 +439,36 @@ def test_project_adapter_rejects_replaced_posix_project_root_identity(tmp_path: 
     assert not (project / MANIFEST_FILENAME).exists()
 
 
+@pytest.mark.skipif(os.name != "posix", reason="no-follow root descriptors bind POSIX adapter initialization")
+def test_project_adapter_rejects_project_root_symlink_swap_during_initialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    original_project = tmp_path / "original-project"
+    original_resolve = Path.resolve
+    swapped = False
+
+    def swap_then_resolve(path: Path, strict: bool = False) -> Path:
+        nonlocal swapped
+        if not swapped and path == project:
+            project.rename(original_project)
+            project.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr("lib.artifact_manifest.Path.resolve", swap_then_resolve)
+
+    with pytest.raises(ArtifactManifestError, match="changed during adapter initialization"):
+        ProjectArtifactManifestAdapter(project)
+
+    assert swapped
+    assert not (outside / MANIFEST_FILENAME).exists()
+
+
 @pytest.mark.skipif(os.name != "posix", reason="opened directory identity is the POSIX replacement defense")
 def test_project_adapter_reports_unavailable_opened_posix_root(tmp_path: Path) -> None:
     project = tmp_path / "project"

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -586,6 +587,61 @@ def test_project_adapter_refuses_runtime_file_symlinks(
     assert outside.read_text(encoding="utf-8") == "do not touch"
 
 
+def test_project_adapter_rejects_portable_manifest_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
+    assert manifest.register(key, artifact_path="episode.json", basis=basis)
+    manifest_path = project / MANIFEST_FILENAME
+    outside = tmp_path / "outside.json"
+    outside.write_bytes(manifest_path.read_bytes())
+    original_open = os.open
+    swapped = False
+
+    def swap_manifest_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if not swapped and dir_fd is None and Path(os.fsdecode(path)) == manifest_path:
+            manifest_path.rename(project / "original-manifest.json")
+            manifest_path.symlink_to(outside)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_manifest_then_open)
+
+    with pytest.raises(ArtifactManifestError, match="artifact manifest is a symlink"):
+        adapter._load_unlocked(None)
+
+    assert swapped
+
+
+def test_project_adapter_revalidates_portable_manifest_identity(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
+    assert ArtifactManifest(adapter).register(key, artifact_path="episode.json", basis=basis)
+
+    entries, raw = adapter._load_unlocked(None)
+
+    assert raw is not None
+    assert entries[key.encode()].basis_digest == basis.digest
+
+
 @pytest.mark.parametrize("schema_version", [999, True, 1.0])
 def test_project_adapter_reports_invalid_manifest_schema_version_as_blocked_without_reset(
     tmp_path: Path,
@@ -610,6 +666,62 @@ def test_project_adapter_reports_invalid_manifest_schema_version_as_blocked_with
     assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
     with pytest.raises(ArtifactManifestError):
         manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert manifest_path.read_bytes() == malformed
+
+
+def test_project_adapter_reports_oversized_manifest_integer_as_blocked_without_reset(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    malformed = (
+        b'{"entries":{},"hash_algorithm":"' + HASH_ALGORITHM.encode() + b'","schema_version":' + b"9" * 5000 + b"}"
+    )
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_path.write_bytes(malformed)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    assert manifest_path.read_bytes() == malformed
+
+
+def test_project_adapter_reports_recursive_encoded_key_as_blocked_without_reset(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    nested_payload = ('["episode-script",' + "[" * 2000 + "0" + "]" * 2000 + "]").encode()
+    encoded_key = "artifact-key-v1:" + base64.urlsafe_b64encode(nested_payload).decode().rstrip("=")
+    malformed = json.dumps(
+        {
+            "entries": {
+                encoded_key: {
+                    "artifact_path": "episode.json",
+                    "basis_digest": ArtifactBasis.build("test/script", kind_version=1, inputs={}).digest,
+                }
+            },
+            "hash_algorithm": HASH_ALGORITHM,
+            "schema_version": 1,
+        },
+        separators=(",", ":"),
+    ).encode()
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_path.write_bytes(malformed)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+
+    comparison = manifest.compare(
+        ArtifactKey.episode_script(1),
+        artifact_path="episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
+    )
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
     assert manifest_path.read_bytes() == malformed
 
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from lib.artifact_manifest import (
+    MANIFEST_FILENAME,
+    ArtifactBasis,
+    ArtifactKey,
+    ArtifactManifest,
+    ArtifactManifestError,
+    ArtifactRegistrationError,
+    ArtifactStatus,
+    ProjectArtifactManifestAdapter,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_project_adapter_persists_deterministic_utf8_and_skips_unchanged_write(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    artifact = project / "scripts" / "第一集.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"标题":"雪夜"}', encoding="utf-8")
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"标题": "雪夜"})
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    manifest_path = project / MANIFEST_FILENAME
+
+    assert manifest.compare(key, artifact_path="scripts/第一集.json", basis=basis).status is ArtifactStatus.MISSING
+    assert not manifest_path.exists()
+    assert manifest.register(key, artifact_path="scripts/第一集.json", basis=basis)
+    first_bytes = manifest_path.read_bytes()
+    first_mtime = manifest_path.stat().st_mtime_ns
+    assert not manifest.register(key, artifact_path="scripts/第一集.json", basis=basis)
+
+    assert manifest_path.read_bytes() == first_bytes
+    assert manifest_path.stat().st_mtime_ns == first_mtime
+    assert b"\xe7\xac\xac\xe4\xb8\x80\xe9\x9b\x86" in first_bytes
+    assert json.loads(first_bytes) == {
+        "entries": {
+            key.encode(): {
+                "artifact_path": "scripts/第一集.json",
+                "basis_digest": basis.digest,
+            }
+        },
+        "hash_algorithm": "sha256-v1",
+        "schema_version": 1,
+    }
+    reloaded = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    assert reloaded.compare(key, artifact_path="scripts/第一集.json", basis=basis).status is ArtifactStatus.CURRENT
+
+
+def test_stale_comparison_preserves_paid_artifact_and_manifest(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    artifact = project / "videos" / "E1S01.mp4"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"paid-video-bytes")
+    key = ArtifactKey.episode_video(1, "E1S01")
+    recorded_basis = ArtifactBasis.build("test/video", kind_version=1, inputs={"prompt": "first"})
+    current_basis = ArtifactBasis.build("test/video", kind_version=1, inputs={"prompt": "changed"})
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    assert manifest.register(key, artifact_path="videos/E1S01.mp4", basis=recorded_basis)
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_bytes = manifest_path.read_bytes()
+
+    comparison = manifest.compare(key, artifact_path="videos/E1S01.mp4", basis=current_basis)
+
+    assert comparison.status is ArtifactStatus.STALE
+    assert comparison.usable
+    assert artifact.read_bytes() == b"paid-video-bytes"
+    assert manifest_path.read_bytes() == manifest_bytes
+
+
+def test_project_adapter_serializes_concurrent_manifest_updates(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    artifact_dir = project / "scripts"
+    artifact_dir.mkdir(parents=True)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "same"})
+    episodes = list(range(1, 17))
+    for episode in episodes:
+        (artifact_dir / f"episode_{episode}.json").write_text("{}", encoding="utf-8")
+
+    def register(episode: int) -> bool:
+        manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+        return manifest.register(
+            ArtifactKey.episode_script(episode),
+            artifact_path=f"scripts/episode_{episode}.json",
+            basis=basis,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(register, episodes))
+
+    assert all(results)
+    stored = json.loads((project / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert len(stored["entries"]) == len(episodes)
+
+
+def test_project_adapter_replace_failure_preserves_manifest_and_cleans_temp_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "episode_1.json").write_text("{}", encoding="utf-8")
+    (scripts / "episode_2.json").write_text("{}", encoding="utf-8")
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    first_key = ArtifactKey.episode_script(1)
+    second_key = ArtifactKey.episode_script(2)
+    assert manifest.register(first_key, artifact_path="scripts/episode_1.json", basis=basis)
+    manifest_path = project / MANIFEST_FILENAME
+    original_bytes = manifest_path.read_bytes()
+
+    def fail_replace(_source: str, _destination: Path) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr("lib.artifact_manifest.os.replace", fail_replace)
+
+    with pytest.raises(ArtifactManifestError, match="replace artifact manifest"):
+        manifest.register(second_key, artifact_path="scripts/episode_2.json", basis=basis)
+
+    assert manifest_path.read_bytes() == original_bytes
+    assert list(project.glob(f"{MANIFEST_FILENAME}.*.tmp")) == []
+    assert (
+        manifest.compare(first_key, artifact_path="scripts/episode_1.json", basis=basis).status
+        is ArtifactStatus.CURRENT
+    )
+    assert (
+        manifest.compare(second_key, artifact_path="scripts/episode_2.json", basis=basis).status
+        is ArtifactStatus.MISSING
+    )
+
+
+def test_project_adapter_blocks_escape_and_symlink_artifact_paths(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"secret":true}', encoding="utf-8")
+    (project / "linked-file.json").symlink_to(outside)
+    (project / "linked-dir").symlink_to(tmp_path, target_is_directory=True)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+
+    traversal = manifest.compare(key, artifact_path="../outside.json", basis=basis)
+    absolute = manifest.compare(key, artifact_path=str(outside), basis=basis)
+    file_link = manifest.compare(key, artifact_path="linked-file.json", basis=basis)
+    parent_link = manifest.compare(key, artifact_path="linked-dir/outside.json", basis=basis)
+
+    assert traversal.status is ArtifactStatus.BLOCKED
+    assert absolute.status is ArtifactStatus.BLOCKED
+    assert file_link.status is ArtifactStatus.BLOCKED
+    assert parent_link.status is ArtifactStatus.BLOCKED
+    assert file_link.blocker is not None and file_link.blocker.code == "artifact_symlink"
+    assert parent_link.blocker is not None and parent_link.blocker.code == "artifact_symlink"
+    with pytest.raises(ArtifactRegistrationError):
+        manifest.register(key, artifact_path="linked-file.json", basis=basis)
+    assert outside.read_text(encoding="utf-8") == '{"secret":true}'
+
+
+@pytest.mark.parametrize("runtime_path", [MANIFEST_FILENAME, ".artifact_manifest.lock"])
+def test_project_adapter_refuses_runtime_file_symlinks(tmp_path: Path, runtime_path: str) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "episode.json"
+    artifact.write_text("{}", encoding="utf-8")
+    outside = tmp_path / "outside.json"
+    outside.write_text("do not touch", encoding="utf-8")
+    (project / runtime_path).symlink_to(outside)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    with pytest.raises(ArtifactManifestError):
+        manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert outside.read_text(encoding="utf-8") == "do not touch"
+
+
+def test_project_adapter_reports_malformed_manifest_as_blocked_without_reset(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    malformed = b'{"schema_version":999,"entries":{}}'
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_path.write_bytes(malformed)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    with pytest.raises(ArtifactManifestError):
+        manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert manifest_path.read_bytes() == malformed

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -22,6 +24,25 @@ from lib.artifact_manifest import (
 )
 
 pytestmark = pytest.mark.integration
+
+_RUNTIME_FIFO_COMPARISON = """
+import json
+import sys
+from pathlib import Path
+
+from lib.artifact_manifest import ArtifactBasis, ArtifactKey, ArtifactManifest, ProjectArtifactManifestAdapter
+
+project = Path(sys.argv[1])
+comparison = ArtifactManifest(ProjectArtifactManifestAdapter(project)).compare(
+    ArtifactKey.episode_script(1),
+    artifact_path="episode.json",
+    basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
+)
+print(json.dumps({
+    "status": comparison.status.value,
+    "blocker": comparison.blocker.code if comparison.blocker is not None else None,
+}))
+"""
 
 
 def test_project_adapter_persists_deterministic_utf8_and_skips_unchanged_write(tmp_path: Path) -> None:
@@ -254,16 +275,20 @@ def test_project_adapter_rejects_runtime_fifo_without_blocking(tmp_path: Path, r
     project.mkdir()
     (project / "episode.json").write_text("{}", encoding="utf-8")
     os.mkfifo(project / runtime_path)
-    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _RUNTIME_FIFO_COMPARISON, str(project)],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"manifest comparison blocked on runtime FIFO: {runtime_path}")
 
-    comparison = manifest.compare(
-        ArtifactKey.episode_script(1),
-        artifact_path="episode.json",
-        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"}),
-    )
-
-    assert comparison.status is ArtifactStatus.BLOCKED
-    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"status": "blocked", "blocker": "manifest_unreadable"}
 
 
 def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) -> None:
@@ -292,6 +317,40 @@ def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) 
         )
     assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
     assert not (outside / MANIFEST_FILENAME).exists()
+
+
+def test_project_adapter_rejects_swapped_portable_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "episode.json").write_text("inside", encoding="utf-8")
+    adapter = ProjectArtifactManifestAdapter(project)
+    moved_scripts = project / "original-scripts"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "episode.json").write_text("outside", encoding="utf-8")
+    original_open = os.open
+    swapped = False
+
+    def swap_parent_then_open(path: str | bytes | Path, flags: int, mode: int = 0o777) -> int:
+        nonlocal swapped
+        if not swapped and Path(path) == scripts / "episode.json":
+            scripts.rename(moved_scripts)
+            scripts.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return original_open(path, flags, mode)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", swap_parent_then_open)
+
+    observation = adapter._inspect_artifact_portable("scripts/episode.json")
+
+    assert swapped
+    assert not observation.present
+    assert observation.blocker is not None and observation.blocker.code == "artifact_symlink"
+    assert (outside / "episode.json").read_text(encoding="utf-8") == "outside"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="dir_fd anchors manifest storage to the opened POSIX root")
@@ -366,12 +425,16 @@ def test_project_adapter_refuses_runtime_file_symlinks(tmp_path: Path, runtime_p
     assert outside.read_text(encoding="utf-8") == "do not touch"
 
 
-def test_project_adapter_reports_malformed_manifest_as_blocked_without_reset(tmp_path: Path) -> None:
+@pytest.mark.parametrize("schema_version", [999, True, 1.0])
+def test_project_adapter_reports_invalid_manifest_schema_version_as_blocked_without_reset(
+    tmp_path: Path,
+    schema_version: object,
+) -> None:
     project = tmp_path / "project"
     project.mkdir()
     (project / "episode.json").write_text("{}", encoding="utf-8")
     malformed = json.dumps(
-        {"entries": {}, "hash_algorithm": HASH_ALGORITHM, "schema_version": 999},
+        {"entries": {}, "hash_algorithm": HASH_ALGORITHM, "schema_version": schema_version},
         separators=(",", ":"),
     ).encode()
     manifest_path = project / MANIFEST_FILENAME

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -197,6 +197,8 @@ def test_project_adapter_blocks_escape_and_symlink_artifact_paths(tmp_path: Path
     assert absolute.status is ArtifactStatus.BLOCKED
     assert file_link.status is ArtifactStatus.BLOCKED
     assert parent_link.status is ArtifactStatus.BLOCKED
+    assert traversal.blocker is not None and traversal.blocker.code == "artifact_path_invalid"
+    assert absolute.blocker is not None and absolute.blocker.code == "artifact_path_invalid"
     assert file_link.blocker is not None and file_link.blocker.code == "artifact_symlink"
     assert parent_link.blocker is not None and parent_link.blocker.code == "artifact_symlink"
     with pytest.raises(ArtifactRegistrationError):
@@ -319,6 +321,17 @@ def test_project_adapter_rejects_replaced_portable_project_root(tmp_path: Path) 
     assert not (outside / MANIFEST_FILENAME).exists()
 
 
+def test_project_adapter_rejects_replaced_portable_project_root_identity(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    adapter = ProjectArtifactManifestAdapter(project)
+    project.rename(tmp_path / "original-project")
+    project.mkdir()
+
+    with pytest.raises(ArtifactManifestError, match="changed after adapter initialization"):
+        adapter._assert_portable_project_root_identity()
+
+
 def test_project_adapter_rejects_swapped_portable_parent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -335,13 +348,19 @@ def test_project_adapter_rejects_swapped_portable_parent(
     original_open = os.open
     swapped = False
 
-    def swap_parent_then_open(path: str | bytes | Path, flags: int, mode: int = 0o777) -> int:
+    def swap_parent_then_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
         nonlocal swapped
-        if not swapped and Path(os.fsdecode(path)) == scripts / "episode.json":
+        if not swapped and dir_fd is None and Path(os.fsdecode(path)) == scripts / "episode.json":
             scripts.rename(moved_scripts)
             scripts.symlink_to(outside, target_is_directory=True)
             swapped = True
-        return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
 
     monkeypatch.setattr("lib.artifact_manifest.os.open", swap_parent_then_open)
 
@@ -480,6 +499,26 @@ def test_project_adapter_reports_duplicate_manifest_fields_as_blocked_without_re
     manifest_path = project / MANIFEST_FILENAME
     manifest_path.write_bytes(malformed)
     manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+
+    comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
+
+    assert comparison.status is ArtifactStatus.BLOCKED
+    assert comparison.blocker is not None and comparison.blocker.code == "manifest_unreadable"
+    with pytest.raises(ArtifactManifestError):
+        manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert manifest_path.read_bytes() == malformed
+
+
+def test_project_adapter_reports_excessive_manifest_nesting_as_blocked_without_reset(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "episode.json").write_text("{}", encoding="utf-8")
+    malformed = b"[" * 2000 + b"]" * 2000
+    manifest_path = project / MANIFEST_FILENAME
+    manifest_path.write_bytes(malformed)
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
 
     comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -125,6 +125,45 @@ def test_project_adapter_serializes_concurrent_manifest_updates(tmp_path: Path) 
     assert len(stored["entries"]) == len(episodes)
 
 
+@pytest.mark.skipif(os.name != "posix", reason="exclusive lock-file creation protects concurrent openat calls")
+def test_project_adapter_creates_lock_file_exclusively(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "episode.json"
+    artifact.write_text("{}", encoding="utf-8")
+    original_open = os.open
+    lock_open_flags: list[int] = []
+
+    def record_lock_open(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if dir_fd is not None and os.fsdecode(path) == LOCK_FILENAME:
+            lock_open_flags.append(flags)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", record_lock_open)
+
+    key = ArtifactKey.episode_script(1)
+    adapter = ProjectArtifactManifestAdapter(project)
+    assert ArtifactManifest(adapter).register(
+        key,
+        artifact_path="episode.json",
+        basis=ArtifactBasis.build("test/script", kind_version=1, inputs={}),
+    )
+    assert lock_open_flags[0] & os.O_CREAT
+    assert lock_open_flags[0] & os.O_EXCL
+
+    lock_open_flags.clear()
+    assert adapter.get_entry(key) is not None
+    assert len(lock_open_flags) == 2
+    assert lock_open_flags[0] & os.O_EXCL
+    assert not lock_open_flags[1] & os.O_CREAT
+
+
 def test_project_adapter_replace_failure_preserves_manifest_and_cleans_temp_file(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -102,7 +102,7 @@ def test_step1_basis_treats_null_source_kind_as_default() -> None:
     assert defaulted.digest == explicit.digest
 
 
-@pytest.mark.parametrize("source_language", [None, ""])
+@pytest.mark.parametrize("source_language", [None, "", False, 0, [], {}])
 def test_step1_basis_canonicalizes_default_source_language(source_language: object) -> None:
     project = {
         "content_mode": "narration",

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -87,3 +87,16 @@ def test_structured_basis_rejects_malformed_formal_inputs() -> None:
             {"duration": float("nan")},
             project={"content_mode": "narration", "generation_mode": "storyboard"},
         )
+
+
+def test_step1_basis_treats_null_source_kind_as_default() -> None:
+    project = {
+        "content_mode": "narration",
+        "generation_mode": "storyboard",
+        "source_kind": None,
+    }
+
+    defaulted = build_step1_basis("source", project=project)
+    explicit = build_step1_basis("source", project={**project, "source_kind": "novel"})
+
+    assert defaulted.digest == explicit.digest

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.artifact_manifest import ArtifactBasis
+from lib.artifact_provenance import build_episode_script_basis, build_step1_basis
+
+pytestmark = pytest.mark.unit
+
+
+def test_artifact_basis_has_deterministic_canonical_json() -> None:
+    first = ArtifactBasis.build(
+        "structured-content-test",
+        kind_version=2,
+        inputs={"z": "雪", "a": [1, True, None]},
+    )
+    second = ArtifactBasis.build(
+        "structured-content-test",
+        kind_version=2,
+        inputs={"a": [1, True, None], "z": "雪"},
+    )
+
+    assert (
+        first.normalized_bytes()
+        == ('{"inputs":{"a":[1,true,null],"z":"雪"},"kind":"structured-content-test","kind_version":2}').encode()
+    )
+    assert second.normalized_bytes() == first.normalized_bytes()
+    assert second.digest == first.digest
+
+
+def test_structured_content_basis_tracks_only_the_direct_formal_chain() -> None:
+    first_project = {
+        "content_mode": "drama",
+        "generation_mode": "storyboard",
+        "source_kind": "screenplay",
+        "source_language": "zh",
+        "provider": "first-provider",
+        "model": "first-model",
+        "credentials": {"api_key": "first-secret"},
+        "endpoint": "https://first.invalid",
+        "resolution": "720p",
+        "aspect_ratio": "16:9",
+        "prompt_builder_version": 1,
+        "voice": "first-voice",
+        "speed": 1.0,
+    }
+    changed_execution_project = {
+        **first_project,
+        "provider": "second-provider",
+        "model": "second-model",
+        "credentials": {"api_key": "second-secret"},
+        "endpoint": "https://second.invalid",
+        "resolution": "4k",
+        "aspect_ratio": "9:16",
+        "prompt_builder_version": 99,
+        "voice": "second-voice",
+        "speed": 2.0,
+    }
+
+    step1 = build_step1_basis("第一场\n对白", project=first_project)
+    same_step1 = build_step1_basis("第一场\n对白", project=changed_execution_project)
+    changed_source = build_step1_basis("第一场\n另一句对白", project=first_project)
+    script = build_episode_script_basis({"scenes": [{"scene_id": "E1S01"}]}, project=first_project)
+    same_script = build_episode_script_basis(
+        {"scenes": [{"scene_id": "E1S01"}]},
+        project=changed_execution_project,
+    )
+    changed_step1 = build_episode_script_basis(
+        {"scenes": [{"scene_id": "E1S01", "source_text": "changed"}]},
+        project=first_project,
+    )
+
+    assert same_step1.digest == step1.digest
+    assert changed_source.digest != step1.digest
+    assert same_script.digest == script.digest
+    assert changed_step1.digest != script.digest
+
+
+def test_structured_basis_rejects_malformed_formal_inputs() -> None:
+    with pytest.raises(ValueError, match="content_mode"):
+        build_step1_basis(
+            "source",
+            project={"content_mode": [], "generation_mode": "storyboard"},
+        )
+    with pytest.raises(ValueError, match="non-finite"):
+        build_episode_script_basis(
+            {"duration": float("nan")},
+            project={"content_mode": "narration", "generation_mode": "storyboard"},
+        )

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -100,3 +100,17 @@ def test_step1_basis_treats_null_source_kind_as_default() -> None:
     explicit = build_step1_basis("source", project={**project, "source_kind": "novel"})
 
     assert defaulted.digest == explicit.digest
+
+
+@pytest.mark.parametrize("source_language", [None, ""])
+def test_step1_basis_canonicalizes_default_source_language(source_language: object) -> None:
+    project = {
+        "content_mode": "narration",
+        "generation_mode": "storyboard",
+        "source_language": source_language,
+    }
+
+    defaulted = build_step1_basis("source", project=project)
+    explicit = build_step1_basis("source", project={**project, "source_language": "中文"})
+
+    assert defaulted.digest == explicit.digest


### PR DESCRIPTION
## Summary

- add a versioned project-local Artifact Manifest with typed reversible keys and deterministic basis hashing
- add safe locked storage, atomic unchanged writes, fail-closed comparisons, and structured source → step1 → script provenance
- harden POSIX path traversal against parent-directory symlink replacement and derive asset types from the repository registry

## Validation

- .venv/bin/python -m pytest — 8467 passed, 1 skipped
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/basedpyright — 0 errors
- .venv/bin/lint-imports

Closes #1672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增工件清单管理，记录工件身份、来源依据及状态。
  * 支持识别当前、过期、缺失和受阻工件，并支持注册与比较。
  * 支持内存及项目目录存储、确定性持久化和并发更新。
  * 新增来源内容规范化与摘要生成，便于追踪正式内容变更。

* **错误修复**
  * 防止路径遍历、符号链接、特殊文件及损坏清单导致不安全操作。
  * 写入失败时自动回滚并清理临时文件，避免内容丢失。

* **测试**
  * 新增覆盖状态比较、来源追踪、持久化、安全防护及异常场景的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->