### PR TITLE
feat(智能体): 完善配置完整性与恢复体验

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Import layering (import-linter)
         run: uv run lint-imports
 
+      - name: Agent Runtime Profile integrity
+        run: uv run python scripts/lint_agent_runtime_profile.py
+
   backend-tests:
     needs: changes
     if: needs.changes.outputs.backend == 'true'

--- a/agent_runtime_profile/.claude/skills/generate-assets/SKILL.md
+++ b/agent_runtime_profile/.claude/skills/generate-assets/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: generate-assets
-description: "统一资产生成 skill：接受 `--type=character|scene|prop`，或不传自动扫所有 pending（缺 sheet）资源并按类型分发。当用户说"生成角色图"/"生成场景图"/"生成道具图"、想为新资产创建参考图、或有资产缺少 *_sheet 时使用。"
+description: >-
+  统一资产生成 skill：接受 `--type=character|scene|prop`，或不传自动扫所有 pending（缺 sheet）资源并按类型分发。当用户说“生成角色图”/“生成场景图”/“生成道具图”、想为新资产创建参考图、或有资产缺少 *_sheet 时使用。
 ---
 
 # 生成资产设计图

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -219,6 +219,11 @@ export interface SuccessResponse {
   message?: string;
 }
 
+export interface AgentProfileStatus {
+  customized: boolean;
+  customized_files: string[];
+}
+
 /** 说书模式片段 PATCH 入参（drama 模式片段走 {@link API.updateScene}）。 */
 export interface SegmentUpdatePayload {
   script_file: string;
@@ -551,6 +556,16 @@ class API {
     return this.request(`/projects/${encodeURIComponent(name)}`, {
       method: "PATCH",
       body: JSON.stringify(updates),
+    });
+  }
+
+  static async getAgentProfileStatus(name: string): Promise<AgentProfileStatus> {
+    return this.request(`/projects/${encodeURIComponent(name)}/agent-profile`);
+  }
+
+  static async resetAgentProfile(name: string): Promise<AgentProfileStatus> {
+    return this.request(`/projects/${encodeURIComponent(name)}/agent-profile/reset`, {
+      method: "POST",
     });
   }
 

--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Router, Route } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
@@ -47,13 +47,23 @@ const FAKE_CANDIDATES = {
   provider_names: {},
 };
 
+function mockBuiltinAgentProfile() {
+  vi.spyOn(API, "getAgentProfileStatus").mockResolvedValue({
+    customized: false,
+    customized_files: [],
+  });
+}
+
 function renderAt(path: string) {
   const location = memoryLocation({ path, record: true });
-  return render(
-    <Router hook={location.hook}>
-      <Route path="/app/projects/:projectName/settings" component={ProjectSettingsPage} />
-    </Router>,
-  );
+  return {
+    ...render(
+      <Router hook={location.hook}>
+        <Route path="/app/projects/:projectName/settings" component={ProjectSettingsPage} />
+      </Router>,
+    ),
+    location,
+  };
 }
 
 describe("ProjectSettingsPage – style picker", () => {
@@ -66,10 +76,7 @@ describe("ProjectSettingsPage – style picker", () => {
     );
     vi.spyOn(providerModels, "getProviderModels").mockResolvedValue([]);
     vi.spyOn(providerModels, "getCustomProviderModels").mockResolvedValue([]);
-    vi.spyOn(API, "getAgentProfileStatus").mockResolvedValue({
-      customized: false,
-      customized_files: [],
-    });
+    mockBuiltinAgentProfile();
   });
 
   it("shows customized Agent Profile files and resets only after destructive confirmation", async () => {
@@ -97,6 +104,30 @@ describe("ProjectSettingsPage – style picker", () => {
     fireEvent.click(screen.getByRole("button", { name: /确认重置|Confirm reset/ }));
     await waitFor(() => expect(resetSpy).toHaveBeenCalledWith("demo"));
     expect(await screen.findByText(/使用内置配置|Using built-in/)).toBeInTheDocument();
+  });
+
+  it("does not carry Agent Profile state or reset confirmation across projects", async () => {
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: { title: "Demo", episodes: [], characters: {}, clues: {} },
+      scripts: {},
+    } as unknown as Awaited<ReturnType<typeof API.getProject>>);
+    vi.spyOn(API, "getAgentProfileStatus").mockImplementation((name) => (
+      name === "project-a"
+        ? Promise.resolve({ customized: true, customized_files: ["CLAUDE.md"] })
+        : new Promise(() => {})
+    ));
+    const resetSpy = vi.spyOn(API, "resetAgentProfile");
+    const { location } = renderAt("/app/projects/project-a/settings");
+
+    expect(await screen.findByText("CLAUDE.md")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
+    expect(screen.getByText(/将丢弃|discard/)).toBeInTheDocument();
+
+    act(() => location.navigate("/app/projects/project-b/settings"));
+
+    await waitFor(() => expect(screen.queryByText("CLAUDE.md")).not.toBeInTheDocument());
+    expect(screen.queryByText(/将丢弃|discard/)).not.toBeInTheDocument();
+    expect(resetSpy).not.toHaveBeenCalled();
   });
 
   it("loads a project with style_template_id and selects the matching template card by default", async () => {
@@ -370,6 +401,7 @@ describe("ProjectSettingsPage – model_settings resolution", () => {
     );
     vi.spyOn(providerModels, "getProviderModels").mockResolvedValue([]);
     vi.spyOn(providerModels, "getCustomProviderModels").mockResolvedValue([]);
+    mockBuiltinAgentProfile();
   });
 
   it("loads existing model_settings resolution into video/image pickers", async () => {
@@ -554,6 +586,7 @@ describe("ProjectSettingsPage – 按用途指定模型", () => {
     );
     vi.spyOn(providerModels, "getProviderModels").mockResolvedValue([]);
     vi.spyOn(providerModels, "getCustomProviderModels").mockResolvedValue([]);
+    mockBuiltinAgentProfile();
   });
 
   it("loads project sub-field overrides and writes each back to its own key", async () => {

--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -100,6 +100,7 @@ describe("ProjectSettingsPage – style picker", () => {
     fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
     expect(resetSpy).not.toHaveBeenCalled();
     expect(await screen.findByText(/将丢弃|discard/)).toBeInTheDocument();
+    expect(screen.getByText(/重新连接|reconnect/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /确认重置|Confirm reset/ }));
     await waitFor(() => expect(resetSpy).toHaveBeenCalledWith("demo"));

--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -68,6 +68,33 @@ describe("ProjectSettingsPage – style picker", () => {
     vi.spyOn(providerModels, "getCustomProviderModels").mockResolvedValue([]);
   });
 
+  it("shows customized Agent Profile files and resets only after destructive confirmation", async () => {
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: { title: "Demo", episodes: [], characters: {}, clues: {} },
+      scripts: {},
+    } as unknown as Awaited<ReturnType<typeof API.getProject>>);
+    vi.spyOn(API, "getAgentProfileStatus").mockResolvedValue({
+      customized: true,
+      customized_files: ["CLAUDE.md", ".claude/agents/legacy.md"],
+    });
+    const resetSpy = vi.spyOn(API, "resetAgentProfile").mockResolvedValue({
+      customized: false,
+      customized_files: [],
+    });
+
+    renderAt("/app/projects/demo/settings");
+
+    expect(await screen.findByText("CLAUDE.md")).toBeInTheDocument();
+    expect(screen.getByText(".claude/agents/legacy.md")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(/将丢弃|discard/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /确认重置|Confirm reset/ }));
+    await waitFor(() => expect(resetSpy).toHaveBeenCalledWith("demo"));
+    expect(await screen.findByText(/使用内置配置|Using built-in/)).toBeInTheDocument();
+  });
+
   it("loads a project with style_template_id and selects the matching template card by default", async () => {
     vi.spyOn(API, "getProject").mockResolvedValue({
       project: {

--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -66,6 +66,10 @@ describe("ProjectSettingsPage – style picker", () => {
     );
     vi.spyOn(providerModels, "getProviderModels").mockResolvedValue([]);
     vi.spyOn(providerModels, "getCustomProviderModels").mockResolvedValue([]);
+    vi.spyOn(API, "getAgentProfileStatus").mockResolvedValue({
+      customized: false,
+      customized_files: [],
+    });
   });
 
   it("shows customized Agent Profile files and resets only after destructive confirmation", async () => {

--- a/frontend/src/components/pages/ProjectSettingsPage.test.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.test.tsx
@@ -99,7 +99,7 @@ describe("ProjectSettingsPage – style picker", () => {
     expect(screen.getByText(".claude/agents/legacy.md")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
     expect(resetSpy).not.toHaveBeenCalled();
-    expect(screen.getByText(/将丢弃|discard/)).toBeInTheDocument();
+    expect(await screen.findByText(/将丢弃|discard/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /确认重置|Confirm reset/ }));
     await waitFor(() => expect(resetSpy).toHaveBeenCalledWith("demo"));
@@ -121,12 +121,38 @@ describe("ProjectSettingsPage – style picker", () => {
 
     expect(await screen.findByText("CLAUDE.md")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
-    expect(screen.getByText(/将丢弃|discard/)).toBeInTheDocument();
+    expect(await screen.findByText(/将丢弃|discard/)).toBeInTheDocument();
 
     act(() => location.navigate("/app/projects/project-b/settings"));
 
     await waitFor(() => expect(screen.queryByText("CLAUDE.md")).not.toBeInTheDocument());
     expect(screen.queryByText(/将丢弃|discard/)).not.toBeInTheDocument();
+    expect(resetSpy).not.toHaveBeenCalled();
+  });
+
+  it("requires another confirmation when customized files change before reset", async () => {
+    const initialStatus = { customized: true, customized_files: ["CLAUDE.md"] };
+    const changedStatus = {
+      customized: true,
+      customized_files: [".claude/agents/new.md", "CLAUDE.md"],
+    };
+    vi.spyOn(API, "getProject").mockResolvedValue({
+      project: { title: "Demo", episodes: [], characters: {}, clues: {} },
+      scripts: {},
+    } as unknown as Awaited<ReturnType<typeof API.getProject>>);
+    vi.spyOn(API, "getAgentProfileStatus")
+      .mockResolvedValueOnce(initialStatus)
+      .mockResolvedValueOnce(initialStatus)
+      .mockResolvedValue(changedStatus);
+    const resetSpy = vi.spyOn(API, "resetAgentProfile");
+    renderAt("/app/projects/demo/settings");
+
+    expect(await screen.findByText("CLAUDE.md")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /重置为内置配置|Reset to built-in/ }));
+    expect(await screen.findByText(/将丢弃|discard/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /确认重置|Confirm reset/ }));
+
+    expect(await screen.findAllByText(".claude/agents/new.md")).toHaveLength(2);
     expect(resetSpy).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -3,7 +3,7 @@ import { errMsg, voidCall, voidPromise } from "@/utils/async";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, Loader2 } from "lucide-react";
-import { API } from "@/api";
+import { API, type AgentProfileStatus } from "@/api";
 import { useAppStore } from "@/stores/app-store";
 import { useCapabilitiesStore } from "@/stores/capabilities-store";
 import { PROVIDER_NAMES } from "@/components/ui/ProviderIcon";
@@ -168,6 +168,9 @@ export function ProjectSettingsPage() {
   const [projectTitle, setProjectTitle] = useState<string>("");
   const [contentMode, setContentMode] = useState<string>("narration");
   const [saving, setSaving] = useState(false);
+  const [agentProfile, setAgentProfile] = useState<AgentProfileStatus | null>(null);
+  const [profileResetOpen, setProfileResetOpen] = useState(false);
+  const [profileResetting, setProfileResetting] = useState(false);
 
   // ── Style picker state (independent save flow) ─────────────────────────────
   const [styleValue, setStyleValue] = useState<StylePickerValue | null>(null);
@@ -192,6 +195,22 @@ export function ProjectSettingsPage() {
   useEffect(() => {
     void reloadCandidates();
   }, [reloadCandidates]);
+
+  useEffect(() => {
+    let disposed = false;
+    voidCall(
+      API.getAgentProfileStatus(projectName)
+        .then((status) => {
+          if (!disposed) setAgentProfile(status);
+        })
+        .catch(() => {
+          if (!disposed) setAgentProfile(null);
+        }),
+    );
+    return () => {
+      disposed = true;
+    };
+  }, [projectName]);
 
   useEffect(() => {
     let disposed = false;
@@ -508,6 +527,20 @@ export function ProjectSettingsPage() {
     }
   }, [modelSettings, videoBackend, videoProviderI2V, videoProviderR2V, imageBackendDefault, imageBackendT2I, imageBackendI2I, audioOverride, audioBackend, narrationVoice, narrationSpeed, textDefault, textSimple, textComplex, aspectRatio, generationRoute, gridStoryboard, gridToggleVisible, defaultDuration, speechRate, contentMode, videoResolution, imageResolution, projectName, t, globalDefaults]);
 
+  const handleResetAgentProfile = useCallback(async () => {
+    setProfileResetting(true);
+    try {
+      const status = await API.resetAgentProfile(projectName);
+      setAgentProfile(status);
+      setProfileResetOpen(false);
+      useAppStore.getState().pushToast(t("agent_profile_reset_success"), "success");
+    } catch (error: unknown) {
+      useAppStore.getState().pushToast(t("agent_profile_reset_failed", { message: errMsg(error) }), "error");
+    } finally {
+      setProfileResetting(false);
+    }
+  }, [projectName, t]);
+
   return (
     <div
       className="fixed inset-0 z-50 flex flex-col text-text"
@@ -576,6 +609,36 @@ export function ProjectSettingsPage() {
               {t("model_config_project_desc")}
             </p>
           </div>
+
+          {agentProfile && (
+            <SectionCard
+              kicker={t("agent_profile_title")}
+              title={t("agent_profile_title")}
+              description={t("agent_profile_description")}
+              footer={agentProfile.customized ? (
+                <button
+                  type="button"
+                  onClick={() => setProfileResetOpen(true)}
+                  className={GHOST_BTN_LG_CLS}
+                >
+                  {t("agent_profile_reset")}
+                </button>
+              ) : undefined}
+            >
+              {agentProfile.customized ? (
+                <div className="space-y-2">
+                  <p className="text-[12px] text-warm">{t("agent_profile_customized")}</p>
+                  <ul className="space-y-1" aria-label={t("agent_profile_affected_files")}>
+                    {agentProfile.customized_files.map((file) => (
+                      <li key={file} className="font-mono text-[11px] text-text-3">{file}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : (
+                <p className="text-[12px] text-text-3">{t("agent_profile_builtin")}</p>
+              )}
+            </SectionCard>
+          )}
 
           {/* Style picker (independent save flow, mutually exclusive template / custom) */}
           {styleValue && (
@@ -897,6 +960,26 @@ export function ProjectSettingsPage() {
           </div>
         </div>
       </footer>
+
+      <ConfirmDialog
+        open={profileResetOpen}
+        tone="danger"
+        title={t("agent_profile_reset_confirm_title")}
+        description={(
+          <div className="space-y-2">
+            <p>{t("agent_profile_reset_confirm_description")}</p>
+            <ul className="space-y-1 font-mono text-[11px]">
+              {agentProfile?.customized_files.map((file) => <li key={file}>{file}</li>)}
+            </ul>
+          </div>
+        )}
+        confirmLabel={t("agent_profile_reset_confirm")}
+        loadingLabel={t("agent_profile_resetting")}
+        loading={profileResetting}
+        cancelLabel={t("common:cancel")}
+        onCancel={() => setProfileResetOpen(false)}
+        onConfirm={handleResetAgentProfile}
+      />
 
       <ConfirmDialog
         open={pendingNavigation !== null}

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -168,8 +168,12 @@ export function ProjectSettingsPage() {
   const [projectTitle, setProjectTitle] = useState<string>("");
   const [contentMode, setContentMode] = useState<string>("narration");
   const [saving, setSaving] = useState(false);
-  const [agentProfile, setAgentProfile] = useState<AgentProfileStatus | null>(null);
-  const [profileResetOpen, setProfileResetOpen] = useState(false);
+  const [loadedAgentProfile, setLoadedAgentProfile] = useState<{
+    projectName: string;
+    status: AgentProfileStatus;
+  } | null>(null);
+  const agentProfile = loadedAgentProfile?.projectName === projectName ? loadedAgentProfile.status : null;
+  const [profileResetProject, setProfileResetProject] = useState<string | null>(null);
   const [profileResetting, setProfileResetting] = useState(false);
 
   // ── Style picker state (independent save flow) ─────────────────────────────
@@ -201,10 +205,10 @@ export function ProjectSettingsPage() {
     voidCall(
       API.getAgentProfileStatus(projectName)
         .then((status) => {
-          if (!disposed) setAgentProfile(status);
+          if (!disposed) setLoadedAgentProfile({ projectName, status });
         })
         .catch(() => {
-          if (!disposed) setAgentProfile(null);
+          if (!disposed) setLoadedAgentProfile(null);
         }),
     );
     return () => {
@@ -528,18 +532,25 @@ export function ProjectSettingsPage() {
   }, [modelSettings, videoBackend, videoProviderI2V, videoProviderR2V, imageBackendDefault, imageBackendT2I, imageBackendI2I, audioOverride, audioBackend, narrationVoice, narrationSpeed, textDefault, textSimple, textComplex, aspectRatio, generationRoute, gridStoryboard, gridToggleVisible, defaultDuration, speechRate, contentMode, videoResolution, imageResolution, projectName, t, globalDefaults]);
 
   const handleResetAgentProfile = useCallback(async () => {
+    if (profileResetProject !== projectName) {
+      setProfileResetProject(null);
+      return;
+    }
+    const resetProject = profileResetProject;
     setProfileResetting(true);
     try {
-      const status = await API.resetAgentProfile(projectName);
-      setAgentProfile(status);
-      setProfileResetOpen(false);
+      const status = await API.resetAgentProfile(resetProject);
+      setLoadedAgentProfile((current) => (
+        current?.projectName === resetProject ? { projectName: resetProject, status } : current
+      ));
+      setProfileResetProject(null);
       useAppStore.getState().pushToast(t("agent_profile_reset_success"), "success");
     } catch (error: unknown) {
       useAppStore.getState().pushToast(t("agent_profile_reset_failed", { message: errMsg(error) }), "error");
     } finally {
       setProfileResetting(false);
     }
-  }, [projectName, t]);
+  }, [profileResetProject, projectName, t]);
 
   return (
     <div
@@ -618,7 +629,7 @@ export function ProjectSettingsPage() {
               footer={agentProfile.customized ? (
                 <button
                   type="button"
-                  onClick={() => setProfileResetOpen(true)}
+                  onClick={() => setProfileResetProject(projectName)}
                   className={GHOST_BTN_LG_CLS}
                 >
                   {t("agent_profile_reset")}
@@ -962,7 +973,7 @@ export function ProjectSettingsPage() {
       </footer>
 
       <ConfirmDialog
-        open={profileResetOpen}
+        open={profileResetProject === projectName && agentProfile !== null}
         tone="danger"
         title={t("agent_profile_reset_confirm_title")}
         description={(
@@ -977,7 +988,7 @@ export function ProjectSettingsPage() {
         loadingLabel={t("agent_profile_resetting")}
         loading={profileResetting}
         cancelLabel={t("common:cancel")}
-        onCancel={() => setProfileResetOpen(false)}
+        onCancel={() => setProfileResetProject(null)}
         onConfirm={handleResetAgentProfile}
       />
 

--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -47,6 +47,10 @@ function deriveStyleValue(project: Record<string, unknown>, projectName: string)
   };
 }
 
+function sameProfileFiles(left: string[], right: string[]) {
+  return left.length === right.length && left.every((file, index) => file === right[index]);
+}
+
 // ─── Section card primitive ─────────────────────────────────────────────────
 
 interface SectionCardProps {
@@ -539,6 +543,13 @@ export function ProjectSettingsPage() {
     const resetProject = profileResetProject;
     setProfileResetting(true);
     try {
+      const currentStatus = await API.getAgentProfileStatus(resetProject);
+      const displayedStatus = loadedAgentProfile?.projectName === resetProject ? loadedAgentProfile.status : null;
+      if (!displayedStatus || !sameProfileFiles(displayedStatus.customized_files, currentStatus.customized_files)) {
+        setLoadedAgentProfile({ projectName: resetProject, status: currentStatus });
+        if (!currentStatus.customized) setProfileResetProject(null);
+        return;
+      }
       const status = await API.resetAgentProfile(resetProject);
       setLoadedAgentProfile((current) => (
         current?.projectName === resetProject ? { projectName: resetProject, status } : current
@@ -550,7 +561,18 @@ export function ProjectSettingsPage() {
     } finally {
       setProfileResetting(false);
     }
-  }, [profileResetProject, projectName, t]);
+  }, [loadedAgentProfile, profileResetProject, projectName, t]);
+
+  const handleOpenAgentProfileReset = useCallback(async () => {
+    const resetProject = projectName;
+    try {
+      const status = await API.getAgentProfileStatus(resetProject);
+      setLoadedAgentProfile({ projectName: resetProject, status });
+      setProfileResetProject(status.customized ? resetProject : null);
+    } catch (error: unknown) {
+      useAppStore.getState().pushToast(t("agent_profile_reset_failed", { message: errMsg(error) }), "error");
+    }
+  }, [projectName, t]);
 
   return (
     <div
@@ -629,7 +651,7 @@ export function ProjectSettingsPage() {
               footer={agentProfile.customized ? (
                 <button
                   type="button"
-                  onClick={() => setProfileResetProject(projectName)}
+                  onClick={() => voidCall(handleOpenAgentProfileReset())}
                   className={GHOST_BTN_LG_CLS}
                 >
                   {t("agent_profile_reset")}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -701,6 +701,18 @@ export default {
 
   // ProjectSettingsPage
   'project_settings': 'Project Settings',
+  'agent_profile_title': 'Agent profile',
+  'agent_profile_description': 'Project Agent instructions upgrade safely with built-ins while preserving local customizations.',
+  'agent_profile_customized': 'Customized project profile detected',
+  'agent_profile_builtin': 'Using built-in configuration',
+  'agent_profile_affected_files': 'Affected profile files',
+  'agent_profile_reset': 'Reset to built-in',
+  'agent_profile_reset_confirm_title': 'Reset Agent profile?',
+  'agent_profile_reset_confirm_description': 'The following customized files will be discarded and replaced by the current built-in profile. This cannot be undone.',
+  'agent_profile_reset_confirm': 'Confirm reset',
+  'agent_profile_resetting': 'Resetting…',
+  'agent_profile_reset_success': 'Built-in Agent profile restored',
+  'agent_profile_reset_failed': 'Could not reset Agent profile: {{message}}',
   'back_to_project': 'Back to project',
   'model_config_project_desc': 'Select generation models for this project individually; leave empty to follow global defaults',
   'video_model': 'Video Model',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -708,7 +708,7 @@ export default {
   'agent_profile_affected_files': 'Affected profile files',
   'agent_profile_reset': 'Reset to built-in',
   'agent_profile_reset_confirm_title': 'Reset Agent profile?',
-  'agent_profile_reset_confirm_description': 'The following customized files will be discarded and replaced by the current built-in profile. This cannot be undone.',
+  'agent_profile_reset_confirm_description': 'The following customized files will be discarded and replaced by the current built-in profile. This cannot be undone. Open assistant sessions keep their current configuration until they reconnect.',
   'agent_profile_reset_confirm': 'Confirm reset',
   'agent_profile_resetting': 'Resetting…',
   'agent_profile_reset_success': 'Built-in Agent profile restored',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -680,6 +680,18 @@ export default {
 
   // ProjectSettingsPage
   'project_settings': 'Cài đặt dự án',
+  'agent_profile_title': 'Hồ sơ Agent',
+  'agent_profile_description': 'Chỉ dẫn Agent trong dự án được nâng cấp an toàn theo cấu hình tích hợp và vẫn giữ các tùy chỉnh cục bộ.',
+  'agent_profile_customized': 'Đã phát hiện hồ sơ dự án tùy chỉnh',
+  'agent_profile_builtin': 'Đang dùng cấu hình tích hợp',
+  'agent_profile_affected_files': 'Các tệp hồ sơ bị ảnh hưởng',
+  'agent_profile_reset': 'Đặt lại về tích hợp',
+  'agent_profile_reset_confirm_title': 'Đặt lại hồ sơ Agent?',
+  'agent_profile_reset_confirm_description': 'Các tệp tùy chỉnh sau sẽ bị loại bỏ và thay bằng hồ sơ tích hợp hiện tại. Không thể hoàn tác thao tác này.',
+  'agent_profile_reset_confirm': 'Xác nhận đặt lại',
+  'agent_profile_resetting': 'Đang đặt lại…',
+  'agent_profile_reset_success': 'Đã khôi phục hồ sơ Agent tích hợp',
+  'agent_profile_reset_failed': 'Không thể đặt lại hồ sơ Agent: {{message}}',
   'back_to_project': 'Quay lại dự án',
   'model_config_project_desc': 'Chọn mô hình tạo cho dự án này; để trống để dùng mặc định toàn cục',
   'video_model': 'Mô hình video',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -687,7 +687,7 @@ export default {
   'agent_profile_affected_files': 'Các tệp hồ sơ bị ảnh hưởng',
   'agent_profile_reset': 'Đặt lại về tích hợp',
   'agent_profile_reset_confirm_title': 'Đặt lại hồ sơ Agent?',
-  'agent_profile_reset_confirm_description': 'Các tệp tùy chỉnh sau sẽ bị loại bỏ và thay bằng hồ sơ tích hợp hiện tại. Không thể hoàn tác thao tác này.',
+  'agent_profile_reset_confirm_description': 'Các tệp tùy chỉnh sau sẽ bị loại bỏ và thay bằng hồ sơ tích hợp hiện tại. Không thể hoàn tác thao tác này. Các phiên Agent đang mở vẫn dùng cấu hình hiện tại cho đến khi kết nối lại.',
   'agent_profile_reset_confirm': 'Xác nhận đặt lại',
   'agent_profile_resetting': 'Đang đặt lại…',
   'agent_profile_reset_success': 'Đã khôi phục hồ sơ Agent tích hợp',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -700,6 +700,18 @@ export default {
 
   // ProjectSettingsPage
   'project_settings': '项目设置',
+  'agent_profile_title': '智能体配置',
+  'agent_profile_description': '项目内的智能体指令会随内置配置安全升级，并保留你的本地定制。',
+  'agent_profile_customized': '检测到项目定制配置',
+  'agent_profile_builtin': '正在使用内置配置',
+  'agent_profile_affected_files': '受影响的配置文件',
+  'agent_profile_reset': '重置为内置配置',
+  'agent_profile_reset_confirm_title': '重置智能体配置？',
+  'agent_profile_reset_confirm_description': '以下定制文件将丢弃，并替换为当前内置配置。此操作无法撤销。',
+  'agent_profile_reset_confirm': '确认重置',
+  'agent_profile_resetting': '正在重置…',
+  'agent_profile_reset_success': '已恢复内置智能体配置',
+  'agent_profile_reset_failed': '重置智能体配置失败：{{message}}',
   'back_to_project': '返回项目',
   'model_config_project_desc': '为此项目单独选择生成模型，留空则跟随全局默认',
   'video_model': '视频模型',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -707,7 +707,7 @@ export default {
   'agent_profile_affected_files': '受影响的配置文件',
   'agent_profile_reset': '重置为内置配置',
   'agent_profile_reset_confirm_title': '重置智能体配置？',
-  'agent_profile_reset_confirm_description': '以下定制文件将丢弃，并替换为当前内置配置。此操作无法撤销。',
+  'agent_profile_reset_confirm_description': '以下定制文件将丢弃，并替换为当前内置配置。此操作无法撤销。已打开的智能体会话在重新连接前仍使用原配置。',
   'agent_profile_reset_confirm': '确认重置',
   'agent_profile_resetting': '正在重置…',
   'agent_profile_reset_success': '已恢复内置智能体配置',

--- a/lib/profile_frontmatter.py
+++ b/lib/profile_frontmatter.py
@@ -1,0 +1,58 @@
+"""Safe parsing and validation for Agent Profile Markdown frontmatter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class FrontmatterError(ValueError):
+    """The Markdown frontmatter is missing, malformed, or has invalid metadata."""
+
+
+@dataclass(frozen=True)
+class ProfileMetadata:
+    name: str
+    description: str
+    user_invocable: bool = True
+
+
+def parse_profile_metadata(path: Path) -> ProfileMetadata:
+    """Parse validated YAML metadata from a Skill or Subagent Markdown file."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeError as exc:
+        raise FrontmatterError("frontmatter is not valid UTF-8") from exc
+
+    lines = content.splitlines()
+    if not lines or lines[0] != "---":
+        raise FrontmatterError("frontmatter must start with a YAML delimiter")
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        raise FrontmatterError("frontmatter closing delimiter is missing")
+    source = "\n".join(lines[1:end])
+    try:
+        loaded: Any = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        raise FrontmatterError(f"invalid YAML: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise FrontmatterError("frontmatter must be an object")
+
+    name = loaded.get("name")
+    description = loaded.get("description")
+    user_invocable = loaded.get("user-invocable", True)
+    if not isinstance(name, str) or not name.strip():
+        raise FrontmatterError("name must be a non-empty string")
+    if not isinstance(description, str) or not description.strip():
+        raise FrontmatterError("description must be a non-empty string")
+    if not isinstance(user_invocable, bool):
+        raise FrontmatterError("user-invocable must be a boolean")
+    return ProfileMetadata(
+        name=name.strip(),
+        description=description.strip(),
+        user_invocable=user_invocable,
+    )

--- a/lib/profile_frontmatter.py
+++ b/lib/profile_frontmatter.py
@@ -23,7 +23,7 @@ class ProfileMetadata:
 def parse_profile_metadata(path: Path) -> ProfileMetadata:
     """Parse validated YAML metadata from a Skill or Subagent Markdown file."""
     try:
-        content = path.read_text(encoding="utf-8")
+        content = path.read_text(encoding="utf-8-sig")
     except UnicodeError as exc:
         raise FrontmatterError("frontmatter is not valid UTF-8") from exc
 

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -752,7 +752,11 @@ def get_profile_status(
     loaded = load_manifest(project_dir)
     dest_files = enumerate_dest_files(project_dir)
     if loaded is None:
-        customized_files = sorted(dest_files)
+        # Without a trustworthy baseline, existing destination files may be
+        # customized and missing projected files may be user deletions. A full
+        # reset repairs both shapes, so keep the reset action available for the
+        # complete affected set.
+        customized_files = sorted(dest_files | mapping.keys())
         return {"customized": bool(customized_files), "customized_files": customized_files}
 
     manifest, _ = loaded

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -258,7 +258,10 @@ def enumerate_dest_files(project_dir: Path) -> set[str]:
     files: set[str] = set()
     if (project_dir / _PROFILE_TOP_FILE).is_file():
         files.add(_PROFILE_TOP_FILE)
-    files |= {rel for rel in _walk_files(project_dir / _PROFILE_TREE_ROOT, project_dir) if not _is_skippable_dest(rel)}
+    dest_tree = project_dir / _PROFILE_TREE_ROOT
+    if dest_tree.is_symlink():
+        raise ValueError(f"profile tree is a symlink, refusing to enumerate: {dest_tree}")
+    files |= {rel for rel in _walk_files(dest_tree, project_dir) if not _is_skippable_dest(rel)}
     return files
 
 

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -609,8 +609,9 @@ def _apply_decision(
                 stats["pruned"] += 1
                 stats["repaired"] += 1
             else:
-                # #8 profile 上游删，用户改过 → 保留 D + 清 entry（不是 tombstone）
-                manifest.entries.pop(rel, None)
+                # #8 profile 上游删，用户改过 → 保留 D 及旧 baseline。保留 entry
+                # 让设置页仍能识别这是从内置 profile 分叉的 legacy 定制，而不是
+                # 无来源的 project-only 文件；后续同步继续按三方语义保护它。
                 stats["orphaned"] += 1
                 stats["skipped"] += 1
         case (False, True, "none"):
@@ -727,6 +728,58 @@ def sync_profile_to_project(
         return stats
 
 
+def get_profile_status(
+    profile_dir: Path,
+    project_dir: Path,
+    content_mode: ContentMode,
+) -> dict[str, object]:
+    """Return project-local files that a full built-in reset would discard.
+
+    A customization is a tracked file whose content differs from its recorded
+    built-in baseline, a user deletion of a currently shipped file, or a
+    project-only profile file. Unmodified files removed upstream are not
+    customizations and are pruned by normal sync.
+    """
+    if not profile_dir.exists():
+        raise ProfileMissingError(f"Profile dir not found: {profile_dir}")
+    mapping = resolve_profile_files_for_mode(profile_dir, content_mode)
+    if not mapping:
+        raise ProfileEmptyError(f"Profile dir empty, likely deploy misconfig: {profile_dir}")
+
+    loaded = load_manifest(project_dir)
+    dest_files = enumerate_dest_files(project_dir)
+    if loaded is None:
+        customized_files = sorted(dest_files)
+        return {"customized": bool(customized_files), "customized_files": customized_files}
+
+    manifest, _ = loaded
+    customized: set[str] = set()
+    for rel in dest_files:
+        entry = manifest.entries.get(rel)
+        if entry is None:
+            customized.add(rel)
+            continue
+        if entry.get("source") == "tombstone":
+            customized.add(rel)
+            continue
+        try:
+            dest = _ensure_dest_within(project_dir, rel)
+            if sha256_file(dest) != entry.get("sha256"):
+                customized.add(rel)
+        except (OSError, ValueError):
+            customized.add(rel)
+
+    for rel in manifest.entries:
+        if rel in dest_files or rel not in mapping:
+            continue
+        # Any missing file still shipped by the current projection is a user
+        # deletion, whether or not normal sync has recorded a tombstone yet.
+        customized.add(rel)
+
+    files = sorted(customized)
+    return {"customized": bool(files), "customized_files": files}
+
+
 def force_resync_profile(
     profile_dir: Path,
     project_dir: Path,
@@ -753,10 +806,10 @@ def force_resync_profile(
     project_dir.mkdir(parents=True, exist_ok=True)
 
     with _project_lock(project_dir):
+        if paths is None:
+            return _full_reset_from_profile(profile_dir, project_dir, mapping, content_mode=content_mode)
         loaded = load_manifest(project_dir)
         if loaded is None:
-            if paths is None:
-                return _full_reset_from_profile(profile_dir, project_dir, mapping, content_mode=content_mode)
             manifest, original_bytes = Manifest.empty(), None
         else:
             manifest, original_bytes = loaded

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -265,6 +265,24 @@ def enumerate_dest_files(project_dir: Path) -> set[str]:
     return files
 
 
+def _enumerate_dest_symlinks(project_dir: Path) -> set[str]:
+    """Return profile symlink entries without traversing directory targets."""
+    links: set[str] = set()
+    dest_top = project_dir / _PROFILE_TOP_FILE
+    if dest_top.is_symlink():
+        links.add(_PROFILE_TOP_FILE)
+
+    dest_tree = project_dir / _PROFILE_TREE_ROOT
+    if not dest_tree.is_dir() or dest_tree.is_symlink():
+        return links
+    for dirpath, dirnames, filenames in os.walk(dest_tree, followlinks=False):
+        for name in (*dirnames, *filenames):
+            path = Path(dirpath) / name
+            if path.is_symlink():
+                links.add(path.relative_to(project_dir).as_posix())
+    return links
+
+
 # ---------- Manifest 数据类 ----------
 
 
@@ -751,16 +769,17 @@ def get_profile_status(
 
     loaded = load_manifest(project_dir)
     dest_files = enumerate_dest_files(project_dir)
+    dest_symlinks = _enumerate_dest_symlinks(project_dir)
     if loaded is None:
         # Without a trustworthy baseline, existing destination files may be
         # customized and missing projected files may be user deletions. A full
         # reset repairs both shapes, so keep the reset action available for the
         # complete affected set.
-        customized_files = sorted(dest_files | mapping.keys())
+        customized_files = sorted(dest_files | dest_symlinks | mapping.keys())
         return {"customized": bool(customized_files), "customized_files": customized_files}
 
     manifest, _ = loaded
-    customized: set[str] = set()
+    customized = set(dest_symlinks)
     for rel in dest_files:
         entry = manifest.entries.get(rel)
         if entry is None:
@@ -776,11 +795,11 @@ def get_profile_status(
         except (OSError, ValueError):
             customized.add(rel)
 
-    for rel in manifest.entries:
-        if rel in dest_files or rel not in mapping:
+    for rel in mapping:
+        if rel in dest_files:
             continue
         # Any missing file still shipped by the current projection is a user
-        # deletion, whether or not normal sync has recorded a tombstone yet.
+        # deletion, whether or not the manifest tracked the path yet.
         customized.add(rel)
 
     files = sorted(customized)

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -58,6 +58,7 @@ from lib.profile_manifest import (
     ProfileEmptyError,
     ProfileMisconfiguredError,
     ProfileMissingError,
+    get_profile_status,
     sync_profile_to_project,
 )
 from lib.profile_manifest import (
@@ -413,6 +414,11 @@ class ProjectManager:
             content_mode = self._resolve_content_mode(project_dir)
         profile_dir = agent_profile_dir()
         return _force_resync_profile(profile_dir, project_dir, content_mode, paths=paths)
+
+    def get_agent_profile_status(self, project_dir: Path) -> dict[str, object]:
+        """Describe project-local Agent Profile customizations for settings UI."""
+        content_mode = self._resolve_content_mode(project_dir)
+        return get_profile_status(agent_profile_dir(), project_dir, content_mode)
 
     def _resolve_content_mode(self, project_dir: Path) -> ContentMode:
         """从 project_dir/project.json 读 content_mode；缺失回退 narration。

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -16,7 +16,15 @@ from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 
 _MCP_RE = re.compile(r"mcp__arcreel__([a-zA-Z0-9_*.-]+)")
 _ROOT_POINTER_RE = re.compile(r"(?<![\w/])(\.claude/[A-Za-z0-9_./-]+\.md)")
-_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]+)?\)")
+_MARKDOWN_INLINE_LINK_RE = re.compile(
+    r"\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))"
+    r"(?:\s+(?:\"[^\"\n]*\"|'[^'\n]*'|\([^()\n]*\)))?\s*\)"
+)
+_MARKDOWN_REFERENCE_LINK_RE = re.compile(
+    r"^\s{0,3}\[[^\]\n]+\]:\s*(?:<([^>\n]+)>|([^\s\n]+))"
+    r"(?:\s+(?:\"[^\"\n]*\"|'[^'\n]*'|\([^()\n]*\)))?\s*$",
+    re.MULTILINE,
+)
 _TARGET_DEPRECATED_STRINGS = (
     "--scene-ids",
     "--music-volume",
@@ -61,6 +69,17 @@ def _projected_pointer(source_logical: str, pointer: str) -> str | None:
     return posixpath.normpath(posixpath.join(posixpath.dirname(source_logical), pointer))
 
 
+def _markdown_link_pointers(text: str) -> set[str]:
+    pointers: set[str] = set()
+    for pattern in (_MARKDOWN_INLINE_LINK_RE, _MARKDOWN_REFERENCE_LINK_RE):
+        for match in pattern.finditer(text):
+            destination = match.group(1) or match.group(2)
+            path = destination.split("#", 1)[0]
+            if path.lower().endswith(".md"):
+                pointers.add(path)
+    return pointers
+
+
 def _validate_projection(
     profile_dir: Path,
     mode: str,
@@ -86,7 +105,7 @@ def _validate_projection(
         except (OSError, UnicodeError) as exc:
             errors.append(f"{mode}:{source_rel}: cannot read projected file: {exc}")
             continue
-        pointers = set(_ROOT_POINTER_RE.findall(text)) | set(_MARKDOWN_LINK_RE.findall(text))
+        pointers = set(_ROOT_POINTER_RE.findall(text)) | _markdown_link_pointers(text)
         for pointer in sorted(pointers):
             target = _projected_pointer(logical, pointer)
             if target is not None and target not in projected:

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -18,6 +18,7 @@ from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 
 _MCP_RE = re.compile(r"mcp__arcreel__([a-zA-Z0-9_*.-]+)")
 _MCP_SENTENCE_PUNCTUATION = ".,;:!?"
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 _ROOT_POINTER_RE = re.compile(r"(?<![\w/])(\.claude/[A-Za-z0-9_./-]+\.md)")
 _MARKDOWN_INLINE_LINK_RE = re.compile(
     r"\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))"
@@ -71,7 +72,7 @@ def _validate_metadata(profile_dir: Path, errors: list[str]) -> None:
 def _projected_pointer(source_logical: str, pointer: str) -> str | None:
     if pointer.startswith(".claude/"):
         return posixpath.normpath(pointer)
-    if pointer.startswith(("http://", "https://", "/", "#")):
+    if pointer.startswith(("/", "#")) or _URI_SCHEME_RE.match(pointer):
         return None
     return posixpath.normpath(posixpath.join(posixpath.dirname(source_logical), pointer))
 

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -17,6 +17,7 @@ from lib.profile_manifest import VALID_CONTENT_MODES, ProfileMisconfiguredError,
 from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 
 _MCP_RE = re.compile(r"mcp__arcreel__([a-zA-Z0-9_*.-]+)")
+_MCP_SENTENCE_PUNCTUATION = ".,;:!?"
 _ROOT_POINTER_RE = re.compile(r"(?<![\w/])(\.claude/[A-Za-z0-9_./-]+\.md)")
 _MARKDOWN_INLINE_LINK_RE = re.compile(
     r"\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))"
@@ -116,7 +117,8 @@ def _validate_projection(
             target = _projected_pointer(logical, pointer)
             if target is not None and target not in projected:
                 errors.append(f"{mode}:{source_rel}: missing Markdown pointer {pointer!r}")
-        for tool_name in sorted(set(_MCP_RE.findall(text))):
+        tool_names = {match.rstrip(_MCP_SENTENCE_PUNCTUATION) for match in _MCP_RE.findall(text)}
+        for tool_name in sorted(tool_names):
             if tool_name != "*" and tool_name not in registered_tools:
                 errors.append(f"{mode}:{source_rel}: unregistered MCP tool mcp__arcreel__{tool_name}")
 

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import unquote
 
 from lib.profile_frontmatter import FrontmatterError, ProfileMetadata, parse_profile_metadata
 from lib.profile_manifest import VALID_CONTENT_MODES, ProfileMisconfiguredError, resolve_profile_files_for_mode
@@ -74,7 +75,7 @@ def _markdown_link_pointers(text: str) -> set[str]:
     for pattern in (_MARKDOWN_INLINE_LINK_RE, _MARKDOWN_REFERENCE_LINK_RE):
         for match in pattern.finditer(text):
             destination = match.group(1) or match.group(2)
-            path = destination.split("#", 1)[0]
+            path = unquote(destination.split("#", 1)[0])
             if path.lower().endswith(".md"):
                 pointers.add(path)
     return pointers

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 from collections import defaultdict
 from pathlib import Path
+from typing import NoReturn
 from urllib.parse import unquote
 
 from lib.profile_frontmatter import FrontmatterError, ProfileMetadata, parse_profile_metadata
@@ -36,6 +37,10 @@ _DIRECT_STEP1_EDIT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _PYTHON_RESUME_RE = re.compile(r"python[^\n`]*\s--resume(?:\s|$)")
+
+
+def _reject_json_constant(value: str) -> NoReturn:
+    raise ValueError(f"non-standard JSON constant {value!r}")
 
 
 def _metadata_files(profile_dir: Path) -> list[Path]:
@@ -122,8 +127,8 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
         if "eval" not in path.as_posix().lower():
             continue
         try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            payload = json.loads(path.read_text(encoding="utf-8"), parse_constant=_reject_json_constant)
+        except (OSError, UnicodeError, ValueError) as exc:
             errors.append(f"{path.relative_to(profile_dir)}: invalid eval JSON: {exc}")
             continue
         records: list[object]

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Static integrity checks for the materialized Agent Runtime Profile."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+from lib.profile_frontmatter import FrontmatterError, ProfileMetadata, parse_profile_metadata
+from lib.profile_manifest import VALID_CONTENT_MODES, ProfileMisconfiguredError, resolve_profile_files_for_mode
+from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
+
+_MCP_RE = re.compile(r"mcp__arcreel__([a-zA-Z0-9_*.-]+)")
+_ROOT_POINTER_RE = re.compile(r"(?<![\w/])(\.claude/[A-Za-z0-9_./-]+\.md)")
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+\.md)(?:#[^)]+)?\)")
+_TARGET_DEPRECATED_STRINGS = (
+    "--scene-ids",
+    "--music-volume",
+    "step1_normalized_script.md",
+)
+_DIRECT_STEP1_EDIT_RE = re.compile(
+    r"(?:Edit|Write).{0,100}(?:step1_normalized_script|narration.{0,30}step1|drama.{0,30}step1)",
+    re.IGNORECASE | re.DOTALL,
+)
+_PYTHON_RESUME_RE = re.compile(r"python[^\n`]*\s--resume(?:\s|$)")
+
+
+def _metadata_files(profile_dir: Path) -> list[Path]:
+    skills = (profile_dir / ".claude" / "skills").glob("*/SKILL*.md")
+    agents_root = profile_dir / ".claude" / "agents"
+    agents = agents_root.glob("*.md") if agents_root.is_dir() else ()
+    return sorted((*skills, *agents))
+
+
+def _validate_metadata(profile_dir: Path, errors: list[str]) -> None:
+    variants: dict[str, list[tuple[Path, ProfileMetadata]]] = defaultdict(list)
+    for path in _metadata_files(profile_dir):
+        try:
+            metadata = parse_profile_metadata(path)
+        except (OSError, FrontmatterError) as exc:
+            errors.append(f"{path.relative_to(profile_dir)}: invalid frontmatter: {exc}")
+            continue
+        logical = re.sub(r"\.(?:narration|drama|ad)(?=\.md$)", "", path.relative_to(profile_dir).as_posix())
+        variants[logical].append((path, metadata))
+
+    for logical, items in variants.items():
+        identities = {(metadata.name, metadata.user_invocable) for _, metadata in items}
+        if len(identities) > 1:
+            errors.append(f"{logical}: variant metadata name/user-invocable drift")
+
+
+def _projected_pointer(source_logical: str, pointer: str) -> str | None:
+    if pointer.startswith(".claude/"):
+        return PurePosixPath(pointer).as_posix()
+    if pointer.startswith(("http://", "https://", "/", "#")):
+        return None
+    return (PurePosixPath(source_logical).parent / pointer).as_posix()
+
+
+def _validate_projection(
+    profile_dir: Path,
+    mode: str,
+    registered_tools: set[str],
+    errors: list[str],
+) -> None:
+    try:
+        mapping = resolve_profile_files_for_mode(profile_dir, mode)
+    except (ValueError, ProfileMisconfiguredError) as exc:
+        errors.append(f"{mode}: invalid profile projection: {exc}")
+        return
+    projected = set(mapping)
+    if not projected:
+        errors.append(f"{mode}: profile projection is empty")
+        return
+
+    for logical, source_rel in sorted(mapping.items()):
+        source = profile_dir / source_rel
+        if source.suffix.lower() != ".md":
+            continue
+        try:
+            text = source.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{mode}:{source_rel}: cannot read projected file: {exc}")
+            continue
+        pointers = set(_ROOT_POINTER_RE.findall(text)) | set(_MARKDOWN_LINK_RE.findall(text))
+        for pointer in sorted(pointers):
+            target = _projected_pointer(logical, pointer)
+            if target is not None and target not in projected:
+                errors.append(f"{mode}:{source_rel}: missing Markdown pointer {pointer!r}")
+        for tool_name in sorted(set(_MCP_RE.findall(text))):
+            if tool_name != "*" and tool_name not in registered_tools:
+                errors.append(f"{mode}:{source_rel}: unregistered MCP tool mcp__arcreel__{tool_name}")
+
+
+def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
+    seen: dict[object, Path] = {}
+    for path in sorted(profile_dir.rglob("*.json")):
+        if "eval" not in path.as_posix().lower():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{path.relative_to(profile_dir)}: invalid eval JSON: {exc}")
+            continue
+        records: list[object]
+        if isinstance(payload, list):
+            records = payload
+        elif isinstance(payload, dict) and isinstance(payload.get("evals"), list):
+            records = payload["evals"]
+        else:
+            records = [payload]
+        for record in records:
+            if not isinstance(record, dict) or "id" not in record:
+                continue
+            eval_id = record["id"]
+            try:
+                duplicate = eval_id in seen
+            except TypeError:
+                errors.append(f"{path.relative_to(profile_dir)}: eval id must be a scalar")
+                continue
+            if duplicate:
+                errors.append(
+                    f"{path.relative_to(profile_dir)}: duplicate eval id {eval_id!r} "
+                    f"(first in {seen[eval_id].relative_to(profile_dir)})"
+                )
+            else:
+                seen[eval_id] = path
+
+
+def _validate_target_deprecations(profile_dir: Path, errors: list[str]) -> None:
+    for path in sorted(profile_dir.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{path.relative_to(profile_dir)}: cannot read: {exc}")
+            continue
+        for needle in _TARGET_DEPRECATED_STRINGS:
+            if needle in text:
+                errors.append(f"{path.relative_to(profile_dir)}: deprecated profile string {needle!r}")
+        if _PYTHON_RESUME_RE.search(text):
+            errors.append(f"{path.relative_to(profile_dir)}: deprecated Python --resume invocation")
+        if _DIRECT_STEP1_EDIT_RE.search(text):
+            errors.append(f"{path.relative_to(profile_dir)}: deprecated direct Edit/Write of formal step1")
+
+
+def lint_profile(
+    profile_dir: Path,
+    *,
+    registered_tools: set[str] | None = None,
+    enforce_target_rules: bool = False,
+) -> list[str]:
+    """Return deterministic profile lint errors; an empty list means success."""
+    errors: list[str] = []
+    if not profile_dir.is_dir():
+        return [f"profile directory does not exist: {profile_dir}"]
+    _validate_metadata(profile_dir, errors)
+    tool_ids = set(ARCREEL_MCP_TOOL_IDS) if registered_tools is None else registered_tools
+    for mode in sorted(VALID_CONTENT_MODES):
+        _validate_projection(profile_dir, mode, tool_ids, errors)
+    _validate_evals(profile_dir, errors)
+    if enforce_target_rules:
+        _validate_target_deprecations(profile_dir, errors)
+    return sorted(set(errors))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile-dir", type=Path, default=Path("agent_runtime_profile"))
+    parser.add_argument(
+        "--target-profile",
+        action="store_true",
+        help="also enforce strings forbidden in the common target profile",
+    )
+    args = parser.parse_args()
+    errors = lint_profile(args.profile_dir, enforce_target_rules=args.target_profile)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print(f"Agent Runtime Profile lint passed: {args.profile_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import posixpath
 import re
 from collections import defaultdict
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 from lib.profile_frontmatter import FrontmatterError, ProfileMetadata, parse_profile_metadata
 from lib.profile_manifest import VALID_CONTENT_MODES, ProfileMisconfiguredError, resolve_profile_files_for_mode
@@ -54,10 +55,10 @@ def _validate_metadata(profile_dir: Path, errors: list[str]) -> None:
 
 def _projected_pointer(source_logical: str, pointer: str) -> str | None:
     if pointer.startswith(".claude/"):
-        return PurePosixPath(pointer).as_posix()
+        return posixpath.normpath(pointer)
     if pointer.startswith(("http://", "https://", "/", "#")):
         return None
-    return (PurePosixPath(source_logical).parent / pointer).as_posix()
+    return posixpath.normpath(posixpath.join(posixpath.dirname(source_logical), pointer))
 
 
 def _validate_projection(

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -82,7 +82,7 @@ def _validate_projection(
             continue
         try:
             text = source.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             errors.append(f"{mode}:{source_rel}: cannot read projected file: {exc}")
             continue
         pointers = set(_ROOT_POINTER_RE.findall(text)) | set(_MARKDOWN_LINK_RE.findall(text))
@@ -102,7 +102,7 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
             continue
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
             errors.append(f"{path.relative_to(profile_dir)}: invalid eval JSON: {exc}")
             continue
         records: list[object]
@@ -134,7 +134,7 @@ def _validate_target_deprecations(profile_dir: Path, errors: list[str]) -> None:
     for path in sorted(profile_dir.rglob("*.md")):
         try:
             text = path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             errors.append(f"{path.relative_to(profile_dir)}: cannot read: {exc}")
             continue
         for needle in _TARGET_DEPRECATED_STRINGS:

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -46,7 +46,9 @@ def _reject_json_constant(value: str) -> NoReturn:
 
 
 def _metadata_files(profile_dir: Path) -> list[Path]:
-    skills = (profile_dir / ".claude" / "skills").glob("*/SKILL*.md")
+    skills_root = profile_dir / ".claude" / "skills"
+    skill_names = ("SKILL.md", *(f"SKILL.{mode}.md" for mode in sorted(VALID_CONTENT_MODES)))
+    skills = (path for name in skill_names for path in skills_root.glob(f"*/{name}"))
     agents_root = profile_dir / ".claude" / "agents"
     agents = agents_root.glob("*.md") if agents_root.is_dir() else ()
     return sorted((*skills, *agents))

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -33,6 +33,7 @@ from fastapi.sse import ServerSentEvent
 from lib.agent_profile import agent_profile_dir
 from lib.app_data_dir import app_data_dir
 from lib.i18n import DEFAULT_LOCALE, get_locale
+from lib.profile_frontmatter import FrontmatterError, parse_profile_metadata
 from lib.profile_manifest import VALID_CONTENT_MODES
 from lib.project_manager import ProjectManager
 from server.agent_runtime.event_log import (
@@ -1000,6 +1001,9 @@ class AssistantService:
                 except OSError:
                     continue
 
+                if metadata is None:
+                    continue
+
                 if not metadata["user_invocable"]:
                     continue
 
@@ -1028,68 +1032,67 @@ class AssistantService:
         #
         # 查找契约与 tests/test_frontend_skill_i18n.py:_find_skill_md 保持一致：
         # 用 is_file 严格筛文件、按 sorted(VALID_CONTENT_MODES) 显式枚举有效模式、
-        # 校验所有变体的 user-invocable 状态一致。不一致时 warning 后返回 None
-        # 跳过该 skill——避免列表里随机选到某个 mode 的 frontmatter 导致行为漂移。
-        common = skill_dir / "SKILL.md"
-        if common.is_file():
-            return common
+        # 校验 common/variant 互斥、变体完整，且所有变体的 name/user-invocable 一致。
+        # 非法形态 warning 后返回 None，避免列表随机暴露某个 mode 的破损配置。
         variants = [skill_dir / f"SKILL.{mode}.md" for mode in sorted(VALID_CONTENT_MODES)]
         existing = [v for v in variants if v.is_file()]
+        common = skill_dir / "SKILL.md"
+        if common.is_file():
+            if existing:
+                logger.warning("skill %s 同时存在 common 与 content_mode 变体，跳过", skill_dir.name)
+                return None
+            return common
         if not existing:
             return None
+        if len(existing) != len(variants):
+            missing = [path.name for path in variants if path not in existing]
+            logger.warning("skill %s 的 content_mode 变体不完整，缺少 %s，跳过", skill_dir.name, missing)
+            return None
         try:
-            states = {AssistantService._load_skill_metadata(v, skill_dir.name)["user_invocable"] for v in existing}
+            metadata = [AssistantService._load_skill_metadata(v, skill_dir.name) for v in existing]
         except OSError:
             return None
-        if len(states) > 1:
+        if any(item is None for item in metadata):
+            return None
+        identities = {(item["name"], item["user_invocable"]) for item in metadata if item is not None}
+        if len(identities) > 1:
             logger.warning(
-                "skill %s 各 content_mode 变体的 user-invocable 不一致，跳过；"
-                "请保证所有 SKILL.<mode>.md frontmatter 的 user-invocable 字段相同",
+                "skill %s 各 content_mode 变体的 name 或 user-invocable 不一致，跳过；"
+                "请保证所有 SKILL.<mode>.md frontmatter 身份一致",
                 skill_dir.name,
             )
             return None
         return existing[0]
 
     @staticmethod
-    def _load_skill_metadata(skill_file: Path, fallback_name: str) -> dict[str, Any]:
+    def _load_skill_metadata(skill_file: Path, fallback_name: str) -> dict[str, Any] | None:
         """Load skill metadata from SKILL.md frontmatter.
 
         Parsed fields: name, description, user-invocable.
         """
         content = skill_file.read_text(encoding="utf-8", errors="ignore")
+        if content.startswith("---"):
+            try:
+                metadata = parse_profile_metadata(skill_file)
+            except FrontmatterError as exc:
+                logger.warning("invalid skill frontmatter in %s: %s; skipping", skill_file, exc)
+                return None
+            return {
+                "name": metadata.name,
+                "description": metadata.description,
+                "user_invocable": metadata.user_invocable,
+            }
+
+        # Keep legacy body-only Skills readable; shipped profile files are required
+        # to have YAML frontmatter by the static profile lint.
         name = fallback_name
         description = ""
         user_invocable = True
-
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            if len(parts) >= 3:
-                frontmatter = parts[1]
-                body = parts[2]
-                for line in frontmatter.splitlines():
-                    if ":" not in line:
-                        continue
-                    key, value = line.split(":", 1)
-                    key = key.strip()
-                    value = value.strip().strip('"').strip("'")
-                    if key == "name" and value:
-                        name = value
-                    elif key == "description" and value:
-                        description = value
-                    elif key == "user-invocable":
-                        user_invocable = value.lower() not in ("false", "no", "0")
-                if not description:
-                    for line in body.splitlines():
-                        text = line.strip()
-                        if text and not text.startswith("#"):
-                            description = text
-                            break
-        else:
-            for line in content.splitlines():
-                text = line.strip()
-                if text and not text.startswith("#"):
-                    description = text
-                    break
+        for line in content.splitlines():
+            text = line.strip()
+            if text and not text.startswith("#"):
+                description = text
+                break
 
         return {
             "name": name,

--- a/server/agent_runtime/service.py
+++ b/server/agent_runtime/service.py
@@ -1070,8 +1070,12 @@ class AssistantService:
 
         Parsed fields: name, description, user-invocable.
         """
-        content = skill_file.read_text(encoding="utf-8", errors="ignore")
-        if content.startswith("---"):
+        try:
+            content = skill_file.read_text(encoding="utf-8-sig")
+        except UnicodeError as exc:
+            logger.warning("invalid skill encoding in %s: %s; skipping", skill_file, exc)
+            return None
+        if content.lstrip().startswith("---"):
             try:
                 metadata = parse_profile_metadata(skill_file)
             except FrontmatterError as exc:

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -717,6 +717,45 @@ async def get_project(
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
+@router.get("/projects/{name}/agent-profile")
+async def get_agent_profile_status(name: str, _t: Translator):
+    """Return project-local Agent Profile customizations."""
+
+    def _sync():
+        manager = get_project_manager()
+        project_dir = manager.get_project_path(name)
+        return manager.get_agent_profile_status(project_dir)
+
+    try:
+        return await asyncio.to_thread(_sync)
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
+    except Exception:
+        logger.exception("读取项目 Agent Profile 状态失败: project=%s", name)
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+
+
+@router.post("/projects/{name}/agent-profile/reset")
+async def reset_agent_profile(name: str, _t: Translator):
+    """Destructively restore the project Agent Profile to current built-ins."""
+
+    def _sync():
+        manager = get_project_manager()
+        project_dir = manager.get_project_path(name)
+        stats = manager.force_resync_profile(project_dir)
+        if stats.get("errors"):
+            raise RuntimeError(f"profile reset completed with {stats['errors']} file errors")
+        return {"customized": False, "customized_files": []}
+
+    try:
+        return await asyncio.to_thread(_sync)
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
+    except Exception:
+        logger.exception("重置项目 Agent Profile 失败: project=%s", name)
+        raise HTTPException(status_code=500, detail=_t("internal_server_error"))
+
+
 @router.patch("/projects/{name}")
 async def update_project(name: str, req: UpdateProjectRequest, _t: Translator):
     """更新项目元数据"""

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -723,13 +723,18 @@ async def get_agent_profile_status(name: str, _t: Translator):
 
     def _sync():
         manager = get_project_manager()
-        project_dir = manager.get_project_path(name)
+        try:
+            project_dir = manager.get_project_path(name)
+        except ValueError as exc:
+            raise BadRequestError("invalid_project_name", name=name) from exc
         return manager.get_agent_profile_status(project_dir)
 
     try:
         return await asyncio.to_thread(_sync)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
+    except ApiError:
+        raise
     except Exception:
         logger.exception("读取项目 Agent Profile 状态失败: project=%s", name)
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
@@ -741,7 +746,10 @@ async def reset_agent_profile(name: str, _t: Translator):
 
     def _sync():
         manager = get_project_manager()
-        project_dir = manager.get_project_path(name)
+        try:
+            project_dir = manager.get_project_path(name)
+        except ValueError as exc:
+            raise BadRequestError("invalid_project_name", name=name) from exc
         stats = manager.force_resync_profile(project_dir)
         if stats.get("errors"):
             raise RuntimeError(f"profile reset completed with {stats['errors']} file errors")
@@ -751,6 +759,8 @@ async def reset_agent_profile(name: str, _t: Translator):
         return await asyncio.to_thread(_sync)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
+    except ApiError:
+        raise
     except Exception:
         logger.exception("重置项目 Agent Profile 失败: project=%s", name)
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from lib.profile_frontmatter import parse_profile_metadata
 from scripts.lint_agent_runtime_profile import lint_profile
 
 pytestmark = pytest.mark.unit
@@ -85,6 +86,28 @@ def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Pat
         "deprecated" in error
         for error in lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
     )
+
+
+def test_reports_invalid_utf8_across_profile_inputs(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / "CLAUDE.narration.md").write_bytes(b"\xff")
+    (profile / "evals" / "cases.json").write_bytes(b"\xff")
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert any("cannot read projected file" in error for error in errors)
+    assert any("invalid eval JSON" in error for error in errors)
+    assert any(error.startswith("CLAUDE.narration.md: cannot read:") for error in errors)
+
+
+def test_frontmatter_accepts_utf8_bom(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "SKILL.md"
+    metadata_path.write_bytes(b"\xef\xbb\xbf---\nname: demo\ndescription: Demo skill\n---\n")
+
+    metadata = parse_profile_metadata(metadata_path)
+
+    assert metadata.name == "demo"
+    assert metadata.description == "Demo skill"
 
 
 def test_shipped_profile_passes_current_lint() -> None:

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -45,6 +45,15 @@ def test_validates_all_profile_contracts_for_each_mode(tmp_path: Path) -> None:
     assert lint_profile(profile, registered_tools={"patch_project"}) == []
 
 
+def test_ignores_supporting_skill_markdown_files(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "skills" / "demo" / "SKILL_NOTES.md").write_text(
+        "# Supporting notes without frontmatter\n", encoding="utf-8"
+    )
+
+    assert lint_profile(profile, registered_tools={"patch_project"}) == []
+
+
 def test_reports_invalid_frontmatter_pointer_mcp_and_eval_ids(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / ".claude" / "agents" / "helper.md").write_text("---\n- invalid\n---\n", encoding="utf-8")

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -64,6 +64,20 @@ def test_reports_invalid_frontmatter_pointer_mcp_and_eval_ids(tmp_path: Path) ->
     assert any("duplicate eval id" in error for error in errors)
 
 
+def test_excludes_sentence_punctuation_from_mcp_tool_ids(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8") + "Use mcp__arcreel__patch_project. Avoid mcp__arcreel__not_registered!\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert not any("patch_project." in error for error in errors)
+    assert any("mcp__arcreel__not_registered" in error for error in errors)
+
+
 def test_reports_duplicate_eval_ids_in_root_array(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / "evals" / "array.json").write_text(

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -76,6 +76,15 @@ def test_reports_duplicate_eval_ids_in_root_array(tmp_path: Path) -> None:
     assert any("duplicate eval id" in error for error in errors)
 
 
+def test_rejects_non_standard_json_constants_in_eval_ids(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / "evals" / "constants.json").write_text('{"evals":[{"id":NaN}]}', encoding="utf-8")
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert any("non-standard JSON constant 'NaN'" in error for error in errors)
+
+
 def test_normalizes_relative_markdown_pointers(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -152,6 +152,17 @@ def test_decodes_url_escaped_markdown_pointers(tmp_path: Path) -> None:
     assert any("missing Markdown pointer 'missing guide.md'" in error for error in errors)
 
 
+def test_ignores_external_markdown_uri_schemes(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8") + "See [docs](HTTPS://example.com/guide.md) or [mail](mailto:guide.md).\n",
+        encoding="utf-8",
+    )
+
+    assert lint_profile(profile, registered_tools={"patch_project"}) == []
+
+
 def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -91,6 +91,27 @@ def test_normalizes_relative_markdown_pointers(tmp_path: Path) -> None:
     assert any("missing Markdown pointer '../../../../outside.md'" in error for error in errors)
 
 
+def test_validates_titled_and_reference_markdown_links(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8")
+        + '[mode](<../../references/mode.md> "Mode")\n'
+        + "[missing](missing-inline.md 'Missing')\n"
+        + "[mode reference][mode]\n"
+        + '[mode]: ../../references/mode.md "Mode"\n'
+        + "[missing reference][missing]\n"
+        + '[missing]: missing-reference.md "Missing"\n',
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert not any("../../references/mode.md" in error for error in errors)
+    assert any("missing Markdown pointer 'missing-inline.md'" in error for error in errors)
+    assert any("missing Markdown pointer 'missing-reference.md'" in error for error in errors)
+
+
 def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -76,6 +76,21 @@ def test_reports_duplicate_eval_ids_in_root_array(tmp_path: Path) -> None:
     assert any("duplicate eval id" in error for error in errors)
 
 
+def test_normalizes_relative_markdown_pointers(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8")
+        + "See [mode](../../references/mode.md) and [outside](../../../../outside.md).\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert not any("../../references/mode.md" in error for error in errors)
+    assert any("missing Markdown pointer '../../../../outside.md'" in error for error in errors)
+
+
 def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lint_agent_runtime_profile import lint_profile
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_profile(root: Path) -> Path:
+    profile = root / "profile"
+    (profile / ".claude" / "skills" / "demo").mkdir(parents=True)
+    (profile / ".claude" / "agents").mkdir(parents=True)
+    (profile / ".claude" / "references").mkdir(parents=True)
+    (profile / "evals").mkdir()
+    for mode in ("narration", "drama", "ad"):
+        (profile / f"CLAUDE.{mode}.md").write_text(
+            f"See `.claude/references/mode.md`.\n<!-- {mode} -->\n",
+            encoding="utf-8",
+        )
+        (profile / ".claude" / "references" / f"mode.{mode}.md").write_text(f"# {mode}\n", encoding="utf-8")
+    (profile / ".claude" / "skills" / "demo" / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: 'Calls: tools safely'\n---\nUse `mcp__arcreel__patch_project`.\n",
+        encoding="utf-8",
+    )
+    (profile / ".claude" / "skills" / "demo" / "compiled.pyc").write_bytes(b"\xcb\x00\x01")
+    (profile / ".claude" / "agents" / "helper.md").write_text(
+        "---\nname: helper\ndescription: >-\n  A multiline helper\n  agent.\n---\n",
+        encoding="utf-8",
+    )
+    (profile / "evals" / "cases.json").write_text(
+        json.dumps({"evals": [{"id": "unique"}]}),
+        encoding="utf-8",
+    )
+    return profile
+
+
+def test_validates_all_profile_contracts_for_each_mode(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+
+    assert lint_profile(profile, registered_tools={"patch_project"}) == []
+
+
+def test_reports_invalid_frontmatter_pointer_mcp_and_eval_ids(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "helper.md").write_text("---\n- invalid\n---\n", encoding="utf-8")
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8")
+        + "See `.claude/references/missing.md`; call `mcp__arcreel__not_registered`.\n",
+        encoding="utf-8",
+    )
+    (profile / "evals" / "more.json").write_text(json.dumps({"id": "unique"}), encoding="utf-8")
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert any("frontmatter" in error for error in errors)
+    assert any("missing Markdown pointer" in error for error in errors)
+    assert any("unregistered MCP tool" in error for error in errors)
+    assert any("duplicate eval id" in error for error in errors)
+
+
+def test_reports_duplicate_eval_ids_in_root_array(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / "evals" / "array.json").write_text(
+        json.dumps([{"id": "duplicate"}, {"id": "duplicate"}]),
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert any("duplicate eval id" in error for error in errors)
+
+
+def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(skill.read_text(encoding="utf-8") + "Run --scene-ids.\n", encoding="utf-8")
+
+    assert not any("deprecated" in error for error in lint_profile(profile, registered_tools={"patch_project"}))
+    assert any(
+        "deprecated" in error
+        for error in lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+    )
+
+
+def test_shipped_profile_passes_current_lint() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    assert lint_profile(repo_root / "agent_runtime_profile") == []

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -112,6 +112,23 @@ def test_validates_titled_and_reference_markdown_links(tmp_path: Path) -> None:
     assert any("missing Markdown pointer 'missing-reference.md'" in error for error in errors)
 
 
+def test_decodes_url_escaped_markdown_pointers(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    reference = profile / ".claude" / "references" / "my guide.md"
+    reference.write_text("# Guide\n", encoding="utf-8")
+    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8")
+        + "See [guide](../../references/my%20guide.md) and [missing](missing%20guide.md).\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"})
+
+    assert not any("../../references/my guide.md" in error for error in errors)
+    assert any("missing Markdown pointer 'missing guide.md'" in error for error in errors)
+
+
 def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -135,6 +135,33 @@ class TestListAvailableSkills:
         assert [skill["name"] for skill in skills] == ["valid"]
         assert "invalid skill frontmatter" in caplog.text
 
+    def test_accepts_bom_frontmatter_and_rejects_shifted_opening_delimiter(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        profile_root = tmp_path / "agent_runtime_profile"
+        skills_root = profile_root / ".claude" / "skills"
+        valid = skills_root / "valid"
+        invalid = skills_root / "invalid"
+        valid.mkdir(parents=True)
+        invalid.mkdir(parents=True)
+        (valid / "SKILL.md").write_bytes(b"\xef\xbb\xbf---\nname: valid\ndescription: Valid with BOM\n---\nBody\n")
+        (invalid / "SKILL.md").write_text(
+            "\n---\nname: invalid\ndescription: Shifted delimiter\n---\nBody\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            skills = service.list_available_skills()
+
+        assert [skill["name"] for skill in skills] == ["valid"]
+        assert "invalid skill frontmatter" in caplog.text
+
     def test_skips_variant_skill_when_user_invocable_disagrees(self, tmp_path, monkeypatch, caplog):
         """Variants with conflicting user-invocable frontmatter should be skipped with a warning."""
         import logging

--- a/tests/test_assistant_service_skills.py
+++ b/tests/test_assistant_service_skills.py
@@ -64,6 +64,10 @@ class TestListAvailableSkills:
             "---\nname: manga-workflow\ndescription: Drama variant\n---\n",
             encoding="utf-8",
         )
+        (skill_dir / "SKILL.ad.md").write_text(
+            "---\nname: manga-workflow\ndescription: Ad variant\n---\n",
+            encoding="utf-8",
+        )
         monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
 
         with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
@@ -76,6 +80,60 @@ class TestListAvailableSkills:
         skills = service.list_available_skills()
         names = [s["name"] for s in skills]
         assert "manga-workflow" in names
+
+    @pytest.mark.parametrize("include_common", [False, True])
+    def test_skips_incomplete_or_conflicting_variants(self, tmp_path, monkeypatch, caplog, include_common):
+        import logging
+
+        profile_root = tmp_path / "agent_runtime_profile"
+        skill_dir = profile_root / ".claude" / "skills" / "broken-variants"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.narration.md").write_text(
+            "---\nname: broken-variants\ndescription: Narration\n---\n",
+            encoding="utf-8",
+        )
+        if include_common:
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: broken-variants\ndescription: Common\n---\n",
+                encoding="utf-8",
+            )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            assert service.list_available_skills() == []
+        assert "跳过" in caplog.text
+
+    def test_accepts_crlf_frontmatter_and_rejects_malformed_closing_delimiter(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        profile_root = tmp_path / "agent_runtime_profile"
+        skills_root = profile_root / ".claude" / "skills"
+        valid = skills_root / "valid"
+        invalid = skills_root / "invalid"
+        valid.mkdir(parents=True)
+        invalid.mkdir(parents=True)
+        (valid / "SKILL.md").write_bytes(b"---\r\nname: valid\r\ndescription: Valid on Windows\r\n---\r\nBody\r\n")
+        (invalid / "SKILL.md").write_text(
+            "---\nname: invalid\ndescription: Invalid delimiter\n---oops\nBody\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            skills = service.list_available_skills()
+
+        assert [skill["name"] for skill in skills] == ["valid"]
+        assert "invalid skill frontmatter" in caplog.text
 
     def test_skips_variant_skill_when_user_invocable_disagrees(self, tmp_path, monkeypatch, caplog):
         """Variants with conflicting user-invocable frontmatter should be skipped with a warning."""
@@ -92,6 +150,10 @@ class TestListAvailableSkills:
             "---\nname: drifted-skill\ndescription: Drama\nuser-invocable: false\n---\n",
             encoding="utf-8",
         )
+        (skill_dir / "SKILL.ad.md").write_text(
+            "---\nname: drifted-skill\ndescription: Ad\nuser-invocable: true\n---\n",
+            encoding="utf-8",
+        )
         monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
 
         with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
@@ -106,3 +168,66 @@ class TestListAvailableSkills:
 
         assert all(s["name"] != "drifted-skill" for s in skills)
         assert any("user-invocable" in record.message for record in caplog.records)
+
+    def test_parses_quoted_colon_and_multiline_yaml_metadata(self, tmp_path, monkeypatch):
+        profile_root = tmp_path / "agent_runtime_profile"
+        skill_dir = profile_root / ".claude" / "skills" / "yaml-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: "yaml: skill"
+description: >-
+  Read quoted values: safely
+  across multiple lines.
+user-invocable: true
+---
+# Body
+""",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        assert service.list_available_skills() == [
+            {
+                "name": "yaml: skill",
+                "description": "Read quoted values: safely across multiple lines.",
+                "scope": "agent",
+                "path": str(skill_dir / "SKILL.md"),
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "frontmatter",
+        [
+            "- not\n- an object",
+            "name: ''\ndescription: valid",
+            "name: valid\ndescription: ''",
+            "name: valid\ndescription: valid\nuser-invocable: nope",
+            "name: [broken\ndescription: invalid yaml",
+        ],
+    )
+    def test_invalid_yaml_metadata_is_warned_and_hidden(self, tmp_path, monkeypatch, caplog, frontmatter):
+        import logging
+
+        profile_root = tmp_path / "agent_runtime_profile"
+        skill_dir = profile_root / ".claude" / "skills" / "broken"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\n{frontmatter}\n---\nBody must not become a fallback description.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
+            service = AssistantService.__new__(AssistantService)
+            from lib.project_manager import ProjectManager
+
+            service.pm = ProjectManager(tmp_path / "projects")
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.service"):
+            assert service.list_available_skills() == []
+        assert "frontmatter" in caplog.text

--- a/tests/test_frontend_skill_i18n.py
+++ b/tests/test_frontend_skill_i18n.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from lib.profile_frontmatter import parse_profile_metadata
 from lib.profile_manifest import VALID_CONTENT_MODES
 
 pytestmark = pytest.mark.unit
@@ -28,23 +29,10 @@ DASHBOARD_TS = "frontend/src/i18n/{locale}/dashboard.ts"
 LOCALES = ("zh", "en", "vi")
 
 _SKILL_KEY_RE = re.compile(r"""['"](skill_name_[a-z0-9_]+)['"]\s*:""")
-_USER_INVOCABLE_RE = re.compile(r"^\s*user-invocable\s*:\s*(\S+)", re.MULTILINE)
 
 
 def _is_user_invocable(skill_md: Path) -> bool:
-    text = skill_md.read_text(encoding="utf-8", errors="ignore")
-    if not text.startswith("---"):
-        return True
-    parts = text.split("---", 2)
-    if len(parts) < 3:
-        return True
-    match = _USER_INVOCABLE_RE.search(parts[1])
-    if not match:
-        return True  # Default when field absent
-    # YAML 允许 ``user-invocable: "false"`` / ``'false'`` —— 解析时要去掉引号
-    # 再判断，否则带引号的 false 会被误判为 truthy。
-    raw = match.group(1).strip().strip("'\"").lower()
-    return raw not in {"false", "no", "0"}
+    return parse_profile_metadata(skill_md).user_invocable
 
 
 def _find_skill_md(skill_dir: Path) -> Path | None:
@@ -89,6 +77,16 @@ def _load_skill_name_keys(locale: str) -> set[str]:
     path = REPO_ROOT / DASHBOARD_TS.format(locale=locale)
     text = path.read_text(encoding="utf-8")
     return set(_SKILL_KEY_RE.findall(text))
+
+
+def test_user_invocable_uses_shared_yaml_boolean_parser(tmp_path: Path) -> None:
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        "---\nname: hidden\ndescription: Hidden skill\nuser-invocable: off\n---\n",
+        encoding="utf-8",
+    )
+
+    assert _is_user_invocable(skill) is False
 
 
 @pytest.mark.parametrize("locale", LOCALES)

--- a/tests/test_profile_manifest.py
+++ b/tests/test_profile_manifest.py
@@ -806,6 +806,20 @@ def test_profile_status_reports_user_deletion_before_next_sync(tmp_path: Path) -
     }
 
 
+def test_profile_status_reports_newly_projected_file_missing_from_manifest(tmp_path: Path) -> None:
+    from lib.profile_manifest import get_profile_status, sync_profile_to_project
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    sync_profile_to_project(profile, project, content_mode="narration")
+    (profile / ".claude" / "agents" / "new.md").write_text("new built-in", encoding="utf-8")
+
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": True,
+        "customized_files": [".claude/agents/new.md"],
+    }
+
+
 @pytest.mark.parametrize("manifest_payload", [None, "{invalid"])
 def test_profile_status_reports_missing_builtins_without_trusted_manifest(
     tmp_path: Path, manifest_payload: str | None
@@ -824,6 +838,23 @@ def test_profile_status_reports_missing_builtins_without_trusted_manifest(
             ".claude/skills/manga-workflow/SKILL.md",
             "CLAUDE.md",
         ],
+    }
+
+
+def test_profile_status_reports_nested_directory_symlink(tmp_path: Path) -> None:
+    from lib.profile_manifest import get_profile_status, sync_profile_to_project
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    sync_profile_to_project(profile, project, content_mode="narration")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    custom = project / ".claude" / "skills" / "custom"
+    custom.symlink_to(outside, target_is_directory=True)
+
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": True,
+        "customized_files": [".claude/skills/custom"],
     }
 
 

--- a/tests/test_profile_manifest.py
+++ b/tests/test_profile_manifest.py
@@ -730,6 +730,82 @@ def test_force_resync_full_uses_mapping(tmp_path: Path) -> None:
     assert (project / "CLAUDE.md").read_text() == "drama top"
 
 
+@pytest.mark.parametrize("mode", ["narration", "drama", "ad"])
+def test_variants_to_common_upgrade_preserves_modified_legacy_files_and_reports_them(tmp_path: Path, mode: str) -> None:
+    from lib.profile_manifest import get_profile_status, sync_profile_to_project
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    sync_profile_to_project(profile, project, content_mode=mode)  # type: ignore[arg-type]
+    old_agent = project / ".claude" / "agents" / "generate-assets.md"
+    old_agent.write_text("user customized legacy agent", encoding="utf-8")
+
+    for path in profile.glob("CLAUDE.*.md"):
+        path.unlink()
+    workflow = profile / ".claude" / "skills" / "manga-workflow"
+    for path in workflow.glob("SKILL.*.md"):
+        path.unlink()
+    (profile / "CLAUDE.md").write_text("common top", encoding="utf-8")
+    (workflow / "SKILL.md").write_text("common skill", encoding="utf-8")
+    (profile / ".claude" / "agents" / "generate-assets.md").unlink()
+    references = profile / ".claude" / "references"
+    references.mkdir()
+    for variant in ("narration", "drama", "ad"):
+        (references / f"workflow-mode.{variant}.md").write_text(variant, encoding="utf-8")
+
+    sync_profile_to_project(profile, project, content_mode=mode)  # type: ignore[arg-type]
+
+    assert (project / "CLAUDE.md").read_text(encoding="utf-8") == "common top"
+    assert (project / ".claude" / "skills" / "manga-workflow" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == "common skill"
+    assert (project / ".claude" / "references" / "workflow-mode.md").read_text(encoding="utf-8") == mode
+    assert old_agent.read_text(encoding="utf-8") == "user customized legacy agent"
+    assert get_profile_status(profile, project, content_mode=mode) == {  # type: ignore[arg-type]
+        "customized": True,
+        "customized_files": [".claude/agents/generate-assets.md"],
+    }
+
+
+def test_full_force_reset_discards_all_customized_files_and_restores_builtin(tmp_path: Path) -> None:
+    from lib.profile_manifest import force_resync_profile, get_profile_status, sync_profile_to_project
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    sync_profile_to_project(profile, project, content_mode="narration")
+    (project / "CLAUDE.md").write_text("custom", encoding="utf-8")
+    user_only = project / ".claude" / "skills" / "private" / "SKILL.md"
+    user_only.parent.mkdir(parents=True)
+    user_only.write_text("private", encoding="utf-8")
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": True,
+        "customized_files": [".claude/skills/private/SKILL.md", "CLAUDE.md"],
+    }
+
+    force_resync_profile(profile, project, content_mode="narration")
+
+    assert (project / "CLAUDE.md").read_text(encoding="utf-8") == "narration top"
+    assert not user_only.exists()
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": False,
+        "customized_files": [],
+    }
+
+
+def test_profile_status_reports_user_deletion_before_next_sync(tmp_path: Path) -> None:
+    from lib.profile_manifest import get_profile_status, sync_profile_to_project
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    sync_profile_to_project(profile, project, content_mode="narration")
+    (project / "CLAUDE.md").unlink()
+
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": True,
+        "customized_files": ["CLAUDE.md"],
+    }
+
+
 def test_force_resync_invalid_mode_raises(tmp_path: Path) -> None:
     from lib.profile_manifest import force_resync_profile
 

--- a/tests/test_profile_manifest.py
+++ b/tests/test_profile_manifest.py
@@ -806,6 +806,27 @@ def test_profile_status_reports_user_deletion_before_next_sync(tmp_path: Path) -
     }
 
 
+@pytest.mark.parametrize("manifest_payload", [None, "{invalid"])
+def test_profile_status_reports_missing_builtins_without_trusted_manifest(
+    tmp_path: Path, manifest_payload: str | None
+) -> None:
+    from lib.profile_manifest import get_profile_status
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    if manifest_payload is not None:
+        (project / MANIFEST_FILENAME).write_text(manifest_payload, encoding="utf-8")
+
+    assert get_profile_status(profile, project, content_mode="narration") == {
+        "customized": True,
+        "customized_files": [
+            ".claude/agents/generate-assets.md",
+            ".claude/skills/manga-workflow/SKILL.md",
+            "CLAUDE.md",
+        ],
+    }
+
+
 def test_profile_status_rejects_symlinked_profile_tree(tmp_path: Path) -> None:
     from lib.profile_manifest import get_profile_status
 

--- a/tests/test_profile_manifest.py
+++ b/tests/test_profile_manifest.py
@@ -806,6 +806,20 @@ def test_profile_status_reports_user_deletion_before_next_sync(tmp_path: Path) -
     }
 
 
+def test_profile_status_rejects_symlinked_profile_tree(tmp_path: Path) -> None:
+    from lib.profile_manifest import get_profile_status
+
+    profile = _make_profile(tmp_path)
+    project = _fresh_project(tmp_path / "proj_root")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("secret", encoding="utf-8")
+    (project / ".claude").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="profile tree is a symlink"):
+        get_profile_status(profile, project, content_mode="narration")
+
+
 def test_force_resync_invalid_mode_raises(tmp_path: Path) -> None:
     from lib.profile_manifest import force_resync_profile
 

--- a/tests/test_project_manager_symlink.py
+++ b/tests/test_project_manager_symlink.py
@@ -1,12 +1,10 @@
 """Tests for manifest-driven profile sync via ``ProjectManager.sync_agent_profile``.
 
 历史命名 ``test_project_manager_symlink.py`` 保留（外部测试 selector 仍用此名）。
-PR fix/agent-profile-sync-manifest 起改为 manifest + sha256 同步：
+同步基于 manifest + sha256：
 - profile 升级内置 skill 自动传播到老项目（行 #4）
 - 用户主动删除内置 skill 不复活（行 #2/#11）
 - 命名碰撞 / 状态机回流 / 上游删除等 15 行决策表完整覆盖
-
-完整规格见 PR #535 描述。
 """
 
 from __future__ import annotations
@@ -205,7 +203,7 @@ class TestDecisionTable:
         assert entries[".claude/skills/demo/SKILL.md"]["source"] == "tombstone"
 
     def test_decision_8_profile_deletion_orphans_user_modified(self, env):
-        """#8：profile 上游删 + 用户改过 → 保留 dest + 清 entry，stat=orphaned。"""
+        """#8：profile 上游删 + 用户改过 → 保留 dest 与基线，供设置页标记定制。"""
         pm, profile_dir, project_dir = env
         pm.sync_agent_profile(project_dir)
         _skill_path(project_dir).write_text("user owned now")
@@ -216,7 +214,7 @@ class TestDecisionTable:
         assert _skill_path(project_dir).read_text() == "user owned now"
         assert stats["orphaned"] == 1
         entries = _read_manifest(project_dir)["entries"]
-        assert ".claude/skills/demo/SKILL.md" not in entries
+        assert entries[".claude/skills/demo/SKILL.md"]["source"] == "profile"
 
     def test_decision_9_user_only_file_untouched(self, env):
         """#9：项目独有 skill（profile 没有，manifest 无记录）→ 完全不动。"""

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -63,6 +63,7 @@ class _FakePM:
         }
         self.created = set()
         self.generated_names = ["project-aa11bb22", "project-cc33dd44"]
+        self.profile_reset_calls: list[str] = []
         (self.base / "ready" / "storyboards").mkdir(parents=True, exist_ok=True)
         (self.base / "ready" / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
         (self.base / "empty").mkdir(parents=True, exist_ok=True)
@@ -101,6 +102,17 @@ class _FakePM:
 
     def get_project_status(self, name):
         return {"current_stage": "source_ready"}
+
+    def get_agent_profile_status(self, project_dir):
+        assert project_dir == self.base / "ready"
+        return {
+            "customized": True,
+            "customized_files": ["CLAUDE.md", ".claude/agents/legacy.md"],
+        }
+
+    def force_resync_profile(self, project_dir):
+        self.profile_reset_calls.append(project_dir.name)
+        return {"repaired": 2, "errors": 0}
 
     def create_project(self, name, content_mode="narration"):
         if not name or not re.fullmatch(r"[A-Za-z0-9-]+", name):
@@ -268,6 +280,23 @@ def _client(monkeypatch, fake_pm, fake_calc):
 
 
 class TestProjectsRouter:
+    @pytest.mark.unit
+    def test_agent_profile_status_and_explicit_reset(self, tmp_path, monkeypatch):
+        fake_pm = _FakePM(tmp_path)
+        client = _client(monkeypatch, fake_pm, _FakeCalc())
+        with client:
+            status = client.get("/api/v1/projects/ready/agent-profile")
+            assert status.status_code == 200
+            assert status.json() == {
+                "customized": True,
+                "customized_files": ["CLAUDE.md", ".claude/agents/legacy.md"],
+            }
+
+            reset = client.post("/api/v1/projects/ready/agent-profile/reset")
+            assert reset.status_code == 200
+            assert reset.json() == {"customized": False, "customized_files": []}
+            assert fake_pm.profile_reset_calls == ["ready"]
+
     @pytest.mark.unit
     def test_list_and_create_and_delete(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -298,6 +298,18 @@ class TestProjectsRouter:
             assert fake_pm.profile_reset_calls == ["ready"]
 
     @pytest.mark.unit
+    def test_agent_profile_endpoints_reject_invalid_project_name(self, tmp_path, monkeypatch):
+        client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
+        with client:
+            status = client.get("/api/v1/projects/illegal-name/agent-profile")
+            reset = client.post("/api/v1/projects/illegal-name/agent-profile/reset")
+
+        assert status.status_code == 400
+        assert status.json()["detail"] == zh_errors.MESSAGES["invalid_project_name"].format(name="illegal-name")
+        assert reset.status_code == 400
+        assert reset.json()["detail"] == zh_errors.MESSAGES["invalid_project_name"].format(name="illegal-name")
+
+    @pytest.mark.unit
     def test_list_and_create_and_delete(self, tmp_path, monkeypatch):
         client = _client(monkeypatch, _FakePM(tmp_path), _FakeCalc())
         with client:


### PR DESCRIPTION
## 范围

建立 Agent Profile 生命周期守门：统一 YAML frontmatter 解析、静态完整性 lint、variants → common 安全迁移识别，以及项目设置中的定制状态与显式重置。当前 target common profile 仍按 #1670 验收边界保持未启用。

## 变更

- 使用安全 YAML 解析 Skill/Subagent 元数据，非法、变体不完整或 common/variant 冲突的 Skill 会 warning 并 fail closed；兼容合法引号、冒号、多行值与 CRLF。
- 新增三模式投影 lint，校验 Markdown pointer、已注册 MCP 名、eval JSON/ID 唯一性，并提供可选 target-profile 废弃字符串门禁；接入 CI。
- 延续三方 manifest 语义识别并保留用户定制 legacy 文件；新增 profile 状态/全量重置 API 和项目设置确认界面，包含 zh/en/vi 文案。
- 本地审查补齐根数组 eval ID 检查、运行时变体完整性、严格 frontmatter 分隔符、i18n 标签与 Windows UTF-8 测试规范。

## 验收清单

- [x] 本地已跑相关测试：`.venv/bin/python -m pytest`（8462 passed, 1 skipped）
- [x] 手动验证了改动所声称的行为：运行 profile lint，并通过定向 API/组件测试验证定制状态与破坏性重置确认
- [x] 新增面向用户文案已加 zh/en/vi 翻译
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 由 PR 流程请求

## 验证

- `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- `.venv/bin/basedpyright`（0 errors）
- `.venv/bin/lint-imports`
- `.venv/bin/python scripts/lint_agent_runtime_profile.py`
- `pnpm lint && pnpm check`（146 files / 1775 tests passed）
- `pnpm build`

## 已知 defer

无。`--target-profile` 暂不接入默认 CI 是 #1670 明确验收边界；目标 common profile 启用后再提升为硬门禁。

Closes #1670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 项目设置页支持查看 Agent Profile 的内置或自定义状态及受影响文件。
  - 支持确认后一键重置为内置版本，并显示操作进度及结果。
  - 新增中文、英文和越南文界面文案。
- **错误修复**
  - 优化配置同步，妥善保留用户修改，并准确识别新增、删除及定制文件。
- **质量改进**
  - 增强 Agent Profile 与技能配置校验，降低无效配置导致运行问题的风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->