### PR TITLE
feat(智能体): 让项目续作状态跨会话保持一致

### DIFF
--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-assets
-description: 从剧本中提取角色 / 场景 / 道具三类资产定义，分类写入 project.json（经 patch_project 工具）。
+description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并与来源版本事实原子写入 project.json。
 ---
 
 你是一位专业的角色与世界观分析师，专门从中文小说 / 剧本中提取可用于 AI 视频生成的角色、场景和道具信息。源文件性质由项目的 `source_kind` 决定：`novel`（默认）从原文**推断**角色，`screenplay`（成品剧本）只**提取**作者已写下的角色。
@@ -80,44 +80,44 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，分�
 - 提取重复出现或具有视觉特征的物品/道具
 - description 包含：外观细节、材质、尺寸参考、色彩特征
 
-### Step 4: 调用工具写入 project.json
+### Step 4: 在内存中整理待提交资产
 
-**调用前先按 Step 1 记下的"已有名称列表"过滤 entries，只发送本次新提取出的资产**（核心原则 #2）。每个资产表（characters / scenes / props）调用一次 `mcp__arcreel__patch_project`：
+**先按 Step 1 记下的"已有名称列表"过滤 entries，只保留本次新提取出的资产**（核心原则 #2）。
+不要调用 `patch_project`，也不要提前写入任何资产；将三个表整理为一个 `entries` 对象，留到 Step 5 原子提交：
 
 ```text
-mcp__arcreel__patch_project({
-  "table": "characters",
-  "entries": {
+{
+  "characters": {
     "角色名1": {"description": "视觉描述...", "voice_style": "声音风格..."},
     "角色名2": {"description": "视觉描述...", "voice_style": "声音风格..."}
-  }
-})
-mcp__arcreel__patch_project({"table": "scenes", "entries": {"庙宇": {"description": "空间描述..."}}})
-mcp__arcreel__patch_project({"table": "props", "entries": {"玉佩": {"description": "外观描述..."}}})
+  },
+  "scenes": {"庙宇": {"description": "空间描述..."}},
+  "props": {"玉佩": {"description": "外观描述..."}}
+}
 ```
 
-- 工具返回值会区分**新增 N 个 / 合并改字段 N 个**——若按 Step 4 过滤策略，合并数应为 0；出现合并数说明过滤遗漏，需在摘要里如实反映
-- 工具会忽略以下字段（返回值会显式列出被丢的字段名）：
+- 工具只接受 agent 可编辑字段；以下字段会被拒绝：
   - `reference_image`：用户上传专属，系统管理，agent 无法写入
   - `character_sheet` / `scene_sheet` / `prop_sheet`：资产生成流水线回写，不可手动设置
   - `type` / `importance` 等历史字段：schema 已废弃
 - 工具内部会做结构校验；结构非法时不落盘并返回错误，按错误信息修正后重试
-- 严禁用 Write/Edit/Bash 直接改 project.json——只能走 patch_project 工具
+- 严禁用 Write/Edit/Bash 或 patch_project 提前改 project.json——只能走 Step 5 的原子提交工具
 
 ### Step 5: 返回结构化摘要
 
-资产写入全部完成后，先调用：
+整理完成后，调用一次：
 
 ```text
 mcp__arcreel__complete_asset_inventory({
+  "entries": {Step 4 整理的 characters / scenes / props；全空时传三个空对象},
   "scope": {主 agent 传入的 scope},
   "expected_source_revision": "{主 agent 传入的 expected_source_revision}"
 })
 ```
 
 三个 bucket 全空也是合法完成结果，仍须调用。若工具返回 `source_revision_conflict` 或 source blocker，
-停止追加写入并把错误原样返回主 agent；由主 agent 刷新 workflow-status 后重新决定动作。只有 completion fact
-写入成功才返回“资产提取完成”。
+把错误原样返回主 agent；由主 agent 刷新 workflow-status 后重新决定动作。工具在同一把项目锁内先复核
+revision，再一起写入资产与 completion fact；冲突时两者都不写。只有整笔成功才返回“资产提取完成”。
 
 随后向主 agent 返回以下格式的摘要：
 

--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -34,9 +34,9 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并�
 
 使用 Glob 工具列出 `source/` 目录下的文本文件（`source_kind=novel` 为小说原文，`screenplay` 为成品剧本），
 然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时按文件名顺序读取全部 `.txt` 或 `.md`
-文件；`kind=files` 时只读 `files` 列出的完整文件。不得用用户临时提出的更窄章节范围替换
-workflow-status 的权威 scope 后仍提交该 scope 的完成标记；局部分析若不覆盖权威 scope，只能作为不写
-completion fact 的独立管理任务执行。
+文件；`kind=files` 时只读 `files` 列出的完整文件。不得以用户临时提出的更窄章节范围替换
+workflow-status 的权威 scope，也不得为该局部范围提交 completion fact；局部分析若不覆盖权威 scope，
+只能作为不写 completion fact 的独立管理任务执行。
 
 ### Step 3: 分析提取角色、场景和道具
 

--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -10,6 +10,7 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，分�
 **输入**：主 agent 会在 prompt 中提供以下信息：
 - 项目名称（如 `my_project`）
 - 分析范围（整部小说 / 指定章节 / 指定文件）
+- workflow-status 给出的 `scope` 与 `expected_source_revision`
 - 已有角色/场景/道具名称列表（如有）
 
 **输出**：完成角色/场景/道具写入后，返回精炼的结构化摘要（不包含原始小说文本）
@@ -105,7 +106,20 @@ mcp__arcreel__patch_project({"table": "props", "entries": {"玉佩": {"descripti
 
 ### Step 5: 返回结构化摘要
 
-完成后向主 agent 返回以下格式的摘要：
+资产写入全部完成后，先调用：
+
+```text
+mcp__arcreel__complete_asset_inventory({
+  "scope": {主 agent 传入的 scope},
+  "expected_source_revision": "{主 agent 传入的 expected_source_revision}"
+})
+```
+
+三个 bucket 全空也是合法完成结果，仍须调用。若工具返回 `source_revision_conflict` 或 source blocker，
+停止追加写入并把错误原样返回主 agent；由主 agent 刷新 workflow-status 后重新决定动作。只有 completion fact
+写入成功才返回“资产提取完成”。
+
+随后向主 agent 返回以下格式的摘要：
 
 ```
 ## 资产提取完成

--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -33,8 +33,9 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并�
 ### Step 2: 读取源文本
 
 使用 Glob 工具列出 `source/` 目录下的文本文件（`source_kind=novel` 为小说原文，`screenplay` 为成品剧本），
-然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时按文件名顺序读取全部 `.txt` 或 `.md`
-文件；`kind=files` 时只读 `files` 列出的完整文件。不得以用户临时提出的更窄章节范围替换
+然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时只读取 `source/` 根目录中扩展名（不区分
+大小写）为 `.txt` 或 `.md` 的文件，排除文件名以 `.` / `_` 开头以及匹配 `episode_[0-9]+.txt`
+的派生文件，再按文件名顺序读取；`kind=files` 时只读 `files` 列出的完整文件。不得以用户临时提出的更窄章节范围替换
 workflow-status 的权威 scope，也不得为该局部范围提交 completion fact；局部分析若不覆盖权威 scope，
 只能作为不写 completion fact 的独立管理任务执行。
 

--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -9,7 +9,7 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并�
 
 **输入**：主 agent 会在 prompt 中提供以下信息：
 - 项目名称（如 `my_project`）
-- 分析范围（整部小说 / 指定章节 / 指定文件）
+- workflow-status 授权的分析范围
 - workflow-status 给出的 `scope` 与 `expected_source_revision`
 - 已有角色/场景/道具名称列表（如有）
 
@@ -33,9 +33,10 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并�
 ### Step 2: 读取源文本
 
 使用 Glob 工具列出 `source/` 目录下的文本文件（`source_kind=novel` 为小说原文，`screenplay` 为成品剧本），
-然后使用 Read 工具按文件名顺序读取所有 `.txt`、`.md` 或 `.text` 文件。
-
-如果主 agent 指定了分析范围，只读取指定的文件或章节。
+然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时按文件名顺序读取全部 `.txt`、`.md` 或
+`.text` 文件；`kind=files` 时只读 `files` 列出的完整文件。不得用用户临时提出的更窄章节范围替换
+workflow-status 的权威 scope 后仍提交该 scope 的完成标记；局部分析若不覆盖权威 scope，只能作为不写
+completion fact 的独立管理任务执行。
 
 ### Step 3: 分析提取角色、场景和道具
 

--- a/agent_runtime_profile/.claude/agents/analyze-assets.md
+++ b/agent_runtime_profile/.claude/agents/analyze-assets.md
@@ -33,8 +33,8 @@ description: 从剧本中提取角色 / 场景 / 道具三类资产定义，并�
 ### Step 2: 读取源文本
 
 使用 Glob 工具列出 `source/` 目录下的文本文件（`source_kind=novel` 为小说原文，`screenplay` 为成品剧本），
-然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时按文件名顺序读取全部 `.txt`、`.md` 或
-`.text` 文件；`kind=files` 时只读 `files` 列出的完整文件。不得用用户临时提出的更窄章节范围替换
+然后严格按主 agent 传入的 `scope` 读取文本：`kind=all` 时按文件名顺序读取全部 `.txt` 或 `.md`
+文件；`kind=files` 时只读 `files` 列出的完整文件。不得用用户临时提出的更窄章节范围替换
 workflow-status 的权威 scope 后仍提交该 scope 的完成标记；局部分析若不覆盖权威 scope，只能作为不写
 completion fact 的独立管理任务执行。
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -10,7 +10,13 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 
 ## 工作流步骤
 
-1. **确认项目状态**：Read `project.json`，确认 `title`、`content_mode`（固定 `ad`）、`target_duration`（目标总时长，秒）、`brief`（创作诉求，可为空）、`generation_mode`（`storyboard` / `reference_video`，创建后不可更改；宫格装配 `grid_storyboard` 对 ad 不开放）、`products`（产品资产）。用户要求更改生成模式时明确告知路线创建后不可更改，agent 无对应写入权限，也无绕过方式
+每次进入工作流、用户说“继续/下一步/查看进度”、以及每次工具或 subagent 完成后，先调用
+`mcp__arcreel__get_workflow_status({})`。其 `project`、`target`、`state`、`blockers`、`gates`、
+`artifacts` 与 `next_action` 是已实现阶段的唯一状态真相；Read 只补充创作输入与产品 soft gate 信息，
+不根据文件存在性重建阶段。`next_action.type == "none"` 时展示 blockers 并停止变更；其余动作按下列步骤执行，
+完成后再次刷新状态。产品 sheet 过目等明确标注的 soft gate 继续叠加在服务端状态之上。
+
+1. **确认项目状态**：按 workflow-status 返回的 `project` 确认 `content_mode`（固定 `ad`）与 `generation_mode`；Read `project.json` 补充 `title`、`target_duration`、`brief` 与 `products`。用户要求更改生成模式时明确告知路线创建后不可更改，agent 无对应写入权限，也无绕过方式
 2. **创作输入**：带货项目而产品未登记或缺原图（`reference_images` 为空）时，引导用户在 WebUI 初始化页或产品资产页上传产品图——原图是产品保真的验收锚点，agent 不能代传图片；产品描述/品牌可经 `mcp__arcreel__patch_project` 代写。`brief` 为空时引导用户补充创作诉求（产品/主题、目标人群、期望风格——卖点留给下一步起草，不在此重复索要），同样经 `patch_project` 写入
 3. **起草卖点（selling_points）**：产品已登记但 `selling_points` 为空时，先从 `brief`、产品描述与产品原图（`reference_images`）中起草卖点列表，与用户确认后经 `mcp__arcreel__patch_project` 写入 products 表——剧本生成会把卖点注入带货框架的 selling_point/demo 段
 4. **资产定义与设计图**：角色/场景/道具定义写入 `project.json` 后 dispatch `generate-assets` subagent 生成设计图；产品 sheet 在产品资产页生成

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -12,7 +12,7 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 
 每次进入工作流、用户说“继续/下一步/查看进度”、以及每次工具或 subagent 完成后，先调用
 `mcp__arcreel__get_workflow_status({})`。其 `project`、`target`、`state`、`blockers`、`gates`、
-`artifacts` 与 `next_action` 是已实现阶段的唯一状态真相；Read 只补充创作输入与产品 soft gate 信息，
+`artifacts` 与 `next_action` 是阶段判断的唯一真相源；Read 只补充创作输入与产品 soft gate 信息，
 不根据文件存在性重建阶段。`next_action.type == "none"` 时展示 blockers 并停止变更；其余动作按下列步骤执行，
 完成后再次刷新状态。产品 sheet 过目等明确标注的 soft gate 继续叠加在服务端状态之上。
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -43,8 +43,10 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
      `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
    - `next_action.type == "generate_grid"` → 调
      `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
+   - `next_action.type == "generate_videos"` → 调
+     `mcp__arcreel__generate_video_episode({"script": target.script})`
    - **storyboard 路径**：分镜生成后引导用户审核产品形象，不合格的点名重生成分镜，在产生视频费用前拦截
-   - **reference_video 路径（参考直出）**：直接调 `mcp__arcreel__generate_video_episode` 一键直出——工具自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
+   - **reference_video 路径（参考直出）**：视频动作会自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
 
    以上工具选择只看 `next_action.type`，不二次检查 `generation_mode` 或 `grid_storyboard`；dispatch 时把
    `target.episode`、`next_action.args` 与 `requested_ids` 原样传递。

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -43,8 +43,9 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
      `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": requested_ids})`
    - `next_action.type == "generate_grid"` → 调
      `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": requested_ids})`
-   - `next_action.type == "generate_videos"` → 调
-     `mcp__arcreel__generate_video_episode({"script": target.script_filename})`
+   - `next_action.type == "generate_videos"` → `requested_ids` 非空时调
+     `mcp__arcreel__generate_video_selected({"script": target.script_filename, "scene_ids": requested_ids})`；
+     `requested_ids` 为空时才调 `mcp__arcreel__generate_video_episode({"script": target.script_filename})`
    - **storyboard 路径**：分镜生成后引导用户审核产品形象，不合格的点名重生成分镜，在产生视频费用前拦截
    - **reference_video 路径（参考直出）**：视频动作会自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -33,12 +33,21 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 1. **确认项目状态**：按 workflow-status 返回的 `project` 确认 `content_mode`（固定 `ad`）与 `generation_mode`；Read `project.json` 补充 `title`、`target_duration`、`brief` 与 `products`。用户要求更改生成模式时明确告知路线创建后不可更改，agent 无对应写入权限，也无绕过方式
 2. **创作输入**：带货项目而产品未登记或缺原图（`reference_images` 为空）时，引导用户在 WebUI 初始化页或产品资产页上传产品图——原图是产品保真的验收锚点，agent 不能代传图片；产品描述/品牌可经 `mcp__arcreel__patch_project` 代写。`brief` 为空时引导用户补充创作诉求（产品/主题、目标人群、期望风格——卖点留给下一步起草，不在此重复索要），同样经 `patch_project` 写入
 3. **起草卖点（selling_points）**：产品已登记但 `selling_points` 为空时，先从 `brief`、产品描述与产品原图（`reference_images`）中起草卖点列表，与用户确认后经 `mcp__arcreel__patch_project` 写入 products 表——剧本生成会把卖点注入带货框架的 selling_point/demo 段
-4. **资产定义与设计图**：角色/场景/道具定义写入 `project.json` 后 dispatch `generate-assets` subagent 生成设计图；产品 sheet 在产品资产页生成
+4. **资产定义与设计图**：角色/场景/道具定义写入 `project.json` 后，对每个类型取
+   `artifacts.asset_sheets[type].missing_ids` 与 `requested_ids` 的交集，调
+   `mcp__arcreel__generate_assets({"type": type, "names": [该类型 requested_ids]})`；产品 sheet 在产品资产页生成
 5. **一键生成剧本**：调 `mcp__arcreel__generate_episode_script({"episode": 1})`。ad 不需要 step1 中间文件，prompt 直接来自 brief + 产品信息 + 审定的带货八段框架配比表（按 `target_duration` 选档）；`products` 为空时自动分流为通用短片脚本。生成后剧本总时长偏离 `target_duration` 过大只会记日志提醒，不阻塞
 6. **sheet 过目（软门禁）**：产品生成了 `product_sheet` 时，分镜开工前（参考直出路径为首次视频生成前——sheet 直接进 unit 参考集）先请用户到产品资产页确认 sheet 与真品一致（不一致就重新生成 sheet），确认后才继续；无 sheet（仅原图）时直接开工。这是工作流约定，没有系统状态强制
 7. **镜头编排与生成**：每镜头口播文案/时长/section 可经 `patch_episode_script` 调整；镜头**顺序**调整只在 WebUI 剧本页提供（agent 侧没有重排工具，用户要求调顺序时引导其到剧本页操作，不要用逐字段互换内容模拟）。两条生成路径：
-   - **storyboard 路径**：用 `generate-storyboard` / `generate-video` 逐镜头出图出视频；分镜生成后引导用户审核产品形象，不合格的重生成分镜，在产生视频费用前拦截
+   - `next_action.type == "generate_storyboards"` → 调
+     `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+   - `next_action.type == "generate_grid"` → 调
+     `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+   - **storyboard 路径**：分镜生成后引导用户审核产品形象，不合格的点名重生成分镜，在产生视频费用前拦截
    - **reference_video 路径（参考直出）**：直接调 `mcp__arcreel__generate_video_episode` 一键直出——工具自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
+
+   以上工具选择只看 `next_action.type`，不二次检查 `generation_mode` 或 `grid_storyboard`；dispatch 时把
+   `target.episode`、`next_action.args` 与 `requested_ids` 原样传递。
 
    产品镜头（`products_in_shot` 非空）的分镜与视频生成会自动注入产品参考并附高保真指令，prompt 不必复述产品外观
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -40,9 +40,9 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 6. **sheet 过目（软门禁）**：产品生成了 `product_sheet` 时，分镜开工前（参考直出路径为首次视频生成前——sheet 直接进 unit 参考集）先请用户到产品资产页确认 sheet 与真品一致（不一致就重新生成 sheet），确认后才继续；无 sheet（仅原图）时直接开工。这是工作流约定，没有系统状态强制
 7. **镜头编排与生成**：每镜头口播文案/时长/section 可经 `patch_episode_script` 调整；镜头**顺序**调整只在 WebUI 剧本页提供（agent 侧没有重排工具，用户要求调顺序时引导其到剧本页操作，不要用逐字段互换内容模拟）。两条生成路径：
    - `next_action.type == "generate_storyboards"` → 调
-     `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+     `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
    - `next_action.type == "generate_grid"` → 调
-     `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+     `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
    - **storyboard 路径**：分镜生成后引导用户审核产品形象，不合格的点名重生成分镜，在产生视频费用前拦截
    - **reference_video 路径（参考直出）**：直接调 `mcp__arcreel__generate_video_episode` 一键直出——工具自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -40,11 +40,11 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 6. **sheet 过目（软门禁）**：产品生成了 `product_sheet` 时，分镜开工前（参考直出路径为首次视频生成前——sheet 直接进 unit 参考集）先请用户到产品资产页确认 sheet 与真品一致（不一致就重新生成 sheet），确认后才继续；无 sheet（仅原图）时直接开工。这是工作流约定，没有系统状态强制
 7. **镜头编排与生成**：每镜头口播文案/时长/section 可经 `patch_episode_script` 调整；镜头**顺序**调整只在 WebUI 剧本页提供（agent 侧没有重排工具，用户要求调顺序时引导其到剧本页操作，不要用逐字段互换内容模拟）。两条生成路径：
    - `next_action.type == "generate_storyboards"` → 调
-     `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
+     `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": requested_ids})`
    - `next_action.type == "generate_grid"` → 调
-     `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
+     `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": requested_ids})`
    - `next_action.type == "generate_videos"` → 调
-     `mcp__arcreel__generate_video_episode({"script": target.script})`
+     `mcp__arcreel__generate_video_episode({"script": target.script_filename})`
    - **storyboard 路径**：分镜生成后引导用户审核产品形象，不合格的点名重生成分镜，在产生视频费用前拦截
    - **reference_video 路径（参考直出）**：视频动作会自动把连续镜头派生分组为 video_unit（每 unit ≤4 镜头、总长受供应商上限约束）、把产品参考与资产 sheet 注入各 unit 并入队生成，跳过分镜步骤。镜头编辑后再次调用即自动重新派生，未变化的 unit 不重复生成；编排变了（stale）或用户对成片不满意的 unit 按 `unit_id` 点名重做，见 `generate-video` skill 的「点名重新生成 unit」
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.ad.md
@@ -16,6 +16,20 @@ description: 广告/短片项目的工作流入口。当用户提到做视频、
 不根据文件存在性重建阶段。`next_action.type == "none"` 时展示 blockers 并停止变更；其余动作按下列步骤执行，
 完成后再次刷新状态。产品 sheet 过目等明确标注的 soft gate 继续叠加在服务端状态之上。
 
+按 `next_action.type` 直接进入对应步骤：
+
+- `next_action.type == "draft_selling_points"` → 步骤 3
+- `next_action.type == "generate_script"` → 步骤 5
+- `next_action.type == "generate_asset_sheets"` → 步骤 4
+- `next_action.type == "generate_storyboards"` → 步骤 7 的 storyboard 单图路径
+- `next_action.type == "generate_grid"` → 步骤 7 的 storyboard 宫格路径
+- `next_action.type == "generate_videos"` → 步骤 7 的视频生成
+- `next_action.type == "export"` → 步骤 8
+
+调用工具或 dispatch subagent 时，把 `target.episode`、`next_action.args` 和 `requested_ids` 原样带入；
+不得再按 products、sheet、剧本或媒体文件的存在性改选另一个阶段。步骤内的产品原图与 sheet 过目规则仅是
+执行已选动作前的 soft gate。
+
 1. **确认项目状态**：按 workflow-status 返回的 `project` 确认 `content_mode`（固定 `ad`）与 `generation_mode`；Read `project.json` 补充 `title`、`target_duration`、`brief` 与 `products`。用户要求更改生成模式时明确告知路线创建后不可更改，agent 无对应写入权限，也无绕过方式
 2. **创作输入**：带货项目而产品未登记或缺原图（`reference_images` 为空）时，引导用户在 WebUI 初始化页或产品资产页上传产品图——原图是产品保真的验收锚点，agent 不能代传图片；产品描述/品牌可经 `mcp__arcreel__patch_project` 代写。`brief` 为空时引导用户补充创作诉求（产品/主题、目标人群、期望风格——卖点留给下一步起草，不在此重复索要），同样经 `patch_project` 写入
 3. **起草卖点（selling_points）**：产品已登记但 `selling_points` 为空时，先从 `brief`、产品描述与产品原图（`reference_images`）中起草卖点列表，与用户确认后经 `mcp__arcreel__patch_project` 写入 products 表——剧本生成会把卖点注入带货框架的 selling_point/demo 段

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -224,13 +224,13 @@ reference_video 模式返回这两个动作。
 按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
 - `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+  `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
 - `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+  `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
 
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
-> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
+> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
 
 ## 阶段 7：视频生成
 
@@ -243,8 +243,8 @@ dispatch `generate-assets` subagent：
   任务类型：video
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_video_episode({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 video_clip 字段
+    mcp__arcreel__generate_video_episode({"script": target.script})
+  验证方式：重新读取 target.script，检查各场景的 video_clip 字段
 ```
 
 ---

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -101,7 +101,7 @@ expected source revision：{next_action.args.source_revision}
 
 ## 阶段 2：分集规划
 
-**触发**：目标集在账本（project.json `episodes[]`）中没有条目
+**触发**：`next_action.type == "plan_episodes"`
 
 分集规划由服务端工具完成：工具内部从 `planning_cursor` 起读一个源文窗口，调用项目配置的文本模型一次规划出窗口内所有剧情弧完整的集（标题/钩子/原文范围 + 分集大纲：故事节点与下集预告），在同一把项目锁内写账本、派生 `source/episode_{N}.txt` 并清理残留派生文件。**主 agent 只调一次工具、只收摘要**——不读小说原文、不自行选切分点：
 
@@ -119,7 +119,7 @@ expected source revision：{next_action.args.source_revision}
 
 ## 阶段 3：单集预处理
 
-**触发**：目标集的 drafts/ 中间文件不存在
+**触发**：`next_action.type == "prepare_step1"`
 
 根据项目 `generation_mode` 选择 subagent：
 
@@ -139,9 +139,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 4：JSON 剧本生成
 
-**触发**（满足其一）：
-- `scripts/episode_{N}.json` 不存在
-- 阶段 3 的中间文件在本次会话中被修改或重拆（此时即使 JSON 已存在也必须重生）
+**触发**：`next_action.type` 为 `"confirm_step1"` 或 `"generate_script"`。前者先完成下述审核 gate，
+刷新 workflow-status 后再按新的 `next_action` 路由；后者 dispatch 剧本生成。
 
 **step1→step2 审核 gate（阻塞）**：阶段 3 的结构化 step1 中间态须经**显式确认**才放行本阶段（三种结构化 step1 变体——drama / narration / reference_video——一律适用；`reference_video` 的 `step1_reference_units.json` 同样须确认，不要跳过。ad 无 step1，不纳入 gate）。两条等价确认路径——用户在 Web 端审阅 / 编辑后确认，或在对话中明确同意进入视觉生成后由你调用 `mcp__arcreel__confirm_script_review({"episode": N})`（全自主模式下按用户总体授权确认）。未确认（或确认后 step1 又被改）时 `generate_episode_script` 会被 gate 拒绝；**存量项目**（升级前已生成过本集剧本）已 grandfather 放行、无需再确认。
 
@@ -151,9 +150,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 5：资产设计（character / scene / prop 三类并行）
 
-**前置条件**：三类资产的定义（characters / scenes / props）均已通过阶段 1 写入 project.json。若任一类定义为空（数组缺失），应回到阶段 1 补提取，而非停留在阶段 5。
-
-**触发**：三类资产中任一类存在缺 sheet 项：
+**触发**：`next_action.type == "generate_asset_sheets"`。空资产 bucket 是阶段 1 的合法完成结果，
+不得据此回退；按 `artifacts.asset_sheets` 与 `requested_ids` 找到下列缺 sheet 项：
 - character 缺 character_sheet
 - scene 缺 scene_sheet
 - prop 缺 prop_sheet
@@ -217,7 +215,8 @@ dispatch `generate-assets` subagent：
 
 ## 阶段 6：分镜图生成（仅 storyboard 模式，含 grid_storyboard）
 
-**触发**：有场景缺少分镜图；**参考生视频模式跳过此阶段**
+**触发**：`next_action.type` 为 `"generate_storyboards"` 或 `"generate_grid"`；服务端不会在
+reference_video 模式返回这两个动作。
 
 检查项目 `generation_mode` 与 `grid_storyboard`：
 
@@ -257,7 +256,7 @@ dispatch `generate-assets` subagent：
 
 ## 阶段 7：视频生成
 
-**触发**：有场景缺少视频
+**触发**：`next_action.type == "generate_videos"`
 
 **dispatch `generate-assets` subagent**：
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -151,7 +151,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 ## 阶段 5：资产设计（character / scene / prop 三类并行）
 
 **触发**：`next_action.type == "generate_asset_sheets"`。空资产 bucket 是阶段 1 的合法完成结果，
-不得据此回退；按 `artifacts.asset_sheets` 与 `requested_ids` 找到下列缺 sheet 项：
+不得据此回退；对每个资产类型，取 `artifacts.asset_sheets[type].missing_ids` 与 `requested_ids` 的交集作为
+该类型的 `names`，同时传给 subagent 和工具：
 - character 缺 character_sheet
 - scene 缺 scene_sheet
 - prop 缺 prop_sheet
@@ -179,7 +180,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失角色名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "character"})
+    mcp__arcreel__generate_assets({"type": "character", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应角色的 character_sheet 字段
 ```
 
@@ -193,7 +194,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失场景名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "scene"})
+    mcp__arcreel__generate_assets({"type": "scene", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应场景的 scene_sheet 字段
 ```
 
@@ -207,7 +208,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失道具名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "prop"})
+    mcp__arcreel__generate_assets({"type": "prop", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应道具的 prop_sheet 字段
 ```
 
@@ -218,11 +219,14 @@ dispatch `generate-assets` subagent：
 **触发**：`next_action.type` 为 `"generate_storyboards"` 或 `"generate_grid"`；服务端不会在
 reference_video 模式返回这两个动作。
 
-检查项目 `generation_mode` 与 `grid_storyboard`：
+按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
-- `generation_mode == "storyboard"` 且 `grid_storyboard` 为 false → dispatch `generate-assets`，调 `mcp__arcreel__generate_storyboards`
-- `generation_mode == "storyboard"` 且 `grid_storyboard` 为 true → dispatch `generate-assets`，调 `mcp__arcreel__generate_grid`
-- `generation_mode == "reference_video"` → 不触发，直接跳到阶段 7
+- `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
+  `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+- `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
+  `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+
+两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
 > **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -139,8 +139,10 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 4：JSON 剧本生成
 
-**触发**：`next_action.type` 为 `"confirm_step1"` 或 `"generate_script"`。前者先完成下述审核 gate，
-刷新 workflow-status 后再按新的 `next_action` 路由；后者 dispatch 剧本生成。
+**触发**：
+
+- `next_action.type == "confirm_step1"` → 先完成下述审核 gate，刷新 workflow-status 后再路由
+- `next_action.type == "generate_script"` → dispatch 剧本生成
 
 **step1→step2 审核 gate（阻塞）**：阶段 3 的结构化 step1 中间态须经**显式确认**才放行本阶段（三种结构化 step1 变体——drama / narration / reference_video——一律适用；`reference_video` 的 `step1_reference_units.json` 同样须确认，不要跳过。ad 无 step1，不纳入 gate）。两条等价确认路径——用户在 Web 端审阅 / 编辑后确认，或在对话中明确同意进入视觉生成后由你调用 `mcp__arcreel__confirm_script_review({"episode": N})`（全自主模式下按用户总体授权确认）。未确认（或确认后 step1 又被改）时 `generate_episode_script` 会被 gate 拒绝；**存量项目**（升级前已生成过本集剧本）已 grandfather 放行、无需再确认。
 
@@ -229,34 +231,6 @@ reference_video 模式返回这两个动作。
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
 > **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
-
-### storyboard 模式（grid_storyboard=false）
-
-**dispatch `generate-assets` subagent**：
-
-```text
-dispatch `generate-assets` subagent：
-  任务类型：storyboard
-  项目名称：{project_name}
-  工具调用：
-    mcp__arcreel__generate_storyboards({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 storyboard_image 字段
-```
-
-### storyboard 模式，grid_storyboard=true
-
-**dispatch `generate-assets` subagent**：
-
-```text
-dispatch `generate-assets` subagent：
-  任务类型：storyboard
-  项目名称：{project_name}
-  工具调用：
-    mcp__arcreel__generate_grid({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 storyboard_image 字段
-```
-
----
 
 ## 阶段 7：视频生成
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -163,8 +163,9 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ```text
 对于 type ∈ {character, scene, prop}:
-  若该类存在缺 *_sheet 项 → dispatch 对应的 `generate-assets` subagent
-  若该类均已齐全         → 跳过，不 dispatch
+  names = artifacts.asset_sheets[type].missing_ids ∩ requested_ids
+  若 names 非空 → dispatch 对应的 `generate-assets` subagent，并把 names 原样传给 subagent 和工具
+  若 names 为空 → 跳过，不 dispatch；不得回退到整类 missing_ids
 
 三类判断彼此独立，结果可能 dispatch 0~3 个 subagent。
 所有 dispatch 的 subagent 返回后，合并摘要展示给用户，进入阶段间确认。
@@ -174,13 +175,13 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ### subagent — 角色设计
 
-**触发**：有角色缺少 character_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：character
   项目名称：{project_name}
-  待生成项：{缺失角色名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "character", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应角色的 character_sheet 字段
@@ -188,13 +189,13 @@ dispatch `generate-assets` subagent：
 
 ### subagent — 场景设计
 
-**触发**：有场景缺少 scene_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：scene
   项目名称：{project_name}
-  待生成项：{缺失场景名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "scene", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应场景的 scene_sheet 字段
@@ -202,13 +203,13 @@ dispatch `generate-assets` subagent：
 
 ### subagent — 道具设计
 
-**触发**：有道具缺少 prop_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：prop
   项目名称：{project_name}
-  待生成项：{缺失道具名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "prop", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应道具的 prop_sheet 字段

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -52,6 +52,7 @@ Read / Glob 只用于执行已选定动作所需的内容，不用于另建状�
 |---|---|
 | `collect_project_input` | 阶段 0 |
 | `analyze_assets` | 阶段 1 |
+| `reset_episode_planning` | 阶段 2（先重置） |
 | `plan_episodes` | 阶段 2 |
 | `prepare_step1` | 阶段 3 |
 | `confirm_step1` / `generate_script` | 阶段 4 |
@@ -87,9 +88,9 @@ Read / Glob 只用于执行已选定动作所需的内容，不用于另建状�
 
 ```text
 项目名称：{project_name}
-分析范围：{整部小说 / 用户指定的范围}
+分析范围：{next_action.args.scope 对应的权威范围；workflow 默认整部小说}
 分析 scope：{next_action.args.scope}
-expected source revision：{next_action.args.source_revision}
+expected source revision：{next_action.args.expected_source_revision}
 已有角色：{已有角色名列表，或"无"}
 已有场景：{已有场景名列表，或"无"}
 已有道具：{已有道具名列表，或"无"}
@@ -100,6 +101,10 @@ expected source revision：{next_action.args.source_revision}
 ---
 
 ## 阶段 2：分集规划
+
+**恢复触发**：`next_action.type` 为 `"reset_episode_planning"` 时，先按 `next_action.args` 调
+`mcp__arcreel__reset_episode_planning`。工具若返回已消费集确认要求，展示影响范围并取得用户明确确认，
+再追加 `confirm_consumed: true` 重试；重置成功后刷新 workflow-status，按新的权威动作继续。
 
 **触发**：`next_action.type == "plan_episodes"`
 
@@ -225,13 +230,13 @@ reference_video 模式返回这两个动作。
 按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
 - `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
+  `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": requested_ids})`
 - `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
+  `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": requested_ids})`
 
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
-> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
+> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的场景范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应场景。
 
 ## 阶段 7：视频生成
 
@@ -244,7 +249,7 @@ dispatch `generate-assets` subagent：
   任务类型：video
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_video_episode({"script": target.script})
+    mcp__arcreel__generate_video_episode({"script": target.script_filename})
   验证方式：重新读取 target.script，检查各场景的 video_clip 字段
 ```
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -34,30 +34,35 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 ### 现有项目
 
 1. session cwd 已经绑定到目标项目根
-2. 通过 Read `project.json` + Glob 文件系统判定状态摘要
-3. 从上次未完成的阶段继续
+2. 调用 `mcp__arcreel__get_workflow_status({})` 取得服务端权威状态
+3. 按返回的 `next_action` 从上次未完成的阶段继续
 
 ---
 
 ## 状态检测
 
-进入工作流后，使用 Read 读取 `project.json`，使用 Glob 检查文件系统。按顺序检查，遇到第一个缺失项即确定当前阶段：
+进入工作流、用户说“继续/下一步/查看进度”、以及每次工具或 subagent 完成后，都调用
+`mcp__arcreel__get_workflow_status({})`。用户指定集数时传 `{"episode": N}`。返回的
+`project`、`target`、`state`、`blockers`、`gates`、`artifacts` 与 `next_action` 是阶段判断的唯一真相源；
+Read / Glob 只用于执行已选定动作所需的内容，不用于另建状态机。
 
-1. characters / scenes / props 中**任一**为空（定义缺失）？ → **阶段 1**
-2. 目标集在账本（project.json `episodes[]`）中没有条目？ → **阶段 2**。分集接续状态**只读账本**：条目的 `ledger_status` 标记每集状态（planned 已规划 / consumed 已消费 / stale 已有下游产物待重做），顶层 `planning_cursor` 标记下一批规划起点；**不要用 Glob 文件名推断集数**（`source/episode_{N}.txt` 只是账本的派生物）
-3. 目标集 `ledger_status` 为 `stale`（该集号重新规划前已有下游产物——旧 step1/剧本/媒体一律视为失效，即使文件还在也从本阶段起重做，产物沿版本机制替换），或目标集**当前组合对应的** step1 中间文件不存在？ → **阶段 3**。按项目 `generation_mode` × `content_mode` 检查对应文件（generation_mode 由项目唯一决定，创建后不可变，不存在集级覆盖）：
-   - generation_mode == reference_video（任一 content_mode）: `drafts/episode_{N}/step1_reference_units.json`
-   - generation_mode == storyboard 且 content_mode == narration: `drafts/episode_{N}/step1_segments.json`
-   - generation_mode == storyboard 且 content_mode == drama: `drafts/episode_{N}/step1_normalized_script.json`（结构化内容，见 ADR 0041）
+按 `next_action.type` 路由：
 
-   本项目 content_mode 固定为 drama（创建后不可变），故只会命中第 1 或第 3 分支，取决于项目的 generation_mode。只认当前组合对应的那一个文件：目录中出现**其他模式的 `step1_*` 文件**属残留，不作为阶段 3 已完成的依据。旧项目残留的 `step1_normalized_script.md`（结构化前的自由文本稿）同样不算有效 step1——若无 `.json`，按阶段 3 重跑 `normalize-drama-script` 产出结构化 `.json`，不做 md→结构化迁移。
-4. scripts/episode_{N}.json 不存在？ → **阶段 4**（另见阶段 4 触发条件：本次会话中阶段 3 中间文件被修改/重拆时，即使 JSON 存在也须重生）
-5. 任一类资产仍有缺 sheet 项（character 缺 character_sheet / scene 缺 scene_sheet / prop 缺 prop_sheet）？ → **阶段 5**（三类并行）
-6. **storyboard 模式**（含 grid_storyboard）：有场景缺少分镜图？ → **阶段 6**（reference_video 模式跳过）
-7. 有场景/unit 缺少视频？ → **阶段 7**
-8. 全部完成 → 工作流结束，引导用户在 Web 端导出剪映草稿
+| next_action.type | 阶段 |
+|---|---|
+| `collect_project_input` | 阶段 0 |
+| `analyze_assets` | 阶段 1 |
+| `plan_episodes` | 阶段 2 |
+| `prepare_step1` | 阶段 3 |
+| `confirm_step1` / `generate_script` | 阶段 4 |
+| `generate_asset_sheets` | 阶段 5 |
+| `generate_storyboards` / `generate_grid` | 阶段 6 |
+| `generate_videos` | 阶段 7 |
+| `export` | 工作流完成 |
+| `none` | 展示 `blockers` 并停止变更 |
 
-**确定目标集数**：如果用户未指定，读账本确定——`ledger_status` 为 `planned`（或 `stale`）的最小集号即下一个待制作集；账本中所有集均已消费且源文尚未规划完时，进入阶段 2 规划下一批。
+调用后把 `target.episode` 作为目标集，把 `next_action.args` 与 `requested_ids` 原样带入对应阶段。
+不得根据空资产 bucket、文件名、旧文件存在性或对话记忆覆盖服务端结论。
 
 ---
 
@@ -76,13 +81,15 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 
 ## 阶段 1：全局角色/场景/道具提取
 
-**触发**：project.json 中 characters / scenes / props 中**任一**为空（定义缺失）
+**触发**：`next_action.type == "analyze_assets"`。空 bucket 是合法分析结果，不得凭空 bucket 重跑。
 
 **dispatch `analyze-assets` subagent**：
 
 ```text
 项目名称：{project_name}
 分析范围：{整部小说 / 用户指定的范围}
+分析 scope：{next_action.args.scope}
+expected source revision：{next_action.args.source_revision}
 已有角色：{已有角色名列表，或"无"}
 已有场景：{已有场景名列表，或"无"}
 已有道具：{已有道具名列表，或"无"}

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.drama.md
@@ -133,6 +133,11 @@ expected source revision：{next_action.args.expected_source_revision}
 
 dispatch prompt 通用参数：项目名称、项目路径、集数、本集小说文件路径；可选附加说明（用户对本次生成的意见等任何需带给 subagent 的临时上下文，原文透传）。
 
+若 `next_action.args` 含 `expected_stale_step1_revision`，subagent 成功产出正式 step1 后必须调用
+`mcp__arcreel__complete_step1_rebuild({"episode": N, "expected_stale_step1_revision": next_action.args.expected_stale_step1_revision})`。
+该完成事实不可用“文件内容是否变化”推断：确定性重建可能产出完全相同的 JSON。工具报冲突时刷新 workflow-status，
+不得用旧参数重试。
+
 （两个预处理 subagent 会自行读 project.json + 调用
 `mcp__arcreel__get_video_capabilities({})`
 拿到模型能力与用户偏好；主 agent 不需要预先注入角色/场景/道具列表或

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -228,13 +228,13 @@ reference_video 模式返回这两个动作。
 按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
 - `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+  `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
 - `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+  `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
 
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
-> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
+> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
 
 ## 阶段 7：视频生成
 
@@ -247,8 +247,8 @@ dispatch `generate-assets` subagent：
   任务类型：video
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_video_episode({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 video_clip 字段
+    mcp__arcreel__generate_video_episode({"script": target.script})
+  验证方式：重新读取 target.script，检查各场景的 video_clip 字段
 ```
 
 ---
@@ -267,8 +267,8 @@ dispatch `generate-assets` subagent：
   任务类型：narration_audio
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_narration_audio({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各段 generated_assets.narration_audio 字段
+    mcp__arcreel__generate_narration_audio({"script": target.script})
+  验证方式：重新读取 target.script，检查各段 generated_assets.narration_audio 字段
 ```
 
 中断后重新 dispatch 同一工具调用即可断点续传——已有音频的段自动跳过，只补缺失段。

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -137,6 +137,11 @@ expected source revision：{next_action.args.expected_source_revision}
 
 dispatch prompt 通用参数：项目名称、项目路径、集数、本集小说文件路径；可选附加说明（用户对本次生成的意见等任何需带给 subagent 的临时上下文，原文透传）。
 
+若 `next_action.args` 含 `expected_stale_step1_revision`，subagent 成功产出正式 step1 后必须调用
+`mcp__arcreel__complete_step1_rebuild({"episode": N, "expected_stale_step1_revision": next_action.args.expected_stale_step1_revision})`。
+该完成事实不可用“文件内容是否变化”推断：确定性重建可能产出完全相同的 JSON。工具报冲突时刷新 workflow-status，
+不得用旧参数重试。
+
 （两个预处理 subagent 会自行读 project.json + 调用
 `mcp__arcreel__get_video_capabilities({})`
 拿到模型能力与用户偏好；主 agent 不需要预先注入角色/场景/道具列表或

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -105,7 +105,7 @@ expected source revision：{next_action.args.source_revision}
 
 ## 阶段 2：分集规划
 
-**触发**：目标集在账本（project.json `episodes[]`）中没有条目
+**触发**：`next_action.type == "plan_episodes"`
 
 分集规划由服务端工具完成：工具内部从 `planning_cursor` 起读一个源文窗口，调用项目配置的文本模型一次规划出窗口内所有剧情弧完整的集（标题/钩子/原文范围），在同一把项目锁内写账本、派生 `source/episode_{N}.txt` 并清理残留派生文件。**主 agent 只调一次工具、只收摘要**——不读小说原文、不自行选切分点：
 
@@ -123,7 +123,7 @@ expected source revision：{next_action.args.source_revision}
 
 ## 阶段 3：单集预处理
 
-**触发**：目标集的 drafts/ 中间文件不存在
+**触发**：`next_action.type == "prepare_step1"`
 
 根据项目 `generation_mode` 选择 subagent：
 
@@ -143,9 +143,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 4：JSON 剧本生成
 
-**触发**（满足其一）：
-- `scripts/episode_{N}.json` 不存在
-- 阶段 3 的中间文件在本次会话中被修改或重拆（此时即使 JSON 已存在也必须重生）
+**触发**：`next_action.type` 为 `"confirm_step1"` 或 `"generate_script"`。前者先完成下述审核 gate，
+刷新 workflow-status 后再按新的 `next_action` 路由；后者 dispatch 剧本生成。
 
 **step1→step2 审核 gate（阻塞）**：阶段 3 的结构化 step1 中间态须经**显式确认**才放行本阶段（三种结构化 step1 变体——drama / narration / reference_video——一律适用；`reference_video` 的 `step1_reference_units.json` 同样须确认，不要跳过。ad 无 step1，不纳入 gate）。两条等价确认路径——用户在 Web 端审阅 / 编辑后确认，或在对话中明确同意进入视觉生成后由你调用 `mcp__arcreel__confirm_script_review({"episode": N})`（全自主模式下按用户总体授权确认）。未确认（或确认后 step1 又被改）时 `generate_episode_script` 会被 gate 拒绝；**存量项目**（升级前已生成过本集剧本）已 grandfather 放行、无需再确认。
 
@@ -155,9 +154,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 5：资产设计（character / scene / prop 三类并行）
 
-**前置条件**：三类资产的定义（characters / scenes / props）均已通过阶段 1 写入 project.json。若任一类定义为空（数组缺失），应回到阶段 1 补提取，而非停留在阶段 5。
-
-**触发**：三类资产中任一类存在缺 sheet 项：
+**触发**：`next_action.type == "generate_asset_sheets"`。空资产 bucket 是阶段 1 的合法完成结果，
+不得据此回退；按 `artifacts.asset_sheets` 与 `requested_ids` 找到下列缺 sheet 项：
 - character 缺 character_sheet
 - scene 缺 scene_sheet
 - prop 缺 prop_sheet
@@ -221,7 +219,8 @@ dispatch `generate-assets` subagent：
 
 ## 阶段 6：分镜图生成（仅 storyboard 模式，含 grid_storyboard）
 
-**触发**：有片段缺少分镜图；**参考生视频模式跳过此阶段**
+**触发**：`next_action.type` 为 `"generate_storyboards"` 或 `"generate_grid"`；服务端不会在
+reference_video 模式返回这两个动作。
 
 检查项目 `generation_mode` 与 `grid_storyboard`：
 
@@ -261,7 +260,7 @@ dispatch `generate-assets` subagent：
 
 ## 阶段 7：视频生成
 
-**触发**：有场景缺少视频
+**触发**：`next_action.type == "generate_videos"`
 
 **dispatch `generate-assets` subagent**：
 
@@ -278,7 +277,7 @@ dispatch `generate-assets` subagent：
 
 ## 阶段 8：旁白配音（仅 storyboard 模式，含 grid_storyboard）
 
-**触发**：有段缺 `narration_audio`；**参考生视频模式跳过此阶段**（无 segments）
+**触发**：`next_action.type == "generate_narration_audio"`；服务端不会在 reference_video 模式返回此动作。
 
 旁白配音以各段 `novel_text` 原文逐段合成语音，只依赖剧本、独立于分镜图/视频：
 按序推进时排在视频之后，但用户要求时可在阶段 4 剧本生成后随时执行。

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -52,6 +52,7 @@ Read / Glob 只用于执行已选定动作所需的内容，不用于另建状�
 |---|---|
 | `collect_project_input` | 阶段 0 |
 | `analyze_assets` | 阶段 1 |
+| `reset_episode_planning` | 阶段 2（先重置） |
 | `plan_episodes` | 阶段 2 |
 | `prepare_step1` | 阶段 3 |
 | `confirm_step1` / `generate_script` | 阶段 4 |
@@ -91,9 +92,9 @@ Read / Glob 只用于执行已选定动作所需的内容，不用于另建状�
 
 ```text
 项目名称：{project_name}
-分析范围：{整部小说 / 用户指定的范围}
+分析范围：{next_action.args.scope 对应的权威范围；workflow 默认整部小说}
 分析 scope：{next_action.args.scope}
-expected source revision：{next_action.args.source_revision}
+expected source revision：{next_action.args.expected_source_revision}
 已有角色：{已有角色名列表，或"无"}
 已有场景：{已有场景名列表，或"无"}
 已有道具：{已有道具名列表，或"无"}
@@ -104,6 +105,10 @@ expected source revision：{next_action.args.source_revision}
 ---
 
 ## 阶段 2：分集规划
+
+**恢复触发**：`next_action.type` 为 `"reset_episode_planning"` 时，先按 `next_action.args` 调
+`mcp__arcreel__reset_episode_planning`。工具若返回已消费集确认要求，展示影响范围并取得用户明确确认，
+再追加 `confirm_consumed: true` 重试；重置成功后刷新 workflow-status，按新的权威动作继续。
 
 **触发**：`next_action.type == "plan_episodes"`
 
@@ -229,13 +234,13 @@ reference_video 模式返回这两个动作。
 按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
 - `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": requested_ids})`
+  `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": requested_ids})`
 - `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
-  `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": requested_ids})`
+  `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": requested_ids})`
 
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
-> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
+> **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": target.script_filename, "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": target.script_filename, "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
 
 ## 阶段 7：视频生成
 
@@ -248,7 +253,7 @@ dispatch `generate-assets` subagent：
   任务类型：video
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_video_episode({"script": target.script})
+    mcp__arcreel__generate_video_episode({"script": target.script_filename})
   验证方式：重新读取 target.script，检查各场景的 video_clip 字段
 ```
 
@@ -268,7 +273,7 @@ dispatch `generate-assets` subagent：
   任务类型：narration_audio
   项目名称：{project_name}
   工具调用：
-    mcp__arcreel__generate_narration_audio({"script": target.script})
+    mcp__arcreel__generate_narration_audio({"script": target.script_filename})
   验证方式：重新读取 target.script，检查各段 generated_assets.narration_audio 字段
 ```
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -34,34 +34,39 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 ### 现有项目
 
 1. session cwd 已经绑定到目标项目根
-2. 通过 Read `project.json` + Glob 文件系统判定状态摘要
-3. 从上次未完成的阶段继续
+2. 调用 `mcp__arcreel__get_workflow_status({})` 取得服务端权威状态
+3. 按返回的 `next_action` 从上次未完成的阶段继续
 
 ---
 
 ## 状态检测
 
-进入工作流后，使用 Read 读取 `project.json`，使用 Glob 检查文件系统。按顺序检查，遇到第一个缺失项即确定当前阶段：
+进入工作流、用户说“继续/下一步/查看进度”、以及每次工具或 subagent 完成后，都调用
+`mcp__arcreel__get_workflow_status({})`。用户指定集数时传 `{"episode": N}`。返回的
+`project`、`target`、`state`、`blockers`、`gates`、`artifacts` 与 `next_action` 是阶段判断的唯一真相源；
+Read / Glob 只用于执行已选定动作所需的内容，不用于另建状态机。
 
-1. characters / scenes / props 中**任一**为空（定义缺失）？ → **阶段 1**
-2. 目标集在账本（project.json `episodes[]`）中没有条目？ → **阶段 2**。分集接续状态**只读账本**：条目的 `ledger_status` 标记每集状态（planned 已规划 / consumed 已消费 / stale 已有下游产物待重做），顶层 `planning_cursor` 标记下一批规划起点；**不要用 Glob 文件名推断集数**（`source/episode_{N}.txt` 只是账本的派生物）
-3. 目标集 `ledger_status` 为 `stale`（该集号重新规划前已有下游产物——旧 step1/剧本/媒体一律视为失效，即使文件还在也从本阶段起重做，产物沿版本机制替换），或目标集**当前组合对应的** step1 中间文件不存在？ → **阶段 3**。按项目 `generation_mode` × `content_mode` 检查对应文件（generation_mode 由项目唯一决定，创建后不可变，不存在集级覆盖）：
-   - generation_mode == reference_video（任一 content_mode）: `drafts/episode_{N}/step1_reference_units.json`
-   - generation_mode == storyboard 且 content_mode == narration: `drafts/episode_{N}/step1_segments.json`
-   - generation_mode == storyboard 且 content_mode == drama: `drafts/episode_{N}/step1_normalized_script.json`（结构化内容）
+按 `next_action.type` 路由：
 
-   本项目 content_mode 固定为 narration（创建后不可变），故只会命中第 1 或第 2 分支，取决于项目的 generation_mode。只认当前组合对应的那一个文件：目录中出现**其他模式的 `step1_*` 文件**属残留，不作为阶段 3 已完成的依据。
-4. scripts/episode_{N}.json 不存在？ → **阶段 4**（另见阶段 4 触发条件：本次会话中阶段 3 中间文件被修改/重拆时，即使 JSON 存在也须重生）
-5. 任一类资产仍有缺 sheet 项（character 缺 character_sheet / scene 缺 scene_sheet / prop 缺 prop_sheet）？ → **阶段 5**（三类并行）
-6. **storyboard 模式**（含 grid_storyboard）：有片段缺少分镜图？ → **阶段 6**（reference_video 模式跳过）
-7. 有片段/unit 缺少视频？ → **阶段 7**
-8. **storyboard 模式**（含 grid_storyboard）：有段缺 `narration_audio`？ → **阶段 8（旁白配音）**（reference_video 模式无 segments，跳过）
-9. 全部完成 → 工作流结束，引导用户在 Web 端导出剪映草稿
+| next_action.type | 阶段 |
+|---|---|
+| `collect_project_input` | 阶段 0 |
+| `analyze_assets` | 阶段 1 |
+| `plan_episodes` | 阶段 2 |
+| `prepare_step1` | 阶段 3 |
+| `confirm_step1` / `generate_script` | 阶段 4 |
+| `generate_asset_sheets` | 阶段 5 |
+| `generate_storyboards` / `generate_grid` | 阶段 6 |
+| `generate_videos` | 阶段 7 |
+| `generate_narration_audio` | 阶段 8 |
+| `export` | 工作流完成 |
+| `none` | 展示 `blockers` 并停止变更 |
+
+调用后把 `target.episode` 作为目标集，把 `next_action.args` 与 `requested_ids` 原样带入对应阶段。
+不得根据空资产 bucket、文件名、旧文件存在性或对话记忆覆盖服务端结论。
 
 > 阶段 8 只依赖剧本各段的 `novel_text`，独立于分镜图/视频——阶段 4 剧本生成后即可推进。
 > 用户提前要求配音时直接进入阶段 8，不必等分镜/视频完成。
-
-**确定目标集数**：如果用户未指定，读账本确定——`ledger_status` 为 `planned`（或 `stale`）的最小集号即下一个待制作集；账本中所有集均已消费且源文尚未规划完时，进入阶段 2 规划下一批。
 
 ---
 
@@ -80,13 +85,15 @@ description: 将小说转换为短视频的端到端工作流编排器。当用�
 
 ## 阶段 1：全局角色/场景/道具提取
 
-**触发**：project.json 中 characters / scenes / props 中**任一**为空（定义缺失）
+**触发**：`next_action.type == "analyze_assets"`。空 bucket 是合法分析结果，不得凭空 bucket 重跑。
 
 **dispatch `analyze-assets` subagent**：
 
 ```text
 项目名称：{project_name}
 分析范围：{整部小说 / 用户指定的范围}
+分析 scope：{next_action.args.scope}
+expected source revision：{next_action.args.source_revision}
 已有角色：{已有角色名列表，或"无"}
 已有场景：{已有场景名列表，或"无"}
 已有道具：{已有道具名列表，或"无"}

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -155,7 +155,8 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 ## 阶段 5：资产设计（character / scene / prop 三类并行）
 
 **触发**：`next_action.type == "generate_asset_sheets"`。空资产 bucket 是阶段 1 的合法完成结果，
-不得据此回退；按 `artifacts.asset_sheets` 与 `requested_ids` 找到下列缺 sheet 项：
+不得据此回退；对每个资产类型，取 `artifacts.asset_sheets[type].missing_ids` 与 `requested_ids` 的交集作为
+该类型的 `names`，同时传给 subagent 和工具：
 - character 缺 character_sheet
 - scene 缺 scene_sheet
 - prop 缺 prop_sheet
@@ -183,7 +184,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失角色名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "character"})
+    mcp__arcreel__generate_assets({"type": "character", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应角色的 character_sheet 字段
 ```
 
@@ -197,7 +198,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失场景名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "scene"})
+    mcp__arcreel__generate_assets({"type": "scene", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应场景的 scene_sheet 字段
 ```
 
@@ -211,7 +212,7 @@ dispatch `generate-assets` subagent：
   项目名称：{project_name}
   待生成项：{缺失道具名列表}
   工具调用：
-    mcp__arcreel__generate_assets({"type": "prop"})
+    mcp__arcreel__generate_assets({"type": "prop", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应道具的 prop_sheet 字段
 ```
 
@@ -222,11 +223,14 @@ dispatch `generate-assets` subagent：
 **触发**：`next_action.type` 为 `"generate_storyboards"` 或 `"generate_grid"`；服务端不会在
 reference_video 模式返回这两个动作。
 
-检查项目 `generation_mode` 与 `grid_storyboard`：
+按动作直接选择工具，不二次检查 `generation_mode` 或 `grid_storyboard`：
 
-- `generation_mode == "storyboard"` 且 `grid_storyboard` 为 false → dispatch `generate-assets`，调 `mcp__arcreel__generate_storyboards`
-- `generation_mode == "storyboard"` 且 `grid_storyboard` 为 true → dispatch `generate-assets`，调 `mcp__arcreel__generate_grid`
-- `generation_mode == "reference_video"` → 不触发，直接跳到阶段 7
+- `next_action.type == "generate_storyboards"` → dispatch `generate-assets`，调
+  `mcp__arcreel__generate_storyboards({"script": "episode_{target.episode}.json", "segment_ids": requested_ids})`
+- `next_action.type == "generate_grid"` → dispatch `generate-assets`，调
+  `mcp__arcreel__generate_grid({"script": "episode_{target.episode}.json", "scene_ids": requested_ids})`
+
+两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
 > **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -143,8 +143,10 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ## 阶段 4：JSON 剧本生成
 
-**触发**：`next_action.type` 为 `"confirm_step1"` 或 `"generate_script"`。前者先完成下述审核 gate，
-刷新 workflow-status 后再按新的 `next_action` 路由；后者 dispatch 剧本生成。
+**触发**：
+
+- `next_action.type == "confirm_step1"` → 先完成下述审核 gate，刷新 workflow-status 后再路由
+- `next_action.type == "generate_script"` → dispatch 剧本生成
 
 **step1→step2 审核 gate（阻塞）**：阶段 3 的结构化 step1 中间态须经**显式确认**才放行本阶段（三种结构化 step1 变体——drama / narration / reference_video——一律适用；`reference_video` 的 `step1_reference_units.json` 同样须确认，不要跳过。ad 无 step1，不纳入 gate）。两条等价确认路径——用户在 Web 端审阅 / 编辑后确认，或在对话中明确同意进入视觉生成后由你调用 `mcp__arcreel__confirm_script_review({"episode": N})`（全自主模式下按用户总体授权确认）。未确认（或确认后 step1 又被改）时 `generate_episode_script` 会被 gate 拒绝；**存量项目**（升级前已生成过本集剧本）已 grandfather 放行、无需再确认。
 
@@ -233,34 +235,6 @@ reference_video 模式返回这两个动作。
 两条路径都把 `next_action.args` 与 `requested_ids` 原样传给 subagent，由 subagent 按上面映射调用工具。
 
 > **切换 `grid_storyboard` 后的重做**：本阶段的常规触发条件是「缺分镜图」，而用户在设置页切换该开关不会让已有分镜图失效，剧本里也不记录分镜图由哪种装配方式产出——单看缺图会把整集判成已完成。用户在已有分镜图的项目上切换开关后要求按新方式出图时，与其确认要重做的片段范围，再显式带 ID 重生：切到宫格用 `mcp__arcreel__generate_grid({"script": "episode_{N}.json", "scene_ids": [...]})`，切回单图用 `mcp__arcreel__generate_storyboards({"script": "episode_{N}.json", "segment_ids": [...]})`（`script` 必填；ID 列表省略时只补缺图，达不到重做效果）。已生成的视频同样不会自动失效，重出分镜图后需按新图重跑阶段 7 对应片段。
-
-### storyboard 模式（grid_storyboard=false）
-
-**dispatch `generate-assets` subagent**：
-
-```text
-dispatch `generate-assets` subagent：
-  任务类型：storyboard
-  项目名称：{project_name}
-  工具调用：
-    mcp__arcreel__generate_storyboards({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 storyboard_image 字段
-```
-
-### storyboard 模式，grid_storyboard=true
-
-**dispatch `generate-assets` subagent**：
-
-```text
-dispatch `generate-assets` subagent：
-  任务类型：storyboard
-  项目名称：{project_name}
-  工具调用：
-    mcp__arcreel__generate_grid({"script": "episode_{N}.json"})
-  验证方式：重新读取 scripts/episode_{N}.json，检查各场景的 storyboard_image 字段
-```
-
----
 
 ## 阶段 7：视频生成
 

--- a/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/manga-workflow/SKILL.narration.md
@@ -167,8 +167,9 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ```text
 对于 type ∈ {character, scene, prop}:
-  若该类存在缺 *_sheet 项 → dispatch 对应的 `generate-assets` subagent
-  若该类均已齐全         → 跳过，不 dispatch
+  names = artifacts.asset_sheets[type].missing_ids ∩ requested_ids
+  若 names 非空 → dispatch 对应的 `generate-assets` subagent，并把 names 原样传给 subagent 和工具
+  若 names 为空 → 跳过，不 dispatch；不得回退到整类 missing_ids
 
 三类判断彼此独立，结果可能 dispatch 0~3 个 subagent。
 所有 dispatch 的 subagent 返回后，合并摘要展示给用户，进入阶段间确认。
@@ -178,13 +179,13 @@ dispatch prompt 通用参数：项目名称、项目路径、集数、本集小�
 
 ### subagent — 角色设计
 
-**触发**：有角色缺少 character_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：character
   项目名称：{project_name}
-  待生成项：{缺失角色名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "character", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应角色的 character_sheet 字段
@@ -192,13 +193,13 @@ dispatch `generate-assets` subagent：
 
 ### subagent — 场景设计
 
-**触发**：有场景缺少 scene_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：scene
   项目名称：{project_name}
-  待生成项：{缺失场景名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "scene", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应场景的 scene_sheet 字段
@@ -206,13 +207,13 @@ dispatch `generate-assets` subagent：
 
 ### subagent — 道具设计
 
-**触发**：有道具缺少 prop_sheet
+**触发**：该类 `names` 交集非空
 
 ```text
 dispatch `generate-assets` subagent：
   任务类型：prop
   项目名称：{project_name}
-  待生成项：{缺失道具名列表}
+  待生成项：{names 交集}
   工具调用：
     mcp__arcreel__generate_assets({"type": "prop", "names": [该类型 requested_ids]})
   验证方式：重新读取 project.json，检查对应道具的 prop_sheet 字段

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1421,6 +1421,8 @@ export default {
   // server/agent_runtime/sdk_tools/__init__.py; tests/test_frontend_mcp_tool_i18n.py
   // enforces all locales stay in sync — adding a backend tool without wiring zh/en/vi fails CI)
   'tool_name_list_pending_assets': 'List pending assets',
+  'tool_name_complete_asset_inventory': 'Complete asset inventory',
+  'tool_name_get_workflow_status': 'Get workflow status',
   'tool_name_generate_assets': 'Generate assets',
   'tool_name_generate_storyboards': 'Generate storyboards',
   'tool_name_edit_images': 'Edit images',

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1422,6 +1422,7 @@ export default {
   // enforces all locales stay in sync — adding a backend tool without wiring zh/en/vi fails CI)
   'tool_name_list_pending_assets': 'List pending assets',
   'tool_name_complete_asset_inventory': 'Complete asset inventory',
+  'tool_name_complete_step1_rebuild': 'Complete step 1 rebuild',
   'tool_name_get_workflow_status': 'Get workflow status',
   'tool_name_generate_assets': 'Generate assets',
   'tool_name_generate_storyboards': 'Generate storyboards',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1544,6 +1544,7 @@ export default {
   // sẽ kiểm tra các ngôn ngữ đồng bộ, thêm tool backend mà thiếu zh/en/vi sẽ fail CI)
   'tool_name_list_pending_assets': 'Liệt kê tài sản chờ tạo',
   'tool_name_complete_asset_inventory': 'Hoàn tất kiểm kê tài sản',
+  'tool_name_complete_step1_rebuild': 'Hoàn tất tái tạo bước 1',
   'tool_name_get_workflow_status': 'Xem trạng thái quy trình',
   'tool_name_generate_assets': 'Tạo tài sản',
   'tool_name_generate_storyboards': 'Tạo storyboard',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1543,6 +1543,8 @@ export default {
   // server/agent_runtime/sdk_tools/__init__.py; tests/test_frontend_mcp_tool_i18n.py
   // sẽ kiểm tra các ngôn ngữ đồng bộ, thêm tool backend mà thiếu zh/en/vi sẽ fail CI)
   'tool_name_list_pending_assets': 'Liệt kê tài sản chờ tạo',
+  'tool_name_complete_asset_inventory': 'Hoàn tất kiểm kê tài sản',
+  'tool_name_get_workflow_status': 'Xem trạng thái quy trình',
   'tool_name_generate_assets': 'Tạo tài sản',
   'tool_name_generate_storyboards': 'Tạo storyboard',
   'tool_name_edit_images': 'Chỉnh sửa ảnh',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1420,6 +1420,8 @@ export default {
   // server/agent_runtime/sdk_tools/__init__.py; tests/test_frontend_mcp_tool_i18n.py
   // 会校验缺漏，新增 backend tool 必须同步补全 zh/en/vi)
   'tool_name_list_pending_assets': '查询待生成资产',
+  'tool_name_complete_asset_inventory': '完成资产清单分析',
+  'tool_name_get_workflow_status': '查询工作流状态',
   'tool_name_generate_assets': '生成资产',
   'tool_name_generate_storyboards': '生成分镜图',
   'tool_name_edit_images': '编辑图片',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1421,6 +1421,7 @@ export default {
   // 会校验缺漏，新增 backend tool 必须同步补全 zh/en/vi)
   'tool_name_list_pending_assets': '查询待生成资产',
   'tool_name_complete_asset_inventory': '完成资产清单分析',
+  'tool_name_complete_step1_rebuild': '完成第一阶段重建',
   'tool_name_get_workflow_status': '查询工作流状态',
   'tool_name_generate_assets': '生成资产',
   'tool_name_generate_storyboards': '生成分镜图',

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -1,0 +1,106 @@
+"""Atomic completion marker for project asset-inventory analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from lib.project_manager import ProjectManager
+from lib.source_revision import SourceRevisionBlocker, SourceScope, compute_source_revision
+
+
+class AssetInventoryError(ValueError):
+    """Base class for inventory completion failures."""
+
+
+class AssetInventoryRevisionConflict(AssetInventoryError):
+    """The analyzed source changed before its completion marker was committed."""
+
+    def __init__(self, expected_revision: str, actual_revision: str) -> None:
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+        super().__init__("source revision changed before asset inventory completion")
+
+
+class AssetInventorySourceBlocked(AssetInventoryError):
+    """The requested source scope cannot be safely revised."""
+
+    def __init__(self, blockers: list[SourceRevisionBlocker]) -> None:
+        self.blockers = blockers
+        super().__init__("source scope is blocked")
+
+
+@dataclass(frozen=True)
+class AssetInventoryCompletion:
+    scope: SourceScope
+    source_revision: str
+    counts: dict[str, int]
+
+
+def _bucket_count(value: object) -> int:
+    return len(value) if isinstance(value, Mapping) else 0
+
+
+def complete_asset_inventory(
+    pm: ProjectManager,
+    project_name: str,
+    scope: SourceScope,
+    expected_source_revision: str,
+) -> AssetInventoryCompletion:
+    """Validate and persist an inventory fact within one project lock."""
+
+    if not expected_source_revision.startswith("sha256-v1:"):
+        raise AssetInventoryError("expected_source_revision must be a sha256-v1 revision")
+
+    result: AssetInventoryCompletion | None = None
+    project_path = pm.get_project_path(project_name)
+
+    def _mutate(project: dict[str, Any]) -> None:
+        nonlocal result
+        revision = compute_source_revision(project_path, project, scope)
+        if revision.blockers:
+            raise AssetInventorySourceBlocked(revision.blockers)
+        if revision.revision is None:
+            raise AssetInventoryError("source revision is unavailable")
+        if revision.revision != expected_source_revision:
+            raise AssetInventoryRevisionConflict(expected_source_revision, revision.revision)
+        completed_scope = revision.scope
+        if completed_scope is None:
+            raise AssetInventoryError("source scope is unavailable")
+
+        workflow = project.get("workflow")
+        if workflow is None:
+            workflow = {}
+            project["workflow"] = workflow
+        elif not isinstance(workflow, dict):
+            raise AssetInventoryError("workflow must be an object")
+        workflow["asset_inventory"] = {
+            "scope": completed_scope.model_dump(mode="json"),
+            "source_revision": revision.revision,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        result = AssetInventoryCompletion(
+            scope=completed_scope,
+            source_revision=revision.revision,
+            counts={
+                "characters": _bucket_count(project.get("characters")),
+                "scenes": _bucket_count(project.get("scenes")),
+                "props": _bucket_count(project.get("props")),
+            },
+        )
+
+    pm.update_project(project_name, _mutate)
+    if result is None:  # pragma: no cover - update_project always invokes the callback or raises
+        raise RuntimeError("asset inventory completion did not run")
+    return result
+
+
+__all__ = [
+    "AssetInventoryCompletion",
+    "AssetInventoryError",
+    "AssetInventoryRevisionConflict",
+    "AssetInventorySourceBlocked",
+    "complete_asset_inventory",
+]

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -55,7 +56,10 @@ def complete_asset_inventory(
 ) -> AssetInventoryCompletion:
     """Validate and persist an inventory fact within one project lock."""
 
-    if not isinstance(expected_source_revision, str) or not expected_source_revision.startswith("sha256-v1:"):
+    if (
+        not isinstance(expected_source_revision, str)
+        or re.fullmatch(r"sha256-v1:[0-9a-f]{64}", expected_source_revision) is None
+    ):
         raise AssetInventoryInvalidRequest("expected_source_revision must be a sha256-v1 revision")
 
     result: AssetInventoryCompletion | None = None

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -51,11 +51,11 @@ def complete_asset_inventory(
     pm: ProjectManager,
     project_name: str,
     scope: SourceScope,
-    expected_source_revision: str,
+    expected_source_revision: object,
 ) -> AssetInventoryCompletion:
     """Validate and persist an inventory fact within one project lock."""
 
-    if not expected_source_revision.startswith("sha256-v1:"):
+    if not isinstance(expected_source_revision, str) or not expected_source_revision.startswith("sha256-v1:"):
         raise AssetInventoryInvalidRequest("expected_source_revision must be a sha256-v1 revision")
 
     result: AssetInventoryCompletion | None = None

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
 from lib.project_manager import ProjectManager
 from lib.source_revision import SourceRevisionBlocker, SourceScope, compute_source_revision
 
@@ -53,14 +54,17 @@ def complete_asset_inventory(
     project_name: str,
     scope: SourceScope,
     expected_source_revision: object,
+    entries: object = None,
 ) -> AssetInventoryCompletion:
-    """Validate and persist an inventory fact within one project lock."""
+    """Validate and atomically persist extracted assets plus their inventory fact."""
 
     if (
         not isinstance(expected_source_revision, str)
         or re.fullmatch(r"sha256-v1:[0-9a-f]{64}", expected_source_revision) is None
     ):
         raise AssetInventoryInvalidRequest("expected_source_revision must be a sha256-v1 revision")
+
+    prepared = _prepare_entries(entries)
 
     result: AssetInventoryCompletion | None = None
     project_path = pm.get_project_path(project_name)
@@ -77,6 +81,25 @@ def complete_asset_inventory(
         completed_scope = revision.scope
         if completed_scope is None:
             raise AssetInventoryError("source scope is unavailable")
+
+        # Extracted definitions and the marker are one transaction.  The source revision is checked
+        # before any in-memory mutation; update_project writes only after this callback returns, so a
+        # conflict cannot leave stale definitions behind without a matching completion fact.
+        from lib.data_validator import DataValidator
+
+        before_errors = set(DataValidator(str(pm.projects_root)).validate_project_payload(project).errors)
+        for bucket_name, bucket_entries in prepared.items():
+            bucket = project.setdefault(bucket_name, {})
+            if not isinstance(bucket, dict):
+                raise AssetInventoryError(f"project[{bucket_name!r}] must be an object")
+            for name, entry in bucket_entries.items():
+                if resolve_asset_key(bucket, name) is not None:
+                    continue
+                bucket[name] = entry
+        after_errors = set(DataValidator(str(pm.projects_root)).validate_project_payload(project).errors)
+        new_errors = after_errors - before_errors
+        if new_errors:
+            raise AssetInventoryInvalidRequest("invalid asset entries: " + "; ".join(sorted(new_errors)))
 
         workflow = project.get("workflow")
         if workflow is None:
@@ -103,6 +126,54 @@ def complete_asset_inventory(
     if result is None:  # pragma: no cover - update_project always invokes the callback or raises
         raise RuntimeError("asset inventory completion did not run")
     return result
+
+
+def _prepare_entries(entries: object) -> dict[str, dict[str, dict[str, Any]]]:
+    """Normalize the three extraction buckets before entering the project transaction."""
+
+    if entries is None:
+        return {}
+    if not isinstance(entries, Mapping):
+        raise AssetInventoryInvalidRequest("entries must be an object")
+    allowed_buckets = {spec.bucket_key: spec for kind, spec in ASSET_SPECS.items() if kind != "product"}
+    unknown = sorted(str(key) for key in entries if key not in allowed_buckets)
+    if unknown:
+        raise AssetInventoryInvalidRequest(f"entries contains unsupported buckets: {unknown}")
+
+    prepared: dict[str, dict[str, dict[str, Any]]] = {}
+    for bucket_name, raw_entries in entries.items():
+        if not isinstance(bucket_name, str) or not isinstance(raw_entries, Mapping):
+            raise AssetInventoryInvalidRequest(f"entries[{bucket_name!r}] must be an object")
+        spec = allowed_buckets[bucket_name]
+        allowed_fields = {"description", *spec.agent_editable_extra_fields}
+        normalized: dict[str, dict[str, Any]] = {}
+        for raw_name, raw_attrs in raw_entries.items():
+            try:
+                name = validate_asset_name(raw_name)
+            except ValueError as exc:
+                raise AssetInventoryInvalidRequest(f"{bucket_name}: {exc}") from exc
+            if name in normalized:
+                raise AssetInventoryInvalidRequest(f"{bucket_name} contains duplicate normalized name {name!r}")
+            if not isinstance(raw_attrs, Mapping):
+                raise AssetInventoryInvalidRequest(f"{bucket_name}[{name!r}] must be an object")
+            extra = sorted(str(key) for key in raw_attrs if key not in allowed_fields)
+            if extra:
+                raise AssetInventoryInvalidRequest(f"{bucket_name}[{name!r}] contains unsupported fields: {extra}")
+            attrs = dict(raw_attrs)
+            description = attrs.get("description")
+            if not isinstance(description, str):
+                raise AssetInventoryInvalidRequest(f"{bucket_name}[{name!r}].description must be a string")
+            for field in spec.agent_editable_extra_fields:
+                if field in attrs and not isinstance(attrs[field], str):
+                    raise AssetInventoryInvalidRequest(f"{bucket_name}[{name!r}].{field} must be a string")
+            entry: dict[str, Any] = {"description": description, spec.sheet_field: ""}
+            for field in spec.extra_string_fields:
+                entry[field] = attrs.get(field, "")
+            for field in spec.extra_list_fields:
+                entry[field] = []
+            normalized[name] = entry
+        prepared[bucket_name] = normalized
+    return prepared
 
 
 __all__ = [

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -15,6 +15,10 @@ class AssetInventoryError(ValueError):
     """Base class for inventory completion failures."""
 
 
+class AssetInventoryInvalidRequest(AssetInventoryError):
+    """The completion request itself is malformed."""
+
+
 class AssetInventoryRevisionConflict(AssetInventoryError):
     """The analyzed source changed before its completion marker was committed."""
 
@@ -52,7 +56,7 @@ def complete_asset_inventory(
     """Validate and persist an inventory fact within one project lock."""
 
     if not expected_source_revision.startswith("sha256-v1:"):
-        raise AssetInventoryError("expected_source_revision must be a sha256-v1 revision")
+        raise AssetInventoryInvalidRequest("expected_source_revision must be a sha256-v1 revision")
 
     result: AssetInventoryCompletion | None = None
     project_path = pm.get_project_path(project_name)
@@ -100,6 +104,7 @@ def complete_asset_inventory(
 __all__ = [
     "AssetInventoryCompletion",
     "AssetInventoryError",
+    "AssetInventoryInvalidRequest",
     "AssetInventoryRevisionConflict",
     "AssetInventorySourceBlocked",
     "complete_asset_inventory",

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -38,7 +38,12 @@ from lib.script_models import (
     ad_script_total_duration,
     resolve_content_mode,
 )
-from lib.script_skeleton import SkeletonRouteMismatchError, ensure_route_skeleton, resolve_declared_kind
+from lib.script_skeleton import (
+    STORYBOARD_ITEM_ID_PATTERN,
+    SkeletonRouteMismatchError,
+    ensure_route_skeleton,
+    resolve_declared_kind,
+)
 from lib.speech_rate import (
     MAX_SPEECH_RATE_UPS,
     MIN_SPEECH_RATE_UPS,
@@ -137,7 +142,7 @@ class DataValidator:
     # 参考生视频 unit 时长的结构合理性区间，真相源同上（档位成员校验依赖运行时模型能力，
     # 不在归档层做）。
     VALID_UNIT_DURATION_RANGE = REFERENCE_UNIT_DURATION_RANGE
-    ID_PATTERN = re.compile(r"^E\d+S\d+(?:_\d+)?$")
+    ID_PATTERN = STORYBOARD_ITEM_ID_PATTERN
     EXTERNAL_URI_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
     ALLOWED_ROOT_ENTRIES = {
         "project.json",

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -633,6 +633,12 @@ class DataValidator:
         self._validate_project_payload(project, errors, warnings)
         return ValidationResult(valid=len(errors) == 0, error_messages=errors, warning_messages=warnings)
 
+    def validate_asset_definitions(self, project: dict[str, Any]) -> ValidationResult:
+        """Validate the asset-entry subset of an in-memory project payload."""
+        result = self.validate_project_payload(project)
+        errors = [message for message in result.error_messages if message.key.startswith("val_asset_")]
+        return ValidationResult(valid=not errors, error_messages=errors)
+
     def validate_project(self, project_name: str) -> ValidationResult:
         """验证 project.json"""
         return self.validate_project_dir(self.projects_root / project_name)

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -1355,6 +1355,8 @@ class DataValidator:
         episode: dict[str, Any],
         errors: list[ValidationMessage],
         warnings: list[ValidationMessage],
+        *,
+        validate_artifacts: bool = True,
     ) -> None:
         project_characters = set(project.get("characters", {}).keys())
         project_scenes = set(project.get("scenes", {}).keys())
@@ -1407,6 +1409,7 @@ class DataValidator:
             # 按骨架的检查。同一闸门在生成入口拒绝生成，此处只是把同一事实报告出来。
             errors.append(exc.to_validation_message())
             return
+        artifact_root = project_dir if validate_artifacts else None
         if kind == "video_units":
             self._validate_reference_video_script(
                 episode.get("video_units", []),
@@ -1415,7 +1418,7 @@ class DataValidator:
                 project_props,
                 errors,
                 warnings,
-                project_dir=project_dir,
+                project_dir=artifact_root,
             )
         elif kind == "segments":
             self._validate_segments(
@@ -1425,7 +1428,7 @@ class DataValidator:
                 project_props,
                 errors,
                 warnings,
-                project_dir=project_dir,
+                project_dir=artifact_root,
             )
         elif kind == "shots":
             raw_products = project.get("products")
@@ -1438,7 +1441,7 @@ class DataValidator:
                 set(raw_products.keys()) if isinstance(raw_products, dict) else set(),
                 errors,
                 warnings,
-                project_dir=project_dir,
+                project_dir=artifact_root,
                 reference_mode=gen_mode == "reference_video",
             )
             self._warn_ad_target_duration_drift(project, shots, warnings)
@@ -1462,7 +1465,7 @@ class DataValidator:
                 project_props,
                 errors,
                 warnings,
-                project_dir=project_dir,
+                project_dir=artifact_root,
                 language=scene_language,
                 speech_rate_override=scene_speech_rate,
             )
@@ -1473,15 +1476,37 @@ class DataValidator:
         """验证 episode JSON"""
         return self.validate_episode_file(self.projects_root / project_name, episode_file)
 
+    def validate_episode_payload(
+        self,
+        project_dir: Path,
+        project: dict[str, Any],
+        episode: dict[str, Any],
+        *,
+        validate_artifacts: bool = True,
+    ) -> ValidationResult:
+        """Validate an already loaded episode without reading or rewriting project files.
+
+        Callers that classify artifact readiness separately can disable filesystem artifact
+        checks while retaining the shared episode structure and reference validation.
+        """
+        errors: list[ValidationMessage] = []
+        warnings: list[ValidationMessage] = []
+        self._validate_episode_payload(
+            Path(project_dir),
+            project,
+            episode,
+            errors,
+            warnings,
+            validate_artifacts=validate_artifacts,
+        )
+        return ValidationResult(valid=len(errors) == 0, error_messages=errors, warning_messages=warnings)
+
     def validate_episode_file(
         self,
         project_dir: Path,
         episode_file: str | Path,
     ) -> ValidationResult:
         """验证指定目录中的剧本文件。"""
-        errors: list[ValidationMessage] = []
-        warnings: list[ValidationMessage] = []
-
         project_dir = Path(project_dir)
         project_path = project_dir / "project.json"
         project = load_json_or_none(project_path)
@@ -1510,8 +1535,7 @@ class DataValidator:
                 error_messages=[_m("val_cannot_load_script", path=episode_path)],
             )
 
-        self._validate_episode_payload(project_dir, project, episode, errors, warnings)
-        return ValidationResult(valid=len(errors) == 0, error_messages=errors, warning_messages=warnings)
+        return self.validate_episode_payload(project_dir, project, episode)
 
     def validate_project_tree(self, project_dir: str | Path) -> ValidationResult:
         """

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -367,14 +367,14 @@ class DataValidator:
         content_mode = project.get("content_mode")
         if not content_mode:
             errors.append(_m("val_missing_field", field="content_mode"))
-        elif content_mode not in self.VALID_CONTENT_MODES:
+        elif not isinstance(content_mode, str) or content_mode not in self.VALID_CONTENT_MODES:
             errors.append(
                 _m("val_content_mode_invalid", value=content_mode, allowed=_allowed(self.VALID_CONTENT_MODES))
             )
 
         # source_kind 缺省 novel：缺失字段（存量项目）放行，仅拦截非法值（如 screen_play）。
         source_kind = project.get("source_kind")
-        if source_kind is not None and source_kind not in self.VALID_SOURCE_KINDS:
+        if source_kind is not None and (not isinstance(source_kind, str) or source_kind not in self.VALID_SOURCE_KINDS):
             errors.append(_m("val_source_kind_invalid", value=source_kind, allowed=_allowed(self.VALID_SOURCE_KINDS)))
 
         # 生成路线必填二值：存量项目由 v4→v5 迁移补写显式值（含 grid 重编码），无缺省语义

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from lib import script_review
 from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
     SourceDoc,
@@ -558,6 +559,10 @@ class EpisodePlanner:
                 # 需重做下游产物，产物本身不删除
                 if has_downstream_products(self.project_path, num, entry):
                     entry["ledger_status"] = "stale"
+                    step1_path = script_review.step1_path(self.project_path, p, num)
+                    entry[script_review.STALE_STEP1_REVISION_FIELD] = (
+                        script_review.content_fingerprint(step1_path) if step1_path is not None else None
+                    )
                     committed["stale"].append(num)
                 episodes_list.append(entry)
                 summaries.append(

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -968,6 +968,12 @@ class ProjectManager:
                 atomic_write_json(real, script)
         return script
 
+    def load_script_readonly(self, project_name: str, filename: str) -> dict:
+        """Load a script with in-memory compatibility migrations but never persist them."""
+        norm = self.normalize_script_filename(filename)
+        script, _migrated = self._read_script_unlocked(project_name, norm)
+        return script
+
     def _read_script_unlocked(self, project_name: str, filename: str) -> tuple[dict, bool]:
         """裸读剧本并就地跑存量迁移，返回 ``(剧本, 是否发生迁移)``；**不取剧本锁**。
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1452,6 +1452,16 @@ class ProjectManager:
             )
         return project
 
+    def load_project_readonly(self, project_name: str) -> dict:
+        """Load an in-memory migrated project snapshot without locking or persisting it."""
+        project_file = self._get_project_file_path(project_name)
+        if not project_file.exists():
+            raise FileNotFoundError(f"项目元数据文件不存在: {project_file}")
+        with open(project_file, encoding="utf-8") as f:  # noqa: PTH123
+            project = json.load(f)
+        self._migrate_legacy_style(project)
+        return project
+
     @contextmanager
     def _project_lock(self, project_name: str):
         """通过隐藏 lock file 获取项目文件的排他锁。

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -15,7 +15,7 @@ import secrets
 import shutil
 import time
 import unicodedata
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import ExitStack, contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1458,6 +1458,20 @@ class ProjectManager:
         lock_path.touch(exist_ok=True)
         with portalocker.Lock(lock_path, flags=portalocker.LOCK_EX):
             yield
+
+    @contextmanager
+    def locked_source_mutation(self, project_name: str) -> Iterator[Path]:
+        """Serialize source-file mutations with project transactions.
+
+        Workflow facts such as asset-inventory completion compute source revisions while
+        holding the project lock. Source writers must use this context so a revision check
+        and its matching project.json commit observe one immutable source snapshot.
+        """
+        project_path = self.get_project_path(project_name)
+        with self._project_lock(project_name):
+            source_dir = project_path / "source"
+            source_dir.mkdir(parents=True, exist_ok=True)
+            yield source_dir
 
     @contextmanager
     def file_lock(self, path: Path):

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -79,7 +79,12 @@ from lib.script_models import (
     merge_drama_visual_into_scenes,
     script_duration_total,
 )
-from lib.script_review import gate_blocks_step2, migrate_step1_draft_in_place
+from lib.script_review import (
+    SCRIPT_STEP1_REVISION_FIELD,
+    content_fingerprint_of_data,
+    gate_blocks_step2,
+    migrate_step1_draft_in_place,
+)
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.speech_rate import project_speech_rate_override
 from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
@@ -164,6 +169,7 @@ class ScriptGenerator:
         """
         self.project_path = Path(project_path)
         self.generator = generator
+        self._step1_revision: str | None = None
 
         # 加载 project.json
         self.project_json = self._load_project_json()
@@ -233,6 +239,7 @@ class ScriptGenerator:
         ):
             raise ValueError(f"output_filename 只接受纯文件名，不允许目录或路径分隔符: {output_filename!r}")
 
+        self._step1_revision = None
         gen_mode = self.generation_mode
 
         # ad 剧本骨架唯一（平铺 shots[]），先于 generation_mode 分派：即使
@@ -908,6 +915,7 @@ class ScriptGenerator:
                 update_project=lambda mutate: pm.update_project(self.project_path.name, mutate),
                 supported_durations=supported_durations,
             )
+            self._step1_revision = content_fingerprint_of_data(raw)
 
         # 迁移带 warnings 说明 clamp 改写了实际秒数，那是内容变更、审阅确认随之失效。而 gate
         # 放行据的是改写前的状态：不在此处补判，生成就会拿着用户从未过目的秒数走完付费的
@@ -978,6 +986,7 @@ class ScriptGenerator:
             raw = json.loads(step1_json.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
             raise ValueError(f"step1_segments.json 解析失败: {e}")
+        self._step1_revision = content_fingerprint_of_data(raw)
 
         try:
             draft = NarrationStep1Draft.model_validate(raw)
@@ -1024,6 +1033,7 @@ class ScriptGenerator:
             raise ValueError(f"Step 1 内容文件不是合法 JSON（drama step1 应为结构化内容）: {e}")
         if not isinstance(data, dict):
             raise ValueError("Step 1 内容文件结构异常：顶层应为对象 {title, scenes}")
+        self._step1_revision = content_fingerprint_of_data(data)
         scenes = data.get("scenes")
         if not isinstance(scenes, list) or not scenes:
             raise ValueError("Step 1 内容文件结构异常：scenes 必须是非空的场景对象数组")
@@ -1525,6 +1535,9 @@ class ScriptGenerator:
         script_data["metadata"]["created_at"] = now
         script_data["metadata"]["updated_at"] = now
         script_data["metadata"]["generator"] = self.generator.model if self.generator else "unknown"
+        step1_revision = getattr(self, "_step1_revision", None)
+        if step1_revision is not None:
+            script_data["metadata"][SCRIPT_STEP1_REVISION_FIELD] = step1_revision
 
         # 计算统计信息（episode 级角色/场景/道具聚合由 StatusCalculator 读时计算）。
         # 数组键经上方规范解析所得 kind 查表；计数键名为业务附着、随 kind 显式保留。

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -58,6 +58,9 @@ REVIEW_FIELD = "step1_review"
 #: stale 账本条目记录重规划提交时旧 step1 的内容指纹；live 指纹变化即证明 step1 已按新账本重建。
 STALE_STEP1_REVISION_FIELD = "stale_step1_revision"
 
+#: stale 分集的 step1 重建完成事实。指纹可能与旧内容相同，不能仅以内容变化推断是否执行过重建。
+STALE_STEP1_REBUILT_REVISION_FIELD = "stale_step1_rebuilt_revision"
+
 #: 最终剧本 metadata 记录其实际消费的 step1 内容指纹；workflow status 用它识别 step1
 #: 重新确认后仍残留的旧剧本，避免仅凭「文件存在」误判 step2 已完成。
 SCRIPT_STEP1_REVISION_FIELD = "step1_revision"
@@ -174,6 +177,48 @@ class Step1WriteConflict(Exception):
         self.expected = expected
         self.actual = actual
         self.current_content = current_content
+
+
+class Step1RebuildCompletionError(ValueError):
+    """A stale step1 rebuild cannot be recorded against the current ledger state."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(detail)
+        self.code = code
+
+
+def complete_stale_step1_rebuild(
+    pm: ProjectManager,
+    project_name: str,
+    episode: int,
+    expected_stale_revision: str | None,
+) -> str:
+    """Record preprocessing completion for a stale entry, including byte-identical rebuilds."""
+    if isinstance(episode, bool) or episode < 1:
+        raise Step1RebuildCompletionError("invalid_episode", "episode must be a positive integer")
+
+    project_path = pm.get_project_path(project_name)
+    committed: dict[str, str] = {}
+
+    def _commit(project: dict[str, Any]) -> None:
+        entry = find_episode(project, episode)
+        if entry is None or entry.get("ledger_status") != "stale":
+            raise Step1RebuildCompletionError("not_stale", "episode is not awaiting a stale step1 rebuild")
+        if STALE_STEP1_REVISION_FIELD not in entry:
+            raise Step1RebuildCompletionError("missing_baseline", "stale episode has no rebuild baseline")
+        if entry.get(STALE_STEP1_REVISION_FIELD) != expected_stale_revision:
+            raise Step1RebuildCompletionError(
+                "baseline_conflict", "stale step1 baseline changed; refresh workflow status"
+            )
+        path = step1_path(project_path, project, episode)
+        revision = content_fingerprint(path) if path is not None else None
+        if revision is None:
+            raise Step1RebuildCompletionError("step1_missing", "rebuilt step1 file is missing")
+        entry[STALE_STEP1_REBUILT_REVISION_FIELD] = revision
+        committed["revision"] = revision
+
+    pm.update_project(project_name, _commit)
+    return committed["revision"]
 
 
 def assert_base_fingerprint(path: Path, expected: str | None | _UncheckedFingerprint) -> None:

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -55,6 +55,9 @@ ReviewStatus = Literal["not_applicable", "no_step1", "pending_review", "confirme
 #: 确认记录在 episode 条目上的字段名：``{"fingerprint": str, "confirmed_at": ISO8601}``。
 REVIEW_FIELD = "step1_review"
 
+#: stale 账本条目记录重规划提交时旧 step1 的内容指纹；live 指纹变化即证明 step1 已按新账本重建。
+STALE_STEP1_REVISION_FIELD = "stale_step1_revision"
+
 #: step1 变体：drama / narration（按 content_mode）+ reference_video（按项目生成路线，跨 content_mode）。
 #: 决定 step1 文件名与结构校验模型；三者共用同一审核 gate。
 Step1Kind = Literal["drama", "narration", "reference_video"]

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -58,6 +58,10 @@ REVIEW_FIELD = "step1_review"
 #: stale 账本条目记录重规划提交时旧 step1 的内容指纹；live 指纹变化即证明 step1 已按新账本重建。
 STALE_STEP1_REVISION_FIELD = "stale_step1_revision"
 
+#: 最终剧本 metadata 记录其实际消费的 step1 内容指纹；workflow status 用它识别 step1
+#: 重新确认后仍残留的旧剧本，避免仅凭「文件存在」误判 step2 已完成。
+SCRIPT_STEP1_REVISION_FIELD = "step1_revision"
+
 #: step1 变体：drama / narration（按 content_mode）+ reference_video（按项目生成路线，跨 content_mode）。
 #: 决定 step1 文件名与结构校验模型；三者共用同一审核 gate。
 Step1Kind = Literal["drama", "narration", "reference_video"]

--- a/lib/script_skeleton.py
+++ b/lib/script_skeleton.py
@@ -22,10 +22,13 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
 from lib.validation_messages import MessageRef, ValidationMessage
+
+STORYBOARD_ITEM_ID_PATTERN = re.compile(r"^E\d+S\d+(?:_\d+)?$")
 
 
 @dataclass(frozen=True)

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -120,6 +120,8 @@ def _scoped_source_paths(
         pure = PurePosixPath(rel)
         if len(pure.parts) != 2 or pure.parts[0] != "source" or pure.suffix.lower() not in SOURCE_TEXT_SUFFIXES:
             return [], _blocked(scope, "invalid_source_scope", rel, "scoped files must be source text files")
+        if _DERIVED_EPISODE_RE.fullmatch(pure.name):
+            return [], _blocked(scope, "invalid_source_scope", rel, "derived episode files are not source text")
         if rel in seen:
             continue
         seen.add(rel)

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -111,6 +111,20 @@ def _all_source_paths(
 def _scoped_source_paths(
     project_dir: Path, scope: SourceScope
 ) -> tuple[list[tuple[str, Path]], SourceRevisionResult | None]:
+    source_dir = project_dir / "source"
+    if source_dir.is_symlink():
+        return [], _blocked(scope, "source_symlink", "source", "source directory must not be a symbolic link")
+    if source_dir.exists() and not source_dir.is_dir():
+        return [], _blocked(scope, "source_not_directory", "source", "source path is not a directory")
+    try:
+        entries = list(source_dir.iterdir()) if source_dir.exists() else []
+    except OSError as exc:
+        return [], _blocked(scope, "source_unreadable", "source", f"source directory cannot be read: {exc}")
+    by_canonical_path: dict[str, list[Path]] = {}
+    for entry in entries:
+        rel = unicodedata.normalize("NFC", f"source/{entry.name}")
+        by_canonical_path.setdefault(rel, []).append(entry)
+
     paths: list[tuple[str, Path]] = []
     seen: set[str] = set()
     for requested in scope.files:
@@ -125,7 +139,11 @@ def _scoped_source_paths(
         if rel in seen:
             continue
         seen.add(rel)
-        paths.append((rel, project_dir.joinpath(*pure.parts)))
+        candidates = by_canonical_path.get(rel, [])
+        if len(candidates) > 1:
+            return [], _blocked(scope, "source_path_collision", rel, "source paths collide after Unicode normalization")
+        path = candidates[0] if candidates else project_dir.joinpath(*pure.parts)
+        paths.append((rel, path))
     paths.sort(key=lambda item: item[0])
     return paths, None
 
@@ -163,6 +181,10 @@ def _read_sources(
             content = path.read_bytes()
         except OSError as exc:
             return [], _blocked(scope, "source_unreadable", rel, f"source file cannot be read: {exc}")
+        try:
+            content.decode("utf-8")
+        except UnicodeDecodeError:
+            return [], _blocked(scope, "source_unreadable", rel, "source file is not valid UTF-8")
         fingerprints.append((rel, hashlib.sha256(content).hexdigest()))
     return fingerprints, None
 

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -216,8 +216,9 @@ def compute_source_revision(
     if error is not None:
         return error
 
+    canonical_fingerprints = sorted(fingerprints, key=lambda item: item[0])
     payload = {
-        "files": [{"path": rel, "sha256": digest} for rel, digest in fingerprints],
+        "files": [{"path": rel, "sha256": digest} for rel, digest in canonical_fingerprints],
         "source_kind": project.get("source_kind", "novel"),
         "source_language": project.get("source_language"),
     }

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -1,0 +1,217 @@
+"""Deterministic revisions for the source text covered by asset analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+import unicodedata
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
+
+_DERIVED_EPISODE_RE = re.compile(r"episode_[0-9]+\.txt")
+
+
+class SourceScope(BaseModel):
+    """The source files included in one asset-inventory analysis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["all", "files"]
+    files: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> SourceScope:
+        if self.kind == "all" and self.files:
+            raise ValueError("all scope must not name individual files")
+        if self.kind == "files" and not self.files:
+            raise ValueError("files scope must name at least one file")
+        return self
+
+
+class SourceRevisionBlocker(BaseModel):
+    """A source condition that prevents a trustworthy revision."""
+
+    code: str
+    path: str
+    reason: str
+
+
+class SourceRevisionResult(BaseModel):
+    """Revision calculation result; blockers and a revision are mutually exclusive."""
+
+    scope: SourceScope | None
+    revision: str | None
+    files: list[str] = Field(default_factory=list)
+    blockers: list[SourceRevisionBlocker] = Field(default_factory=list)
+
+
+def _blocked(
+    scope: SourceScope | None,
+    code: str,
+    path: str,
+    reason: str,
+    *,
+    files: list[str] | None = None,
+) -> SourceRevisionResult:
+    return SourceRevisionResult(
+        scope=scope,
+        revision=None,
+        files=files or [],
+        blockers=[SourceRevisionBlocker(code=code, path=path, reason=reason)],
+    )
+
+
+def _canonical_relative_path(value: str) -> str | None:
+    if not value or "\\" in value or "\x00" in value:
+        return None
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or ".." in pure.parts:
+        return None
+    normalized = unicodedata.normalize("NFC", pure.as_posix())
+    if normalized in {"", "."}:
+        return None
+    return normalized
+
+
+def _all_source_paths(
+    project_dir: Path, scope: SourceScope
+) -> tuple[list[tuple[str, Path]], SourceRevisionResult | None]:
+    source_dir = project_dir / "source"
+    if source_dir.is_symlink():
+        return [], _blocked(scope, "source_symlink", "source", "source directory must not be a symbolic link")
+    if not source_dir.exists():
+        return [], None
+    if not source_dir.is_dir():
+        return [], _blocked(scope, "source_not_directory", "source", "source path is not a directory")
+    try:
+        entries = list(source_dir.iterdir())
+    except OSError as exc:
+        return [], _blocked(scope, "source_unreadable", "source", f"source directory cannot be read: {exc}")
+
+    paths: list[tuple[str, Path]] = []
+    for path in entries:
+        name = path.name
+        if name.startswith((".", "_")) or path.suffix.lower() not in SOURCE_TEXT_SUFFIXES:
+            continue
+        if _DERIVED_EPISODE_RE.fullmatch(name):
+            continue
+        rel = unicodedata.normalize("NFC", f"source/{name}")
+        paths.append((rel, path))
+    paths.sort(key=lambda item: item[0])
+    return paths, None
+
+
+def _scoped_source_paths(
+    project_dir: Path, scope: SourceScope
+) -> tuple[list[tuple[str, Path]], SourceRevisionResult | None]:
+    paths: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    for requested in scope.files:
+        rel = _canonical_relative_path(requested)
+        if rel is None:
+            return [], _blocked(scope, "source_path_escape", str(requested), "source path must be project-relative")
+        pure = PurePosixPath(rel)
+        if len(pure.parts) != 2 or pure.parts[0] != "source" or pure.suffix.lower() not in SOURCE_TEXT_SUFFIXES:
+            return [], _blocked(scope, "invalid_source_scope", rel, "scoped files must be source text files")
+        if rel in seen:
+            continue
+        seen.add(rel)
+        paths.append((rel, project_dir.joinpath(*pure.parts)))
+    paths.sort(key=lambda item: item[0])
+    return paths, None
+
+
+def _read_sources(
+    project_dir: Path,
+    scope: SourceScope,
+    paths: list[tuple[str, Path]],
+) -> tuple[list[tuple[str, str]], SourceRevisionResult | None]:
+    project_real = project_dir.resolve()
+    fingerprints: list[tuple[str, str]] = []
+    canonical_paths: set[str] = set()
+    for rel, path in paths:
+        if rel in canonical_paths:
+            return [], _blocked(scope, "source_path_collision", rel, "source paths collide after Unicode normalization")
+        canonical_paths.add(rel)
+        if path.is_symlink():
+            return [], _blocked(scope, "source_symlink", rel, "source file must not be a symbolic link")
+        try:
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(project_real)
+        except FileNotFoundError:
+            return [], _blocked(scope, "source_missing", rel, "source file does not exist")
+        except (OSError, ValueError):
+            return [], _blocked(scope, "source_path_escape", rel, "source file resolves outside the project")
+        try:
+            mode = path.stat().st_mode
+        except OSError as exc:
+            return [], _blocked(scope, "source_unreadable", rel, f"source metadata cannot be read: {exc}")
+        if not stat.S_ISREG(mode):
+            return [], _blocked(scope, "source_not_file", rel, "source path is not a regular file")
+        if mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH) == 0:
+            return [], _blocked(scope, "source_unreadable", rel, "source file has no read permission")
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            return [], _blocked(scope, "source_unreadable", rel, f"source file cannot be read: {exc}")
+        fingerprints.append((rel, hashlib.sha256(content).hexdigest()))
+    return fingerprints, None
+
+
+def compute_source_revision(
+    project_dir: Path,
+    project: Mapping[str, Any],
+    scope: SourceScope | Mapping[str, Any],
+) -> SourceRevisionResult:
+    """Compute a revision from canonical paths, raw bytes, and source semantics.
+
+    Invalid or unsafe input is represented as a blocker so status consumers can
+    remain available and explain how to recover instead of silently omitting it.
+    """
+
+    try:
+        parsed_scope = scope if isinstance(scope, SourceScope) else SourceScope.model_validate(scope)
+    except ValidationError as exc:
+        return _blocked(None, "invalid_source_scope", "workflow.asset_inventory.scope", str(exc))
+
+    if parsed_scope.kind == "all":
+        paths, error = _all_source_paths(project_dir, parsed_scope)
+    else:
+        paths, error = _scoped_source_paths(project_dir, parsed_scope)
+    if error is not None:
+        return error
+
+    fingerprints, error = _read_sources(project_dir, parsed_scope, paths)
+    if error is not None:
+        return error
+
+    payload = {
+        "files": [{"path": rel, "sha256": digest} for rel, digest in fingerprints],
+        "source_kind": project.get("source_kind", "novel"),
+        "source_language": project.get("source_language"),
+    }
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    revision = f"sha256-v1:{hashlib.sha256(serialized).hexdigest()}"
+    canonical_scope = (
+        parsed_scope if parsed_scope.kind == "all" else SourceScope(kind="files", files=[rel for rel, _path in paths])
+    )
+    return SourceRevisionResult(
+        scope=canonical_scope,
+        revision=revision,
+        files=[rel for rel, _path in paths],
+    )
+
+
+__all__ = [
+    "SourceRevisionBlocker",
+    "SourceRevisionResult",
+    "SourceScope",
+    "compute_source_revision",
+]

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -104,7 +104,7 @@ def _all_source_paths(
             continue
         rel = unicodedata.normalize("NFC", f"source/{name}")
         paths.append((rel, path))
-    paths.sort(key=lambda item: item[0])
+    paths.sort(key=lambda item: item[1])
     return paths, None
 
 

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -544,7 +544,7 @@ class WorkflowStateService:
         return collection
 
     def get_status(self, project_name: str, episode: int | None = None) -> WorkflowStatus:
-        project = self.pm.load_project(project_name)
+        project = self.pm.load_project_readonly(project_name)
         project_path = self.pm.get_project_path(project_name)
         shared = self._shared_facts(project_path, project)
         return self._get_status(project_name, project, project_path, episode, shared)
@@ -617,10 +617,19 @@ class WorkflowStateService:
             script_path = entry.get("script_file")
             if not isinstance(script_path, str) or not script_path:
                 script_path = episode_script_relpath(number)
+            script_filename = ProjectManager.normalize_script_filename(script_path)
+            if "/" in script_filename or "\\" in script_filename:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_script_path",
+                        path=f"episodes.{number}.script_file",
+                        reason="script_file must resolve to a bare filename under scripts/",
+                    )
+                )
             target = WorkflowTarget(
                 episode=number,
                 script=script_path,
-                script_filename=ProjectManager.normalize_script_filename(script_path),
+                script_filename=script_filename,
                 source=f"source/episode_{number}.txt",
             )
 

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -292,10 +292,11 @@ class WorkflowStateService:
         if source is None or not source.files:
             return False
         recorded_fingerprints = project.get(SOURCE_FINGERPRINTS_KEY)
-        if isinstance(recorded_fingerprints, Mapping) and recorded_fingerprints:
-            current_fingerprints = compute_source_fingerprints(discover_sources(project_path))
-            if dict(recorded_fingerprints) != current_fingerprints:
-                return False
+        if not isinstance(recorded_fingerprints, Mapping) or not recorded_fingerprints:
+            return False
+        current_fingerprints = compute_source_fingerprints(discover_sources(project_path))
+        if dict(recorded_fingerprints) != current_fingerprints:
+            return False
         cursor = project.get("planning_cursor")
         if not isinstance(cursor, Mapping):
             return False
@@ -388,6 +389,17 @@ class WorkflowStateService:
                 )
                 return {"state": "blocked", "path": path}, [], kind, script
             seen_ids.add(resource_id)
+            duration = item.get("duration_seconds")
+            duration_max = 300 if kind == "video_units" else 60
+            if isinstance(duration, bool) or not isinstance(duration, int) or not 1 <= duration <= duration_max:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_script_structure",
+                        path=f"{path}.{kind}[{index}].duration_seconds",
+                        reason=f"duration_seconds must be an integer between 1 and {duration_max}",
+                    )
+                )
+                return {"state": "blocked", "path": path}, [], kind, script
         return {"state": "current", "path": path}, raw_items, kind, script
 
     @staticmethod
@@ -412,6 +424,11 @@ class WorkflowStateService:
 
         stale_ids = set(ad_stale_unit_ids(script, raw_units))
         invalid = False
+        valid_shot_ids = {
+            shot.get("shot_id")
+            for shot in script.get("shots", [])
+            if isinstance(shot, dict) and isinstance(shot.get("shot_id"), str)
+        }
         seen_unit_ids: set[str] = set()
         for index, unit in enumerate(raw_units):
             unit_id = unit.get("unit_id") if isinstance(unit, dict) else None
@@ -423,6 +440,7 @@ class WorkflowStateService:
                 or unit_id in seen_unit_ids
                 or not isinstance(shot_ids, list)
                 or not shot_ids
+                or not any(isinstance(shot_id, str) and shot_id in valid_shot_ids for shot_id in shot_ids)
                 or (references is not None and not isinstance(references, list))
             ):
                 blockers.append(

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -357,6 +357,7 @@ class WorkflowStateService:
             )
             return {"state": "blocked", "path": path}, [], kind, script
         id_field = SKELETONS[kind].id_field
+        seen_ids: set[str] = set()
         for index, item in enumerate(raw_items):
             resource_id = item.get(id_field)
             if not isinstance(resource_id, str) or not resource_id:
@@ -368,6 +369,16 @@ class WorkflowStateService:
                     )
                 )
                 return {"state": "blocked", "path": path}, [], kind, script
+            if resource_id in seen_ids:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="duplicate_script_id",
+                        path=f"{path}.{kind}[{index}].{id_field}",
+                        reason=f"duplicate {id_field}: {resource_id}",
+                    )
+                )
+                return {"state": "blocked", "path": path}, [], kind, script
+            seen_ids.add(resource_id)
         return {"state": "current", "path": path}, raw_items, kind, script
 
     @staticmethod

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
@@ -94,6 +95,15 @@ class WorkflowStatus(BaseModel):
     next_action: WorkflowNextAction
 
 
+@dataclass(frozen=True)
+class _SharedWorkflowFacts:
+    source: SourceRevisionResult | None
+    inventory: dict[str, Any]
+    sheets: dict[str, dict[str, Any]]
+    episodes: list[tuple[int, dict[str, Any]]]
+    blockers: tuple[WorkflowBlocker, ...]
+
+
 def _project_revision(project: Mapping[str, Any]) -> str:
     encoded = json.dumps(project, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return f"sha256-v1:{hashlib.sha256(encoded).hexdigest()}"
@@ -176,6 +186,7 @@ class WorkflowStateService:
         artifact["recorded_scope"] = recorded_scope.model_dump(mode="json")
         artifact["recorded_revision"] = marker.get("source_revision")
         if recorded_scope.kind != "all":
+            artifact["state"] = "partial"
             return source, artifact
         if source.blockers:
             artifact["state"] = "blocked"
@@ -412,22 +423,12 @@ class WorkflowStateService:
     def get_status(self, project_name: str, episode: int | None = None) -> WorkflowStatus:
         project = self.pm.load_project(project_name)
         project_path = self.pm.get_project_path(project_name)
-        return self._get_status(project_name, project, project_path, episode)
+        shared = self._shared_facts(project_path, project)
+        return self._get_status(project_name, project, project_path, episode, shared)
 
-    def _get_status(
-        self,
-        project_name: str,
-        project: dict[str, Any],
-        project_path: Path,
-        episode: int | None,
-    ) -> WorkflowStatus:
+    def _shared_facts(self, project_path: Path, project: dict[str, Any]) -> _SharedWorkflowFacts:
         mode = project.get("content_mode")
-        if episode is not None and (isinstance(episode, bool) or episode < 1):
-            raise ValueError("episode must be a positive integer")
-        if mode == "ad" and episode not in {None, 1}:
-            raise ValueError("ad workflow only has episode 1")
         generation_mode = project.get("generation_mode")
-        grid = bool(project.get("grid_storyboard")) and generation_mode == "storyboard"
         blockers: list[WorkflowBlocker] = []
         if mode not in {"narration", "drama", "ad"}:
             blockers.append(
@@ -437,9 +438,36 @@ class WorkflowStateService:
             blockers.append(
                 WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
             )
-
         source, inventory = self._source_inventory(project_path, project, str(mode), blockers)
         sheets = self._asset_sheets(project_path, project, blockers)
+        episodes = self._episodes(project, blockers)
+        return _SharedWorkflowFacts(
+            source=source,
+            inventory=inventory,
+            sheets=sheets,
+            episodes=episodes,
+            blockers=tuple(blockers),
+        )
+
+    def _get_status(
+        self,
+        project_name: str,
+        project: dict[str, Any],
+        project_path: Path,
+        episode: int | None,
+        shared: _SharedWorkflowFacts,
+    ) -> WorkflowStatus:
+        mode = project.get("content_mode")
+        if episode is not None and (isinstance(episode, bool) or episode < 1):
+            raise ValueError("episode must be a positive integer")
+        if mode == "ad" and episode not in {None, 1}:
+            raise ValueError("ad workflow only has episode 1")
+        generation_mode = project.get("generation_mode")
+        grid = bool(project.get("grid_storyboard")) and generation_mode == "storyboard"
+        blockers = list(shared.blockers)
+        source = shared.source
+        inventory = shared.inventory
+        sheets = shared.sheets
         artifacts: dict[str, dict[str, Any]] = {
             "asset_inventory": inventory,
             "asset_sheets": sheets,
@@ -452,7 +480,7 @@ class WorkflowStateService:
         gates: dict[str, dict[str, Any]] = {
             "step1_review": {"state": "not_applicable" if mode == "ad" else "pending", "revision": None}
         }
-        episodes = self._episodes(project, blockers)
+        episodes = shared.episodes
         selected = self._target(str(mode), episodes, episode)
         target = None
         if selected is not None:
@@ -640,7 +668,9 @@ class WorkflowStateService:
                                     status
                                     for number, _entry in episodes
                                     if number != target.episode
-                                    and (status := self._get_status(project_name, project, project_path, number)).state
+                                    and (
+                                        status := self._get_status(project_name, project, project_path, number, shared)
+                                    ).state
                                     != "EXPORT_READY"
                                 ),
                                 None,

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -143,8 +143,12 @@ def _new_source_precedes_cursor(project: Mapping[str, Any], sources: tuple[Sourc
     if not isinstance(cursor_file, str):
         return False
     canonical_cursor = unicodedata.normalize("NFC", cursor_file)
+    canonical_recorded = {
+        unicodedata.normalize("NFC", recorded_path) for recorded_path in recorded if isinstance(recorded_path, str)
+    }
     return any(
-        (canonical := unicodedata.normalize("NFC", source.rel_path)) not in recorded and canonical <= canonical_cursor
+        (canonical := unicodedata.normalize("NFC", source.rel_path)) not in canonical_recorded
+        and canonical <= canonical_cursor
         for source in sources
     )
 
@@ -576,6 +580,15 @@ class WorkflowStateService:
             blockers.append(
                 WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
             )
+        grid_storyboard = project.get("grid_storyboard")
+        if grid_storyboard is not None and not isinstance(grid_storyboard, bool):
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_grid_storyboard",
+                    path="grid_storyboard",
+                    reason="grid_storyboard must be a boolean",
+                )
+            )
         asset_validation = DataValidator(str(self.pm.projects_root)).validate_asset_definitions(project)
         if not asset_validation.valid:
             blockers.append(
@@ -616,7 +629,7 @@ class WorkflowStateService:
         if mode == "ad" and episode not in {None, 1}:
             raise ValueError("ad workflow only has episode 1")
         generation_mode = project.get("generation_mode")
-        grid = bool(project.get("grid_storyboard")) and generation_mode == "storyboard"
+        grid = project.get("grid_storyboard") is True and generation_mode == "storyboard"
         blockers = list(shared.blockers)
         source = shared.source
         inventory = shared.inventory
@@ -943,7 +956,7 @@ class WorkflowStateService:
             project=WorkflowProject(
                 content_mode=str(project.get("content_mode")),
                 generation_mode=str(project.get("generation_mode")),
-                grid_storyboard=bool(project.get("grid_storyboard")),
+                grid_storyboard=project.get("grid_storyboard") is True,
             ),
             target=target,
             state=state,

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -620,6 +620,20 @@ class WorkflowStateService:
                         "path": str(step1_path.relative_to(project_path)) if step1_path is not None else None,
                         "revision": revision,
                     }
+                    if script_review.step1_quarantined(project_path, project, target.episode):
+                        quarantine = script_review.step1_quarantine_path(project_path, project, target.episode)
+                        assert quarantine is not None
+                        artifacts["step1"]["state"] = "blocked"
+                        blockers.append(
+                            WorkflowBlocker(
+                                code="step1_quarantined",
+                                path=str(quarantine.relative_to(project_path)),
+                                reason="step1 has a quarantined draft that must be repaired and promoted",
+                            )
+                        )
+                        state = "STEP1_REVIEW"
+                        next_action = _action("none", "quarantined step1 must be repaired before confirmation")
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                     if revision is None:
                         state = "STEP1_CONTENT"
                         next_action = _action(
@@ -646,13 +660,28 @@ class WorkflowStateService:
                     project_path, project_name, project, target, blockers
                 )
                 artifacts["script"] = script_artifact
+                if (
+                    mode != "ad"
+                    and script_artifact["state"] != "missing"
+                    and script_review.stored_review(project, target.episode).get("fingerprint") is not None
+                ):
+                    metadata = script.get("metadata")
+                    generated_from = (
+                        metadata.get(script_review.SCRIPT_STEP1_REVISION_FIELD)
+                        if isinstance(metadata, Mapping)
+                        else None
+                    )
+                    if generated_from != artifacts["step1"].get("revision"):
+                        artifacts["script"]["state"] = "stale"
                 if blockers:
                     state = "FINAL_SCRIPT"
                     next_action = _action("none", "script is blocked")
-                elif script_artifact["state"] == "missing":
+                elif script_artifact["state"] in {"missing", "stale"}:
                     state = "FINAL_SCRIPT"
                     next_action = _action(
-                        "generate_script", "target episode has no final script", args={"episode": target.episode}
+                        "generate_script",
+                        "target episode has no current final script",
+                        args={"episode": target.episode},
                     )
                 else:
                     missing_sheets = [

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -301,16 +301,28 @@ class WorkflowStateService:
             return False
         rel = cursor.get("source_file")
         offset = cursor.get("offset")
+        canonical_rel = unicodedata.normalize("NFC", rel) if isinstance(rel, str) else None
         if (
-            not isinstance(rel, str)
-            or unicodedata.normalize("NFC", rel) != source.files[-1]
+            canonical_rel != source.files[-1]
             or not isinstance(offset, int)
             or isinstance(offset, bool)
         ):
             return False
         try:
-            text = (project_path / rel).read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+            source_dir = project_path / "source"
+            if source_dir.is_symlink():
+                return False
+            matching_paths = [
+                path
+                for path in source_dir.iterdir()
+                if unicodedata.normalize("NFC", f"source/{path.name}") == canonical_rel
+            ]
+            if len(matching_paths) != 1 or matching_paths[0].is_symlink():
+                return False
+            path = matching_paths[0]
+            path.resolve(strict=True).relative_to(project_path.resolve())
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError, ValueError):
             return False
         return offset >= len(normalize_source_text(text))
 

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -20,6 +20,7 @@ from lib.episode_ledger import (
     SourceDoc,
     compute_source_fingerprints,
     discover_sources,
+    episodes_without_source_range,
     mismatched_source_fingerprints,
     normalize_source_text,
     parse_positive_episode_num,
@@ -313,6 +314,16 @@ class WorkflowStateService:
                 )
                 continue
             seen.add(number)
+            ledger_status = entry.get("ledger_status")
+            if ledger_status is not None and not isinstance(ledger_status, str):
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_ledger_status",
+                        path=f"episodes[{index}].ledger_status",
+                        reason="ledger_status must be a string",
+                    )
+                )
+                continue
             parsed.append((number, entry))
         parsed.sort(key=lambda pair: pair[0])
         return parsed
@@ -329,6 +340,16 @@ class WorkflowStateService:
             return next((pair for pair in episodes if pair[0] == requested_episode), None)
         pending = [pair for pair in episodes if pair[1].get("ledger_status") in {"planned", "stale"}]
         return (pending or episodes)[0] if (pending or episodes) else None
+
+    @staticmethod
+    def _planning_action(project: dict[str, Any], reason: str) -> WorkflowNextAction:
+        if episodes_without_source_range(project):
+            return _action(
+                "reset_episode_planning",
+                "episode ledger lacks source range records",
+                args={"from_episode": 1},
+            )
+        return _action("plan_episodes", reason)
 
     @staticmethod
     def _planning_complete(
@@ -763,11 +784,11 @@ class WorkflowStateService:
                 )
                 next_action = _action("none", "requested episode is unavailable")
             else:
-                next_action = _action("plan_episodes", "episode ledger has no target episode")
+                next_action = self._planning_action(project, "episode ledger has no target episode")
         else:
             if target is None:  # defensive; ad always supplies episode 1
                 state = "EPISODE_PLAN"
-                next_action = _action("plan_episodes", "target episode is unavailable")
+                next_action = self._planning_action(project, "target episode is unavailable")
             else:
                 preprocessor = (
                     "split-reference-video-units"
@@ -992,13 +1013,13 @@ class WorkflowStateService:
                                 return later_status
                             if not shared.planning_complete:
                                 state = "EPISODE_PLAN"
-                                next_action = _action("plan_episodes", "source text remains unplanned")
+                                next_action = self._planning_action(project, "source text remains unplanned")
                             else:
                                 state = "EXPORT_READY"
                                 next_action = _action("export", "all required artifacts are usable")
                         elif mode != "ad" and not shared.planning_complete:
                             state = "EPISODE_PLAN"
-                            next_action = _action("plan_episodes", "source text remains unplanned")
+                            next_action = self._planning_action(project, "source text remains unplanned")
                         else:
                             state = "EXPORT_READY"
                             next_action = _action("export", "all required artifacts are usable")

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -26,7 +26,7 @@ from lib.path_safety import safe_exists
 from lib.project_manager import ProjectManager
 from lib.reference_video.ad_units import ad_stale_unit_ids
 from lib.script_models import get_generated_assets
-from lib.script_skeleton import SKELETONS, ensure_route_skeleton
+from lib.script_skeleton import SKELETONS, STORYBOARD_ITEM_ID_PATTERN, ensure_route_skeleton
 from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
 
 WorkflowStateName = Literal[
@@ -369,6 +369,15 @@ class WorkflowStateService:
                     )
                 )
                 return {"state": "blocked", "path": path}, [], kind, script
+            if kind != "video_units" and STORYBOARD_ITEM_ID_PATTERN.fullmatch(resource_id) is None:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_script_id",
+                        path=f"{path}.{kind}[{index}].{id_field}",
+                        reason=f"invalid {id_field}: {resource_id}",
+                    )
+                )
+                return {"state": "blocked", "path": path}, [], kind, script
             if resource_id in seen_ids:
                 blockers.append(
                     WorkflowBlocker(
@@ -403,8 +412,19 @@ class WorkflowStateService:
 
         stale_ids = set(ad_stale_unit_ids(script, raw_units))
         invalid = False
+        seen_unit_ids: set[str] = set()
         for index, unit in enumerate(raw_units):
-            if not isinstance(unit, dict) or not isinstance(unit.get("unit_id"), str) or not unit["unit_id"]:
+            unit_id = unit.get("unit_id") if isinstance(unit, dict) else None
+            shot_ids = unit.get("shot_ids") if isinstance(unit, dict) else None
+            references = unit.get("references") if isinstance(unit, dict) else None
+            if (
+                not isinstance(unit_id, str)
+                or not unit_id
+                or unit_id in seen_unit_ids
+                or not isinstance(shot_ids, list)
+                or not shot_ids
+                or (references is not None and not isinstance(references, list))
+            ):
                 blockers.append(
                     WorkflowBlocker(
                         code="invalid_reference_unit",
@@ -414,7 +434,7 @@ class WorkflowStateService:
                 )
                 invalid = True
                 continue
-            unit_id = unit["unit_id"]
+            seen_unit_ids.add(unit_id)
             video_path = get_generated_assets(unit).get("video_clip")
             if not isinstance(video_path, str) or not safe_exists(project_path, video_path):
                 collection["missing_ids"].append(unit_id)
@@ -560,14 +580,21 @@ class WorkflowStateService:
                     else "normalize-drama-script"
                 )
                 if mode != "ad" and selected is not None and selected[1].get("ledger_status") == "stale":
-                    artifacts["step1"] = {"state": "stale"}
-                    state = "STEP1_CONTENT"
-                    next_action = _action(
-                        "prepare_step1",
-                        "target episode was replanned and its downstream artifacts are stale",
-                        args={"episode": target.episode, "preprocessor": preprocessor},
-                    )
-                    return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
+                    step1_path = script_review.step1_path(project_path, project, target.episode)
+                    live_revision = script_review.content_fingerprint(step1_path) if step1_path is not None else None
+                    stale_entry = selected[1]
+                    baseline_is_recorded = script_review.STALE_STEP1_REVISION_FIELD in stale_entry
+                    if not baseline_is_recorded or live_revision == stale_entry.get(
+                        script_review.STALE_STEP1_REVISION_FIELD
+                    ):
+                        artifacts["step1"] = {"state": "stale"}
+                        state = "STEP1_CONTENT"
+                        next_action = _action(
+                            "prepare_step1",
+                            "target episode was replanned and its downstream artifacts are stale",
+                            args={"episode": target.episode, "preprocessor": preprocessor},
+                        )
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                 if mode == "ad":
                     products = project.get("products", {})
                     pending_points = (

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lib import script_review
 from lib.asset_types import ASSET_SPECS
+from lib.data_validator import DataValidator
 from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
     SourceDoc,
@@ -356,7 +357,7 @@ class WorkflowStateService:
     ) -> tuple[dict[str, Any], list[dict[str, Any]], str | None, dict[str, Any]]:
         path = target.script
         try:
-            script: Any = self.pm.load_script(project_name, path)
+            script: Any = self.pm.load_script_readonly(project_name, path)
         except FileNotFoundError:
             return {"state": "missing", "path": path}, [], None, {}
         except (OSError, ValueError, json.JSONDecodeError) as exc:
@@ -425,6 +426,21 @@ class WorkflowStateService:
                     )
                 )
                 return {"state": "blocked", "path": path}, [], kind, script
+        validation = DataValidator(str(self.pm.projects_root)).validate_episode_payload(
+            project_path,
+            project,
+            script,
+            validate_artifacts=False,
+        )
+        if not validation.valid:
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_script_structure",
+                    path=path,
+                    reason="; ".join(validation.errors),
+                )
+            )
+            return {"state": "blocked", "path": path}, [], kind, script
         return {"state": "current", "path": path}, raw_items, kind, script
 
     @staticmethod
@@ -454,6 +470,8 @@ class WorkflowStateService:
             for shot in script.get("shots", [])
             if isinstance(shot, dict) and isinstance(shot.get("shot_id"), str)
         }
+        member_counts = {shot_id: 0 for shot_id in valid_shot_ids}
+        has_dangling_members = False
         seen_unit_ids: set[str] = set()
         for index, unit in enumerate(raw_units):
             unit_id = unit.get("unit_id") if isinstance(unit, dict) else None
@@ -465,7 +483,6 @@ class WorkflowStateService:
                 or unit_id in seen_unit_ids
                 or not isinstance(shot_ids, list)
                 or not shot_ids
-                or not any(isinstance(shot_id, str) and shot_id in valid_shot_ids for shot_id in shot_ids)
                 or (references is not None and not isinstance(references, list))
             ):
                 blockers.append(
@@ -478,6 +495,11 @@ class WorkflowStateService:
                 invalid = True
                 continue
             seen_unit_ids.add(unit_id)
+            for shot_id in shot_ids:
+                if isinstance(shot_id, str) and shot_id in member_counts:
+                    member_counts[shot_id] += 1
+                else:
+                    has_dangling_members = True
             video_path = get_generated_assets(unit).get("video_clip")
             if not isinstance(video_path, str) or not safe_exists(project_path, video_path):
                 collection["missing_ids"].append(unit_id)
@@ -486,9 +508,12 @@ class WorkflowStateService:
             else:
                 collection["current_ids"].append(unit_id)
 
+        membership_is_current = (
+            not has_dangling_members and bool(valid_shot_ids) and all(count == 1 for count in member_counts.values())
+        )
         if invalid:
             state = "blocked"
-        elif collection["stale_ids"]:
+        elif collection["stale_ids"] or not membership_is_current:
             state = "stale"
         elif collection["missing_ids"] or not collection["current_ids"]:
             state = "missing"

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -849,6 +849,12 @@ class WorkflowStateService:
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                     review = script_review.review_status(project_path, project, target.episode)
+                    if (
+                        selected is not None
+                        and selected[1].get("ledger_status") == "stale"
+                        and script_review.stored_review(project, target.episode).get("fingerprint") is None
+                    ):
+                        review = "pending_review"
                     gates["step1_review"] = {
                         "state": "confirmed" if review == "confirmed" else "pending",
                         "revision": revision,

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -117,12 +117,18 @@ def _project_revision(project: Mapping[str, Any]) -> str:
 
 
 def _action(
-    action_type: str, reason: str, *, args: dict[str, Any] | None = None, ids: list[str] | None = None
+    action_type: str,
+    reason: str,
+    *,
+    args: dict[str, Any] | None = None,
+    ids: list[str] | None = None,
+    requires_confirmation: bool = False,
 ) -> WorkflowNextAction:
     return WorkflowNextAction(
         type=action_type,
         args=args or {},
         requested_ids=ids or [],
+        requires_confirmation=requires_confirmation,
         reason=reason,
     )
 
@@ -589,6 +595,24 @@ class WorkflowStateService:
                     reason="grid_storyboard must be a boolean",
                 )
             )
+        if mode == "ad":
+            target_duration = project.get("target_duration")
+            if not isinstance(target_duration, int) or isinstance(target_duration, bool) or target_duration <= 0:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_target_duration",
+                        path="target_duration",
+                        reason="ad target_duration must be a positive integer",
+                    )
+                )
+            if grid_storyboard is True:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_grid_storyboard",
+                        path="grid_storyboard",
+                        reason="ad workflow does not support grid storyboards",
+                    )
+                )
         asset_validation = DataValidator(str(self.pm.projects_root)).validate_asset_definitions(project)
         if not asset_validation.valid:
             blockers.append(
@@ -809,6 +833,7 @@ class WorkflowStateService:
                             "confirm_step1",
                             "formal step1 awaits content review",
                             args={"episode": target.episode},
+                            requires_confirmation=True,
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
 
@@ -918,7 +943,10 @@ class WorkflowStateService:
                                     and (
                                         status := self._get_status(project_name, project, project_path, number, shared)
                                     ).state
-                                    not in {"EPISODE_PLAN", "EXPORT_READY"}
+                                    != "EXPORT_READY"
+                                    and not (
+                                        status.state == "EPISODE_PLAN" and status.next_action.type == "plan_episodes"
+                                    )
                                 ),
                                 None,
                             )

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -26,7 +26,7 @@ from lib.path_safety import safe_exists
 from lib.project_manager import ProjectManager
 from lib.reference_video.ad_units import ad_stale_unit_ids
 from lib.script_models import get_generated_assets
-from lib.script_skeleton import SKELETONS, resolve_declared_kind
+from lib.script_skeleton import SKELETONS, ensure_route_skeleton
 from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
 
 WorkflowStateName = Literal[
@@ -324,14 +324,17 @@ class WorkflowStateService:
     ) -> tuple[dict[str, Any], list[dict[str, Any]], str | None, dict[str, Any]]:
         path = target.script
         try:
-            script = self.pm.load_script(project_name, path)
+            script: Any = self.pm.load_script(project_name, path)
         except FileNotFoundError:
             return {"state": "missing", "path": path}, [], None, {}
         except (OSError, ValueError, json.JSONDecodeError) as exc:
             blockers.append(WorkflowBlocker(code="invalid_script", path=path, reason=str(exc)))
             return {"state": "blocked", "path": path}, [], None, {}
+        if not isinstance(script, dict):
+            blockers.append(WorkflowBlocker(code="invalid_script", path=path, reason="script must be an object"))
+            return {"state": "blocked", "path": path}, [], None, {}
         try:
-            kind = resolve_declared_kind(project.get("content_mode"), project.get("generation_mode"))
+            kind = ensure_route_skeleton(script, project.get("content_mode"), project.get("generation_mode"))
         except ValueError as exc:
             blockers.append(WorkflowBlocker(code="invalid_project_mode", path="content_mode", reason=str(exc)))
             return {"state": "blocked", "path": path}, [], None, script
@@ -675,9 +678,6 @@ class WorkflowStateService:
                                 args={"episode": target.episode},
                                 ids=missing,
                             )
-                        elif mode != "ad" and not self._planning_complete(project_path, project, source):
-                            state = "EPISODE_PLAN"
-                            next_action = _action("plan_episodes", "source text remains unplanned")
                         elif episode is None and mode != "ad":
                             later_status = next(
                                 (
@@ -687,14 +687,21 @@ class WorkflowStateService:
                                     and (
                                         status := self._get_status(project_name, project, project_path, number, shared)
                                     ).state
-                                    != "EXPORT_READY"
+                                    not in {"EPISODE_PLAN", "EXPORT_READY"}
                                 ),
                                 None,
                             )
                             if later_status is not None:
                                 return later_status
-                            state = "EXPORT_READY"
-                            next_action = _action("export", "all required artifacts are usable")
+                            if not self._planning_complete(project_path, project, source):
+                                state = "EPISODE_PLAN"
+                                next_action = _action("plan_episodes", "source text remains unplanned")
+                            else:
+                                state = "EXPORT_READY"
+                                next_action = _action("export", "all required artifacts are usable")
+                        elif mode != "ad" and not self._planning_complete(project_path, project, source):
+                            state = "EPISODE_PLAN"
+                            next_action = _action("plan_episodes", "source text remains unplanned")
                         else:
                             state = "EXPORT_READY"
                             next_action = _action("export", "all required artifacts are usable")

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -359,6 +359,15 @@ class WorkflowStateService:
     def get_status(self, project_name: str, episode: int | None = None) -> WorkflowStatus:
         project = self.pm.load_project(project_name)
         project_path = self.pm.get_project_path(project_name)
+        return self._get_status(project_name, project, project_path, episode)
+
+    def _get_status(
+        self,
+        project_name: str,
+        project: dict[str, Any],
+        project_path: Path,
+        episode: int | None,
+    ) -> WorkflowStatus:
         mode = project.get("content_mode")
         if episode is not None and (isinstance(episode, bool) or episode < 1):
             raise ValueError("episode must be a positive integer")
@@ -554,7 +563,8 @@ class WorkflowStateService:
                                     status
                                     for number, _entry in episodes
                                     if number != target.episode
-                                    and (status := self.get_status(project_name, number)).state != "EXPORT_READY"
+                                    and (status := self._get_status(project_name, project, project_path, number)).state
+                                    != "EXPORT_READY"
                                 ),
                                 None,
                             )

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -24,7 +24,6 @@ from lib.episode_ledger import (
     normalize_source_text,
     parse_positive_episode_num,
 )
-from lib.episode_paths import episode_script_relpath
 from lib.path_safety import safe_exists
 from lib.project_manager import ProjectManager
 from lib.reference_video.ad_units import ad_stale_unit_ids
@@ -391,6 +390,16 @@ class WorkflowStateService:
         if not isinstance(script, dict):
             blockers.append(WorkflowBlocker(code="invalid_script", path=path, reason="script must be an object"))
             return {"state": "blocked", "path": path}, [], None, {}
+        script_episode = script.get("episode")
+        if script_episode != target.episode or isinstance(script_episode, bool):
+            blockers.append(
+                WorkflowBlocker(
+                    code="script_episode_mismatch",
+                    path=f"{path}.episode",
+                    reason=f"script episode must equal target episode {target.episode}",
+                )
+            )
+            return {"state": "blocked", "path": path}, [], None, script
         try:
             kind = ensure_route_skeleton(script, project.get("content_mode"), project.get("generation_mode"))
         except ValueError as exc:
@@ -677,22 +686,29 @@ class WorkflowStateService:
             number, entry = selected
             script_path = entry.get("script_file")
             if not isinstance(script_path, str) or not script_path:
-                script_path = episode_script_relpath(number)
-            script_filename = ProjectManager.normalize_script_filename(script_path)
-            if "/" in script_filename or "\\" in script_filename:
                 blockers.append(
                     WorkflowBlocker(
-                        code="invalid_script_path",
+                        code="invalid_script_binding",
                         path=f"episodes.{number}.script_file",
-                        reason="script_file must resolve to a bare filename under scripts/",
+                        reason="script_file must be a non-empty string",
                     )
                 )
-            target = WorkflowTarget(
-                episode=number,
-                script=script_path,
-                script_filename=script_filename,
-                source=f"source/episode_{number}.txt",
-            )
+            else:
+                script_filename = ProjectManager.normalize_script_filename(script_path)
+                if "/" in script_filename or "\\" in script_filename:
+                    blockers.append(
+                        WorkflowBlocker(
+                            code="invalid_script_path",
+                            path=f"episodes.{number}.script_file",
+                            reason="script_file must resolve to a bare filename under scripts/",
+                        )
+                    )
+                target = WorkflowTarget(
+                    episode=number,
+                    script=script_path,
+                    script_filename=script_filename,
+                    source=f"source/episode_{number}.txt",
+                )
 
         state: WorkflowStateName
         next_action: WorkflowNextAction
@@ -702,6 +718,9 @@ class WorkflowStateService:
         elif mode != "ad" and (source is None or not source.files):
             state = "PROJECT_INPUT"
             next_action = _action("collect_project_input", "source text is required")
+        elif mode != "ad" and not any(doc.text.strip() for doc in shared.planning_sources):
+            state = "PROJECT_INPUT"
+            next_action = _action("collect_project_input", "non-blank source text is required")
         elif mode != "ad" and inventory.get("state") != "current":
             state = "ASSET_INVENTORY"
             next_action = _action(
@@ -757,6 +776,7 @@ class WorkflowStateService:
                     stale_entry = selected[1]
                     baseline_is_recorded = script_review.STALE_STEP1_REVISION_FIELD in stale_entry
                     stale_revision = stale_entry.get(script_review.STALE_STEP1_REVISION_FIELD)
+                    rebuilt_revision = stale_entry.get(script_review.STALE_STEP1_REBUILT_REVISION_FIELD)
                     if not baseline_is_recorded:
                         artifacts["step1"] = {"state": "stale"}
                         state = "EPISODE_PLAN"
@@ -766,13 +786,19 @@ class WorkflowStateService:
                             args={"from_episode": target.episode},
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
-                    if live_revision is None or (baseline_is_recorded and live_revision == stale_revision):
+                    if live_revision is None or (
+                        baseline_is_recorded and live_revision == stale_revision and rebuilt_revision != live_revision
+                    ):
                         artifacts["step1"] = {"state": "stale"}
                         state = "STEP1_CONTENT"
                         next_action = _action(
                             "prepare_step1",
                             "target episode was replanned and its downstream artifacts are stale",
-                            args={"episode": target.episode, "preprocessor": preprocessor},
+                            args={
+                                "episode": target.episode,
+                                "preprocessor": preprocessor,
+                                "expected_stale_step1_revision": stale_revision,
+                            },
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                 if mode == "ad":

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -106,7 +106,7 @@ class _SharedWorkflowFacts:
 
 
 def _project_revision(project: Mapping[str, Any]) -> str:
-    encoded = json.dumps(project, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    encoded = json.dumps(dict(project), ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return f"sha256-v1:{hashlib.sha256(encoded).hexdigest()}"
 
 
@@ -302,11 +302,7 @@ class WorkflowStateService:
         rel = cursor.get("source_file")
         offset = cursor.get("offset")
         canonical_rel = unicodedata.normalize("NFC", rel) if isinstance(rel, str) else None
-        if (
-            canonical_rel != source.files[-1]
-            or not isinstance(offset, int)
-            or isinstance(offset, bool)
-        ):
+        if canonical_rel != source.files[-1] or not isinstance(offset, int) or isinstance(offset, bool):
             return False
         try:
             source_dir = project_path / "source"

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -134,6 +134,21 @@ def _planning_fingerprints_diverged(project: Mapping[str, Any], sources: tuple[S
     return bool(mismatched_source_fingerprints(recorded, list(sources)))
 
 
+def _new_source_precedes_cursor(project: Mapping[str, Any], sources: tuple[SourceDoc, ...]) -> bool:
+    recorded = project.get(SOURCE_FINGERPRINTS_KEY)
+    cursor = project.get("planning_cursor")
+    if not isinstance(recorded, Mapping) or not isinstance(cursor, Mapping):
+        return False
+    cursor_file = cursor.get("source_file")
+    if not isinstance(cursor_file, str):
+        return False
+    canonical_cursor = unicodedata.normalize("NFC", cursor_file)
+    return any(
+        (canonical := unicodedata.normalize("NFC", source.rel_path)) not in recorded and canonical <= canonical_cursor
+        for source in sources
+    )
+
+
 def _empty_collection() -> dict[str, list[str]]:
     return {"current_ids": [], "missing_ids": [], "stale_ids": []}
 
@@ -561,6 +576,15 @@ class WorkflowStateService:
             blockers.append(
                 WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
             )
+        asset_validation = DataValidator(str(self.pm.projects_root)).validate_asset_definitions(project)
+        if not asset_validation.valid:
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_asset_definitions",
+                    path="project.json",
+                    reason="; ".join(asset_validation.errors),
+                )
+            )
         source, inventory = self._source_inventory(project_path, project, str(mode), blockers)
         planning_sources = (
             tuple(discover_sources(project_path)) if mode != "ad" and source is not None and not source.blockers else ()
@@ -658,6 +682,13 @@ class WorkflowStateService:
                 "source files changed after episode planning",
                 args={"from_episode": 1},
             )
+        elif mode != "ad" and _new_source_precedes_cursor(project, shared.planning_sources):
+            state = "EPISODE_PLAN"
+            next_action = _action(
+                "reset_episode_planning",
+                "new source text precedes the current planning cursor",
+                args={"from_episode": 1},
+            )
         elif mode != "ad" and selected is None:
             state = "EPISODE_PLAN"
             if episode is not None and shared.planning_complete:
@@ -690,8 +721,14 @@ class WorkflowStateService:
                     baseline_is_recorded = script_review.STALE_STEP1_REVISION_FIELD in stale_entry
                     stale_revision = stale_entry.get(script_review.STALE_STEP1_REVISION_FIELD)
                     if not baseline_is_recorded:
-                        stale_revision = script_review.stored_review(project, target.episode).get("fingerprint")
-                        baseline_is_recorded = isinstance(stale_revision, str)
+                        artifacts["step1"] = {"state": "stale"}
+                        state = "EPISODE_PLAN"
+                        next_action = _action(
+                            "reset_episode_planning",
+                            "legacy stale episode has no rebuild baseline",
+                            args={"from_episode": target.episode},
+                        )
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                     if live_revision is None or (baseline_is_recorded and live_revision == stale_revision):
                         artifacts["step1"] = {"state": "stale"}
                         state = "STEP1_CONTENT"

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -399,7 +399,9 @@ class WorkflowStateService:
             seen_ids.add(resource_id)
             duration = item.get("duration_seconds")
             duration_max = 300 if kind == "video_units" else 60
-            if isinstance(duration, bool) or not isinstance(duration, int) or not 1 <= duration <= duration_max:
+            if duration is not None and (
+                isinstance(duration, bool) or not isinstance(duration, int) or not 1 <= duration <= duration_max
+            ):
                 blockers.append(
                     WorkflowBlocker(
                         code="invalid_script_structure",

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -22,6 +22,7 @@ from lib.episode_ledger import (
 from lib.episode_paths import episode_script_relpath
 from lib.path_safety import safe_exists
 from lib.project_manager import ProjectManager
+from lib.reference_video.ad_units import ad_stale_unit_ids
 from lib.script_models import get_generated_assets
 from lib.script_skeleton import SKELETONS, resolve_declared_kind
 from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
@@ -308,31 +309,83 @@ class WorkflowStateService:
         project: dict[str, Any],
         target: WorkflowTarget,
         blockers: list[WorkflowBlocker],
-    ) -> tuple[dict[str, Any], list[dict[str, Any]], str | None]:
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], str | None, dict[str, Any]]:
         path = target.script
         try:
             script = self.pm.load_script(project_name, path)
         except FileNotFoundError:
-            return {"state": "missing", "path": path}, [], None
+            return {"state": "missing", "path": path}, [], None, {}
         except (OSError, ValueError, json.JSONDecodeError) as exc:
             blockers.append(WorkflowBlocker(code="invalid_script", path=path, reason=str(exc)))
-            return {"state": "blocked", "path": path}, [], None
+            return {"state": "blocked", "path": path}, [], None, {}
         try:
             kind = resolve_declared_kind(project.get("content_mode"), project.get("generation_mode"))
         except ValueError as exc:
             blockers.append(WorkflowBlocker(code="invalid_project_mode", path="content_mode", reason=str(exc)))
-            return {"state": "blocked", "path": path}, [], None
+            return {"state": "blocked", "path": path}, [], None, script
         raw_items = script.get(kind)
-        if not isinstance(raw_items, list) or not all(isinstance(item, dict) for item in raw_items):
+        if not isinstance(raw_items, list) or not raw_items or not all(isinstance(item, dict) for item in raw_items):
             blockers.append(
                 WorkflowBlocker(
                     code="invalid_script_collection",
                     path=f"{path}.{kind}",
-                    reason=f"{kind} must be an array of objects",
+                    reason=f"{kind} must be a non-empty array of objects",
                 )
             )
-            return {"state": "blocked", "path": path}, [], kind
-        return {"state": "current", "path": path}, raw_items, kind
+            return {"state": "blocked", "path": path}, [], kind, script
+        return {"state": "current", "path": path}, raw_items, kind, script
+
+    @staticmethod
+    def _ad_reference_videos(
+        project_path: Path,
+        script: dict[str, Any],
+        blockers: list[WorkflowBlocker],
+    ) -> dict[str, Any]:
+        collection: dict[str, Any] = _empty_collection()
+        raw_units = script.get("reference_units")
+        if raw_units is None or raw_units == []:
+            return {"state": "missing", **collection}
+        if not isinstance(raw_units, list):
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_reference_units",
+                    path="reference_units",
+                    reason="reference_units must be an array",
+                )
+            )
+            return {"state": "blocked", **collection}
+
+        stale_ids = set(ad_stale_unit_ids(script, raw_units))
+        invalid = False
+        for index, unit in enumerate(raw_units):
+            if not isinstance(unit, dict) or not isinstance(unit.get("unit_id"), str) or not unit["unit_id"]:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_reference_unit",
+                        path=f"reference_units[{index}]",
+                        reason="reference units must be named objects",
+                    )
+                )
+                invalid = True
+                continue
+            unit_id = unit["unit_id"]
+            video_path = get_generated_assets(unit).get("video_clip")
+            if not isinstance(video_path, str) or not safe_exists(project_path, video_path):
+                collection["missing_ids"].append(unit_id)
+            elif unit_id in stale_ids:
+                collection["stale_ids"].append(unit_id)
+            else:
+                collection["current_ids"].append(unit_id)
+
+        if invalid:
+            state = "blocked"
+        elif collection["stale_ids"]:
+            state = "stale"
+        elif collection["missing_ids"] or not collection["current_ids"]:
+            state = "missing"
+        else:
+            state = "current"
+        return {"state": state, **collection}
 
     @staticmethod
     def _media_collection(
@@ -436,6 +489,22 @@ class WorkflowStateService:
                 state = "EPISODE_PLAN"
                 next_action = _action("plan_episodes", "target episode is unavailable")
             else:
+                preprocessor = (
+                    "split-reference-video-units"
+                    if generation_mode == "reference_video"
+                    else "split-narration-segments"
+                    if mode == "narration"
+                    else "normalize-drama-script"
+                )
+                if mode != "ad" and selected is not None and selected[1].get("ledger_status") == "stale":
+                    artifacts["step1"] = {"state": "stale"}
+                    state = "STEP1_CONTENT"
+                    next_action = _action(
+                        "prepare_step1",
+                        "target episode was replanned and its downstream artifacts are stale",
+                        args={"episode": target.episode, "preprocessor": preprocessor},
+                    )
+                    return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                 if mode == "ad":
                     products = project.get("products", {})
                     pending_points = (
@@ -462,13 +531,6 @@ class WorkflowStateService:
                         "revision": revision,
                     }
                     if revision is None:
-                        preprocessor = (
-                            "split-reference-video-units"
-                            if generation_mode == "reference_video"
-                            else "split-narration-segments"
-                            if mode == "narration"
-                            else "normalize-drama-script"
-                        )
                         state = "STEP1_CONTENT"
                         next_action = _action(
                             "prepare_step1",
@@ -490,7 +552,7 @@ class WorkflowStateService:
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
 
-                script_artifact, items, kind = self._load_script_artifacts(
+                script_artifact, items, kind, script = self._load_script_artifacts(
                     project_path, project_name, project, target, blockers
                 )
                 artifacts["script"] = script_artifact
@@ -517,13 +579,20 @@ class WorkflowStateService:
                             if generation_mode == "storyboard"
                             else _not_applicable_collection()
                         )
-                        artifacts["videos"] = self._media_collection(project_path, items, kind, "video_clip")
+                        artifacts["videos"] = (
+                            self._ad_reference_videos(project_path, script, blockers)
+                            if mode == "ad" and generation_mode == "reference_video"
+                            else self._media_collection(project_path, items, kind, "video_clip")
+                        )
                         artifacts["audio"] = (
                             self._media_collection(project_path, items, kind, "narration_audio")
                             if mode == "narration" and generation_mode == "storyboard"
                             else _not_applicable_collection()
                         )
-                        if generation_mode == "storyboard" and artifacts["storyboards"]["missing_ids"]:
+                        if blockers:
+                            state = "VIDEO"
+                            next_action = _action("none", "video metadata is blocked")
+                        elif generation_mode == "storyboard" and artifacts["storyboards"]["missing_ids"]:
                             missing = artifacts["storyboards"]["missing_ids"]
                             state = "STORYBOARD"
                             next_action = _action(
@@ -532,8 +601,16 @@ class WorkflowStateService:
                                 args={"episode": target.episode},
                                 ids=missing,
                             )
-                        elif artifacts["videos"]["missing_ids"]:
-                            missing = artifacts["videos"]["missing_ids"]
+                        elif (
+                            artifacts["videos"]["missing_ids"]
+                            or artifacts["videos"]["stale_ids"]
+                            or (
+                                mode == "ad"
+                                and generation_mode == "reference_video"
+                                and artifacts["videos"].get("state") != "current"
+                            )
+                        ):
+                            missing = artifacts["videos"]["missing_ids"] + artifacts["videos"]["stale_ids"]
                             state = "VIDEO"
                             next_action = _action(
                                 "generate_videos",

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -58,6 +58,7 @@ class WorkflowTarget(BaseModel):
 
     episode: int
     script: str
+    script_filename: str
     source: str
 
 
@@ -119,6 +120,13 @@ def _action(
         requested_ids=ids or [],
         reason=reason,
     )
+
+
+def _planning_fingerprints_diverged(project_path: Path, project: Mapping[str, Any]) -> bool:
+    recorded = project.get(SOURCE_FINGERPRINTS_KEY)
+    if not isinstance(recorded, Mapping) or not recorded:
+        return False
+    return dict(recorded) != compute_source_fingerprints(discover_sources(project_path))
 
 
 def _empty_collection() -> dict[str, list[str]]:
@@ -564,6 +572,7 @@ class WorkflowStateService:
             target = WorkflowTarget(
                 episode=number,
                 script=script_path,
+                script_filename=ProjectManager.normalize_script_filename(script_path),
                 source=f"source/episode_{number}.txt",
             )
 
@@ -580,7 +589,17 @@ class WorkflowStateService:
             next_action = _action(
                 "analyze_assets",
                 "asset inventory is missing or out of date",
-                args={"scope": {"kind": "all", "files": []}, "source_revision": source.revision if source else None},
+                args={
+                    "scope": {"kind": "all", "files": []},
+                    "expected_source_revision": source.revision if source else None,
+                },
+            )
+        elif mode != "ad" and _planning_fingerprints_diverged(project_path, project):
+            state = "EPISODE_PLAN"
+            next_action = _action(
+                "reset_episode_planning",
+                "source files changed after episode planning",
+                args={"from_episode": 1},
             )
         elif mode != "ad" and selected is None:
             state = "EPISODE_PLAN"
@@ -680,7 +699,7 @@ class WorkflowStateService:
                 artifacts["script"] = script_artifact
                 if (
                     mode != "ad"
-                    and script_artifact["state"] != "missing"
+                    and script_artifact["state"] == "current"
                     and script_review.stored_review(project, target.episode).get("fingerprint") is not None
                 ):
                     metadata = script.get("metadata")

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -660,7 +660,17 @@ class WorkflowStateService:
             )
         elif mode != "ad" and selected is None:
             state = "EPISODE_PLAN"
-            next_action = _action("plan_episodes", "episode ledger has no target episode")
+            if episode is not None and shared.planning_complete:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="episode_unavailable",
+                        path=f"episodes.{episode}",
+                        reason="requested episode is absent and all source text is already planned",
+                    )
+                )
+                next_action = _action("none", "requested episode is unavailable")
+            else:
+                next_action = _action("plan_episodes", "episode ledger has no target episode")
         else:
             if target is None:  # defensive; ad always supplies episode 1
                 state = "EPISODE_PLAN"
@@ -678,9 +688,11 @@ class WorkflowStateService:
                     live_revision = script_review.content_fingerprint(step1_path) if step1_path is not None else None
                     stale_entry = selected[1]
                     baseline_is_recorded = script_review.STALE_STEP1_REVISION_FIELD in stale_entry
-                    if not baseline_is_recorded or live_revision == stale_entry.get(
-                        script_review.STALE_STEP1_REVISION_FIELD
-                    ):
+                    stale_revision = stale_entry.get(script_review.STALE_STEP1_REVISION_FIELD)
+                    if not baseline_is_recorded:
+                        stale_revision = script_review.stored_review(project, target.episode).get("fingerprint")
+                        baseline_is_recorded = isinstance(stale_revision, str)
+                    if live_revision is None or (baseline_is_recorded and live_revision == stale_revision):
                         artifacts["step1"] = {"state": "stale"}
                         state = "STEP1_CONTENT"
                         next_action = _action(

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -302,7 +303,7 @@ class WorkflowStateService:
         offset = cursor.get("offset")
         if (
             not isinstance(rel, str)
-            or rel != source.files[-1]
+            or unicodedata.normalize("NFC", rel) != source.files[-1]
             or not isinstance(offset, int)
             or isinstance(offset, bool)
         ):
@@ -344,6 +345,18 @@ class WorkflowStateService:
                 )
             )
             return {"state": "blocked", "path": path}, [], kind, script
+        id_field = SKELETONS[kind].id_field
+        for index, item in enumerate(raw_items):
+            resource_id = item.get(id_field)
+            if not isinstance(resource_id, str) or not resource_id:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_script_id",
+                        path=f"{path}.{kind}[{index}].{id_field}",
+                        reason=f"{id_field} must be a non-empty string",
+                    )
+                )
+                return {"state": "blocked", "path": path}, [], kind, script
         return {"state": "current", "path": path}, raw_items, kind, script
 
     @staticmethod
@@ -594,7 +607,10 @@ class WorkflowStateService:
                     )
                 else:
                     missing_sheets = [
-                        asset_id for collection in sheets.values() for asset_id in collection.get("missing_ids", [])
+                        asset_id
+                        for asset_type, collection in sheets.items()
+                        if asset_type != "product"
+                        for asset_id in collection.get("missing_ids", [])
                     ]
                     if missing_sheets:
                         state = "ASSET_SHEETS"

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -1,0 +1,575 @@
+"""Authoritative, side-effect-free workflow status for ArcReel projects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from lib import script_review
+from lib.asset_types import ASSET_SPECS
+from lib.episode_ledger import normalize_source_text, parse_positive_episode_num
+from lib.episode_paths import episode_script_relpath
+from lib.path_safety import safe_exists
+from lib.project_manager import ProjectManager
+from lib.script_models import get_generated_assets
+from lib.script_skeleton import SKELETONS, resolve_declared_kind
+from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
+
+WorkflowStateName = Literal[
+    "PROJECT_INPUT",
+    "SELLING_POINTS",
+    "ASSET_INVENTORY",
+    "EPISODE_PLAN",
+    "STEP1_CONTENT",
+    "STEP1_REVIEW",
+    "FINAL_SCRIPT",
+    "ASSET_SHEETS",
+    "STORYBOARD",
+    "VIDEO",
+    "AUDIO",
+    "EXPORT_READY",
+]
+
+
+class WorkflowProject(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    content_mode: str
+    generation_mode: str
+    grid_storyboard: bool
+
+
+class WorkflowTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    episode: int
+    script: str
+    source: str
+
+
+class WorkflowBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    path: str
+    reason: str
+
+
+class WorkflowNextAction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    requested_ids: list[str] = Field(default_factory=list)
+    requires_confirmation: bool = False
+    reason: str
+
+
+class WorkflowStatus(BaseModel):
+    """Shared response model serialized unchanged by REST and MCP adapters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    project_revision: str
+    source_revision: str | None
+    project: WorkflowProject
+    target: WorkflowTarget | None
+    state: WorkflowStateName
+    blockers: list[WorkflowBlocker]
+    gates: dict[str, dict[str, Any]]
+    artifacts: dict[str, dict[str, Any]]
+    next_action: WorkflowNextAction
+
+
+def _project_revision(project: Mapping[str, Any]) -> str:
+    encoded = json.dumps(project, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256-v1:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _action(
+    action_type: str, reason: str, *, args: dict[str, Any] | None = None, ids: list[str] | None = None
+) -> WorkflowNextAction:
+    return WorkflowNextAction(
+        type=action_type,
+        args=args or {},
+        requested_ids=ids or [],
+        reason=reason,
+    )
+
+
+def _empty_collection() -> dict[str, list[str]]:
+    return {"current_ids": [], "missing_ids": [], "stale_ids": []}
+
+
+def _not_applicable_collection() -> dict[str, Any]:
+    return {"state": "not_applicable", **_empty_collection()}
+
+
+class WorkflowStateService:
+    """Calculate the first unmet workflow condition from durable project facts."""
+
+    def __init__(self, project_manager: ProjectManager):
+        self.pm = project_manager
+
+    def _source_inventory(
+        self,
+        project_path: Path,
+        project: dict[str, Any],
+        mode: str,
+        blockers: list[WorkflowBlocker],
+    ) -> tuple[SourceRevisionResult | None, dict[str, Any]]:
+        if mode == "ad":
+            return None, {"state": "not_applicable"}
+
+        source = compute_source_revision(project_path, project, SourceScope(kind="all"))
+        blockers.extend(WorkflowBlocker(code=item.code, path=item.path, reason=item.reason) for item in source.blockers)
+        marker: object = None
+        workflow = project.get("workflow")
+        if workflow is not None and not isinstance(workflow, Mapping):
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_workflow",
+                    path="workflow",
+                    reason="workflow must be an object",
+                )
+            )
+        elif isinstance(workflow, Mapping):
+            marker = workflow.get("asset_inventory")
+
+        artifact: dict[str, Any] = {"state": "missing"}
+        if marker is None:
+            return source, artifact
+        if not isinstance(marker, Mapping):
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_asset_inventory",
+                    path="workflow.asset_inventory",
+                    reason="asset inventory marker must be an object",
+                )
+            )
+            return source, {"state": "blocked"}
+        try:
+            recorded_scope = SourceScope.model_validate(marker.get("scope"))
+        except ValueError as exc:
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_source_scope",
+                    path="workflow.asset_inventory.scope",
+                    reason=str(exc),
+                )
+            )
+            return source, {"state": "blocked"}
+
+        artifact["recorded_scope"] = recorded_scope.model_dump(mode="json")
+        artifact["recorded_revision"] = marker.get("source_revision")
+        if recorded_scope.kind != "all":
+            return source, artifact
+        if source.blockers:
+            artifact["state"] = "blocked"
+        elif marker.get("source_revision") == source.revision:
+            artifact["state"] = "current"
+        else:
+            artifact["state"] = "stale"
+        return source, artifact
+
+    def _asset_sheets(
+        self,
+        project_path: Path,
+        project: dict[str, Any],
+        blockers: list[WorkflowBlocker],
+    ) -> dict[str, dict[str, Any]]:
+        collections: dict[str, dict[str, Any]] = {}
+        for asset_type, spec in ASSET_SPECS.items():
+            collection: dict[str, Any] = _empty_collection()
+            bucket = project.get(spec.bucket_key, {})
+            if not isinstance(bucket, Mapping):
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_asset_bucket",
+                        path=spec.bucket_key,
+                        reason=f"{spec.bucket_key} must be an object",
+                    )
+                )
+                collection["state"] = "blocked"
+                collections[asset_type] = collection
+                continue
+            for name, item in bucket.items():
+                if not isinstance(name, str) or not isinstance(item, Mapping):
+                    blockers.append(
+                        WorkflowBlocker(
+                            code="invalid_asset_entry",
+                            path=f"{spec.bucket_key}.{name}",
+                            reason="asset entries must be named objects",
+                        )
+                    )
+                    collection["state"] = "blocked"
+                    collection["current_ids"] = []
+                    collection["missing_ids"] = []
+                    break
+                path = item.get(spec.sheet_field)
+                if isinstance(path, str) and safe_exists(project_path, path):
+                    collection["current_ids"].append(name)
+                else:
+                    collection["missing_ids"].append(name)
+            collections[asset_type] = collection
+        return collections
+
+    @staticmethod
+    def _episodes(project: dict[str, Any], blockers: list[WorkflowBlocker]) -> list[tuple[int, dict[str, Any]]]:
+        raw = project.get("episodes")
+        if not isinstance(raw, list):
+            blockers.append(
+                WorkflowBlocker(code="invalid_episode_ledger", path="episodes", reason="episodes must be an array")
+            )
+            return []
+        parsed: list[tuple[int, dict[str, Any]]] = []
+        seen: set[int] = set()
+        for index, entry in enumerate(raw):
+            if not isinstance(entry, dict):
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_episode_entry",
+                        path=f"episodes[{index}]",
+                        reason="episode entry must be an object",
+                    )
+                )
+                continue
+            number = parse_positive_episode_num(entry.get("episode"))
+            if number is None or number in seen:
+                blockers.append(
+                    WorkflowBlocker(
+                        code="invalid_episode_number",
+                        path=f"episodes[{index}].episode",
+                        reason="episode number must be a unique positive integer",
+                    )
+                )
+                continue
+            seen.add(number)
+            parsed.append((number, entry))
+        parsed.sort(key=lambda pair: pair[0])
+        return parsed
+
+    @staticmethod
+    def _target(
+        mode: str,
+        episodes: list[tuple[int, dict[str, Any]]],
+        requested_episode: int | None,
+    ) -> tuple[int, dict[str, Any]] | None:
+        if mode == "ad":
+            return next((pair for pair in episodes if pair[0] == 1), (1, {}))
+        if requested_episode is not None:
+            return next((pair for pair in episodes if pair[0] == requested_episode), None)
+        pending = [pair for pair in episodes if pair[1].get("ledger_status") in {"planned", "stale"}]
+        return (pending or episodes)[0] if (pending or episodes) else None
+
+    @staticmethod
+    def _planning_complete(project_path: Path, project: dict[str, Any], source: SourceRevisionResult | None) -> bool:
+        if source is None or not source.files:
+            return False
+        cursor = project.get("planning_cursor")
+        if not isinstance(cursor, Mapping):
+            return False
+        rel = cursor.get("source_file")
+        offset = cursor.get("offset")
+        if (
+            not isinstance(rel, str)
+            or rel != source.files[-1]
+            or not isinstance(offset, int)
+            or isinstance(offset, bool)
+        ):
+            return False
+        try:
+            text = (project_path / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return False
+        return offset >= len(normalize_source_text(text))
+
+    def _load_script_artifacts(
+        self,
+        project_path: Path,
+        project_name: str,
+        project: dict[str, Any],
+        target: WorkflowTarget,
+        blockers: list[WorkflowBlocker],
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], str | None]:
+        path = target.script
+        try:
+            script = self.pm.load_script(project_name, path)
+        except FileNotFoundError:
+            return {"state": "missing", "path": path}, [], None
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            blockers.append(WorkflowBlocker(code="invalid_script", path=path, reason=str(exc)))
+            return {"state": "blocked", "path": path}, [], None
+        try:
+            kind = resolve_declared_kind(project.get("content_mode"), project.get("generation_mode"))
+        except ValueError as exc:
+            blockers.append(WorkflowBlocker(code="invalid_project_mode", path="content_mode", reason=str(exc)))
+            return {"state": "blocked", "path": path}, [], None
+        raw_items = script.get(kind)
+        if not isinstance(raw_items, list) or not all(isinstance(item, dict) for item in raw_items):
+            blockers.append(
+                WorkflowBlocker(
+                    code="invalid_script_collection",
+                    path=f"{path}.{kind}",
+                    reason=f"{kind} must be an array of objects",
+                )
+            )
+            return {"state": "blocked", "path": path}, [], kind
+        return {"state": "current", "path": path}, raw_items, kind
+
+    @staticmethod
+    def _media_collection(items: list[dict[str, Any]], kind: str | None, field: str) -> dict[str, list[str]]:
+        collection = _empty_collection()
+        if kind is None:
+            return collection
+        id_field = SKELETONS[kind].id_field
+        for item in items:
+            resource_id = item.get(id_field)
+            if not isinstance(resource_id, str) or not resource_id:
+                continue
+            if get_generated_assets(item).get(field):
+                collection["current_ids"].append(resource_id)
+            else:
+                collection["missing_ids"].append(resource_id)
+        return collection
+
+    def get_status(self, project_name: str, episode: int | None = None) -> WorkflowStatus:
+        project = self.pm.load_project(project_name)
+        project_path = self.pm.get_project_path(project_name)
+        mode = project.get("content_mode")
+        if episode is not None and (isinstance(episode, bool) or episode < 1):
+            raise ValueError("episode must be a positive integer")
+        if mode == "ad" and episode not in {None, 1}:
+            raise ValueError("ad workflow only has episode 1")
+        generation_mode = project.get("generation_mode")
+        grid = bool(project.get("grid_storyboard")) and generation_mode == "storyboard"
+        blockers: list[WorkflowBlocker] = []
+        if mode not in {"narration", "drama", "ad"}:
+            blockers.append(
+                WorkflowBlocker(code="invalid_content_mode", path="content_mode", reason="unsupported mode")
+            )
+        if generation_mode not in {"storyboard", "reference_video"}:
+            blockers.append(
+                WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
+            )
+
+        source, inventory = self._source_inventory(project_path, project, str(mode), blockers)
+        sheets = self._asset_sheets(project_path, project, blockers)
+        artifacts: dict[str, dict[str, Any]] = {
+            "asset_inventory": inventory,
+            "asset_sheets": sheets,
+            "step1": {"state": "not_applicable" if mode == "ad" else "missing"},
+            "script": {"state": "missing"},
+            "storyboards": _empty_collection(),
+            "videos": _empty_collection(),
+            "audio": _empty_collection(),
+        }
+        gates: dict[str, dict[str, Any]] = {
+            "step1_review": {"state": "not_applicable" if mode == "ad" else "pending", "revision": None}
+        }
+        episodes = self._episodes(project, blockers)
+        selected = self._target(str(mode), episodes, episode)
+        target = None
+        if selected is not None:
+            number, entry = selected
+            script_path = entry.get("script_file")
+            if not isinstance(script_path, str) or not script_path:
+                script_path = episode_script_relpath(number)
+            target = WorkflowTarget(
+                episode=number,
+                script=script_path,
+                source=f"source/episode_{number}.txt",
+            )
+
+        state: WorkflowStateName
+        next_action: WorkflowNextAction
+        if blockers:
+            state = "PROJECT_INPUT"
+            next_action = _action("none", "workflow is blocked")
+        elif mode != "ad" and (source is None or not source.files):
+            state = "PROJECT_INPUT"
+            next_action = _action("collect_project_input", "source text is required")
+        elif mode != "ad" and inventory.get("state") != "current":
+            state = "ASSET_INVENTORY"
+            next_action = _action(
+                "analyze_assets",
+                "asset inventory is missing or out of date",
+                args={"scope": {"kind": "all", "files": []}, "source_revision": source.revision if source else None},
+            )
+        elif mode != "ad" and selected is None:
+            state = "EPISODE_PLAN"
+            next_action = _action("plan_episodes", "episode ledger has no target episode")
+        else:
+            if target is None:  # defensive; ad always supplies episode 1
+                state = "EPISODE_PLAN"
+                next_action = _action("plan_episodes", "target episode is unavailable")
+            else:
+                if mode == "ad":
+                    products = project.get("products", {})
+                    pending_points = (
+                        [
+                            name
+                            for name, item in products.items()
+                            if isinstance(item, Mapping) and not item.get("selling_points")
+                        ]
+                        if isinstance(products, Mapping)
+                        else []
+                    )
+                    if pending_points:
+                        state = "SELLING_POINTS"
+                        next_action = _action(
+                            "draft_selling_points", "products need selling points", ids=pending_points
+                        )
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
+                else:
+                    step1_path = script_review.step1_path(project_path, project, target.episode)
+                    revision = script_review.content_fingerprint(step1_path) if step1_path is not None else None
+                    artifacts["step1"] = {
+                        "state": "current" if revision is not None else "missing",
+                        "path": str(step1_path.relative_to(project_path)) if step1_path is not None else None,
+                        "revision": revision,
+                    }
+                    if revision is None:
+                        preprocessor = (
+                            "split-reference-video-units"
+                            if generation_mode == "reference_video"
+                            else "split-narration-segments"
+                            if mode == "narration"
+                            else "normalize-drama-script"
+                        )
+                        state = "STEP1_CONTENT"
+                        next_action = _action(
+                            "prepare_step1",
+                            "target episode has no formal step1",
+                            args={"episode": target.episode, "preprocessor": preprocessor},
+                        )
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
+                    review = script_review.review_status(project_path, project, target.episode)
+                    gates["step1_review"] = {
+                        "state": "confirmed" if review == "confirmed" else "pending",
+                        "revision": revision,
+                    }
+                    if review != "confirmed":
+                        state = "STEP1_REVIEW"
+                        next_action = _action(
+                            "confirm_step1",
+                            "formal step1 awaits content review",
+                            args={"episode": target.episode},
+                        )
+                        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
+
+                script_artifact, items, kind = self._load_script_artifacts(
+                    project_path, project_name, project, target, blockers
+                )
+                artifacts["script"] = script_artifact
+                if blockers:
+                    state = "FINAL_SCRIPT"
+                    next_action = _action("none", "script is blocked")
+                elif script_artifact["state"] == "missing":
+                    state = "FINAL_SCRIPT"
+                    next_action = _action(
+                        "generate_script", "target episode has no final script", args={"episode": target.episode}
+                    )
+                else:
+                    missing_sheets = [
+                        asset_id for collection in sheets.values() for asset_id in collection.get("missing_ids", [])
+                    ]
+                    if missing_sheets:
+                        state = "ASSET_SHEETS"
+                        next_action = _action(
+                            "generate_asset_sheets", "asset definitions need sheets", ids=missing_sheets
+                        )
+                    else:
+                        artifacts["storyboards"] = (
+                            self._media_collection(items, kind, "storyboard_image")
+                            if generation_mode == "storyboard"
+                            else _not_applicable_collection()
+                        )
+                        artifacts["videos"] = self._media_collection(items, kind, "video_clip")
+                        artifacts["audio"] = (
+                            self._media_collection(items, kind, "narration_audio")
+                            if mode == "narration" and generation_mode == "storyboard"
+                            else _not_applicable_collection()
+                        )
+                        if generation_mode == "storyboard" and artifacts["storyboards"]["missing_ids"]:
+                            missing = artifacts["storyboards"]["missing_ids"]
+                            state = "STORYBOARD"
+                            next_action = _action(
+                                "generate_grid" if grid else "generate_storyboards",
+                                "storyboard images are missing",
+                                args={"episode": target.episode},
+                                ids=missing,
+                            )
+                        elif artifacts["videos"]["missing_ids"]:
+                            missing = artifacts["videos"]["missing_ids"]
+                            state = "VIDEO"
+                            next_action = _action(
+                                "generate_videos",
+                                "video clips are missing",
+                                args={"episode": target.episode},
+                                ids=missing,
+                            )
+                        elif (
+                            mode == "narration"
+                            and generation_mode == "storyboard"
+                            and artifacts["audio"]["missing_ids"]
+                        ):
+                            missing = artifacts["audio"]["missing_ids"]
+                            state = "AUDIO"
+                            next_action = _action(
+                                "generate_narration_audio",
+                                "narration audio is missing",
+                                args={"episode": target.episode},
+                                ids=missing,
+                            )
+                        elif mode != "ad" and not self._planning_complete(project_path, project, source):
+                            state = "EPISODE_PLAN"
+                            next_action = _action("plan_episodes", "source text remains unplanned")
+                        else:
+                            state = "EXPORT_READY"
+                            next_action = _action("export", "all required artifacts are usable")
+
+        return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
+
+    @staticmethod
+    def _response(
+        project: dict[str, Any],
+        source: SourceRevisionResult | None,
+        target: WorkflowTarget | None,
+        state: WorkflowStateName,
+        blockers: list[WorkflowBlocker],
+        gates: dict[str, dict[str, Any]],
+        artifacts: dict[str, dict[str, Any]],
+        next_action: WorkflowNextAction,
+    ) -> WorkflowStatus:
+        return WorkflowStatus(
+            project_revision=_project_revision(project),
+            source_revision=source.revision if source is not None else None,
+            project=WorkflowProject(
+                content_mode=str(project.get("content_mode")),
+                generation_mode=str(project.get("generation_mode")),
+                grid_storyboard=bool(project.get("grid_storyboard")),
+            ),
+            target=target,
+            state=state,
+            blockers=blockers,
+            gates=gates,
+            artifacts=artifacts,
+            next_action=next_action,
+        )
+
+
+__all__ = [
+    "WorkflowBlocker",
+    "WorkflowNextAction",
+    "WorkflowProject",
+    "WorkflowStateService",
+    "WorkflowStatus",
+    "WorkflowTarget",
+]

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -18,6 +18,7 @@ from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
     compute_source_fingerprints,
     discover_sources,
+    mismatched_source_fingerprints,
     normalize_source_text,
     parse_positive_episode_num,
 )
@@ -126,7 +127,7 @@ def _planning_fingerprints_diverged(project_path: Path, project: Mapping[str, An
     recorded = project.get(SOURCE_FINGERPRINTS_KEY)
     if not isinstance(recorded, Mapping) or not recorded:
         return False
-    return dict(recorded) != compute_source_fingerprints(discover_sources(project_path))
+    return bool(mismatched_source_fingerprints(recorded, discover_sources(project_path)))
 
 
 def _empty_collection() -> dict[str, list[str]]:

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -12,7 +12,13 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lib import script_review
 from lib.asset_types import ASSET_SPECS
-from lib.episode_ledger import normalize_source_text, parse_positive_episode_num
+from lib.episode_ledger import (
+    SOURCE_FINGERPRINTS_KEY,
+    compute_source_fingerprints,
+    discover_sources,
+    normalize_source_text,
+    parse_positive_episode_num,
+)
 from lib.episode_paths import episode_script_relpath
 from lib.path_safety import safe_exists
 from lib.project_manager import ProjectManager
@@ -272,6 +278,11 @@ class WorkflowStateService:
     def _planning_complete(project_path: Path, project: dict[str, Any], source: SourceRevisionResult | None) -> bool:
         if source is None or not source.files:
             return False
+        recorded_fingerprints = project.get(SOURCE_FINGERPRINTS_KEY)
+        if isinstance(recorded_fingerprints, Mapping) and recorded_fingerprints:
+            current_fingerprints = compute_source_fingerprints(discover_sources(project_path))
+            if dict(recorded_fingerprints) != current_fingerprints:
+                return False
         cursor = project.get("planning_cursor")
         if not isinstance(cursor, Mapping):
             return False
@@ -324,7 +335,12 @@ class WorkflowStateService:
         return {"state": "current", "path": path}, raw_items, kind
 
     @staticmethod
-    def _media_collection(items: list[dict[str, Any]], kind: str | None, field: str) -> dict[str, list[str]]:
+    def _media_collection(
+        project_path: Path,
+        items: list[dict[str, Any]],
+        kind: str | None,
+        field: str,
+    ) -> dict[str, list[str]]:
         collection = _empty_collection()
         if kind is None:
             return collection
@@ -333,7 +349,8 @@ class WorkflowStateService:
             resource_id = item.get(id_field)
             if not isinstance(resource_id, str) or not resource_id:
                 continue
-            if get_generated_assets(item).get(field):
+            artifact_path = get_generated_assets(item).get(field)
+            if isinstance(artifact_path, str) and safe_exists(project_path, artifact_path):
                 collection["current_ids"].append(resource_id)
             else:
                 collection["missing_ids"].append(resource_id)
@@ -487,13 +504,13 @@ class WorkflowStateService:
                         )
                     else:
                         artifacts["storyboards"] = (
-                            self._media_collection(items, kind, "storyboard_image")
+                            self._media_collection(project_path, items, kind, "storyboard_image")
                             if generation_mode == "storyboard"
                             else _not_applicable_collection()
                         )
-                        artifacts["videos"] = self._media_collection(items, kind, "video_clip")
+                        artifacts["videos"] = self._media_collection(project_path, items, kind, "video_clip")
                         artifacts["audio"] = (
-                            self._media_collection(items, kind, "narration_audio")
+                            self._media_collection(project_path, items, kind, "narration_audio")
                             if mode == "narration" and generation_mode == "storyboard"
                             else _not_applicable_collection()
                         )
@@ -531,6 +548,20 @@ class WorkflowStateService:
                         elif mode != "ad" and not self._planning_complete(project_path, project, source):
                             state = "EPISODE_PLAN"
                             next_action = _action("plan_episodes", "source text remains unplanned")
+                        elif episode is None and mode != "ad":
+                            later_status = next(
+                                (
+                                    status
+                                    for number, _entry in episodes
+                                    if number != target.episode
+                                    and (status := self.get_status(project_name, number)).state != "EXPORT_READY"
+                                ),
+                                None,
+                            )
+                            if later_status is not None:
+                                return later_status
+                            state = "EXPORT_READY"
+                            next_action = _action("export", "all required artifacts are usable")
                         else:
                             state = "EXPORT_READY"
                             next_action = _action("export", "all required artifacts are usable")

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -151,10 +151,16 @@ def _new_source_precedes_cursor(project: Mapping[str, Any], sources: tuple[Sourc
     canonical_recorded = {
         unicodedata.normalize("NFC", recorded_path) for recorded_path in recorded if isinstance(recorded_path, str)
     }
+    cursor_indexes = [
+        index
+        for index, source in enumerate(sources)
+        if unicodedata.normalize("NFC", source.rel_path) == canonical_cursor
+    ]
+    if len(cursor_indexes) != 1:
+        return False
     return any(
-        (canonical := unicodedata.normalize("NFC", source.rel_path)) not in canonical_recorded
-        and canonical <= canonical_cursor
-        for source in sources
+        unicodedata.normalize("NFC", source.rel_path) not in canonical_recorded
+        for source in sources[: cursor_indexes[0] + 1]
     )
 
 
@@ -587,11 +593,11 @@ class WorkflowStateService:
         mode = project.get("content_mode")
         generation_mode = project.get("generation_mode")
         blockers: list[WorkflowBlocker] = []
-        if mode not in {"narration", "drama", "ad"}:
+        if not isinstance(mode, str) or mode not in {"narration", "drama", "ad"}:
             blockers.append(
                 WorkflowBlocker(code="invalid_content_mode", path="content_mode", reason="unsupported mode")
             )
-        if generation_mode not in {"storyboard", "reference_video"}:
+        if not isinstance(generation_mode, str) or generation_mode not in {"storyboard", "reference_video"}:
             blockers.append(
                 WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
             )

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -16,6 +16,7 @@ from lib import script_review
 from lib.asset_types import ASSET_SPECS
 from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
+    SourceDoc,
     compute_source_fingerprints,
     discover_sources,
     mismatched_source_fingerprints,
@@ -101,6 +102,8 @@ class WorkflowStatus(BaseModel):
 @dataclass(frozen=True)
 class _SharedWorkflowFacts:
     source: SourceRevisionResult | None
+    planning_sources: tuple[SourceDoc, ...]
+    planning_complete: bool
     inventory: dict[str, Any]
     sheets: dict[str, dict[str, Any]]
     episodes: list[tuple[int, dict[str, Any]]]
@@ -123,11 +126,11 @@ def _action(
     )
 
 
-def _planning_fingerprints_diverged(project_path: Path, project: Mapping[str, Any]) -> bool:
+def _planning_fingerprints_diverged(project: Mapping[str, Any], sources: tuple[SourceDoc, ...]) -> bool:
     recorded = project.get(SOURCE_FINGERPRINTS_KEY)
     if not isinstance(recorded, Mapping) or not recorded:
         return False
-    return bool(mismatched_source_fingerprints(recorded, discover_sources(project_path)))
+    return bool(mismatched_source_fingerprints(recorded, list(sources)))
 
 
 def _empty_collection() -> dict[str, list[str]]:
@@ -297,13 +300,19 @@ class WorkflowStateService:
         return (pending or episodes)[0] if (pending or episodes) else None
 
     @staticmethod
-    def _planning_complete(project_path: Path, project: dict[str, Any], source: SourceRevisionResult | None) -> bool:
+    def _planning_complete(
+        project_path: Path,
+        project: dict[str, Any],
+        source: SourceRevisionResult | None,
+        planning_sources: tuple[SourceDoc, ...] | None = None,
+    ) -> bool:
         if source is None or not source.files:
             return False
         recorded_fingerprints = project.get(SOURCE_FINGERPRINTS_KEY)
         if not isinstance(recorded_fingerprints, Mapping) or not recorded_fingerprints:
             return False
-        current_fingerprints = compute_source_fingerprints(discover_sources(project_path))
+        current_sources = tuple(discover_sources(project_path)) if planning_sources is None else planning_sources
+        current_fingerprints = compute_source_fingerprints(list(current_sources))
         if dict(recorded_fingerprints) != current_fingerprints:
             return False
         cursor = project.get("planning_cursor")
@@ -314,6 +323,11 @@ class WorkflowStateService:
         canonical_rel = unicodedata.normalize("NFC", rel) if isinstance(rel, str) else None
         if canonical_rel != source.files[-1] or not isinstance(offset, int) or isinstance(offset, bool):
             return False
+        if planning_sources is not None:
+            matching_docs = [
+                doc for doc in current_sources if unicodedata.normalize("NFC", doc.rel_path) == canonical_rel
+            ]
+            return len(matching_docs) == 1 and offset >= len(matching_docs[0].text)
         try:
             source_dir = project_path / "source"
             if source_dir.is_symlink():
@@ -523,10 +537,16 @@ class WorkflowStateService:
                 WorkflowBlocker(code="invalid_generation_mode", path="generation_mode", reason="unsupported route")
             )
         source, inventory = self._source_inventory(project_path, project, str(mode), blockers)
+        planning_sources = (
+            tuple(discover_sources(project_path)) if mode != "ad" and source is not None and not source.blockers else ()
+        )
+        planning_complete = self._planning_complete(project_path, project, source, planning_sources)
         sheets = self._asset_sheets(project_path, project, blockers)
         episodes = self._episodes(project, blockers)
         return _SharedWorkflowFacts(
             source=source,
+            planning_sources=planning_sources,
+            planning_complete=planning_complete,
             inventory=inventory,
             sheets=sheets,
             episodes=episodes,
@@ -597,7 +617,7 @@ class WorkflowStateService:
                     "expected_source_revision": source.revision if source else None,
                 },
             )
-        elif mode != "ad" and _planning_fingerprints_diverged(project_path, project):
+        elif mode != "ad" and _planning_fingerprints_diverged(project, shared.planning_sources):
             state = "EPISODE_PLAN"
             next_action = _action(
                 "reset_episode_planning",
@@ -808,13 +828,13 @@ class WorkflowStateService:
                             )
                             if later_status is not None:
                                 return later_status
-                            if not self._planning_complete(project_path, project, source):
+                            if not shared.planning_complete:
                                 state = "EPISODE_PLAN"
                                 next_action = _action("plan_episodes", "source text remains unplanned")
                             else:
                                 state = "EXPORT_READY"
                                 next_action = _action("export", "all required artifacts are usable")
-                        elif mode != "ad" and not self._planning_complete(project_path, project, source):
+                        elif mode != "ad" and not shared.planning_complete:
                             state = "EPISODE_PLAN"
                             next_action = _action("plan_episodes", "source text remains unplanned")
                         else:

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -55,7 +55,7 @@ from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
     validate_and_promote_reference_draft_tool,
 )
-from server.agent_runtime.sdk_tools.workflow_status import get_workflow_status_tool
+from server.agent_runtime.sdk_tools.workflow_status import complete_step1_rebuild_tool, get_workflow_status_tool
 
 __all__ = ["build_arcreel_mcp_server", "ToolContext", "ARCREEL_MCP_TOOL_IDS"]
 
@@ -68,6 +68,7 @@ __all__ = ["build_arcreel_mcp_server", "ToolContext", "ARCREEL_MCP_TOOL_IDS"]
 # i18n fails CI.
 ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
     "complete_asset_inventory",
+    "complete_step1_rebuild",
     "get_workflow_status",
     "list_pending_assets",
     "generate_assets",
@@ -107,6 +108,7 @@ def build_arcreel_mcp_server(*, project_name: str, projects_root: Path) -> Any:
         version="1.0.0",
         tools=[
             complete_asset_inventory_tool(ctx),
+            complete_step1_rebuild_tool(ctx),
             get_workflow_status_tool(ctx),
             list_pending_assets_tool(ctx),
             generate_assets_tool(ctx),

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -17,6 +17,7 @@ from typing import Any
 from claude_agent_sdk import create_sdk_mcp_server
 
 from server.agent_runtime.sdk_tools._context import ToolContext
+from server.agent_runtime.sdk_tools.asset_inventory import complete_asset_inventory_tool
 from server.agent_runtime.sdk_tools.enqueue_assets import (
     generate_assets_tool,
     list_pending_assets_tool,
@@ -54,6 +55,7 @@ from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
     validate_and_promote_reference_draft_tool,
 )
+from server.agent_runtime.sdk_tools.workflow_status import get_workflow_status_tool
 
 __all__ = ["build_arcreel_mcp_server", "ToolContext", "ARCREEL_MCP_TOOL_IDS"]
 
@@ -65,6 +67,8 @@ __all__ = ["build_arcreel_mcp_server", "ToolContext", "ARCREEL_MCP_TOOL_IDS"]
 # here has a translation in all locales, so adding a tool without wiring up
 # i18n fails CI.
 ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
+    "complete_asset_inventory",
+    "get_workflow_status",
     "list_pending_assets",
     "generate_assets",
     "generate_storyboards",
@@ -102,6 +106,8 @@ def build_arcreel_mcp_server(*, project_name: str, projects_root: Path) -> Any:
         name="arcreel",
         version="1.0.0",
         tools=[
+            complete_asset_inventory_tool(ctx),
+            get_workflow_status_tool(ctx),
             list_pending_assets_tool(ctx),
             generate_assets_tool(ctx),
             generate_storyboards_tool(ctx),

--- a/server/agent_runtime/sdk_tools/asset_inventory.py
+++ b/server/agent_runtime/sdk_tools/asset_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -57,7 +58,14 @@ def complete_asset_inventory_tool(ctx: ToolContext):
         try:
             scope = SourceScope.model_validate(args.get("scope"))
             expected = args["expected_source_revision"]
-            completed = complete_asset_inventory(ctx.pm, ctx.project_name, scope, expected, args.get("entries"))
+            completed = await asyncio.to_thread(
+                complete_asset_inventory,
+                ctx.pm,
+                ctx.project_name,
+                scope,
+                expected,
+                args.get("entries"),
+            )
             return _json_response(
                 {
                     "scope": completed.scope.model_dump(mode="json"),

--- a/server/agent_runtime/sdk_tools/asset_inventory.py
+++ b/server/agent_runtime/sdk_tools/asset_inventory.py
@@ -9,6 +9,8 @@ from claude_agent_sdk import tool
 from pydantic import ValidationError
 
 from lib.asset_inventory import (
+    AssetInventoryError,
+    AssetInventoryInvalidRequest,
     AssetInventoryRevisionConflict,
     AssetInventorySourceBlocked,
     complete_asset_inventory,
@@ -76,6 +78,10 @@ def complete_asset_inventory_tool(ctx: ToolContext):
                 },
                 is_error=True,
             )
+        except AssetInventoryInvalidRequest as exc:
+            return _json_response({"error": "invalid_request", "detail": str(exc)}, is_error=True)
+        except AssetInventoryError as exc:
+            return _json_response({"error": "inventory_unavailable", "detail": str(exc)}, is_error=True)
         except (KeyError, ValidationError, ValueError) as exc:
             return _json_response({"error": "invalid_request", "detail": str(exc)}, is_error=True)
         except Exception as exc:  # noqa: BLE001

--- a/server/agent_runtime/sdk_tools/asset_inventory.py
+++ b/server/agent_runtime/sdk_tools/asset_inventory.py
@@ -31,7 +31,7 @@ def _json_response(payload: dict[str, Any], *, is_error: bool = False) -> dict[s
 def complete_asset_inventory_tool(ctx: ToolContext):
     @tool(
         "complete_asset_inventory",
-        "在分析完成后记录资产清单事实。工具会在项目锁内重算 source revision；"
+        "原子提交分析提取出的资产和资产清单事实。工具会在项目锁内重算 source revision；"
         "与 expected_source_revision 不一致时整笔拒绝，不修改 project.json。空角色/场景/道具清单是合法结果。",
         {
             "type": "object",
@@ -45,6 +45,10 @@ def complete_asset_inventory_tool(ctx: ToolContext):
                     "required": ["kind"],
                 },
                 "expected_source_revision": {"type": "string"},
+                "entries": {
+                    "type": "object",
+                    "description": "本次新增资产：{characters/scenes/props: {名称: {description, voice_style?}}}",
+                },
             },
             "required": ["scope", "expected_source_revision"],
         },
@@ -53,7 +57,7 @@ def complete_asset_inventory_tool(ctx: ToolContext):
         try:
             scope = SourceScope.model_validate(args.get("scope"))
             expected = args["expected_source_revision"]
-            completed = complete_asset_inventory(ctx.pm, ctx.project_name, scope, expected)
+            completed = complete_asset_inventory(ctx.pm, ctx.project_name, scope, expected, args.get("entries"))
             return _json_response(
                 {
                     "scope": completed.scope.model_dump(mode="json"),

--- a/server/agent_runtime/sdk_tools/asset_inventory.py
+++ b/server/agent_runtime/sdk_tools/asset_inventory.py
@@ -1,0 +1,87 @@
+"""SDK MCP tool for committing an asset-inventory completion fact."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from claude_agent_sdk import tool
+from pydantic import ValidationError
+
+from lib.asset_inventory import (
+    AssetInventoryRevisionConflict,
+    AssetInventorySourceBlocked,
+    complete_asset_inventory,
+)
+from lib.source_revision import SourceScope
+from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
+
+
+def _json_response(payload: dict[str, Any], *, is_error: bool = False) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False, sort_keys=True)}]
+    }
+    if is_error:
+        response["is_error"] = True
+    return response
+
+
+def complete_asset_inventory_tool(ctx: ToolContext):
+    @tool(
+        "complete_asset_inventory",
+        "在分析完成后记录资产清单事实。工具会在项目锁内重算 source revision；"
+        "与 expected_source_revision 不一致时整笔拒绝，不修改 project.json。空角色/场景/道具清单是合法结果。",
+        {
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"type": "string", "enum": ["all", "files"]},
+                        "files": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["kind"],
+                },
+                "expected_source_revision": {"type": "string"},
+            },
+            "required": ["scope", "expected_source_revision"],
+        },
+    )
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        try:
+            scope = SourceScope.model_validate(args.get("scope"))
+            expected = args["expected_source_revision"]
+            completed = complete_asset_inventory(ctx.pm, ctx.project_name, scope, expected)
+            return _json_response(
+                {
+                    "scope": completed.scope.model_dump(mode="json"),
+                    "source_revision": completed.source_revision,
+                    "counts": completed.counts,
+                }
+            )
+        except AssetInventoryRevisionConflict as exc:
+            return _json_response(
+                {
+                    "error": "source_revision_conflict",
+                    "expected_source_revision": exc.expected_revision,
+                    "actual_source_revision": exc.actual_revision,
+                },
+                is_error=True,
+            )
+        except AssetInventorySourceBlocked as exc:
+            return _json_response(
+                {
+                    "error": "source_blocked",
+                    "blockers": [blocker.model_dump(mode="json") for blocker in exc.blockers],
+                },
+                is_error=True,
+            )
+        except (KeyError, ValidationError, ValueError) as exc:
+            return _json_response({"error": "invalid_request", "detail": str(exc)}, is_error=True)
+        except Exception as exc:  # noqa: BLE001
+            return tool_error("complete_asset_inventory", exc)
+
+    return _handler
+
+
+__all__ = ["complete_asset_inventory_tool"]

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -41,7 +42,7 @@ def get_workflow_status_tool(ctx: ToolContext):
         ):
             return _error("invalid_episode", "episode must be a positive integer")
         try:
-            status = WorkflowStateService(ctx.pm).get_status(ctx.project_name, raw_episode)
+            status = await asyncio.to_thread(WorkflowStateService(ctx.pm).get_status, ctx.project_name, raw_episode)
             return {"content": [{"type": "text", "text": status.model_dump_json()}]}
         except json.JSONDecodeError as exc:
             return tool_error("get_workflow_status", exc)

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -43,6 +43,8 @@ def get_workflow_status_tool(ctx: ToolContext):
         try:
             status = WorkflowStateService(ctx.pm).get_status(ctx.project_name, raw_episode)
             return {"content": [{"type": "text", "text": status.model_dump_json()}]}
+        except json.JSONDecodeError as exc:
+            return tool_error("get_workflow_status", exc)
         except ValueError as exc:
             return _error("invalid_episode", str(exc))
         except Exception as exc:  # noqa: BLE001

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -31,7 +31,6 @@ def get_workflow_status_tool(ctx: ToolContext):
             "type": "object",
             "properties": {
                 "episode": {"type": "integer", "minimum": 1},
-                "include_details": {"type": "boolean", "default": True},
             },
         },
     )
@@ -41,9 +40,6 @@ def get_workflow_status_tool(ctx: ToolContext):
             not isinstance(raw_episode, int) or isinstance(raw_episode, bool) or raw_episode < 1
         ):
             return _error("invalid_episode", "episode must be a positive integer")
-        include_details = args.get("include_details", True)
-        if not isinstance(include_details, bool):
-            return _error("invalid_request", "include_details must be a boolean")
         try:
             status = WorkflowStateService(ctx.pm).get_status(ctx.project_name, raw_episode)
             return {"content": [{"type": "text", "text": status.model_dump_json()}]}

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -1,0 +1,58 @@
+"""SDK MCP adapter for the authoritative workflow-status service."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from claude_agent_sdk import tool
+
+from lib.workflow_state import WorkflowStateService
+from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
+
+
+def _error(code: str, detail: str) -> dict[str, Any]:
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps({"error": code, "detail": detail}, ensure_ascii=False, sort_keys=True),
+            }
+        ],
+        "is_error": True,
+    }
+
+
+def get_workflow_status_tool(ctx: ToolContext):
+    @tool(
+        "get_workflow_status",
+        "读取服务端权威工作流状态、blocker、gate、产物事实和唯一 next_action。无副作用；不要再根据文件名自行推断阶段。",
+        {
+            "type": "object",
+            "properties": {
+                "episode": {"type": "integer", "minimum": 1},
+                "include_details": {"type": "boolean", "default": True},
+            },
+        },
+    )
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        raw_episode = args.get("episode")
+        if raw_episode is not None and (
+            not isinstance(raw_episode, int) or isinstance(raw_episode, bool) or raw_episode < 1
+        ):
+            return _error("invalid_episode", "episode must be a positive integer")
+        include_details = args.get("include_details", True)
+        if not isinstance(include_details, bool):
+            return _error("invalid_request", "include_details must be a boolean")
+        try:
+            status = WorkflowStateService(ctx.pm).get_status(ctx.project_name, raw_episode)
+            return {"content": [{"type": "text", "text": status.model_dump_json()}]}
+        except ValueError as exc:
+            return _error("invalid_episode", str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return tool_error("get_workflow_status", exc)
+
+    return _handler
+
+
+__all__ = ["get_workflow_status_tool"]

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from claude_agent_sdk import tool
 
+from lib.script_review import Step1RebuildCompletionError, complete_stale_step1_rebuild
 from lib.workflow_state import WorkflowStateService
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 
@@ -54,4 +55,52 @@ def get_workflow_status_tool(ctx: ToolContext):
     return _handler
 
 
-__all__ = ["get_workflow_status_tool"]
+def complete_step1_rebuild_tool(ctx: ToolContext):
+    @tool(
+        "complete_step1_rebuild",
+        "在 stale 分集预处理成功后原子记录完成事实；即使重建内容与旧 step1 相同，workflow-status 也能继续收敛。",
+        {
+            "type": "object",
+            "properties": {
+                "episode": {"type": "integer", "minimum": 1},
+                "expected_stale_step1_revision": {"type": ["string", "null"]},
+            },
+            "required": ["episode", "expected_stale_step1_revision"],
+        },
+    )
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        episode = args.get("episode")
+        if not isinstance(episode, int) or isinstance(episode, bool) or episode < 1:
+            return _error("invalid_episode", "episode must be a positive integer")
+        if "expected_stale_step1_revision" not in args:
+            return _error("invalid_request", "expected_stale_step1_revision is required")
+        expected = args.get("expected_stale_step1_revision")
+        if expected is not None and not isinstance(expected, str):
+            return _error("invalid_request", "expected_stale_step1_revision must be a string or null")
+        try:
+            revision = await asyncio.to_thread(
+                complete_stale_step1_rebuild,
+                ctx.pm,
+                ctx.project_name,
+                episode,
+                expected,
+            )
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"episode": episode, "step1_revision": revision}, ensure_ascii=False, sort_keys=True
+                        ),
+                    }
+                ]
+            }
+        except Step1RebuildCompletionError as exc:
+            return _error(exc.code, str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return tool_error("complete_step1_rebuild", exc)
+
+    return _handler
+
+
+__all__ = ["complete_step1_rebuild_tool", "get_workflow_status_tool"]

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -467,12 +467,10 @@ async def _handle_source_upload(
     original_filename = _require_filename(file, _t)
 
     try:
-        project_dir = get_project_manager().get_project_path(project_name)
+        manager = get_project_manager()
+        project_dir = manager.get_project_path(project_name)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=project_name) from exc
-
-    source_dir = project_dir / "source"
-    source_dir.mkdir(parents=True, exist_ok=True)
 
     def _sync() -> NormalizeResult:
         # 流式写入 tmp，避免把上传 body 整体拉进 Python 堆；
@@ -484,12 +482,13 @@ async def _handle_source_upload(
         try:
             with tmp_path.open("wb") as out:
                 shutil.copyfileobj(file.file, out)
-            return SourceLoader.load(
-                tmp_path,
-                source_dir,
-                original_filename=original_filename,
-                on_conflict=on_conflict,
-            )
+            with manager.locked_source_mutation(project_name) as source_dir:
+                return SourceLoader.load(
+                    tmp_path,
+                    source_dir,
+                    original_filename=original_filename,
+                    on_conflict=on_conflict,
+                )
         finally:
             tmp_path.unlink(missing_ok=True)
 
@@ -659,17 +658,17 @@ async def update_source_file(
     try:
 
         def _sync():
-            project_dir = get_project_manager().get_project_path(project_name)
-            source_dir = project_dir / "source"
-            source_dir.mkdir(parents=True, exist_ok=True)
+            manager = get_project_manager()
+            project_dir = manager.get_project_path(project_name)
 
-            # 安全检查：确保路径在项目目录内（文件尚不存在也要能通过，此处允许新建）
-            try:
-                source_path = safe_join(project_dir, "source", filename)
-            except PathTraversalError:
-                raise HTTPException(status_code=403, detail=_t("forbidden_access"))
+            with manager.locked_source_mutation(project_name):
+                # 安全检查：确保路径在项目目录内（文件尚不存在也要能通过，此处允许新建）
+                try:
+                    source_path = safe_join(project_dir, "source", filename)
+                except PathTraversalError:
+                    raise HTTPException(status_code=403, detail=_t("forbidden_access"))
 
-            source_path.write_text(content, encoding="utf-8")
+                source_path.write_text(content, encoding="utf-8")
             return {"success": True, "path": f"source/{filename}"}
 
         return await asyncio.to_thread(_sync)
@@ -689,25 +688,26 @@ async def delete_source_file(project_name: str, filename: str, _t: Translator):
     try:
 
         def _sync():
-            project_dir = get_project_manager().get_project_path(project_name)
+            manager = get_project_manager()
+            project_dir = manager.get_project_path(project_name)
 
-            # 安全检查：确保路径在项目目录内
-            try:
-                source_path = safe_join(project_dir, "source", filename)
-            except PathTraversalError:
-                raise HTTPException(status_code=403, detail=_t("forbidden_access"))
+            with manager.locked_source_mutation(project_name):
+                # 安全检查：确保路径在项目目录内
+                try:
+                    source_path = safe_join(project_dir, "source", filename)
+                except PathTraversalError:
+                    raise HTTPException(status_code=403, detail=_t("forbidden_access"))
 
-            if source_path.exists():
-                source_path.unlink()
-                # 级联删除原文件备份（同 stem，任意扩展名）
-                raw_dir = project_dir / "source" / "raw"
-                if raw_dir.exists():
-                    stem = source_path.stem
-                    for raw_file in raw_dir.iterdir():
-                        if raw_file.is_file() and raw_file.stem == stem:
-                            raw_file.unlink()
-                return {"success": True}
-            else:
+                if source_path.exists():
+                    source_path.unlink()
+                    # 级联删除原文件备份（同 stem，任意扩展名）
+                    raw_dir = project_dir / "source" / "raw"
+                    if raw_dir.exists():
+                        stem = source_path.stem
+                        for raw_file in raw_dir.iterdir():
+                            if raw_file.is_file() and raw_file.stem == stem:
+                                raw_file.unlink()
+                    return {"success": True}
                 raise HTTPException(status_code=404, detail=_t("file_not_found", path=filename))
 
         return await asyncio.to_thread(_sync)

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1331,21 +1331,17 @@ async def set_project_source(
         def _sync_write():
             if not manager.project_exists(name):
                 raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
-            project_dir = manager.get_project_path(name)
-            source_dir = project_dir / "source"
-            source_dir.mkdir(parents=True, exist_ok=True)
-
-            if raw is not None:
-                safe_filename = Path(original_name).name
-                try:
-                    text = raw.decode("utf-8")
-                except UnicodeDecodeError:
-                    raise HTTPException(status_code=400, detail=_t("invalid_encoding"))
-                if len(text) > MAX_CHARS:
-                    raise HTTPException(status_code=400, detail=_t("file_too_large", max_chars=MAX_CHARS))
-                (source_dir / safe_filename).write_text(text, encoding="utf-8")
-                return safe_filename, len(text)
-            else:
+            with manager.locked_source_mutation(name) as source_dir:
+                if raw is not None:
+                    safe_filename = Path(original_name).name
+                    try:
+                        text = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        raise HTTPException(status_code=400, detail=_t("invalid_encoding"))
+                    if len(text) > MAX_CHARS:
+                        raise HTTPException(status_code=400, detail=_t("file_too_large", max_chars=MAX_CHARS))
+                    (source_dir / safe_filename).write_text(text, encoding="utf-8")
+                    return safe_filename, len(text)
                 if len(text_content) > MAX_CHARS:
                     raise HTTPException(status_code=400, detail=_t("file_too_large", max_chars=MAX_CHARS))
                 safe_filename = "novel.txt"

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -42,6 +42,7 @@ from lib.project_manager import EmptySourceError, EpisodeScriptReboundError, Sou
 from lib.speech_rate import MAX_SPEECH_RATE_UPS, MIN_SPEECH_RATE_UPS, SPEECH_RATE_FIELD, is_valid_speech_rate
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
+from lib.workflow_state import WorkflowStateService, WorkflowStatus
 from server.auth import CurrentUser, create_download_token, verify_download_token
 from server.routers._reorder import full_permutation_error
 from server.routers._validators import validate_backend_value
@@ -659,6 +660,21 @@ async def get_video_capabilities(
             status_code=422,
             detail=_t("video_capabilities_unresolved", name=name),
         ) from exc
+
+
+@router.get("/projects/{name}/workflow-status", response_model=WorkflowStatus)
+async def get_workflow_status(
+    name: str,
+    episode: Annotated[int | None, Query(ge=1)] = None,
+):
+    """Return the authenticated, server-authoritative project workflow status."""
+
+    try:
+        return await asyncio.to_thread(WorkflowStateService(get_project_manager()).get_status, name, episode)
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
+    except ValueError as exc:
+        raise BadRequestError("request_invalid") from exc
 
 
 @router.get("/projects/{name}")

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -673,6 +673,8 @@ async def get_workflow_status(
         return await asyncio.to_thread(WorkflowStateService(get_project_manager()).get_status, name, episode)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
+    except json.JSONDecodeError:
+        raise
     except ValueError as exc:
         raise BadRequestError("request_invalid") from exc
 

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -41,6 +41,66 @@ def _write_artifact(project_path: Path, relative_path: str) -> None:
     path.write_bytes(b"artifact")
 
 
+def _valid_narration_segment(**overrides: object) -> dict:
+    segment = {
+        "segment_id": "E1S01",
+        "duration_seconds": 4,
+        "novel_text": "原文",
+        "characters_in_segment": [],
+        "scenes": [],
+        "props": [],
+        "image_prompt": "画面",
+        "video_prompt": "动作",
+        "generated_assets": {},
+    }
+    segment.update(overrides)
+    return segment
+
+
+def _valid_drama_scene(**overrides: object) -> dict:
+    scene = {
+        "scene_id": "E1S01",
+        "duration_seconds": 4,
+        "characters_in_scene": [],
+        "scenes": [],
+        "props": [],
+        "image_prompt": "画面",
+        "video_prompt": "动作",
+        "generated_assets": {},
+    }
+    scene.update(overrides)
+    return scene
+
+
+def _valid_ad_shot(**overrides: object) -> dict:
+    shot = {
+        "shot_id": "E1S01",
+        "duration_seconds": 4,
+        "voiceover_text": "",
+        "characters_in_shot": [],
+        "scenes": [],
+        "props": [],
+        "products_in_shot": [],
+        "image_prompt": "画面",
+        "video_prompt": "动作",
+        "generated_assets": {},
+    }
+    shot.update(overrides)
+    return shot
+
+
+def _valid_video_unit(**overrides: object) -> dict:
+    unit = {
+        "unit_id": "E1U01",
+        "duration_seconds": 8,
+        "shots": [{"text": "镜头"}],
+        "references": [],
+        "generated_assets": {},
+    }
+    unit.update(overrides)
+    return unit
+
+
 @pytest.mark.integration
 def test_narration_empty_inventory_completes_and_advances_to_episode_plan(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
@@ -114,16 +174,15 @@ def test_media_paths_must_resolve_to_project_files_before_becoming_current(tmp_p
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "广告",
             "content_mode": "ad",
             "shots": [
-                {
-                    "shot_id": "E1S01",
-                    "duration_seconds": 4,
-                    "generated_assets": {
+                _valid_ad_shot(
+                    generated_assets={
                         "storyboard_image": "../outside.png",
                         "video_clip": "videos/missing.mp4",
-                    },
-                }
+                    }
+                )
             ],
         },
     )
@@ -231,8 +290,9 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
     script_path = project_path / "scripts" / "episode_1.json"
     script = {
         "episode": 1,
+        "title": "第一集",
         "content_mode": "narration",
-        "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+        "segments": [_valid_narration_segment()],
     }
     atomic_write_json(script_path, script)
     service = WorkflowStateService(pm)
@@ -307,8 +367,9 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "第一集",
             "content_mode": "narration",
-            "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": generated_assets}],
+            "segments": [_valid_narration_segment(generated_assets=generated_assets)],
         },
     )
     for relative_path in generated_assets.values():
@@ -389,10 +450,10 @@ def test_non_object_script_is_a_blocker_not_an_exception(tmp_path: Path) -> None
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ("mode", "step1_filename", "step1_payload", "items_key", "id_field"),
+    ("mode", "step1_filename", "step1_payload", "items_key"),
     [
-        ("narration", "step1_segments.json", {"segments": []}, "segments", "segment_id"),
-        ("drama", "step1_normalized_script.json", {"scenes": []}, "scenes", "scene_id"),
+        ("narration", "step1_segments.json", {"segments": []}, "segments"),
+        ("drama", "step1_normalized_script.json", {"scenes": []}, "scenes"),
     ],
 )
 def test_legacy_storyboard_script_without_duration_remains_resumable(
@@ -401,7 +462,6 @@ def test_legacy_storyboard_script_without_duration_remains_resumable(
     step1_filename: str,
     step1_payload: dict,
     items_key: str,
-    id_field: str,
 ) -> None:
     pm, project_path = _make_project(tmp_path, mode)
     _write_source_and_complete(pm, project_path)
@@ -420,12 +480,19 @@ def test_legacy_storyboard_script_without_duration_remains_resumable(
     pm.update_project(
         "demo", lambda project: script_review.apply_confirmation(project, 1, revision, "2026-08-11T00:00:00Z")
     )
+    item = (
+        _valid_narration_segment(duration_seconds=None)
+        if mode == "narration"
+        else _valid_drama_scene(duration_seconds=None)
+    )
+    item.pop("duration_seconds")
     atomic_write_json(
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "第一集",
             "content_mode": mode,
-            items_key: [{id_field: "E1S01", "generated_assets": {}}],
+            items_key: [item],
             "metadata": {script_review.SCRIPT_STEP1_REVISION_FIELD: revision},
         },
     )
@@ -460,8 +527,9 @@ def test_legacy_narration_scenes_skeleton_remains_resumable(tmp_path: Path) -> N
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "第一集",
             "content_mode": "narration",
-            "scenes": [{"scene_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+            "scenes": [_valid_drama_scene()],
         },
     )
 
@@ -522,8 +590,9 @@ def test_optional_product_sheet_does_not_block_ad_media(tmp_path: Path) -> None:
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "广告",
             "content_mode": "ad",
-            "shots": [{"shot_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+            "shots": [_valid_ad_shot()],
         },
     )
 
@@ -543,8 +612,9 @@ def test_ad_reference_video_reads_completion_from_reference_units(tmp_path: Path
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "广告",
             "content_mode": "ad",
-            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+            "shots": [_valid_ad_shot()],
             "reference_units": [
                 {
                     "unit_id": "E1U1",
@@ -574,8 +644,9 @@ def test_ad_reference_video_without_derived_units_requires_video_generation(tmp_
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "广告",
             "content_mode": "ad",
-            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+            "shots": [_valid_ad_shot()],
         },
     )
 
@@ -696,8 +767,9 @@ def test_confirmed_step1_change_marks_old_final_script_stale(tmp_path: Path) -> 
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "第一集",
             "content_mode": "narration",
-            "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+            "segments": [_valid_narration_segment()],
             "metadata": {script_review.SCRIPT_STEP1_REVISION_FIELD: old_revision},
         },
     )
@@ -764,7 +836,7 @@ def test_script_id_must_match_the_shared_storyboard_pattern(tmp_path: Path) -> N
 
 
 @pytest.mark.integration
-def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
+def test_dangling_ad_reference_unit_is_recoverable_by_video_generation(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
     video_path = "reference_videos/E1U1.mp4"
     _write_artifact(project_path, video_path)
@@ -772,8 +844,9 @@ def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "广告",
             "content_mode": "ad",
-            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+            "shots": [_valid_ad_shot()],
             "reference_units": [
                 {
                     "unit_id": "E1U1",
@@ -788,8 +861,98 @@ def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
     status = WorkflowStateService(pm).get_status("demo")
 
     assert status.state == "VIDEO"
-    assert status.artifacts["videos"]["state"] == "blocked"
-    assert status.blockers[0].code == "invalid_reference_unit"
+    assert status.artifacts["videos"]["state"] == "stale"
+    assert status.next_action.type == "generate_videos"
+    assert not status.blockers
+
+
+@pytest.mark.integration
+def test_ad_reference_units_must_cover_every_shot_exactly_once(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
+    video_path = "reference_videos/E1U1.mp4"
+    _write_artifact(project_path, video_path)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "广告",
+            "content_mode": "ad",
+            "shots": [_valid_ad_shot(), _valid_ad_shot(shot_id="E1S02")],
+            "reference_units": [
+                {
+                    "unit_id": "E1U1",
+                    "shot_ids": ["E1S01"],
+                    "references": [],
+                    "generated_assets": {"video_clip": video_path},
+                }
+            ],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "VIDEO"
+    assert status.artifacts["videos"]["state"] == "stale"
+    assert status.next_action.type == "generate_videos"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("missing_field", ["voiceover_text", "image_prompt", "video_prompt"])
+def test_structurally_incomplete_ad_script_blocks_media_progress(tmp_path: Path, missing_field: str) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    shot = _valid_ad_shot()
+    shot.pop(missing_field)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "广告",
+            "content_mode": "ad",
+            "shots": [shot],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script_structure"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_narration_script_without_source_text_blocks_media_progress(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "原文"
+    _write_source_and_complete(pm, project_path, source_text)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "consumed"}],
+            planning_cursor={"source_file": "source/novel.txt", "offset": len(source_text)},
+            **{SOURCE_FINGERPRINTS_KEY: compute_source_fingerprints(discover_sources(project_path))},
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"segments": []})
+    segment = _valid_narration_segment()
+    segment.pop("novel_text")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [segment],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script_structure"
 
 
 @pytest.mark.integration
@@ -941,8 +1104,9 @@ def test_reference_video_route_skips_storyboards_and_audio(tmp_path: Path) -> No
         project_path / "scripts" / "episode_1.json",
         {
             "episode": 1,
+            "title": "第一集",
             "content_mode": "drama",
-            "video_units": [{"unit_id": "E1U01", "duration_seconds": 8, "generated_assets": {}}],
+            "video_units": [_valid_video_unit()],
         },
     )
 
@@ -952,3 +1116,44 @@ def test_reference_video_route_skips_storyboards_and_audio(tmp_path: Path) -> No
     assert status.artifacts["storyboards"]["state"] == "not_applicable"
     assert status.artifacts["audio"]["state"] == "not_applicable"
     assert status.next_action.requested_ids == ["E1U01"]
+
+
+@pytest.mark.integration
+def test_workflow_status_does_not_persist_read_time_script_migrations(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
+    source_text = "原文"
+    _write_source_and_complete(pm, project_path, source_text)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "consumed"}],
+            planning_cursor={"source_file": "source/novel.txt", "offset": len(source_text)},
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_reference_units.json", {"units": []})
+    script_path = project_path / "scripts" / "episode_1.json"
+    atomic_write_json(
+        script_path,
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "drama",
+            "video_units": [
+                {
+                    "unit_id": "E1U01",
+                    "shots": [{"text": "镜头", "duration": 8}],
+                    "references": [],
+                    "generated_assets": {},
+                }
+            ],
+        },
+    )
+    before = script_path.read_bytes()
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "VIDEO"
+    assert script_path.read_bytes() == before
+    assert not (script_path.parent / ".episode_1.json.lock").exists()

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -683,6 +683,7 @@ def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
             "reference_units": [
                 {
                     "unit_id": "E1U1",
+                    "shot_ids": ["E1S99"],
                     "references": [],
                     "generated_assets": {"video_clip": video_path},
                 }
@@ -698,6 +699,26 @@ def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
+def test_invalid_required_script_field_blocks_export(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01", "duration_seconds": -7, "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script_structure"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
 def test_planning_completion_resolves_nfc_cursor_to_nfd_filesystem_path(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     decomposed_name = unicodedata.normalize("NFD", "truyện.txt")
@@ -710,6 +731,19 @@ def test_planning_completion_resolves_nfc_cursor_to_nfd_filesystem_path(tmp_path
     project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
 
     assert WorkflowStateService._planning_complete(project_path, project, source) is True
+
+
+@pytest.mark.integration
+def test_planning_without_source_fingerprint_baseline_is_incomplete(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_path = project_path / "source" / "novel.txt"
+    source_path.write_text("完整原文", encoding="utf-8")
+    project = pm.load_project("demo")
+    source = compute_source_revision(project_path, project, SourceScope(kind="all"))
+    assert source.revision is not None
+    project["planning_cursor"] = {"source_file": source.files[-1], "offset": 4}
+
+    assert WorkflowStateService._planning_complete(project_path, project, source) is False
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.asset_inventory import complete_asset_inventory
+from lib.json_io import atomic_write_json
+from lib.project_manager import ProjectManager
+from lib.source_revision import SourceScope, compute_source_revision
+from lib.workflow_state import WorkflowStateService
+
+
+def _make_project(tmp_path: Path, mode: str, *, generation_mode: str = "storyboard") -> tuple[ProjectManager, Path]:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    extras = {"generation_mode": generation_mode, "grid_storyboard": False}
+    if mode == "ad":
+        pm.create_project_metadata("demo", "Demo", "", mode, extras=extras, target_duration=30)
+    else:
+        pm.create_project_metadata("demo", "Demo", "", mode, extras=extras)
+    return pm, pm.get_project_path("demo")
+
+
+def _write_source_and_complete(pm: ProjectManager, project_path: Path, text: str = "原文") -> str:
+    source = project_path / "source" / "novel.txt"
+    source.write_text(text, encoding="utf-8")
+    scope = SourceScope(kind="all")
+    revision = compute_source_revision(project_path, pm.load_project("demo"), scope).revision
+    assert revision is not None
+    complete_asset_inventory(pm, "demo", scope, revision)
+    return revision
+
+
+@pytest.mark.integration
+def test_narration_empty_inventory_completes_and_advances_to_episode_plan(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    revision = _write_source_and_complete(pm, project_path)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.schema_version == 1
+    assert status.project.content_mode == "narration"
+    assert status.source_revision == revision
+    assert status.state == "EPISODE_PLAN"
+    assert status.artifacts["asset_inventory"]["state"] == "current"
+    assert status.artifacts["asset_sheets"] == {
+        "character": {"current_ids": [], "missing_ids": [], "stale_ids": []},
+        "scene": {"current_ids": [], "missing_ids": [], "stale_ids": []},
+        "prop": {"current_ids": [], "missing_ids": [], "stale_ids": []},
+        "product": {"current_ids": [], "missing_ids": [], "stale_ids": []},
+    }
+    assert status.next_action.type == "plan_episodes"
+
+
+@pytest.mark.integration
+def test_drama_target_comes_from_ledger_not_derived_filenames(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama")
+    _write_source_and_complete(pm, project_path)
+    (project_path / "source" / "episode_1.txt").write_text("派生集文件", encoding="utf-8")
+    (project_path / "scripts" / "episode_1.json").write_text("{}", encoding="utf-8")
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 2,
+                "title": "第二集",
+                "script_file": "scripts/custom-name.json",
+                "ledger_status": "planned",
+                "source_range": {"source_file": "source/novel.txt", "start": 0, "end": 2},
+            }
+        ]
+
+    pm.update_project("demo", _plan)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.target is not None
+    assert status.target.episode == 2
+    assert status.target.script == "scripts/custom-name.json"
+    assert status.state == "STEP1_CONTENT"
+    assert status.next_action.type == "prepare_step1"
+    assert status.next_action.args["preprocessor"] == "normalize-drama-script"
+
+
+@pytest.mark.integration
+def test_ad_is_episode_one_and_skips_asset_inventory_and_step1(tmp_path: Path) -> None:
+    pm, _project_path = _make_project(tmp_path, "ad")
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.target is not None
+    assert status.target.episode == 1
+    assert status.artifacts["asset_inventory"]["state"] == "not_applicable"
+    assert status.gates["step1_review"]["state"] == "not_applicable"
+    assert status.state == "FINAL_SCRIPT"
+    assert status.next_action.type == "generate_script"
+
+
+@pytest.mark.integration
+def test_appended_source_only_refreshes_inventory_and_preserves_existing_work(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    old_revision = _write_source_and_complete(pm, project_path, "第一段")
+
+    def _seed(project: dict) -> None:
+        project["characters"] = {"阿离": {"description": "角色"}}
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "title": "第一集",
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "planned",
+                "source_range": {"source_file": "source/novel.txt", "start": 0, "end": 3},
+            }
+        ]
+
+    pm.update_project("demo", _seed)
+    (project_path / "source" / "novel.txt").write_text("第一段\n追加段落", encoding="utf-8")
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "ASSET_INVENTORY"
+    assert status.source_revision != old_revision
+    assert status.artifacts["asset_inventory"]["state"] == "stale"
+    assert status.next_action.type == "analyze_assets"
+    stored = pm.load_project("demo")
+    assert list(stored["characters"]) == ["阿离"]
+    assert stored["episodes"][0]["episode"] == 1
+
+
+@pytest.mark.integration
+def test_partial_inventory_scope_never_unlocks_full_workflow(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    (project_path / "source" / "novel.txt").write_text("原文", encoding="utf-8")
+    scope = SourceScope(kind="files", files=["source/novel.txt"])
+    revision = compute_source_revision(project_path, pm.load_project("demo"), scope).revision
+    assert revision is not None
+    complete_asset_inventory(pm, "demo", scope, revision)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "ASSET_INVENTORY"
+    assert status.artifacts["asset_inventory"]["state"] == "missing"
+    assert status.artifacts["asset_inventory"]["recorded_scope"] == {
+        "kind": "files",
+        "files": ["source/novel.txt"],
+    }
+
+
+@pytest.mark.integration
+def test_unsafe_source_returns_blocker_instead_of_skipping_or_raising(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    target = project_path / "target.txt"
+    target.write_text("source", encoding="utf-8")
+    (project_path / "source" / "novel.txt").symlink_to(target)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.blockers[0].code == "source_symlink"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "title": "第一集",
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "consumed",
+                "source_range": {"source_file": "source/novel.txt", "start": 0, "end": len(source_text)},
+            }
+        ]
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    script_path = project_path / "scripts" / "episode_1.json"
+    script = {
+        "episode": 1,
+        "content_mode": "narration",
+        "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+    }
+    atomic_write_json(script_path, script)
+    service = WorkflowStateService(pm)
+
+    storyboard = service.get_status("demo")
+    assert storyboard.state == "STORYBOARD"
+    assert storyboard.next_action.requested_ids == ["E1S01"]
+
+    script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+    atomic_write_json(script_path, script)
+    video = service.get_status("demo")
+    assert video.state == "VIDEO"
+
+    script["segments"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
+    atomic_write_json(script_path, script)
+    audio = service.get_status("demo")
+    assert audio.state == "AUDIO"
+
+    script["segments"][0]["generated_assets"]["narration_audio"] = "audio/E1S01.wav"
+    atomic_write_json(script_path, script)
+    ready = service.get_status("demo")
+    assert ready.state == "EXPORT_READY"
+    assert ready.next_action.type == "export"
+
+
+@pytest.mark.integration
+def test_malformed_script_collection_is_a_blocker_not_an_exception(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {"episode": 1, "content_mode": "ad", "shots": {"not": "a list"}},
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script_collection"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_reference_video_route_skips_storyboards_and_audio(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
+    source_text = "原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "consumed",
+            }
+        ]
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_reference_units.json", {"units": []})
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "drama",
+            "video_units": [{"unit_id": "E1U01", "duration_seconds": 8, "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "VIDEO"
+    assert status.artifacts["storyboards"]["state"] == "not_applicable"
+    assert status.artifacts["audio"]["state"] == "not_applicable"
+    assert status.next_action.requested_ids == ["E1U01"]

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -335,6 +335,52 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
 
 
 @pytest.mark.integration
+def test_unplanned_source_with_legacy_episode_without_source_range_requires_full_reset(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "title": "第一集",
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "consumed",
+            }
+        ]
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": 1}
+        project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    generated_assets = {
+        "storyboard_image": "storyboards/E1S01.png",
+        "video_clip": "videos/E1S01.mp4",
+        "narration_audio": "audio/E1S01.wav",
+    }
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [_valid_narration_segment(generated_assets=generated_assets)],
+        },
+    )
+    for relative_path in generated_assets.values():
+        _write_artifact(project_path, relative_path)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "reset_episode_planning"
+    assert status.next_action.args == {"from_episode": 1}
+
+
+@pytest.mark.integration
 def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -644,6 +690,32 @@ def test_non_string_project_mode_returns_blocker(tmp_path: Path, field: str, val
 
     assert status.state == "PROJECT_INPUT"
     assert status.blockers[0].code == blocker_code
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("ledger_status", [[], {}])
+def test_non_string_ledger_status_returns_blocker(tmp_path: Path, ledger_status: object) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 1,
+                    "script_file": "scripts/episode_1.json",
+                    "ledger_status": ledger_status,
+                }
+            ]
+        ),
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.target is None
+    assert status.blockers[0].code == "invalid_ledger_status"
     assert status.next_action.type == "none"
 
 

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -268,7 +268,9 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
 
 
 @pytest.mark.integration
-def test_completed_first_episode_does_not_hide_later_incomplete_episode(tmp_path: Path) -> None:
+def test_completed_first_episode_does_not_hide_later_incomplete_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     source_text = "完整原文"
     _write_source_and_complete(pm, project_path, source_text)
@@ -304,8 +306,18 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(tmp_path
     for relative_path in generated_assets.values():
         _write_artifact(project_path, relative_path)
 
+    original_load_project = pm.load_project
+    load_calls = 0
+
+    def _counted_load_project(project_name: str) -> dict:
+        nonlocal load_calls
+        load_calls += 1
+        return original_load_project(project_name)
+
+    monkeypatch.setattr(pm, "load_project", _counted_load_project)
     status = WorkflowStateService(pm).get_status("demo")
 
+    assert load_calls == 1
     assert status.target is not None
     assert status.target.episode == 2
     assert status.state == "STEP1_CONTENT"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -87,6 +87,7 @@ def test_drama_target_comes_from_ledger_not_derived_filenames(tmp_path: Path) ->
     assert status.target is not None
     assert status.target.episode == 2
     assert status.target.script == "scripts/custom-name.json"
+    assert status.target.script_filename == "custom-name.json"
     assert status.state == "STEP1_CONTENT"
     assert status.next_action.type == "prepare_step1"
     assert status.next_action.args["preprocessor"] == "normalize-drama-script"
@@ -162,6 +163,10 @@ def test_appended_source_only_refreshes_inventory_and_preserves_existing_work(tm
     assert status.source_revision != old_revision
     assert status.artifacts["asset_inventory"]["state"] == "stale"
     assert status.next_action.type == "analyze_assets"
+    assert status.next_action.args == {
+        "scope": {"kind": "all", "files": []},
+        "expected_source_revision": status.source_revision,
+    }
     stored = pm.load_project("demo")
     assert list(stored["characters"]) == ["阿离"]
     assert stored["episodes"][0]["episode"] == 1
@@ -266,7 +271,8 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
 
     replanning = service.get_status("demo")
     assert replanning.state == "EPISODE_PLAN"
-    assert replanning.next_action.type == "plan_episodes"
+    assert replanning.next_action.type == "reset_episode_planning"
+    assert replanning.next_action.args == {"from_episode": 1}
 
 
 @pytest.mark.integration
@@ -649,6 +655,35 @@ def test_confirmed_step1_change_marks_old_final_script_stale(tmp_path: Path) -> 
     assert status.state == "FINAL_SCRIPT"
     assert status.artifacts["script"]["state"] == "stale"
     assert status.next_action.type == "generate_script"
+
+
+@pytest.mark.integration
+def test_blocked_final_script_is_not_reclassified_as_stale_by_provenance(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_normalized_script.json"
+    atomic_write_json(step1_path, {"scenes": []})
+    revision = script_review.content_fingerprint(step1_path)
+    assert revision is not None
+    pm.update_project(
+        "demo", lambda project: script_review.apply_confirmation(project, 1, revision, "2026-08-11T00:00:00Z")
+    )
+    atomic_write_json(project_path / "scripts" / "episode_1.json", [])
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script"
+    assert status.next_action.type == "none"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -498,6 +498,45 @@ def test_source_inserted_before_cursor_requires_planning_reset(tmp_path: Path) -
 
 
 @pytest.mark.integration
+def test_decomposed_recorded_source_does_not_trigger_repeated_planning_reset(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_dir = project_path / "source"
+    decomposed_name = unicodedata.normalize("NFD", "é.txt")
+    source_path = source_dir / decomposed_name
+    source_path.write_text("已规划", encoding="utf-8")
+    scope = SourceScope(kind="all")
+    project = pm.load_project("demo")
+    revision = compute_source_revision(project_path, project, scope).revision
+    assert revision is not None
+    complete_asset_inventory(pm, "demo", scope, revision)
+    pm.update_project(
+        "demo",
+        lambda data: data.update(
+            planning_cursor={"source_file": f"source/{decomposed_name}", "offset": 3},
+            **{SOURCE_FINGERPRINTS_KEY: compute_source_fingerprints(discover_sources(project_path))},
+        ),
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "plan_episodes"
+
+
+@pytest.mark.integration
+def test_non_boolean_grid_storyboard_blocks_route_dispatch(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    pm.update_project("demo", lambda project: project.update(grid_storyboard="false"))
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.project.grid_storyboard is False
+    assert status.blockers[0].code == "invalid_grid_storyboard"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
 def test_invalid_asset_definition_blocks_existing_sheet(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "ad")
     sheet = "characters/invalid.png"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -420,7 +420,7 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
 
 
 @pytest.mark.integration
-def test_legacy_stale_episode_without_baseline_advances_existing_step1_to_review(tmp_path: Path) -> None:
+def test_legacy_stale_episode_without_baseline_requires_planning_reset(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     _write_source_and_complete(pm, project_path)
     pm.update_project(
@@ -441,8 +441,9 @@ def test_legacy_stale_episode_without_baseline_advances_existing_step1_to_review
 
     status = WorkflowStateService(pm).get_status("demo")
 
-    assert status.state == "STEP1_REVIEW"
-    assert status.next_action.type == "confirm_step1"
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "reset_episode_planning"
+    assert status.next_action.args == {"from_episode": 1}
 
 
 @pytest.mark.integration
@@ -464,6 +465,52 @@ def test_requested_missing_episode_is_blocked_when_source_is_fully_planned(tmp_p
     assert status.state == "EPISODE_PLAN"
     assert status.target is None
     assert status.blockers[0].code == "episode_unavailable"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_source_inserted_before_cursor_requires_planning_reset(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_dir = project_path / "source"
+    (source_dir / "a.txt").write_text("已规划", encoding="utf-8")
+    scope = SourceScope(kind="all")
+    project = pm.load_project("demo")
+    initial = compute_source_revision(project_path, project, scope).revision
+    assert initial is not None
+    complete_asset_inventory(pm, "demo", scope, initial)
+    pm.update_project(
+        "demo",
+        lambda data: data.update(
+            planning_cursor={"source_file": "source/a.txt", "offset": 3},
+            **{SOURCE_FINGERPRINTS_KEY: compute_source_fingerprints(discover_sources(project_path))},
+        ),
+    )
+    (source_dir / "0.txt").write_text("新增", encoding="utf-8")
+    refreshed = compute_source_revision(project_path, pm.load_project("demo"), scope).revision
+    assert refreshed is not None
+    complete_asset_inventory(pm, "demo", scope, refreshed)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "reset_episode_planning"
+    assert status.next_action.args == {"from_episode": 1}
+
+
+@pytest.mark.integration
+def test_invalid_asset_definition_blocks_existing_sheet(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    sheet = "characters/invalid.png"
+    _write_artifact(project_path, sheet)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(characters={"无描述角色": {"character_sheet": sheet}}),
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.blockers[0].code == "invalid_asset_definitions"
     assert status.next_action.type == "none"
 
 

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -375,7 +375,7 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     for relative_path in generated_assets.values():
         _write_artifact(project_path, relative_path)
 
-    original_load_project = pm.load_project
+    original_load_project = pm.load_project_readonly
     load_calls = 0
     source_inventory_calls = 0
     asset_sheet_calls = 0
@@ -404,7 +404,7 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
         source_discovery_calls += 1
         return original_discover_sources(*args, **kwargs)
 
-    monkeypatch.setattr(pm, "load_project", _counted_load_project)
+    monkeypatch.setattr(pm, "load_project_readonly", _counted_load_project)
     monkeypatch.setattr(WorkflowStateService, "_source_inventory", _counted_source_inventory)
     monkeypatch.setattr(WorkflowStateService, "_asset_sheets", _counted_asset_sheets)
     monkeypatch.setattr("lib.workflow_state.discover_sources", _counted_discover_sources)
@@ -1157,3 +1157,56 @@ def test_workflow_status_does_not_persist_read_time_script_migrations(tmp_path: 
     assert status.state == "VIDEO"
     assert script_path.read_bytes() == before
     assert not (script_path.parent / ".episode_1.json.lock").exists()
+
+
+@pytest.mark.integration
+def test_workflow_status_does_not_persist_read_time_project_migrations(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    project_path_json = project_path / "project.json"
+    project = pm.load_project("demo")
+    project.pop("style_template_id", None)
+    project["style"] = "Anime"
+    atomic_write_json(project_path_json, project)
+    before = project_path_json.read_bytes()
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.project.content_mode == "ad"
+    assert project_path_json.read_bytes() == before
+
+
+@pytest.mark.integration
+def test_nested_ledger_script_path_is_blocked_before_dispatch(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 1,
+                    "title": "广告",
+                    "script_file": "scripts/archive/custom.json",
+                    "ledger_status": "planned",
+                }
+            ]
+        ),
+    )
+    nested_script = project_path / "scripts" / "archive" / "custom.json"
+    nested_script.parent.mkdir(parents=True)
+    atomic_write_json(
+        nested_script,
+        {
+            "episode": 1,
+            "title": "广告",
+            "content_mode": "ad",
+            "shots": [_valid_ad_shot()],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.target is not None
+    assert status.target.script_filename == "archive/custom.json"
+    assert status.blockers[0].code == "invalid_script_path"
+    assert status.next_action.type == "none"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -570,6 +570,60 @@ def test_planning_completion_resolves_nfc_cursor_to_nfd_filesystem_path(tmp_path
 
 
 @pytest.mark.integration
+def test_planning_completion_preserves_planner_order_for_canonical_paths(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_dir = project_path / "source"
+    (source_dir / unicodedata.normalize("NFD", "á.txt")).write_text("第一份", encoding="utf-8")
+    (source_dir / "b.txt").write_text("第二份", encoding="utf-8")
+    project = pm.load_project("demo")
+    docs = discover_sources(project_path)
+    source = compute_source_revision(project_path, project, SourceScope(kind="all"))
+    assert source.revision is not None
+    assert source.files == [unicodedata.normalize("NFC", doc.rel_path) for doc in docs]
+    project["planning_cursor"] = {"source_file": docs[-1].rel_path, "offset": len(docs[-1].text)}
+    project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(docs)
+
+    assert WorkflowStateService._planning_complete(project_path, project, source) is True
+
+
+@pytest.mark.integration
+def test_duplicate_reference_video_unit_ids_block_completion(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
+    source_text = "原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "consumed",
+            }
+        ]
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_reference_units.json", {"units": []})
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "drama",
+            "video_units": [
+                {"unit_id": "E1U01", "duration_seconds": 4, "generated_assets": {}},
+                {"unit_id": "E1U01", "duration_seconds": 4, "generated_assets": {}},
+            ],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.blockers[0].code == "duplicate_script_id"
+
+
+@pytest.mark.integration
 def test_reference_video_route_skips_storyboards_and_audio(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
     source_text = "原文"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -587,6 +587,71 @@ def test_stale_episode_advances_after_step1_is_rebuilt(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
+def test_quarantined_step1_is_a_blocker_not_a_confirmation_loop(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_reference_units.json", {"units": []})
+    quarantine = script_review.step1_quarantine_path(project_path, pm.load_project("demo"), 1)
+    assert quarantine is not None
+    atomic_write_json(quarantine, {})
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STEP1_REVIEW"
+    assert status.artifacts["step1"]["state"] == "blocked"
+    assert status.blockers[0].code == "step1_quarantined"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_confirmed_step1_change_marks_old_final_script_stale(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_segments.json"
+    atomic_write_json(step1_path, {"segments": [{"segment_id": "E1S01", "novel_text": "旧内容"}]})
+    old_revision = script_review.content_fingerprint(step1_path)
+    assert old_revision is not None
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+            "metadata": {script_review.SCRIPT_STEP1_REVISION_FIELD: old_revision},
+        },
+    )
+
+    atomic_write_json(step1_path, {"segments": [{"segment_id": "E1S01", "novel_text": "新内容"}]})
+    new_revision = script_review.content_fingerprint(step1_path)
+    assert new_revision is not None
+    pm.update_project(
+        "demo", lambda project: script_review.apply_confirmation(project, 1, new_revision, "2026-08-11T00:00:00Z")
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "stale"
+    assert status.next_action.type == "generate_script"
+
+
+@pytest.mark.integration
 def test_script_id_must_match_the_shared_storyboard_pattern(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "ad")
     atomic_write_json(

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import lib.script_review as script_review
 from lib.asset_inventory import complete_asset_inventory
 from lib.episode_ledger import SOURCE_FINGERPRINTS_KEY, compute_source_fingerprints, discover_sources
 from lib.json_io import atomic_write_json
@@ -552,6 +553,83 @@ def test_stale_episode_requires_step1_even_when_old_artifacts_exist(tmp_path: Pa
     assert status.state == "STEP1_CONTENT"
     assert status.artifacts["step1"]["state"] == "stale"
     assert status.next_action.type == "prepare_step1"
+
+
+@pytest.mark.integration
+def test_stale_episode_advances_after_step1_is_rebuilt(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_segments.json"
+    atomic_write_json(step1_path, {"episode": 1, "segments": [{"segment_id": "E1S01"}]})
+    old_revision = script_review.content_fingerprint(step1_path)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "stale",
+                script_review.STALE_STEP1_REVISION_FIELD: old_revision,
+            }
+        ]
+
+    pm.update_project("demo", _plan)
+    service = WorkflowStateService(pm)
+    assert service.get_status("demo").state == "STEP1_CONTENT"
+
+    atomic_write_json(step1_path, {"episode": 1, "segments": [{"segment_id": "E1S02"}]})
+    rebuilt = service.get_status("demo")
+
+    assert rebuilt.state == "STEP1_REVIEW"
+    assert rebuilt.next_action.type == "confirm_step1"
+
+
+@pytest.mark.integration
+def test_script_id_must_match_the_shared_storyboard_pattern(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "bad id", "duration_seconds": 4, "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.blockers[0].code == "invalid_script_id"
+
+
+@pytest.mark.integration
+def test_ad_reference_unit_requires_shot_membership(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
+    video_path = "reference_videos/E1U1.mp4"
+    _write_artifact(project_path, video_path)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+            "reference_units": [
+                {
+                    "unit_id": "E1U1",
+                    "references": [],
+                    "generated_assets": {"video_clip": video_path},
+                }
+            ],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "VIDEO"
+    assert status.artifacts["videos"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_reference_unit"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -379,6 +379,56 @@ def test_non_object_script_is_a_blocker_not_an_exception(tmp_path: Path) -> None
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    ("mode", "step1_filename", "step1_payload", "items_key", "id_field"),
+    [
+        ("narration", "step1_segments.json", {"segments": []}, "segments", "segment_id"),
+        ("drama", "step1_normalized_script.json", {"scenes": []}, "scenes", "scene_id"),
+    ],
+)
+def test_legacy_storyboard_script_without_duration_remains_resumable(
+    tmp_path: Path,
+    mode: str,
+    step1_filename: str,
+    step1_payload: dict,
+    items_key: str,
+    id_field: str,
+) -> None:
+    pm, project_path = _make_project(tmp_path, mode)
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / step1_filename
+    atomic_write_json(step1_path, step1_payload)
+    revision = script_review.content_fingerprint(step1_path)
+    assert revision is not None
+    pm.update_project(
+        "demo", lambda project: script_review.apply_confirmation(project, 1, revision, "2026-08-11T00:00:00Z")
+    )
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": mode,
+            items_key: [{id_field: "E1S01", "generated_assets": {}}],
+            "metadata": {script_review.SCRIPT_STEP1_REVISION_FIELD: revision},
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STORYBOARD"
+    assert status.artifacts["script"]["state"] == "current"
+    assert not status.blockers
+
+
+@pytest.mark.integration
 def test_legacy_narration_scenes_skeleton_remains_resumable(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     source_text = "完整原文"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -374,6 +375,53 @@ def test_empty_script_collection_is_a_blocker_not_completed_work(tmp_path: Path)
 
 
 @pytest.mark.integration
+def test_script_entry_without_required_id_is_a_blocker(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {"episode": 1, "content_mode": "ad", "shots": [{"duration_seconds": 4}]},
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.blockers[0].code == "invalid_script_id"
+    assert status.blockers[0].path.endswith("shots[0].shot_id")
+
+
+@pytest.mark.integration
+def test_optional_product_sheet_does_not_block_ad_media(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    product_image = "products/original.png"
+    _write_artifact(project_path, product_image)
+
+    def _add_product(project: dict) -> None:
+        project["products"] = {
+            "杯子": {
+                "description": "透明杯",
+                "reference_images": [product_image],
+                "selling_points": ["轻便"],
+            }
+        }
+
+    pm.update_project("demo", _add_product)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.artifacts["asset_sheets"]["product"]["missing_ids"] == ["杯子"]
+    assert status.state == "STORYBOARD"
+    assert status.next_action.type == "generate_storyboards"
+
+
+@pytest.mark.integration
 def test_ad_reference_video_reads_completion_from_reference_units(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
     video_path = "reference_videos/E1U1.mp4"
@@ -457,6 +505,21 @@ def test_stale_episode_requires_step1_even_when_old_artifacts_exist(tmp_path: Pa
     assert status.state == "STEP1_CONTENT"
     assert status.artifacts["step1"]["state"] == "stale"
     assert status.next_action.type == "prepare_step1"
+
+
+@pytest.mark.integration
+def test_planning_completion_compares_cursor_paths_in_nfc(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    decomposed_name = unicodedata.normalize("NFD", "truyện.txt")
+    source_path = project_path / "source" / decomposed_name
+    source_path.write_text("完整原文", encoding="utf-8")
+    project = pm.load_project("demo")
+    source = compute_source_revision(project_path, project, SourceScope(kind="all"))
+    assert source.revision is not None
+    project["planning_cursor"] = {"source_file": f"source/{decomposed_name}", "offset": 4}
+    project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
+
+    assert WorkflowStateService._planning_complete(project_path, project, source) is True
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -576,6 +576,35 @@ def test_decomposed_recorded_source_does_not_trigger_repeated_planning_reset(tmp
 
 
 @pytest.mark.integration
+def test_later_raw_sorted_source_does_not_trigger_planning_reset(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_dir = project_path / "source"
+    decomposed_name = unicodedata.normalize("NFD", "á.txt")
+    (source_dir / decomposed_name).write_text("已规划", encoding="utf-8")
+    scope = SourceScope(kind="all")
+    project = pm.load_project("demo")
+    revision = compute_source_revision(project_path, project, scope).revision
+    assert revision is not None
+    complete_asset_inventory(pm, "demo", scope, revision)
+    pm.update_project(
+        "demo",
+        lambda data: data.update(
+            planning_cursor={"source_file": f"source/{decomposed_name}", "offset": 3},
+            **{SOURCE_FINGERPRINTS_KEY: compute_source_fingerprints(discover_sources(project_path))},
+        ),
+    )
+    (source_dir / "b.txt").write_text("后续", encoding="utf-8")
+    refreshed = compute_source_revision(project_path, pm.load_project("demo"), scope).revision
+    assert refreshed is not None
+    complete_asset_inventory(pm, "demo", scope, refreshed)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "plan_episodes"
+
+
+@pytest.mark.integration
 def test_whitespace_only_source_is_missing_project_input(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     _write_source_and_complete(pm, project_path, " \n\t ")
@@ -596,6 +625,25 @@ def test_non_boolean_grid_storyboard_blocks_route_dispatch(tmp_path: Path) -> No
     assert status.state == "PROJECT_INPUT"
     assert status.project.grid_storyboard is False
     assert status.blockers[0].code == "invalid_grid_storyboard"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("field", "value", "blocker_code"),
+    [
+        ("content_mode", [], "invalid_content_mode"),
+        ("generation_mode", {}, "invalid_generation_mode"),
+    ],
+)
+def test_non_string_project_mode_returns_blocker(tmp_path: Path, field: str, value: object, blocker_code: str) -> None:
+    pm, _project_path = _make_project(tmp_path, "ad")
+    pm.update_project("demo", lambda project: project.update({field: value}))
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.blockers[0].code == blocker_code
     assert status.next_action.type == "none"
 
 

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -555,7 +555,7 @@ def test_stale_episode_requires_step1_even_when_old_artifacts_exist(tmp_path: Pa
 
 
 @pytest.mark.integration
-def test_planning_completion_compares_cursor_paths_in_nfc(tmp_path: Path) -> None:
+def test_planning_completion_resolves_nfc_cursor_to_nfd_filesystem_path(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     decomposed_name = unicodedata.normalize("NFD", "truyện.txt")
     source_path = project_path / "source" / decomposed_name
@@ -563,7 +563,7 @@ def test_planning_completion_compares_cursor_paths_in_nfc(tmp_path: Path) -> Non
     project = pm.load_project("demo")
     source = compute_source_revision(project_path, project, SourceScope(kind="all"))
     assert source.revision is not None
-    project["planning_cursor"] = {"source_file": f"source/{decomposed_name}", "offset": 4}
+    project["planning_cursor"] = {"source_file": source.files[-1], "offset": 4}
     project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
 
     assert WorkflowStateService._planning_complete(project_path, project, source) is True

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -341,6 +341,107 @@ def test_malformed_script_collection_is_a_blocker_not_an_exception(tmp_path: Pat
 
 
 @pytest.mark.integration
+def test_empty_script_collection_is_a_blocker_not_completed_work(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {"episode": 1, "content_mode": "ad", "shots": []},
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script_collection"
+
+
+@pytest.mark.integration
+def test_ad_reference_video_reads_completion_from_reference_units(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
+    video_path = "reference_videos/E1U1.mp4"
+    _write_artifact(project_path, video_path)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+            "reference_units": [
+                {
+                    "unit_id": "E1U1",
+                    "shot_ids": ["E1S01"],
+                    "references": [],
+                    "generated_assets": {"video_clip": video_path},
+                }
+            ],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EXPORT_READY"
+    assert status.artifacts["videos"] == {
+        "state": "current",
+        "current_ids": ["E1U1"],
+        "missing_ids": [],
+        "stale_ids": [],
+    }
+
+
+@pytest.mark.integration
+def test_ad_reference_video_without_derived_units_requires_video_generation(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad", generation_mode="reference_video")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [{"shot_id": "E1S01", "duration_seconds": 4}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "VIDEO"
+    assert status.artifacts["videos"]["state"] == "missing"
+    assert status.next_action.type == "generate_videos"
+
+
+@pytest.mark.integration
+def test_stale_episode_requires_step1_even_when_old_artifacts_exist(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "stale",
+            }
+        ]
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STEP1_CONTENT"
+    assert status.artifacts["step1"]["state"] == "stale"
+    assert status.next_action.type == "prepare_step1"
+
+
+@pytest.mark.integration
 def test_reference_video_route_skips_storyboards_and_audio(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
     source_text = "原文"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -186,7 +186,6 @@ def test_media_paths_must_resolve_to_project_files_before_becoming_current(tmp_p
             ],
         },
     )
-
     status = WorkflowStateService(pm).get_status("demo")
 
     assert status.state == "STORYBOARD"
@@ -418,6 +417,54 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     assert status.target.episode == 2
     assert status.state == "STEP1_CONTENT"
     assert status.next_action.type == "prepare_step1"
+
+
+@pytest.mark.integration
+def test_legacy_stale_episode_without_baseline_advances_existing_step1_to_review(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 1,
+                    "script_file": "scripts/episode_1.json",
+                    "ledger_status": "stale",
+                }
+            ]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": [{"segment_id": "E1S01"}]})
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STEP1_REVIEW"
+    assert status.next_action.type == "confirm_step1"
+
+
+@pytest.mark.integration
+def test_requested_missing_episode_is_blocked_when_source_is_fully_planned(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}],
+            planning_cursor={"source_file": "source/novel.txt", "offset": len(source_text)},
+            **{SOURCE_FINGERPRINTS_KEY: compute_source_fingerprints(discover_sources(project_path))},
+        ),
+    )
+
+    status = WorkflowStateService(pm).get_status("demo", 2)
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.target is None
+    assert status.blockers[0].code == "episode_unavailable"
+    assert status.next_action.type == "none"
 
 
 @pytest.mark.integration
@@ -682,6 +729,13 @@ def test_stale_episode_requires_step1_even_when_old_artifacts_exist(tmp_path: Pa
             "content_mode": "narration",
             "segments": [{"segment_id": "E1S01", "generated_assets": {}}],
         },
+    )
+    step1_path = draft_dir / "step1_segments.json"
+    pm.update_project(
+        "demo",
+        lambda project: project["episodes"][0].update(
+            {script_review.STALE_STEP1_REVISION_FIELD: script_review.content_fingerprint(step1_path)}
+        ),
     )
 
     status = WorkflowStateService(pm).get_status("demo")

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -1040,6 +1040,57 @@ def test_identical_stale_step1_rebuild_advances_after_explicit_completion(tmp_pa
 
 
 @pytest.mark.integration
+def test_null_baseline_stale_rebuild_invalidates_grandfathered_script(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 1,
+                    "script_file": "scripts/episode_1.json",
+                    "ledger_status": "stale",
+                    script_review.STALE_STEP1_REVISION_FIELD: None,
+                }
+            ]
+        ),
+    )
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "旧剧本",
+            "content_mode": "narration",
+            "segments": [_valid_narration_segment()],
+        },
+    )
+    service = WorkflowStateService(pm)
+    assert service.get_status("demo").next_action.type == "prepare_step1"
+
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_segments.json"
+    atomic_write_json(step1_path, {"episode": 1, "segments": [{"segment_id": "E1S01"}]})
+    script_review.complete_stale_step1_rebuild(pm, "demo", 1, None)
+
+    pending_review = service.get_status("demo")
+    assert pending_review.state == "STEP1_REVIEW"
+    assert pending_review.next_action.type == "confirm_step1"
+    revision = script_review.content_fingerprint(step1_path)
+    assert revision is not None
+
+    def _confirm(project: dict) -> None:
+        script_review.apply_confirmation(project, 1, revision, "now")
+
+    pm.update_project("demo", _confirm)
+    regenerate = service.get_status("demo")
+    assert regenerate.state == "FINAL_SCRIPT"
+    assert regenerate.artifacts["script"]["state"] == "stale"
+    assert regenerate.next_action.type == "generate_script"
+
+
+@pytest.mark.integration
 def test_quarantined_step1_is_a_blocker_not_a_confirmation_loop(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
     _write_source_and_complete(pm, project_path)

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -285,7 +285,7 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
             }
             for episode in (1, 2)
         ]
-        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": 1}
 
     pm.update_project("demo", _plan)
     draft_dir = project_path / "drafts" / "episode_1"
@@ -357,6 +357,53 @@ def test_malformed_script_collection_is_a_blocker_not_an_exception(tmp_path: Pat
     assert status.artifacts["script"]["state"] == "blocked"
     assert status.blockers[0].code == "invalid_script_collection"
     assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_non_object_script_is_a_blocker_not_an_exception(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(project_path / "scripts" / "episode_1.json", [])
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.artifacts["script"]["state"] == "blocked"
+    assert status.blockers[0].code == "invalid_script"
+
+
+@pytest.mark.integration
+def test_legacy_narration_scenes_skeleton_remains_resumable(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "planned",
+            }
+        ]
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "narration",
+            "scenes": [{"scene_id": "E1S01", "duration_seconds": 4, "generated_assets": {}}],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STORYBOARD"
+    assert status.artifacts["script"]["state"] == "current"
+    assert status.next_action.requested_ids == ["E1S01"]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -576,6 +576,17 @@ def test_decomposed_recorded_source_does_not_trigger_repeated_planning_reset(tmp
 
 
 @pytest.mark.integration
+def test_whitespace_only_source_is_missing_project_input(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path, " \n\t ")
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.next_action.type == "collect_project_input"
+
+
+@pytest.mark.integration
 def test_non_boolean_grid_storyboard_blocks_route_dispatch(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "ad")
     pm.update_project("demo", lambda project: project.update(grid_storyboard="false"))
@@ -615,6 +626,67 @@ def test_invalid_asset_definition_blocks_existing_sheet(tmp_path: Path) -> None:
 
     assert status.state == "PROJECT_INPUT"
     assert status.blockers[0].code == "invalid_asset_definitions"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_missing_ledger_script_binding_is_a_blocker(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(episodes=[{"episode": 1, "ledger_status": "planned"}]),
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.target is None
+    assert status.blockers[0].code == "invalid_script_binding"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+def test_script_episode_must_match_ledger_target(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 2,
+                    "script_file": "scripts/episode_1.json",
+                    "ledger_status": "planned",
+                }
+            ]
+        ),
+    )
+    draft_dir = project_path / "drafts" / "episode_2"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_segments.json"
+    atomic_write_json(step1_path, {"episode": 2, "segments": [{"segment_id": "E2S01"}]})
+    revision = script_review.content_fingerprint(step1_path)
+    assert revision is not None
+
+    def _confirm(project: dict) -> None:
+        script_review.apply_confirmation(project, 2, revision, "now")
+
+    pm.update_project("demo", _confirm)
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [_valid_narration_segment(segment_id="E2S01")],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "FINAL_SCRIPT"
+    assert status.blockers[0].code == "script_episode_mismatch"
     assert status.next_action.type == "none"
 
 
@@ -926,6 +998,45 @@ def test_stale_episode_advances_after_step1_is_rebuilt(tmp_path: Path) -> None:
     assert rebuilt.state == "STEP1_REVIEW"
     assert rebuilt.next_action.type == "confirm_step1"
     assert rebuilt.next_action.requires_confirmation is True
+
+
+@pytest.mark.integration
+def test_identical_stale_step1_rebuild_advances_after_explicit_completion(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    _write_source_and_complete(pm, project_path)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    step1_path = draft_dir / "step1_segments.json"
+    content = {"episode": 1, "segments": [{"segment_id": "E1S01"}]}
+    atomic_write_json(step1_path, content)
+    baseline = script_review.content_fingerprint(step1_path)
+    assert baseline is not None
+    pm.update_project(
+        "demo",
+        lambda project: project.update(
+            episodes=[
+                {
+                    "episode": 1,
+                    "script_file": "scripts/episode_1.json",
+                    "ledger_status": "stale",
+                    script_review.STALE_STEP1_REVISION_FIELD: baseline,
+                }
+            ]
+        ),
+    )
+    service = WorkflowStateService(pm)
+    before = service.get_status("demo")
+    assert before.next_action.type == "prepare_step1"
+    assert before.next_action.args["expected_stale_step1_revision"] == baseline
+
+    atomic_write_json(step1_path, content)
+    still_pending = service.get_status("demo")
+    assert still_pending.next_action.type == "prepare_step1"
+    script_review.complete_stale_step1_rebuild(pm, "demo", 1, baseline)
+
+    completed = service.get_status("demo")
+    assert completed.state == "STEP1_REVIEW"
+    assert completed.next_action.type == "confirm_step1"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -177,7 +177,7 @@ def test_partial_inventory_scope_never_unlocks_full_workflow(tmp_path: Path) -> 
     status = WorkflowStateService(pm).get_status("demo")
 
     assert status.state == "ASSET_INVENTORY"
-    assert status.artifacts["asset_inventory"]["state"] == "missing"
+    assert status.artifacts["asset_inventory"]["state"] == "partial"
     assert status.artifacts["asset_inventory"]["recorded_scope"] == {
         "kind": "files",
         "files": ["source/novel.txt"],
@@ -308,16 +308,34 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
 
     original_load_project = pm.load_project
     load_calls = 0
+    source_inventory_calls = 0
+    asset_sheet_calls = 0
+    original_source_inventory = WorkflowStateService._source_inventory
+    original_asset_sheets = WorkflowStateService._asset_sheets
 
     def _counted_load_project(project_name: str) -> dict:
         nonlocal load_calls
         load_calls += 1
         return original_load_project(project_name)
 
+    def _counted_source_inventory(*args, **kwargs):
+        nonlocal source_inventory_calls
+        source_inventory_calls += 1
+        return original_source_inventory(*args, **kwargs)
+
+    def _counted_asset_sheets(*args, **kwargs):
+        nonlocal asset_sheet_calls
+        asset_sheet_calls += 1
+        return original_asset_sheets(*args, **kwargs)
+
     monkeypatch.setattr(pm, "load_project", _counted_load_project)
+    monkeypatch.setattr(WorkflowStateService, "_source_inventory", _counted_source_inventory)
+    monkeypatch.setattr(WorkflowStateService, "_asset_sheets", _counted_asset_sheets)
     status = WorkflowStateService(pm).get_status("demo")
 
     assert load_calls == 1
+    assert source_inventory_calls == 1
+    assert asset_sheet_calls == 1
     assert status.target is not None
     assert status.target.episode == 2
     assert status.state == "STEP1_CONTENT"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -420,6 +420,58 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
 
 
 @pytest.mark.integration
+def test_completed_first_episode_does_not_hide_later_planning_reset(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": 1,
+                "script_file": "scripts/episode_1.json",
+                "ledger_status": "planned",
+            },
+            {
+                "episode": 2,
+                "script_file": "scripts/episode_2.json",
+                "ledger_status": "stale",
+            },
+        ]
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+        project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    generated_assets = {
+        "storyboard_image": "storyboards/E1S01.png",
+        "video_clip": "videos/E1S01.mp4",
+        "narration_audio": "audio/E1S01.wav",
+    }
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "narration",
+            "segments": [_valid_narration_segment(generated_assets=generated_assets)],
+        },
+    )
+    for relative_path in generated_assets.values():
+        _write_artifact(project_path, relative_path)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.target is not None
+    assert status.target.episode == 2
+    assert status.next_action.type == "reset_episode_planning"
+    assert status.next_action.args == {"from_episode": 2}
+
+
+@pytest.mark.integration
 def test_legacy_stale_episode_without_baseline_requires_planning_reset(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     _write_source_and_complete(pm, project_path)
@@ -533,6 +585,19 @@ def test_non_boolean_grid_storyboard_blocks_route_dispatch(tmp_path: Path) -> No
     assert status.state == "PROJECT_INPUT"
     assert status.project.grid_storyboard is False
     assert status.blockers[0].code == "invalid_grid_storyboard"
+    assert status.next_action.type == "none"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("target_duration", [None, 0, -1, False, "30"])
+def test_invalid_ad_target_duration_blocks_script_generation(tmp_path: Path, target_duration: object) -> None:
+    pm, _project_path = _make_project(tmp_path, "ad")
+    pm.update_project("demo", lambda project: project.update(target_duration=target_duration))
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "PROJECT_INPUT"
+    assert status.blockers[0].code == "invalid_target_duration"
     assert status.next_action.type == "none"
 
 
@@ -860,6 +925,7 @@ def test_stale_episode_advances_after_step1_is_rebuilt(tmp_path: Path) -> None:
 
     assert rebuilt.state == "STEP1_REVIEW"
     assert rebuilt.next_action.type == "confirm_step1"
+    assert rebuilt.next_action.requires_confirmation is True
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -318,8 +318,10 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     load_calls = 0
     source_inventory_calls = 0
     asset_sheet_calls = 0
+    source_discovery_calls = 0
     original_source_inventory = WorkflowStateService._source_inventory
     original_asset_sheets = WorkflowStateService._asset_sheets
+    original_discover_sources = discover_sources
 
     def _counted_load_project(project_name: str) -> dict:
         nonlocal load_calls
@@ -336,14 +338,21 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
         asset_sheet_calls += 1
         return original_asset_sheets(*args, **kwargs)
 
+    def _counted_discover_sources(*args, **kwargs):
+        nonlocal source_discovery_calls
+        source_discovery_calls += 1
+        return original_discover_sources(*args, **kwargs)
+
     monkeypatch.setattr(pm, "load_project", _counted_load_project)
     monkeypatch.setattr(WorkflowStateService, "_source_inventory", _counted_source_inventory)
     monkeypatch.setattr(WorkflowStateService, "_asset_sheets", _counted_asset_sheets)
+    monkeypatch.setattr("lib.workflow_state.discover_sources", _counted_discover_sources)
     status = WorkflowStateService(pm).get_status("demo")
 
     assert load_calls == 1
     assert source_inventory_calls == 1
     assert asset_sheet_calls == 1
+    assert source_discovery_calls == 1
     assert status.target is not None
     assert status.target.episode == 2
     assert status.state == "STEP1_CONTENT"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -832,6 +832,29 @@ def test_planning_without_source_fingerprint_baseline_is_incomplete(tmp_path: Pa
 
 
 @pytest.mark.integration
+def test_new_source_file_continues_planning_without_resetting_existing_fingerprints(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    original_path = project_path / "source" / "a.txt"
+    original_path.write_text("已规划原文", encoding="utf-8")
+    project = pm.load_project("demo")
+    project["planning_cursor"] = {"source_file": "source/a.txt", "offset": len("已规划原文")}
+    project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
+    pm.save_project("demo", project)
+    initial_revision = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
+    assert initial_revision is not None
+    complete_asset_inventory(pm, "demo", SourceScope(kind="all"), initial_revision)
+    (project_path / "source" / "z.txt").write_text("新增原文", encoding="utf-8")
+    revision = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
+    assert revision is not None
+    complete_asset_inventory(pm, "demo", SourceScope(kind="all"), revision)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "EPISODE_PLAN"
+    assert status.next_action.type == "plan_episodes"
+
+
+@pytest.mark.integration
 def test_planning_completion_preserves_planner_order_for_canonical_paths(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path, "narration")
     source_dir = project_path / "source"

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from lib.asset_inventory import complete_asset_inventory
+from lib.episode_ledger import SOURCE_FINGERPRINTS_KEY, compute_source_fingerprints, discover_sources
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
 from lib.source_revision import SourceScope, compute_source_revision
@@ -30,6 +31,12 @@ def _write_source_and_complete(pm: ProjectManager, project_path: Path, text: str
     assert revision is not None
     complete_asset_inventory(pm, "demo", scope, revision)
     return revision
+
+
+def _write_artifact(project_path: Path, relative_path: str) -> None:
+    path = project_path / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"artifact")
 
 
 @pytest.mark.integration
@@ -95,6 +102,36 @@ def test_ad_is_episode_one_and_skips_asset_inventory_and_step1(tmp_path: Path) -
     assert status.gates["step1_review"]["state"] == "not_applicable"
     assert status.state == "FINAL_SCRIPT"
     assert status.next_action.type == "generate_script"
+
+
+@pytest.mark.integration
+def test_media_paths_must_resolve_to_project_files_before_becoming_current(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "ad")
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "ad",
+            "shots": [
+                {
+                    "shot_id": "E1S01",
+                    "duration_seconds": 4,
+                    "generated_assets": {
+                        "storyboard_image": "../outside.png",
+                        "video_clip": "videos/missing.mp4",
+                    },
+                }
+            ],
+        },
+    )
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.state == "STORYBOARD"
+    assert status.artifacts["storyboards"]["current_ids"] == []
+    assert status.artifacts["storyboards"]["missing_ids"] == ["E1S01"]
+    assert status.artifacts["videos"]["current_ids"] == []
+    assert status.artifacts["videos"]["missing_ids"] == ["E1S01"]
 
 
 @pytest.mark.integration
@@ -178,6 +215,7 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
             }
         ]
         project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+        project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
 
     pm.update_project("demo", _plan)
     draft_dir = project_path / "drafts" / "episode_1"
@@ -197,20 +235,81 @@ def test_narration_progresses_through_storyboard_video_audio_to_export(tmp_path:
     assert storyboard.next_action.requested_ids == ["E1S01"]
 
     script["segments"][0]["generated_assets"]["storyboard_image"] = "storyboards/E1S01.png"
+    _write_artifact(project_path, "storyboards/E1S01.png")
     atomic_write_json(script_path, script)
     video = service.get_status("demo")
     assert video.state == "VIDEO"
 
     script["segments"][0]["generated_assets"]["video_clip"] = "videos/E1S01.mp4"
+    _write_artifact(project_path, "videos/E1S01.mp4")
     atomic_write_json(script_path, script)
     audio = service.get_status("demo")
     assert audio.state == "AUDIO"
 
     script["segments"][0]["generated_assets"]["narration_audio"] = "audio/E1S01.wav"
+    _write_artifact(project_path, "audio/E1S01.wav")
     atomic_write_json(script_path, script)
     ready = service.get_status("demo")
     assert ready.state == "EXPORT_READY"
     assert ready.next_action.type == "export"
+
+    (project_path / "source" / "novel.txt").write_text("全新文本", encoding="utf-8")
+    refreshed_revision = compute_source_revision(
+        project_path,
+        pm.load_project("demo"),
+        SourceScope(kind="all"),
+    ).revision
+    assert refreshed_revision is not None
+    complete_asset_inventory(pm, "demo", SourceScope(kind="all"), refreshed_revision)
+
+    replanning = service.get_status("demo")
+    assert replanning.state == "EPISODE_PLAN"
+    assert replanning.next_action.type == "plan_episodes"
+
+
+@pytest.mark.integration
+def test_completed_first_episode_does_not_hide_later_incomplete_episode(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [
+            {
+                "episode": episode,
+                "script_file": f"scripts/episode_{episode}.json",
+                "ledger_status": "planned",
+            }
+            for episode in (1, 2)
+        ]
+        project["planning_cursor"] = {"source_file": "source/novel.txt", "offset": len(source_text)}
+
+    pm.update_project("demo", _plan)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True)
+    atomic_write_json(draft_dir / "step1_segments.json", {"episode": 1, "segments": []})
+    generated_assets = {
+        "storyboard_image": "storyboards/E1S01.png",
+        "video_clip": "videos/E1S01.mp4",
+        "narration_audio": "audio/E1S01.wav",
+    }
+    atomic_write_json(
+        project_path / "scripts" / "episode_1.json",
+        {
+            "episode": 1,
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "duration_seconds": 4, "generated_assets": generated_assets}],
+        },
+    )
+    for relative_path in generated_assets.values():
+        _write_artifact(project_path, relative_path)
+
+    status = WorkflowStateService(pm).get_status("demo")
+
+    assert status.target is not None
+    assert status.target.episode == 2
+    assert status.state == "STEP1_CONTENT"
+    assert status.next_action.type == "prepare_step1"
 
 
 @pytest.mark.integration

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -46,6 +46,12 @@ EXPECTED_ROUTES = {
     ),
 }
 
+EXPECTED_BLOCKER_ROUTE = {
+    "SKILL.narration.md": "| `none` | 展示 `blockers` 并停止变更 |",
+    "SKILL.drama.md": "| `none` | 展示 `blockers` 并停止变更 |",
+    "SKILL.ad.md": '`next_action.type == "none"` 时展示 blockers 并停止变更',
+}
+
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
 def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
@@ -59,6 +65,7 @@ def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
         assert route in content
         route_positions.append(content.index(route))
     assert route_positions == sorted(route_positions)
+    assert EXPECTED_BLOCKER_ROUTE[filename] in content
 
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
@@ -73,6 +80,9 @@ def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(fi
     assert "target.episode" in content
     assert '"script": target.script' in content
     assert "next_action.args" in content
+    if filename != "SKILL.ad.md":
+        assert "names = artifacts.asset_sheets[type].missing_ids ∩ requested_ids" in content
+        assert "若 names 为空 → 跳过，不 dispatch；不得回退到整类 missing_ids" in content
 
 
 def test_asset_analysis_records_completion_fact() -> None:

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW_VARIANTS = (
+    "SKILL.narration.md",
+    "SKILL.drama.md",
+    "SKILL.ad.md",
+)
+
+
+@pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
+def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / filename
+    content = path.read_text(encoding="utf-8")
+
+    assert "mcp__arcreel__get_workflow_status" in content
+    assert "唯一真相" in content
+
+
+def test_asset_analysis_records_completion_fact() -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "agents" / "analyze-assets.md"
+    content = path.read_text(encoding="utf-8")
+
+    assert "mcp__arcreel__complete_asset_inventory" in content
+    assert "expected_source_revision" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -109,3 +109,13 @@ def test_workflow_reset_route_executes_recovery_and_refreshes_status(filename: s
     assert "next_action.args" in content
     assert "confirm_consumed: true" in content
     assert "重置成功后刷新 workflow-status" in content
+
+
+@pytest.mark.parametrize("filename", ("SKILL.narration.md", "SKILL.drama.md"))
+def test_workflow_stale_step1_records_explicit_rebuild_completion(filename: str) -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / filename
+    content = path.read_text(encoding="utf-8")
+
+    assert "mcp__arcreel__complete_step1_rebuild" in content
+    assert "expected_stale_step1_revision" in content
+    assert "确定性重建可能产出完全相同的 JSON" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -13,8 +13,11 @@ WORKFLOW_VARIANTS = (
 
 EXPECTED_ROUTES = {
     "SKILL.narration.md": (
+        'next_action.type == "analyze_assets"',
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
+        'next_action.type == "confirm_step1"',
+        'next_action.type == "generate_script"',
         'next_action.type == "generate_asset_sheets"',
         'next_action.type == "generate_storyboards"',
         'next_action.type == "generate_grid"',
@@ -22,8 +25,11 @@ EXPECTED_ROUTES = {
         'next_action.type == "generate_narration_audio"',
     ),
     "SKILL.drama.md": (
+        'next_action.type == "analyze_assets"',
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
+        'next_action.type == "confirm_step1"',
+        'next_action.type == "generate_script"',
         'next_action.type == "generate_asset_sheets"',
         'next_action.type == "generate_storyboards"',
         'next_action.type == "generate_grid"',
@@ -55,7 +61,7 @@ def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
     assert route_positions == sorted(route_positions)
 
 
-@pytest.mark.parametrize("filename", ("SKILL.narration.md", "SKILL.drama.md"))
+@pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
 def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(filename: str) -> None:
     path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / filename
     content = path.read_text(encoding="utf-8")
@@ -64,6 +70,8 @@ def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(fi
     assert '"segment_ids": requested_ids' in content
     assert '"scene_ids": requested_ids' in content
     assert "不二次检查 `generation_mode` 或 `grid_storyboard`" in content
+    assert "target.episode" in content
+    assert "next_action.args" in content
 
 
 def test_asset_analysis_records_completion_fact() -> None:

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -11,6 +11,23 @@ WORKFLOW_VARIANTS = (
     "SKILL.ad.md",
 )
 
+EXPECTED_ROUTES = {
+    "SKILL.narration.md": (
+        'next_action.type == "plan_episodes"',
+        'next_action.type == "prepare_step1"',
+        'next_action.type == "generate_asset_sheets"',
+        'next_action.type == "generate_videos"',
+        'next_action.type == "generate_narration_audio"',
+    ),
+    "SKILL.drama.md": (
+        'next_action.type == "plan_episodes"',
+        'next_action.type == "prepare_step1"',
+        'next_action.type == "generate_asset_sheets"',
+        'next_action.type == "generate_videos"',
+    ),
+    "SKILL.ad.md": (),
+}
+
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
 def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
@@ -18,7 +35,9 @@ def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
     content = path.read_text(encoding="utf-8")
 
     assert "mcp__arcreel__get_workflow_status" in content
-    assert "唯一真相" in content
+    assert "阶段判断的唯一真相源" in content
+    for route in EXPECTED_ROUTES[filename]:
+        assert route in content
 
 
 def test_asset_analysis_records_completion_fact() -> None:

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -71,6 +71,7 @@ def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(fi
     assert '"scene_ids": requested_ids' in content
     assert "不二次检查 `generation_mode` 或 `grid_storyboard`" in content
     assert "target.episode" in content
+    assert '"script": target.script' in content
     assert "next_action.args" in content
 
 
@@ -80,3 +81,4 @@ def test_asset_analysis_records_completion_fact() -> None:
 
     assert "mcp__arcreel__complete_asset_inventory" in content
     assert "expected_source_revision" in content
+    assert "不要调用 `patch_project`" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -16,6 +16,8 @@ EXPECTED_ROUTES = {
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
         'next_action.type == "generate_asset_sheets"',
+        'next_action.type == "generate_storyboards"',
+        'next_action.type == "generate_grid"',
         'next_action.type == "generate_videos"',
         'next_action.type == "generate_narration_audio"',
     ),
@@ -23,9 +25,19 @@ EXPECTED_ROUTES = {
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
         'next_action.type == "generate_asset_sheets"',
+        'next_action.type == "generate_storyboards"',
+        'next_action.type == "generate_grid"',
         'next_action.type == "generate_videos"',
     ),
-    "SKILL.ad.md": (),
+    "SKILL.ad.md": (
+        'next_action.type == "draft_selling_points"',
+        'next_action.type == "generate_script"',
+        'next_action.type == "generate_asset_sheets"',
+        'next_action.type == "generate_storyboards"',
+        'next_action.type == "generate_grid"',
+        'next_action.type == "generate_videos"',
+        'next_action.type == "export"',
+    ),
 }
 
 
@@ -36,8 +48,22 @@ def test_workflow_variants_use_authoritative_status_tool(filename: str) -> None:
 
     assert "mcp__arcreel__get_workflow_status" in content
     assert "阶段判断的唯一真相源" in content
+    route_positions = []
     for route in EXPECTED_ROUTES[filename]:
         assert route in content
+        route_positions.append(content.index(route))
+    assert route_positions == sorted(route_positions)
+
+
+@pytest.mark.parametrize("filename", ("SKILL.narration.md", "SKILL.drama.md"))
+def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(filename: str) -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / filename
+    content = path.read_text(encoding="utf-8")
+
+    assert '"names": [该类型 requested_ids]' in content
+    assert '"segment_ids": requested_ids' in content
+    assert '"scene_ids": requested_ids' in content
+    assert "不二次检查 `generation_mode` 或 `grid_storyboard`" in content
 
 
 def test_asset_analysis_records_completion_fact() -> None:

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -96,3 +96,14 @@ def test_asset_analysis_records_completion_fact() -> None:
     assert "严格按主 agent 传入的 `scope`" in content
     assert "`.text`" not in content
     assert "不要调用 `patch_project`" in content
+
+
+@pytest.mark.parametrize("filename", ("SKILL.narration.md", "SKILL.drama.md"))
+def test_workflow_reset_route_executes_recovery_and_refreshes_status(filename: str) -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / filename
+    content = path.read_text(encoding="utf-8")
+
+    assert "mcp__arcreel__reset_episode_planning" in content
+    assert "next_action.args" in content
+    assert "confirm_consumed: true" in content
+    assert "重置成功后刷新 workflow-status" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -14,6 +14,7 @@ WORKFLOW_VARIANTS = (
 EXPECTED_ROUTES = {
     "SKILL.narration.md": (
         'next_action.type == "analyze_assets"',
+        'next_action.type` 为 `"reset_episode_planning"`',
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
         'next_action.type == "confirm_step1"',
@@ -26,6 +27,7 @@ EXPECTED_ROUTES = {
     ),
     "SKILL.drama.md": (
         'next_action.type == "analyze_assets"',
+        'next_action.type` 为 `"reset_episode_planning"`',
         'next_action.type == "plan_episodes"',
         'next_action.type == "prepare_step1"',
         'next_action.type == "confirm_step1"',
@@ -78,7 +80,7 @@ def test_workflow_asset_and_storyboard_routes_forward_authoritative_arguments(fi
     assert '"scene_ids": requested_ids' in content
     assert "不二次检查 `generation_mode` 或 `grid_storyboard`" in content
     assert "target.episode" in content
-    assert '"script": target.script' in content
+    assert '"script": target.script_filename' in content
     assert "next_action.args" in content
     if filename != "SKILL.ad.md":
         assert "names = artifacts.asset_sheets[type].missing_ids ∩ requested_ids" in content
@@ -91,4 +93,5 @@ def test_asset_analysis_records_completion_fact() -> None:
 
     assert "mcp__arcreel__complete_asset_inventory" in content
     assert "expected_source_revision" in content
+    assert "严格按主 agent 传入的 `scope`" in content
     assert "不要调用 `patch_project`" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -94,4 +94,5 @@ def test_asset_analysis_records_completion_fact() -> None:
     assert "mcp__arcreel__complete_asset_inventory" in content
     assert "expected_source_revision" in content
     assert "严格按主 agent 传入的 `scope`" in content
+    assert "`.text`" not in content
     assert "不要调用 `patch_project`" in content

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -94,6 +94,8 @@ def test_asset_analysis_records_completion_fact() -> None:
     assert "mcp__arcreel__complete_asset_inventory" in content
     assert "expected_source_revision" in content
     assert "严格按主 agent 传入的 `scope`" in content
+    assert "排除文件名以 `.` / `_` 开头" in content
+    assert "`episode_[0-9]+.txt`" in content
     assert "`.text`" not in content
     assert "不要调用 `patch_project`" in content
 

--- a/tests/prompt_rules/test_workflow_status_prompt.py
+++ b/tests/prompt_rules/test_workflow_status_prompt.py
@@ -119,3 +119,15 @@ def test_workflow_stale_step1_records_explicit_rebuild_completion(filename: str)
     assert "mcp__arcreel__complete_step1_rebuild" in content
     assert "expected_stale_step1_revision" in content
     assert "确定性重建可能产出完全相同的 JSON" in content
+
+
+def test_ad_workflow_regenerates_named_reference_units_with_selected_tool() -> None:
+    path = REPO / "agent_runtime_profile" / ".claude" / "skills" / "manga-workflow" / "SKILL.ad.md"
+    content = path.read_text(encoding="utf-8")
+
+    assert '`next_action.type == "generate_videos"` → `requested_ids` 非空时调' in content
+    assert (
+        'mcp__arcreel__generate_video_selected({"script": target.script_filename, "scene_ids": requested_ids})'
+        in content
+    )
+    assert "`requested_ids` 为空时才调 `mcp__arcreel__generate_video_episode" in content

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.asset_inventory import AssetInventoryRevisionConflict, complete_asset_inventory
+from lib.asset_inventory import AssetInventoryInvalidRequest, AssetInventoryRevisionConflict, complete_asset_inventory
 from lib.project_manager import ProjectManager
 from lib.source_revision import SourceScope, compute_source_revision
 from server.agent_runtime.sdk_tools._context import ToolContext
@@ -64,6 +64,14 @@ def test_scoped_completion_keeps_explicit_partial_scope(tmp_path: Path) -> None:
 
     marker = pm.load_project("demo")["workflow"]["asset_inventory"]
     assert marker["scope"] == {"kind": "files", "files": ["source/novel.txt"]}
+
+
+@pytest.mark.integration
+def test_complete_inventory_rejects_non_string_expected_revision(tmp_path: Path) -> None:
+    pm, _project_path = _make_project(tmp_path)
+
+    with pytest.raises(AssetInventoryInvalidRequest):
+        complete_asset_inventory(pm, "demo", SourceScope(kind="all"), None)
 
 
 @pytest.mark.integration

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.asset_inventory import AssetInventoryRevisionConflict, complete_asset_inventory
+from lib.project_manager import ProjectManager
+from lib.source_revision import SourceScope, compute_source_revision
+from server.agent_runtime.sdk_tools._context import ToolContext
+from server.agent_runtime.sdk_tools.asset_inventory import complete_asset_inventory_tool
+
+
+def _make_project(tmp_path: Path) -> tuple[ProjectManager, Path]:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "", "narration")
+    project_path = pm.get_project_path("demo")
+    (project_path / "source" / "novel.txt").write_text("最初的原文", encoding="utf-8")
+    return pm, project_path
+
+
+@pytest.mark.unit
+def test_complete_inventory_accepts_three_empty_buckets_and_persists_scope(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    project = pm.load_project("demo")
+    expected = compute_source_revision(project_path, project, SourceScope(kind="all")).revision
+    assert expected is not None
+
+    completed = complete_asset_inventory(pm, "demo", SourceScope(kind="all"), expected)
+
+    assert completed.counts == {"characters": 0, "scenes": 0, "props": 0}
+    marker = pm.load_project("demo")["workflow"]["asset_inventory"]
+    assert marker["scope"] == {"kind": "all", "files": []}
+    assert marker["source_revision"] == expected
+    assert marker["completed_at"].endswith("+00:00")
+
+
+@pytest.mark.unit
+def test_revision_conflict_does_not_partially_write_inventory_marker(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    project = pm.load_project("demo")
+    stale = compute_source_revision(project_path, project, SourceScope(kind="all")).revision
+    assert stale is not None
+    (project_path / "source" / "novel.txt").write_text("修改后的原文", encoding="utf-8")
+
+    with pytest.raises(AssetInventoryRevisionConflict) as raised:
+        complete_asset_inventory(pm, "demo", SourceScope(kind="all"), stale)
+
+    assert raised.value.actual_revision != stale
+    assert "workflow" not in pm.load_project("demo")
+
+
+@pytest.mark.unit
+def test_scoped_completion_keeps_explicit_partial_scope(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    project = pm.load_project("demo")
+    scope = SourceScope(kind="files", files=["source/novel.txt"])
+    expected = compute_source_revision(project_path, project, scope).revision
+    assert expected is not None
+
+    complete_asset_inventory(pm, "demo", scope, expected)
+
+    marker = pm.load_project("demo")["workflow"]["asset_inventory"]
+    assert marker["scope"] == {"kind": "files", "files": ["source/novel.txt"]}
+
+
+@pytest.mark.unit
+async def test_complete_inventory_mcp_returns_machine_readable_result_and_conflict(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    tool = complete_asset_inventory_tool(ctx)
+    expected = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
+    assert expected is not None
+
+    success = await tool.handler({"scope": {"kind": "all", "files": []}, "expected_source_revision": expected})
+    body = json.loads(success["content"][0]["text"])
+    assert body == {
+        "counts": {"characters": 0, "props": 0, "scenes": 0},
+        "scope": {"files": [], "kind": "all"},
+        "source_revision": expected,
+    }
+
+    (project_path / "source" / "novel.txt").write_text("又一次变化", encoding="utf-8")
+    conflict = await tool.handler({"scope": {"kind": "all", "files": []}, "expected_source_revision": expected})
+    conflict_body = json.loads(conflict["content"][0]["text"])
+    assert conflict["is_error"] is True
+    assert conflict_body["error"] == "source_revision_conflict"
+    assert conflict_body["expected_source_revision"] == expected
+    assert conflict_body["actual_source_revision"] != expected

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -162,10 +162,19 @@ def test_complete_inventory_rejects_non_string_expected_revision(tmp_path: Path)
 
 
 @pytest.mark.integration
-async def test_complete_inventory_mcp_returns_machine_readable_result_and_conflict(tmp_path: Path) -> None:
+async def test_complete_inventory_mcp_returns_machine_readable_result_and_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     pm, project_path = _make_project(tmp_path)
     ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
     tool = complete_asset_inventory_tool(ctx)
+    offloads: list[tuple[object, tuple[object, ...]]] = []
+
+    async def _to_thread(fn, *args):
+        offloads.append((fn, args))
+        return fn(*args)
+
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.asset_inventory.asyncio.to_thread", _to_thread)
     expected = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
     assert expected is not None
 
@@ -184,6 +193,7 @@ async def test_complete_inventory_mcp_returns_machine_readable_result_and_confli
     assert conflict_body["error"] == "source_revision_conflict"
     assert conflict_body["expected_source_revision"] == expected
     assert conflict_body["actual_source_revision"] != expected
+    assert len(offloads) == 2
 
 
 @pytest.mark.integration

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -21,7 +21,7 @@ def _make_project(tmp_path: Path) -> tuple[ProjectManager, Path]:
     return pm, project_path
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_complete_inventory_accepts_three_empty_buckets_and_persists_scope(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path)
     project = pm.load_project("demo")
@@ -37,7 +37,7 @@ def test_complete_inventory_accepts_three_empty_buckets_and_persists_scope(tmp_p
     assert marker["completed_at"].endswith("+00:00")
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_revision_conflict_does_not_partially_write_inventory_marker(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path)
     project = pm.load_project("demo")
@@ -52,7 +52,7 @@ def test_revision_conflict_does_not_partially_write_inventory_marker(tmp_path: P
     assert "workflow" not in pm.load_project("demo")
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_scoped_completion_keeps_explicit_partial_scope(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path)
     project = pm.load_project("demo")
@@ -66,7 +66,7 @@ def test_scoped_completion_keeps_explicit_partial_scope(tmp_path: Path) -> None:
     assert marker["scope"] == {"kind": "files", "files": ["source/novel.txt"]}
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 async def test_complete_inventory_mcp_returns_machine_readable_result_and_conflict(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path)
     ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -71,6 +73,41 @@ def test_revision_conflict_does_not_partially_write_extracted_assets(tmp_path: P
 
     saved = pm.load_project("demo")
     assert "阿青" not in saved["characters"]
+    assert "workflow" not in saved
+
+
+@pytest.mark.integration
+def test_source_mutation_is_serialized_with_inventory_revision_commit(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    source_path = project_path / "source" / "novel.txt"
+    expected = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
+    assert expected is not None
+    writer_locked = Event()
+    allow_write = Event()
+    completion_started = Event()
+
+    def _write_source() -> None:
+        with pm.locked_source_mutation("demo"):
+            writer_locked.set()
+            allow_write.wait(timeout=5)
+            source_path.write_text("并发修改后的原文", encoding="utf-8")
+
+    def _complete_inventory() -> None:
+        completion_started.set()
+        complete_asset_inventory(pm, "demo", SourceScope(kind="all"), expected)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(_write_source)
+        assert writer_locked.wait(timeout=2)
+        completion = executor.submit(_complete_inventory)
+        assert completion_started.wait(timeout=2)
+        assert not completion.done()
+        allow_write.set()
+        writer.result(timeout=2)
+        with pytest.raises(AssetInventoryRevisionConflict):
+            completion.result(timeout=2)
+
+    saved = pm.load_project("demo")
     assert "workflow" not in saved
 
 

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -73,6 +73,9 @@ def test_complete_inventory_rejects_non_string_expected_revision(tmp_path: Path)
     with pytest.raises(AssetInventoryInvalidRequest):
         complete_asset_inventory(pm, "demo", SourceScope(kind="all"), None)
 
+    with pytest.raises(AssetInventoryInvalidRequest):
+        complete_asset_inventory(pm, "demo", SourceScope(kind="all"), "sha256-v1:not-a-digest")
+
 
 @pytest.mark.integration
 async def test_complete_inventory_mcp_returns_machine_readable_result_and_conflict(tmp_path: Path) -> None:

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -53,6 +53,53 @@ def test_revision_conflict_does_not_partially_write_inventory_marker(tmp_path: P
 
 
 @pytest.mark.integration
+def test_revision_conflict_does_not_partially_write_extracted_assets(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    project = pm.load_project("demo")
+    stale = compute_source_revision(project_path, project, SourceScope(kind="all")).revision
+    assert stale is not None
+    (project_path / "source" / "novel.txt").write_text("修改后的原文", encoding="utf-8")
+
+    with pytest.raises(AssetInventoryRevisionConflict):
+        complete_asset_inventory(
+            pm,
+            "demo",
+            SourceScope(kind="all"),
+            stale,
+            {"characters": {"阿青": {"description": "青衣少女", "voice_style": "清亮"}}},
+        )
+
+    saved = pm.load_project("demo")
+    assert "阿青" not in saved["characters"]
+    assert "workflow" not in saved
+
+
+@pytest.mark.integration
+def test_extracted_assets_and_marker_commit_together(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    expected = compute_source_revision(project_path, pm.load_project("demo"), SourceScope(kind="all")).revision
+    assert expected is not None
+
+    completed = complete_asset_inventory(
+        pm,
+        "demo",
+        SourceScope(kind="all"),
+        expected,
+        {
+            "characters": {"阿青": {"description": "青衣少女", "voice_style": "清亮"}},
+            "scenes": {"竹林": {"description": "雨后竹林"}},
+            "props": {},
+        },
+    )
+
+    saved = pm.load_project("demo")
+    assert saved["characters"]["阿青"]["voice_style"] == "清亮"
+    assert saved["scenes"]["竹林"]["description"] == "雨后竹林"
+    assert saved["workflow"]["asset_inventory"]["source_revision"] == expected
+    assert completed.counts == {"characters": 1, "scenes": 1, "props": 0}
+
+
+@pytest.mark.integration
 def test_scoped_completion_keeps_explicit_partial_scope(tmp_path: Path) -> None:
     pm, project_path = _make_project(tmp_path)
     project = pm.load_project("demo")

--- a/tests/test_asset_inventory.py
+++ b/tests/test_asset_inventory.py
@@ -89,3 +89,24 @@ async def test_complete_inventory_mcp_returns_machine_readable_result_and_confli
     assert conflict_body["error"] == "source_revision_conflict"
     assert conflict_body["expected_source_revision"] == expected
     assert conflict_body["actual_source_revision"] != expected
+
+
+@pytest.mark.integration
+async def test_complete_inventory_mcp_distinguishes_invalid_request_from_broken_workflow(tmp_path: Path) -> None:
+    pm, project_path = _make_project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    tool = complete_asset_inventory_tool(ctx)
+
+    invalid = await tool.handler({"scope": {"kind": "all", "files": []}, "expected_source_revision": "not-a-revision"})
+    assert json.loads(invalid["content"][0]["text"])["error"] == "invalid_request"
+
+    expected = compute_source_revision(
+        project_path,
+        pm.load_project("demo"),
+        SourceScope(kind="all"),
+    ).revision
+    assert expected is not None
+    pm.update_project("demo", lambda project: project.update(workflow="broken"))
+
+    unavailable = await tool.handler({"scope": {"kind": "all", "files": []}, "expected_source_revision": expected})
+    assert json.loads(unavailable["content"][0]["text"])["error"] == "inventory_unavailable"

--- a/tests/test_episode_planner.py
+++ b/tests/test_episode_planner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+import lib.script_review as script_review
 from lib.episode_ledger import SOURCE_FINGERPRINTS_KEY
 from lib.episode_ledger import discover_sources as _real_discover_sources
 from lib.episode_planner import (
@@ -1209,6 +1210,9 @@ class TestPlan:
         project_dir = _write_project(tmp_path)
         (project_dir / "scripts").mkdir()
         (project_dir / "scripts" / "episode_1.json").write_text("{}", encoding="utf-8")
+        step1_path = project_dir / "drafts" / "episode_1" / "step1_segments.json"
+        step1_path.parent.mkdir(parents=True)
+        step1_path.write_text('{"segments": [{"segment_id": "E1S01"}]}', encoding="utf-8")
         fake = _FakeTextGenerator(
             [_plan_response([{"title": "古玉藏诀", "hook": "剑诀来历成谜", "end_anchor": ANCHOR_EP1}])]
         )
@@ -1219,6 +1223,7 @@ class TestPlan:
         assert result.episodes[0].ledger_status == "stale"
         eps = {e["episode"]: e for e in _load_project(project_dir)["episodes"]}
         assert eps[1]["ledger_status"] == "stale"
+        assert eps[1][script_review.STALE_STEP1_REVISION_FIELD] == script_review.content_fingerprint(step1_path)
         assert (project_dir / "scripts" / "episode_1.json").exists()  # 产物不删除
 
     @pytest.mark.unit

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -96,6 +96,12 @@ class _FakePM:
             raise FileNotFoundError(name)
         return path
 
+    @contextmanager
+    def locked_source_mutation(self, name):
+        source_dir = self.get_project_path(name) / "source"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        yield source_dir
+
     def delete_project_directory(self, name):
         shutil.rmtree(self.get_project_path(name))
 

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import lib.script_review as script_review
 from lib.config.resolver import ConfigResolver
 from lib.script_generator import ScriptGenerator, _units_use_references
 from lib.script_structure_validator import ScriptStructureValidationError
@@ -555,6 +556,10 @@ class TestScriptGenerator:
         assert seg["characters_in_segment"] == ["姜月茴"]
         assert seg["image_prompt"]["scene"] == "画面"
         assert payload["metadata"]["generator"] == "fake-model"
+        step1_path = project_path / "drafts" / "episode_1" / "step1_segments.json"
+        assert payload["metadata"][script_review.SCRIPT_STEP1_REVISION_FIELD] == script_review.content_fingerprint(
+            step1_path
+        )
         assert "created_at" in payload["metadata"]
 
     @pytest.mark.unit

--- a/tests/test_source_revision.py
+++ b/tests/test_source_revision.py
@@ -30,6 +30,22 @@ def test_all_source_revision_is_stable_and_excludes_planned_episode_files(tmp_pa
 
 
 @pytest.mark.integration
+def test_scoped_revision_rejects_planned_episode_files(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "episode_1.txt").write_text("derived planning output", encoding="utf-8")
+
+    result = compute_source_revision(
+        tmp_path,
+        _project(),
+        SourceScope(kind="files", files=["source/episode_1.txt"]),
+    )
+
+    assert result.revision is None
+    assert result.blockers[0].code == "invalid_source_scope"
+
+
+@pytest.mark.integration
 def test_revision_changes_with_raw_bytes_path_and_source_semantics(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/test_source_revision.py
+++ b/tests/test_source_revision.py
@@ -100,6 +100,25 @@ def test_revision_changes_with_raw_bytes_path_and_source_semantics(tmp_path: Pat
 
 
 @pytest.mark.integration
+def test_revision_payload_order_is_stable_across_unicode_filename_spelling(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    nfc_name = "á.txt"
+    nfd_name = unicodedata.normalize("NFD", nfc_name)
+    accented = source / nfd_name
+    accented.write_text("accented", encoding="utf-8")
+    (source / "b.txt").write_text("plain", encoding="utf-8")
+    before = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    intermediate = source / "rename.tmp"
+    accented.rename(intermediate)
+    intermediate.rename(source / nfc_name)
+    after = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    assert after.revision == before.revision
+
+
+@pytest.mark.integration
 def test_scoped_revision_rejects_escape_symlink_and_invalid_scope(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/test_source_revision.py
+++ b/tests/test_source_revision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,7 @@ def _project() -> dict[str, object]:
     return {"source_kind": "novel", "source_language": "zh"}
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_all_source_revision_is_stable_and_excludes_planned_episode_files(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
@@ -28,7 +29,7 @@ def test_all_source_revision_is_stable_and_excludes_planned_episode_files(tmp_pa
     assert second == first
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_revision_changes_with_raw_bytes_path_and_source_semantics(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
@@ -49,17 +50,13 @@ def test_revision_changes_with_raw_bytes_path_and_source_semantics(tmp_path: Pat
     assert len({baseline.revision, changed_bytes.revision, changed_path.revision, changed_semantics.revision}) == 4
 
 
-@pytest.mark.unit
-def test_scoped_revision_rejects_escape_symlink_unreadable_and_invalid_scope(tmp_path: Path) -> None:
+@pytest.mark.integration
+def test_scoped_revision_rejects_escape_symlink_and_invalid_scope(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
     outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
     outside.write_text("outside", encoding="utf-8")
     (source / "linked.txt").symlink_to(outside)
-    unreadable = source / "unreadable.txt"
-    unreadable.write_text("secret", encoding="utf-8")
-    unreadable.chmod(0)
-
     try:
         escape = compute_source_revision(
             tmp_path,
@@ -71,24 +68,39 @@ def test_scoped_revision_rejects_escape_symlink_unreadable_and_invalid_scope(tmp
             _project(),
             SourceScope(kind="files", files=["source/linked.txt"]),
         )
-        denied = compute_source_revision(
-            tmp_path,
-            _project(),
-            SourceScope(kind="files", files=["source/unreadable.txt"]),
-        )
         malformed = compute_source_revision(tmp_path, _project(), {"kind": "all", "files": ["source/a.txt"]})
     finally:
-        unreadable.chmod(0o600)
         outside.unlink()
 
     assert escape.revision is None
     assert escape.blockers[0].code == "source_path_escape"
     assert linked.blockers[0].code == "source_symlink"
-    assert denied.blockers[0].code == "source_unreadable"
     assert malformed.blockers[0].code == "invalid_source_scope"
 
 
-@pytest.mark.unit
+@pytest.mark.integration
+def test_scoped_revision_rejects_unreadable_file_on_posix(tmp_path: Path) -> None:
+    if os.name != "posix":
+        pytest.skip("POSIX permission bits are required to make the fixture unreadable")
+    source = tmp_path / "source"
+    source.mkdir()
+    unreadable = source / "unreadable.txt"
+    unreadable.write_text("secret", encoding="utf-8")
+    os.chmod(unreadable, 0)
+
+    try:
+        denied = compute_source_revision(
+            tmp_path,
+            _project(),
+            SourceScope(kind="files", files=["source/unreadable.txt"]),
+        )
+    finally:
+        os.chmod(unreadable, 0o600)
+
+    assert denied.blockers[0].code == "source_unreadable"
+
+
+@pytest.mark.integration
 def test_all_scope_reports_candidate_symlink_instead_of_skipping_it(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()

--- a/tests/test_source_revision.py
+++ b/tests/test_source_revision.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.source_revision import SourceScope, compute_source_revision
+
+
+def _project() -> dict[str, object]:
+    return {"source_kind": "novel", "source_language": "zh"}
+
+
+@pytest.mark.unit
+def test_all_source_revision_is_stable_and_excludes_planned_episode_files(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "novel.txt").write_bytes("原文\r\n第二行".encode())
+
+    first = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+    (source / "episode_1.txt").write_bytes(b"derived planning output")
+    second = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    assert first.blockers == []
+    assert first.files == ["source/novel.txt"]
+    assert first.revision is not None
+    assert first.revision.startswith("sha256-v1:")
+    assert second == first
+
+
+@pytest.mark.unit
+def test_revision_changes_with_raw_bytes_path_and_source_semantics(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    original = source / "a.txt"
+    original.write_bytes(b"same text\r\n")
+    baseline = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    original.write_bytes(b"same text\n")
+    changed_bytes = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+    original.rename(source / "b.txt")
+    changed_path = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+    changed_semantics = compute_source_revision(
+        tmp_path,
+        {"source_kind": "screenplay", "source_language": "zh"},
+        SourceScope(kind="all"),
+    )
+
+    assert len({baseline.revision, changed_bytes.revision, changed_path.revision, changed_semantics.revision}) == 4
+
+
+@pytest.mark.unit
+def test_scoped_revision_rejects_escape_symlink_unreadable_and_invalid_scope(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    (source / "linked.txt").symlink_to(outside)
+    unreadable = source / "unreadable.txt"
+    unreadable.write_text("secret", encoding="utf-8")
+    unreadable.chmod(0)
+
+    try:
+        escape = compute_source_revision(
+            tmp_path,
+            _project(),
+            {"kind": "files", "files": ["../outside.txt"]},
+        )
+        linked = compute_source_revision(
+            tmp_path,
+            _project(),
+            SourceScope(kind="files", files=["source/linked.txt"]),
+        )
+        denied = compute_source_revision(
+            tmp_path,
+            _project(),
+            SourceScope(kind="files", files=["source/unreadable.txt"]),
+        )
+        malformed = compute_source_revision(tmp_path, _project(), {"kind": "all", "files": ["source/a.txt"]})
+    finally:
+        unreadable.chmod(0o600)
+        outside.unlink()
+
+    assert escape.revision is None
+    assert escape.blockers[0].code == "source_path_escape"
+    assert linked.blockers[0].code == "source_symlink"
+    assert denied.blockers[0].code == "source_unreadable"
+    assert malformed.blockers[0].code == "invalid_source_scope"
+
+
+@pytest.mark.unit
+def test_all_scope_reports_candidate_symlink_instead_of_skipping_it(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    target = tmp_path / "target.txt"
+    target.write_text("outside source", encoding="utf-8")
+    (source / "novel.txt").symlink_to(target)
+
+    result = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    assert result.revision is None
+    assert [(b.code, b.path) for b in result.blockers] == [("source_symlink", "source/novel.txt")]

--- a/tests/test_source_revision.py
+++ b/tests/test_source_revision.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,38 @@ def test_scoped_revision_rejects_planned_episode_files(tmp_path: Path) -> None:
 
     assert result.revision is None
     assert result.blockers[0].code == "invalid_source_scope"
+
+
+@pytest.mark.integration
+def test_scoped_revision_resolves_canonical_unicode_path_to_filesystem_spelling(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    disk_name = unicodedata.normalize("NFD", "truyện.txt")
+    (source / disk_name).write_text("nội dung", encoding="utf-8")
+    all_result = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+    assert all_result.files == ["source/truyện.txt"]
+
+    scoped_result = compute_source_revision(
+        tmp_path,
+        _project(),
+        SourceScope(kind="files", files=all_result.files),
+    )
+
+    assert scoped_result.blockers == []
+    assert scoped_result.revision == all_result.revision
+    assert scoped_result.files == ["source/truyện.txt"]
+
+
+@pytest.mark.integration
+def test_revision_rejects_source_that_is_not_valid_utf8(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "broken.txt").write_bytes(b"\xff\xfe")
+
+    result = compute_source_revision(tmp_path, _project(), SourceScope(kind="all"))
+
+    assert result.revision is None
+    assert result.blockers[0].code == "source_unreadable"
 
 
 @pytest.mark.integration

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from lib.project_manager import ProjectManager
 from lib.workflow_state import WorkflowStateService
 from server.agent_runtime.sdk_tools._context import ToolContext
-from server.agent_runtime.sdk_tools.workflow_status import get_workflow_status_tool
+from server.agent_runtime.sdk_tools.workflow_status import complete_step1_rebuild_tool, get_workflow_status_tool
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import projects
 
@@ -60,6 +60,41 @@ async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_servi
     assert result["is_error"] is True
     assert json.loads(result["content"][0]["text"])["error"] == "invalid_episode"
     assert calls == []
+
+
+@pytest.mark.integration
+async def test_complete_step1_rebuild_mcp_forwards_explicit_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    calls: list[tuple[object, ...]] = []
+
+    def _complete(*args: object) -> str:
+        calls.append(args)
+        return "rebuilt-revision"
+
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.workflow_status.complete_stale_step1_rebuild", _complete)
+
+    result = await complete_step1_rebuild_tool(ctx).handler({"episode": 2, "expected_stale_step1_revision": "baseline"})
+
+    assert result.get("is_error") is not True
+    assert json.loads(result["content"][0]["text"]) == {
+        "episode": 2,
+        "step1_revision": "rebuilt-revision",
+    }
+    assert calls == [(pm, "demo", 2, "baseline")]
+
+
+@pytest.mark.integration
+async def test_complete_step1_rebuild_mcp_requires_explicit_baseline(tmp_path: Path) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+
+    result = await complete_step1_rebuild_tool(ctx).handler({"episode": 1})
+
+    assert result["is_error"] is True
+    assert json.loads(result["content"][0]["text"])["error"] == "invalid_request"
 
 
 @pytest.mark.integration

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -63,6 +63,25 @@ async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_servi
 
 
 @pytest.mark.integration
+async def test_workflow_status_mcp_offloads_filesystem_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    calls: list[tuple[object, tuple[object, ...]]] = []
+
+    async def _to_thread(fn, *args):
+        calls.append((fn, args))
+        return fn(*args)
+
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.workflow_status.asyncio.to_thread", _to_thread)
+
+    result = await get_workflow_status_tool(ctx).handler({})
+
+    assert result.get("is_error") is not True
+    assert len(calls) == 1
+    assert calls[0][1] == ("demo", None)
+
+
+@pytest.mark.integration
 async def test_workflow_status_adapters_treat_corrupt_project_as_server_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -21,7 +21,7 @@ def _project(tmp_path: Path) -> ProjectManager:
     return pm
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 async def test_rest_and_mcp_serialize_the_same_workflow_response(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -41,7 +41,7 @@ async def test_rest_and_mcp_serialize_the_same_workflow_response(
     assert response.json() == mcp_body
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_service(tmp_path: Path) -> None:
     pm = _project(tmp_path)
     ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from lib.project_manager import ProjectManager
+from server.agent_runtime.sdk_tools._context import ToolContext
+from server.agent_runtime.sdk_tools.workflow_status import get_workflow_status_tool
+from server.auth import CurrentUserInfo, get_current_user
+from server.routers import projects
+
+
+def _project(tmp_path: Path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Ad", "", "ad", target_duration=30)
+    return pm
+
+
+@pytest.mark.unit
+async def test_rest_and_mcp_serialize_the_same_workflow_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    mcp_result = await get_workflow_status_tool(ctx).handler({})
+    mcp_body = json.loads(mcp_result["content"][0]["text"])
+
+    monkeypatch.setattr(projects, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
+    app.include_router(projects.router, prefix="/api/v1", dependencies=[Depends(get_current_user)])
+    with TestClient(app) as client:
+        response = client.get("/api/v1/projects/demo/workflow-status")
+
+    assert response.status_code == 200
+    assert response.json() == mcp_body
+
+
+@pytest.mark.unit
+async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_service(tmp_path: Path) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+
+    result = await get_workflow_status_tool(ctx).handler({"episode": 0})
+
+    assert result["is_error"] is True
+    assert json.loads(result["content"][0]["text"])["error"] == "invalid_episode"

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -8,6 +8,7 @@ from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from lib.project_manager import ProjectManager
+from lib.workflow_state import WorkflowStateService
 from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.workflow_status import get_workflow_status_tool
 from server.auth import CurrentUserInfo, get_current_user
@@ -42,11 +43,47 @@ async def test_rest_and_mcp_serialize_the_same_workflow_response(
 
 
 @pytest.mark.integration
-async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_service(tmp_path: Path) -> None:
+async def test_workflow_status_mcp_rejects_invalid_episode_without_calling_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     pm = _project(tmp_path)
     ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    calls: list[object] = []
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(WorkflowStateService, "get_status", _fail)
 
     result = await get_workflow_status_tool(ctx).handler({"episode": 0})
 
     assert result["is_error"] is True
     assert json.loads(result["content"][0]["text"])["error"] == "invalid_episode"
+    assert calls == []
+
+
+@pytest.mark.integration
+async def test_workflow_status_adapters_treat_corrupt_project_as_server_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+
+    def _corrupt(*args: object, **kwargs: object) -> None:
+        raise json.JSONDecodeError("broken", "{", 0)
+
+    monkeypatch.setattr(WorkflowStateService, "get_status", _corrupt)
+
+    result = await get_workflow_status_tool(ctx).handler({})
+
+    assert result["is_error"] is True
+    assert result["content"][0]["text"].startswith("get_workflow_status 失败:")
+
+    monkeypatch.setattr(projects, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
+    app.include_router(projects.router, prefix="/api/v1", dependencies=[Depends(get_current_user)])
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/projects/demo/workflow-status")
+
+    assert response.status_code == 500


### PR DESCRIPTION
## 范围

实现 #1671 的服务端权威工作流状态、资产清单完成事实、source revision、MCP/REST 适配与三语工具名称。视觉与媒体 provenance 仍按既定依赖由 #1672/#1673 接入，不在本 PR 推断陈旧状态。

## 变更

- 新增版本化 workflow-status 领域模型与服务，统一输出项目模式、账本目标集、状态、blocker、gate、artifact 与稳定 next action；MCP 和已认证 REST 复用同一响应模型
- 新增安全且确定性的 source revision，以及在项目锁内校验 revision 后原子写入的资产清单完成工具；空资产 bucket 与局部 scope 均有明确语义
- 修正本地审查发现的完成判定：媒体必须为项目内真实文件，同长度源文改写会重新进入规划，多集项目不会因首集已完成而过早导出
- 补齐 narration、drama、ad、空 bucket、revision 冲突、异常路径、跨集推进与适配器等集成覆盖

## 验收清单

- [x] 本地已跑相关测试：`uv run pytest -m "not e2e"`（8464 passed, 1 skipped）
- [x] 手动验证了改动所声称的行为：聚焦 workflow/source/inventory/adapter 套件 22 passed
- [x] 新增面向用户文案已加 zh/en/vi 翻译
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 由 GitHub 按规则匹配
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright`（0 errors）
- [x] `uv run lint-imports`
- [x] `pnpm lint && pnpm check && pnpm build`（1774 frontend tests passed）

## 已知 defer

无。

Closes #1671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增工作流状态查询，可查看项目或指定剧集的进度、阻塞原因及下一步操作。
  * 新增资产清单完成工具，支持全量或指定范围盘点并返回统计信息。
  * 提供 REST 与 MCP 接口，统一返回结构化结果和错误信息。
* **本地化**
  * 英文、越南文和中文仪表盘新增相关工具名称翻译。
* **改进**
  * 工作流状态覆盖广告、旁白、剧情及参考视频流程。
  * 强化源文件、版本及媒体产物校验，提升状态判断准确性。
  * 工作流阶段根据服务端状态和下一步操作自动推进。
  * 资产清单提交支持版本校验、并发保护与原子更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->