### PR TITLE
fix(grid): clean up superseded grid generations in SDK enqueue path

### DIFF
--- a/lib/grid_manager.py
+++ b/lib/grid_manager.py
@@ -70,3 +70,29 @@ class GridManager:
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning("Skipping invalid grid file %s: %s", p.name, e)
         return sorted(grids, key=lambda g: g.created_at)
+
+    def cleanup_superseded(self, script_file: str, episode: int, scene_ids: set[str]) -> int:
+        """Delete finished grid records superseded by a regenerate of ``scene_ids``.
+
+        A record is superseded when it belongs to the same script and episode, its
+        ``scene_ids`` are a subset of the freshly generated group, and it is not still
+        in flight (pending/generating). In-flight records are kept so the generation
+        worker can still find its resource.
+
+        This is the single cleanup rule shared by the HTTP route and the SDK tool so
+        both regenerate paths stop accumulating stale grid generations.
+
+        Returns the number of deleted records.
+        """
+        deleted = 0
+        for old in self.list_all():
+            if (
+                old.script_file == script_file
+                and old.episode == episode
+                and old.status not in ("pending", "generating")
+                and old.scene_ids
+                and set(old.scene_ids) <= scene_ids
+            ):
+                if self.delete(old.id):
+                    deleted += 1
+        return deleted

--- a/server/agent_runtime/sdk_tools/enqueue_grid.py
+++ b/server/agent_runtime/sdk_tools/enqueue_grid.py
@@ -148,6 +148,11 @@ def generate_grid_tool(ctx: ToolContext):
                 # （末张不足一档时落小档 + 占位格），与预览、费用估算同源。
                 # 空分组（``plan_grid_chunks`` 的唯一空产出）自然跳过循环体。
                 plans = plan_grid_chunks(group, aspect_ratio, allow_large_grid=allow_large_grid)
+                # 与 WebUI 入队路径同源：重生成该组时清理旧的已完成记录（同脚本
+                # 同集、scene_ids 是当前组子集、非在途），前端列表只显示新一代
+                # 宫格图。规则唯一定义在 GridManager.cleanup_superseded。
+                if plans:
+                    gm.cleanup_superseded(script_filename, episode, {item[id_field] for item in group})
                 for chunk, layout in plans:
                     chunk_ids = [item[id_field] for item in chunk]
                     prompt = build_grid_prompt(

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -106,9 +106,6 @@ async def generate_grid(
     queue = get_generation_queue()
     gm = GridManager(project_path)
 
-    # Pre-load existing grids for cleanup
-    existing_grids = gm.list_all()
-
     for group in groups:
         all_scene_ids = [item[id_field] for item in group]
         # 超上限分组切为多张宫格批次（末批不足一档时落小档 + 占位格），
@@ -118,18 +115,11 @@ async def generate_grid(
         if not plans:
             continue
 
-        # 清理该组旧的 grid 记录（限定同脚本同集，scene_ids 是当前组子集的旧 grid）
-        # 跳过 pending/generating 状态的记录，避免 worker 执行时找不到资源
-        group_id_set = set(all_scene_ids)
-        for old_grid in existing_grids:
-            if (
-                old_grid.script_file == req.script_file
-                and old_grid.episode == episode
-                and old_grid.status not in ("pending", "generating")
-                and old_grid.scene_ids
-                and set(old_grid.scene_ids) <= group_id_set
-            ):
-                gm.delete(old_grid.id)
+        # 清理该组旧的 grid 记录（限定同脚本同集，scene_ids 是当前组子集的旧 grid；
+        # 跳过 pending/generating 状态的记录，避免 worker 执行时找不到资源）。
+        # 规则唯一定义在 GridManager.cleanup_superseded，HTTP 路由与 SDK 工具
+        # (generate_grid) 两条路径共用同一实现。
+        gm.cleanup_superseded(req.script_file, episode, set(all_scene_ids))
 
         for chunk, chunk_layout in plans:
             chunk_ids = [item[id_field] for item in chunk]

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1149,7 +1149,7 @@ async def test_generate_grid_falls_back_on_null_aspect_ratio(
 
 @pytest.mark.unit
 async def test_generate_grid_cleans_superseded_records(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> None:
-    """重生成清理规则对 SDK 路径生效：旧记录不残留在前端列表（issue #1728 回归）。
+    """重生成清理规则对 SDK 路径生效：旧记录不残留在前端列表。
 
     通过 generate_grid 重生成某组宫格后，该组旧的已完成记录（同脚本同集、
     scene_ids 是当前组子集）被清理；其它组/代与非在途无关的记录不得误删。

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -1148,6 +1148,83 @@ async def test_generate_grid_falls_back_on_null_aspect_ratio(
 
 
 @pytest.mark.unit
+async def test_generate_grid_cleans_superseded_records(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    """重生成清理规则对 SDK 路径生效：旧记录不残留在前端列表（issue #1728 回归）。
+
+    通过 generate_grid 重生成某组宫格后，该组旧的已完成记录（同脚本同集、
+    scene_ids 是当前组子集）被清理；其它组/代与非在途无关的记录不得误删。
+    """
+    from lib.grid.models import GridGeneration
+    from lib.grid_manager import GridManager
+
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+        {"segment_id": f"E1S0{i}", "image_prompt": "p", "video_prompt": "v", "segment_break": False}
+        for i in range(1, 5)
+    ]
+
+    async def _gate(_project: dict) -> bool:
+        return False
+
+    async def fake_enqueue(*, project_name, task_type, media_type, resource_id, payload, script_file, source):
+        return {"task_id": f"t{resource_id}"}
+
+    async def fake_wait(_task_id: str) -> dict[str, Any]:
+        return {"status": "succeeded"}
+
+    async def fake_split(project_name: str, grid: Any) -> Any:
+        from server.services.grid_split import GridSplitResult
+
+        return GridSplitResult(updated_scene_ids=list(grid.scene_ids), missing_scene_ids=[], asset_fingerprints={})
+
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_grid.resolve_large_grid_allowed", _gate)
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_grid.enqueue_task_only", fake_enqueue)
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_grid.wait_for_task", fake_wait)
+    monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_grid.apply_grid_split", fake_split)
+
+    # 预置两代旧记录：一代属于本组（应被清理），一代属于其它组（不得误删）
+    gm = GridManager(fake_ctx.project_path)
+    superseded = GridGeneration.create(
+        episode=1,
+        script_file="episode_1.json",
+        scene_ids=["E1S01", "E1S02"],
+        rows=2,
+        cols=2,
+        grid_size="grid_4",
+        provider="",
+        model="",
+        video_aspect_ratio="9:16",
+    )
+    superseded.status = "completed"
+    gm.save(superseded)
+    other_group = GridGeneration.create(
+        episode=1,
+        script_file="episode_1.json",
+        scene_ids=["E1S99"],
+        rows=1,
+        cols=1,
+        grid_size="grid_1",
+        provider="",
+        model="",
+        video_aspect_ratio="9:16",
+    )
+    other_group.status = "completed"
+    gm.save(other_group)
+
+    tool_obj = generate_grid_tool(fake_ctx)
+    out = await _call(tool_obj, {"script": "episode_1.json"})
+    assert out.get("is_error") is not True
+
+    remaining = gm.list_all()
+    ids = [g.id for g in remaining]
+    assert superseded.id not in ids, "superseded old record must be cleaned up"
+    assert other_group.id in ids, "records of other groups must not be deleted"
+    fresh = [g for g in remaining if g.id != other_group.id]
+    assert [g.scene_ids for g in fresh] == [["E1S01", "E1S02", "E1S03", "E1S04"]]
+
+
+@pytest.mark.unit
 async def test_generate_grid_list_only_falls_back_on_null_aspect_ratio(
     fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_grid_manager.py
+++ b/tests/test_grid_manager.py
@@ -117,3 +117,66 @@ class TestLegacyRecordMigration:
         payload["status"] = "completed"
         payload["split_at"] = None
         assert GridGeneration.from_dict(payload).split_at is None
+
+
+class TestCleanupSuperseded:
+    """重生成清理规则：同脚本同集、scene_ids 是当前组子集、非在途的旧记录被删。
+
+    HTTP 路由与 SDK 工具 (generate_grid) 共用 GridManager.cleanup_superseded，
+    本类锁定规则的唯一实现。
+    """
+
+    def _save(self, gm: GridManager, *, status: str = "completed", **kwargs) -> GridGeneration:
+        grid = _make_grid(**kwargs)
+        grid.status = status
+        gm.save(grid)
+        return grid
+
+    def test_deletes_superseded_completed_records(self, tmp_path):
+        gm = GridManager(tmp_path)
+        old = self._save(gm, scene_ids=["S1", "S2"])
+        deleted = gm.cleanup_superseded("ep1.json", 1, {"S1", "S2", "S3", "S4"})
+        assert deleted == 1
+        assert gm.get(old.id) is None
+
+    def test_returns_zero_when_nothing_to_delete(self, tmp_path):
+        assert GridManager(tmp_path).cleanup_superseded("ep1.json", 1, {"S1"}) == 0
+
+    def test_skips_inflight_records(self, tmp_path):
+        """pending/generating 的记录必须保留：worker 执行时还要找得到资源。"""
+        gm = GridManager(tmp_path)
+        pending = self._save(gm, status="pending", scene_ids=["S1", "S2"])
+        generating = self._save(gm, status="generating", scene_ids=["S3"])
+        deleted = gm.cleanup_superseded("ep1.json", 1, {"S1", "S2", "S3"})
+        assert deleted == 0
+        assert gm.get(pending.id) is not None
+        assert gm.get(generating.id) is not None
+
+    def test_skips_records_with_non_subset_scene_ids(self, tmp_path):
+        """scene_ids 不是当前组子集的记录属于其它组/代，不得误删。"""
+        gm = GridManager(tmp_path)
+        overlap = self._save(gm, scene_ids=["S1", "S9"])
+        outside = self._save(gm, scene_ids=["S9"])
+        deleted = gm.cleanup_superseded("ep1.json", 1, {"S1", "S2", "S3", "S4"})
+        assert deleted == 0
+        assert gm.get(overlap.id) is not None
+        assert gm.get(outside.id) is not None
+
+    def test_skips_records_of_other_script_or_episode(self, tmp_path):
+        gm = GridManager(tmp_path)
+        other_script = self._save(gm, script_file="ep2.json", scene_ids=["S1", "S2"])
+        other_episode = self._save(gm, episode=2, scene_ids=["S1", "S2"])
+        deleted = gm.cleanup_superseded("ep1.json", 1, {"S1", "S2", "S3", "S4"})
+        assert deleted == 0
+        assert gm.get(other_script.id) is not None
+        assert gm.get(other_episode.id) is not None
+
+    def test_dedupes_many_generations(self, tmp_path):
+        """反复重生成后，同一组只留下最新一批（在途记录除外）。"""
+        gm = GridManager(tmp_path)
+        for _ in range(3):
+            self._save(gm, scene_ids=["S1", "S2", "S3", "S4"])
+        self._save(gm, status="generating", scene_ids=["S1", "S2", "S3", "S4"])
+        deleted = gm.cleanup_superseded("ep1.json", 1, {"S1", "S2", "S3", "S4"})
+        assert deleted == 3
+        assert len(gm.list_all()) == 1


### PR DESCRIPTION
Closes #1728

## 范围

本 PR 聚焦宫格重生成时过期记录的生命周期管理，覆盖 SDK 入队路径与现有 HTTP 路径的共享清理规则。本 PR 不改变宫格生成请求格式、正在执行记录的保留策略或其它资源类型的生命周期。

## 变更

- 将过期宫格记录筛选与关联图像清理收敛到 `GridManager.cleanup_superseded`。
- 在 SDK `generate_grid` 路径接入共享清理逻辑，避免 agent-driven 重生成留下多代旧记录。
- 让 HTTP 路径复用同一规则，避免两条重生成路径行为漂移。
- 保留当前场景组范围，并避免删除进行中的记录及其它场景组记录。
- 更新回归测试说明，明确测试验证的行为与约束。

## 验收清单

- [x] 本地已跑相关测试：`uv run pytest -q tests/server/agent_runtime/test_sdk_tools.py -k cleans_superseded_records`
- [x] 已验证 SDK 重生成清理回归测试通过：1 passed, 263 deselected
- [x] 无新增面向用户文案，因此不涉及翻译
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review：待维护者审阅

## 已知 defer

无。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 重新生成场景宫格时，自动清理同脚本、同集数且已完成的旧记录及其图像。
  * 保留正在生成中的记录，以及属于其他场景组、脚本或集数的记录。

* **问题修复**
  * 避免重复生成导致旧宫格记录残留，确保当前场景组显示最新生成结果。

* **测试**
  * 增加覆盖旧记录清理、记录保留及多次生成场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->