### PR TITLE
fix(agent): 会话启动失败时的清理不再被断开挂起卡住

### DIFF
--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -652,14 +652,21 @@ class SessionManager:
 
             Runs send_disconnect first (which causes actor to exit and
             _on_actor_done to push the None sentinel, letting _process_inbox
-            finish naturally), then belt-and-suspenders cancels the processor
-            in case it is stuck elsewhere.
+            finish naturally), bounded by _session_actor_shutdown_timeout so an
+            SDK-side hang cannot stall this error-only cleanup path indefinitely;
+            then belt-and-suspenders cancels the processor in case it is stuck
+            elsewhere.
             """
             self.sessions.pop(temp_id, None)
             # sdk_session_id 就绪后 key swap 已把会话挂到正式 id 下，两个键都清。
             self.sessions.pop(managed.session_id, None)
             try:
-                await managed.send_disconnect()
+                await asyncio.wait_for(managed.send_disconnect(), timeout=self._session_actor_shutdown_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "send_disconnect on error path 超时，继续后续清理 session_id=%s",
+                    temp_id,
+                )
             except Exception:
                 logger.exception(
                     "send_disconnect on error path failed session_id=%s",

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -654,10 +654,10 @@ class SessionManager:
             Runs send_disconnect first (which causes actor to exit and
             _on_actor_done to push the None sentinel, letting _process_inbox
             finish naturally), bounded by _session_actor_shutdown_timeout so an
-            SDK-side hang cannot stall this error-only cleanup path indefinitely
-            — on timeout the actor is cancelled outright so it cannot leak; then
-            belt-and-suspenders cancels the processor in case it is stuck
-            elsewhere.
+            SDK-side hang does not stall this error-only cleanup path on the
+            graceful wait — on timeout the actor is cancelled so it does not leak
+            with the failed session; then belt-and-suspenders cancels the
+            processor in case it is stuck elsewhere.
             """
             self.sessions.pop(temp_id, None)
             # sdk_session_id 就绪后 key swap 已把会话挂到正式 id 下，两个键都清。

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -676,6 +676,12 @@ class SessionManager:
                     "send_disconnect on error path failed session_id=%s",
                     temp_id,
                 )
+            # 断开成功时 send_disconnect 已把 status 落到 "closed"；失败或超时则停在
+            # "running"，而下面取消 _process_task 会让 _process_inbox 的 CancelledError
+            # 分支据此写 interrupted 终态，并把待回放登记记为未认领。启动失败既不是中断、
+            # 也无回放可言，先落 error 收口这条判断。
+            if managed.status == "running":
+                managed.status = "error"
             if managed._process_task is not None and not managed._process_task.done():
                 managed._process_task.cancel()
                 await asyncio.gather(managed._process_task, return_exceptions=True)

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -653,8 +653,9 @@ class SessionManager:
             Runs send_disconnect first (which causes actor to exit and
             _on_actor_done to push the None sentinel, letting _process_inbox
             finish naturally), bounded by _session_actor_shutdown_timeout so an
-            SDK-side hang cannot stall this error-only cleanup path indefinitely;
-            then belt-and-suspenders cancels the processor in case it is stuck
+            SDK-side hang cannot stall this error-only cleanup path indefinitely
+            — on timeout the actor is cancelled outright so it cannot leak; then
+            belt-and-suspenders cancels the processor in case it is stuck
             elsewhere.
             """
             self.sessions.pop(temp_id, None)
@@ -664,9 +665,11 @@ class SessionManager:
                 await asyncio.wait_for(managed.send_disconnect(), timeout=self._session_actor_shutdown_timeout)
             except TimeoutError:
                 logger.warning(
-                    "send_disconnect on error path 超时，继续后续清理 session_id=%s",
+                    "send_disconnect on error path 超时，走 cancel 兜底 session_id=%s",
                     temp_id,
                 )
+                if managed.actor is not None:
+                    await managed.actor.cancel_and_wait()
             except Exception:
                 logger.exception(
                     "send_disconnect on error path failed session_id=%s",

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -364,7 +364,8 @@ class SessionManager:
         # 轮次终结时仍未被认领的回显登记累计数，见 _drain_pending_user_echoes。
         self.unclaimed_user_echoes = 0
         self._disconnecting: set[str] = set()
-        self._session_actor_shutdown_timeout: float = 15.0  # total budget for send_disconnect + cancel fallback
+        # 优雅 send_disconnect 的等待上限；超时后各调用点再走无界的 cancel 兜底。
+        self._session_actor_shutdown_timeout: float = 15.0
         self._connect_locks: dict[str, asyncio.Lock] = {}
         # 实例不变量缓存：避免每次构建 access policy 都重做 path resolve。
         self._project_root_resolved = self.project_root.resolve()

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -250,6 +250,7 @@ class TestSessionManagerUserInput:
         (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
 
         seen_commands: list[str] = []
+        cancelled: list[bool] = []
 
         class _FakeActor:
             def __init__(self, *_, on_message=None, client_factory=None):
@@ -278,6 +279,9 @@ class TestSessionManagerUserInput:
             async def wait(self):
                 return None
 
+            async def cancel_and_wait(self):
+                cancelled.append(True)
+
         async def fake_env():
             return {"ANTHROPIC_API_KEY": "sk"}
 
@@ -292,6 +296,11 @@ class TestSessionManagerUserInput:
 
         assert "disconnect" in seen_commands
         assert any("超时" in r.getMessage() for r in caplog.records)
+        # 断开挂起时 actor 必须被取消，否则协程随失败的会话一起泄漏。
+        assert cancelled == [True]
+        # 超时不阻断后续清理：会话从注册表摘除、登记的回放标识清空。
+        assert session_manager.sessions == {}
+        assert session_manager.unclaimed_user_echoes == 0
 
     async def test_ask_user_question_waits_for_answer_and_merges_answers(self, session_manager, meta_store):
         if not SDK_AVAILABLE:

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -8,7 +8,7 @@ import pytest
 
 from server.agent_runtime.event_log import REPLAYED_USER_ECHO_ENTRY_UUID_KEY, REPLAYED_USER_ECHO_KEY
 from server.agent_runtime.message_serialization import PendingUserEcho, match_user_echo, message_to_dict
-from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError
+from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError, ManagedSession
 from tests.fakes import build_managed_with_actor
 
 pytestmark = pytest.mark.unit
@@ -251,6 +251,8 @@ class TestSessionManagerUserInput:
 
         seen_commands: list[str] = []
         cancelled: list[bool] = []
+        captured_sessions: list[ManagedSession] = []
+        echoes_at_query: list[int] = []
 
         class _FakeActor:
             def __init__(self, *_, on_message=None, client_factory=None):
@@ -265,6 +267,9 @@ class TestSessionManagerUserInput:
             async def enqueue(self, cmd):
                 seen_commands.append(cmd.type)
                 if cmd.type == "query":
+                    # 此刻会话尚在注册表里、回显登记也已写入，取到的是清理前的现场。
+                    captured_sessions.extend(session_manager.sessions.values())
+                    echoes_at_query.extend(len(s.pending_user_echoes) for s in session_manager.sessions.values())
                     cmd.error = RuntimeError("SDK 拒绝了这次投递")
                     cmd.sent.set()
                     cmd.done.set()
@@ -298,9 +303,68 @@ class TestSessionManagerUserInput:
         assert any("超时" in r.getMessage() for r in caplog.records)
         # 断开挂起时 actor 必须被取消，否则协程随失败的会话一起泄漏。
         assert cancelled == [True]
-        # 超时不阻断后续清理：会话从注册表摘除、登记的回放标识清空。
+        # 超时不阻断后续清理：会话从注册表摘除、登记的回放标识清空且不计入未认领。
         assert session_manager.sessions == {}
+        assert echoes_at_query == [1]
+        assert captured_sessions[0].pending_user_echoes == []
         assert session_manager.unclaimed_user_echoes == 0
+
+    async def test_cleanup_on_error_disconnect_timeout_keeps_startup_failure_out_of_echo_accounting(
+        self, session_manager, meta_store, monkeypatch, caplog, tmp_path
+    ):
+        """会话跑起来后才启动失败时，断开挂起不得把待回放登记误记为未认领。"""
+        proj_dir = tmp_path / "projects" / "demo"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
+
+        captured_sessions: list[ManagedSession] = []
+
+        class _FakeActor:
+            def __init__(self, *_, on_message=None, client_factory=None):
+                self.task = None
+
+            async def start(self):
+                return None
+
+            def add_done_callback(self, _cb):
+                pass
+
+            async def enqueue(self, cmd):
+                if cmd.type == "query":
+                    # 投递成功：status 落到 "running"，但 SDK 始终不回 init 消息，
+                    # 会话卡在等 sdk_session_id，最终由超时走进 _cleanup_on_error。
+                    captured_sessions.extend(session_manager.sessions.values())
+                    cmd.sent.set()
+                elif cmd.type == "disconnect":
+                    await asyncio.Event().wait()
+                else:
+                    cmd.sent.set()
+                    cmd.done.set()
+
+            async def wait(self):
+                return None
+
+            async def cancel_and_wait(self):
+                return None
+
+        async def fake_env():
+            return {"ANTHROPIC_API_KEY": "sk"}
+
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
+        monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+        monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
+        monkeypatch.setattr(type(session_manager), "_SDK_ID_TIMEOUT", 0.05)
+        session_manager._session_actor_shutdown_timeout = 0.05
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(session_manager.send_new_session("demo", "你好"), timeout=2.0)
+
+        # 启动失败不是中断：终态不写 interrupted，登记的回放标识直接清空不记账。
+        assert captured_sessions[0].status == "error"
+        assert captured_sessions[0].pending_user_echoes == []
+        assert session_manager.unclaimed_user_echoes == 0
+        assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
 
     async def test_ask_user_question_waits_for_answer_and_merges_answers(self, session_manager, meta_store):
         if not SDK_AVAILABLE:

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -241,6 +241,58 @@ class TestSessionManagerUserInput:
         assert session_manager.unclaimed_user_echoes == 0
         assert not [r for r in caplog.records if "unclaimed" in r.getMessage()]
 
+    async def test_cleanup_on_error_disconnect_timeout_does_not_block(
+        self, session_manager, meta_store, monkeypatch, caplog, tmp_path
+    ):
+        """启动失败清理路径里 send_disconnect 挂起时，超时兜底让清理仍在限时内完成。"""
+        proj_dir = tmp_path / "projects" / "demo"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
+
+        seen_commands: list[str] = []
+
+        class _FakeActor:
+            def __init__(self, *_, on_message=None, client_factory=None):
+                self.task = None
+
+            async def start(self):
+                return None
+
+            def add_done_callback(self, _cb):
+                pass
+
+            async def enqueue(self, cmd):
+                seen_commands.append(cmd.type)
+                if cmd.type == "query":
+                    cmd.error = RuntimeError("SDK 拒绝了这次投递")
+                    cmd.sent.set()
+                    cmd.done.set()
+                elif cmd.type == "disconnect":
+                    # 模拟 SDK 侧挂起：send_disconnect 内部等待的 cmd.done 永不 set，
+                    # 只有 asyncio.wait_for 的超时能让 _cleanup_on_error 脱身。
+                    await asyncio.Event().wait()
+                else:
+                    cmd.sent.set()
+                    cmd.done.set()
+
+            async def wait(self):
+                return None
+
+        async def fake_env():
+            return {"ANTHROPIC_API_KEY": "sk"}
+
+        monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
+        monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
+        monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
+        session_manager._session_actor_shutdown_timeout = 0.05
+
+        with caplog.at_level(logging.WARNING, logger="server.agent_runtime.session_manager"):
+            with pytest.raises(AgentStartupError, match="SDK 拒绝了这次投递"):
+                await asyncio.wait_for(session_manager.send_new_session("demo", "你好"), timeout=2.0)
+
+        assert "disconnect" in seen_commands
+        assert any("超时" in r.getMessage() for r in caplog.records)
+
     async def test_ask_user_question_waits_for_answer_and_merges_answers(self, session_manager, meta_store):
         if not SDK_AVAILABLE:
             pytest.skip("claude_agent_sdk is not installed")

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -269,7 +269,7 @@ class TestSessionManagerUserInput:
                     cmd.sent.set()
                     cmd.done.set()
                 elif cmd.type == "disconnect":
-                    # 模拟 SDK 侧挂起：send_disconnect 内部等待的 cmd.done 永不 set，
+                    # 模拟 SDK 侧挂起：投递就卡住，send_disconnect 连 cmd.done 都等不到，
                     # 只有 asyncio.wait_for 的超时能让 _cleanup_on_error 脱身。
                     await asyncio.Event().wait()
                 else:


### PR DESCRIPTION
Closes #1788

## 问题

`SessionManager._cleanup_on_error` 是会话启动/首次发送失败后的统一清理路径，其中 `await managed.send_disconnect()` 没有超时包裹。SDK 侧一旦挂起，这条本该收拾残局的路径自己会无限期阻塞，后续的注册表摘除、inbox 处理器取消、回显登记清理、stderr 捕获收尾全都到不了。

## 改动

- disconnect 等待改为 `asyncio.wait_for(...)`，上限复用同文件既有的 `_session_actor_shutdown_timeout`（15s），不新造第二个需要同步维护的超时值。
- 超时后告警并 `cancel_and_wait()` 取消 actor，避免挂起的协程随失败会话一起泄漏，随后照常走完剩余清理步骤。整个分支与同文件 `_evict_one` 的优雅关停路径逐字同形。
- 顺带修正两处与代码实际行为不符的注释：`_session_actor_shutdown_timeout` 原注释称其是「send_disconnect + cancel fallback 的总预算」，实际只约束 send_disconnect。

## 验证

- 新增 `test_cleanup_on_error_disconnect_timeout_does_not_block`：伪 actor 在 disconnect 投递处永久阻塞，断言清理在限时内完成、actor 被取消、会话已摘除、回显登记清空且未计入未认领。已实证该测试可证伪——移除 `asyncio.wait_for` 后测试以超时失败。
- `uv run python -m pytest`：8649 passed / 2 skipped。
- `uv run ruff check` + `ruff format --check`、`uv run basedpyright`（0 errors）、`uv run lint-imports` 均通过。
- 已 rebase 到最新 main 后重新验证。

## 已知边界

超时分支里的 `cancel_and_wait()` 自身无超时。若卡住 disconnect 的正是 SDK，取消展开时进入的 `ClaudeSDKClient.__aexit__` 理论上可能再次挂起。这是与 `_evict_one` 同源的既有暴露面，本 PR 未扩大，留作独立跟进。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化会话关闭流程，避免断开请求长时间无响应导致清理操作卡住。
  - 新增 15 秒优雅关停超时，超时后自动终止会话并继续完成清理。
  - 启动失败时及时移除会话、清理待处理输入，并避免错误计入未认领回显。
  - 会话清理未完成前，将仍处于运行状态的会话标记为错误，确保启动失败及时反馈。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->