### PR TITLE
fix(供应商): 火山方舟 base_url 支持带尾斜杠或多余空白的输入

### DIFF
--- a/lib/ark_shared.py
+++ b/lib/ark_shared.py
@@ -6,6 +6,7 @@ Ark (火山方舟) 共享工具模块
 包含：
 - ARK_BASE_URL — 火山方舟 API 基础 URL
 - resolve_ark_api_key — API Key 解析（缺失即 raise，不再走 env fallback）
+- ark_base_url — 归一化用户输入（strip + 去尾斜杠），缺省回落 ARK_BASE_URL
 - create_ark_client — Ark 客户端工厂
 """
 
@@ -20,9 +21,20 @@ def resolve_ark_api_key(api_key: str | None = None) -> str:
     return api_key.strip()
 
 
+def ark_base_url(configured: str | None = None) -> str:
+    """归一化用户填入的 base_url：strip + 去尾斜杠，缺省回落 ARK_BASE_URL。
+
+    不像 dashscope/minimax/agnes 那样按已知后缀做 host 派生再重建——ark 的 backend 会传入
+    非标准变体路径（如 ark-agent-plan 用的 /api/plan/v3），按后缀重建会把这类路径拼坏，
+    所以只做保守的空白/尾斜杠归一化，不改写路径结构。
+    """
+    # 先 strip 再判空：纯空白串（"   "）是真值会绕过 or，回落必须在 strip 之后。
+    base = (configured or "").strip()
+    return base.rstrip("/") if base else ARK_BASE_URL
+
+
 def create_ark_client(*, api_key: str | None = None, base_url: str | None = None):
-    """创建 Ark 客户端；base_url 缺省走 ARK_BASE_URL（即 /api/v3）。"""
+    """创建 Ark 客户端；base_url 缺省走 ARK_BASE_URL（即 /api/v3），经 ark_base_url 归一化。"""
     from volcenginesdkarkruntime import Ark
 
-    effective_base_url = base_url or ARK_BASE_URL
-    return Ark(base_url=effective_base_url, api_key=resolve_ark_api_key(api_key))
+    return Ark(base_url=ark_base_url(base_url), api_key=resolve_ark_api_key(api_key))

--- a/lib/text_backends/ark.py
+++ b/lib/text_backends/ark.py
@@ -7,7 +7,7 @@ import logging
 
 from openai import OpenAI
 
-from lib.ark_shared import ARK_BASE_URL, create_ark_client, resolve_ark_api_key
+from lib.ark_shared import ark_base_url, create_ark_client, resolve_ark_api_key
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_ARK
 from lib.retry import with_retry_async
@@ -36,7 +36,7 @@ class ArkTextBackend:
         # Instructor 要求 openai.OpenAI 实例；Ark SDK client 类型不兼容，
         # 但 Ark API 是 OpenAI 兼容的，因此额外创建原生 OpenAI 客户端供降级使用。
         resolved_key = resolve_ark_api_key(api_key)
-        effective_base_url = base_url or ARK_BASE_URL
+        effective_base_url = ark_base_url(base_url)
         self._client = create_ark_client(api_key=resolved_key, base_url=effective_base_url)
         self._openai_client = OpenAI(base_url=effective_base_url, api_key=resolved_key)
         self._model = model or DEFAULT_MODEL

--- a/tests/test_ark_shared.py
+++ b/tests/test_ark_shared.py
@@ -1,0 +1,66 @@
+"""lib.ark_shared 纯函数单元测试（不打真实 HTTP）。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.ark_shared import ARK_BASE_URL, ark_base_url, create_ark_client, resolve_ark_api_key
+
+pytestmark = pytest.mark.unit
+
+
+class TestBaseUrlNormalization:
+    def test_default_base(self):
+        assert ark_base_url(None) == ARK_BASE_URL
+
+    def test_trailing_slash_stripped(self):
+        assert ark_base_url("https://ark.cn-beijing.volces.com/api/v3/") == ARK_BASE_URL
+
+    def test_multiple_trailing_slashes_stripped(self):
+        assert ark_base_url("https://ark.cn-beijing.volces.com/api/v3//") == ARK_BASE_URL
+
+    def test_no_trailing_slash_is_idempotent(self):
+        assert ark_base_url(ARK_BASE_URL) == ARK_BASE_URL
+
+    def test_whitespace_falls_back_to_default(self):
+        # 纯空白 base_url 是真值会绕过 or，须 strip 后回落默认值
+        assert ark_base_url("   ") == ARK_BASE_URL
+
+    def test_surrounding_whitespace_stripped(self):
+        assert ark_base_url("  https://ark.cn-beijing.volces.com/api/v3/  ") == ARK_BASE_URL
+
+    def test_non_standard_path_preserved(self):
+        # ark-agent-plan 走 /api/plan/v3 这类非标准路径，只去尾斜杠，不按已知后缀重建，
+        # 否则会拼出 .../api/plan/v3/api/v3 这种错误 URL。
+        custom = "https://ark.cn-beijing.volces.com/api/plan/v3"
+        assert ark_base_url(custom) == custom
+        assert ark_base_url(custom + "/") == custom
+
+
+class TestApiKeyResolution:
+    def test_strips_and_returns(self):
+        assert resolve_ark_api_key("  sk-abc  ") == "sk-abc"
+
+    def test_missing_raises(self):
+        with pytest.raises(ValueError):
+            resolve_ark_api_key(None)
+
+    def test_blank_raises(self):
+        with pytest.raises(ValueError):
+            resolve_ark_api_key("   ")
+
+
+class TestCreateArkClient:
+    def test_trailing_slash_normalized_before_client_construction(self):
+        mock_ark_cls = MagicMock()
+        with patch("volcenginesdkarkruntime.Ark", mock_ark_cls):
+            create_ark_client(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/v3/")
+        mock_ark_cls.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")
+
+    def test_default_base_url_when_omitted(self):
+        mock_ark_cls = MagicMock()
+        with patch("volcenginesdkarkruntime.Ark", mock_ark_cls):
+            create_ark_client(api_key="k")
+        mock_ark_cls.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")


### PR DESCRIPTION
Closes #1790

## 问题

凭证存储层对所有供应商的 `base_url` 统一调用 `normalize_base_url()`（确保以 `/` 结尾，为 Google genai SDK 而设，`lib/config/url_utils.py`）。ark 的消费侧此前把该值原样透传给 SDK client，用户在设置页填写的地址在请求期拼接出错，表现为「填对了却报错」。

## 改动

- `lib/ark_shared.py` 新增 `ark_base_url()`：`strip()` + 去尾斜杠，缺省回落 `ARK_BASE_URL`；`create_ark_client()` 统一经它归一化。
- `lib/text_backends/ark.py` 的第二条出口（Instructor 降级用的原生 OpenAI client）同样切到 `ark_base_url()`——它此前不经 `create_ark_client`，是唯一漏网的透传路径。
- 其余消费方（`lib/image_backends/ark.py`、`lib/video_backends/ark.py`、`server/routers/providers.py` 的 ark 连接测试）均经 `create_ark_client` 构造，自动覆盖。

## 口径说明

不照抄 dashscope / minimax / agnes 的「剥离已知后缀再重建 base」：那是它们从一份配置派生多个不同后缀 base 的前置步骤；ark 的 base_url 直接透传给 SDK 且允许非标准变体路径（ark-agent-plan 用的 `/api/plan/v3`），按后缀重建会把该端点拼坏。因此只做共通的输入卫生层，不改写路径结构，并以测试正面钉住该路径不被改写。

## 验证

- `uv run python -m pytest tests/test_ark_shared.py tests/test_text_backends/test_ark.py tests/backends/test_no_env_fallback.py tests/test_imports.py` — 99 passed
- `uv run ruff check` / `ruff format`（改动文件）— 通过
- `uv run basedpyright` — 0 errors
- `uv run lint-imports` — 契约 KEPT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 Ark 服务地址配置处理，自动清理空白字符和末尾斜杠。
  * 未配置有效地址时，自动使用默认服务地址。
  * 保留自定义地址中的非标准路径结构，提升配置兼容性。
  * 同步规范 API 密钥处理，并完善缺失配置校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->