### PR TITLE
fix(自定义供应商): 统一 wan3 连字符形态的时长档位与端点路由识别

### DIFF
--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -13,6 +13,10 @@ import re
 
 DEFAULT_FALLBACK: list[int] = [4, 8]
 
+# 万相 3.0 家族 model_id 识别（连字符可选、不锚版本号），供 endpoints.py 路由推断复用，
+# 避免两处各写一份正则、匹配宽度悄悄漂移。
+WAN3_PATTERN = re.compile(r"wan-?3", re.I)
+
 # 按特异性从高到低排列；命中一条即返回。range 全展开为离散集。
 PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     # OpenAI Sora 第一方（严格 regex：可选 -pro，可选 -YYYY-MM-DD 日期后缀）
@@ -46,7 +50,7 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     (re.compile(r"hailuo", re.I), [6]),
     # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
     # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
-    (re.compile(r"wan-?3", re.I), list(range(2, 31))),
+    (WAN3_PATTERN, list(range(2, 31))),
     # Wan（其余系列）
     (re.compile(r"wan-?\d", re.I), [4, 5]),
     # Pika

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import re
 
+from lib.video_backends.dashscope import WAN3_PATTERN
+
 DEFAULT_FALLBACK: list[int] = [4, 8]
 
-# 万相 3.0 家族 model_id 识别（连字符可选、不锚版本号），供 endpoints.py 路由推断复用，
-# 避免两处各写一份正则、匹配宽度悄悄漂移。
-WAN3_PATTERN = re.compile(r"wan-?3", re.I)
+# WAN3_PATTERN（连字符可选、不锚版本号）源出 lib.video_backends.dashscope——那里是本后端
+# 请求形态分派的单一真相源，endpoints.py 路由推断与本模块的时长档位推断均复用同一份，
+# 避免三处各写一份正则、匹配宽度悄悄漂移。
 
 # 按特异性从高到低排列；命中一条即返回。range 全展开为离散集。
 PRESETS: list[tuple[re.Pattern[str], list[int]]] = [

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -562,8 +562,10 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
     # 走百炼原生端点的万相家族 id（视频与图像变体都命中），下面路由与 is_video 排除各用一次。
-    # wan3 分支复用 duration_presets.WAN3_PATTERN（连字符可选、不锚版本号），与时长档位推断
-    # 保持同一匹配宽度，否则同一 model_id 会出现"档位按 wan3 给、路由却按普通 wan 走"的矛盾。
+    # wan3 分支复用 duration_presets.WAN3_PATTERN（源出 video_backends.dashscope，连字符可选、
+    # 不锚版本号），与时长档位推断、DashScopeVideoBackend 的请求形态分派保持同一匹配宽度，
+    # 否则同一 model_id 会出现"档位按 wan3 给、路由却按普通 wan 走"或"路由到本后端却被当
+    # 通用型号丢失能力声明"的矛盾。
     # wan2 保留字面量：连字符形态的 wan2 在时长推断走通用 wan 预设、路由走 openai-video，
     # 两处结论自洽，无须并入正则。
     is_wan_family = "wan2." in lowered or bool(WAN3_PATTERN.search(model_id))

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -541,10 +541,12 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
-    1) 阿里百炼视频 → happyhorse / wan2.x / 万相 3 家族（含 wan-3-xxx 连字符形态，非 image）走
-       "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；万相视频
-       抢在通用 is_video 前拦截。图像不自动推 dashscope（中转可能是 OpenAI 兼容），qwen-image /
-       wan2.x-image / wan3.0-video-image 落到既有图像家族推断。
+    1) 阿里百炼视频 → happyhorse / wan2.x / 万相 3 家族（含 wan-3-xxx 连字符形态、image-to-video
+       别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；
+       万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope（中转可能是 OpenAI
+       兼容）：qwen-image / wan2.7-image / wan3.0-video-image 这类以 "image" 结尾的 id 落到既有
+       图像家族推断；wan-3-turbo-image-to-video 这类以 "video"/"2video" 结尾的 i2v 别名仍归视频，
+       不按结尾以外位置出现的 "image" 子串误判（同 2.5 节 kling-image2video 的处理原则）。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -569,11 +571,16 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # wan2 保留字面量：连字符形态的 wan2 在时长推断走通用 wan 预设、路由走 openai-video，
     # 两处结论自洽，无须并入正则。
     is_wan_family = "wan2." in lowered or bool(WAN3_PATTERN.search(model_id))
+    # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
+    # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
+    # 变体。真正的图像变体（wan2.7-image / wan3.0-video-image）以 "image" 结尾，i2v 别名以
+    # "video"/"2video" 结尾，故按结尾 token 而非笼统 is_image 判别。
+    wan_image_variant = is_wan_family and lowered.endswith("image")
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if "happyhorse" in lowered:
         return "dashscope-async-video"
-    if is_wan_family and not is_image:
+    if is_wan_family and not wan_image_variant:
         return "dashscope-async-video"
 
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
@@ -597,8 +604,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
         return "kling-image" if is_image else "kling-video"
 
     # wan2.x-image / wan3.0-video-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到
-    # 图像家族推断
-    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not (is_wan_family and is_image)
+    # 图像家族推断。复用上面的 wan_image_variant（结尾 token 判别）而非笼统 is_image。
+    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not wan_image_variant
 
     if "imagen" in lowered:
         return "gemini-image"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -532,6 +532,10 @@ _VIDEO_PATTERN = re.compile(
 _AUDIO_PATTERN = re.compile(r"tts|speech|cosyvoice", re.IGNORECASE)
 # 裸 "speech" 会撞上 ASR（语音转文字）家族 id，按内容排除，避免把识别模型默认归到 TTS 端点
 _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNORECASE)
+# wan 家族 image-to-video 续接语法："image" 紧跟 "to"/"2" 再接 "video"（wan-3-turbo-image-to-video /
+# wan3-image2video）。只挑这一种确定形态当"实为视频"的例外，不覆盖 img2vid/i2v 等未见实例的缩写——
+# 出现新形态再补，不预先扩面。
+_WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
@@ -542,11 +546,12 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     openai-chat/openai-images，每次都要手动改回。
 
     1) 阿里百炼视频 → happyhorse / wan2.x / 万相 3 家族（含 wan-3-xxx 连字符形态、image-to-video
-       别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；
+       续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；
        万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope（中转可能是 OpenAI
-       兼容）：qwen-image / wan2.7-image / wan3.0-video-image 这类以 "image" 结尾的 id 落到既有
-       图像家族推断；wan-3-turbo-image-to-video 这类以 "video"/"2video" 结尾的 i2v 别名仍归视频，
-       不按结尾以外位置出现的 "image" 子串误判（同 2.5 节 kling-image2video 的处理原则）。
+       兼容）：qwen-image / wan2.7-image / wan3.0-video-image 及带版本/日期后缀的同类 id 落到既有
+       图像家族推断；wan-3-turbo-image-to-video / wan3-image2video 这类显式 image-to-video 续接
+       语法仍归视频（同 2.5 节 kling-image2video 的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确
+       挑出这一种形态，不对图像变体的命名形态（结尾 token 等）做任何假设。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -573,9 +578,12 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     is_wan_family = "wan2." in lowered or bool(WAN3_PATTERN.search(model_id))
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
-    # 变体。真正的图像变体（wan2.7-image / wan3.0-video-image）以 "image" 结尾，i2v 别名以
-    # "video"/"2video" 结尾，故按结尾 token 而非笼统 is_image 判别。
-    wan_image_variant = is_wan_family and lowered.endswith("image")
+    # 变体。反过来"以 image 结尾才算图像变体"同样错——wan3.0-image-edit / wan-3-turbo-image-preview /
+    # 带日期后缀的 wan3.0-video-image-20260801 这类真图像别名不以 "image" 结尾，会被误判成视频。
+    # 故只把 image-to-video 续接语法（"image" 后紧跟 "to"/"2" 再接 "video"）当例外挑出来，其余
+    # 含 image 语义一律按图像变体处理，不对图像变体的命名形态做任何假设。
+    wan_video_continuation = is_wan_family and bool(_WAN_IMAGE_TO_VIDEO_PATTERN.search(model_id))
+    wan_image_variant = is_wan_family and is_image and not wan_video_continuation
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if "happyhorse" in lowered:
@@ -604,7 +612,7 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
         return "kling-image" if is_image else "kling-video"
 
     # wan2.x-image / wan3.0-video-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到
-    # 图像家族推断。复用上面的 wan_image_variant（结尾 token 判别）而非笼统 is_image。
+    # 图像家族推断。复用上面的 wan_image_variant（排除 image-to-video 续接别名后的图像判定）。
     is_video = bool(_VIDEO_PATTERN.search(model_id)) and not wan_image_variant
 
     if "imagen" in lowered:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -22,6 +22,7 @@ from lib.custom_provider.backends import (
     CustomTextBackend,
     CustomVideoBackend,
 )
+from lib.custom_provider.duration_presets import WAN3_PATTERN
 from lib.image_backends.base import ImageCapability
 from lib.image_backends.dashscope import DashScopeImageBackend
 from lib.image_backends.gemini import GeminiImageBackend
@@ -540,10 +541,10 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
-    1) 阿里百炼视频 → happyhorse / wan2.x / wan3.0（非 image）走 "dashscope-async-video"（原生异步
-       端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；wan2.x / wan3.0 视频抢在通用 is_video 前拦截。
-       图像不自动推 dashscope（中转可能是 OpenAI 兼容），qwen-image / wan2.x-image / wan3.0-video-image
-       落到既有图像家族推断。
+    1) 阿里百炼视频 → happyhorse / wan2.x / 万相 3 家族（含 wan-3-xxx 连字符形态，非 image）走
+       "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；万相视频
+       抢在通用 is_video 前拦截。图像不自动推 dashscope（中转可能是 OpenAI 兼容），qwen-image /
+       wan2.x-image / wan3.0-video-image 落到既有图像家族推断。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -560,13 +561,17 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
-    # 万相带版本号的 id（视频与图像变体都含该 token），下面路由与 is_video 排除各用一次
-    is_wan_versioned = "wan2." in lowered or "wan3." in lowered
+    # 走百炼原生端点的万相家族 id（视频与图像变体都命中），下面路由与 is_video 排除各用一次。
+    # wan3 分支复用 duration_presets.WAN3_PATTERN（连字符可选、不锚版本号），与时长档位推断
+    # 保持同一匹配宽度，否则同一 model_id 会出现"档位按 wan3 给、路由却按普通 wan 走"的矛盾。
+    # wan2 保留字面量：连字符形态的 wan2 在时长推断走通用 wan 预设、路由走 openai-video，
+    # 两处结论自洽，无须并入正则。
+    is_wan_family = "wan2." in lowered or bool(WAN3_PATTERN.search(model_id))
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if "happyhorse" in lowered:
         return "dashscope-async-video"
-    if is_wan_versioned and not is_image:
+    if is_wan_family and not is_image:
         return "dashscope-async-video"
 
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
@@ -591,7 +596,7 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
 
     # wan2.x-image / wan3.0-video-image 含 "wan" 会被 _VIDEO_PATTERN 误判为视频；显式排除让它落到
     # 图像家族推断
-    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not (is_wan_versioned and is_image)
+    is_video = bool(_VIDEO_PATTERN.search(model_id)) and not (is_wan_family and is_image)
 
     if "imagen" in lowered:
         return "gemini-image"

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import re
 from pathlib import Path
 
 import httpx
@@ -118,6 +119,12 @@ _WAN3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
 _WAN3_MAX_PROMPT_CHARS = 20000
 _WAN3_MODEL_KEY = "wan3.0-video"
 
+# 万相 3.0 家族 model_id 识别（连字符可选、不锚版本号）：此处是本后端的请求形态分派，也是
+# lib.custom_provider.duration_presets（时长档位推断）与 endpoints.py（端点路由推断）共用的
+# 唯一正则来源——三处按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
+# 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。
+WAN3_PATTERN = re.compile(r"wan-?3", re.I)
+
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
 _MODEL_PROFILES: dict[str, VideoCapabilities] = {
@@ -165,7 +172,7 @@ def _is_wan3(model: str | None) -> bool:
     专用，无参考图即无输入）；二是音轨由请求参数控制而非恒开；三是可走独立 maas 域名。
     三处都按型号名分派，profile 表只承载 VideoCapabilities 声明。
     """
-    return _WAN3_MODEL_KEY in (model or "").strip().lower()
+    return bool(WAN3_PATTERN.search((model or "").strip().lower()))
 
 
 def _profile_for_model(model: str | None) -> VideoCapabilities:
@@ -182,8 +189,12 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
         return _DEFAULT_PROFILE
     if normalized in _MODEL_PROFILES:
         return _MODEL_PROFILES[normalized]
-    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v} / wan3.0-video）
-    # 互不为子串，无歧义
+    # wan3 家族按 WAN3_PATTERN 先行判定（先于下方子串匹配）：discovery 返回的 "wan-3-turbo" /
+    # "wan3-turbo" 这类别名不含字面量 "wan3.0-video" 子串，若只靠子串匹配会静默落到
+    # _DEFAULT_PROFILE，丢失参考图/尾帧/音轨参数等 wan3 专属能力声明。
+    if WAN3_PATTERN.search(normalized):
+        return _MODEL_PROFILES[_WAN3_MODEL_KEY]
+    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
     for known, profile in _MODEL_PROFILES.items():
         if known in normalized:
             return profile

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -121,11 +121,12 @@ _WAN3_MODEL_KEY = "wan3.0-video"
 
 # 万相 3.0 家族 model_id 识别（连字符/下划线可选、不锚版本号）：此处是本后端的请求形态分派，
 # 也是 lib.custom_provider.duration_presets（时长档位推断）与 endpoints.py（端点路由推断）共用
-# 的唯一正则来源——三处按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
-# 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。分隔符同时容忍连字符
-# 与下划线：本文件下方 _WAN_IMAGE_TO_VIDEO_PATTERN 已对模态 token（image-to-video）两种分隔符
-# 一视同仁，版本前缀若只认连字符会造成同一 diff 内两种命名装饰的宽容度不对称。
-WAN3_PATTERN = re.compile(r"wan[-_]?3", re.I)
+# 的唯一正则来源——三处须按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
+# 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。版本前缀与模态 token
+# （下方 _WAN_IMAGE_TO_VIDEO_PATTERN）须接受相同的分隔符集合，避免同一规则组内宽容度不对称。
+# 两侧标识符边界要求非字母数字，避免匹配到 "swan3"、"vendorwan3" 这类含 wan3 子串但并非该家族
+# 的第三方型号名。
+WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -119,11 +119,13 @@ _WAN3_MAX_REFERENCE_AUDIO_TOTAL_SECONDS = 15.0
 _WAN3_MAX_PROMPT_CHARS = 20000
 _WAN3_MODEL_KEY = "wan3.0-video"
 
-# 万相 3.0 家族 model_id 识别（连字符可选、不锚版本号）：此处是本后端的请求形态分派，也是
-# lib.custom_provider.duration_presets（时长档位推断）与 endpoints.py（端点路由推断）共用的
-# 唯一正则来源——三处按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
-# 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。
-WAN3_PATTERN = re.compile(r"wan-?3", re.I)
+# 万相 3.0 家族 model_id 识别（连字符/下划线可选、不锚版本号）：此处是本后端的请求形态分派，
+# 也是 lib.custom_provider.duration_presets（时长档位推断）与 endpoints.py（端点路由推断）共用
+# 的唯一正则来源——三处按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
+# 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。分隔符同时容忍连字符
+# 与下划线：本文件下方 _WAN_IMAGE_TO_VIDEO_PATTERN 已对模态 token（image-to-video）两种分隔符
+# 一视同仁，版本前缀若只认连字符会造成同一 diff 内两种命名装饰的宽容度不对称。
+WAN3_PATTERN = re.compile(r"wan[-_]?3", re.I)
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -300,6 +300,15 @@ class TestInferEndpoint:
             ("wan3.0-image-edit", "openai", "openai-images"),
             ("wan-3-turbo-image-preview", "openai", "openai-images"),
             ("wan3.0-video-image-20260801", "openai", "openai-images"),
+            # 分隔符混用：下划线与连字符匹配宽度一致（WAN3_PATTERN 同时容忍二者）。
+            ("wan_3_turbo", "openai", "dashscope-async-video"),
+            ("wan_3.0-image", "openai", "openai-images"),
+            ("WAN_3_TURBO_IMAGE_TO_VIDEO", "openai", "dashscope-async-video"),
+            # 已知局限（非本 PR 引入、维持现状不修）：wan2 家族仅认字面 "wan2." 触发 is_wan_family，
+            # 连字符形态 wan-2.7 不触发，故其 image 变体会被裸 "wan" 命中 _VIDEO_PATTERN 误判为视频。
+            # wan2 字面量保留决策见 duration_presets 对应用例，此处锁定端点路由侧同一结论，防止
+            # 未来改动误当作待修 bug。
+            ("wan-2.7-image", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -294,6 +294,12 @@ class TestInferEndpoint:
             # kling-image2video 的"video 语义优先"原则），不能被笼统 is_image 误判成图像变体。
             ("wan-3-turbo-image-to-video", "openai", "dashscope-async-video"),
             ("wan3-image2video", "openai", "dashscope-async-video"),
+            # 反向陷阱：真图像别名不保证以 "image" 结尾（版本/日期/变体后缀），不能靠"结尾是不是
+            # image"反推是不是图像——只有显式 image-to-video 续接语法才算视频例外，其余含 image
+            # 语义一律仍是图像。
+            ("wan3.0-image-edit", "openai", "openai-images"),
+            ("wan-3-turbo-image-preview", "openai", "openai-images"),
+            ("wan3.0-video-image-20260801", "openai", "openai-images"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -285,8 +285,11 @@ class TestInferEndpoint:
             ("wan3.0-video", "openai", "dashscope-async-video"),
             ("Wan3.0-Video", "openai", "dashscope-async-video"),  # 大小写不敏感
             ("proxy/wan3.0-video", "openai", "dashscope-async-video"),
+            ("wan-3-turbo", "openai", "dashscope-async-video"),  # 连字符形态与点号形态匹配宽度一致
+            ("wan3-turbo", "openai", "dashscope-async-video"),
             ("wan2.7-image", "openai", "openai-images"),  # image 变体不受影响
             ("wan3.0-video-image", "openai", "openai-images"),  # 含 image 语义不受影响
+            ("wan-3-turbo-image", "openai", "openai-images"),  # 连字符形态的 image 变体同样不受影响
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -304,10 +304,14 @@ class TestInferEndpoint:
             ("wan_3_turbo", "openai", "dashscope-async-video"),
             ("wan_3.0-image", "openai", "openai-images"),
             ("WAN_3_TURBO_IMAGE_TO_VIDEO", "openai", "dashscope-async-video"),
-            # 已知局限（非本 PR 引入、维持现状不修）：wan2 家族仅认字面 "wan2." 触发 is_wan_family，
-            # 连字符形态 wan-2.7 不触发，故其 image 变体会被裸 "wan" 命中 _VIDEO_PATTERN 误判为视频。
-            # wan2 字面量保留决策见 duration_presets 对应用例，此处锁定端点路由侧同一结论，防止
-            # 未来改动误当作待修 bug。
+            # 标识符边界：含 "wan3" 子串但并非该家族的型号名不得被误判——WAN3_PATTERN 两侧要求
+            # 非字母数字边界，裸 "wan" 命中 _VIDEO_PATTERN 仍落回通用视频分支。
+            ("swan3", "openai", "openai-video"),
+            ("vendorwan3", "openai", "openai-video"),
+            ("wan30", "openai", "openai-video"),
+            # wan2 家族仅认字面 "wan2." 触发 is_wan_family，连字符形态 wan-2.7 不触发，故其
+            # image 变体会被裸 "wan" 命中 _VIDEO_PATTERN 判定为视频。wan2 字面量保留决策见
+            # duration_presets 对应用例，此处锁定端点路由侧同一结论。
             ("wan-2.7-image", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -290,6 +290,10 @@ class TestInferEndpoint:
             ("wan2.7-image", "openai", "openai-images"),  # image 变体不受影响
             ("wan3.0-video-image", "openai", "openai-images"),  # 含 image 语义不受影响
             ("wan-3-turbo-image", "openai", "openai-images"),  # 连字符形态的 image 变体同样不受影响
+            # image-to-video 别名含 "image" 子串但本质是视频，须留在 dashscope-async-video（同
+            # kling-image2video 的"video 语义优先"原则），不能被笼统 is_image 误判成图像变体。
+            ("wan-3-turbo-image-to-video", "openai", "dashscope-async-video"),
+            ("wan3-image2video", "openai", "dashscope-async-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -940,6 +940,16 @@ class TestWan3:
         assert caps.max_prompt_chars == 20000
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["swan3", "vendorwan3", "wan30"])
+    def test_wan3_substring_without_boundary_does_not_get_wan3_capabilities(self, model):
+        """含 "wan3" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 3.0 家族。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars is None
+
+    @pytest.mark.unit
     def test_first_and_last_frame_in_media(self, tmp_path):
         payload = self._backend()._build_payload(
             VideoGenerationRequest(

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -924,9 +924,9 @@ class TestWan3:
         assert caps.reference_audio_per_image is False
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo"])
+    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo", "wan_3-turbo", "wan_3_turbo"])
     def test_alias_forms_get_wan3_capabilities(self, model):
-        """discovery 返回的连字符别名（endpoints.py 已路由到本后端）须认作 wan3.0，不落回默认档案。
+        """discovery 返回的连字符/下划线别名（endpoints.py 已路由到本后端）须认作 wan3.0，不落回默认档案。
 
         与 endpoints.infer_endpoint / duration_presets 共用 WAN3_PATTERN：三处不同宽即会出现
         "路由到本后端却被当通用型号丢失参考图/尾帧/音轨参数" 的矛盾。
@@ -1005,7 +1005,7 @@ class TestWan3:
         assert "audio" not in payload["parameters"]
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo"])
+    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo", "wan_3-turbo", "wan_3_turbo"])
     def test_audio_switch_is_sent_for_alias_forms(self, tmp_path, model):
         """别名同样按可控音轨型号分派，不落回恒有声默认档案。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -924,6 +924,22 @@ class TestWan3:
         assert caps.reference_audio_per_image is False
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo"])
+    def test_alias_forms_get_wan3_capabilities(self, model):
+        """discovery 返回的连字符别名（endpoints.py 已路由到本后端）须认作 wan3.0，不落回默认档案。
+
+        与 endpoints.infer_endpoint / duration_presets 共用 WAN3_PATTERN：三处不同宽即会出现
+        "路由到本后端却被当通用型号丢失参考图/尾帧/音轨参数" 的矛盾。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.last_frame is True
+        assert caps.max_reference_images == 10
+        assert caps.reference_audio_mode is ReferenceAudioMode.DIRECT
+        assert caps.max_prompt_chars == 20000
+
+    @pytest.mark.unit
     def test_first_and_last_frame_in_media(self, tmp_path):
         payload = self._backend()._build_payload(
             VideoGenerationRequest(
@@ -987,6 +1003,17 @@ class TestWan3:
             VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", generate_audio=False)
         )
         assert "audio" not in payload["parameters"]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-3-turbo", "wan3-turbo"])
+    def test_audio_switch_is_sent_for_alias_forms(self, tmp_path, model):
+        """别名同样按可控音轨型号分派，不落回恒有声默认档案。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        payload = DashScopeVideoBackend(api_key="sk", model=model)._build_payload(
+            VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", generate_audio=False)
+        )
+        assert payload["parameters"]["audio"] is False
 
     @pytest.mark.unit
     def test_prompt_over_limit_rejected_before_submit(self, tmp_path):

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -67,6 +67,9 @@ pytestmark = pytest.mark.unit
         # 连字符形态（第三方聚合命名）与点号形态匹配宽度一致，均识别为万相 3.0
         ("wan-3-turbo", list(range(2, 31))),
         ("wan3-turbo", list(range(2, 31))),
+        # 下划线形态匹配宽度同样一致
+        ("wan_3_turbo", list(range(2, 31))),
+        ("wan_3.0-turbo", list(range(2, 31))),
         # Pika
         ("pika-2.0", [3, 5, 10]),
         # 未知模型 → fallback

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -64,6 +64,9 @@ pytestmark = pytest.mark.unit
         # 万相 3.0（不落入通用 Wan 的 [4, 5] 预设）
         ("wan3.0-video", list(range(2, 31))),
         ("Wan3.0-Video", list(range(2, 31))),
+        # 连字符形态（第三方聚合命名）与点号形态匹配宽度一致，均识别为万相 3.0
+        ("wan-3-turbo", list(range(2, 31))),
+        ("wan3-turbo", list(range(2, 31))),
         # Pika
         ("pika-2.0", [3, 5, 10]),
         # 未知模型 → fallback

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -70,6 +70,10 @@ pytestmark = pytest.mark.unit
         # 下划线形态匹配宽度同样一致
         ("wan_3_turbo", list(range(2, 31))),
         ("wan_3.0-turbo", list(range(2, 31))),
+        # 标识符边界：含 "wan3" 子串但非该家族的型号名不落入万相 3.0 档位
+        ("swan3", [4, 5]),
+        ("vendorwan3", [4, 5]),
+        ("wan30", [4, 5]),
         # Pika
         ("pika-2.0", [3, 5, 10]),
         # 未知模型 → fallback


### PR DESCRIPTION
Closes #1792

## 问题

`wan-3-turbo` 这类带连字符的自定义供应商 model_id，时长档位推断已按万相 3.0 给出 2-30 秒档位，端点路由却要求字面 `wan3.` 才归百炼原生异步端点，同一 model_id 的档位声明与实际路由互相矛盾，用户看到的是费解的生成失败而非清晰报错。

## 改动

- 把 `duration_presets.py` 里已有的 `wan-?3` 正则抽成共享常量 `WAN3_PATTERN`，规范定义迁到 `lib/video_backends/dashscope.py`（分层契约最底层），`endpoints.py` 的万相家族判定、`dashscope._is_wan3`、`dashscope._profile_for_model` 均改用它替换原字面量判断，四处按同一匹配宽度识别。
- 判定变量改名 `is_wan_versioned` → `is_wan_family`：该标志对图像变体（`wan3.0-video-image`、`wan-3-turbo-image`）同样为真，且新宽度不锚版本号，原名与实际语义不符。`infer_endpoint` docstring 与相邻注释同步为当前匹配宽度。
- 新增 `_WAN_IMAGE_TO_VIDEO_PATTERN`：`wan-3-turbo-image-to-video` / `wan3-image2video` 这类 i2v 别名含 "image" 子串但本质是视频，仿 kling-image2video 已有的"video 语义优先"处理精确挑出续接语法作为图像判定的例外，不对图像变体命名形态本身做任何假设（`wan3.0-image-edit` 等真图像别名不要求以 "image" 结尾）。
- `WAN3_PATTERN` 分隔符同时容忍连字符与下划线（`wan-3` / `wan_3`），与模态词侧已有的下划线容忍度一致；两侧加非字母数字标识符边界，避免 `swan3` / `vendorwan3` / `wan30` 这类含 wan3 子串但非该家族的第三方型号名被误判。

## 命名形态覆盖

按真值表穷尽核验：版本写法（`wan3` / `wan-3` / `wan3.0` / `wan-3.0` / `wan_3` / `wan_3.0`）× 家族后缀（空 / `-turbo` / `-plus` / `-pro`）× 模态词位置（空 / `-video` / `-image` / `-image-to-video` / `-image2video` / `-i2v`）× 附加后缀（空 / 日期戳 / `-preview` / `-edit` / `-latest`）× 大小写与分隔符混用，端点路由 / 时长档位 / 能力档案三处判定结论一致；家族后缀与附加后缀两维度不改变任何结论。额外覆盖标识符边界负例（`swan3` / `vendorwan3` / `wan30` 等含子串但非该家族的型号名不得误判）。测试补齐见 `test_custom_provider_endpoints.py` / `test_duration_presets.py` / `test_dashscope_video_backend.py` 三处新增用例。

## 取舍

匹配宽度取「同认连字符/下划线」一侧。反向收窄 `duration_presets` 的 wan3 正则会让已在用连字符命名的第三方聚合模型退回通用 `[4, 5]` 档位，属于收窄用户已见到的推断结果。

已知行为变更：任何含 `wan3` / `wan-3` 子串的非 image model_id，端点推断结果由 `openai-video` 变为 `dashscope-async-video`。这是统一宽度的必然结果；issue 正文已说明这类 id 在旧路由下本就生成失败，且端点推断只是默认值，用户可在配置页手动改选。

wan2 保留字面量 `"wan2." in lowered` 不并入正则：连字符形态的 wan2（`wan-2.7` 等，无点号）在时长推断走通用 wan 预设 `[4, 5]`、端点路由走 `openai-video`，两处结论自洽；其 `-image` 变体因此仍会被误判为视频而非图像，这是既有局限而非本 PR 引入的回归，已加回归测试锁定该行为，不在本票范围内扩面修复。

wan3.x 小版本（wan3.1 vs wan3.0）的时长档位细分锚定不在本票范围，按 issue 原文约定真出现分化时再做。

## 验证

`uv run ruff check` + `ruff format --check`（改动文件）通过；`uv run basedpyright`（全量）0 errors；`uv run lint-imports` 契约 kept；`uv run python -m pytest`（全量）8681 passed, 2 skipped。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 统一支持 Wan 3.0 模型名称中的连字符、点号、下划线及大小写变体。
  * Wan 3.0 视频及 image-to-video 模型可正确路由至视频处理服务。
  * Wan 3.0 图像模型继续使用图像处理服务。
  * Wan 3.0 模型别名可正确使用专属能力配置。
  * Wan 3.0 模型的可选时长保持为 2–30 秒。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
