### PR TITLE
chore(skills): delegate AFK worktree setup to implementer

### DIFF
--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -6,11 +6,11 @@ disable-model-invocation: true
 
 # AFK 团队执行流程
 
-你是 team-lead：组建由独立 agent 组成的团队，把一批 issue 无人值守推进到全部合并或明确搁置。你负责调度、合并、裁决、健康检查与清尾，自己不写代码；实现、本地审查、外部审查循环分别运行 `/tdd`、`/code-review`、`/pr-ai-review-loop`。
+你是 team-lead：始终在主仓库组建和调度由独立 agent 组成的团队，把一批 issue 无人值守推进到全部合并或明确搁置。你负责调度、合并、裁决、健康检查与清尾，自己不写代码。
 
 ## 第一步：确定批次成员
 
-用户显式要求接管或恢复既有批次时，按 [references/recovery.md](references/recovery.md) 处理，不按新批次开工。每次新执行生成唯一 batch-id：Spec 批次用 `spec-<N>-<UTC YYYYMMDD-HHMMSS>-<6 位随机十六进制>`，显式 issue 批次用带相同时间戳与随机后缀的简短 slug。Spec 开工前列出 `.afk/spec-<N>.jsonl` 与 `.afk/spec-<N>-*.jsonl` 中末条不是 `closed` 的账本并暂停；用户明确选择一个 batch-id 后，接管转入 recovery.md，重开则执行其清理并使用新的 batch-id。
+每次新执行生成唯一 batch-id：Spec 批次用 `spec-<N>-<UTC YYYYMMDD-HHMMSS>-<6 位随机十六进制>`，显式 issue 批次用带相同时间戳与随机后缀的简短 slug。Spec 开工前列出 `.afk/spec-<N>.jsonl` 与 `.afk/spec-<N>-*.jsonl` 中末条不是 `closed` 的账本并暂停；用户明确选择一个 batch-id 后，接管转入 recovery.md，重开则执行其清理并使用新的 batch-id。
 
 运行 batch-poll，取得批次的机械底图：展开 Spec 子 issue、解析依赖图、给出每个 issue 的远端落点（标签、`blocked_by`、分支/PR 状态、`stage_hint`）：
 
@@ -33,7 +33,7 @@ batch-poll 只产出 gh/git 事实与机械汇总，不做语义判断。取得�
 
 建立团队，并为每个阶段委派独立 agent。并发上限只计算同时处于**实现 / 本地审查**阶段的 issue；进入 AI 审查循环即释放该槽位。AI 审查循环另设软上限 6，team-lead 可在批次计划中覆盖。
 
-issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assign 给自己（`gh issue edit <N> --add-assignee @me`），先 `git fetch origin`，再从最新 `origin/main` 创建专属 worktree 与 `issue/<N>` 分支并委派实现 agent；不做跨分支依赖。blocker 被搁置时下游不启动，归入收尾清单。
+issue 的启动条件：全部 blocker 已合入 main。启动时 team-lead 将 issue assign 给自己（`gh issue edit <N> --add-assignee @me`）并委派实现 agent；implementer 更新远端状态，从最新 `origin/main` 创建 `issue/<N>` 分支的专属 worktree。不做跨分支依赖。blocker 被搁置时下游不启动，归入收尾清单。
 
 每个 issue 由三个阶段接力，每个阶段使用干净上下文：
 
@@ -45,7 +45,7 @@ issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assig
 
 ### 模型与委派
 
-按 [references/model-selection.md](references/model-selection.md) 为每个阶段显式选择模型。委派时按 [references/spawn-prompts.md](references/spawn-prompts.md) 的模板填变量。实现 agent 交付后，机械核验 worktree：分支名为 `issue/<N>`、改动已全部 commit、未 push、未建 PR、质量门已通过。交付物不完整就退回原 agent 补齐，不得把残缺现场传给下一阶段。
+按 [references/model-selection.md](references/model-selection.md) 为每个阶段显式选择模型。委派时按 [references/spawn-prompts.md](references/spawn-prompts.md) 的模板填变量。实现阶段不预设 worktree 路径；implementer 创建后回报实际绝对路径，team-lead 将它传给后续阶段。实现 agent 交付后，机械核验 worktree：分支名为 `issue/<N>`、改动已全部 commit、未 push、未建 PR、质量门已通过。交付物不完整就退回原 agent 补齐，不得把残缺现场传给下一阶段。
 
 三个阶段不要合并、不要让同一 agent 连任：本地审查必须由未参与实现的干净上下文执行（实现者自查存在盲区），审查循环是长周期轮询，不应背负实现阶段的上下文。
 
@@ -85,7 +85,7 @@ issue 的启动条件：全部 blocker 已合入 main。启动时将 issue assig
 
 批次执行期间保持健康检查循环，约每 30 分钟恢复 team-lead 执行一次。每次检查跑一遍 batch-poll 取全批次远端快照（各 issue `stage_hint`、PR `updatedAt` / `mergeable`、`conflicting` / `merge_candidate`），结合各 agent 的执行状态与最近一次汇报判断进展——batch-poll 不判定 agent 存活状态。长时间无进展且无合理等待理由（等待 reviewer 响应属合理）时，向负责 agent 询问；无回应且确认其已停止后，按 spawn-prompts.md 的替补附言委派新 agent 接管。原 agent 未停止前不得让替补写同一个 worktree。
 
-替补接管前先核验现场。现场可信就沿用 worktree 继续；现场不可信就清理该 issue 的 worktree，从最新 `origin/main` 重建后重新实现。
+替补接管前先核验现场。现场可信就沿用 worktree 继续；现场不可信就清理该 issue 的 worktree，重新委派 implementer 建立基于最新 `origin/main` 的工作现场并实现。
 
 ## 账本
 
@@ -105,3 +105,7 @@ bash scripts/ledger.sh --repo-root <repo-root> <batch-id> <kind> [--issue N] [--
 ## 发现 Spec 落点缺口时
 
 gap 专指功能性缺口：Spec 有要求但任何子 issue 均未覆盖——"未覆盖"可能是用户拆解时的有意裁剪，故必须人工确认，不入清尾授权；批内发现的缺陷类 follow-up 不走本节，按收尾的清尾轮处置。发现 gap 时主动通知用户，说明缺口描述、建议与对本批次的影响，同时让批次继续。用户中途授权则直接立项并按依赖加入批次；未获回复则相关 issue 按字面验收标准收口。append 账本 `gap`，并记入收尾转呈与 QA comment。
+
+## 续跑与接管
+
+team-lead 仍持有本批计划、授权、裁决和 agent 状态时，暂停后继续（含上下文压缩）直接**续跑**；单个 agent 失效走「健康检查与替补」。只有无法直接续接这些运行上下文、需要从账本与远端事实重建状态，或用户明确要求重新对账、从账本恢复、接管指定 batch-id 时，才按 [references/recovery.md](references/recovery.md) **接管**。

--- a/.agents/skills/afk-team-workflow/references/implementer.md
+++ b/.agents/skills/afk-team-workflow/references/implementer.md
@@ -2,16 +2,17 @@
 
 你是批次中某个 issue 的实现者。交付一个**质量门通过、基于最新 main、改动已全部 commit、未建 PR** 的 worktree，由下一阶段（本地审查）接手——它要在此基础上 rebase 与 push，未 commit 的改动接不了手。不建 PR、不 push：PR 由本地审查阶段在独立审查完成后创建。
 
-输入变量（来自委派 prompt）：issue 号、worktree 路径、分支名、handoff 路径。
+输入变量（来自委派 prompt）：issue 号、主仓库路径、分支名、handoff 路径。
 
 ## 步骤
 
-1. **读 issue**：`gh issue view <N> --comments` 通读正文与评论。验收标准即工作边界——按字面完成，不扩展范围；验收标准与代码现实冲突、或遇到拿不准的取舍时请示 team-lead，不自行选边
-2. **接管 worktree**：进入 team-lead 提供的 worktree，确认分支为 `issue/<N>`、基点来自启动时的最新 `origin/main`。所有代码读写都限定在该 worktree；主仓库只用于读取契约和追加 handoff
-3. **环境隔离**：需要启动 server 或写数据库验证时，端口与数据目录与其他 agent 错开——批次中多个 worktree 同时运行，共用默认端口或 dev 数据库会互相污染
-4. **实现**：可行处运行 `/tdd`。tdd 流程中"与用户确认计划/接口/测试范围"的环节在本流程没有用户：issue 的验收标准就是已批准的计划，照此自行决策；只有超出 issue 范围的重大接口取舍才请示 team-lead
-5. **质量门**：运行项目质量门（测试、lint、类型检查，改动涉及前端则含前端检查），全部通过后交付。质量门可能改写文件（如 formatter），改完补 commit
+1. **开工准备**：
+   - `gh issue view <N> --comments` 通读正文与评论。验收标准即工作边界——按字面完成，不扩展范围；验收标准与代码现实冲突、或遇到拿不准的取舍时请示 team-lead，不自行选边
+   - 更新远端状态，从最新 `origin/main` 创建分支 `issue/<N>` 的专属 worktree；创建后立即向 team-lead 回报实际绝对路径。worktree 建立后的所有代码读写都限定在其中；主仓库只用于读取契约和追加 handoff
+2. **环境隔离**：需要启动 server 或写数据库验证时，端口与数据目录与其他 agent 错开——批次中多个 worktree 同时运行，共用默认端口或 dev 数据库会互相污染
+3. **实现**：可行处运行 `/tdd`。tdd 流程中"与用户确认计划/接口/测试范围"的环节在本流程没有用户：issue 的验收标准就是已批准的计划，照此自行决策；只有超出 issue 范围的重大接口取舍才请示 team-lead
+4. **质量门**：运行项目质量门（测试、lint、类型检查，改动涉及前端则含前端检查），全部通过后交付。质量门可能改写文件（如 formatter），改完补 commit
 
 ## 交付与退役
 
-退役前按 [handoff.md](handoff.md) 在 handoff 文件追加「实现」段；超范围发现只记入其 follow-up 候选，不自行立项。向 team-lead 汇报：worktree 路径、分支名、改动概要、测试结果、备案的环境失败（如有）。保留 worktree 供后续阶段接手，team-lead 确认后退役。
+退役前按 [handoff.md](handoff.md) 在 handoff 文件追加「实现」段；超范围发现只记入其 follow-up 候选，不自行立项。向 team-lead 再次确认 worktree 实际绝对路径，并汇报分支名、改动概要、测试结果、备案的环境失败（如有）。保留 worktree 供后续阶段接手，team-lead 确认后退役。

--- a/.agents/skills/afk-team-workflow/references/recovery.md
+++ b/.agents/skills/afk-team-workflow/references/recovery.md
@@ -1,6 +1,6 @@
 # 接管未收尾批次
 
-用户显式要求接管或恢复某批次，或 SKILL.md 第一步命中未收尾账本且用户裁决接管时，加载本契约。gh/git 是唯一真相：恢复即 replay 账本补回不可从远端重推的事实，再以一次 poll 对账，而非重建状态机。账本不存在或末条已是 `closed` 时不存在未收尾批次：告知用户并转 SKILL.md，用新的 batch-id 开工。
+本契约只处理**接管**：当前 team-lead 无法直接续接本批计划、授权、裁决和 agent 状态，需要从账本与远端事实重建；用户明确要求重新对账、从账本恢复或接管指定 batch-id；或 SKILL.md 第一步命中未收尾账本且用户裁决接管。同一 team-lead session 暂停后继续（含上下文压缩）属于**续跑**，直接沿用现有运行上下文；单个 agent 失效走 SKILL.md 的「健康检查与替补」。gh/git 是唯一真相：接管时 replay 账本补回不可从远端重推的事实，再以一次 poll 对账，而非重建状态机。账本不存在或末条已是 `closed` 时不存在未收尾批次：告知用户并转 SKILL.md，用新的 batch-id 开工。
 
 用户裁决重开而非接管时只执行清理。清理所需的成员落点与 needs-human 搁置名单来自 §1 对账与 §2 replay，先完成这两步再执行：停止并确认本批仍在运行的 agent，关闭批次在途 PR，删除远端分支、批次 worktree、本地分支与 handoff 目录（worktree 先于其占用的本地分支，否则 `git branch -D` 会被拒；中途终止的 worktree 常有未提交修改，用 `git worktree remove --force` 删除），账本 append 一条 `closed`，随后按 SKILL.md 第一步的新批次流程重来。已搁置为 needs-human 的 issue 不在清理之列——其 PR 与远端分支按 SKILL.md 搁置流程留待人工接手。
 
@@ -26,4 +26,4 @@ jq -sc 'map(select(.scope != null)) | last | .scope' .afk/<batch-id>.jsonl
 前任 agent 可查询时，逐个查询其执行状态：仍存活且有进展就继续观察，失效时先确认其已停止。前任 agent 不可查询时，将其视为失效。随后按 SKILL.md 第三步阶段表与 Git/worktree 中的持久交付物反推接力起点，使用 spawn-prompts.md 的替补接管附言委派新 agent。能够确认原 agent 仍在运行时，不得让替补写同一个 worktree。
 
 - `review-loop`：poll 显示该 PR `updatedAt` 近期仍在变动时，先观察一个健康检查周期；若原 agent 仍存活就沿用，失效后才替补
-- `no-branch`：先检查 worktree。HEAD 有 `origin/main` 之外的完整 commit，且实现交付物核验通过时，从本地审查阶段接力；否则检查实现 agent 状态——在途且有进展就等待，已停止或停滞就按 SKILL.md 健康检查节处置。现场不可信时删除该 issue 的 worktree，从最新 `origin/main` 重建后重新实现
+- `no-branch`：先检查 worktree。HEAD 有 `origin/main` 之外的完整 commit，且实现交付物核验通过时，从本地审查阶段接力；否则检查实现 agent 状态——在途且有进展就等待，已停止或停滞就按 SKILL.md 健康检查节处置。现场不可信时删除该 issue 的 worktree，重新委派 implementer 建立基于最新 `origin/main` 的工作现场并实现

--- a/.agents/skills/afk-team-workflow/references/spawn-prompts.md
+++ b/.agents/skills/afk-team-workflow/references/spawn-prompts.md
@@ -1,17 +1,12 @@
 # 委派 prompt 模板
 
-按阶段取用，填入变量。
-
 ## 实现
 
 ```text
 你是 afk-team-workflow 批次中 issue #<N> 的实现者。先读 <skill 目录绝对路径>/references/implementer.md，按契约工作。
-变量：issue=#<N>；worktree=<路径>；分支=issue/<N>；handoff=<主仓库绝对路径>/.afk/<batch-id>/handoff-<N>.md。
-所有路径按绝对路径字面解释：除读取契约与追加 handoff 外，一切文件读写都限定在 worktree；任务若要修改契约文件本身，也必须修改 worktree 内的副本，经分支与 PR 交付。
-交付或遇到契约规定的请示场景时，联系 team-lead。
+变量：issue=#<N>；repo-root=<主仓库绝对路径>；分支=issue/<N>；handoff=<主仓库绝对路径>/.afk/<batch-id>/handoff-<N>.md。
+所有路径按绝对路径字面解释。worktree 由你按契约创建；任务若要修改契约文件本身，也必须修改 worktree 内的副本，经分支与 PR 交付。
 ```
-
-> 委派时使用批次计划按 [model-selection.md](model-selection.md) 定下的模型。
 
 改动面大的 issue，附加：
 
@@ -25,10 +20,7 @@
 你是 afk-team-workflow 批次中 issue #<N> 的本地审查者。先读 <skill 目录绝对路径>/references/local-reviewer.md，按契约工作。
 变量：issue=#<N>；worktree=<路径>；分支=issue/<N>；handoff=<主仓库绝对路径>/.afk/<batch-id>/handoff-<N>.md。
 所有路径按绝对路径字面解释：除读取契约与追加 handoff 外，一切文件读写都限定在 worktree；任务若要修改契约文件本身，也必须修改 worktree 内的副本，经分支与 PR 交付。
-交付或遇到契约规定的请示场景时，联系 team-lead。
 ```
-
-> 按 [model-selection.md](model-selection.md) 选择本阶段模型。
 
 ## AI 审查循环
 
@@ -36,10 +28,7 @@
 你是 afk-team-workflow 批次中 issue #<N> 的审查循环负责人。先读 <skill 目录绝对路径>/references/review-looper.md，按契约工作。
 变量：issue=#<N>；PR=#<M>；worktree=<路径>；handoff=<主仓库绝对路径>/.afk/<batch-id>/handoff-<N>.md。
 所有路径按绝对路径字面解释：除读取契约与追加 handoff 外，一切文件读写都限定在 worktree；任务若要修改契约文件本身，也必须修改 worktree 内的副本，经分支与 PR 交付。
-达标或遇到契约规定的请示场景时，联系 team-lead。
 ```
-
-> 按 [model-selection.md](model-selection.md) 在委派时选择本阶段模型；选择理由 append 账本 `decision`。
 
 ## 替补接管附言
 


### PR DESCRIPTION
## 范围

- 更新 `.agents/skills/afk-team-workflow/` 的团队调度、worktree 交接与恢复说明。
- 不修改产品运行时代码、CI 配置或其他 skill。

## 变更

- team-lead 始终留在主仓库，issue assignment 仍由其负责；implementer 从最新 `origin/main` 创建自己的 worktree。
- implementer 在创建后和交付时报告实际绝对路径，team-lead 将该路径传给后续审查阶段并负责最终清理。
- 区分保留运行上下文的直接续跑与依据账本、远端事实重建状态的接管，并将接管说明移至文末。
- 删除重复的阶段命令、顺序提示和模型选择提醒。

## 验收清单

- [x] 本地已跑相关检查：`git diff --check`
- [x] 手动核对了 implementer、spawn prompt、recovery 与主流程之间的交接契约
- [x] 新增面向用户文案已加 zh/en 翻译（不适用：仅 agent 文档）
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求（提交者为该路径的默认 CODEOWNER）

## 已知 defer

无。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新团队协作流程，明确团队负责人、实现者及审查流程的职责分工。
  - 新增批次续跑与接管规范，区分保留上下文续跑和基于远端事实恢复。
  - 明确实现者需自行创建工作区，并汇报实际路径、分支、改动及测试状态。
  - 完善现场不可信或代理失效时的恢复与重建流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
