### PR TITLE
fix(助手): 改写带图消息不再丢失图片

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1925,12 +1925,16 @@ class API {
    *
    * `sessionId` 是被改写的原会话，响应里的 `session_id` 是承接改写的新会话。
    * 运行中的会话由端点自动中断，调用方不必先停止。
+   *
+   * `images` 是锚点消息的图片附件，随改写后的文本一同进入分支会话的首条输入，
+   * 形态与发送端点一致。
    */
   static async rewriteAssistantMessage(
     projectName: string,
     sessionId: string,
     anchorEntryUuid: string,
     content: string,
+    images?: Array<{ data: string; media_type: string }>,
     clientKey?: string
   ): Promise<{ status: string; session_id: string; origin_session_id: string | null; entry: TimelineEntry | null }> {
     return this.request(
@@ -1940,6 +1944,7 @@ class API {
         body: JSON.stringify({
           anchor_entry_uuid: anchorEntryUuid,
           content,
+          images: images || [],
           client_key: clientKey || undefined,
         }),
       }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,7 @@ import type {
   TaskItem,
   TaskStats,
   SessionMeta,
+  ImagePayload,
   EntriesResponse,
   TimelineEntry,
   FailureObservation,
@@ -1906,7 +1907,7 @@ class API {
     projectName: string,
     content: string,
     sessionId?: string | null,
-    images?: Array<{ data: string; media_type: string }>,
+    images?: ImagePayload[],
     clientKey?: string
   ): Promise<{ session_id: string; status: string; entry: TimelineEntry | null }> {
     return this.request(`${this.assistantBase(projectName)}/sessions/send`, {
@@ -1934,7 +1935,7 @@ class API {
     sessionId: string,
     anchorEntryUuid: string,
     content: string,
-    images?: Array<{ data: string; media_type: string }>,
+    images?: ImagePayload[],
     clientKey?: string
   ): Promise<{ status: string; session_id: string; origin_session_id: string | null; entry: TimelineEntry | null }> {
     return this.request(

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -9,6 +9,7 @@ import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
 import { useAssistantSession } from "@/hooks/useAssistantSession";
 import type { AttachedImage } from "@/hooks/useAssistantSession";
+import type { ImagePayload } from "@/types";
 import { GlassPopover } from "@/components/ui/GlassPopover";
 import { ContextBanner } from "./ContextBanner";
 import { PendingQuestionWizard } from "./PendingQuestionWizard";
@@ -286,8 +287,8 @@ export function AgentCopilot() {
 
   // 改写成功后由会话切换重建时间线（编辑态随 resetTimeline 清空）；失败保留编辑态，
   // 用户可以改完再试，错误经消息区上方的错误条呈现
-  const handleSubmitEdit = useCallback((turnUuid: string, text: string) => {
-    voidCall(rewriteMessage(turnUuid, text));
+  const handleSubmitEdit = useCallback((turnUuid: string, text: string, images: ImagePayload[]) => {
+    voidCall(rewriteMessage(turnUuid, text, images.length > 0 ? images : undefined));
   }, [rewriteMessage]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -288,7 +288,7 @@ export function AgentCopilot() {
   // 改写成功后由会话切换重建时间线（编辑态随 resetTimeline 清空）；失败保留编辑态，
   // 用户可以改完再试，错误经消息区上方的错误条呈现
   const handleSubmitEdit = useCallback((turnUuid: string, text: string, images: ImagePayload[]) => {
-    voidCall(rewriteMessage(turnUuid, text, images.length > 0 ? images : undefined));
+    voidCall(rewriteMessage(turnUuid, text, images));
   }, [rewriteMessage]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/copilot/chat/MessageRow.test.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.test.tsx
@@ -10,6 +10,16 @@ const userTurn: Turn = {
   content: [{ type: "text", text: "只改第 3 集" }],
 };
 
+const imageTurn: Turn = {
+  type: "user",
+  uuid: "u-2",
+  timestamp: "2026-05-02T14:25:00Z",
+  content: [
+    { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+    { type: "text", text: "按这张图改人设" },
+  ],
+};
+
 describe("MessageRow", () => {
   it("renders the edit entry on an editable user message", () => {
     render(<MessageRow turn={userTurn} editable />);
@@ -45,7 +55,44 @@ describe("MessageRow", () => {
     fireEvent.change(textarea, { target: { value: "逐条给我看要改哪些台词" } });
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
-    expect(onSubmitEdit).toHaveBeenCalledWith("u-1", "逐条给我看要改哪些台词");
+    expect(onSubmitEdit).toHaveBeenCalledWith("u-1", "逐条给我看要改哪些台词", []);
+  });
+
+  it("carries the anchor's image attachments along with the rewritten text", () => {
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={imageTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    const textarea = screen.getByLabelText("改写消息内容");
+    expect(textarea).toHaveValue("按这张图改人设");
+
+    fireEvent.change(textarea, { target: { value: "按这张图改场景" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(onSubmitEdit).toHaveBeenCalledWith("u-2", "按这张图改场景", [
+      { data: "AAAA", media_type: "image/png" },
+    ]);
+  });
+
+  it("lets a message with attachments be rewritten down to the attachments alone", () => {
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={imageTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    fireEvent.change(screen.getByLabelText("改写消息内容"), { target: { value: "  " } });
+
+    expect(screen.getByRole("button", { name: "重新发送" })).toBeEnabled();
+    fireEvent.keyDown(screen.getByLabelText("改写消息内容"), { key: "Enter", metaKey: true });
+    expect(onSubmitEdit).toHaveBeenCalledWith("u-2", "  ", [{ data: "AAAA", media_type: "image/png" }]);
+  });
+
+  it("keeps an empty draft unsubmittable on a text-only message", () => {
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={userTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    fireEvent.change(screen.getByLabelText("改写消息内容"), { target: { value: "  " } });
+
+    expect(screen.getByRole("button", { name: "重新发送" })).toBeDisabled();
+    fireEvent.keyDown(screen.getByLabelText("改写消息内容"), { key: "Enter", metaKey: true });
+    expect(onSubmitEdit).not.toHaveBeenCalled();
   });
 
   it("cancels the edit on Escape", () => {

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Copy, Pencil, TriangleAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { Turn } from "@/types";
+import type { ImagePayload, Turn } from "@/types";
 import { copyText } from "@/utils/clipboard";
 import { formatClockTime } from "@/utils/date-format";
 import { ChatMessage } from "./ChatMessage";
@@ -12,7 +12,7 @@ import {
   USER_BUBBLE_LAYOUT_CLASS,
   USER_BUBBLE_STYLE,
 } from "./bubble";
-import { turnPlainText } from "./utils";
+import { turnImageAttachments, turnPlainText } from "./utils";
 
 // ---------------------------------------------------------------------------
 // MessageRow — 一条时间线消息及其操作行。
@@ -37,7 +37,8 @@ interface MessageRowProps {
   submitting?: boolean;
   onStartEdit?: (turnUuid: string, text: string) => void;
   onCancelEdit?: () => void;
-  onSubmitEdit?: (turnUuid: string, text: string) => void;
+  /** 提交改写。`images` 是锚点消息的图片附件，原样随改写后的文本一同透传。 */
+  onSubmitEdit?: (turnUuid: string, text: string, images: ImagePayload[]) => void;
 }
 
 export function MessageRow({
@@ -54,6 +55,8 @@ export function MessageRow({
   const text = turnPlainText(turn);
   const time = formatClockTime(turn.timestamp);
   const turnUuid = turn.uuid;
+  // 编辑框只呈现文本，图片附件不进编辑器：用户改不动它们，提交时原样跟着走
+  const images = turnImageAttachments(turn);
 
   if (editing && turnUuid) {
     // 编辑期间会话可能开跑或弹出问答卡片。此时不关编辑器（用户写到一半的草稿不能
@@ -62,10 +65,11 @@ export function MessageRow({
     return (
       <MessageEditor
         initialText={text}
+        hasAttachments={images.length > 0}
         submitting={submitting}
         canSubmit={editable}
         onCancel={() => onCancelEdit?.()}
-        onSubmit={(draft) => onSubmitEdit?.(turnUuid, draft)}
+        onSubmit={(draft) => onSubmitEdit?.(turnUuid, draft, images)}
       />
     );
   }
@@ -154,12 +158,15 @@ function CopyButton({ text }: { text: string }) {
 
 function MessageEditor({
   initialText,
+  hasAttachments,
   submitting,
   canSubmit,
   onCancel,
   onSubmit,
 }: {
   initialText: string;
+  /** 锚点消息带图片附件——正文可以清空，改写后的消息仍有内容。 */
+  hasAttachments: boolean;
   submitting: boolean;
   /** 此刻允许提交改写；false 时保留草稿但锁住重新发送。 */
   canSubmit: boolean;
@@ -182,10 +189,12 @@ function MessageEditor({
     el.style.height = `${el.scrollHeight}px`;
   }, []);
 
+  const hasContent = Boolean(draft.trim()) || hasAttachments;
+
   const submit = useCallback(() => {
-    if (submitting || !canSubmit || !draft.trim()) return;
+    if (submitting || !canSubmit || !hasContent) return;
     onSubmit(draft);
-  }, [draft, submitting, canSubmit, onSubmit]);
+  }, [draft, hasContent, submitting, canSubmit, onSubmit]);
 
   return (
     <div className={`${USER_BUBBLE_LAYOUT_CLASS} ${BUBBLE_SHELL_CLASS}`} style={USER_BUBBLE_STYLE}>
@@ -248,7 +257,7 @@ function MessageEditor({
         </button>
         <button
           type="button"
-          disabled={submitting || !canSubmit || !draft.trim()}
+          disabled={submitting || !canSubmit || !hasContent}
           onClick={submit}
           title={t("message_edit_resend_hint")}
           className="focus-ring rounded-md px-2.5 py-1 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/components/copilot/chat/utils.test.ts
+++ b/frontend/src/components/copilot/chat/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Turn } from "@/types";
-import { canEditUserTurn, composeAllTurns, turnPlainText } from "./utils";
+import { canEditUserTurn, composeAllTurns, turnImageAttachments, turnPlainText } from "./utils";
 
 const userTurn: Turn = {
   type: "user",
@@ -67,6 +67,28 @@ describe("turnPlainText", () => {
       ],
     };
     expect(turnPlainText(turn)).toBe("第一段\n\n第二段");
+  });
+});
+
+describe("turnImageAttachments", () => {
+  it("takes image blocks back to the transport shape, in block order", () => {
+    const turn: Turn = {
+      type: "user",
+      uuid: "u-10",
+      content: [
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+        { type: "text", text: "按图改" },
+        { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "BBBB" } },
+      ],
+    };
+    expect(turnImageAttachments(turn)).toEqual([
+      { data: "AAAA", media_type: "image/png" },
+      { data: "BBBB", media_type: "image/jpeg" },
+    ]);
+  });
+
+  it("gives an empty list for a text-only turn", () => {
+    expect(turnImageAttachments(userTurn)).toEqual([]);
   });
 });
 

--- a/frontend/src/components/copilot/chat/utils.test.ts
+++ b/frontend/src/components/copilot/chat/utils.test.ts
@@ -90,6 +90,18 @@ describe("turnImageAttachments", () => {
   it("gives an empty list for a text-only turn", () => {
     expect(turnImageAttachments(userTurn)).toEqual([]);
   });
+
+  it("drops image blocks that carry no base64 payload", () => {
+    const turn: Turn = {
+      type: "user",
+      uuid: "u-11",
+      content: [
+        { type: "image" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+      ],
+    };
+    expect(turnImageAttachments(turn)).toEqual([{ data: "AAAA", media_type: "image/png" }]);
+  });
 });
 
 describe("canEditUserTurn", () => {

--- a/frontend/src/components/copilot/chat/utils.ts
+++ b/frontend/src/components/copilot/chat/utils.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from "i18next";
-import type { SessionStatus, Turn } from "@/types";
+import type { ImagePayload, SessionStatus, Turn } from "@/types";
 
 // ---------------------------------------------------------------------------
 // cn – lightweight className concatenation utility.
@@ -67,6 +67,21 @@ export function turnPlainText(turn: Turn): string {
     .filter((block) => block.type === "text" && typeof block.text === "string")
     .map((block) => block.text)
     .join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// turnImageAttachments – 一个 turn 携带的图片附件，按发送侧的传输形态还原。
+//
+// 图片块以 base64 原样存在日志条目里，改写时直接从锚点消息取回随新消息一同提交，
+// 与普通带图发送走同一条请求形态。块顺序即提交顺序（服务端图在前、文本在后）。
+// ---------------------------------------------------------------------------
+
+export function turnImageAttachments(turn: Turn): ImagePayload[] {
+  return (turn.content ?? []).flatMap((block) => {
+    const source = block.type === "image" ? block.source : undefined;
+    if (!source?.data) return [];
+    return [{ data: source.data, media_type: source.media_type }];
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/hooks/useAssistantSession.test.tsx
+++ b/frontend/src/hooks/useAssistantSession.test.tsx
@@ -1365,7 +1365,14 @@ describe("useAssistantSession", () => {
       await result.current.rewriteMessage("u-0", "改写后的消息");
     });
 
-    expect(rewriteSpy).toHaveBeenCalledWith("demo", "session-1", "u-0", "改写后的消息", expect.any(String));
+    expect(rewriteSpy).toHaveBeenCalledWith(
+      "demo",
+      "session-1",
+      "u-0",
+      "改写后的消息",
+      undefined,
+      expect.any(String),
+    );
 
     const state = useAssistantStore.getState();
     expect(state.currentSessionId).toBe("session-2");
@@ -1410,7 +1417,71 @@ describe("useAssistantSession", () => {
     await act(async () => {
       await result.current.rewriteMessage("u-0", "改写后的消息");
     });
-    expect(rewriteSpy.mock.calls[0][4]).toBe(rewriteSpy.mock.calls[1][4]);
+    expect(rewriteSpy.mock.calls[0][5]).toBe(rewriteSpy.mock.calls[1][5]);
+  });
+
+  it("carries the anchor's image attachments into the rewrite, empty text included", async () => {
+    mockIdleSession([userEntry(0, "原始消息")]);
+    const rewriteSpy = vi.spyOn(API, "rewriteAssistantMessage").mockResolvedValue({
+      status: "accepted",
+      session_id: "session-2",
+      origin_session_id: "session-1",
+      entry: null,
+    });
+    const images = [{ data: "AAAA", media_type: "image/png" }];
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    // 正文被改空的带图消息仍是有内容的消息，附件即内容
+    await act(async () => {
+      expect(await result.current.rewriteMessage("u-0", "   ", images)).toBe(true);
+    });
+
+    expect(rewriteSpy).toHaveBeenCalledWith("demo", "session-1", "u-0", "   ", images, expect.any(String));
+  });
+
+  it("rejects a rewrite with neither text nor attachments", async () => {
+    mockIdleSession([userEntry(0, "原始消息")]);
+    const rewriteSpy = vi.spyOn(API, "rewriteAssistantMessage");
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      expect(await result.current.rewriteMessage("u-0", "   ")).toBe(false);
+    });
+
+    expect(rewriteSpy).not.toHaveBeenCalled();
+  });
+
+  it("mints a new idempotency key when only the attachments differ", async () => {
+    mockIdleSession([userEntry(0, "原始消息")]);
+    const rewriteSpy = vi
+      .spyOn(API, "rewriteAssistantMessage")
+      .mockRejectedValue(new Error("改写失败"));
+
+    const { result } = renderHook(() => useAssistantSession("demo"));
+    await waitFor(() => {
+      expect(useAssistantStore.getState().currentSessionId).toBe("session-1");
+    });
+
+    await act(async () => {
+      await result.current.rewriteMessage("u-0", "改写后的消息", [
+        { data: "AAAA", media_type: "image/png" },
+      ]);
+    });
+    await act(async () => {
+      await result.current.rewriteMessage("u-0", "改写后的消息", [
+        { data: "BBBB", media_type: "image/png" },
+      ]);
+    });
+
+    expect(rewriteSpy.mock.calls[0][5]).not.toBe(rewriteSpy.mock.calls[1][5]);
   });
 
   it("does not let a session-list refresh started before the fork resurrect the superseded origin", async () => {
@@ -1908,7 +1979,7 @@ describe("useAssistantSession", () => {
     await act(async () => {
       await result.current.switchSession("session-1");
     });
-    const firstKey = rewriteSpy.mock.calls[0][4];
+    const firstKey = rewriteSpy.mock.calls[0][5];
     rewriteSpy.mockResolvedValue({
       status: "accepted",
       session_id: "session-3",
@@ -1918,7 +1989,7 @@ describe("useAssistantSession", () => {
     await act(async () => {
       await result.current.rewriteMessage("u-0", "改写后的消息");
     });
-    expect(rewriteSpy.mock.calls[1][4]).toBe(firstKey);
+    expect(rewriteSpy.mock.calls[1][5]).toBe(firstKey);
   });
 
   it("surfaces a failed session load and lets the same session be retried", async () => {

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -7,6 +7,7 @@ import { useAssistantStore } from "@/stores/assistant-store";
 import type {
   DraftDeltaPayload,
   DraftState,
+  ImagePayload,
   PendingQuestion,
   SessionMeta,
   TimelineEntry,
@@ -628,9 +629,11 @@ export function useAssistantSession(projectName: string | null) {
   // 原会话已被取代 409），被拒时用户仍留在原会话，时间线原样。受理之后才整体
   // 切换到承接改写的新会话——时间线重建、SSE 重连，不做增量缝合。
   const rewriteMessage = useCallback(
-    async (anchorEntryUuid: string, content: string): Promise<boolean> => {
+    async (anchorEntryUuid: string, content: string, images?: ImagePayload[]): Promise<boolean> => {
       const originSessionId = store.getState().currentSessionId;
-      if (!projectName || !originSessionId || !content.trim()) return false;
+      if (!projectName || !originSessionId) return false;
+      // 与发送同口径：图片附件本身就是内容，正文被改空的带图消息仍可提交
+      if (!content.trim() && (!images || images.length === 0)) return false;
       // sending 同时是发送与改写的在途锁：两者都会开启新一轮，不能并发
       if (store.getState().sending) return false;
 
@@ -643,8 +646,14 @@ export function useAssistantSession(projectName: string | null) {
       store.getState().setStartupFailure(null);
 
       // 幂等键：响应丢失后的重试由服务端在新分支里认领同一条权威条目，
-      // 不会再分叉一次。签名含锚点与改写后内容，改了内容即换新键。
-      const signature = JSON.stringify([projectName, originSessionId, anchorEntryUuid, content.trim()]);
+      // 不会再分叉一次。签名含锚点与改写后内容（含附件），改了内容即换新键。
+      const signature = JSON.stringify([
+        projectName,
+        originSessionId,
+        anchorEntryUuid,
+        content.trim(),
+        images ?? [],
+      ]);
       const clientKey =
         failedRewriteRef.current?.signature === signature
           ? failedRewriteRef.current.clientKey
@@ -656,6 +665,7 @@ export function useAssistantSession(projectName: string | null) {
           originSessionId,
           anchorEntryUuid,
           content,
+          images,
           clientKey,
         );
 

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -19,6 +19,12 @@ export interface SessionMeta {
   updated_at: string;
 }
 
+/** 图片附件的传输形态：与 `/sessions/send`、`/sessions/{id}/rewrite` 的 `images` 元素同构。 */
+export interface ImagePayload {
+  data: string;
+  media_type: string;
+}
+
 export interface ContentBlock {
   type:
     | "text"

--- a/tests/agent_runtime/test_assistant_rewrite.py
+++ b/tests/agent_runtime/test_assistant_rewrite.py
@@ -27,6 +27,7 @@ from server.agent_runtime.service import (
 )
 from server.agent_runtime.session_branch import SessionBranchService
 from server.agent_runtime.session_store import SessionMetaStore
+from server.routers.assistant import ImageAttachment
 from tests.agent_runtime.conftest import make_transcript_entry
 
 pytestmark = pytest.mark.integration
@@ -98,7 +99,14 @@ class FakeSessionManager:
                 session_id, user_entry, client_key=client_key
             )
         self.dispatched.append(
-            {"session_id": session_id, "prompt": prompt, "resumable": resumable, "client_key": client_key}
+            {
+                "session_id": session_id,
+                "prompt": prompt,
+                "resumable": resumable,
+                "client_key": client_key,
+                "echo_text": echo_text,
+                "echo_content": echo_content,
+            }
         )
         self.statuses[session_id] = "running"
         return entry
@@ -154,6 +162,19 @@ async def _rewrite(service: AssistantService, session_id: str, anchor: str, **kw
     params: dict[str, Any] = {"content": "只改第 3 集", "client_key": "ck-1"}
     params.update(kwargs)
     return await service.rewrite_message(PROJECT_NAME, session_id, anchor_entry_uuid=anchor, **params)
+
+
+def _image(data: str, media_type: str = "image/png") -> ImageAttachment:
+    return ImageAttachment(data=data, media_type=media_type)
+
+
+def _image_block(data: str, media_type: str = "image/png") -> dict[str, Any]:
+    return {"type": "image", "source": {"type": "base64", "media_type": media_type, "data": data}}
+
+
+async def _collect_prompt(prompt: Any) -> list[dict[str, Any]]:
+    """多模态 prompt 是 async generator——把它投递出的 wire 消息收下来。"""
+    return [message async for message in prompt]
 
 
 class TestRewriteHappyPath:
@@ -226,6 +247,44 @@ class TestRewriteHappyPath:
 
         assert runtime.interrupted == [session_id], "冷/闲会话也走同一入口，只是立刻返回终态"
         assert runtime.dispatched
+
+    async def test_attachments_ride_along_into_the_branch_first_input(self, rewriting):
+        """AC：改写带图消息——分支会话首条用户消息含原图与编辑后文本，agent 可见图片。"""
+        service, runtime, session_id, project_cwd = rewriting
+
+        result = await _rewrite(
+            service,
+            session_id,
+            SECOND_USER_ENTRY,
+            images=[_image("AAAA"), _image("BBBB", "image/jpeg")],
+        )
+
+        # 派发给 SDK 的是多模态 prompt，与普通带图发送同构：图在前、文本在后
+        messages = await _collect_prompt(runtime.dispatched[0]["prompt"])
+        assert [m["message"]["content"] for m in messages] == [
+            [
+                _image_block("AAAA"),
+                _image_block("BBBB", "image/jpeg"),
+                {"type": "text", "text": "只改第 3 集"},
+            ]
+        ]
+        # 落库的权威条目同样带图，刷新后时间线仍能渲染出这两张图
+        entries = await service.event_log.list_entries(result["session_id"], project_cwd)
+        assert entries[-1]["content"] == [
+            _image_block("AAAA"),
+            _image_block("BBBB", "image/jpeg"),
+            {"type": "text", "text": "只改第 3 集"},
+        ]
+        assert entries[-1]["uuid"] == result["entry"]["uuid"]
+
+    async def test_text_only_rewrite_stays_a_plain_string_prompt(self, rewriting):
+        """不带附件的改写不因附件透传而改变形态。"""
+        service, runtime, session_id, _ = rewriting
+
+        await _rewrite(service, session_id, SECOND_USER_ENTRY, images=[])
+
+        assert runtime.dispatched[0]["prompt"] == "只改第 3 集"
+        assert runtime.dispatched[0]["echo_content"] is None
 
 
 class TestRewriteIdempotency:
@@ -310,6 +369,18 @@ class TestRewriteRejections:
 
         assert runtime.interrupted == []
         assert runtime.dispatched == []
+
+    async def test_empty_content_with_attachments_is_accepted(self, rewriting):
+        """改写把正文清空的带图消息仍是有内容的消息——附件即内容。"""
+        service, runtime, session_id, _ = rewriting
+
+        result = await _rewrite(service, session_id, SECOND_USER_ENTRY, content="   ", images=[_image("AAAA")])
+
+        assert result["status"] == "accepted"
+        assert result["entry"]["content"] == [_image_block("AAAA")]
+        # 纯图消息的 echo 匹配靠 sentinel：显示文本为空、echo_content 非空即走那条路径
+        assert runtime.dispatched[0]["echo_text"] == ""
+        assert runtime.dispatched[0]["echo_content"] == [_image_block("AAAA")]
 
     async def test_session_from_another_project_is_not_found(self, rewriting):
         service, _, session_id, _ = rewriting

--- a/tests/agent_runtime/test_assistant_rewrite.py
+++ b/tests/agent_runtime/test_assistant_rewrite.py
@@ -276,6 +276,8 @@ class TestRewriteHappyPath:
             {"type": "text", "text": "只改第 3 集"},
         ]
         assert entries[-1]["uuid"] == result["entry"]["uuid"]
+        # 正文非空时 echo 匹配仍按改写后的文本落链——SDK 回放丢掉图块，只剩这段文本
+        assert runtime.dispatched[0]["echo_text"] == "只改第 3 集"
 
     async def test_text_only_rewrite_stays_a_plain_string_prompt(self, rewriting):
         """不带附件的改写不因附件透传而改变形态。"""

--- a/tests/test_session_manager_user_input.py
+++ b/tests/test_session_manager_user_input.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from server.agent_runtime.event_log import REPLAYED_USER_ECHO_ENTRY_UUID_KEY, REPLAYED_USER_ECHO_KEY
-from server.agent_runtime.message_serialization import PendingUserEcho, match_user_echo, message_to_dict
+from server.agent_runtime.message_serialization import (
+    IMAGE_ONLY_SENTINEL,
+    PendingUserEcho,
+    match_user_echo,
+    message_to_dict,
+)
 from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError, ManagedSession
 from tests.fakes import build_managed_with_actor
 
@@ -99,6 +104,30 @@ class TestSessionManagerUserInput:
             while not queue.empty():
                 broadcasted.append(queue.get_nowait())
             assert not any(isinstance(item, dict) and item.get("local_echo") for item in broadcasted)
+        finally:
+            await _finish(managed)
+
+    async def test_image_only_input_registers_the_sentinel_dedup_key(self, session_manager, meta_store):
+        """正文为空的带图消息（改写把文本清空即落在这条路上）靠 sentinel 认领回放副本。
+
+        SDK 的 parser 丢掉 image 块，回放的 UserMessage content 为空，按文本匹配
+        永远对不上——身份映射会漏，条目被二次落库。
+        """
+        messages = [{"type": "result", "subtype": "success", "is_error": False, "uuid": "r1"}]
+        meta, managed, _client = await _seed(session_manager, meta_store, messages=messages)
+        try:
+            await session_manager.send_message(
+                meta.id,
+                "",
+                echo_text="",
+                echo_content=[
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+                ],
+                user_entry=None,
+            )
+            assert [echo.dedup_key for echo in managed.pending_user_echoes] == [IMAGE_ONLY_SENTINEL]
+            # 空 content 的回放副本被这条 pending echo 认领
+            assert match_user_echo(managed.pending_user_echoes, {"type": "user", "content": []}) is not None
         finally:
             await _finish(managed)
 


### PR DESCRIPTION
Closes #1787

## 范围

只动助手会话的消息改写提交链路（前端）与其测试。后端改写端点本就接受 `images`（`RewriteRequest.images` → `AssistantService.rewrite_message` → `_prepare_prompt` 的多模态构造与 echo sentinel 全部已就位），本 PR 不改后端源码，只补回归测试。不动编辑态的附件呈现与移除（issue 已明确另行立项）。

## 变更

- 改写提交把锚点消息的图片附件原样透传：`turnImageAttachments` 从锚点 turn 取回 image 块，经 `MessageRow` → `useAssistantSession.rewriteMessage` → `API.rewriteAssistantMessage` 的 `images` 送到分支会话首条输入，与普通带图发送同构（图在前、文本在后）
- 带图消息可以被改写成纯图：编辑器的「草稿为空则不可提交」门槛在有附件时放开，走服务端已有的 image-only sentinel 匹配路径
- 幂等键签名纳入附件，口径与 `sendMessage` 一致——只换图不换文字也会换新键
- 两个助手发送端点的 `images` 参数统一用 `ImagePayload` 类型，不再各写一份匿名结构
- 测试：分支首条输入的多模态 prompt 与落库条目、纯文本改写形态不变、空正文+附件被受理、image-only 输入登记 sentinel 去重键

## 验收清单

- [x] 本地已跑相关测试：`uv run ruff check . && uv run ruff format --check .`、`uv run basedpyright`（0 errors）、`uv run lint-imports`、`uv run python -m pytest`、`cd frontend && pnpm lint && pnpm check`（145 文件 / 1750 用例全过）
- [ ] 手动验证了改动所声称的行为 —— 未启服务端，验证全部经单元/集成测试
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）—— 无新增面向用户文案
- [x] 无新增 ESLint disable
- [x] CODEOWNERS 要求的 review 已请求

四条 AC 的对应测试：

| AC | 测试 |
|---|---|
| 带图改写：分支首条含原图与新文本 | `test_attachments_ride_along_into_the_branch_first_input` |
| 纯图消息路径不回归 | `test_image_only_input_registers_the_sentinel_dedup_key`、`test_empty_content_with_attachments_is_accepted` |
| 纯文本改写行为不变 | `test_text_only_rewrite_stays_a_plain_string_prompt` |
| echo 匹配在附件透传下仍落链 | 同上两组：正文非空断言 `echo_text` 为改写后文本，正文清空断言走 sentinel |

## 已知 defer

- 编辑态的附件可视化与逐张移除（待复盘确认后立项）。issue #1787 正文已把它划出本票范围（「如需图片可视化/可移除，另行立项」）。当前后果是正文被清空后编辑框看起来空白、提交按钮仍可用，用户无从看出附件仍在
- 纯图消息（原本就无正文）目前没有改写入口（待复盘确认后立项）。`canEditUserTurn` 仍以纯文本为判据，本 PR 未扩大入口
- 附件体积无端到端上限（待复盘确认后立项）。后端 `max_length=5` 只限张数，5MB/张的门槛在主输入框采集处，改写透传的是已入库附件（这些附件当初就是过了检查才进来的），多张大图会重传全量 base64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持在助手消息编辑和重写时保留并提交图片附件。
  * 支持仅包含图片、无文字内容的消息进行提交和重写。
  * 图片附件将按原始顺序传递，并保留图片格式信息。

* **错误修复**
  * 修复编辑消息时图片附件丢失的问题。
  * 优化空内容校验：纯文本为空时仍可提交带附件的消息，同时阻止完全空白的提交。

* **测试**
  * 新增图片与文本混合、纯图片消息及附件回放场景的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
