### PR TITLE
refactor(视频): 收编各供应商素材 data URI 编码为共享实现

### DIFF
--- a/lib/dashscope_shared.py
+++ b/lib/dashscope_shared.py
@@ -14,11 +14,11 @@
 
 from __future__ import annotations
 
-import base64
 import logging
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from pathlib import Path
 
+from lib.data_uri import image_to_data_uri as _image_to_data_uri
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 
 logger = logging.getLogger(__name__)
@@ -108,9 +108,7 @@ def dashscope_headers(api_key: str, *, async_mode: bool = False) -> dict[str, st
 
 def image_to_data_uri(image_path: Path) -> str:
     """本地图片 → base64 data URI（百炼 media/image 接受 URL 或 data URI）。"""
-    mime = _IMAGE_MIME_TYPES.get(image_path.suffix.lower(), "image/png")
-    b64 = base64.b64encode(image_path.read_bytes()).decode("ascii")
-    return f"data:{mime};base64,{b64}"
+    return _image_to_data_uri(image_path, _IMAGE_MIME_TYPES)
 
 
 # ── 视频异步任务状态工具 ──────────────────────────────────────────────────────

--- a/lib/data_uri.py
+++ b/lib/data_uri.py
@@ -2,7 +2,7 @@
 
 各供应商的图像/视频接口普遍接受 `data:<mime>;base64,<内容>` 形态的内联素材，走 data URI
 可以免掉一层文件服务。编码动作本身各家一致，差异只在「哪些扩展名映射到哪个 MIME」——
-表由各供应商的 `*_shared` 模块自己持有并传入，本模块不持有任何供应商口径。
+表由各供应商模块自己持有并传入，本模块不持有任何供应商口径。
 
 与 `lib/image_utils.py` / `lib/audio_utils.py` 的分工：那两个模块守的是入站上传侧
 （尺寸压缩、时长与格式校验），本模块只负责把已落盘的素材编成出站请求体里的字段。
@@ -14,7 +14,7 @@ import base64
 from collections.abc import Mapping
 from pathlib import Path
 
-DEFAULT_IMAGE_MIME = "image/png"
+_DEFAULT_IMAGE_MIME = "image/png"
 
 
 def file_to_data_uri(path: Path, mime: str) -> str:
@@ -22,16 +22,11 @@ def file_to_data_uri(path: Path, mime: str) -> str:
     return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
 
 
-def image_to_data_uri(
-    image_path: Path,
-    mime_types: Mapping[str, str],
-    *,
-    default_mime: str = DEFAULT_IMAGE_MIME,
-) -> str:
-    """本地图片 → base64 data URI，按 `mime_types` 查扩展名，未登记时回落 `default_mime`。
+def image_to_data_uri(image_path: Path, mime_types: Mapping[str, str]) -> str:
+    """本地图片 → base64 data URI，按 `mime_types` 查扩展名，未登记时回落 `image/png`。
 
     回落而非报错：图片扩展名的受理口径由上传侧把关，各家 `mime_types` 只列各自明确声明
-    过的格式，落表外的按 png 送出与既有行为一致。
+    过的格式，落表外的按 png 送出即可。
     """
-    mime = mime_types.get(image_path.suffix.lower(), default_mime)
+    mime = mime_types.get(image_path.suffix.lower(), _DEFAULT_IMAGE_MIME)
     return file_to_data_uri(image_path, mime)

--- a/lib/data_uri.py
+++ b/lib/data_uri.py
@@ -1,0 +1,37 @@
+"""出站请求侧的 base64 data URI 编码。
+
+各供应商的图像/视频接口普遍接受 `data:<mime>;base64,<内容>` 形态的内联素材，走 data URI
+可以免掉一层文件服务。编码动作本身各家一致，差异只在「哪些扩展名映射到哪个 MIME」——
+表由各供应商的 `*_shared` 模块自己持有并传入，本模块不持有任何供应商口径。
+
+与 `lib/image_utils.py` / `lib/audio_utils.py` 的分工：那两个模块守的是入站上传侧
+（尺寸压缩、时长与格式校验），本模块只负责把已落盘的素材编成出站请求体里的字段。
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from pathlib import Path
+
+DEFAULT_IMAGE_MIME = "image/png"
+
+
+def file_to_data_uri(path: Path, mime: str) -> str:
+    """本地文件 → base64 data URI；读不到时 OSError 向上冒泡由调用方决定语义。"""
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
+def image_to_data_uri(
+    image_path: Path,
+    mime_types: Mapping[str, str],
+    *,
+    default_mime: str = DEFAULT_IMAGE_MIME,
+) -> str:
+    """本地图片 → base64 data URI，按 `mime_types` 查扩展名，未登记时回落 `default_mime`。
+
+    回落而非报错：图片扩展名的受理口径由上传侧把关，各家 `mime_types` 只列各自明确声明
+    过的格式，落表外的按 png 送出与既有行为一致。
+    """
+    mime = mime_types.get(image_path.suffix.lower(), default_mime)
+    return file_to_data_uri(image_path, mime)

--- a/lib/image_backends/base.py
+++ b/lib/image_backends/base.py
@@ -11,16 +11,13 @@ from typing import Protocol
 
 import httpx
 
+from lib.data_uri import image_to_data_uri as _image_to_data_uri
 from lib.video_backends.base import IMAGE_MIME_TYPES
 
 
 def image_to_base64_data_uri(image_path: Path) -> str:
     """将本地图片转为 base64 data URI。"""
-    suffix = image_path.suffix.lower()
-    mime_type = IMAGE_MIME_TYPES.get(suffix, "image/png")
-    image_data = image_path.read_bytes()
-    b64 = base64.b64encode(image_data).decode("ascii")
-    return f"data:{mime_type};base64,{b64}"
+    return _image_to_data_uri(image_path, IMAGE_MIME_TYPES)
 
 
 async def download_image_to_path(url: str, output_path: Path, *, timeout: int = 60) -> None:

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -17,8 +17,9 @@
 
 from __future__ import annotations
 
-import base64
 from pathlib import Path
+
+from lib.data_uri import image_to_data_uri as _image_to_data_uri
 
 # 国内站默认 base（含 /v1）；国际站经配置覆盖 base_url 指向 MINIMAX_INTL_BASE_URL。
 MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
@@ -109,9 +110,7 @@ def _as_dict(value: object) -> dict:
 
 def image_to_data_uri(image_path: Path) -> str:
     """本地图片 → base64 data URI（first_frame_image 接受 URL 或 data URI）。"""
-    mime = _IMAGE_MIME_TYPES.get(image_path.suffix.lower(), "image/png")
-    b64 = base64.b64encode(image_path.read_bytes()).decode("ascii")
-    return f"data:{mime};base64,{b64}"
+    return _image_to_data_uri(image_path, _IMAGE_MIME_TYPES)
 
 
 # ── 单步 image_generation 响应工具 ────────────────────────────────────────────

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 import re
 from pathlib import Path
@@ -25,6 +24,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     poll_with_retry,
+    reference_audio_to_data_uri,
 )
 
 logger = logging.getLogger(__name__)
@@ -59,8 +59,8 @@ def _safe_create_params_for_log(create_params: dict[str, Any]) -> dict[str, Any]
 
     content 里的图片与音频都是 base64 data URI。``format_kwargs_for_log`` 只截断长字符串、
     不认识这层结构，直接交给它会把每个素材的 base64 前缀写进 info 日志（音频还可能带上
-    mp3 文件头的 ID3 元数据）。dashscope / vidu / minimax 三家均已各有同名的安全视图并在
-    注释里点明对齐 CodeQL clear-text-logging，Ark 此前是唯一漏网的一家。
+    mp3 文件头的 ID3 元数据）。dashscope / vidu / minimax 三家各有同名的安全视图，同为
+    对齐 CodeQL clear-text-logging。
 
     prompt 是用户文本、不是素材，仍按 ``format_kwargs_for_log`` 的既有截断规则输出，
     以保留排查生成效果时最常用的那一项。
@@ -79,28 +79,6 @@ def _safe_create_params_for_log(create_params: dict[str, Any]) -> dict[str, Any]
         if isinstance(prompt, str):
             view["prompt"] = prompt
     return view
-
-
-def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
-    """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
-
-    与参考图的「缺失即跳过」不同，音频不能静默跳过：prompt 里的「音频N」按 content 数组中
-    音频条目的出现顺序编号，跳过一段会让其后所有编号整体前移，把某个角色的音色安到另一个
-    角色头上——错得无声无息，且照常扣费。
-    """
-    mime = _REFERENCE_AUDIO_MIME_TYPES.get(path.suffix.lower())
-    if mime is None:
-        raise VideoCapabilityError(
-            "video_reference_audio_format_unsupported",
-            model=model,
-            name=path.name,
-            supported=", ".join(sorted(_REFERENCE_AUDIO_MIME_TYPES)),
-        )
-    try:
-        raw = path.read_bytes()
-    except OSError as exc:
-        raise VideoCapabilityError("video_reference_audio_unreadable", model=model, names=path.name) from exc
-    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
 class ArkVideoBackend(ProviderJobIdPersistenceMixin):
@@ -378,7 +356,11 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
                 content.append(
                     {
                         "type": "audio_url",
-                        "audio_url": {"url": _reference_audio_to_data_uri(Path(audio_path), model=self._model)},
+                        "audio_url": {
+                            "url": reference_audio_to_data_uri(
+                                Path(audio_path), model=self._model, mime_types=_REFERENCE_AUDIO_MIME_TYPES
+                            )
+                        },
                         "role": "reference_audio",
                     }
                 )

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -14,6 +14,7 @@ from typing import Protocol
 import httpx
 from sqlalchemy.exc import InterfaceError, OperationalError
 
+from lib.data_uri import file_to_data_uri
 from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
 
 # `_should_retry` 默认会做字符串模式兜底（"timeout"/"503" 等），
@@ -412,6 +413,30 @@ class VideoCapabilityError(RuntimeError):
         self.code = code
         self.params = params
         super().__init__(code)
+
+
+def reference_audio_to_data_uri(path: Path, *, model: str, mime_types: Mapping[str, str]) -> str:
+    """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
+
+    音频不能像参考图那样「缺失即跳过」：prompt 里的「音频N」按 content 数组中音频条目的
+    出现顺序编号，跳过一段会让其后所有编号整体前移，把某个角色的音色安到另一个角色头上
+    ——错得无声无息，且照常扣费。
+
+    ``mime_types`` 由各 backend 传入：同一个扩展名各家接受的 MIME 写法不一致（mp3 有
+    ``audio/mp3`` 与 ``audio/mpeg`` 两种口径），合表会让其中一家收到没验证过的 MIME。
+    """
+    mime = mime_types.get(path.suffix.lower())
+    if mime is None:
+        raise VideoCapabilityError(
+            "video_reference_audio_format_unsupported",
+            model=model,
+            name=path.name,
+            supported=", ".join(sorted(mime_types)),
+        )
+    try:
+        return file_to_data_uri(path, mime)
+    except OSError as exc:
+        raise VideoCapabilityError("video_reference_audio_unreadable", model=model, names=path.name) from exc
 
 
 class ReferenceAudioMode(StrEnum):

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -15,7 +15,6 @@ schema 的确权程度按型号分两档：happyhorse 与 wan2.7 依据 docs/das
 
 from __future__ import annotations
 
-import base64
 import logging
 from pathlib import Path
 
@@ -35,6 +34,7 @@ from lib.dashscope_shared import (
     resolve_dashscope_api_key,
     safe_body_for_log,
 )
+from lib.data_uri import file_to_data_uri
 from lib.logging_utils import format_kwargs_for_log
 from lib.providers import PROVIDER_DASHSCOPE
 from lib.retry import (
@@ -85,7 +85,7 @@ def _read_reference_audio_or_none(path: Path) -> str | None:
     if not path.is_file():
         return None
     try:
-        return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+        return file_to_data_uri(path, mime)
     except OSError as exc:
         logger.warning("DashScope 参考音频读取失败: %s (%s)", path, exc)
         return None

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 from datetime import timedelta
 from pathlib import Path
 
+from lib.data_uri import image_to_data_uri
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.grok_shared import create_grok_client, grok_should_retry
 from lib.logging_utils import format_kwargs_for_log
@@ -114,21 +114,17 @@ class GrokVideoBackend:
         if request.resolution is not None:
             generate_kwargs["resolution"] = request.resolution
 
-        def _encode_to_data_uri(path: Path) -> str:
-            suffix = path.suffix.lower()
-            mime_type = IMAGE_MIME_TYPES.get(suffix, "image/png")
-            b64 = base64.b64encode(path.read_bytes()).decode("ascii")
-            return f"data:{mime_type};base64,{b64}"
-
         if request.start_image and Path(request.start_image).exists():
             image_path = Path(request.start_image)
-            generate_kwargs["image_url"] = await asyncio.to_thread(_encode_to_data_uri, image_path)
+            generate_kwargs["image_url"] = await asyncio.to_thread(image_to_data_uri, image_path, IMAGE_MIME_TYPES)
 
         if request.reference_images:
             ref_paths = [Path(p) if not isinstance(p, Path) else p for p in request.reference_images]
             existing_paths = [p for p in ref_paths if p.exists()]
             if existing_paths:
-                ref_urls = await asyncio.gather(*[asyncio.to_thread(_encode_to_data_uri, p) for p in existing_paths])
+                ref_urls = await asyncio.gather(
+                    *[asyncio.to_thread(image_to_data_uri, p, IMAGE_MIME_TYPES) for p in existing_paths]
+                )
                 generate_kwargs["reference_image_urls"] = list(ref_urls)
 
         logger.info("Grok 视频生成开始: model=%s, duration=%ds", self._model, request.duration_seconds)

--- a/lib/video_backends/minimax.py
+++ b/lib/video_backends/minimax.py
@@ -19,7 +19,6 @@ subject_reference（reference_images[0]→{"type":"character","image":[...]}）�
 
 from __future__ import annotations
 
-import base64
 import logging
 from pathlib import Path
 from typing import Any
@@ -63,6 +62,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     poll_with_retry,
+    reference_audio_to_data_uri,
     should_retry_download,
     should_retry_poll,
     should_retry_submit,
@@ -161,28 +161,6 @@ def _safe_body_for_log(body: dict) -> dict:
 def _image_content_item(data_uri: str, *, role: str) -> dict[str, Any]:
     """图片 data URI → v2 content[] 条目。"""
     return {"type": "image_url", "image_url": {"url": data_uri}, "role": role}
-
-
-def _reference_audio_to_data_uri(path: Path, *, model: str) -> str:
-    """参考音频 → base64 data URI；格式不受支持或文件不可读一律抛错。
-
-    与参考图的处理同为 fail-loud：prompt 里的「音频N」按 content 数组中音频条目的出现顺序
-    编号，跳过一段会让其后所有编号整体前移，把某个角色的音色安到另一个角色头上——错得无声
-    无息，且照常扣费。
-    """
-    mime = _REFERENCE_AUDIO_MIME_TYPES.get(path.suffix.lower())
-    if mime is None:
-        raise VideoCapabilityError(
-            "video_reference_audio_format_unsupported",
-            model=model,
-            name=path.name,
-            supported=", ".join(sorted(_REFERENCE_AUDIO_MIME_TYPES)),
-        )
-    try:
-        raw = path.read_bytes()
-    except OSError as exc:
-        raise VideoCapabilityError("video_reference_audio_unreadable", model=model, names=path.name) from exc
-    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
 
 
 class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
@@ -386,7 +364,11 @@ class MiniMaxVideoBackend(ProviderJobIdPersistenceMixin):
             content.append(
                 {
                     "type": "audio_url",
-                    "audio_url": {"url": _reference_audio_to_data_uri(Path(audio_path), model=self._model)},
+                    "audio_url": {
+                        "url": reference_audio_to_data_uri(
+                            Path(audio_path), model=self._model, mime_types=_REFERENCE_AUDIO_MIME_TYPES
+                        )
+                    },
                     "role": "reference_audio",
                 }
             )

--- a/lib/vidu_shared.py
+++ b/lib/vidu_shared.py
@@ -15,13 +15,13 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 from pathlib import Path
 
 import httpx
 
+from lib.data_uri import image_to_data_uri as _image_to_data_uri
 from lib.retry import BASE_RETRYABLE_ERRORS
 
 logger = logging.getLogger(__name__)
@@ -73,10 +73,7 @@ def create_vidu_client(
 
 def image_to_data_uri(image_path: Path) -> str:
     """本地图片 → base64 data URI（Vidu 接受 URL 或 data URI；走 data URI 免依赖文件服务）。"""
-    suffix = image_path.suffix.lower()
-    mime = _IMAGE_MIME_TYPES.get(suffix, "image/png")
-    b64 = base64.b64encode(image_path.read_bytes()).decode("ascii")
-    return f"data:{mime};base64,{b64}"
+    return _image_to_data_uri(image_path, _IMAGE_MIME_TYPES)
 
 
 # 日志输出仅允许的字段白名单（避免 CodeQL 担心 body 里其他字段含敏感数据）。

--- a/tests/test_data_uri.py
+++ b/tests/test_data_uri.py
@@ -1,0 +1,69 @@
+"""lib.data_uri 单元测试 — 出站素材编码的 MIME 查表与回落语义。"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from lib.data_uri import file_to_data_uri, image_to_data_uri
+from lib.video_backends.base import VideoCapabilityError, reference_audio_to_data_uri
+
+pytestmark = pytest.mark.unit
+
+_IMAGE_MIME_TYPES = {".png": "image/png", ".jpg": "image/jpeg", ".webp": "image/webp"}
+_AUDIO_MIME_TYPES = {".wav": "audio/wav", ".mp3": "audio/mp3"}
+
+
+class TestFileToDataUri:
+    def test_encodes_bytes_with_given_mime(self, tmp_path: Path):
+        path = tmp_path / "blob.bin"
+        path.write_bytes(b"\x00\x01hello")
+        expected = base64.b64encode(b"\x00\x01hello").decode("ascii")
+        assert file_to_data_uri(path, "application/octet-stream") == f"data:application/octet-stream;base64,{expected}"
+
+    def test_unreadable_file_raises_oserror(self, tmp_path: Path):
+        with pytest.raises(OSError):
+            file_to_data_uri(tmp_path / "missing.bin", "image/png")
+
+
+class TestImageToDataUri:
+    @pytest.mark.parametrize(("name", "mime"), [("a.JPG", "image/jpeg"), ("b.webp", "image/webp")])
+    def test_suffix_lookup_is_case_insensitive(self, tmp_path: Path, name: str, mime: str):
+        path = tmp_path / name
+        path.write_bytes(b"img")
+        assert image_to_data_uri(path, _IMAGE_MIME_TYPES).startswith(f"data:{mime};base64,")
+
+    def test_unlisted_suffix_falls_back_to_png(self, tmp_path: Path):
+        path = tmp_path / "c.tiff"
+        path.write_bytes(b"img")
+        assert image_to_data_uri(path, _IMAGE_MIME_TYPES).startswith("data:image/png;base64,")
+
+    def test_default_mime_is_overridable(self, tmp_path: Path):
+        path = tmp_path / "c.tiff"
+        path.write_bytes(b"img")
+        assert image_to_data_uri(path, _IMAGE_MIME_TYPES, default_mime="image/bmp").startswith("data:image/bmp;base64,")
+
+
+class TestReferenceAudioToDataUri:
+    def test_encodes_listed_suffix(self, tmp_path: Path):
+        path = tmp_path / "voice.WAV"
+        path.write_bytes(b"riff")
+        expected = base64.b64encode(b"riff").decode("ascii")
+        uri = reference_audio_to_data_uri(path, model="m", mime_types=_AUDIO_MIME_TYPES)
+        assert uri == f"data:audio/wav;base64,{expected}"
+
+    def test_unlisted_suffix_fails_loud(self, tmp_path: Path):
+        # 音频不回落也不跳过：编号按条目顺序，静默丢一段会把音色错配到别的角色。
+        path = tmp_path / "voice.ogg"
+        path.write_bytes(b"ogg")
+        with pytest.raises(VideoCapabilityError) as exc:
+            reference_audio_to_data_uri(path, model="m", mime_types=_AUDIO_MIME_TYPES)
+        assert exc.value.code == "video_reference_audio_format_unsupported"
+        assert exc.value.params["supported"] == ".mp3, .wav"
+
+    def test_unreadable_file_fails_loud(self, tmp_path: Path):
+        with pytest.raises(VideoCapabilityError) as exc:
+            reference_audio_to_data_uri(tmp_path / "gone.wav", model="m", mime_types=_AUDIO_MIME_TYPES)
+        assert exc.value.code == "video_reference_audio_unreadable"

--- a/tests/test_data_uri.py
+++ b/tests/test_data_uri.py
@@ -40,11 +40,6 @@ class TestImageToDataUri:
         path.write_bytes(b"img")
         assert image_to_data_uri(path, _IMAGE_MIME_TYPES).startswith("data:image/png;base64,")
 
-    def test_default_mime_is_overridable(self, tmp_path: Path):
-        path = tmp_path / "c.tiff"
-        path.write_bytes(b"img")
-        assert image_to_data_uri(path, _IMAGE_MIME_TYPES, default_mime="image/bmp").startswith("data:image/bmp;base64,")
-
 
 class TestReferenceAudioToDataUri:
     def test_encodes_listed_suffix(self, tmp_path: Path):


### PR DESCRIPTION
Closes #1793

## 改动

各供应商出站素材的 base64 data URI 编码此前在六处各写一份，本次收编为 `lib/data_uri.py`（`file_to_data_uri` / `image_to_data_uri`，纯 stdlib、不持有任何供应商 MIME 口径）与 `lib/video_backends/base.py::reference_audio_to_data_uri`（参考音频的 fail-loud 语义）。

- 图片：`dashscope_shared` / `minimax_shared` / `vidu_shared` 保留同名薄包装（消费方与 9 处测试 patch 点不动），`image_backends/base.py` 与 `video_backends/grok.py` 的两份逐字副本一并收编
- 音频：ark 与 minimax 的两份近乎逐字重复合为一处；dashscope 侧语义不同（缺失返回 None、不可读批量收集），仅编码动作改走 `file_to_data_uri`
- MIME 表全部留在各消费方按参数传入：三张图片表内容本就不同，音频表 dashscope 对 mp3 用 `audio/mpeg`、ark/minimax 用 `audio/mp3`，合表会让其中一家收到没验证过的 MIME

行为不变，纯维护性重构：MIME 回落值、fail-loud 的错误 code 与 kwarg（含 `name=` / `names=` 的既有不对称）、data URI 拼接、异常类型与传播路径均逐字保留。

音频版落在 `video_backends/base.py` 而非 `data_uri.py`，是分层契约的硬约束：它抛的 `VideoCapabilityError` 定义在 `video_backends/base.py`，而 `lib/config/registry.py` 顶层 import 了 `minimax_shared`（要用图片版共享实现），两者同处一个模块会形成 `lib.config → lib.minimax_shared → lib.data_uri → lib.video_backends.base` 的反向边——本地实验已复现该链使 `lint-imports` BROKEN。

## 验证

`pytest` 全量 8668 passed / 2 skipped；`ruff check` + `format`、`basedpyright` 0 errors、`lint-imports` KEPT。新增 `tests/test_data_uri.py` 覆盖 MIME 回落、大小写扩展名，以及音频的格式不受支持 / 文件不可读两条 fail-loud 路径（原先零直接覆盖）。前端未改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一图片和音频文件的 Data URI 转换处理，提升不同媒体后端之间的行为一致性。
  * 支持根据文件扩展名识别 MIME 类型，并为未知图片格式提供 PNG 回退。
  * 对不支持的音频格式及文件读取失败情况提供更明确的错误提示。

* **测试**
  * 新增文件编码、MIME 类型识别、格式回退及错误处理的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->