### PR TITLE
test(视频): wan-2.7-image 用例改为表征测试写法

### DIFF
--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -311,8 +311,7 @@ class TestInferEndpoint:
             ("wan30", "openai", "openai-video"),
             # 表征测试，非期望结论：wan2 家族仅认字面 "wan2."（要求点号）触发 is_wan_family，
             # 连字符无点号形态 wan-2.7 不触发，其 image 变体因此被裸 "wan" 命中 _VIDEO_PATTERN
-            # 误判为视频而非图像，这是已知局限而非设计意图。断言钉住当前行为、防止无意变更；
-            # wan2 家族命名口径统一时应同步更新本断言。
+            # 误判为视频而非图像，这是已知局限而非设计意图。断言钉住当前行为、防止无意变更。
             ("wan-2.7-image", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -309,9 +309,10 @@ class TestInferEndpoint:
             ("swan3", "openai", "openai-video"),
             ("vendorwan3", "openai", "openai-video"),
             ("wan30", "openai", "openai-video"),
-            # wan2 家族仅认字面 "wan2." 触发 is_wan_family，连字符形态 wan-2.7 不触发，故其
-            # image 变体会被裸 "wan" 命中 _VIDEO_PATTERN 判定为视频。wan2 字面量保留决策见
-            # duration_presets 对应用例，此处锁定端点路由侧同一结论。
+            # 表征测试，非期望结论：wan2 家族仅认字面 "wan2."（要求点号）触发 is_wan_family，
+            # 连字符无点号形态 wan-2.7 不触发，其 image 变体因此被裸 "wan" 命中 _VIDEO_PATTERN
+            # 误判为视频而非图像，这是已知局限而非设计意图。断言钉住当前行为、防止无意变更；
+            # wan2 家族命名口径统一时应同步更新本断言。
             ("wan-2.7-image", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),


### PR DESCRIPTION
## 问题

`tests/test_custom_provider_endpoints.py` 中 `wan-2.7-image` 一条用例的注释把已知局限写成了「锁定该行为防止未来被误当 bug 修改」，这等于把一处真实缺陷（wan2 连字符无点号形态的 `-image` 变体被误判为视频而非图像）固化成了看起来像设计意图的契约。

## 改动

改为表征测试写法：断言保持不变（仍钉住当前行为、防止无意变更），注释明确标注这是已知局限而非期望结论，wan2 家族命名口径统一时应同步更新本断言。

## 验证

`uv run ruff check` + `ruff format --check`（改动文件）通过；`uv run python -m pytest tests/test_custom_provider_endpoints.py` 130 passed。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 更新了 `wan-2.7-image` 路由行为相关的测试注释，使其与当前实际行为保持一致。
  * 测试断言和产品功能未发生变化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->