### PR TITLE
fix(自定义供应商): 万相 2.x 模型的连字符/下划线命名不再被误判为视频

### DIFF
--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -53,9 +53,11 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
     # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
     (WAN3_PATTERN, list(range(2, 31))),
-    # Wan（其余系列）。分隔符集合与 WAN3_PATTERN 一致（连字符/下划线均可选），否则
-    # wan_2.7-i2v 这类下划线别名会落 DEFAULT_FALLBACK，与它在端点路由、能力档上被认作
-    # 万相家族的结论相互矛盾（用户会拿到该型号并不支持的时长档）。
+    # Wan（其余系列）。分隔符接受连字符与下划线，与 WAN3_PATTERN 同宽，否则 wan_2.7-i2v 这类
+    # 下划线别名会落 DEFAULT_FALLBACK，与它在端点路由、能力档上被认作万相家族的结论相互矛盾
+    # （用户会拿到该型号并不支持的时长档）。这里不加 WAN3_PATTERN 的标识符边界：本条是兜底
+    # 启发式，"swan3"/"wan20" 一类含 wan 子串的第三方型号名落到这条比落 DEFAULT_FALLBACK 更
+    # 接近常见值，且预设本就要求用户在输入框 review。
     (re.compile(r"wan[-_]?\d", re.I), [4, 5]),
     # Pika
     (re.compile(r"pika", re.I), [3, 5, 10]),

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -75,9 +75,9 @@ def infer_supported_durations(model_id: str) -> list[int]:
     classification = classify_wan_model(model_id)
     if classification.family == "wan3":
         return list(_WAN3_DURATIONS)
-    # wan2.7-videoedit 时长上限与 t2v/i2v/r2v 不同，且本后端未实现该模态的请求构造（同
-    # endpoints.py::infer_endpoint 排除出原生路由的处理），不套用家族档，落到下方通用预设。
-    if classification.family == "wan2.7" and not classification.is_videoedit:
+    # wan2.7 未实现请求构造的模态（videoedit / s2v / v2v 等，见 classify_wan_model 的
+    # has_known_modality 处的说明）时长上限与 t2v/i2v/r2v 不同，不套用家族档，落到下方通用预设。
+    if classification.family == "wan2.7" and classification.has_known_modality:
         return list(_WAN27_DURATIONS)
     if classification.family == "happyhorse":
         return list(_HAPPYHORSE_DURATIONS)

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -11,13 +11,21 @@ from __future__ import annotations
 
 import re
 
-from lib.video_backends.dashscope import WAN2_PATTERN, WAN3_PATTERN
+from lib.video_backends.dashscope import classify_wan_model
 
 DEFAULT_FALLBACK: list[int] = [4, 8]
 
-# WAN2_PATTERN（只锚 2.7）/ WAN3_PATTERN（不锚版本号，连字符可选）均源出
-# lib.video_backends.dashscope——那里是本后端请求形态分派的单一真相源，endpoints.py 路由推断
-# 与本模块的时长档位推断均复用同一份，避免多处各写一份正则、匹配宽度悄悄漂移。
+# 万相 3.0（2-30 任意）。出处：lib/config/registry.py wan3.0-video 的 supported_durations。
+_WAN3_DURATIONS: list[int] = list(range(2, 31))
+# 万相 2.7（2-15 任意）。出处：lib/config/registry.py wan2.7-{t2v,i2v,r2v} 的 supported_durations。
+_WAN27_DURATIONS: list[int] = list(range(2, 16))
+# Alibaba HappyHorse（3-15 任意）。
+_HAPPYHORSE_DURATIONS: list[int] = list(range(3, 16))
+
+# wan3 / wan2.7 / happyhorse 三个家族的归属判定复用 classify_wan_model（lib.video_backends.dashscope
+# 的单一判定入口），不在本模块另写正则——与 endpoints.py 路由推断、DashScopeVideoBackend 能力档
+# 推断共用同一结论，避免三处宽度各自漂移。下方 PRESETS 里其余家族（sora/veo/kling 等）不受该判定
+# 入口覆盖，仍按各自厂商关键字匹配；末尾的通用 wan 兜底同理（见该条目处的说明）。
 
 # 按特异性从高到低排列；命中一条即返回。range 全展开为离散集。
 PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
@@ -37,8 +45,6 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     (re.compile(r"dreamina|seedance", re.I), list(range(4, 16))),
     # 字节即梦
     (re.compile(r"jimeng", re.I), list(range(4, 16))),
-    # Alibaba HappyHorse（3-15 任意）
-    (re.compile(r"happyhorse", re.I), list(range(3, 16))),
     # xAI Grok Imagine（1-15 任意）
     (re.compile(r"grok[-.]?imagine", re.I), list(range(1, 16))),
     # Vidu Q 系列（1-16 任意）
@@ -50,16 +56,11 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     (re.compile(r"minimax-h3", re.I), list(range(4, 16))),
     # MiniMax Hailuo（固定 6）
     (re.compile(r"hailuo", re.I), [6]),
-    # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
-    # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
-    (WAN3_PATTERN, list(range(2, 31))),
-    # 万相 2.7（2-15 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
-    # 出处：lib/config/registry.py wan2.7-{t2v,i2v,r2v} 的 supported_durations。
-    (WAN2_PATTERN, list(range(2, 16))),
-    # Wan（其余系列，含万相 2.x 中 2.7 以外的小版本）。分隔符接受连字符与下划线，与 WAN3_PATTERN
-    # 同宽。这里不加 WAN3_PATTERN 的标识符边界：本条是兜底启发式，"swan3"/"wan20" 一类含 wan
+    # Wan（classify_wan_model 未归类到 wan3/wan2.7 的其余系列，含万相 2.x 中 2.7 以外的小版本）。
+    # 分隔符接受连字符与下划线，不加标识符边界：本条是兜底启发式，"swan3"/"wan20" 一类含 wan
     # 子串的第三方型号名落到这条比落 DEFAULT_FALLBACK 更接近常见值，且预设本就要求用户在输入框
-    # review。
+    # review。wan3/wan2.7/happyhorse 已在 infer_supported_durations 里由 classify_wan_model
+    # 先行判定并返回，不会落到本条。
     (re.compile(r"wan[-_]?\d", re.I), [4, 5]),
     # Pika
     (re.compile(r"pika", re.I), [3, 5, 10]),
@@ -71,6 +72,13 @@ def infer_supported_durations(model_id: str) -> list[int]:
 
     返回值始终是非空升序去重的正整数列表，且为独立 list（caller 可安全修改）。
     """
+    family = classify_wan_model(model_id).family
+    if family == "wan3":
+        return list(_WAN3_DURATIONS)
+    if family == "wan2.7":
+        return list(_WAN27_DURATIONS)
+    if family == "happyhorse":
+        return list(_HAPPYHORSE_DURATIONS)
     for pattern, durations in PRESETS:
         if pattern.search(model_id):
             return list(durations)

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -72,12 +72,14 @@ def infer_supported_durations(model_id: str) -> list[int]:
 
     返回值始终是非空升序去重的正整数列表，且为独立 list（caller 可安全修改）。
     """
-    family = classify_wan_model(model_id).family
-    if family == "wan3":
+    classification = classify_wan_model(model_id)
+    if classification.family == "wan3":
         return list(_WAN3_DURATIONS)
-    if family == "wan2.7":
+    # wan2.7-videoedit 时长上限与 t2v/i2v/r2v 不同，且本后端未实现该模态的请求构造（同
+    # endpoints.py::infer_endpoint 排除出原生路由的处理），不套用家族档，落到下方通用预设。
+    if classification.family == "wan2.7" and not classification.is_videoedit:
         return list(_WAN27_DURATIONS)
-    if family == "happyhorse":
+    if classification.family == "happyhorse":
         return list(_HAPPYHORSE_DURATIONS)
     for pattern, durations in PRESETS:
         if pattern.search(model_id):

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 
 import re
 
-from lib.video_backends.dashscope import WAN3_PATTERN
+from lib.video_backends.dashscope import WAN2_PATTERN, WAN3_PATTERN
 
 DEFAULT_FALLBACK: list[int] = [4, 8]
 
-# WAN3_PATTERN（连字符可选、不锚版本号）源出 lib.video_backends.dashscope——那里是本后端
-# 请求形态分派的单一真相源，endpoints.py 路由推断与本模块的时长档位推断均复用同一份，
-# 避免三处各写一份正则、匹配宽度悄悄漂移。
+# WAN2_PATTERN（只锚 2.7）/ WAN3_PATTERN（不锚版本号，连字符可选）均源出
+# lib.video_backends.dashscope——那里是本后端请求形态分派的单一真相源，endpoints.py 路由推断
+# 与本模块的时长档位推断均复用同一份，避免多处各写一份正则、匹配宽度悄悄漂移。
 
 # 按特异性从高到低排列；命中一条即返回。range 全展开为离散集。
 PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
@@ -53,11 +53,13 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
     # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
     (WAN3_PATTERN, list(range(2, 31))),
-    # Wan（其余系列）。分隔符接受连字符与下划线，与 WAN3_PATTERN 同宽，否则 wan_2.7-i2v 这类
-    # 下划线别名会落 DEFAULT_FALLBACK，与它在端点路由、能力档上被认作万相家族的结论相互矛盾
-    # （用户会拿到该型号并不支持的时长档）。这里不加 WAN3_PATTERN 的标识符边界：本条是兜底
-    # 启发式，"swan3"/"wan20" 一类含 wan 子串的第三方型号名落到这条比落 DEFAULT_FALLBACK 更
-    # 接近常见值，且预设本就要求用户在输入框 review。
+    # 万相 2.7（2-15 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
+    # 出处：lib/config/registry.py wan2.7-{t2v,i2v,r2v} 的 supported_durations。
+    (WAN2_PATTERN, list(range(2, 16))),
+    # Wan（其余系列，含万相 2.x 中 2.7 以外的小版本）。分隔符接受连字符与下划线，与 WAN3_PATTERN
+    # 同宽。这里不加 WAN3_PATTERN 的标识符边界：本条是兜底启发式，"swan3"/"wan20" 一类含 wan
+    # 子串的第三方型号名落到这条比落 DEFAULT_FALLBACK 更接近常见值，且预设本就要求用户在输入框
+    # review。
     (re.compile(r"wan[-_]?\d", re.I), [4, 5]),
     # Pika
     (re.compile(r"pika", re.I), [3, 5, 10]),

--- a/lib/custom_provider/duration_presets.py
+++ b/lib/custom_provider/duration_presets.py
@@ -53,8 +53,10 @@ PRESETS: list[tuple[re.Pattern[str], list[int]]] = [
     # 万相 3.0（2-30 任意；须先于通用 Wan 判断，否则会落入 [4, 5]）。
     # 出处：lib/config/registry.py wan3.0-video 的 supported_durations。
     (WAN3_PATTERN, list(range(2, 31))),
-    # Wan（其余系列）
-    (re.compile(r"wan-?\d", re.I), [4, 5]),
+    # Wan（其余系列）。分隔符集合与 WAN3_PATTERN 一致（连字符/下划线均可选），否则
+    # wan_2.7-i2v 这类下划线别名会落 DEFAULT_FALLBACK，与它在端点路由、能力档上被认作
+    # 万相家族的结论相互矛盾（用户会拿到该型号并不支持的时长档）。
+    (re.compile(r"wan[-_]?\d", re.I), [4, 5]),
     # Pika
     (re.compile(r"pika", re.I), [3, 5, 10]),
 ]

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -531,6 +531,11 @@ _VIDEO_PATTERN = re.compile(
 _AUDIO_PATTERN = re.compile(r"tts|speech|cosyvoice", re.IGNORECASE)
 # 裸 "speech" 会撞上 ASR（语音转文字）家族 id，按内容排除，避免把识别模型默认归到 TTS 端点
 _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNORECASE)
+# wan 版本号 token："wan" 后紧跟（可选分隔符）数字，用于 MiniMax S2V 二级路由的排除判定：既要
+# 认出 "wan-2.2-s2v"/"vendorwan2.7-s2v" 一类版本号相邻 wan token（无需满足家族严格标识符边界），
+# 又要排除 "swan" 这类只是把 "wan" 作为普通单词一部分的无关子串——裸 "wan" in lowered 分不出这两
+# 者，会把恰好含 "swan" 的 MiniMax id 误判成 wan 家族而错过 MiniMax 路由。
+_WAN_VERSION_TOKEN_PATTERN = re.compile(r"wan[-_]?\d", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
@@ -544,7 +549,7 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        image-to-video 续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在
        _VIDEO_PATTERN 须显式；万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope
        （中转可能是 OpenAI 兼容）：qwen-image / wan2.7-image / wan-2.7-image / wan3.0-video-image
-       及带版本/日期后缀的同类 id 落到既有图像家族推断；wan-3-turbo-image-to-video /
+       及带版本/日期后缀的同类 id 落到图像家族推断；wan-3-turbo-image-to-video /
        wan3-image2video 这类显式 image-to-video 续接语法仍归视频（同 2.5 节 kling-image2video
        的处理原则），按 classify_wan_model 的 is_image_to_video 精确挑出这一种形态，不对图像变体
        的命名形态（结尾 token 等）做任何假设。原生路由只认 2.7（含点号形态 "wan2.x"，见下方
@@ -619,11 +624,17 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
     # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 与 h3 均不被 _VIDEO_PATTERN 覆盖，
     # image-01 含 "image" 否则会被通用图像家族抢走。匹配 "minimax-h3" 而非裸 "h3"——后者过短，
-    # 容易撞上其它厂商恰好含 h3 子串的型号 id。裸 "s2v" 排除含 wan 子串的 id（如未落原生路由的
-    # "wan2.7-s2v"、家族边界未满足的 "wan-2.2-s2v"，本后端均未实现该模态请求构造）：这类 id 应落
-    # 下方 5) 的通用视频端点，而非被误吞成 MiniMax S2V 协议——用 contains_wan_token 而非
-    # is_wan_family 做门槛，理由同上方 wan_image_variant/wan_video_continuation 的排除范围说明。
-    if "hailuo" in lowered or ("s2v" in lowered and not contains_wan_token) or "minimax-h3" in lowered:
+    # 容易撞上其它厂商恰好含 h3 子串的型号 id。裸 "s2v" 排除含 wan 版本号 token 的 id（如未落原生
+    # 路由的 "wan2.7-s2v"、家族边界未满足的 "wan-2.2-s2v"，本后端均未实现该模态请求构造）：这类 id
+    # 应落下方 5) 的通用视频端点，而非被误吞成 MiniMax S2V 协议——用 _WAN_VERSION_TOKEN_PATTERN
+    # 而非 contains_wan_token/is_wan_family 做门槛：前者会把 "minimax-s2v-swan" 这类只是恰好含
+    # "swan" 子串的 MiniMax id 误判成 wan 家族而错过 MiniMax 路由，后者的严格边界又会漏判
+    # "wan-2.2-s2v" 一类版本号相邻但未满足家族边界的 id。
+    if (
+        "hailuo" in lowered
+        or ("s2v" in lowered and not _WAN_VERSION_TOKEN_PATTERN.search(lowered))
+        or "minimax-h3" in lowered
+    ):
         return "minimax-video"
     if "image-01" in lowered:
         return "minimax-image"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -537,6 +537,10 @@ _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNOREC
 # 出现新形态再补，不预先扩面。
 _WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.IGNORECASE)
 
+# 点号形态万相 2.x（2.7 以外，如 "wan2.1-kf2v"）的家族判定：标识符边界要求非字母数字，避免
+# "swan2.7-r2v"、"vendorwan2.7-t2v" 这类含 "wan2." 子串但并非该家族的第三方型号名被误判。
+_WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.IGNORECASE)
+
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """根据模型 id 与 discovery_format 推默认 endpoint（content-first）。
@@ -578,12 +582,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 本后端却被当通用型号丢失能力声明"的矛盾。wan3 分支额外与 duration_presets.WAN3_PATTERN
     # 共用同一常量，保持时长档位推断口径一致。
     #
-    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用字面量子串判定："wan2." 命中即算
-    # 万相家族，不要求版本号是 2.7。本后端固定请求 video-generation/video-synthesis 端点，与万相
-    # 2.1/2.2 实际使用的旧端点及不同 payload 字段不符（出处见 DashScopeVideoBackend 模块顶部
-    # WAN2_PATTERN 处的说明）；是否收窄该字面量判定需要供应商 API 事实与产品判断，不由本函数
-    # 代为决定。
-    is_wan_family = bool(WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id) or "wan2." in lowered)
+    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用 _WAN_DOT_FORM_PATTERN 判定：命中
+    # "wan2.<digit>" 即算万相家族，不要求版本号是 2.7。本后端固定请求
+    # video-generation/video-synthesis 端点，与万相 2.1/2.2 实际使用的旧端点及不同 payload 字段
+    # 不符（出处见 DashScopeVideoBackend 模块顶部 WAN2_PATTERN 处的说明）；是否收窄该判定需要
+    # 供应商 API 事实与产品判断，不由本函数代为决定。
+    is_wan_family = bool(
+        WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id) or _WAN_DOT_FORM_PATTERN.search(model_id)
+    )
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
     # 变体。反过来"以 image 结尾才算图像变体"同样错——wan3.0-image-edit / wan-3-turbo-image-preview /

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -604,8 +604,10 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
     # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 与 h3 均不被 _VIDEO_PATTERN 覆盖，
     # image-01 含 "image" 否则会被通用图像家族抢走。匹配 "minimax-h3" 而非裸 "h3"——后者过短，
-    # 容易撞上其它厂商恰好含 h3 子串的型号 id。
-    if "hailuo" in lowered or "s2v" in lowered or "minimax-h3" in lowered:
+    # 容易撞上其它厂商恰好含 h3 子串的型号 id。裸 "s2v" 排除 wan 家族 id（如未落原生路由的
+    # "wan2.7-s2v"，本后端未实现该模态请求构造）：这类 id 应落下方 5) 的通用视频端点，而非被误吞
+    # 成 MiniMax S2V 协议。
+    if "hailuo" in lowered or ("s2v" in lowered and not is_wan_family) or "minimax-h3" in lowered:
         return "minimax-video"
     if "image-01" in lowered:
         return "minimax-image"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -33,7 +33,7 @@ from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoCapabilities
-from lib.video_backends.dashscope import DashScopeVideoBackend
+from lib.video_backends.dashscope import WAN2_PATTERN, DashScopeVideoBackend
 from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.minimax import MiniMaxVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
@@ -545,13 +545,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
-    1) 阿里百炼视频 → happyhorse / wan2.x / 万相 3 家族（含 wan-3-xxx 连字符形态、image-to-video
-       续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在 _VIDEO_PATTERN 须显式；
-       万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope（中转可能是 OpenAI
-       兼容）：qwen-image / wan2.7-image / wan3.0-video-image 及带版本/日期后缀的同类 id 落到既有
-       图像家族推断；wan-3-turbo-image-to-video / wan3-image2video 这类显式 image-to-video 续接
-       语法仍归视频（同 2.5 节 kling-image2video 的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确
-       挑出这一种形态，不对图像变体的命名形态（结尾 token 等）做任何假设。
+    1) 阿里百炼视频 → happyhorse / wan2 / wan3 家族（含 wan-2.7-xxx / wan-3-xxx 连字符形态、
+       image-to-video 续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在
+       _VIDEO_PATTERN 须显式；万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope
+       （中转可能是 OpenAI 兼容）：qwen-image / wan2.7-image / wan-2.7-image / wan3.0-video-image
+       及带版本/日期后缀的同类 id 落到既有图像家族推断；wan-3-turbo-image-to-video /
+       wan3-image2video 这类显式 image-to-video 续接语法仍归视频（同 2.5 节 kling-image2video
+       的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确挑出这一种形态，不对图像变体的命名形态
+       （结尾 token 等）做任何假设。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -569,13 +570,12 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
     # 走百炼原生端点的万相家族 id（视频与图像变体都命中），下面路由与 is_video 排除各用一次。
-    # wan3 分支复用 duration_presets.WAN3_PATTERN（源出 video_backends.dashscope，连字符可选、
-    # 不锚版本号），与时长档位推断、DashScopeVideoBackend 的请求形态分派保持同一匹配宽度，
-    # 否则同一 model_id 会出现"档位按 wan3 给、路由却按普通 wan 走"或"路由到本后端却被当
-    # 通用型号丢失能力声明"的矛盾。
-    # wan2 保留字面量：连字符形态的 wan2 在时长推断走通用 wan 预设、路由走 openai-video，
-    # 两处结论自洽，无须并入正则。
-    is_wan_family = "wan2." in lowered or bool(WAN3_PATTERN.search(model_id))
+    # WAN2_PATTERN / WAN3_PATTERN 均源出 video_backends.dashscope（连字符/下划线可选、不锚
+    # 版本号、两侧标识符边界避免误吞 "swan2"/"wan20" 一类第三方型号名），与
+    # DashScopeVideoBackend 的请求形态分派保持同一匹配宽度，否则同一 model_id 会出现"路由到
+    # 本后端却被当通用型号丢失能力声明"的矛盾。wan3 分支额外与 duration_presets.WAN3_PATTERN
+    # 共用同一常量，保持时长档位推断口径一致。
+    is_wan_family = bool(WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id))
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
     # 变体。反过来"以 image 结尾才算图像变体"同样错——wan3.0-image-edit / wan-3-turbo-image-preview /

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -541,6 +541,12 @@ _WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.IGN
 # "swan2.7-r2v"、"vendorwan2.7-t2v" 这类含 "wan2." 子串但并非该家族的第三方型号名被误判。
 _WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.IGNORECASE)
 
+# wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
+# 万相家族内真实存在的独立模态，但 DashScopeVideoBackend 只实现了 t2v/i2v/r2v 三档的请求构造，
+# 没有该模态所需的输入视频传输字段。命中家族正则但落这个模态的 id 须排除出原生路由，否则会带着
+# _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。
+_WAN_VIDEOEDIT_PATTERN = re.compile(r"video[-_]?edit", re.IGNORECASE)
+
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """根据模型 id 与 discovery_format 推默认 endpoint（content-first）。
@@ -558,7 +564,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确挑出这一种形态，不对图像变体的命名形态
        （结尾 token 等）做任何假设。原生路由只认 2.7（含点号形态 "wan2.x"，见下方 is_wan_family
        的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v 等）落到下方 5) 的通用
-       视频端点。
+       视频端点。2.7 家族内 videoedit 模态（wan2.7-videoedit）本后端未实现请求构造，同样排除出
+       原生路由（见 _WAN_VIDEOEDIT_PATTERN 处的说明）。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -598,11 +605,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 含 image 语义一律按图像变体处理，不对图像变体的命名形态做任何假设。
     wan_video_continuation = is_wan_family and bool(_WAN_IMAGE_TO_VIDEO_PATTERN.search(model_id))
     wan_image_variant = is_wan_family and is_image and not wan_video_continuation
+    # videoedit 模态本后端未实现请求构造，即便命中家族正则也不走原生端点（见
+    # _WAN_VIDEOEDIT_PATTERN 处的说明），落到下方 5) 的通用视频端点。
+    wan_unsupported_modality = is_wan_family and bool(_WAN_VIDEOEDIT_PATTERN.search(model_id))
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if "happyhorse" in lowered:
         return "dashscope-async-video"
-    if is_wan_family and not wan_image_variant:
+    if is_wan_family and not wan_image_variant and not wan_unsupported_modality:
         return "dashscope-async-video"
 
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -581,8 +581,15 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 带日期后缀的 wan3.0-video-image-20260801 这类真图像别名不以 "image" 结尾，会被误判成视频。
     # 故只把 image-to-video 续接语法（"image" 后紧跟 "to"/"2" 再接 "video"）当例外挑出来，其余
     # 含 image 语义一律按图像变体处理，不对图像变体的命名形态做任何假设。
+    #
+    # 该排除不能拿 is_wan_family（严格标识符边界）做门槛：_VIDEO_PATTERN 的 "wan" 分支本身无边界，
+    # "swan2.7-image" / "vendorwan2.7-image" 这类不满足家族边界的 id 依然会命中 _VIDEO_PATTERN，
+    # 若排除逻辑要求先通过严格家族判定，这类 id 就会被 is_video 误判为视频而不是落到图像家族推断。
+    # 因此排除只看"是否含 wan 子串"（与 _VIDEO_PATTERN 的宽度一致），不要求满足家族标识符边界；
+    # 家族边界只用于下面原生路由（dashscope-async-video）的资格判定。
+    contains_wan_token = "wan" in lowered
     wan_video_continuation = is_wan_family and classification.is_image_to_video
-    wan_image_variant = is_wan_family and is_image and not wan_video_continuation
+    wan_image_variant = contains_wan_token and is_image and not wan_video_continuation
     # videoedit 模态本后端未实现请求构造，即便命中家族正则也不走原生端点（见 classify_wan_model
     # 的 is_videoedit 处的说明），落到下方 5) 的通用视频端点。
     wan_unsupported_modality = is_wan_family and classification.is_videoedit

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -547,6 +547,12 @@ _WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.IGNORECASE)
 # _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。
 _WAN_VIDEOEDIT_PATTERN = re.compile(r"video[-_]?edit", re.IGNORECASE)
 
+# happyhorse 家族路由判定：标识符边界要求非字母数字，与 DashScopeVideoBackend._profile_for_model
+# 兜底子串匹配对同一 key 的边界要求保持一致——两处宽度不同会出现"路由到本后端却拿不到对应能力
+# 档"的矛盾（如 "myhappyhorse-1.0-r2v" 若只在能力档一侧排除，会被路由到原生端点却丢失
+# max_reference_images，_build_media 据此漏发参考图）。
+_HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse", re.IGNORECASE)
+
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """根据模型 id 与 discovery_format 推默认 endpoint（content-first）。
@@ -610,7 +616,7 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     wan_unsupported_modality = is_wan_family and bool(_WAN_VIDEOEDIT_PATTERN.search(model_id))
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
-    if "happyhorse" in lowered:
+    if _HAPPYHORSE_PATTERN.search(model_id):
         return "dashscope-async-video"
     if is_wan_family and not wan_image_variant and not wan_unsupported_modality:
         return "dashscope-async-video"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -590,9 +590,10 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     contains_wan_token = "wan" in lowered
     wan_video_continuation = is_wan_family and classification.is_image_to_video
     wan_image_variant = contains_wan_token and is_image and not wan_video_continuation
-    # videoedit 模态本后端未实现请求构造，即便命中家族正则也不走原生端点（见 classify_wan_model
-    # 的 is_videoedit 处的说明），落到下方 5) 的通用视频端点。
-    wan_unsupported_modality = is_wan_family and classification.is_videoedit
+    # 未实现请求构造的模态（wan2.7-videoedit / wan2.7-s2v / wan2.7-v2v 等）即便命中家族正则也不
+    # 走原生端点（见 classify_wan_model 的 has_known_modality 处的说明），落到下方 5) 的通用视频
+    # 端点，避免本后端收到无法正确构造的请求。
+    wan_unsupported_modality = is_wan_family and not classification.has_known_modality
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if classification.family == "happyhorse":

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -588,18 +588,21 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 因此排除只看"是否含 wan 子串"（与 _VIDEO_PATTERN 的宽度一致），不要求满足家族标识符边界；
     # 家族边界只用于下面原生路由（dashscope-async-video）的资格判定。
     contains_wan_token = "wan" in lowered
-    # wan2.7 已解析出已知 t2v/i2v/r2v profile（has_known_modality）时，该 profile 本身已确立视频
-    # 语义——即便 id 别处（如代理命名空间前缀 "image-proxy/wan-2.7-i2v"）另含无关 "image" 子串，
-    # 也不应被判成图像变体。不对 wan3 套用同一判定：wan3 只有单一 profile key，不区分 t2v/i2v/r2v
-    # 与 image-edit 等真图像别名，has_known_modality 对 wan3 恒真，会反过来误伤 wan3.0-image-edit
-    # 一类真图像别名（见上方注释）。
+    # wan2.7 家族已确认属于视频模态（t2v/i2v/r2v/s2v/v2v/videoedit 任一，即便部分未实现请求构造，
+    # 见 classify_wan_model 的 is_known_video_modality 处的说明）时，该 profile 本身已确立视频
+    # 语义——即便 id 别处（如代理命名空间前缀 "image-proxy/wan-2.7-s2v"）另含无关 "image" 子串，
+    # 也不应被判成图像变体。未落入任一已知模态 token 的其余命名（如 "wan2.7-image"）保守按图像
+    # 变体处理。不对 wan3 套用同一判定：wan3 只有单一 profile key，不区分 t2v/i2v/r2v/s2v 与
+    # image-edit 等真图像别名，套用同一判定会反过来误伤 wan3.0-image-edit 一类真图像别名（见上方
+    # 注释）。
     #
     # 该判定同样不能拿 is_wan_family 做门槛，理由与上面 wan_image_variant 的排除范围一致：
     # "wan-2.2-image-to-video" 一类不满足家族严格边界（连字符隔开 wan 与版本号）的 id，
     # classify_wan_model 仍会按标识符边界识别出其 image-to-video 续接语法（is_image_to_video），
     # 若在这里再要求先通过家族判定，这类显式 i2v 命名会被误判成图像变体。
     wan_video_continuation = contains_wan_token and (
-        classification.is_image_to_video or (classification.family == "wan2.7" and classification.has_known_modality)
+        classification.is_image_to_video
+        or (classification.family == "wan2.7" and classification.is_known_video_modality)
     )
     wan_image_variant = contains_wan_token and is_image and not wan_video_continuation
     # 未实现请求构造的模态（wan2.7-videoedit / wan2.7-s2v / wan2.7-v2v 等）即便命中家族正则也不

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -22,7 +22,6 @@ from lib.custom_provider.backends import (
     CustomTextBackend,
     CustomVideoBackend,
 )
-from lib.custom_provider.duration_presets import WAN3_PATTERN
 from lib.image_backends.base import ImageCapability
 from lib.image_backends.dashscope import DashScopeImageBackend
 from lib.image_backends.gemini import GeminiImageBackend
@@ -33,7 +32,7 @@ from lib.text_backends.gemini import GeminiTextBackend
 from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoCapabilities
-from lib.video_backends.dashscope import WAN2_PATTERN, DashScopeVideoBackend
+from lib.video_backends.dashscope import DashScopeVideoBackend, classify_wan_model
 from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.minimax import MiniMaxVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
@@ -532,26 +531,6 @@ _VIDEO_PATTERN = re.compile(
 _AUDIO_PATTERN = re.compile(r"tts|speech|cosyvoice", re.IGNORECASE)
 # 裸 "speech" 会撞上 ASR（语音转文字）家族 id，按内容排除，避免把识别模型默认归到 TTS 端点
 _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNORECASE)
-# wan 家族 image-to-video 续接语法："image" 紧跟 "to"/"2" 再接 "video"（wan-3-turbo-image-to-video /
-# wan3-image2video）。只挑这一种确定形态当"实为视频"的例外，不覆盖 img2vid/i2v 等未见实例的缩写——
-# 出现新形态再补，不预先扩面。
-_WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.IGNORECASE)
-
-# 点号形态万相 2.x（2.7 以外，如 "wan2.1-kf2v"）的家族判定：标识符边界要求非字母数字，避免
-# "swan2.7-r2v"、"vendorwan2.7-t2v" 这类含 "wan2." 子串但并非该家族的第三方型号名被误判。
-_WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.IGNORECASE)
-
-# wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
-# 万相家族内真实存在的独立模态，但 DashScopeVideoBackend 只实现了 t2v/i2v/r2v 三档的请求构造，
-# 没有该模态所需的输入视频传输字段。命中家族正则但落这个模态的 id 须排除出原生路由，否则会带着
-# _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。
-_WAN_VIDEOEDIT_PATTERN = re.compile(r"video[-_]?edit", re.IGNORECASE)
-
-# happyhorse 家族路由判定：标识符边界要求非字母数字，与 DashScopeVideoBackend._profile_for_model
-# 兜底子串匹配对同一 key 的边界要求保持一致——两处宽度不同会出现"路由到本后端却拿不到对应能力
-# 档"的矛盾（如 "myhappyhorse-1.0-r2v" 若只在能力档一侧排除，会被路由到原生端点却丢失
-# max_reference_images，_build_media 据此漏发参考图）。
-_HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:
@@ -567,11 +546,11 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        （中转可能是 OpenAI 兼容）：qwen-image / wan2.7-image / wan-2.7-image / wan3.0-video-image
        及带版本/日期后缀的同类 id 落到既有图像家族推断；wan-3-turbo-image-to-video /
        wan3-image2video 这类显式 image-to-video 续接语法仍归视频（同 2.5 节 kling-image2video
-       的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确挑出这一种形态，不对图像变体的命名形态
-       （结尾 token 等）做任何假设。原生路由只认 2.7（含点号形态 "wan2.x"，见下方 is_wan_family
-       的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v 等）落到下方 5) 的通用
-       视频端点。2.7 家族内 videoedit 模态（wan2.7-videoedit）本后端未实现请求构造，同样排除出
-       原生路由（见 _WAN_VIDEOEDIT_PATTERN 处的说明）。
+       的处理原则），按 classify_wan_model 的 is_image_to_video 精确挑出这一种形态，不对图像变体
+       的命名形态（结尾 token 等）做任何假设。原生路由只认 2.7（含点号形态 "wan2.x"，见下方
+       classify_wan_model 的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v 等）
+       落到下方 5) 的通用视频端点。2.7 家族内 videoedit 模态（wan2.7-videoedit）本后端未实现
+       请求构造，同样排除出原生路由（见 classify_wan_model 的 is_videoedit 处的说明）。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -588,35 +567,28 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     """
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
-    # 走百炼原生端点的万相家族 id（视频与图像变体都命中），下面路由与 is_video 排除各用一次。
-    # WAN2_PATTERN 只认 2.7（含连字符/下划线形态）、WAN3_PATTERN 不锚版本号，均源出
-    # video_backends.dashscope，两侧标识符边界避免误吞 "swan2"/"wan20" 一类第三方型号名，与
-    # DashScopeVideoBackend 的请求形态分派保持同一匹配宽度，否则同一 model_id 会出现"路由到
-    # 本后端却被当通用型号丢失能力声明"的矛盾。wan3 分支额外与 duration_presets.WAN3_PATTERN
-    # 共用同一常量，保持时长档位推断口径一致。
-    #
-    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用 _WAN_DOT_FORM_PATTERN 判定：命中
-    # "wan2.<digit>" 即算万相家族，不要求版本号是 2.7。本后端固定请求
-    # video-generation/video-synthesis 端点，与万相 2.1/2.2 实际使用的旧端点及不同 payload 字段
-    # 不符（出处见 DashScopeVideoBackend 模块顶部 WAN2_PATTERN 处的说明）；是否收窄该判定需要
-    # 供应商 API 事实与产品判断，不由本函数代为决定。
-    is_wan_family = bool(
-        WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id) or _WAN_DOT_FORM_PATTERN.search(model_id)
-    )
+    # 走百炼原生端点的万相/happyhorse 家族 id（视频与图像变体都命中），下面路由与 is_video 排除
+    # 各用一次。家族归属、分隔符归一化、标识符边界、image-to-video 续接语法、videoedit 模态排除
+    # 全部只在 classify_wan_model（lib.video_backends.dashscope）里判定一次，本函数与
+    # DashScopeVideoBackend._profile_for_model、duration_presets.infer_supported_durations 三处
+    # 只消费其结论，不再各自对 model_id 做正则匹配——避免三处宽度各自漂移，出现"路由到本后端却拿
+    # 不到对应能力档"一类互斥组合。
+    classification = classify_wan_model(model_id)
+    is_wan_family = classification.family is not None and classification.family != "happyhorse"
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
     # 变体。反过来"以 image 结尾才算图像变体"同样错——wan3.0-image-edit / wan-3-turbo-image-preview /
     # 带日期后缀的 wan3.0-video-image-20260801 这类真图像别名不以 "image" 结尾，会被误判成视频。
     # 故只把 image-to-video 续接语法（"image" 后紧跟 "to"/"2" 再接 "video"）当例外挑出来，其余
     # 含 image 语义一律按图像变体处理，不对图像变体的命名形态做任何假设。
-    wan_video_continuation = is_wan_family and bool(_WAN_IMAGE_TO_VIDEO_PATTERN.search(model_id))
+    wan_video_continuation = is_wan_family and classification.is_image_to_video
     wan_image_variant = is_wan_family and is_image and not wan_video_continuation
-    # videoedit 模态本后端未实现请求构造，即便命中家族正则也不走原生端点（见
-    # _WAN_VIDEOEDIT_PATTERN 处的说明），落到下方 5) 的通用视频端点。
-    wan_unsupported_modality = is_wan_family and bool(_WAN_VIDEOEDIT_PATTERN.search(model_id))
+    # videoedit 模态本后端未实现请求构造，即便命中家族正则也不走原生端点（见 classify_wan_model
+    # 的 is_videoedit 处的说明），落到下方 5) 的通用视频端点。
+    wan_unsupported_modality = is_wan_family and classification.is_videoedit
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
-    if _HAPPYHORSE_PATTERN.search(model_id):
+    if classification.family == "happyhorse":
         return "dashscope-async-video"
     if is_wan_family and not wan_image_variant and not wan_unsupported_modality:
         return "dashscope-async-video"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -593,7 +593,12 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 也不应被判成图像变体。不对 wan3 套用同一判定：wan3 只有单一 profile key，不区分 t2v/i2v/r2v
     # 与 image-edit 等真图像别名，has_known_modality 对 wan3 恒真，会反过来误伤 wan3.0-image-edit
     # 一类真图像别名（见上方注释）。
-    wan_video_continuation = is_wan_family and (
+    #
+    # 该判定同样不能拿 is_wan_family 做门槛，理由与上面 wan_image_variant 的排除范围一致：
+    # "wan-2.2-image-to-video" 一类不满足家族严格边界（连字符隔开 wan 与版本号）的 id，
+    # classify_wan_model 仍会按标识符边界识别出其 image-to-video 续接语法（is_image_to_video），
+    # 若在这里再要求先通过家族判定，这类显式 i2v 命名会被误判成图像变体。
+    wan_video_continuation = contains_wan_token and (
         classification.is_image_to_video or (classification.family == "wan2.7" and classification.has_known_modality)
     )
     wan_image_variant = contains_wan_token and is_image and not wan_video_continuation
@@ -611,10 +616,11 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # MiniMax 原生 token 二级路由：海螺（含 minimax-hailuo）/ S2V / H3 → 两步或单步取回的视频端点；
     # image-01 → 单步图像端点。先于通用 is_video/is_image：s2v 与 h3 均不被 _VIDEO_PATTERN 覆盖，
     # image-01 含 "image" 否则会被通用图像家族抢走。匹配 "minimax-h3" 而非裸 "h3"——后者过短，
-    # 容易撞上其它厂商恰好含 h3 子串的型号 id。裸 "s2v" 排除 wan 家族 id（如未落原生路由的
-    # "wan2.7-s2v"，本后端未实现该模态请求构造）：这类 id 应落下方 5) 的通用视频端点，而非被误吞
-    # 成 MiniMax S2V 协议。
-    if "hailuo" in lowered or ("s2v" in lowered and not is_wan_family) or "minimax-h3" in lowered:
+    # 容易撞上其它厂商恰好含 h3 子串的型号 id。裸 "s2v" 排除含 wan 子串的 id（如未落原生路由的
+    # "wan2.7-s2v"、家族边界未满足的 "wan-2.2-s2v"，本后端均未实现该模态请求构造）：这类 id 应落
+    # 下方 5) 的通用视频端点，而非被误吞成 MiniMax S2V 协议——用 contains_wan_token 而非
+    # is_wan_family 做门槛，理由同上方 wan_image_variant/wan_video_continuation 的排除范围说明。
+    if "hailuo" in lowered or ("s2v" in lowered and not contains_wan_token) or "minimax-h3" in lowered:
         return "minimax-video"
     if "image-01" in lowered:
         return "minimax-image"

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -531,11 +531,13 @@ _VIDEO_PATTERN = re.compile(
 _AUDIO_PATTERN = re.compile(r"tts|speech|cosyvoice", re.IGNORECASE)
 # 裸 "speech" 会撞上 ASR（语音转文字）家族 id，按内容排除，避免把识别模型默认归到 TTS 端点
 _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNORECASE)
-# wan 版本号 token："wan" 后紧跟（可选分隔符）数字，用于 MiniMax S2V 二级路由的排除判定：既要
-# 认出 "wan-2.2-s2v"/"vendorwan2.7-s2v" 一类版本号相邻 wan token（无需满足家族严格标识符边界），
-# 又要排除 "swan" 这类只是把 "wan" 作为普通单词一部分的无关子串——裸 "wan" in lowered 分不出这两
-# 者，会把恰好含 "swan" 的 MiniMax id 误判成 wan 家族而错过 MiniMax 路由。
-_WAN_VERSION_TOKEN_PATTERN = re.compile(r"wan[-_]?\d", re.IGNORECASE)
+# wan 版本号 token，用于 MiniMax S2V 二级路由的排除判定：既要认出 "wan-2.2-s2v"/
+# "vendorwan2.7-s2v" 一类版本号相邻 wan token（无需满足家族严格标识符边界），又要排除
+# "swan"/"swan2" 这类只是把 "wan" 作为普通单词一部分、后面恰好粘连数字的无关子串。两条分支：
+# "wan" 与数字间有显式分隔符（"wan-2"/"wan_2"，此时无论数字后是否带小数点均视为版本号，前缀
+# 是否字母粘连不影响判定，"vendorwan-2" 同样成立）；或 "wan" 与数字完全粘连但数字本身是带小数点
+# 的版本号形态（"wan2.7"）——粘连且数字不含小数点（"swan2"）两条分支都不命中，不会被误判成版本号。
+_WAN_VERSION_TOKEN_PATTERN = re.compile(r"wan[-_]\d|wan\d+\.\d+", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -545,14 +545,16 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
-    1) 阿里百炼视频 → happyhorse / wan2 / wan3 家族（含 wan-2.7-xxx / wan-3-xxx 连字符形态、
+    1) 阿里百炼视频 → happyhorse / wan2.7 / wan3 家族（含 wan-2.7-xxx / wan-3-xxx 连字符形态、
        image-to-video 续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在
        _VIDEO_PATTERN 须显式；万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope
        （中转可能是 OpenAI 兼容）：qwen-image / wan2.7-image / wan-2.7-image / wan3.0-video-image
        及带版本/日期后缀的同类 id 落到既有图像家族推断；wan-3-turbo-image-to-video /
        wan3-image2video 这类显式 image-to-video 续接语法仍归视频（同 2.5 节 kling-image2video
        的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确挑出这一种形态，不对图像变体的命名形态
-       （结尾 token 等）做任何假设。
+       （结尾 token 等）做任何假设。原生路由只认 2.7（含裸点号形态 "wan2.x" 的既有兼容例外，
+       见下方 is_wan_family 的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v
+       等）落到下方 5) 的通用视频端点。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -570,12 +572,18 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
     # 走百炼原生端点的万相家族 id（视频与图像变体都命中），下面路由与 is_video 排除各用一次。
-    # WAN2_PATTERN / WAN3_PATTERN 均源出 video_backends.dashscope（连字符/下划线可选、不锚
-    # 版本号、两侧标识符边界避免误吞 "swan2"/"wan20" 一类第三方型号名），与
+    # WAN2_PATTERN 只认 2.7（含连字符/下划线形态）、WAN3_PATTERN 不锚版本号，均源出
+    # video_backends.dashscope，两侧标识符边界避免误吞 "swan2"/"wan20" 一类第三方型号名，与
     # DashScopeVideoBackend 的请求形态分派保持同一匹配宽度，否则同一 model_id 会出现"路由到
     # 本后端却被当通用型号丢失能力声明"的矛盾。wan3 分支额外与 duration_presets.WAN3_PATTERN
     # 共用同一常量，保持时长档位推断口径一致。
-    is_wan_family = bool(WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id))
+    #
+    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用字面量子串判定，是本正则收窄到
+    # 2.7 之前就存在的既有行为：本后端固定请求 video-generation/video-synthesis 端点，与万相
+    # 2.1/2.2 实际使用的旧端点及不同 payload 字段不符（出处见 DashScopeVideoBackend 模块顶部
+    # WAN2_PATTERN 处的说明），继续路由到这里对这些点号形态而言不是新问题——是否收窄需要供应商
+    # API 事实与产品判断，留给人工评估，不在此处顺带处理，避免把未经核实的猜测定型为代码逻辑。
+    is_wan_family = bool(WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id) or "wan2." in lowered)
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像
     # 变体。反过来"以 image 结尾才算图像变体"同样错——wan3.0-image-edit / wan-3-turbo-image-preview /

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -588,7 +588,14 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 因此排除只看"是否含 wan 子串"（与 _VIDEO_PATTERN 的宽度一致），不要求满足家族标识符边界；
     # 家族边界只用于下面原生路由（dashscope-async-video）的资格判定。
     contains_wan_token = "wan" in lowered
-    wan_video_continuation = is_wan_family and classification.is_image_to_video
+    # wan2.7 已解析出已知 t2v/i2v/r2v profile（has_known_modality）时，该 profile 本身已确立视频
+    # 语义——即便 id 别处（如代理命名空间前缀 "image-proxy/wan-2.7-i2v"）另含无关 "image" 子串，
+    # 也不应被判成图像变体。不对 wan3 套用同一判定：wan3 只有单一 profile key，不区分 t2v/i2v/r2v
+    # 与 image-edit 等真图像别名，has_known_modality 对 wan3 恒真，会反过来误伤 wan3.0-image-edit
+    # 一类真图像别名（见上方注释）。
+    wan_video_continuation = is_wan_family and (
+        classification.is_image_to_video or (classification.family == "wan2.7" and classification.has_known_modality)
+    )
     wan_image_variant = contains_wan_token and is_image and not wan_video_continuation
     # 未实现请求构造的模态（wan2.7-videoedit / wan2.7-s2v / wan2.7-v2v 等）即便命中家族正则也不
     # 走原生端点（见 classify_wan_model 的 has_known_modality 处的说明），落到下方 5) 的通用视频

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -532,12 +532,14 @@ _AUDIO_PATTERN = re.compile(r"tts|speech|cosyvoice", re.IGNORECASE)
 # 裸 "speech" 会撞上 ASR（语音转文字）家族 id，按内容排除，避免把识别模型默认归到 TTS 端点
 _ASR_PATTERN = re.compile(r"transcribe|speech.?to.?text|recognition", re.IGNORECASE)
 # wan 版本号 token，用于 MiniMax S2V 二级路由的排除判定：既要认出 "wan-2.2-s2v"/
-# "vendorwan2.7-s2v" 一类版本号相邻 wan token（无需满足家族严格标识符边界），又要排除
-# "swan"/"swan2" 这类只是把 "wan" 作为普通单词一部分、后面恰好粘连数字的无关子串。两条分支：
+# "vendorwan2.7-s2v"/"wan2-s2v" 一类版本号相邻 wan token（无需满足家族严格标识符边界），又要排除
+# "swan"/"swan2" 这类只是把 "wan" 作为普通单词一部分、后面恰好粘连数字的无关子串。三条分支：
 # "wan" 与数字间有显式分隔符（"wan-2"/"wan_2"，此时无论数字后是否带小数点均视为版本号，前缀
 # 是否字母粘连不影响判定，"vendorwan-2" 同样成立）；或 "wan" 与数字完全粘连但数字本身是带小数点
-# 的版本号形态（"wan2.7"）——粘连且数字不含小数点（"swan2"）两条分支都不命中，不会被误判成版本号。
-_WAN_VERSION_TOKEN_PATTERN = re.compile(r"wan[-_]\d|wan\d+\.\d+", re.IGNORECASE)
+# 的版本号形态（"wan2.7"，前缀字母粘连不影响判定，与上一分支同理）；或 "wan" 与数字完全粘连、
+# 数字不含小数点，但 "wan" 前须满足标识符左边界（"wan2"，"swan2" 因左边界不成立被拒）——粘连纯
+# 整数版本号没有小数点这一结构信号可用，只能靠左边界区分真实 wan token 与恰好粘连数字的无关单词。
+_WAN_VERSION_TOKEN_PATTERN = re.compile(r"wan[-_]\d|wan\d+\.\d+|(?<![a-z0-9])wan\d+(?![a-z0-9])", re.IGNORECASE)
 
 
 def infer_endpoint(model_id: str, discovery_format: str) -> str:

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -552,9 +552,9 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        及带版本/日期后缀的同类 id 落到既有图像家族推断；wan-3-turbo-image-to-video /
        wan3-image2video 这类显式 image-to-video 续接语法仍归视频（同 2.5 节 kling-image2video
        的处理原则），按 _WAN_IMAGE_TO_VIDEO_PATTERN 精确挑出这一种形态，不对图像变体的命名形态
-       （结尾 token 等）做任何假设。原生路由只认 2.7（含裸点号形态 "wan2.x" 的既有兼容例外，
-       见下方 is_wan_family 的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v
-       等）落到下方 5) 的通用视频端点。
+       （结尾 token 等）做任何假设。原生路由只认 2.7（含点号形态 "wan2.x"，见下方 is_wan_family
+       的说明）与 wan3；其余 2.x 连字符/下划线形态（wan-2.1、wan_2.2-s2v 等）落到下方 5) 的通用
+       视频端点。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
     2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
@@ -578,11 +578,11 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 本后端却被当通用型号丢失能力声明"的矛盾。wan3 分支额外与 duration_presets.WAN3_PATTERN
     # 共用同一常量，保持时长档位推断口径一致。
     #
-    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用字面量子串判定，是本正则收窄到
-    # 2.7 之前就存在的既有行为：本后端固定请求 video-generation/video-synthesis 端点，与万相
+    # 点号形态的其余 2.x（"wan2.1-kf2v"、"wan2.2-s2v"）额外用字面量子串判定："wan2." 命中即算
+    # 万相家族，不要求版本号是 2.7。本后端固定请求 video-generation/video-synthesis 端点，与万相
     # 2.1/2.2 实际使用的旧端点及不同 payload 字段不符（出处见 DashScopeVideoBackend 模块顶部
-    # WAN2_PATTERN 处的说明），继续路由到这里对这些点号形态而言不是新问题——是否收窄需要供应商
-    # API 事实与产品判断，留给人工评估，不在此处顺带处理，避免把未经核实的猜测定型为代码逻辑。
+    # WAN2_PATTERN 处的说明）；是否收窄该字面量判定需要供应商 API 事实与产品判断，不由本函数
+    # 代为决定。
     is_wan_family = bool(WAN2_PATTERN.search(model_id) or WAN3_PATTERN.search(model_id) or "wan2." in lowered)
     # wan 家族的 image-to-video 别名（如 wan-3-turbo-image-to-video / wan3-image2video）含 "image"
     # 子串但本质是视频模型，与下方 kling-image2video 同类陷阱：笼统 is_image 会把它们错判成图像

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import httpx
 
@@ -123,31 +125,93 @@ _WAN3_MODEL_KEY = "wan3.0-video"
 # 也是 lib.custom_provider.duration_presets（时长档位推断）与 endpoints.py（端点路由推断）共用
 # 的唯一正则来源——三处须按同一匹配宽度判 wan3，否则会出现某个 model_id 被路由到本后端、却因
 # 本后端认不出它是 wan3 而退回通用档案（丢参考图/尾帧/音轨参数）的矛盾。版本前缀与模态 token
-# （下方 _WAN_IMAGE_TO_VIDEO_PATTERN）须接受相同的分隔符集合，避免同一规则组内宽容度不对称。
+# （下方 WAN_IMAGE_TO_VIDEO_PATTERN）须接受相同的分隔符集合，避免同一规则组内宽容度不对称。
 # 两侧标识符边界要求非字母数字，避免匹配到 "swan3"、"vendorwan3" 这类含 wan3 子串但并非该家族
 # 的第三方型号名。
 WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 
 # 万相 2.7 家族 model_id 识别（连字符/下划线可选、标识符边界避免误吞 "swan2"、"wan20"）：
-# endpoints.py::is_wan_family 复用同一正则，使连字符形态（"wan-2.7"）与点号形态（"wan2.7"）
-# 在图像/视频归属与端点路由上得出一致结论——这是本正则唯一确权的范围。
+# 使连字符形态（"wan-2.7"）与点号形态（"wan2.7"）在图像/视频归属与端点路由上得出一致结论——
+# 这是本正则唯一确权的范围。
 #
 # 只锚 2.7、不覆盖其余 2.x 小版本：本后端固定请求
 # `/services/aigc/video-generation/video-synthesis`（_VIDEO_ENDPOINT），而 wan2.1 / wan2.2-s2v
 # 按 docs/research/arcreel-video-api-protocol-research.md 记录走的是旧端点
 # `/services/aigc/image2video/video-synthesis/`、payload 字段也不同（如 wan2.6 用 `size` 而非
 # 2.7 的 `resolution`+`ratio`），并入本正则会把协议不兼容的请求送到这个端点。
-# 点号形态（如 "wan2.1-kf2v"）不受本正则约束；endpoints.py::is_wan_family 对点号形态另有独立的
-# 判定（_WAN_DOT_FORM_PATTERN），其路由是否也应收窄到 2.7 需要供应商 API 事实与产品判断，不由
-# 本正则的匹配宽度代为决定。
+# 点号形态（如 "wan2.1-kf2v"）不受本正则约束，归 WAN_DOT_FORM_PATTERN 判定，其路由是否也应
+# 收窄到 2.7 需要供应商 API 事实与产品判断，不由本正则的匹配宽度代为决定。
 WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
 
-# wan2.7 的 image-to-video 续接别名（"wan-2.7-image-to-video" / "wan_2.7-image2video"）在归一化
-# 后仍带着 "image-to-video"/"image2video" 后缀，不与 _MODEL_PROFILES 的 "wan2.7-i2v" 构成子串
-# 关系，需先把该后缀折成 "i2v" 再查表，否则静默落 _DEFAULT_PROFILE、丢失 first_frame 声明，
-# _build_media 据此不下发 start_image。正则形状与 endpoints.py::_WAN_IMAGE_TO_VIDEO_PATTERN
-# 一致（该文件属上层 custom_provider，不可反向导入，故各自维护同一份字面量）。
-_WAN27_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.I)
+# 点号形态万相 2.x（2.7 以外，如 "wan2.1-kf2v"）的家族判定：标识符边界要求非字母数字，避免
+# "swan2.7-r2v"、"vendorwan2.7-t2v" 这类含 "wan2." 子串但并非该家族的第三方型号名被误判。
+WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.I)
+
+# happyhorse 家族判定：标识符边界要求非字母数字，避免 "myhappyhorse-1.0-r2v" 这类第三方型号名
+# 被字面子串误吞。
+HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse", re.I)
+
+# wan 家族 image-to-video 续接语法（"wan-2.7-image-to-video" / "wan_2.7-image2video" /
+# "wan-3-turbo-image-to-video"）：只挑这一种确定形态当"实为视频"的例外，不覆盖 img2vid/i2v 等
+# 未见实例的缩写——出现新形态再补，不预先扩面。wan2.7 归一化用它把该后缀折成 "i2v" 再查
+# _MODEL_PROFILES；wan3/wan2x_dot 家族用它区分图像/视频归属（wan3.0-video-image 等真图像别名
+# 不含该语法，不受影响）。
+WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.I)
+
+# wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
+# 万相家族内真实存在的独立模态，但本后端只实现了 t2v/i2v/r2v 三档的请求构造，没有该模态所需的
+# 输入视频传输字段。命中家族正则但落这个模态的 id 须排除出原生路由与已知能力档，否则会带着
+# _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。
+WAN_VIDEOEDIT_PATTERN = re.compile(r"video[-_]?edit", re.I)
+
+WanFamily = Literal["happyhorse", "wan2.7", "wan3", "wan2x_dot"]
+
+
+@dataclass(frozen=True)
+class WanClassification:
+    """model_id 在万相/happyhorse 家族判定链上的结构化结论。
+
+    唯一判定入口——家族归属、分隔符归一化、标识符边界、image-to-video 续接语法、videoedit
+    模态排除均只在 `classify_wan_model` 里实现一次。端点路由（endpoints.py::infer_endpoint）、
+    能力档（本模块 `_profile_for_model`）、时长档（duration_presets.py）三处判定点都只消费这份
+    结论，不得再各自对 model_id 做正则匹配，避免同一家族的边界规则在多处漂移出互斥组合（例如
+    命中原生路由却拿到与该路由不兼容的能力档）。
+    """
+
+    family: WanFamily | None
+    is_image_to_video: bool  # wan 系列 image-to-video 续接别名（本质视频，非图像变体）
+    is_videoedit: bool  # wan2.7-videoedit：本后端未实现请求构造的模态
+    profile_key: str | None  # 可直接查 _MODEL_PROFILES 的归一化 key；无法确定具体模态时为 None
+
+
+def classify_wan_model(model_id: str | None) -> WanClassification:
+    """对 model_id 做一次判定，供路由/能力档/时长档复用同一结论。"""
+    normalized = (model_id or "").strip().lower()
+    if HAPPYHORSE_PATTERN.search(normalized):
+        # happyhorse 无 image-to-video 续接语法与 videoedit 模态；t2v/i2v/r2v 具体档位交由
+        # _profile_for_model 末尾的兜底子串匹配解析，此处不预先归一化。
+        return WanClassification(family="happyhorse", is_image_to_video=False, is_videoedit=False, profile_key=None)
+    if WAN3_PATTERN.search(normalized):
+        family: WanFamily = "wan3"
+    elif WAN2_PATTERN.search(normalized):
+        family = "wan2.7"
+    elif WAN_DOT_FORM_PATTERN.search(normalized):
+        family = "wan2x_dot"
+    else:
+        return WanClassification(family=None, is_image_to_video=False, is_videoedit=False, profile_key=None)
+
+    is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
+    is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
+    profile_key: str | None = None
+    if family == "wan3":
+        profile_key = _WAN3_MODEL_KEY
+    elif family == "wan2.7":
+        profile_key = _normalize_wan27_alias(normalized)
+    # wan2x_dot 无法从 model_id 直接归一化出确切 t2v/i2v/r2v 档位（其命名形态未收敛），
+    # profile_key 留空，交由 _profile_for_model 末尾的兜底子串匹配处理（多数落 _DEFAULT_PROFILE）。
+    return WanClassification(
+        family=family, is_image_to_video=is_image_to_video, is_videoedit=is_videoedit, profile_key=profile_key
+    )
 
 
 def _normalize_wan27_alias(normalized: str) -> str:
@@ -161,7 +225,7 @@ def _normalize_wan27_alias(normalized: str) -> str:
     """
     normalized = WAN2_PATTERN.sub("wan2.7", normalized)
     normalized = re.sub(r"wan2\.7_", "wan2.7-", normalized)
-    return _WAN27_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
+    return WAN_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
 
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
@@ -217,7 +281,7 @@ def _is_wan3(model: str | None) -> bool:
 def _profile_for_model(model: str | None) -> VideoCapabilities:
     """按 model_id 解析能力档：先精确命中，再容忍代理中转的前后缀装饰。
 
-    infer_endpoint 用 WAN2_PATTERN / WAN3_PATTERN 路由到 dashscope-async-video，故此处也须
+    infer_endpoint 用 classify_wan_model 的同一结论路由到 dashscope-async-video，故此处也须
     子串容忍，否则 "proxy/happyhorse-1.0-r2v" / "wan2.7-r2v-0715" 这类装饰名会退回 _DEFAULT_PROFILE、
     丢掉 r2v 的 max_reference_images，_build_media 据此构造出错误 payload。
     仅带系列名而无变体后缀（如裸 "happyhorse"）无法判别 t2v/i2v/r2v，按设计回落通用默认。
@@ -228,21 +292,15 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
         return _DEFAULT_PROFILE
     if normalized in _MODEL_PROFILES:
         return _MODEL_PROFILES[normalized]
-    # wan3 家族按 WAN3_PATTERN 先行判定（先于下方子串匹配）：discovery 返回的 "wan-3-turbo" /
-    # "wan3-turbo" 这类别名不含字面量 "wan3.0-video" 子串，若只靠子串匹配会静默落到
-    # _DEFAULT_PROFILE，丢失参考图/尾帧/音轨参数等 wan3 专属能力声明。
-    if WAN3_PATTERN.search(normalized):
-        return _MODEL_PROFILES[_WAN3_MODEL_KEY]
-    # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，改走 _normalize_wan27_alias
-    # 把 wan 前缀、版本号与模态之间的分隔符都折成 _MODEL_PROFILES key 固定使用的连字符形态，
-    # 再走下方子串匹配。
-    if WAN2_PATTERN.search(normalized):
-        normalized = _normalize_wan27_alias(normalized)
-    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义。
-    # 两侧标识符边界均要求非字母数字：左侧避免 "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、
-    # "myhappyhorse-1.0-r2v" 这类第三方型号名被字面子串误吞；右侧避免 "wan2.7-i2vfoo"、
-    # "happyhorse-1.0-r2vfoo" 这类未知变体后缀被截断误判成已知 key。代理中转的装饰
-    # 前缀/后缀（"proxy/xxx"、"xxx-0715"）靠非字母数字分隔符天然满足两侧边界，不受影响。
+    classification = classify_wan_model(normalized)
+    if classification.profile_key is not None:
+        normalized = classification.profile_key
+    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v} /
+    # wan3.0-video）互不为子串，无歧义。两侧标识符边界均要求非字母数字：左侧避免
+    # "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、"myhappyhorse-1.0-r2v" 这类第三方型号名被字面
+    # 子串误吞；右侧避免 "wan2.7-i2vfoo"、"happyhorse-1.0-r2vfoo" 这类未知变体后缀被截断误判成
+    # 已知 key。代理中转的装饰前缀/后缀（"proxy/xxx"、"xxx-0715"）靠非字母数字分隔符天然满足
+    # 两侧边界，不受影响。
     for known, profile in _MODEL_PROFILES.items():
         if re.search(r"(?<![a-z0-9])" + re.escape(known) + r"(?![a-z0-9])", normalized):
             return profile

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -152,11 +153,10 @@ WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d+(?![a-z0-9])", re.I)
 HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse(?![a-z0-9])", re.I)
 
 # wan 家族 image-to-video 续接语法（"wan-2.7-image-to-video" / "wan_2.7-image2video" /
-# "wan-3-turbo-image-to-video"）：只挑这一种确定形态当"实为视频"的例外，不覆盖 img2vid/i2v 等
-# 未见实例的缩写——出现新形态再补，不预先扩面。wan2.7 归一化用它把该后缀折成 "i2v" 再查
-# _MODEL_PROFILES；wan3/wan2x_dot 家族用它区分图像/视频归属（wan3.0-video-image 等真图像别名
-# 不含该语法，不受影响）。两侧标识符边界避免 "wan2.7-fooimage-to-video" /
-# "wan2.7-image-to-videofoo" 这类相邻字母被误判命中。
+# "wan-3-turbo-image-to-video"）：只识别 "image-(to|2)-video" 这一种确定拼写，不识别 img2vid/i2v
+# 等其他缩写。wan2.7 归一化用它把该后缀折成 "i2v" 再查 _MODEL_PROFILES；wan3/wan2x_dot 家族用它
+# 区分图像/视频归属（wan3.0-video-image 等真图像别名不含该语法，不受影响）。两侧标识符边界避免
+# "wan2.7-fooimage-to-video" / "wan2.7-image-to-videofoo" 这类相邻字母被误判命中。
 WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"(?<![a-z0-9])image[-_]?(?:to|2)[-_]?video(?![a-z0-9])", re.I)
 
 # wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
@@ -172,8 +172,8 @@ WanFamily = Literal["happyhorse", "wan2.7", "wan3", "wan2x_dot"]
 class WanClassification:
     """model_id 在万相/happyhorse 家族判定链上的结构化结论。
 
-    唯一判定入口——家族归属、分隔符归一化、标识符边界、image-to-video 续接语法、videoedit
-    模态排除均只在 `classify_wan_model` 里实现一次。端点路由（endpoints.py::infer_endpoint）、
+    唯一判定入口——家族归属、分隔符归一化、标识符边界、image-to-video 续接语法、未实现模态排除
+    均只在 `classify_wan_model` 里实现一次。端点路由（endpoints.py::infer_endpoint）、
     能力档（本模块 `_profile_for_model`）、时长档（duration_presets.py）三处判定点都只消费这份
     结论，不得再各自对 model_id 做正则匹配，避免同一家族的边界规则在多处漂移出互斥组合（例如
     命中原生路由却拿到与该路由不兼容的能力档）。
@@ -183,6 +183,12 @@ class WanClassification:
     is_image_to_video: bool  # wan 系列 image-to-video 续接别名（本质视频，非图像变体）
     is_videoedit: bool  # wan2.7-videoedit：本后端未实现请求构造的模态
     profile_key: str | None  # 可直接查 _MODEL_PROFILES 的归一化 key；无法确定具体模态时为 None
+    # wan2.7 家族是否解析出本后端已实现请求构造的具体模态（t2v/i2v/r2v）。wan2.7-s2v /
+    # wan2.7-v2v / wan2.7-videoedit 等命中家族正则但模态未实现，须与已实现模态区分对待——两者混同
+    # 会让请求体缺字段的模态被静默送去本后端无法正确处理的端点。wan3/happyhorse/wan2x_dot 恒为
+    # True：wan3 单模型覆盖全部模态、happyhorse 与 wan2x_dot 的模态收窄不由本字段判定（前者未见
+    # 需要排除的模态，后者见 profile_key 处的说明）。
+    has_known_modality: bool
 
 
 def classify_wan_model(model_id: str | None) -> WanClassification:
@@ -191,7 +197,9 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     if HAPPYHORSE_PATTERN.search(normalized):
         # happyhorse 无 image-to-video 续接语法与 videoedit 模态；t2v/i2v/r2v 具体档位交由
         # _profile_for_model 末尾的兜底子串匹配解析，此处不预先归一化。
-        return WanClassification(family="happyhorse", is_image_to_video=False, is_videoedit=False, profile_key=None)
+        return WanClassification(
+            family="happyhorse", is_image_to_video=False, is_videoedit=False, profile_key=None, has_known_modality=True
+        )
     if WAN3_PATTERN.search(normalized):
         family: WanFamily = "wan3"
     elif WAN2_PATTERN.search(normalized):
@@ -199,7 +207,9 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     elif WAN_DOT_FORM_PATTERN.search(normalized):
         family = "wan2x_dot"
     else:
-        return WanClassification(family=None, is_image_to_video=False, is_videoedit=False, profile_key=None)
+        return WanClassification(
+            family=None, is_image_to_video=False, is_videoedit=False, profile_key=None, has_known_modality=True
+        )
 
     # videoedit 是 wan2.7 家族内独有的模态（见 WAN_VIDEOEDIT_PATTERN 处的说明）；wan3/wan2x_dot
     # 不受它约束，否则形如 "proxy-videoedit/wan3-turbo" 这类与 videoedit 无关的装饰前缀会被误吞，
@@ -207,14 +217,27 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     is_videoedit = family == "wan2.7" and bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
     is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
     profile_key: str | None = None
+    has_known_modality = True
     if family == "wan3":
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
         profile_key = _normalize_wan27_alias(normalized)
+        # wan2.7 的 payload 构造只实现了 t2v/i2v/r2v；videoedit 已由 is_videoedit 单独标记，
+        # s2v/v2v 等其余未实现模态同样不能落原生路由。按标识符边界匹配 _MODEL_PROFILES 里的
+        # wan2.7 已知 key（而非要求 profile_key 与某个 key 完全相等）：profile_key 保留了代理
+        # 中转的装饰前后缀（"proxy/wan2.7-r2v"），精确相等会把这些合法装饰名也判成未知模态。
+        has_known_modality = (
+            _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-"))) is not None
+        )
     # wan2x_dot 无法从 model_id 直接归一化出确切 t2v/i2v/r2v 档位（其命名形态未收敛），
-    # profile_key 留空，交由 _profile_for_model 末尾的兜底子串匹配处理（多数落 _DEFAULT_PROFILE）。
+    # profile_key 留空，交由 _profile_for_model 末尾的兜底子串匹配处理（多数落 _DEFAULT_PROFILE）；
+    # 是否收窄同 wan2.7 一样按已知模态门控需要供应商 API 事实与产品判断，不由本字段代为决定。
     return WanClassification(
-        family=family, is_image_to_video=is_image_to_video, is_videoedit=is_videoedit, profile_key=profile_key
+        family=family,
+        is_image_to_video=is_image_to_video,
+        is_videoedit=is_videoedit,
+        profile_key=profile_key,
+        has_known_modality=has_known_modality,
     )
 
 
@@ -282,6 +305,20 @@ def _is_wan3(model: str | None) -> bool:
     return bool(WAN3_PATTERN.search((model or "").strip().lower()))
 
 
+def _find_known_profile_key(normalized: str, keys: Iterable[str]) -> str | None:
+    """在 normalized 里按标识符边界查找 keys 中出现的第一个已知 key，均未命中则 None。
+
+    两侧边界要求非字母数字：左侧避免 "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、
+    "myhappyhorse-1.0-r2v" 这类第三方型号名被字面子串误吞；右侧避免 "wan2.7-i2vfoo"、
+    "happyhorse-1.0-r2vfoo" 这类未知变体后缀被截断误判成已知 key。代理中转的装饰前缀/后缀
+    （"proxy/xxx"、"xxx-0715"）靠非字母数字分隔符天然满足两侧边界，不受影响。
+    """
+    for key in keys:
+        if re.search(r"(?<![a-z0-9])" + re.escape(key) + r"(?![a-z0-9])", normalized):
+            return key
+    return None
+
+
 def _profile_for_model(model: str | None) -> VideoCapabilities:
     """按 model_id 解析能力档：先精确命中，再容忍代理中转的前后缀装饰。
 
@@ -300,14 +337,10 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     if classification.profile_key is not None:
         normalized = classification.profile_key
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v} /
-    # wan3.0-video）互不为子串，无歧义。两侧标识符边界均要求非字母数字：左侧避免
-    # "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、"myhappyhorse-1.0-r2v" 这类第三方型号名被字面
-    # 子串误吞；右侧避免 "wan2.7-i2vfoo"、"happyhorse-1.0-r2vfoo" 这类未知变体后缀被截断误判成
-    # 已知 key。代理中转的装饰前缀/后缀（"proxy/xxx"、"xxx-0715"）靠非字母数字分隔符天然满足
-    # 两侧边界，不受影响。
-    for known, profile in _MODEL_PROFILES.items():
-        if re.search(r"(?<![a-z0-9])" + re.escape(known) + r"(?![a-z0-9])", normalized):
-            return profile
+    # wan3.0-video）互不为子串，无歧义，_find_known_profile_key 的边界匹配可安全逐一试探。
+    known = _find_known_profile_key(normalized, _MODEL_PROFILES)
+    if known is not None:
+        return _MODEL_PROFILES[known]
     return _DEFAULT_PROFILE
 
 

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -264,11 +264,14 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     if family == "wan3":
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
-        # _normalize_wan27_alias 保证结果里恒含字面 "wan2.7" 标记；拼回标记前的原始装饰前缀
-        # （不参与归一化，只用于容忍代理中转命名，见 _find_known_profile_key 的边界匹配）
-        # 得到最终 profile_key。
-        profile_key = normalized[: family_match.start()] + _normalize_wan27_alias(family_suffix)
-        wan27_suffix = profile_key[profile_key.index("wan2.7") :]
+        # wan27_suffix 直接取归一化结果，不再从拼接后的 profile_key 里用 index("wan2.7") 反查——
+        # 标记前的原始装饰前缀可能本身就含字面 "wan2.7" 子串（如 "vendorwan2.7-videoedit-proxy/
+        # wan2.7-r2v"，前缀里的 "wan2.7" 不满足 WAN2_PATTERN 边界、未被判定为家族标记，但仍是
+        # 该子串），index() 找到的会是这个更靠前的字面匹配而非真正的家族标记位置，重新引入本就是
+        # family_match 要规避的前缀污染。profile_key 仍需拼回原始装饰前缀（不参与归一化，只用于
+        # 容忍代理中转命名，见 _find_known_profile_key 的边界匹配）。
+        wan27_suffix = _normalize_wan27_alias(family_suffix)
+        profile_key = normalized[: family_match.start()] + wan27_suffix
         is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(wan27_suffix))
         is_s2v_or_v2v = bool(WAN_S2V_V2V_PATTERN.search(wan27_suffix))
         # wan2.7 的 payload 构造只实现了 t2v/i2v/r2v；videoedit/s2v/v2v 等其余已知但未实现模态

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -239,11 +239,12 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     if WAN2_PATTERN.search(normalized):
         normalized = _normalize_wan27_alias(normalized)
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义。
-    # 左侧标识符边界要求非字母数字，否则 "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、
-    # "myhappyhorse-1.0-r2v" 这类第三方型号名会被字面子串误吞；代理中转的装饰前缀（"proxy/xxx"）
-    # 靠非字母数字分隔符（"/"）天然满足边界，不受影响。
+    # 两侧标识符边界均要求非字母数字：左侧避免 "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、
+    # "myhappyhorse-1.0-r2v" 这类第三方型号名被字面子串误吞；右侧避免 "wan2.7-i2vfoo"、
+    # "happyhorse-1.0-r2vfoo" 这类未知变体后缀被截断误判成已知 key。代理中转的装饰
+    # 前缀/后缀（"proxy/xxx"、"xxx-0715"）靠非字母数字分隔符天然满足两侧边界，不受影响。
     for known, profile in _MODEL_PROFILES.items():
-        if re.search(r"(?<![a-z0-9])" + re.escape(known), normalized):
+        if re.search(r"(?<![a-z0-9])" + re.escape(known) + r"(?![a-z0-9])", normalized):
             return profile
     return _DEFAULT_PROFILE
 

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -166,6 +166,11 @@ WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"(?<![a-z0-9])image[-_]?(?:to|2)[-_]?vi
 # 避免 "videoeditor" 一类无关词形（"edit" 后紧邻字母）被误判命中。
 WAN_VIDEOEDIT_PATTERN = re.compile(r"(?<![a-z0-9])video[-_]?edit(?![a-z0-9])", re.I)
 
+# wan2.7-s2v（图生视频续接语音）/ wan2.7-v2v（视频生视频）：命中家族正则但同 videoedit 一样未
+# 实现请求构造的模态。与 has_known_modality 的语义区分：本模式只标记"这是已知的视频模态"（供路由
+# 判定是否落图像端点用），不代表已实现该模态的请求构造（仍须落 has_known_modality 的排除路径）。
+WAN_S2V_V2V_PATTERN = re.compile(r"(?<![a-z0-9])[sv]2v(?![a-z0-9])", re.I)
+
 WanFamily = Literal["happyhorse", "wan2.7", "wan3", "wan2x_dot"]
 
 
@@ -190,6 +195,14 @@ class WanClassification:
     # True：wan3 单模型覆盖全部模态、happyhorse 与 wan2x_dot 的模态收窄不由本字段判定（前者未见
     # 需要排除的模态，后者见 profile_key 处的说明）。
     has_known_modality: bool
+    # wan2.7 家族是否可确认属于视频模态（t2v/i2v/r2v/s2v/v2v/videoedit 任一），即便本后端未实现
+    # 其中部分模态（s2v/v2v/videoedit）的请求构造。与 has_known_modality 语义不同：后者只对已实现
+    # 请求构造的 t2v/i2v/r2v 为真，本字段额外把已知但未实现的视频模态也计入，用于和真图像变体
+    # （wan2.7-image 等未落入任何已知模态 token 的情形）区分——id 别处若另含无关 "image" 装饰
+    # （如代理命名空间前缀），不能让笼统 image 判定盖过已确认的视频语义。该区分只对 wan2.7 生效，
+    # 恒为 False：wan3 单模型覆盖全部模态、happyhorse/wan2x_dot 的图像/视频归属不由本字段判定
+    # （见 profile_key 与 has_known_modality 处的说明）。
+    is_known_video_modality: bool
 
 
 def classify_wan_model(model_id: str | None) -> WanClassification:
@@ -204,7 +217,12 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         # happyhorse 无 image-to-video 续接语法与 videoedit 模态；t2v/i2v/r2v 具体档位交由
         # _profile_for_model 末尾的兜底子串匹配解析，此处不预先归一化。
         return WanClassification(
-            family="happyhorse", is_image_to_video=False, is_videoedit=False, profile_key=None, has_known_modality=True
+            family="happyhorse",
+            is_image_to_video=False,
+            is_videoedit=False,
+            profile_key=None,
+            has_known_modality=True,
+            is_known_video_modality=False,
         )
     if WAN3_PATTERN.search(normalized):
         family: WanFamily = "wan3"
@@ -219,14 +237,17 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
             is_videoedit=False,
             profile_key=None,
             has_known_modality=True,
+            is_known_video_modality=False,
         )
 
     # videoedit 是 wan2.7 家族内独有的模态（见 WAN_VIDEOEDIT_PATTERN 处的说明）；wan3/wan2x_dot
     # 不受它约束，否则形如 "proxy-videoedit/wan3-turbo" 这类与 videoedit 无关的装饰前缀会被误吞，
     # 把本应走原生路由的 wan3 模型错误排除出去。
     is_videoedit = family == "wan2.7" and bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
+    is_s2v_or_v2v = family == "wan2.7" and bool(WAN_S2V_V2V_PATTERN.search(normalized))
     profile_key: str | None = None
     has_known_modality = True
+    is_known_video_modality = False
     if family == "wan3":
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
@@ -238,6 +259,10 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         has_known_modality = not is_videoedit and (
             _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-"))) is not None
         )
+        # t2v/i2v/r2v（has_known_modality）/ videoedit / s2v / v2v 均是已确认的视频模态，即便部分
+        # 未实现请求构造；其余未收敛命名（不落入任一已知模态 token）保守按图像变体处理，不做假设
+        # （见字段处的说明与 endpoints.py 里"不对图像变体的命名形态做任何假设"的既有原则一致）。
+        is_known_video_modality = has_known_modality or is_videoedit or is_s2v_or_v2v
     elif family == "wan2x_dot" and is_image_to_video:
         # wan2x_dot 没有登记任何 VideoCapabilities（profile_key 恒 None，下条注释），image-to-video
         # 续接语法命中时若仍放行原生路由，_profile_for_model 会回落 _DEFAULT_PROFILE（first_frame
@@ -253,6 +278,7 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         is_videoedit=is_videoedit,
         profile_key=profile_key,
         has_known_modality=has_known_modality,
+        is_known_video_modality=is_known_video_modality,
     )
 
 

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -195,6 +195,11 @@ class WanClassification:
 def classify_wan_model(model_id: str | None) -> WanClassification:
     """对 model_id 做一次判定，供路由/能力档/时长档复用同一结论。"""
     normalized = (model_id or "").strip().lower()
+    # image-to-video 续接语法的标识符边界匹配与家族归属判定相互独立：不满足家族严格边界的 id
+    # （如 "wan-2.2-image-to-video"，"wan" 与版本号间的连字符不满足点号形态边界）依然可能是视频
+    # 模型的显式续接语法命名，家族未命中不代表该语法信息作废，须原样带出，供 endpoints.py 的
+    # image 变体排除判定消费——否则这类 id 会被笼统 image 判定误吞成图像端点。
+    is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
     if HAPPYHORSE_PATTERN.search(normalized):
         # happyhorse 无 image-to-video 续接语法与 videoedit 模态；t2v/i2v/r2v 具体档位交由
         # _profile_for_model 末尾的兜底子串匹配解析，此处不预先归一化。
@@ -209,14 +214,17 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         family = "wan2x_dot"
     else:
         return WanClassification(
-            family=None, is_image_to_video=False, is_videoedit=False, profile_key=None, has_known_modality=True
+            family=None,
+            is_image_to_video=is_image_to_video,
+            is_videoedit=False,
+            profile_key=None,
+            has_known_modality=True,
         )
 
     # videoedit 是 wan2.7 家族内独有的模态（见 WAN_VIDEOEDIT_PATTERN 处的说明）；wan3/wan2x_dot
     # 不受它约束，否则形如 "proxy-videoedit/wan3-turbo" 这类与 videoedit 无关的装饰前缀会被误吞，
     # 把本应走原生路由的 wan3 模型错误排除出去。
     is_videoedit = family == "wan2.7" and bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
-    is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
     profile_key: str | None = None
     has_known_modality = True
     if family == "wan3":

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -240,11 +240,12 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
             is_known_video_modality=False,
         )
 
-    # videoedit 是 wan2.7 家族内独有的模态（见 WAN_VIDEOEDIT_PATTERN 处的说明）；wan3/wan2x_dot
-    # 不受它约束，否则形如 "proxy-videoedit/wan3-turbo" 这类与 videoedit 无关的装饰前缀会被误吞，
-    # 把本应走原生路由的 wan3 模型错误排除出去。
-    is_videoedit = family == "wan2.7" and bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
-    is_s2v_or_v2v = family == "wan2.7" and bool(WAN_S2V_V2V_PATTERN.search(normalized))
+    # videoedit/s2v/v2v 是 wan2.7 家族内的模态标记，只在 wan2.7 恒定标记之后的模态段内搜索，不含
+    # 标记前的装饰前缀——否则 "videoedit-proxy/wan2.7-image" / "s2v-proxy/wan2.7-image" 这类与
+    # 模态无关的代理命名空间前缀会被误判成对应模态，掩盖其真实（图像）模态。wan3/wan2x_dot 不受
+    # 二者约束（field 默认 False），否则形如 "proxy-videoedit/wan3-turbo" 这类前缀会把本应走原生
+    # 路由的 wan3 模型错误排除出去。
+    is_videoedit = False
     profile_key: str | None = None
     has_known_modality = True
     is_known_video_modality = False
@@ -252,16 +253,26 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
         profile_key = _normalize_wan27_alias(normalized)
-        # wan2.7 的 payload 构造只实现了 t2v/i2v/r2v；videoedit 已由 is_videoedit 单独标记，
-        # s2v/v2v 等其余未实现模态同样不能落原生路由。按标识符边界匹配 _MODEL_PROFILES 里的
-        # wan2.7 已知 key（而非要求 profile_key 与某个 key 完全相等）：profile_key 保留了代理
-        # 中转的装饰前后缀（"proxy/wan2.7-r2v"），精确相等会把这些合法装饰名也判成未知模态。
-        has_known_modality = not is_videoedit and (
-            _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-"))) is not None
+        # _normalize_wan27_alias 保证 profile_key 里恒含字面 "wan2.7" 标记，据此切出标记之后的
+        # 模态段供 videoedit/s2v/v2v 搜索。
+        wan27_suffix = profile_key[profile_key.index("wan2.7") :]
+        is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(wan27_suffix))
+        is_s2v_or_v2v = bool(WAN_S2V_V2V_PATTERN.search(wan27_suffix))
+        # wan2.7 的 payload 构造只实现了 t2v/i2v/r2v；videoedit/s2v/v2v 等其余已知但未实现模态
+        # 同样不能落原生路由。按标识符边界匹配 _MODEL_PROFILES 里的 wan2.7 已知 key（而非要求
+        # profile_key 与某个 key 完全相等）：profile_key 保留了代理中转的装饰前后缀
+        # （"proxy/wan2.7-r2v"），精确相等会把这些合法装饰名也判成未知模态。命中已知 key 的同时
+        # 若又命中 videoedit/s2v/v2v（如 "wan2.7-i2v-s2v"），已实现的 token 不能掩盖未实现模态
+        # 段共存的事实，一并排除出已实现范围。
+        has_known_modality = (
+            not is_videoedit
+            and not is_s2v_or_v2v
+            and _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-")))
+            is not None
         )
         # t2v/i2v/r2v（has_known_modality）/ videoedit / s2v / v2v 均是已确认的视频模态，即便部分
-        # 未实现请求构造；其余未收敛命名（不落入任一已知模态 token）保守按图像变体处理，不做假设
-        # （见字段处的说明与 endpoints.py 里"不对图像变体的命名形态做任何假设"的既有原则一致）。
+        # 未实现请求构造；其余未收敛命名（不落入任一已知模态 token）保守按图像变体处理，不对图像
+        # 变体的命名形态做任何假设（与 endpoints.py 的判定原则一致）。
         is_known_video_modality = has_known_modality or is_videoedit or is_s2v_or_v2v
     elif family == "wan2x_dot" and is_image_to_video:
         # wan2x_dot 没有登记任何 VideoCapabilities（profile_key 恒 None，下条注释），image-to-video

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -221,10 +221,14 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，故按 WAN2_PATTERN 把
     # "wan-2.7"/"wan_2.7" 归一化成 "wan2.7" 再走下方子串匹配，否则 "wan-2.7-r2v" 这类连字符
     # 别名会因不含字面量 "wan2.7-r2v" 子串而落到 _DEFAULT_PROFILE，丢失参考图/首帧等能力声明。
-    # image-to-video 续接别名（"wan-2.7-image-to-video"）额外需要把该后缀折成 "i2v"，见
-    # _WAN27_IMAGE_TO_VIDEO_PATTERN 处的说明。
+    # 版本号与模态后缀之间的分隔符单独归一化（"wan2.7_r2v" → "wan2.7-r2v"）：_MODEL_PROFILES
+    # 的 key 固定用连字符分隔模态，"wan_2.7_r2v" 这类整段下划线别名在上一步只处理了 wan 与版本号
+    # 之间的分隔符，模态前的下划线不处理会导致同样不构成子串关系。image-to-video 续接别名
+    # （"wan-2.7-image-to-video"）额外需要把该后缀折成 "i2v"，见 _WAN27_IMAGE_TO_VIDEO_PATTERN
+    # 处的说明。
     if WAN2_PATTERN.search(normalized):
         normalized = WAN2_PATTERN.sub("wan2.7", normalized)
+        normalized = re.sub(r"wan2\.7_", "wan2.7-", normalized)
         normalized = _WAN27_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
     for known, profile in _MODEL_PROFILES.items():

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -138,8 +138,8 @@ WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 # `/services/aigc/image2video/video-synthesis/`、payload 字段也不同（如 wan2.6 用 `size` 而非
 # 2.7 的 `resolution`+`ratio`），并入本正则会把协议不兼容的请求送到这个端点。
 # 点号形态（如 "wan2.1-kf2v"）不受本正则约束；endpoints.py::is_wan_family 对点号形态另有独立的
-# 字面量判定，其路由是否也应收窄到 2.7 需要供应商 API 事实与产品判断，不由本正则的匹配宽度代为
-# 决定。
+# 判定（_WAN_DOT_FORM_PATTERN），其路由是否也应收窄到 2.7 需要供应商 API 事实与产品判断，不由
+# 本正则的匹配宽度代为决定。
 WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
 
 # wan2.7 的 image-to-video 续接别名（"wan-2.7-image-to-video" / "wan_2.7-image2video"）在归一化
@@ -148,6 +148,21 @@ WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
 # _build_media 据此不下发 start_image。正则形状与 endpoints.py::_WAN_IMAGE_TO_VIDEO_PATTERN
 # 一致（该文件属上层 custom_provider，不可反向导入，故各自维护同一份字面量）。
 _WAN27_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.I)
+
+
+def _normalize_wan27_alias(normalized: str) -> str:
+    """把 WAN2_PATTERN 命中的 wan2.7 别名折成 _MODEL_PROFILES key 固定使用的形态：
+    "wan[-_]?2.7[-_]<modality>"，无论 wan/版本号/模态三段各自用哪种分隔符，统一成
+    "wan2.7-<modality>"（modality 含 image-to-video 续接语法时进一步折成 "i2v"）。
+
+    分两步是因为两段分隔符独立可变（"wan_2.7-r2v" 只有前段是下划线、"wan-2.7_r2v" 只有后段
+    是下划线、"wan_2.7_r2v" 两段都是），任一段漏归一化都会导致结果不与 _MODEL_PROFILES 的 key
+    构成子串关系，静默落 _DEFAULT_PROFILE。调用方须先用 WAN2_PATTERN.search 确认命中。
+    """
+    normalized = WAN2_PATTERN.sub("wan2.7", normalized)
+    normalized = re.sub(r"wan2\.7_", "wan2.7-", normalized)
+    return _WAN27_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
+
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
@@ -218,21 +233,17 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     # _DEFAULT_PROFILE，丢失参考图/尾帧/音轨参数等 wan3 专属能力声明。
     if WAN3_PATTERN.search(normalized):
         return _MODEL_PROFILES[_WAN3_MODEL_KEY]
-    # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，故按 WAN2_PATTERN 把
-    # "wan-2.7"/"wan_2.7" 归一化成 "wan2.7" 再走下方子串匹配，否则 "wan-2.7-r2v" 这类连字符
-    # 别名会因不含字面量 "wan2.7-r2v" 子串而落到 _DEFAULT_PROFILE，丢失参考图/首帧等能力声明。
-    # 版本号与模态后缀之间的分隔符单独归一化（"wan2.7_r2v" → "wan2.7-r2v"）：_MODEL_PROFILES
-    # 的 key 固定用连字符分隔模态，"wan_2.7_r2v" 这类整段下划线别名在上一步只处理了 wan 与版本号
-    # 之间的分隔符，模态前的下划线不处理会导致同样不构成子串关系。image-to-video 续接别名
-    # （"wan-2.7-image-to-video"）额外需要把该后缀折成 "i2v"，见 _WAN27_IMAGE_TO_VIDEO_PATTERN
-    # 处的说明。
+    # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，改走 _normalize_wan27_alias
+    # 把 wan 前缀、版本号与模态之间的分隔符都折成 _MODEL_PROFILES key 固定使用的连字符形态，
+    # 再走下方子串匹配。
     if WAN2_PATTERN.search(normalized):
-        normalized = WAN2_PATTERN.sub("wan2.7", normalized)
-        normalized = re.sub(r"wan2\.7_", "wan2.7-", normalized)
-        normalized = _WAN27_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
-    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
+        normalized = _normalize_wan27_alias(normalized)
+    # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义。
+    # 左侧标识符边界要求非字母数字，否则 "swan2.7-r2v"（"s" 紧贴 "wan2.7-r2v"）、
+    # "myhappyhorse-1.0-r2v" 这类第三方型号名会被字面子串误吞；代理中转的装饰前缀（"proxy/xxx"）
+    # 靠非字母数字分隔符（"/"）天然满足边界，不受影响。
     for known, profile in _MODEL_PROFILES.items():
-        if known in normalized:
+        if re.search(r"(?<![a-z0-9])" + re.escape(known), normalized):
             return profile
     return _DEFAULT_PROFILE
 

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -226,7 +226,7 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         # s2v/v2v 等其余未实现模态同样不能落原生路由。按标识符边界匹配 _MODEL_PROFILES 里的
         # wan2.7 已知 key（而非要求 profile_key 与某个 key 完全相等）：profile_key 保留了代理
         # 中转的装饰前后缀（"proxy/wan2.7-r2v"），精确相等会把这些合法装饰名也判成未知模态。
-        has_known_modality = (
+        has_known_modality = not is_videoedit and (
             _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-"))) is not None
         )
     elif family == "wan2x_dot" and is_image_to_video:

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -201,7 +201,10 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     else:
         return WanClassification(family=None, is_image_to_video=False, is_videoedit=False, profile_key=None)
 
-    is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
+    # videoedit 是 wan2.7 家族内独有的模态（见 WAN_VIDEOEDIT_PATTERN 处的说明）；wan3/wan2x_dot
+    # 不受它约束，否则形如 "proxy-videoedit/wan3-turbo" 这类与 videoedit 无关的装饰前缀会被误吞，
+    # 把本应走原生路由的 wan3 模型错误排除出去。
+    is_videoedit = family == "wan2.7" and bool(WAN_VIDEOEDIT_PATTERN.search(normalized))
     is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
     profile_key: str | None = None
     if family == "wan3":

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -145,18 +145,19 @@ WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
 
 # 点号形态万相 2.x（2.7 以外，如 "wan2.1-kf2v"）的家族判定：标识符边界要求非字母数字，避免
 # "swan2.7-r2v"、"vendorwan2.7-t2v" 这类含 "wan2." 子串但并非该家族的第三方型号名被误判。
-WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d", re.I)
+WAN_DOT_FORM_PATTERN = re.compile(r"(?<![a-z0-9])wan2\.\d+(?![a-z0-9])", re.I)
 
-# happyhorse 家族判定：标识符边界要求非字母数字，避免 "myhappyhorse-1.0-r2v" 这类第三方型号名
-# 被字面子串误吞。
-HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse", re.I)
+# happyhorse 家族判定：标识符边界要求非字母数字，避免 "myhappyhorse-1.0-r2v" / "happyhorsefoo"
+# 这类第三方型号名被字面子串误吞。
+HAPPYHORSE_PATTERN = re.compile(r"(?<![a-z0-9])happyhorse(?![a-z0-9])", re.I)
 
 # wan 家族 image-to-video 续接语法（"wan-2.7-image-to-video" / "wan_2.7-image2video" /
 # "wan-3-turbo-image-to-video"）：只挑这一种确定形态当"实为视频"的例外，不覆盖 img2vid/i2v 等
 # 未见实例的缩写——出现新形态再补，不预先扩面。wan2.7 归一化用它把该后缀折成 "i2v" 再查
 # _MODEL_PROFILES；wan3/wan2x_dot 家族用它区分图像/视频归属（wan3.0-video-image 等真图像别名
-# 不含该语法，不受影响）。
-WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.I)
+# 不含该语法，不受影响）。两侧标识符边界避免 "wan2.7-fooimage-to-video" /
+# "wan2.7-image-to-videofoo" 这类相邻字母被误判命中。
+WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"(?<![a-z0-9])image[-_]?(?:to|2)[-_]?video(?![a-z0-9])", re.I)
 
 # wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
 # 万相家族内真实存在的独立模态，但本后端只实现了 t2v/i2v/r2v 三档的请求构造，没有该模态所需的

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -128,6 +128,11 @@ _WAN3_MODEL_KEY = "wan3.0-video"
 # 的第三方型号名。
 WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 
+# wan2.7 家族 model_id 识别，匹配宽度与 WAN3_PATTERN 对齐（连字符/下划线可选、标识符边界避免
+# 误吞 "swan2"、"wan20"）：endpoints.py::is_wan_family 复用同一正则，使连字符形态（"wan-2.7"）
+# 与点号形态（"wan2.7"）在图像/视频归属与端点路由上得出一致结论。
+WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2(?![a-z0-9])", re.I)
+
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
 _MODEL_PROFILES: dict[str, VideoCapabilities] = {
@@ -181,7 +186,7 @@ def _is_wan3(model: str | None) -> bool:
 def _profile_for_model(model: str | None) -> VideoCapabilities:
     """按 model_id 解析能力档：先精确命中，再容忍代理中转的前后缀装饰。
 
-    infer_endpoint 用子串（"happyhorse" / "wan2."）路由到 dashscope-async-video，故此处也须
+    infer_endpoint 用 WAN2_PATTERN / WAN3_PATTERN 路由到 dashscope-async-video，故此处也须
     子串容忍，否则 "proxy/happyhorse-1.0-r2v" / "wan2.7-r2v-0715" 这类装饰名会退回 _DEFAULT_PROFILE、
     丢掉 r2v 的 max_reference_images，_build_media 据此构造出错误 payload。
     仅带系列名而无变体后缀（如裸 "happyhorse"）无法判别 t2v/i2v/r2v，按设计回落通用默认。
@@ -197,6 +202,11 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     # _DEFAULT_PROFILE，丢失参考图/尾帧/音轨参数等 wan3 专属能力声明。
     if WAN3_PATTERN.search(normalized):
         return _MODEL_PROFILES[_WAN3_MODEL_KEY]
+    # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，故按 WAN2_PATTERN 把
+    # "wan-2.7"/"wan_2.7" 归一化成 "wan2.7" 再走下方子串匹配，否则 "wan-2.7-r2v" 这类连字符
+    # 别名会因不含字面量 "wan2.7-r2v" 子串而落到 _DEFAULT_PROFILE，丢失参考图/首帧等能力声明。
+    if WAN2_PATTERN.search(normalized):
+        normalized = WAN2_PATTERN.sub("wan2", normalized)
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
     for known, profile in _MODEL_PROFILES.items():
         if known in normalized:

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -264,12 +264,12 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     if family == "wan3":
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
-        # wan27_suffix 直接取归一化结果，不再从拼接后的 profile_key 里用 index("wan2.7") 反查——
-        # 标记前的原始装饰前缀可能本身就含字面 "wan2.7" 子串（如 "vendorwan2.7-videoedit-proxy/
-        # wan2.7-r2v"，前缀里的 "wan2.7" 不满足 WAN2_PATTERN 边界、未被判定为家族标记，但仍是
-        # 该子串），index() 找到的会是这个更靠前的字面匹配而非真正的家族标记位置，重新引入本就是
-        # family_match 要规避的前缀污染。profile_key 仍需拼回原始装饰前缀（不参与归一化，只用于
-        # 容忍代理中转命名，见 _find_known_profile_key 的边界匹配）。
+        # wan27_suffix 直接取自 family_match 定位到的模态段（family_suffix）归一化结果，不基于
+        # 字面文本搜索定位：标记前的原始装饰前缀可能本身含字面 "wan2.7" 子串（如
+        # "vendorwan2.7-videoedit-proxy/wan2.7-r2v"，前缀里的 "wan2.7" 不满足 WAN2_PATTERN 边界、
+        # 未被判定为家族标记，但仍是该字面子串），按文本搜索定位无法区分这类前缀噪音与真正的家族
+        # 标记位置，只有 family_match 的匹配位置本身是可靠锚点。profile_key 仍需拼回原始装饰前缀
+        # （不参与归一化，只用于容忍代理中转命名，见 _find_known_profile_key 的边界匹配）。
         wan27_suffix = _normalize_wan27_alias(family_suffix)
         profile_key = normalized[: family_match.start()] + wan27_suffix
         is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(wan27_suffix))

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -128,12 +128,27 @@ _WAN3_MODEL_KEY = "wan3.0-video"
 # 的第三方型号名。
 WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 
-# 万相 2.x 家族 model_id 识别，匹配宽度与 WAN3_PATTERN 对齐（连字符/下划线可选、不锚版本号、
-# 标识符边界避免误吞 "swan2"、"wan20"）：endpoints.py::is_wan_family 复用同一正则，使连字符形态
-# （"wan-2.7"）与点号形态（"wan2.7"）在图像/视频归属与端点路由上得出一致结论。不锚版本号意味着
-# 整个 2.x 系列（含 "wan-2.1"、裸 "wan2"）都按万相家族路由到百炼原生端点，与点号形态一致；
-# 能力档只有 2.7 三档，其余 2.x 仍按下方子串匹配落通用默认。
-WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2(?![a-z0-9])", re.I)
+# 万相 2.7 家族 model_id 识别（连字符/下划线可选、标识符边界避免误吞 "swan2"、"wan20"）：
+# endpoints.py::is_wan_family 复用同一正则，使连字符形态（"wan-2.7"）与点号形态（"wan2.7"）
+# 在图像/视频归属与端点路由上得出一致结论——这是本正则唯一确权的范围。
+#
+# 刻意只锚 2.7、不覆盖其余 2.x 小版本：本后端固定请求
+# `/services/aigc/video-generation/video-synthesis`（_VIDEO_ENDPOINT），而 wan2.1 / wan2.2-s2v
+# 按 docs/research/arcreel-video-api-protocol-research.md 记录走的是旧端点
+# `/services/aigc/image2video/video-synthesis/`、payload 字段也不同（如 wan2.6 用 `size` 而非
+# 2.7 的 `resolution`+`ratio`）；若把 2.1/2.2 等连字符/下划线形态也并入本正则，会把它们从原本
+# 至少不出错的通用视频端点强改路由到这个协议不兼容的原生端点，属于把死分歧变成活缺陷。
+# 点号形态（如 "wan2.1-kf2v"）不受本正则约束，但 endpoints.py::is_wan_family 仍对其保留独立的
+# 字面量判定——那是路由到原生端点这一行为在本正则引入前就存在的既有状态，是否收窄需要供应商
+# API 事实与产品判断，本处不代为决定，留给人工评估。
+WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
+
+# wan2.7 的 image-to-video 续接别名（"wan-2.7-image-to-video" / "wan_2.7-image2video"）在归一化
+# 后仍带着 "image-to-video"/"image2video" 后缀，不与 _MODEL_PROFILES 的 "wan2.7-i2v" 构成子串
+# 关系，需先把该后缀折成 "i2v" 再查表，否则静默落 _DEFAULT_PROFILE、丢失 first_frame 声明，
+# _build_media 据此不下发 start_image。正则形状与 endpoints.py::_WAN_IMAGE_TO_VIDEO_PATTERN
+# 一致（该文件属上层 custom_provider，不可反向导入，故各自维护同一份字面量）。
+_WAN27_IMAGE_TO_VIDEO_PATTERN = re.compile(r"image[-_]?(?:to|2)[-_]?video", re.I)
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
 # wan2.7-r2v 额外支持首帧与参考音色。
@@ -207,8 +222,11 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     # wan2.7 家族有 t2v/i2v/r2v 三档，无法像 wan3 那样单 key 直返，故按 WAN2_PATTERN 把
     # "wan-2.7"/"wan_2.7" 归一化成 "wan2.7" 再走下方子串匹配，否则 "wan-2.7-r2v" 这类连字符
     # 别名会因不含字面量 "wan2.7-r2v" 子串而落到 _DEFAULT_PROFILE，丢失参考图/首帧等能力声明。
+    # image-to-video 续接别名（"wan-2.7-image-to-video"）额外需要把该后缀折成 "i2v"，见
+    # _WAN27_IMAGE_TO_VIDEO_PATTERN 处的说明。
     if WAN2_PATTERN.search(normalized):
-        normalized = WAN2_PATTERN.sub("wan2", normalized)
+        normalized = WAN2_PATTERN.sub("wan2.7", normalized)
+        normalized = _WAN27_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v}）互不为子串，无歧义
     for known, profile in _MODEL_PROFILES.items():
         if known in normalized:

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -233,11 +233,16 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         # image-to-video 续接语法的标识符边界匹配与家族归属判定相互独立：不满足家族严格边界的 id
         # （如 "wan-2.2-image-to-video"，"wan" 与版本号间的连字符不满足点号形态边界）依然可能是
         # 视频模型的显式续接语法命名，家族未命中不代表该语法信息作废，须原样带出，供 endpoints.py
-        # 的 image 变体排除判定消费——否则这类 id 会被笼统 image 判定误吞成图像端点。家族未命中时
-        # 没有标记位置可供切分，只能退回全串搜索。
+        # 的 image 变体排除判定消费——否则这类 id 会被笼统 image 判定误吞成图像端点。搜索范围仍须
+        # 从字面 "wan" 子串本身开始切分（不要求满足严格标识符边界，"swan2.7-image" 里的 "wan" 同样
+        # 定位），不含其前的装饰前缀——否则 "image-to-video-proxy/swan2.7-image" 这类与模态无关的
+        # 代理命名空间前缀会把真图像变体误判成视频续接。字面无 "wan" 子串时该字段不被下游消费
+        # （endpoints.py 先决 `"wan" in lowered` 才读取本字段），退回全串搜索即可。
+        wan_locator = normalized.find("wan")
+        fallback_scope = normalized[wan_locator:] if wan_locator != -1 else normalized
         return WanClassification(
             family=None,
-            is_image_to_video=bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized)),
+            is_image_to_video=bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(fallback_scope)),
             is_videoedit=False,
             profile_key=None,
             has_known_modality=True,

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -132,15 +132,14 @@ WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 # endpoints.py::is_wan_family 复用同一正则，使连字符形态（"wan-2.7"）与点号形态（"wan2.7"）
 # 在图像/视频归属与端点路由上得出一致结论——这是本正则唯一确权的范围。
 #
-# 刻意只锚 2.7、不覆盖其余 2.x 小版本：本后端固定请求
+# 只锚 2.7、不覆盖其余 2.x 小版本：本后端固定请求
 # `/services/aigc/video-generation/video-synthesis`（_VIDEO_ENDPOINT），而 wan2.1 / wan2.2-s2v
 # 按 docs/research/arcreel-video-api-protocol-research.md 记录走的是旧端点
 # `/services/aigc/image2video/video-synthesis/`、payload 字段也不同（如 wan2.6 用 `size` 而非
-# 2.7 的 `resolution`+`ratio`）；若把 2.1/2.2 等连字符/下划线形态也并入本正则，会把它们从原本
-# 至少不出错的通用视频端点强改路由到这个协议不兼容的原生端点，属于把死分歧变成活缺陷。
-# 点号形态（如 "wan2.1-kf2v"）不受本正则约束，但 endpoints.py::is_wan_family 仍对其保留独立的
-# 字面量判定——那是路由到原生端点这一行为在本正则引入前就存在的既有状态，是否收窄需要供应商
-# API 事实与产品判断，本处不代为决定，留给人工评估。
+# 2.7 的 `resolution`+`ratio`），并入本正则会把协议不兼容的请求送到这个端点。
+# 点号形态（如 "wan2.1-kf2v"）不受本正则约束；endpoints.py::is_wan_family 对点号形态另有独立的
+# 字面量判定，其路由是否也应收窄到 2.7 需要供应商 API 事实与产品判断，不由本正则的匹配宽度代为
+# 决定。
 WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2\.7(?![a-z0-9])", re.I)
 
 # wan2.7 的 image-to-video 续接别名（"wan-2.7-image-to-video" / "wan_2.7-image2video"）在归一化

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -208,11 +208,6 @@ class WanClassification:
 def classify_wan_model(model_id: str | None) -> WanClassification:
     """对 model_id 做一次判定，供路由/能力档/时长档复用同一结论。"""
     normalized = (model_id or "").strip().lower()
-    # image-to-video 续接语法的标识符边界匹配与家族归属判定相互独立：不满足家族严格边界的 id
-    # （如 "wan-2.2-image-to-video"，"wan" 与版本号间的连字符不满足点号形态边界）依然可能是视频
-    # 模型的显式续接语法命名，家族未命中不代表该语法信息作废，须原样带出，供 endpoints.py 的
-    # image 变体排除判定消费——否则这类 id 会被笼统 image 判定误吞成图像端点。
-    is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized))
     if HAPPYHORSE_PATTERN.search(normalized):
         # happyhorse 无 image-to-video 续接语法与 videoedit 模态；t2v/i2v/r2v 具体档位交由
         # _profile_for_model 末尾的兜底子串匹配解析，此处不预先归一化。
@@ -224,27 +219,39 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
             has_known_modality=True,
             is_known_video_modality=False,
         )
-    if WAN3_PATTERN.search(normalized):
+    wan3_match = WAN3_PATTERN.search(normalized)
+    wan2_match = None if wan3_match else WAN2_PATTERN.search(normalized)
+    wan_dot_match = None if (wan3_match or wan2_match) else WAN_DOT_FORM_PATTERN.search(normalized)
+    family_match = wan3_match or wan2_match or wan_dot_match
+    if wan3_match:
         family: WanFamily = "wan3"
-    elif WAN2_PATTERN.search(normalized):
+    elif wan2_match:
         family = "wan2.7"
-    elif WAN_DOT_FORM_PATTERN.search(normalized):
+    elif wan_dot_match:
         family = "wan2x_dot"
     else:
+        # image-to-video 续接语法的标识符边界匹配与家族归属判定相互独立：不满足家族严格边界的 id
+        # （如 "wan-2.2-image-to-video"，"wan" 与版本号间的连字符不满足点号形态边界）依然可能是
+        # 视频模型的显式续接语法命名，家族未命中不代表该语法信息作废，须原样带出，供 endpoints.py
+        # 的 image 变体排除判定消费——否则这类 id 会被笼统 image 判定误吞成图像端点。家族未命中时
+        # 没有标记位置可供切分，只能退回全串搜索。
         return WanClassification(
             family=None,
-            is_image_to_video=is_image_to_video,
+            is_image_to_video=bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(normalized)),
             is_videoedit=False,
             profile_key=None,
             has_known_modality=True,
             is_known_video_modality=False,
         )
 
-    # videoedit/s2v/v2v 是 wan2.7 家族内的模态标记，只在 wan2.7 恒定标记之后的模态段内搜索，不含
-    # 标记前的装饰前缀——否则 "videoedit-proxy/wan2.7-image" / "s2v-proxy/wan2.7-image" 这类与
-    # 模态无关的代理命名空间前缀会被误判成对应模态，掩盖其真实（图像）模态。wan3/wan2x_dot 不受
-    # 二者约束（field 默认 False），否则形如 "proxy-videoedit/wan3-turbo" 这类前缀会把本应走原生
-    # 路由的 wan3 模型错误排除出去。
+    # image-to-video 续接语法与 videoedit/s2v/v2v 均是家族内的模态标记，只在家族标记本身之后的
+    # 模态段内搜索，不含标记前的装饰前缀——否则 "image-to-video-proxy/wan2.7-image"、
+    # "videoedit-proxy/wan2.7-image"、"s2v-proxy/wan2.7-image" 这类与模态无关的代理命名空间前缀
+    # 会被误判成对应模态，掩盖其真实模态（真图像变体被误判成视频续接，或真实 t2v/i2v/r2v 被误判
+    # 成未实现模态）。
+    assert family_match is not None
+    family_suffix = normalized[family_match.start() :]
+    is_image_to_video = bool(WAN_IMAGE_TO_VIDEO_PATTERN.search(family_suffix))
     is_videoedit = False
     profile_key: str | None = None
     has_known_modality = True
@@ -252,22 +259,23 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     if family == "wan3":
         profile_key = _WAN3_MODEL_KEY
     elif family == "wan2.7":
-        profile_key = _normalize_wan27_alias(normalized)
-        # _normalize_wan27_alias 保证 profile_key 里恒含字面 "wan2.7" 标记，据此切出标记之后的
-        # 模态段供 videoedit/s2v/v2v 搜索。
+        # _normalize_wan27_alias 保证结果里恒含字面 "wan2.7" 标记；拼回标记前的原始装饰前缀
+        # （不参与归一化，只用于容忍代理中转命名，见 _find_known_profile_key 的边界匹配）
+        # 得到最终 profile_key。
+        profile_key = normalized[: family_match.start()] + _normalize_wan27_alias(family_suffix)
         wan27_suffix = profile_key[profile_key.index("wan2.7") :]
         is_videoedit = bool(WAN_VIDEOEDIT_PATTERN.search(wan27_suffix))
         is_s2v_or_v2v = bool(WAN_S2V_V2V_PATTERN.search(wan27_suffix))
         # wan2.7 的 payload 构造只实现了 t2v/i2v/r2v；videoedit/s2v/v2v 等其余已知但未实现模态
         # 同样不能落原生路由。按标识符边界匹配 _MODEL_PROFILES 里的 wan2.7 已知 key（而非要求
-        # profile_key 与某个 key 完全相等）：profile_key 保留了代理中转的装饰前后缀
-        # （"proxy/wan2.7-r2v"），精确相等会把这些合法装饰名也判成未知模态。命中已知 key 的同时
+        # wan27_suffix 与某个 key 完全相等）：wan27_suffix 保留了代理中转的装饰后缀
+        # （"wan2.7-r2v-0715"），精确相等会把这些合法装饰名也判成未知模态。命中已知 key 的同时
         # 若又命中 videoedit/s2v/v2v（如 "wan2.7-i2v-s2v"），已实现的 token 不能掩盖未实现模态
         # 段共存的事实，一并排除出已实现范围。
         has_known_modality = (
             not is_videoedit
             and not is_s2v_or_v2v
-            and _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-")))
+            and _find_known_profile_key(wan27_suffix, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-")))
             is not None
         )
         # t2v/i2v/r2v（has_known_modality）/ videoedit / s2v / v2v 均是已确认的视频模态，即便部分
@@ -293,18 +301,19 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     )
 
 
-def _normalize_wan27_alias(normalized: str) -> str:
+def _normalize_wan27_alias(family_suffix: str) -> str:
     """把 WAN2_PATTERN 命中的 wan2.7 别名折成 _MODEL_PROFILES key 固定使用的形态：
     "wan[-_]?2.7[-_]<modality>"，无论 wan/版本号/模态三段各自用哪种分隔符，统一成
     "wan2.7-<modality>"（modality 含 image-to-video 续接语法时进一步折成 "i2v"）。
 
     分两步是因为两段分隔符独立可变（"wan_2.7-r2v" 只有前段是下划线、"wan-2.7_r2v" 只有后段
     是下划线、"wan_2.7_r2v" 两段都是），任一段漏归一化都会导致结果不与 _MODEL_PROFILES 的 key
-    构成子串关系，静默落 _DEFAULT_PROFILE。调用方须先用 WAN2_PATTERN.search 确认命中。
+    构成子串关系，静默落 _DEFAULT_PROFILE。调用方须传入从 wan2.7 标记本身开始的子串（不含标记前
+    的装饰前缀），且须先用 WAN2_PATTERN.search 确认命中。
     """
-    normalized = WAN2_PATTERN.sub("wan2.7", normalized)
-    normalized = re.sub(r"wan2\.7_", "wan2.7-", normalized)
-    return WAN_IMAGE_TO_VIDEO_PATTERN.sub("i2v", normalized)
+    family_suffix = WAN2_PATTERN.sub("wan2.7", family_suffix)
+    family_suffix = re.sub(r"wan2\.7_", "wan2.7-", family_suffix)
+    return WAN_IMAGE_TO_VIDEO_PATTERN.sub("i2v", family_suffix)
 
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；
@@ -386,6 +395,12 @@ def _profile_for_model(model: str | None) -> VideoCapabilities:
     if normalized in _MODEL_PROFILES:
         return _MODEL_PROFILES[normalized]
     classification = classify_wan_model(normalized)
+    # has_known_modality=False 表示 infer_endpoint 已把该 id 排除出原生路由（videoedit/s2v/v2v
+    # 等未实现模态、或 wan2x_dot 的未验证 image-to-video 续接），此处必须同步回落 _DEFAULT_PROFILE
+    # ——否则子串容忍匹配仍可能在装饰后缀里找到共存的已知 token（如 "wan2.7-i2v-s2v"
+    # 里的 "i2v"），让不落原生路由的 id 反而拿到该路由的能力档，与路由判定互斥。
+    if not classification.has_known_modality:
+        return _DEFAULT_PROFILE
     if classification.profile_key is not None:
         normalized = classification.profile_key
     # 各 profile key（happyhorse-{1.0,1.1}-{t2v,i2v,r2v} / wan2.7-{t2v,i2v,r2v} /

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -128,9 +128,11 @@ _WAN3_MODEL_KEY = "wan3.0-video"
 # 的第三方型号名。
 WAN3_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?3(?![a-z0-9])", re.I)
 
-# wan2.7 家族 model_id 识别，匹配宽度与 WAN3_PATTERN 对齐（连字符/下划线可选、标识符边界避免
-# 误吞 "swan2"、"wan20"）：endpoints.py::is_wan_family 复用同一正则，使连字符形态（"wan-2.7"）
-# 与点号形态（"wan2.7"）在图像/视频归属与端点路由上得出一致结论。
+# 万相 2.x 家族 model_id 识别，匹配宽度与 WAN3_PATTERN 对齐（连字符/下划线可选、不锚版本号、
+# 标识符边界避免误吞 "swan2"、"wan20"）：endpoints.py::is_wan_family 复用同一正则，使连字符形态
+# （"wan-2.7"）与点号形态（"wan2.7"）在图像/视频归属与端点路由上得出一致结论。不锚版本号意味着
+# 整个 2.x 系列（含 "wan-2.1"、裸 "wan2"）都按万相家族路由到百炼原生端点，与点号形态一致；
+# 能力档只有 2.7 三档，其余 2.x 仍按下方子串匹配落通用默认。
 WAN2_PATTERN = re.compile(r"(?<![a-z0-9])wan[-_]?2(?![a-z0-9])", re.I)
 
 # 按 model id 派发能力声明。happyhorse-r2v 仅 reference_image（无 first_frame）；

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -229,6 +229,12 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
         has_known_modality = (
             _find_known_profile_key(profile_key, (k for k in _MODEL_PROFILES if k.startswith("wan2.7-"))) is not None
         )
+    elif family == "wan2x_dot" and is_image_to_video:
+        # wan2x_dot 没有登记任何 VideoCapabilities（profile_key 恒 None，下条注释），image-to-video
+        # 续接语法命中时若仍放行原生路由，_profile_for_model 会回落 _DEFAULT_PROFILE（first_frame
+        # 默认 True，恰好掩盖问题），但本后端并未为这些未收窄的 2.x 小版本声明过已验证的首帧请求
+        # 构造，登记前先排除出原生路由，同落下方 5) 的通用视频端点。
+        has_known_modality = False
     # wan2x_dot 无法从 model_id 直接归一化出确切 t2v/i2v/r2v 档位（其命名形态未收敛），
     # profile_key 留空，交由 _profile_for_model 末尾的兜底子串匹配处理（多数落 _DEFAULT_PROFILE）；
     # 是否收窄同 wan2.7 一样按已知模态门控需要供应商 API 事实与产品判断，不由本字段代为决定。

--- a/lib/video_backends/dashscope.py
+++ b/lib/video_backends/dashscope.py
@@ -162,8 +162,9 @@ WAN_IMAGE_TO_VIDEO_PATTERN = re.compile(r"(?<![a-z0-9])image[-_]?(?:to|2)[-_]?vi
 # wan2.7-videoedit（指令式视频编辑，见 docs/research/arcreel-vendor-integration-research.md）是
 # 万相家族内真实存在的独立模态，但本后端只实现了 t2v/i2v/r2v 三档的请求构造，没有该模态所需的
 # 输入视频传输字段。命中家族正则但落这个模态的 id 须排除出原生路由与已知能力档，否则会带着
-# _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。
-WAN_VIDEOEDIT_PATTERN = re.compile(r"video[-_]?edit", re.I)
+# _DEFAULT_PROFILE（丢失该模态实际所需的能力声明）发出本后端无法正确构造的请求。两侧标识符边界
+# 避免 "videoeditor" 一类无关词形（"edit" 后紧邻字母）被误判命中。
+WAN_VIDEOEDIT_PATTERN = re.compile(r"(?<![a-z0-9])video[-_]?edit(?![a-z0-9])", re.I)
 
 WanFamily = Literal["happyhorse", "wan2.7", "wan3", "wan2x_dot"]
 
@@ -232,8 +233,8 @@ def classify_wan_model(model_id: str | None) -> WanClassification:
     elif family == "wan2x_dot" and is_image_to_video:
         # wan2x_dot 没有登记任何 VideoCapabilities（profile_key 恒 None，下条注释），image-to-video
         # 续接语法命中时若仍放行原生路由，_profile_for_model 会回落 _DEFAULT_PROFILE（first_frame
-        # 默认 True，恰好掩盖问题），但本后端并未为这些未收窄的 2.x 小版本声明过已验证的首帧请求
-        # 构造，登记前先排除出原生路由，同落下方 5) 的通用视频端点。
+        # 默认 True，恰好掩盖问题）——但本后端并未为这些未收窄的 2.x 小版本声明过已验证的首帧
+        # 请求构造，没有已验证能力/请求 schema 的 id 排除出原生路由，同落下方 5) 的通用视频端点。
         has_known_modality = False
     # wan2x_dot 无法从 model_id 直接归一化出确切 t2v/i2v/r2v 档位（其命名形态未收敛），
     # profile_key 留空，交由 _profile_for_model 末尾的兜底子串匹配处理（多数落 _DEFAULT_PROFILE）；

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -332,6 +332,10 @@ class TestInferEndpoint:
             ("wan-2.7-videoedit", "openai", "openai-video"),
             ("wan_2.7-videoedit", "openai", "openai-video"),
             ("wan2.7-videoedit", "openai", "openai-video"),
+            # happyhorse 同一边界要求：与 DashScopeVideoBackend._profile_for_model 的兜底子串匹配
+            # 对同一 key 保持同等边界，否则会出现"路由到本后端却拿不到对应能力档"的矛盾。
+            ("myhappyhorse-1.0-r2v", "openai", "openai-chat"),
+            ("happyhorse-1.0-r2v", "openai", "dashscope-async-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -327,6 +327,11 @@ class TestInferEndpoint:
             ("wan-2.1-kf2v", "openai", "openai-video"),  # 连字符 + 非 2.7 → 通用端点
             ("wan_2.2-t2v", "openai", "openai-video"),  # 下划线 + 非 2.7 → 通用端点
             ("wan2.1-kf2v", "openai", "dashscope-async-video"),  # 点号形态走字面量判定，非本正则
+            # 2.7 家族内 videoedit 模态：命中家族正则但 DashScopeVideoBackend 未实现其请求构造，
+            # 排除出原生路由（见 _WAN_VIDEOEDIT_PATTERN 处的说明）。
+            ("wan-2.7-videoedit", "openai", "openai-video"),
+            ("wan_2.7-videoedit", "openai", "openai-video"),
+            ("wan2.7-videoedit", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -282,18 +282,22 @@ class TestInferEndpoint:
             # ── 阿里百炼 wan2.x / wan3.0 → dashscope-async-video（image 变体不受影响）──
             ("wan2.7-i2v", "openai", "dashscope-async-video"),
             ("wan2.7-t2v", "openai", "dashscope-async-video"),
+            ("wan-2.7-i2v", "openai", "dashscope-async-video"),  # 连字符形态与点号形态匹配宽度一致
+            ("wan_2.7-t2v", "openai", "dashscope-async-video"),
             ("wan3.0-video", "openai", "dashscope-async-video"),
             ("Wan3.0-Video", "openai", "dashscope-async-video"),  # 大小写不敏感
             ("proxy/wan3.0-video", "openai", "dashscope-async-video"),
             ("wan-3-turbo", "openai", "dashscope-async-video"),  # 连字符形态与点号形态匹配宽度一致
             ("wan3-turbo", "openai", "dashscope-async-video"),
             ("wan2.7-image", "openai", "openai-images"),  # image 变体不受影响
+            ("wan-2.7-image", "openai", "openai-images"),  # 连字符形态的 image 变体同样落图像端点
             ("wan3.0-video-image", "openai", "openai-images"),  # 含 image 语义不受影响
             ("wan-3-turbo-image", "openai", "openai-images"),  # 连字符形态的 image 变体同样不受影响
             # image-to-video 别名含 "image" 子串但本质是视频，须留在 dashscope-async-video（同
             # kling-image2video 的"video 语义优先"原则），不能被笼统 is_image 误判成图像变体。
             ("wan-3-turbo-image-to-video", "openai", "dashscope-async-video"),
             ("wan3-image2video", "openai", "dashscope-async-video"),
+            ("wan-2.7-image-to-video", "openai", "dashscope-async-video"),
             # 反向陷阱：真图像别名不保证以 "image" 结尾（版本/日期/变体后缀），不能靠"结尾是不是
             # image"反推是不是图像——只有显式 image-to-video 续接语法才算视频例外，其余含 image
             # 语义一律仍是图像。
@@ -304,15 +308,14 @@ class TestInferEndpoint:
             ("wan_3_turbo", "openai", "dashscope-async-video"),
             ("wan_3.0-image", "openai", "openai-images"),
             ("WAN_3_TURBO_IMAGE_TO_VIDEO", "openai", "dashscope-async-video"),
-            # 标识符边界：含 "wan3" 子串但并非该家族的型号名不得被误判——WAN3_PATTERN 两侧要求
-            # 非字母数字边界，裸 "wan" 命中 _VIDEO_PATTERN 仍落回通用视频分支。
+            # 标识符边界：含 "wan3"/"wan2" 子串但并非该家族的型号名不得被误判——WAN2_PATTERN /
+            # WAN3_PATTERN 两侧要求非字母数字边界，裸 "wan" 仍命中 _VIDEO_PATTERN 落回通用视频分支。
             ("swan3", "openai", "openai-video"),
             ("vendorwan3", "openai", "openai-video"),
             ("wan30", "openai", "openai-video"),
-            # 表征测试，非期望结论：wan2 家族仅认字面 "wan2."（要求点号）触发 is_wan_family，
-            # 连字符无点号形态 wan-2.7 不触发，其 image 变体因此被裸 "wan" 命中 _VIDEO_PATTERN
-            # 误判为视频而非图像，这是已知局限而非设计意图。断言钉住当前行为、防止无意变更。
-            ("wan-2.7-image", "openai", "openai-video"),
+            ("swan2", "openai", "openai-video"),
+            ("vendorwan2", "openai", "openai-video"),
+            ("wan20", "openai", "openai-video"),
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -316,6 +316,13 @@ class TestInferEndpoint:
             ("swan2", "openai", "openai-video"),
             ("vendorwan2", "openai", "openai-video"),
             ("wan20", "openai", "openai-video"),
+            # 万相 2.x 小版本边界：WAN2_PATTERN 只认 2.7，其余 2.x（2.1/2.2 等）的连字符/下划线
+            # 形态不落原生端点——本后端固定请求的 video-generation/video-synthesis 端点与这些
+            # 小版本的实际协议不符，强行路由过去只会把死分歧变成活缺陷（见 dashscope.py
+            # WAN2_PATTERN 处的说明）。点号形态维持既有行为（既有的字面量判定，本票不碰）。
+            ("wan-2.1-kf2v", "openai", "openai-video"),  # 连字符 + 非 2.7 → 通用端点
+            ("wan_2.2-t2v", "openai", "openai-video"),  # 下划线 + 非 2.7 → 通用端点
+            ("wan2.1-kf2v", "openai", "dashscope-async-video"),  # 点号形态既有行为不变
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -316,6 +316,10 @@ class TestInferEndpoint:
             ("swan2", "openai", "openai-video"),
             ("vendorwan2", "openai", "openai-video"),
             ("wan20", "openai", "openai-video"),
+            # 同一边界陷阱、但字母粘连前缀后接完整点号形态 + 版本号 + 模态后缀：_WAN_DOT_FORM_PATTERN
+            # 若不做左侧边界校验，"swan2.7-r2v" 去掉首字符即与 "wan2.7-r2v" 字面相同，会被误判命中。
+            ("swan2.7-r2v", "openai", "openai-video"),
+            ("vendorwan2.7-t2v", "openai", "openai-video"),
             # 万相 2.x 小版本边界：WAN2_PATTERN 只认 2.7，其余 2.x（2.1/2.2 等）的连字符/下划线
             # 形态不落原生端点——本后端固定请求的 video-generation/video-synthesis 端点与这些
             # 小版本的实际协议不符（见 dashscope.py WAN2_PATTERN 处的说明）。点号形态另受独立的

--- a/tests/test_custom_provider_endpoints.py
+++ b/tests/test_custom_provider_endpoints.py
@@ -318,11 +318,11 @@ class TestInferEndpoint:
             ("wan20", "openai", "openai-video"),
             # 万相 2.x 小版本边界：WAN2_PATTERN 只认 2.7，其余 2.x（2.1/2.2 等）的连字符/下划线
             # 形态不落原生端点——本后端固定请求的 video-generation/video-synthesis 端点与这些
-            # 小版本的实际协议不符，强行路由过去只会把死分歧变成活缺陷（见 dashscope.py
-            # WAN2_PATTERN 处的说明）。点号形态维持既有行为（既有的字面量判定，本票不碰）。
+            # 小版本的实际协议不符（见 dashscope.py WAN2_PATTERN 处的说明）。点号形态另受独立的
+            # 字面量判定约束，不受 WAN2_PATTERN 的版本锚定限制。
             ("wan-2.1-kf2v", "openai", "openai-video"),  # 连字符 + 非 2.7 → 通用端点
             ("wan_2.2-t2v", "openai", "openai-video"),  # 下划线 + 非 2.7 → 通用端点
-            ("wan2.1-kf2v", "openai", "dashscope-async-video"),  # 点号形态既有行为不变
+            ("wan2.1-kf2v", "openai", "dashscope-async-video"),  # 点号形态走字面量判定，非本正则
             # ── 向后兼容（行为不变）──
             ("gpt-4o", "openai", "openai-chat"),
             ("claude-sonnet-4.5", "openai", "openai-chat"),

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -960,10 +960,10 @@ class TestWan2Aliases:
     def test_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
         """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.x 家族。
 
-        "swan2.7-r2v" / "vendorwan2.7-t2v" 这类完整别名（左侧紧贴字母、右侧带合法模态后缀）
-        单靠 WAN2_PATTERN 的边界锚点会被正确拒绝，但 _profile_for_model 末尾的兜底子串匹配
-        此前对 _MODEL_PROFILES 各 key 没有同等的边界校验——"swan2.7-r2v" 去掉首字符后与
-        "wan2.7-r2v" 逐字符相同，曾被该循环误判命中。
+        "swan2.7-r2v" / "vendorwan2.7-t2v" 这类完整别名（左侧紧贴字母、右侧带合法模态后缀）单靠
+        WAN2_PATTERN 的边界锚点无法拦下——命中的是 _profile_for_model 末尾的兜底子串匹配：
+        "swan2.7-r2v" 去掉首字符后与 _MODEL_PROFILES 的 key "wan2.7-r2v" 逐字符相同，该循环须
+        对每个 key 同样做左侧边界校验才不会误判命中。
         """
         from lib.video_backends.dashscope import DashScopeVideoBackend
 

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -899,13 +899,14 @@ class TestWan2Aliases:
     """
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v"])
+    @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v", "wan_2.7_r2v"])
     def test_alias_forms_get_wan27_r2v_capabilities(self, model):
         """discovery 返回的连字符/下划线 wan2.7 别名（endpoints.py 已路由到本后端）须认作
         wan2.7-r2v，不落回默认档案。
 
         与 endpoints.infer_endpoint 共用 WAN2_PATTERN：两处不同宽即会出现"路由到本后端却被当
-        通用型号丢失参考图/首帧参数"的矛盾。
+        通用型号丢失参考图/首帧参数"的矛盾。"wan_2.7_r2v" 这类版本号与模态后缀之间也用下划线
+        分隔的别名，须额外把该分隔符归一化成连字符才能匹配 _MODEL_PROFILES 的 key。
         """
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
@@ -915,7 +916,7 @@ class TestWan2Aliases:
         assert caps.max_reference_audio_count == 5
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["wan-2.7-image-to-video", "wan_2.7-image2video"])
+    @pytest.mark.parametrize("model", ["wan-2.7-image-to-video", "wan_2.7-image2video", "wan_2.7_image_to_video"])
     def test_image_to_video_alias_gets_wan27_i2v_capabilities(self, model):
         """连字符/下划线形态的 image-to-video 续接别名归一化后仍带该后缀（如
         "wan2.7-image-to-video"），不与 _MODEL_PROFILES 的 "wan2.7-i2v" 构成子串关系；须先把
@@ -926,6 +927,20 @@ class TestWan2Aliases:
 
         caps = DashScopeVideoBackend.video_capabilities_for_model(model)
         assert caps.first_frame is True
+        # r2v 同样 first_frame=True，靠 max_reference_images 区分二者：i2v 无参考图能力，
+        # 缺这条断言时归一化误落 r2v 档案也会通过。
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars == 5000
+
+    @pytest.mark.unit
+    def test_fully_underscored_t2v_alias_does_not_get_default_first_frame(self):
+        """ "wan_2.7_t2v" 的版本号与模态后缀均用下划线分隔；t2v 无首帧能力，与 _DEFAULT_PROFILE
+        的默认 first_frame=True 恰好相反，能验证确实解析到了 wan2.7-t2v 而非静默落回默认档。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model("wan_2.7_t2v")
+        assert caps.first_frame is False
         assert caps.max_prompt_chars == 5000
 
     @pytest.mark.unit

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -893,6 +893,36 @@ class TestWan27ReferenceVoice:
         assert exc.value.code == "video_reference_audio_format_unsupported"
 
 
+class TestWan2Aliases:
+    """wan2 家族 model_id 的能力档解析：连字符/下划线别名与点号形态须归同一档。"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v"])
+    def test_alias_forms_get_wan27_r2v_capabilities(self, model):
+        """discovery 返回的连字符/下划线 wan2.7 别名（endpoints.py 已路由到本后端）须认作
+        wan2.7-r2v，不落回默认档案。
+
+        与 endpoints.infer_endpoint 共用 WAN2_PATTERN：两处不同宽即会出现"路由到本后端却被当
+        通用型号丢失参考图/首帧参数"的矛盾。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.first_frame is True
+        assert caps.max_reference_images == 5
+        assert caps.max_reference_audio_count == 5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20"])
+    def test_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
+        """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.x 家族。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars is None
+
+
 class TestWan3:
     """wan3.0-video：单模型通吃三条路径，首尾帧 + 独立参考音频条目 + 可控音轨。"""
 
@@ -943,32 +973,6 @@ class TestWan3:
     @pytest.mark.parametrize("model", ["swan3", "vendorwan3", "wan30"])
     def test_wan3_substring_without_boundary_does_not_get_wan3_capabilities(self, model):
         """含 "wan3" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 3.0 家族。"""
-        from lib.video_backends.dashscope import DashScopeVideoBackend
-
-        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
-        assert caps.max_reference_images == 0
-        assert caps.max_prompt_chars is None
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v"])
-    def test_wan2_alias_forms_get_wan27_r2v_capabilities(self, model):
-        """discovery 返回的连字符/下划线 wan2.7 别名（endpoints.py 已路由到本后端）须认作
-        wan2.7-r2v，不落回默认档案。
-
-        与 endpoints.infer_endpoint 共用 WAN2_PATTERN：两处不同宽即会出现"路由到本后端却被当
-        通用型号丢失参考图/首帧参数"的矛盾。
-        """
-        from lib.video_backends.dashscope import DashScopeVideoBackend
-
-        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
-        assert caps.first_frame is True
-        assert caps.max_reference_images == 5
-        assert caps.max_reference_audio_count == 5
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20"])
-    def test_wan2_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
-        """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.7 家族。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         caps = DashScopeVideoBackend.video_capabilities_for_model(model)

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -894,7 +894,9 @@ class TestWan27ReferenceVoice:
 
 
 class TestWan2Aliases:
-    """wan2 家族 model_id 的能力档解析：连字符/下划线别名与点号形态须归同一档。"""
+    """wan2.7 的 model_id 能力档解析：连字符/下划线别名与点号形态须归同一档；WAN2_PATTERN 只认
+    2.7，其余 2.x 小版本（2.1/2.2 等）不在本正则确权范围内（见 WAN2_PATTERN 处的说明）。
+    """
 
     @pytest.mark.unit
     @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v"])
@@ -913,9 +915,36 @@ class TestWan2Aliases:
         assert caps.max_reference_audio_count == 5
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-2.7-image-to-video", "wan_2.7-image2video"])
+    def test_image_to_video_alias_gets_wan27_i2v_capabilities(self, model):
+        """连字符/下划线形态的 image-to-video 续接别名归一化后仍带该后缀（如
+        "wan2.7-image-to-video"），不与 _MODEL_PROFILES 的 "wan2.7-i2v" 构成子串关系；须先把
+        该后缀折成 "i2v" 再查表，否则静默落默认档、丢失 first_frame，_build_media 据此不下发
+        start_image。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.first_frame is True
+        assert caps.max_prompt_chars == 5000
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20"])
     def test_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
         """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.x 家族。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars is None
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-2.1-r2v", "wan_2.2-i2v"])
+    def test_non_27_alias_forms_fall_back_to_default_profile(self, model):
+        """WAN2_PATTERN 只认 2.7：连字符/下划线形态的其余 2.x 小版本不落 wan2.7 能力档——
+        本后端固定请求的端点与这些小版本的实际协议不符（见 WAN2_PATTERN 处的说明），
+        endpoints.py 也不会把它们路由到本后端；此处确认能力档解析同样不越界。
+        """
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         caps = DashScopeVideoBackend.video_capabilities_for_model(model)

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -182,6 +182,21 @@ class TestCapabilities:
         assert DashScopeVideoBackend.video_capabilities_for_model("myhappyhorse-1.0-r2v").max_reference_images == 0
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan2.7-i2vfoo", "happyhorse-1.0-r2vfoo"])
+    def test_alnum_glued_suffix_does_not_resolve_known_profile(self, model):
+        """字母数字直接粘连的后缀同样不算装饰名，须落回 _DEFAULT_PROFILE。
+
+        与前两条用例互补的第三个边界方向："wan2.7-i2vfoo" 截断掉 "foo" 后与 key "wan2.7-i2v"
+        逐字符相同，若子串匹配只做左侧边界校验、不做右侧校验，未知变体后缀会被截断误判成已知
+        modality；数字后缀（"-0715"）靠 "-" 分隔满足右侧边界，不受本用例约束。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars is None
+
+    @pytest.mark.unit
     def test_unknown_bare_series_falls_back_to_default(self):
         """仅系列名无变体后缀（裸 "happyhorse"）无法判别 t2v/i2v/r2v → 通用默认（无 r2v）。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -170,6 +170,18 @@ class TestCapabilities:
             assert DashScopeVideoBackend.video_capabilities_for_model(model).max_reference_images == expected_max
 
     @pytest.mark.unit
+    def test_alnum_glued_prefix_does_not_resolve_r2v_caps(self):
+        """字母数字直接粘连的前缀（无分隔符）不算装饰名，须落回 _DEFAULT_PROFILE。
+
+        与上一条用例的边界相反："myhappyhorse-1.0-r2v" 去掉 "my" 后与
+        "happyhorse-1.0-r2v" 逐字符相同，若子串匹配不做标识符边界校验就会误判命中——
+        代理装饰名靠 "/" ":" 等非字母数字分隔符与真实型号名区分，"my" 直接粘连不满足。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        assert DashScopeVideoBackend.video_capabilities_for_model("myhappyhorse-1.0-r2v").max_reference_images == 0
+
+    @pytest.mark.unit
     def test_unknown_bare_series_falls_back_to_default(self):
         """仅系列名无变体后缀（裸 "happyhorse"）无法判别 t2v/i2v/r2v → 通用默认（无 r2v）。"""
         from lib.video_backends.dashscope import DashScopeVideoBackend
@@ -944,9 +956,15 @@ class TestWan2Aliases:
         assert caps.max_prompt_chars == 5000
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20"])
+    @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20", "swan2.7-r2v", "vendorwan2.7-t2v"])
     def test_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
-        """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.x 家族。"""
+        """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.x 家族。
+
+        "swan2.7-r2v" / "vendorwan2.7-t2v" 这类完整别名（左侧紧贴字母、右侧带合法模态后缀）
+        单靠 WAN2_PATTERN 的边界锚点会被正确拒绝，但 _profile_for_model 末尾的兜底子串匹配
+        此前对 _MODEL_PROFILES 各 key 没有同等的边界校验——"swan2.7-r2v" 去掉首字符后与
+        "wan2.7-r2v" 逐字符相同，曾被该循环误判命中。
+        """
         from lib.video_backends.dashscope import DashScopeVideoBackend
 
         caps = DashScopeVideoBackend.video_capabilities_for_model(model)

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -950,6 +950,32 @@ class TestWan3:
         assert caps.max_prompt_chars is None
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["wan-2.7-r2v", "wan_2.7-r2v"])
+    def test_wan2_alias_forms_get_wan27_r2v_capabilities(self, model):
+        """discovery 返回的连字符/下划线 wan2.7 别名（endpoints.py 已路由到本后端）须认作
+        wan2.7-r2v，不落回默认档案。
+
+        与 endpoints.infer_endpoint 共用 WAN2_PATTERN：两处不同宽即会出现"路由到本后端却被当
+        通用型号丢失参考图/首帧参数"的矛盾。
+        """
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.first_frame is True
+        assert caps.max_reference_images == 5
+        assert caps.max_reference_audio_count == 5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("model", ["swan2", "vendorwan2", "wan20"])
+    def test_wan2_substring_without_boundary_does_not_get_wan2_capabilities(self, model):
+        """含 "wan2" 子串但两侧非字母数字边界不成立的型号名，不得被误判为万相 2.7 家族。"""
+        from lib.video_backends.dashscope import DashScopeVideoBackend
+
+        caps = DashScopeVideoBackend.video_capabilities_for_model(model)
+        assert caps.max_reference_images == 0
+        assert caps.max_prompt_chars is None
+
+    @pytest.mark.unit
     def test_first_and_last_frame_in_media(self, tmp_path):
         payload = self._backend()._build_payload(
             VideoGenerationRequest(

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -59,8 +59,11 @@ pytestmark = pytest.mark.unit
         ("minimax-h3", list(range(4, 16))),
         ("MiniMax-H3", list(range(4, 16))),
         ("proxy-minimax-h3-turbo", list(range(4, 16))),
-        # Wan
+        # Wan（连字符/下划线/点号三种分隔符形态同档，与端点路由、能力档的匹配宽度一致）
         ("wan-2.1", [4, 5]),
+        ("wan2.7-i2v", [4, 5]),
+        ("wan_2.7-i2v", [4, 5]),
+        ("WAN_2-T2V", [4, 5]),
         # 万相 3.0（不落入通用 Wan 的 [4, 5] 预设）
         ("wan3.0-video", list(range(2, 31))),
         ("Wan3.0-Video", list(range(2, 31))),

--- a/tests/test_duration_presets.py
+++ b/tests/test_duration_presets.py
@@ -61,9 +61,11 @@ pytestmark = pytest.mark.unit
         ("proxy-minimax-h3-turbo", list(range(4, 16))),
         # Wan（连字符/下划线/点号三种分隔符形态同档，与端点路由、能力档的匹配宽度一致）
         ("wan-2.1", [4, 5]),
-        ("wan2.7-i2v", [4, 5]),
-        ("wan_2.7-i2v", [4, 5]),
         ("WAN_2-T2V", [4, 5]),
+        # 万相 2.7（不落入通用 Wan 的 [4, 5] 预设；连字符/下划线/点号三种形态同档）
+        ("wan2.7-i2v", list(range(2, 16))),
+        ("wan_2.7-i2v", list(range(2, 16))),
+        ("wan-2.7-i2v", list(range(2, 16))),
         # 万相 3.0（不落入通用 Wan 的 [4, 5] 预设）
         ("wan3.0-video", list(range(2, 31))),
         ("Wan3.0-Video", list(range(2, 31))),

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -181,6 +181,14 @@ def test_wan27_videoedit_excluded_even_alongside_recognized_modality_token() -> 
     assert infer_supported_durations("wan2.7-i2v-videoedit") != list(range(2, 16))
 
 
+@pytest.mark.parametrize("model_id", ["proxy-videoeditor/wan2.7-i2v", "proxy-videoedit-service/wan_2.7-r2v"])
+def test_videoedit_token_requires_identifier_boundary(model_id: str) -> None:
+    """ "videoedit" 判定须按标识符边界匹配："videoeditor" 一类无关词形不应误判命中；真正的
+    "videoedit" 装饰前缀（如 "-service" 后缀分隔）仍要正确命中并排除出原生路由。"""
+    is_editor_typo = "videoeditor" in model_id
+    assert infer_endpoint(model_id, "openai") == ("dashscope-async-video" if is_editor_typo else "openai-video")
+
+
 @pytest.mark.parametrize("model_id", ["proxy-videoedit/wan3-turbo", "wan-3-turbo-videoedit"])
 def test_videoedit_exclusion_scoped_to_wan27_only(model_id: str) -> None:
     """videoedit 排除只对 wan2.7 家族生效——wan3 的 id 即便含 "videoedit" 子串（装饰前缀或
@@ -210,7 +218,7 @@ def test_wan27_unrecognized_modality_excluded_from_native_route_and_family_durat
 def test_wan2x_dot_image_to_video_has_no_registered_capability_falls_back_to_generic(model_id: str) -> None:
     """wan2x_dot（2.7 以外的点号形态）没有登记任何 VideoCapabilities；image-to-video 续接语法
     命中时若仍放行原生路由，会静默拿到 _DEFAULT_PROFILE（恰好 first_frame=True，掩盖问题）。
-    登记前排除出原生路由，落通用视频端点。"""
+    没有已验证能力/请求 schema 的 id 排除出原生路由，落通用视频端点。"""
     assert infer_endpoint(model_id, "openai") == "openai-video"
 
 

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -223,6 +223,26 @@ def test_minimax_s2v_routing_survives_incidental_wan_substring(model_id: str) ->
     assert infer_endpoint(model_id, "openai") == "minimax-video"
 
 
+@pytest.mark.parametrize("model_id", ["wan2-s2v", "wan-2-s2v", "wan_2-s2v"])
+def test_wan_glued_bare_digit_version_excluded_from_minimax_routing(model_id: str) -> None:
+    """ "wan" 与纯整数版本号（无小数点）完全粘连时，只要满足标识符左边界（"wan2" 非 "swan2"），
+    仍应识别为 wan 版本号 token、排除 MiniMax S2V 路由，与带分隔符的等价形态（"wan-2"/"wan_2"）
+    结论一致。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    ["image-to-video-proxy/swan2.7-image", "image-to-video-proxy/vendorwan2.7-image"],
+)
+def test_fallback_image_to_video_syntax_scoped_to_wan_marker_not_decoration_prefix(model_id: str) -> None:
+    """family=None 兜底路径的 image-to-video 续接语法识别同样须从字面 "wan" 子串本身开始搜索——
+    "swan2.7-image"/"vendorwan2.7-image" 均不满足家族严格边界（family=None），装饰前缀
+    "image-to-video-proxy/" 里的续接语法拼写不属于该 id 自身的模态段，不能把真图像变体误判成
+    视频续接。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -182,13 +182,29 @@ def test_videoedit_exclusion_scoped_to_wan27_only(model_id: str) -> None:
     assert infer_supported_durations(model_id) == list(range(2, 31))
 
 
-@pytest.mark.parametrize("model_id", ["wan-2.7-v2v", "wan_2.7-foo", "wan-2.7-s2v-0715"])
-def test_wan27_unrecognized_modality_excluded_from_native_route_and_family_duration(model_id: str) -> None:
+@pytest.mark.parametrize(
+    ("model_id", "expected_endpoint"),
+    [
+        ("wan-2.7-v2v", "openai-video"),
+        ("wan_2.7-foo", "openai-video"),
+        ("wan-2.7-s2v-0715", "openai-video"),
+    ],
+)
+def test_wan27_unrecognized_modality_excluded_from_native_route_and_family_duration(
+    model_id: str, expected_endpoint: str
+) -> None:
     """wan2.7 家族命中但模态未实现请求构造（非 t2v/i2v/r2v，videoedit 之外的其余未知后缀）时，
     不落原生端点、时长也不套用家族档——与 videoedit 走同一条排除路径。"""
-    assert infer_endpoint(model_id, "openai") != "dashscope-async-video"
+    assert infer_endpoint(model_id, "openai") == expected_endpoint
     assert infer_supported_durations(model_id) != list(range(2, 16))
-    assert infer_supported_durations("wan-2.7-videoedit") != list(range(2, 16))
+
+
+@pytest.mark.parametrize("model_id", ["wan2.6-image-to-video", "wan2.1-image-to-video"])
+def test_wan2x_dot_image_to_video_has_no_registered_capability_falls_back_to_generic(model_id: str) -> None:
+    """wan2x_dot（2.7 以外的点号形态）没有登记任何 VideoCapabilities；image-to-video 续接语法
+    命中时若仍放行原生路由，会静默拿到 _DEFAULT_PROFILE（恰好 first_frame=True，掩盖问题）。
+    登记前排除出原生路由，落通用视频端点。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -138,17 +138,23 @@ def test_boundary_false_positives_are_rejected(model_id: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "model_id",
+    ("model_id", "expected_endpoint"),
     [
-        "wan2.7foo-r2v",  # WAN_DOT_FORM_PATTERN 右边界：紧跟字母不算 2.x 点号形态
-        "happyhorsefoo-t2v",  # HAPPYHORSE_PATTERN 右边界：紧跟字母不算 happyhorse 家族
-        "wan-2.7-fooimage-to-video",  # WAN_IMAGE_TO_VIDEO_PATTERN 左边界：紧邻字母不算续接语法
-        "wan-2.7-image-to-videofoo",  # WAN_IMAGE_TO_VIDEO_PATTERN 右边界：紧邻字母不算续接语法
+        # WAN_DOT_FORM_PATTERN 右边界：紧跟字母不算 2.x 点号形态，落通用视频端点（裸 "wan" 子串
+        # 仍命中 _VIDEO_PATTERN）。
+        ("wan2.7foo-r2v", "openai-video"),
+        # HAPPYHORSE_PATTERN 右边界：紧跟字母不算 happyhorse 家族，不含视频/图像关键字，落默认
+        # 文本端点。
+        ("happyhorsefoo-t2v", "openai-chat"),
+        # WAN_IMAGE_TO_VIDEO_PATTERN 左边界：紧邻字母不算续接语法，按含 image 语义的图像变体处理。
+        ("wan-2.7-fooimage-to-video", "openai-images"),
+        # WAN_IMAGE_TO_VIDEO_PATTERN 右边界：同上。
+        ("wan-2.7-image-to-videofoo", "openai-images"),
     ],
 )
-def test_adjacent_letters_do_not_qualify_as_classification_tokens(model_id: str) -> None:
+def test_adjacent_letters_do_not_qualify_as_classification_tokens(model_id: str, expected_endpoint: str) -> None:
     """分类 token 两侧标识符边界须完整：紧邻字母/数字的相似子串不应被误判命中。"""
-    assert infer_endpoint(model_id, "openai") != "dashscope-async-video"
+    assert infer_endpoint(model_id, "openai") == expected_endpoint
     caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
     assert caps is _DEFAULT_PROFILE
 

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -168,6 +168,20 @@ def test_wan_substring_image_variant_routes_to_image_endpoint_despite_rejected_f
     assert infer_endpoint(model_id, "openai") == "openai-images"
 
 
+@pytest.mark.parametrize("model_id", ["image-proxy/wan-2.7-i2v", "proxy-image/wan_2.7-r2v"])
+def test_wan27_known_modality_not_downgraded_by_unrelated_image_decoration(model_id: str) -> None:
+    """wan2.7 已解析出已知 t2v/i2v/r2v profile 时，id 别处（如代理命名空间前缀）另含无关 "image"
+    子串不应被误判成图像变体——已知 profile 本身已确立视频语义，须优先于笼统 image 子串判定。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+
+
+@pytest.mark.parametrize("model_id", ["wan3.0-image-edit", "wan-3-turbo-image-preview"])
+def test_wan3_image_variant_still_routes_to_image_endpoint(model_id: str) -> None:
+    """wan3 只有单一 profile key，has_known_modality 恒真，不区分 t2v/i2v/r2v 与 image-edit 等真
+    图像别名——上一条已知 modality 豁免不套用到 wan3，真图像别名仍须正确落图像端点。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -137,6 +137,22 @@ def test_boundary_false_positives_are_rejected(model_id: str) -> None:
     assert caps.max_prompt_chars is None
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "wan2.7foo-r2v",  # WAN_DOT_FORM_PATTERN 右边界：紧跟字母不算 2.x 点号形态
+        "happyhorsefoo-t2v",  # HAPPYHORSE_PATTERN 右边界：紧跟字母不算 happyhorse 家族
+        "wan-2.7-fooimage-to-video",  # WAN_IMAGE_TO_VIDEO_PATTERN 左边界：紧邻字母不算续接语法
+        "wan-2.7-image-to-videofoo",  # WAN_IMAGE_TO_VIDEO_PATTERN 右边界：紧邻字母不算续接语法
+    ],
+)
+def test_adjacent_letters_do_not_qualify_as_classification_tokens(model_id: str) -> None:
+    """分类 token 两侧标识符边界须完整：紧邻字母/数字的相似子串不应被误判命中。"""
+    assert infer_endpoint(model_id, "openai") != "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps is _DEFAULT_PROFILE
+
+
 @pytest.mark.parametrize("model_id", ["swan2.7-image", "vendorwan2.7-image"])
 def test_wan_substring_image_variant_routes_to_image_endpoint_despite_rejected_family(
     model_id: str,

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -199,6 +199,27 @@ def test_wan27_unrecognized_modality_with_image_substring_stays_image_variant(mo
     assert infer_endpoint(model_id, "openai") == "openai-images"
 
 
+@pytest.mark.parametrize("model_id", ["wan2.7-i2v-s2v", "wan-2.7-r2v-v2v"])
+def test_wan27_known_token_does_not_mask_coexisting_s2v_v2v(model_id: str) -> None:
+    """id 同时含已知 profile token（i2v/r2v）与 s2v/v2v 时：s2v/v2v 未实现请求构造这一事实优先于
+    已知 token 命中，不能被后者掩盖而误放行原生路由（与 videoedit 共存已知 token 的既有排除同理）。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+    assert infer_supported_durations(model_id) != list(range(2, 16))
+
+
+@pytest.mark.parametrize("model_id", ["s2v-proxy/wan2.7-image", "v2v-service/wan-2.7-image"])
+def test_wan27_image_variant_not_upgraded_by_s2v_v2v_decoration_before_marker(model_id: str) -> None:
+    """s2v/v2v 的识别只在 wan2.7 标记之后的模态段内生效，不含标记前的装饰前缀——真图像变体
+    （模态段字面即 "image"）不应被装饰前缀里恰好出现的 "s2v"/"v2v" 误判成已知视频模态。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
+def test_minimax_s2v_routing_survives_incidental_wan_substring() -> None:
+    """MiniMax S2V 二级路由的 wan 排除只认版本号相邻的 wan token，不认任意含 "wan" 子串的单词——
+    "swan" 只是恰好含 "wan" 子串的无关词形，不应被误判成 wan 家族而错过 MiniMax 路由。"""
+    assert infer_endpoint("minimax-s2v-swan", "openai") == "minimax-video"
+
+
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""
@@ -213,11 +234,18 @@ def test_wan27_videoedit_excluded_even_alongside_recognized_modality_token() -> 
 
 
 @pytest.mark.parametrize("model_id", ["proxy-videoeditor/wan2.7-i2v", "proxy-videoedit-service/wan_2.7-r2v"])
-def test_videoedit_token_requires_identifier_boundary(model_id: str) -> None:
-    """ "videoedit" 判定须按标识符边界匹配："videoeditor" 一类无关词形不应误判命中；真正的
-    "videoedit" 装饰前缀（如 "-service" 后缀分隔）仍要正确命中并排除出原生路由。"""
-    is_editor_typo = "videoeditor" in model_id
-    assert infer_endpoint(model_id, "openai") == ("dashscope-async-video" if is_editor_typo else "openai-video")
+def test_videoedit_detection_ignores_decoration_before_wan27_marker(model_id: str) -> None:
+    """ "videoedit" 判定只在 wan2.7 标记之后的模态段内生效，不含标记前的装饰前缀："videoeditor"
+    一类无关词形本就不满足标识符边界；"videoedit-service" 这类装饰前缀即便满足边界也不计入——
+    与代理命名空间无关的真实模态（如 i2v/r2v）应正常落原生路由。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+
+
+@pytest.mark.parametrize("model_id", ["wan2.7-r2v-videoedit", "wan_2.7-videoedit-0715"])
+def test_videoedit_detected_within_modality_segment_after_marker(model_id: str) -> None:
+    """真正的 videoedit 标记出现在 wan2.7 标记之后的模态段内（无论是否伴随已知 token 或后缀
+    装饰）时，仍要正确命中并排除出原生路由。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
 
 
 @pytest.mark.parametrize("model_id", ["proxy-videoedit/wan3-turbo", "wan-3-turbo-videoedit"])

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -174,6 +174,13 @@ def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     assert infer_supported_durations("wan2.7-videoedit") != list(range(2, 16))
 
 
+def test_wan27_videoedit_excluded_even_alongside_recognized_modality_token() -> None:
+    """ "wan2.7-i2v-videoedit" 同时含已知 profile token（i2v）与 videoedit 标记：videoedit
+    未实现请求构造这一事实优先于已知 token 命中，不能被后者掩盖而误放行原生路由。"""
+    assert infer_endpoint("wan2.7-i2v-videoedit", "openai") == "openai-video"
+    assert infer_supported_durations("wan2.7-i2v-videoedit") != list(range(2, 16))
+
+
 @pytest.mark.parametrize("model_id", ["proxy-videoedit/wan3-turbo", "wan-3-turbo-videoedit"])
 def test_videoedit_exclusion_scoped_to_wan27_only(model_id: str) -> None:
     """videoedit 排除只对 wan2.7 家族生效——wan3 的 id 即便含 "videoedit" 子串（装饰前缀或

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -243,6 +243,20 @@ def test_fallback_image_to_video_syntax_scoped_to_wan_marker_not_decoration_pref
     assert infer_endpoint(model_id, "openai") == "openai-images"
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    ["vendorwan2.7-videoedit-proxy/wan2.7-r2v", "wan2.7s2v-proxy/wan2.7-i2v"],
+)
+def test_wan27_suffix_not_polluted_by_literal_marker_text_in_decoration_prefix(model_id: str) -> None:
+    """wan27_suffix 须取自家族标记本身的位置，不能通过在拼接后的完整 profile_key 上重新搜索
+    "wan2.7" 字面文本来定位——标记前的装饰前缀可能自身就含 "wan2.7" 字面子串（不满足家族标识符
+    边界、未被判定为家族标记，如 "vendorwan2.7-videoedit-proxy/" 里的 "wan2.7"），重新搜索会先
+    命中这个更靠前的字面文本，把装饰前缀内容（"videoedit"/"s2v"）误当模态段的一部分。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps is not _DEFAULT_PROFILE
+
+
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -180,6 +180,14 @@ def test_videoedit_exclusion_scoped_to_wan27_only(model_id: str) -> None:
     其他来源），也不应被误排除出原生路由，该模态的能力欠缺只记录在 wan2.7 家族下。"""
     assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
     assert infer_supported_durations(model_id) == list(range(2, 31))
+
+
+@pytest.mark.parametrize("model_id", ["wan-2.7-v2v", "wan_2.7-foo", "wan-2.7-s2v-0715"])
+def test_wan27_unrecognized_modality_excluded_from_native_route_and_family_duration(model_id: str) -> None:
+    """wan2.7 家族命中但模态未实现请求构造（非 t2v/i2v/r2v，videoedit 之外的其余未知后缀）时，
+    不落原生端点、时长也不套用家族档——与 videoedit 走同一条排除路径。"""
+    assert infer_endpoint(model_id, "openai") != "dashscope-async-video"
+    assert infer_supported_durations(model_id) != list(range(2, 16))
     assert infer_supported_durations("wan-2.7-videoedit") != list(range(2, 16))
 
 

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -202,7 +202,8 @@ def test_wan27_unrecognized_modality_with_image_substring_stays_image_variant(mo
 @pytest.mark.parametrize("model_id", ["wan2.7-i2v-s2v", "wan-2.7-r2v-v2v"])
 def test_wan27_known_token_does_not_mask_coexisting_s2v_v2v(model_id: str) -> None:
     """id 同时含已知 profile token（i2v/r2v）与 s2v/v2v 时：s2v/v2v 未实现请求构造这一事实优先于
-    已知 token 命中，不能被后者掩盖而误放行原生路由（与 videoedit 共存已知 token 的既有排除同理）。"""
+    已知 token 命中，不能被后者掩盖而误放行原生路由（videoedit 与已知 token 共存时同样按此优先级
+    排除）。"""
     assert infer_endpoint(model_id, "openai") == "openai-video"
     assert infer_supported_durations(model_id) != list(range(2, 16))
 
@@ -214,10 +215,12 @@ def test_wan27_image_variant_not_upgraded_by_s2v_v2v_decoration_before_marker(mo
     assert infer_endpoint(model_id, "openai") == "openai-images"
 
 
-def test_minimax_s2v_routing_survives_incidental_wan_substring() -> None:
+@pytest.mark.parametrize("model_id", ["minimax-s2v-swan", "minimax-s2v-swan2"])
+def test_minimax_s2v_routing_survives_incidental_wan_substring(model_id: str) -> None:
     """MiniMax S2V 二级路由的 wan 排除只认版本号相邻的 wan token，不认任意含 "wan" 子串的单词——
-    "swan" 只是恰好含 "wan" 子串的无关词形，不应被误判成 wan 家族而错过 MiniMax 路由。"""
-    assert infer_endpoint("minimax-s2v-swan", "openai") == "minimax-video"
+    "swan" 只是恰好含 "wan" 子串的无关词形，即便后面粘连数字（"swan2"）也不构成版本号形态，
+    不应被误判成 wan 家族而错过 MiniMax 路由。"""
+    assert infer_endpoint(model_id, "openai") == "minimax-video"
 
 
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -236,6 +236,21 @@ def test_wan2x_dot_image_to_video_has_no_registered_capability_falls_back_to_gen
     assert infer_endpoint(model_id, "openai") == "openai-video"
 
 
+@pytest.mark.parametrize("model_id", ["wan-2.2-image-to-video", "wan_2.6-image2video"])
+def test_image_to_video_syntax_recognized_even_when_family_boundary_unmet(model_id: str) -> None:
+    """image-to-video 续接语法的识别不依赖家族严格边界：家族分隔符（连字符隔开 wan 与版本号）
+    未满足点号形态边界、classify_wan_model 判定 family=None 时，续接语法信息仍须原样带出，
+    不能被笼统 image 判定误吞成图像端点。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+
+
+@pytest.mark.parametrize("model_id", ["wan-2.2-s2v", "wan_2.6-s2v", "vendorwan2.7-s2v"])
+def test_wan_substring_s2v_excluded_from_minimax_routing_even_without_family_match(model_id: str) -> None:
+    """裸 "s2v" 排除 MiniMax 路由的判定同样不能拿家族严格边界做门槛：这些 id 含 "wan" 子串但
+    家族边界未满足（family=None），仍应落通用视频端点而非被误吞成 MiniMax S2V 协议。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+
+
 @pytest.mark.parametrize(
     ("model_id", "expected_max_reference_images"),
     [

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -7,8 +7,8 @@ image-to-video 续接语法、videoedit 模态排除的唯一判定入口；端�
 （`lib.custom_provider.duration_presets.infer_supported_durations`）三处判定点都只消费其结论。
 本文件覆盖分隔符 × 版本 × 模态 × 大小写 × 装饰前缀等轴的组合，逐条比对三处判定点的期望值，
 并对可解析出具体模态（t2v/i2v/r2v）的家族成员做一条通用一致性断言：命中原生路由必有非默认
-能力档，反之亦然——这类互斥组合是过去几轮里三处判定宽度各自漂移时反复引入的缺陷形状，
-逐点单测抓不到，只有跨判定点的组合校验能抓到。
+能力档，反之亦然——三处判定点各自维护一份正则时容易出现宽度不一致，产生这类互斥组合；
+逐点单测无法发现，只有跨判定点的组合校验能发现。
 """
 
 from __future__ import annotations
@@ -99,7 +99,9 @@ def test_wan3_alias_routes_and_durations_consistently(model_id: str) -> None:
 def test_wan2x_non_27_dash_form_stays_generic_dot_form_stays_native(
     prefix_sep: str, modality: str, version: str, case_fn: type[str]
 ) -> None:
-    """万相 2.1/2.2：连字符/下划线前缀落通用视频端点，点号形态（既有行为，本票未变更）走原生。"""
+    """万相 2.1/2.2：连字符/下划线前缀落通用视频端点，点号形态走原生（本后端固定请求
+    video-generation/video-synthesis 端点，是否收窄该判定需要供应商 API 事实与产品判断，
+    见 classify_wan_model 的说明）。"""
     model_id = case_fn(_build(prefix_sep, version, "-", modality))
     expected_endpoint = "dashscope-async-video" if prefix_sep == "" else "openai-video"
     assert infer_endpoint(model_id, "openai") == expected_endpoint
@@ -162,8 +164,8 @@ def test_native_route_and_non_default_profile_agree(model_id: str) -> None:
     """一致性断言：家族成员且模态可解析（t2v/i2v/r2v）时，命中原生路由必有非默认能力档，反之亦然。
 
     该断言只覆盖模态可解析的成员——裸家族名（如 "happyhorse"）、wan2.7-videoedit、非 2.7 的点号形态
-    2.x（"wan2.1-*"）均因模态/协议未确权而按设计落默认档，是文档化的既有例外，不受本断言约束
-    （见 classify_wan_model 与 _profile_for_model 的说明）。
+    2.x（"wan2.1-*"）均因模态/协议未确权而按设计落默认档，不受本断言约束（见 classify_wan_model
+    与 _profile_for_model 的说明）。
     """
     routed_native = infer_endpoint(model_id, "openai") == "dashscope-async-video"
     caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -335,3 +335,45 @@ def test_native_route_and_non_default_profile_agree(model_id: str) -> None:
     has_known_profile = caps is not _DEFAULT_PROFILE
     assert routed_native is True
     assert has_known_profile is True
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "wan2.7-i2v-s2v",  # 已知 token 与未实现模态共存，has_known_modality 应被后者排除
+        "wan-2.7-r2v-v2v",
+        "wan2.7-r2v-videoedit",
+        "image-proxy/wan-2.7-s2v",  # 未实现模态本身即被排除，装饰前缀不改变结论
+    ],
+)
+def test_excluded_from_native_route_agrees_with_default_profile(model_id: str) -> None:
+    """一致性断言的排除方向：has_known_modality=False 时两个判定点须一致落回默认档，不能出现
+    「不落原生路由却仍解析出真实能力档」的互斥组合——`_profile_for_model` 的子串容忍匹配若不
+    检查 has_known_modality，会在装饰后缀里找到共存的已知 token（如 "wan2.7-i2v-s2v" 里的
+    "i2v"）而误判出该已实现模态的能力档。"""
+    routed_native = infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert routed_native is False
+    assert caps is _DEFAULT_PROFILE
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "image-to-video-proxy/wan2.7-image",  # 装饰前缀含完整 "image-to-video" 拼写
+        "video-continuation-proxy/wan-2.7-image",
+    ],
+)
+def test_wan27_image_variant_not_upgraded_by_image_to_video_decoration_before_marker(model_id: str) -> None:
+    """image-to-video 续接语法的识别同 videoedit/s2v/v2v 一样只在 wan2.7 标记之后的模态段内生效：
+    标记前的装饰前缀即便字面拼出完整 "image-to-video"，也不能把真图像变体误判成视频续接。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
+@pytest.mark.parametrize("model_id", ["wan2.7-image-to-video", "wan_2.7-image2video"])
+def test_wan27_image_to_video_detected_within_modality_segment_after_marker(model_id: str) -> None:
+    """真正的 image-to-video 续接语法出现在 wan2.7 标记之后的模态段内时，仍要正确命中并折算成
+    i2v，落原生路由与非默认能力档。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps is not _DEFAULT_PROFILE

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -137,6 +137,22 @@ def test_boundary_false_positives_are_rejected(model_id: str) -> None:
     assert caps.max_prompt_chars is None
 
 
+@pytest.mark.parametrize("model_id", ["swan2.7-image", "vendorwan2.7-image"])
+def test_wan_substring_image_variant_routes_to_image_endpoint_despite_rejected_family(
+    model_id: str,
+) -> None:
+    """不满足家族标识符边界的 id（如 "swan2.7-image"）仍含 "wan" 子串，会被通用 _VIDEO_PATTERN
+    命中——排除到图像端点的判定不能拿严格家族边界做门槛，否则会被误推到 openai-video。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
+def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
+    """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
+    （落到通用预设，而非家族专属的 2-15s 全档）。"""
+    assert infer_supported_durations("wan2.7-videoedit") != list(range(2, 16))
+    assert infer_supported_durations("wan-2.7-videoedit") != list(range(2, 16))
+
+
 @pytest.mark.parametrize(
     ("model_id", "expected_max_reference_images"),
     [

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -1,0 +1,176 @@
+"""万相 / happyhorse 家族判定的组合矩阵回归测试。
+
+`lib.video_backends.dashscope.classify_wan_model` 是家族归属、分隔符归一化、标识符边界、
+image-to-video 续接语法、videoedit 模态排除的唯一判定入口；端点路由
+（`lib.custom_provider.endpoints.infer_endpoint`）、能力档
+（`DashScopeVideoBackend.video_capabilities_for_model`）、时长档
+（`lib.custom_provider.duration_presets.infer_supported_durations`）三处判定点都只消费其结论。
+本文件覆盖分隔符 × 版本 × 模态 × 大小写 × 装饰前缀等轴的组合，逐条比对三处判定点的期望值，
+并对可解析出具体模态（t2v/i2v/r2v）的家族成员做一条通用一致性断言：命中原生路由必有非默认
+能力档，反之亦然——这类互斥组合是过去几轮里三处判定宽度各自漂移时反复引入的缺陷形状，
+逐点单测抓不到，只有跨判定点的组合校验能抓到。
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from lib.custom_provider.duration_presets import infer_supported_durations
+from lib.custom_provider.endpoints import infer_endpoint
+from lib.video_backends.dashscope import _DEFAULT_PROFILE, DashScopeVideoBackend
+
+pytestmark = pytest.mark.unit
+
+_PREFIX_SEPS = ["-", "_", ""]  # wan[-_]?<version>
+_MODALITY_SEPS = ["-", "_"]  # <version>[-_]<modality>
+_CASE_FNS = [str.lower, str.upper, str.title]
+
+
+def _build(prefix_sep: str, version: str, modality_sep: str, modality: str) -> str:
+    return f"wan{prefix_sep}{version}{modality_sep}{modality}"
+
+
+def _wan27_ids() -> list[str]:
+    return [id_ for id_, _modality in _wan27_ids_with_modality()]
+
+
+def _wan27_ids_with_modality() -> list[tuple[str, str]]:
+    return [
+        (case_fn(_build(prefix_sep, "2.7", modality_sep, modality)), modality)
+        for prefix_sep, modality_sep, modality, case_fn in itertools.product(
+            _PREFIX_SEPS, _MODALITY_SEPS, ["t2v", "i2v", "r2v"], _CASE_FNS
+        )
+    ]
+
+
+@pytest.mark.parametrize(("model_id", "modality"), _wan27_ids_with_modality())
+def test_wan27_alias_routes_and_profiles_consistently(model_id: str, modality: str) -> None:
+    """wan2.7 t2v/i2v/r2v：连字符/下划线前缀 × 连字符/下划线模态分隔符 × 大小写全组合。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps.first_frame is (modality in ("i2v", "r2v"))
+    assert caps.max_prompt_chars == 5000
+    assert infer_supported_durations(model_id) == list(range(2, 16))
+
+
+@pytest.mark.parametrize(
+    "modality_word",
+    ["image-to-video", "image2video", "image_to_video"],
+)
+@pytest.mark.parametrize("prefix_sep", _PREFIX_SEPS)
+@pytest.mark.parametrize("case_fn", _CASE_FNS)
+def test_wan27_image_to_video_alias_normalizes_to_i2v(prefix_sep: str, modality_word: str, case_fn: type[str]) -> None:
+    model_id = case_fn(f"wan{prefix_sep}2.7-{modality_word}")
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps.first_frame is True
+    assert caps.max_reference_images == 0  # 与 r2v 档区分
+
+
+@pytest.mark.parametrize("prefix_sep", _PREFIX_SEPS)
+@pytest.mark.parametrize("case_fn", _CASE_FNS)
+def test_wan27_pure_image_variant_is_not_native_video_route(prefix_sep: str, case_fn: type[str]) -> None:
+    """wan2.7-image（无 image-to-video 续接语法）是图像变体，不落原生视频端点。"""
+    model_id = case_fn(f"wan{prefix_sep}2.7-image")
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
+def _wan3_ids() -> list[str]:
+    return [
+        case_fn(_build(prefix_sep, "3", modality_sep, modality))
+        for prefix_sep, modality_sep, modality, case_fn in itertools.product(
+            _PREFIX_SEPS, _MODALITY_SEPS, ["turbo", "video"], _CASE_FNS
+        )
+    ]
+
+
+@pytest.mark.parametrize("model_id", _wan3_ids())
+def test_wan3_alias_routes_and_durations_consistently(model_id: str) -> None:
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    assert infer_supported_durations(model_id) == list(range(2, 31))
+
+
+@pytest.mark.parametrize("version", ["2.1", "2.2"])
+@pytest.mark.parametrize("modality", ["t2v", "i2v", "r2v"])
+@pytest.mark.parametrize("prefix_sep", _PREFIX_SEPS)
+@pytest.mark.parametrize("case_fn", _CASE_FNS)
+def test_wan2x_non_27_dash_form_stays_generic_dot_form_stays_native(
+    prefix_sep: str, modality: str, version: str, case_fn: type[str]
+) -> None:
+    """万相 2.1/2.2：连字符/下划线前缀落通用视频端点，点号形态（既有行为，本票未变更）走原生。"""
+    model_id = case_fn(_build(prefix_sep, version, "-", modality))
+    expected_endpoint = "dashscope-async-video" if prefix_sep == "" else "openai-video"
+    assert infer_endpoint(model_id, "openai") == expected_endpoint
+    assert infer_supported_durations(model_id) == [4, 5]
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_endpoint", "expected_first_frame"),
+    [
+        ("proxy/wan-2.7-r2v", "dashscope-async-video", True),
+        ("proxy/wan_2.7_t2v", "dashscope-async-video", False),
+        ("vendor-wan2.7-i2v-0715", "dashscope-async-video", True),
+    ],
+)
+def test_decorated_prefix_suffix_still_resolves(
+    model_id: str, expected_endpoint: str, expected_first_frame: bool
+) -> None:
+    """代理中转常见的前后缀装饰不影响判定。"""
+    assert infer_endpoint(model_id, "openai") == expected_endpoint
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps.first_frame is expected_first_frame
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    ["swan2.7-r2v", "vendorwan2.7-t2v", "wan20-i2v", "wan27-r2v", "swan2.1-kf2v"],
+)
+def test_boundary_false_positives_are_rejected(model_id: str) -> None:
+    """含 wan2/wan3 子串但并非该家族的型号名不得被误判——两侧标识符边界。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps.max_reference_images == 0
+    assert caps.max_prompt_chars is None
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_max_reference_images"),
+    [
+        ("proxy/happyhorse-1.0-r2v", 9),
+        ("happyhorse-1.0-r2v-0715", 9),
+        ("myhappyhorse-1.0-r2v", 0),  # 标识符边界拒绝：非 happyhorse 家族
+    ],
+)
+def test_happyhorse_boundary_and_decoration(model_id: str, expected_max_reference_images: int) -> None:
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    assert caps.max_reference_images == expected_max_reference_images
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        *_wan27_ids(),
+        *_wan3_ids(),
+        "happyhorse-1.0-t2v",
+        "happyhorse-1.1-i2v",
+        "happyhorse-1.0-r2v",
+    ],
+)
+def test_native_route_and_non_default_profile_agree(model_id: str) -> None:
+    """一致性断言：家族成员且模态可解析（t2v/i2v/r2v）时，命中原生路由必有非默认能力档，反之亦然。
+
+    该断言只覆盖模态可解析的成员——裸家族名（如 "happyhorse"）、wan2.7-videoedit、非 2.7 的点号形态
+    2.x（"wan2.1-*"）均因模态/协议未确权而按设计落默认档，是文档化的既有例外，不受本断言约束
+    （见 classify_wan_model 与 _profile_for_model 的说明）。
+    """
+    routed_native = infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
+    # 用对象身份而非字段相等判定"是否解析出已知档"——happyhorse-i2v 的声明字段值恰好与
+    # VideoCapabilities() 的默认值逐项相同（first_frame 默认即 True），字段级比较会漏判。
+    # `_profile_for_model` 命中已知 key 时返回 `_MODEL_PROFILES` 里的原对象，未命中时返回
+    # `_DEFAULT_PROFILE` 单例，两者身份不同，可靠区分"解析成功"与"落回默认"。
+    has_known_profile = caps is not _DEFAULT_PROFILE
+    assert routed_native is True
+    assert has_known_profile is True

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -172,6 +172,14 @@ def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""
     assert infer_supported_durations("wan2.7-videoedit") != list(range(2, 16))
+
+
+@pytest.mark.parametrize("model_id", ["proxy-videoedit/wan3-turbo", "wan-3-turbo-videoedit"])
+def test_videoedit_exclusion_scoped_to_wan27_only(model_id: str) -> None:
+    """videoedit 排除只对 wan2.7 家族生效——wan3 的 id 即便含 "videoedit" 子串（装饰前缀或
+    其他来源），也不应被误排除出原生路由，该模态的能力欠缺只记录在 wan2.7 家族下。"""
+    assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
+    assert infer_supported_durations(model_id) == list(range(2, 31))
     assert infer_supported_durations("wan-2.7-videoedit") != list(range(2, 16))
 
 

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -248,10 +248,11 @@ def test_fallback_image_to_video_syntax_scoped_to_wan_marker_not_decoration_pref
     ["vendorwan2.7-videoedit-proxy/wan2.7-r2v", "wan2.7s2v-proxy/wan2.7-i2v"],
 )
 def test_wan27_suffix_not_polluted_by_literal_marker_text_in_decoration_prefix(model_id: str) -> None:
-    """wan27_suffix 须取自家族标记本身的位置，不能通过在拼接后的完整 profile_key 上重新搜索
-    "wan2.7" 字面文本来定位——标记前的装饰前缀可能自身就含 "wan2.7" 字面子串（不满足家族标识符
-    边界、未被判定为家族标记，如 "vendorwan2.7-videoedit-proxy/" 里的 "wan2.7"），重新搜索会先
-    命中这个更靠前的字面文本，把装饰前缀内容（"videoedit"/"s2v"）误当模态段的一部分。"""
+    """wan27_suffix 须取自家族标记本身的匹配位置（family_match），不能靠在拼接后的完整
+    profile_key 上搜索 "wan2.7" 字面文本来定位——标记前的装饰前缀可能自身就含 "wan2.7" 字面子串
+    （不满足家族标识符边界、未被判定为家族标记，如 "vendorwan2.7-videoedit-proxy/" 里的
+    "wan2.7"），文本搜索无法区分这类前缀噪音与真正的家族标记位置，会把装饰前缀内容
+    （"videoedit"/"s2v"）误当模态段的一部分。"""
     assert infer_endpoint(model_id, "openai") == "dashscope-async-video"
     caps = DashScopeVideoBackend.video_capabilities_for_model(model_id)
     assert caps is not _DEFAULT_PROFILE

--- a/tests/test_wan_family_consistency.py
+++ b/tests/test_wan_family_consistency.py
@@ -182,6 +182,23 @@ def test_wan3_image_variant_still_routes_to_image_endpoint(model_id: str) -> Non
     assert infer_endpoint(model_id, "openai") == "openai-images"
 
 
+@pytest.mark.parametrize("model_id", ["image-proxy/wan-2.7-s2v", "image-proxy/wan-2.7-v2v", "wan2.7-videoedit"])
+def test_wan27_known_unsupported_video_modality_not_downgraded_by_unrelated_image_decoration(
+    model_id: str,
+) -> None:
+    """s2v/v2v/videoedit 命中家族正则但本后端未实现请求构造（has_known_modality=False），仍是
+    已确认的视频模态——id 别处另含无关 "image" 子串时不应被误判成图像变体，须落通用视频端点
+    （而非图像端点）。"""
+    assert infer_endpoint(model_id, "openai") == "openai-video"
+
+
+@pytest.mark.parametrize("model_id", ["wan-2.7-fooimage-to-video", "wan-2.7-image-to-videofoo"])
+def test_wan27_unrecognized_modality_with_image_substring_stays_image_variant(model_id: str) -> None:
+    """未落入任一已知模态 token（t2v/i2v/r2v/s2v/v2v/videoedit）的其余命名，即便命中家族正则，
+    仍保守按图像变体处理，不能被"family==wan2.7 即视为视频"的宽泛判定误吞。"""
+    assert infer_endpoint(model_id, "openai") == "openai-images"
+
+
 def test_wan27_videoedit_excluded_from_family_duration_preset() -> None:
     """wan2.7-videoedit 本后端未实现该模态的请求构造，时长不套用 t2v/i2v/r2v 家族档
     （落到通用预设，而非家族专属的 2-15s 全档）。"""


### PR DESCRIPTION
Closes #1808

## 问题

自定义供应商下，`wan-2.7-image` 这类带连字符的万相 2.x 图像模型被推到视频端点，用户看到费解的生成失败；同一模型写成 `wan2.7-image`（带点号）则路由正确。根因是原 `is_wan_family` 的 wan2 分支只认字面量 `"wan2."`（要求点号），连字符形态不触发，其 `-image` 变体因此被裸 `wan` 命中通用视频规则。

## 改动

### 原生路由收窄与边界修复

- 新增 `WAN2_PATTERN`，只锚定 2.7（连字符/下划线可选、两侧标识符边界）。`wan-2.7-image` / `wan2.7-image` / `wan_2.7-image` 三种形态在图像/视频归属与端点路由上结论一致，且 `swan2` / `vendorwan2` / `wan20` 一类含子串的第三方型号名不被误吞。
  刻意只锚 2.7、不扩到其余 2.x 小版本：本后端固定请求单一端点，而 wan2.1 / wan2.2 等按供应商协议走的是另一个旧端点、payload 字段也不同——若把这些小版本的连字符/下划线形态也并入正则，会把它们从原本至少不出错的通用视频端点强改路由到协议不兼容的原生端点，属于新增回归。这些小版本的点号形态维持既有行为不动，是否收窄需要供应商 API 事实与产品判断（见「待人工决策」）。
- `DashScopeVideoBackend._profile_for_model` 同步识别 wan2.7 的连字符/下划线形态，含 image-to-video 续接别名的后缀归一化，避免路由与能力档判定结论矛盾（路由到本后端却拿不到对应能力档）；profile key 子串匹配补右侧标识符边界。
- 时长档位推断的通用 wan 条目补下划线容忍，并修复全下划线别名的模态后缀分隔符归一化。
- 补齐两处边界修复：happyhorse 路由边界对齐能力档判定；`wan2.7-videoedit`（本后端未实现该模态请求构造）排除出原生路由。

### 判定入口收编

上述边界规则原先分散在 `lib/custom_provider/endpoints.py`（路由推断）、`lib/video_backends/dashscope.py`（能力档推断）、`lib/custom_provider/duration_presets.py`（时长档推断）三处，各自维护一份正则与边界逻辑，历轮修复反复出现"改了一处、另外两处漏改"的同根因缺陷。收编为单一判定入口 `classify_wan_model`（`lib/video_backends/dashscope.py`），返回家族归属、image-to-video 续接语法、videoedit 模态、profile key 的结构化判定结果；三处消费方改为只消费该结论，不再各自对 `model_id` 做正则匹配。收编前后用 189+15 条组合矩阵逐条比对，结论未变（纯内部重排，不影响既有行为）。

收编落点符合分层契约方向（`lib.video_backends < lib.custom_provider`，`lint-imports` KEPT）：`classify_wan_model` 放在 `lib/video_backends/dashscope.py`，由 `lib/custom_provider/endpoints.py`、`lib/custom_provider/duration_presets.py` 消费。

收编后补的两处遗留缺口：
- 图像变体排除（避免误推到 `openai-video`）不能拿严格家族标识符边界做门槛——通用 `_VIDEO_PATTERN` 的 "wan" 分支本身无边界，`swan2.7-image` 一类不满足家族边界的 id 仍会命中该分支，排除逻辑要求先过家族边界会导致误判；改为按 "wan" 子串宽度独立判定，与家族边界判定解耦。
- `wan2.7-videoedit` 时长不再套用 t2v/i2v/r2v 家族档（本后端未实现该模态的请求构造），落到通用预设。

## 验证

- `uv run python -m pytest` 全量 9041 passed, 2 skipped
- `uv run ruff check` / `ruff format --check`（改动文件）、`uv run basedpyright`（0 errors）、`uv run lint-imports`（1 kept, 0 broken）
- 新增 `tests/test_wan_family_consistency.py`：分隔符 × 版本 × 模态词 × 大小写 × 判定点的组合矩阵回归测试（284 条 parametrize 用例），含一条跨判定点一致性断言——命中原生路由必有非默认能力档，反之亦然（用对象身份而非字段相等判定，避免 happyhorse-i2v 与默认档字段逐项相同导致漏判）

## 待人工决策

万相 2.x 小版本（2.1/2.2/2.5/2.6）的点号形态目前仍会路由到本 PR 未触碰的既有原生端点分支，但该端点固定请求 `video-generation/video-synthesis`，与这些小版本实际使用的旧端点、payload 字段不完全一致（见 `docs/research/arcreel-video-api-protocol-research.md` 记载）。是否收窄这部分既有行为（以及裸 `wan2`、2.5/2.6 payload 差异如何处理）需要供应商 API 事实核实与产品判断，未在本票处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持 Wan 3、Wan 2.7 和 HappyHorse 的多种模型命名格式及大小写组合。
  * 新增对应时长预设：Wan 3 为 2–30 秒，Wan 2.7 为 2–15 秒，HappyHorse 为 3–15 秒。
  * 优化图生视频、视频编辑及相关模型的端点路由。

* **错误修复**
  * 修正无效版本号、不支持模态及相似名称导致的错误识别和路由。

* **测试**
  * 增加模型边界、命名格式、路由及时长配置的一致性验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
