### PR TITLE
fix(助手): 限制图片附件请求体积

### DIFF
--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -144,6 +144,8 @@ MESSAGES = {
         "switch target is ambiguous. Please fill in only one group."
     ),
     # Assistant
+    "assistant_image_too_large": "Each original image must be no larger than 5 MB",
+    "assistant_images_total_too_large": "The original images must be no larger than 25 MB in total",
     "session_not_found": "Session '{session_id}' does not exist",
     "session_or_project_not_found": "Session or project does not exist",
     "sdk_session_timeout": "SDK session creation timed out",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -144,6 +144,8 @@ MESSAGES = {
         "thể xác định muốn chuyển sang nhóm nào. Vui lòng chỉ điền một nhóm."
     ),
     # Assistant
+    "assistant_image_too_large": "Mỗi ảnh gốc không được lớn hơn 5 MB",
+    "assistant_images_total_too_large": "Tổng dung lượng ảnh gốc không được lớn hơn 25 MB",
     "session_not_found": "Phiên '{session_id}' không tồn tại",
     "session_or_project_not_found": "Phiên hoặc dự án không tồn tại",
     "sdk_session_timeout": "Tạo phiên SDK quá thời gian",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -132,6 +132,8 @@ MESSAGES = {
     "missing_credentials": "缺少凭证配置，请先添加密钥",
     "credential_group_ambiguous": "本次提交包含多组互斥凭证的字段，无法判断切换方向，请仅填写其中一组",
     # Assistant
+    "assistant_image_too_large": "每张图片的原图大小不能超过 5 MB",
+    "assistant_images_total_too_large": "图片原图总大小不能超过 25 MB",
     "session_not_found": "会话 '{session_id}' 不存在",
     "session_or_project_not_found": "会话或项目不存在",
     "sdk_session_timeout": "SDK 会话创建超时",

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -15,6 +15,8 @@ import logging
 from collections.abc import Callable, Sequence
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from lib.api_errors import ApiError
@@ -88,6 +90,16 @@ def register_error_handlers(
     async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
         _t = get_translator(request)
         return JSONResponse(status_code=exc.status_code, content={"detail": _t(exc.key, **exc.params)})
+
+    @app.exception_handler(RequestValidationError)
+    async def _handle_request_validation(request: Request, exc: RequestValidationError) -> JSONResponse:
+        _t = get_translator(request)
+        error_types = {error["type"] for error in exc.errors()}
+        if "assistant_image_too_large" in error_types:
+            return JSONResponse(status_code=422, content={"detail": _t("assistant_image_too_large")})
+        if "assistant_images_total_too_large" in error_types:
+            return JSONResponse(status_code=422, content={"detail": _t("assistant_images_total_too_large")})
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
 
     @app.exception_handler(TaskSpecValidationError)
     async def _handle_task_spec_error(request: Request, exc: TaskSpecValidationError) -> JSONResponse:

--- a/server/routers/assistant.py
+++ b/server/routers/assistant.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.sse import EventSourceResponse, ServerSentEvent
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic_core import PydanticCustomError
 
 from lib import PROJECT_ROOT
 from lib.api_errors import BadRequestError, ConflictError, NotFoundError, ServiceUnavailableError
@@ -36,6 +37,12 @@ router = APIRouter()
 self_auth_router = APIRouter()
 
 assistant_service = AssistantService(project_root=PROJECT_ROOT)
+
+MAX_IMAGE_SOURCE_BYTES = 5 * 1024 * 1024
+# Base64 needs four characters for every three source bytes, rounded up to a full quartet.
+MAX_IMAGE_BASE64_CHARS = 4 * ((MAX_IMAGE_SOURCE_BYTES + 2) // 3)
+MAX_IMAGES_PER_REQUEST = 5
+MAX_IMAGES_TOTAL_BASE64_CHARS = MAX_IMAGES_PER_REQUEST * MAX_IMAGE_BASE64_CHARS
 
 
 def get_assistant_service() -> AssistantService:
@@ -83,23 +90,50 @@ async def _assistant_service_for_stream(
 
 
 class ImageAttachment(BaseModel):
-    data: str
+    data: str = Field(max_length=MAX_IMAGE_BASE64_CHARS)
     media_type: str
 
+    @field_validator("data", mode="before")
+    @classmethod
+    def validate_data_size(cls, value: object) -> object:
+        if isinstance(value, str) and len(value) > MAX_IMAGE_BASE64_CHARS:
+            raise PydanticCustomError(
+                "assistant_image_too_large", "assistant image exceeds the base64 character budget"
+            )
+        return value
 
-class SendRequest(BaseModel):
+
+class ImageRequest(BaseModel):
+    images: list[ImageAttachment] = Field(default_factory=list, max_length=MAX_IMAGES_PER_REQUEST)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_total_image_size(cls, value: object) -> object:
+        images = value.get("images", []) if isinstance(value, dict) else []
+        total_chars = sum(
+            len(image.get("data", ""))
+            for image in images
+            if isinstance(image, dict) and isinstance(image.get("data", ""), str)
+        )
+        if total_chars > MAX_IMAGES_TOTAL_BASE64_CHARS:
+            raise PydanticCustomError(
+                "assistant_images_total_too_large",
+                "assistant images exceed the total base64 character budget",
+            )
+        return value
+
+
+class SendRequest(ImageRequest):
     content: str = ""
-    images: list[ImageAttachment] = Field(default_factory=list, max_length=5)
     session_id: str | None = None
     # 请求侧幂等键：同键重试返回既有权威条目，不产生重复。
     client_key: str | None = Field(default=None, max_length=128)
 
 
-class RewriteRequest(BaseModel):
+class RewriteRequest(ImageRequest):
     # 锚点：被改写的那条用户消息在事件日志里的条目 uuid。
     anchor_entry_uuid: str = Field(min_length=1, max_length=256)
     content: str = ""
-    images: list[ImageAttachment] = Field(default_factory=list, max_length=5)
     client_key: str | None = Field(default=None, max_length=128)
 
 

--- a/tests/test_assistant_attachment_limits.py
+++ b/tests/test_assistant_attachment_limits.py
@@ -1,0 +1,113 @@
+"""Assistant image attachment request-size contract."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from server.routers import assistant
+from tests.test_assistant_routes import PREFIX, _build_client
+
+pytestmark = pytest.mark.unit
+
+
+def _image(data: str) -> dict[str, str]:
+    return {"data": data, "media_type": "image/png"}
+
+
+def test_send_request_accepts_single_image_at_base64_character_limit():
+    request = assistant.SendRequest(images=[_image("A" * assistant.MAX_IMAGE_BASE64_CHARS)])
+
+    assert len(request.images[0].data) == 6_990_508
+
+
+def test_send_request_rejects_single_image_above_base64_character_limit():
+    with pytest.raises(ValidationError) as exc_info:
+        assistant.SendRequest(images=[_image("A" * (assistant.MAX_IMAGE_BASE64_CHARS + 1))])
+
+    assert exc_info.value.errors()[0]["type"] == "assistant_image_too_large"
+
+
+def test_rewrite_request_accepts_five_images_at_total_base64_character_limit():
+    request = assistant.RewriteRequest(
+        anchor_entry_uuid="entry-1",
+        images=[_image("A" * assistant.MAX_IMAGE_BASE64_CHARS) for _ in range(assistant.MAX_IMAGES_PER_REQUEST)],
+    )
+
+    assert sum(len(image.data) for image in request.images) == 34_952_540
+
+
+def test_rewrite_request_rejects_images_above_total_base64_character_limit():
+    images = [_image("A" * assistant.MAX_IMAGE_BASE64_CHARS) for _ in range(assistant.MAX_IMAGES_PER_REQUEST)]
+    images[-1]["data"] += "A"
+
+    with pytest.raises(ValidationError) as exc_info:
+        assistant.RewriteRequest(anchor_entry_uuid="entry-1", images=images)
+
+    assert exc_info.value.errors()[0]["type"] == "assistant_images_total_too_large"
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "service_method"),
+    [
+        (f"{PREFIX}/sessions/send", {"content": "hello"}, "send_or_create"),
+        (
+            f"{PREFIX}/sessions/session-1/rewrite",
+            {"anchor_entry_uuid": "entry-1", "content": "hello"},
+            "rewrite_message",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("locale", "expected_detail"),
+    [
+        ("zh", "每张图片的原图大小不能超过 5 MB"),
+        ("en", "Each original image must be no larger than 5 MB"),
+        ("vi", "Mỗi ảnh gốc không được lớn hơn 5 MB"),
+    ],
+)
+def test_send_and_rewrite_return_same_localized_422_for_oversized_image(
+    path: str,
+    body: dict[str, object],
+    service_method: str,
+    locale: str,
+    expected_detail: str,
+):
+    body["images"] = [_image("A" * (assistant.MAX_IMAGE_BASE64_CHARS + 1))]
+
+    with patch.object(assistant.assistant_service, service_method, new=AsyncMock()) as service_call:
+        with _build_client() as client:
+            response = client.post(path, json=body, headers={"Accept-Language": locale})
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": expected_detail}
+    service_call.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "service_method"),
+    [
+        (f"{PREFIX}/sessions/send", {"content": "hello"}, "send_or_create"),
+        (
+            f"{PREFIX}/sessions/session-1/rewrite",
+            {"anchor_entry_uuid": "entry-1", "content": "hello"},
+            "rewrite_message",
+        ),
+    ],
+)
+def test_send_and_rewrite_return_same_localized_422_for_oversized_image_total(
+    path: str,
+    body: dict[str, object],
+    service_method: str,
+):
+    images = [_image("A" * assistant.MAX_IMAGE_BASE64_CHARS) for _ in range(assistant.MAX_IMAGES_PER_REQUEST)]
+    images[-1]["data"] += "A"
+    body["images"] = images
+
+    with patch.object(assistant.assistant_service, service_method, new=AsyncMock()) as service_call:
+        with _build_client() as client:
+            response = client.post(path, json=body, headers={"Accept-Language": "en"})
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "The original images must be no larger than 25 MB in total"}
+    service_call.assert_not_awaited()


### PR DESCRIPTION
## Summary

- 在后端 Pydantic 模型限制单张图片附件与请求总量
- 发送与改写共用同一校验入口，并返回三语本地化 422 错误
- 覆盖边界值、超限拒绝及两个端点行为一致性

## Verification

- `uv run python -m pytest`（8825 passed, 2 skipped）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright`（0 errors）
- `uv run lint-imports`

Closes #1812