### PR TITLE
feat(助手): 改写消息时支持新增图片

### DIFF
--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -188,6 +188,7 @@ export function AgentCopilot() {
   const {
     images: attachedImages,
     error: attachError,
+    isReading: isReadingImages,
     addFiles: addImages,
     removeImage,
     resetImages,
@@ -239,7 +240,7 @@ export function AgentCopilot() {
   }, [addImages]);
 
   const handleSend = useCallback(() => {
-    if (inputDisabled || (!localInput.trim() && attachedImages.length === 0)) return;
+    if (inputDisabled || isReadingImages || (!localInput.trim() && attachedImages.length === 0)) return;
     invalidatePendingReaders();
     setShowSlashMenu(false);
     // 发送期间输入锁定（sending 置位）；受理成功才清空，失败保留内容供重试
@@ -256,7 +257,15 @@ export function AgentCopilot() {
         },
       ),
     );
-  }, [inputDisabled, localInput, attachedImages, sendMessage, invalidatePendingReaders, resetImages]);
+  }, [
+    inputDisabled,
+    isReadingImages,
+    localInput,
+    attachedImages,
+    sendMessage,
+    invalidatePendingReaders,
+    resetImages,
+  ]);
 
   // 改写成功后由会话切换重建时间线（编辑态随 resetTimeline 清空）；失败保留编辑态，
   // 用户可以改完再试，错误经消息区上方的错误条呈现
@@ -682,7 +691,9 @@ export function AgentCopilot() {
           ) : (
             <button
               onClick={handleSend}
-              disabled={(!localInput.trim() && attachedImages.length === 0) || inputDisabled}
+              disabled={
+                (!localInput.trim() && attachedImages.length === 0) || inputDisabled || isReadingImages
+              }
               className="shrink-0 rounded-md p-1.5 transition-opacity focus-ring disabled:cursor-not-allowed disabled:opacity-30"
               style={{
                 color: "oklch(0.14 0 0)",

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -199,7 +199,7 @@ export function AgentCopilot() {
   const allTurns = composeAllTurns(turns, draftTurn);
   const isRunning = sessionStatus === "running";
   const inputDisabled = Boolean(pendingQuestion) || answeringQuestion || isRunning || sending;
-  const attachDisabled = inputDisabled || attachedImages.length >= MAX_ATTACHED_IMAGES;
+  const attachDisabled = inputDisabled || isReadingImages || attachedImages.length >= MAX_ATTACHED_IMAGES;
   const inputPlaceholder = pendingQuestion
     ? t("answer_above_hint")
     : isRunning

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -8,8 +8,8 @@ import { useAssistantStore } from "@/stores/assistant-store";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useAppStore } from "@/stores/app-store";
 import { useAssistantSession } from "@/hooks/useAssistantSession";
-import type { AttachedImage } from "@/hooks/useAssistantSession";
 import type { ImagePayload } from "@/types";
+import { MAX_ATTACHED_IMAGES, useImageAttachments } from "@/hooks/useImageAttachments";
 import { GlassPopover } from "@/components/ui/GlassPopover";
 import { ContextBanner } from "./ContextBanner";
 import { PendingQuestionWizard } from "./PendingQuestionWizard";
@@ -19,11 +19,7 @@ import { TodoListPanel } from "./TodoListPanel";
 import { MessageRow } from "./chat/MessageRow";
 import { AgentFailureCard } from "./chat/AgentFailureCard";
 import { canEditUserTurn, composeAllTurns } from "./chat/utils";
-import { uid } from "@/utils/id";
 import { formatShortDateTime } from "@/utils/date-format";
-
-const MAX_IMAGES = 5;
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -186,45 +182,28 @@ export function AgentCopilot() {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const imageGenRef = useRef(0);
   const slashMenuRef = useRef<SlashCommandMenuHandle>(null);
   const [localInput, setLocalInput] = useState("");
   const [showSlashMenu, setShowSlashMenu] = useState(false);
-  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
-  const [attachError, setAttachError] = useState<string | null>(null);
+  const {
+    images: attachedImages,
+    error: attachError,
+    addFiles: addImages,
+    removeImage,
+    resetImages,
+    invalidatePendingReaders,
+  } = useImageAttachments();
   const [isDragOver, setIsDragOver] = useState(false);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const allTurns = composeAllTurns(turns, draftTurn);
   const isRunning = sessionStatus === "running";
   const inputDisabled = Boolean(pendingQuestion) || answeringQuestion || isRunning || sending;
-  const attachDisabled = inputDisabled || attachedImages.length >= MAX_IMAGES;
+  const attachDisabled = inputDisabled || attachedImages.length >= MAX_ATTACHED_IMAGES;
   const inputPlaceholder = pendingQuestion
     ? t("answer_above_hint")
     : isRunning
       ? t("generating_stop_hint")
       : t("input_placeholder");
-
-  const addImages = useCallback((files: File[]) => {
-    setAttachError(null);
-    const gen = imageGenRef.current;
-    for (const file of files) {
-      if (!file.type.startsWith("image/")) continue;
-      if (file.size > MAX_IMAGE_BYTES) {
-        setAttachError(t("image_too_large_hint", { name: file.name }));
-        continue;
-      }
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        if (imageGenRef.current !== gen) return; // stale — message already sent
-        const dataUrl = e.target?.result as string;
-        setAttachedImages((prev) => {
-          if (prev.length >= MAX_IMAGES) return prev;
-          return [...prev, { id: uid(), dataUrl, mimeType: file.type }];
-        });
-      };
-      reader.readAsDataURL(file);
-    }
-  }, [t]);
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
     const items = Array.from(e.clipboardData.items);
@@ -259,14 +238,9 @@ export function AgentCopilot() {
     e.target.value = "";
   }, [addImages]);
 
-  const removeImage = useCallback((id: string) => {
-    setAttachedImages((prev) => prev.filter((img) => img.id !== id));
-    setAttachError(null);
-  }, []);
-
   const handleSend = useCallback(() => {
     if (inputDisabled || (!localInput.trim() && attachedImages.length === 0)) return;
-    imageGenRef.current += 1; // invalidate pending FileReader callbacks
+    invalidatePendingReaders();
     setShowSlashMenu(false);
     // 发送期间输入锁定（sending 置位）；受理成功才清空，失败保留内容供重试
     voidCall(
@@ -274,8 +248,7 @@ export function AgentCopilot() {
         (accepted) => {
           if (!accepted) return;
           setLocalInput("");
-          setAttachedImages([]);
-          setAttachError(null);
+          resetImages();
           // Reset textarea height
           if (textareaRef.current) {
             textareaRef.current.style.height = "auto";
@@ -283,7 +256,7 @@ export function AgentCopilot() {
         },
       ),
     );
-  }, [inputDisabled, localInput, attachedImages, sendMessage]);
+  }, [inputDisabled, localInput, attachedImages, sendMessage, invalidatePendingReaders, resetImages]);
 
   // 改写成功后由会话切换重建时间线（编辑态随 resetTimeline 清空）；失败保留编辑态，
   // 用户可以改完再试，错误经消息区上方的错误条呈现
@@ -684,7 +657,7 @@ export function AgentCopilot() {
               e.currentTarget.style.background = "transparent";
               e.currentTarget.style.color = "var(--color-text-3)";
             }}
-            title={attachedImages.length >= MAX_IMAGES ? t("max_images_hint", { count: MAX_IMAGES }) : t("attach_image")}
+            title={attachedImages.length >= MAX_ATTACHED_IMAGES ? t("max_images_hint", { count: MAX_ATTACHED_IMAGES }) : t("attach_image")}
             aria-label={t("attach_image")}
           >
             <Paperclip className="h-4 w-4" />

--- a/frontend/src/components/copilot/AgentCopilot.tsx
+++ b/frontend/src/components/copilot/AgentCopilot.tsx
@@ -207,20 +207,22 @@ export function AgentCopilot() {
       : t("input_placeholder");
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
+    if (attachDisabled) return;
     const items = Array.from(e.clipboardData.items);
     const imageItems = items.filter((item) => item.type.startsWith("image/"));
     if (imageItems.length === 0) return;
     e.preventDefault();
     const files = imageItems.map((item) => item.getAsFile()).filter(Boolean) as File[];
     addImages(files);
-  }, [addImages]);
+  }, [addImages, attachDisabled]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (attachDisabled) return;
     const hasFiles = Array.from(e.dataTransfer.items).some((i) => i.kind === "file");
     if (!hasFiles) return;
     e.preventDefault();
     setIsDragOver(true);
-  }, []);
+  }, [attachDisabled]);
 
   const handleDragLeave = useCallback(() => {
     setIsDragOver(false);
@@ -229,9 +231,10 @@ export function AgentCopilot() {
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
+    if (attachDisabled) return;
     const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith("image/"));
     if (files.length > 0) addImages(files);
-  }, [addImages]);
+  }, [addImages, attachDisabled]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);

--- a/frontend/src/components/copilot/chat/MessageRow.test.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Turn } from "@/types";
 import { MessageRow } from "./MessageRow";
@@ -29,6 +29,13 @@ const twoImageTurn: Turn = {
   ],
 };
 
+const imageOnlyTurn: Turn = {
+  type: "user",
+  uuid: "u-3",
+  timestamp: "2026-05-02T14:27:00Z",
+  content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } }],
+};
+
 describe("MessageRow", () => {
   it("renders the edit entry on an editable user message", () => {
     render(<MessageRow turn={userTurn} editable />);
@@ -51,6 +58,13 @@ describe("MessageRow", () => {
     fireEvent.click(screen.getByLabelText("编辑此消息并从这里重新发送"));
 
     expect(onStartEdit).toHaveBeenCalledWith("u-1", "只改第 3 集");
+  });
+
+  it("shows the edit entry but no copy button for an image-only user message", () => {
+    render(<MessageRow turn={imageOnlyTurn} editable />);
+
+    expect(screen.getByLabelText("编辑此消息并从这里重新发送")).toBeInTheDocument();
+    expect(screen.queryByLabelText("复制消息")).not.toBeInTheDocument();
   });
 
   it("edits in place, showing the consequence note and submitting on ⌘/Ctrl+Enter", () => {
@@ -95,6 +109,24 @@ describe("MessageRow", () => {
     fireEvent.keyDown(screen.getByLabelText("改写消息内容"), { key: "Enter", metaKey: true });
     expect(onSubmitEdit).toHaveBeenCalledWith("u-2", "按这两张图改人设", [
       { data: "BBBB", media_type: "image/jpeg" },
+    ]);
+  });
+
+  it("adds an image in the editor and includes it in the rewrite payload", async () => {
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={imageTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    const added = new File(["new-image"], "new.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText("上传附件图片"), { target: { files: [added] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "编辑中的附件 2/2" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "重新发送" }));
+
+    expect(onSubmitEdit).toHaveBeenCalledWith("u-2", "按这张图改人设", [
+      { data: "AAAA", media_type: "image/png" },
+      { data: "bmV3LWltYWdl", media_type: "image/png" },
     ]);
   });
 

--- a/frontend/src/components/copilot/chat/MessageRow.test.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Turn } from "@/types";
 import { MessageRow } from "./MessageRow";
@@ -128,6 +128,38 @@ describe("MessageRow", () => {
       { data: "AAAA", media_type: "image/png" },
       { data: "bmV3LWltYWdl", media_type: "image/png" },
     ]);
+  });
+
+  it("keeps resend disabled until a newly selected image finishes loading", () => {
+    const originalFileReader = globalThis.FileReader;
+    let finishRead: (() => void) | undefined;
+    class DeferredReader {
+      onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+
+      readAsDataURL() {
+        finishRead = () => {
+          this.onload?.({
+            target: { result: "data:image/png;base64,bmV3LWltYWdl" },
+          } as unknown as ProgressEvent<FileReader>);
+        };
+      }
+    }
+    vi.stubGlobal("FileReader", DeferredReader);
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={imageTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    fireEvent.change(screen.getByLabelText("上传附件图片"), {
+      target: { files: [new File(["new-image"], "new.png", { type: "image/png" })] },
+    });
+    expect(screen.getByRole("button", { name: "重新发送" })).toBeDisabled();
+    fireEvent.keyDown(screen.getByLabelText("改写消息内容"), { key: "Enter", metaKey: true });
+    expect(onSubmitEdit).not.toHaveBeenCalled();
+
+    act(() => finishRead?.());
+    expect(screen.getByRole("button", { name: "重新发送" })).toBeEnabled();
+    vi.stubGlobal("FileReader", originalFileReader);
   });
 
   it("disables resend when removing the final attachment leaves an empty draft", () => {

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, Copy, Pencil, TriangleAlert, X } from "lucide-react";
+import { Check, Copy, Paperclip, Pencil, TriangleAlert, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ImagePayload, Turn } from "@/types";
 import { copyText } from "@/utils/clipboard";
@@ -13,6 +13,12 @@ import {
   USER_BUBBLE_STYLE,
 } from "./bubble";
 import { turnImageAttachments, turnPlainText } from "./utils";
+import {
+  attachmentToImagePayload,
+  imagePayloadToAttachment,
+  MAX_ATTACHED_IMAGES,
+  useImageAttachments,
+} from "@/hooks/useImageAttachments";
 
 // ---------------------------------------------------------------------------
 // MessageRow — 一条时间线消息及其操作行。
@@ -73,8 +79,9 @@ export function MessageRow({
     );
   }
 
-  // 操作行只服务于有正文的已落库消息：草稿、工具卡片、系统事件没有可复制的正文
-  const showActions = !streaming && Boolean(text.trim()) && (turn.type === "user" || turn.type === "assistant");
+  // 操作行只服务于有正文或附件的已落库消息：草稿、工具卡片、系统事件没有消息操作
+  const showActions = !streaming && (Boolean(text.trim()) || images.length > 0)
+    && (turn.type === "user" || turn.type === "assistant");
   if (!showActions) {
     return <ChatMessage message={turn} streaming={streaming} />;
   }
@@ -90,7 +97,7 @@ export function MessageRow({
         }`}
       >
         {isUser && time && <TimeStamp time={time} className="mr-1" />}
-        <CopyButton text={text} />
+        {Boolean(text.trim()) && <CopyButton text={text} />}
         {isUser && editable && turnUuid && (
           <button
             type="button"
@@ -174,13 +181,14 @@ function MessageEditor({
 }) {
   const { t } = useTranslation("dashboard");
   const [draft, setDraft] = useState(initialText);
-  const [images, setImages] = useState(() =>
-    initialImages.map((image, id) => ({
-      id,
-      image,
-      src: `data:${image.media_type};base64,${image.data}`,
-    })),
-  );
+  const {
+    images,
+    error: attachError,
+    addFiles,
+    removeImage,
+    invalidatePendingReaders,
+  } = useImageAttachments(initialImages.map(imagePayloadToAttachment));
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // 部分输入法在组合确认的那次 keydown 上不置 isComposing，靠组合事件补齐
   const isComposingRef = useRef(false);
@@ -199,11 +207,9 @@ function MessageEditor({
 
   const submit = useCallback(() => {
     if (submitting || !canSubmit || !hasContent) return;
-    onSubmit(
-      draft,
-      images.map(({ image }) => image),
-    );
-  }, [draft, images, hasContent, submitting, canSubmit, onSubmit]);
+    invalidatePendingReaders();
+    onSubmit(draft, images.map(attachmentToImagePayload));
+  }, [draft, images, hasContent, submitting, canSubmit, onSubmit, invalidatePendingReaders]);
 
   return (
     <div className={`${USER_BUBBLE_LAYOUT_CLASS} ${BUBBLE_SHELL_CLASS}`} style={USER_BUBBLE_STYLE}>
@@ -215,10 +221,10 @@ function MessageEditor({
       </div>
       {images.length > 0 && (
         <div className="mb-2 flex flex-wrap gap-2">
-          {images.map(({ id, src }, index) => (
+          {images.map(({ id, dataUrl }, index) => (
             <div key={id} className="relative">
               <img
-                src={src}
+                src={dataUrl}
                 alt={t("message_edit_attachment", { index: index + 1, total: images.length })}
                 className="h-14 w-14 rounded-md object-cover"
                 style={{ border: "1px solid var(--color-hairline)" }}
@@ -226,7 +232,7 @@ function MessageEditor({
               <button
                 type="button"
                 disabled={submitting}
-                onClick={() => setImages((current) => current.filter((attachment) => attachment.id !== id))}
+                onClick={() => removeImage(id)}
                 className="focus-ring absolute -right-1 -top-1 grid h-4 w-4 place-items-center rounded-full transition-colors hover:bg-[var(--color-danger)] disabled:cursor-not-allowed disabled:opacity-50"
                 style={{
                   background: "oklch(0.14 0.008 265)",
@@ -241,6 +247,35 @@ function MessageEditor({
           ))}
         </div>
       )}
+      <div className="mb-2 flex items-center gap-2">
+        <button
+          type="button"
+          disabled={submitting || images.length >= MAX_ATTACHED_IMAGES}
+          onClick={() => fileInputRef.current?.click()}
+          className="focus-ring flex items-center gap-1 rounded-md px-2 py-1 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ color: "var(--color-text-3)", border: "1px solid var(--color-hairline-soft)" }}
+          title={images.length >= MAX_ATTACHED_IMAGES
+            ? t("max_images_hint", { count: MAX_ATTACHED_IMAGES })
+            : t("attach_image")}
+        >
+          <Paperclip aria-hidden className="h-3 w-3" />
+          {t("attach_image")}
+        </button>
+        {attachError && <span role="alert" className="text-[10.5px] text-[var(--color-danger)]">{attachError}</span>}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*"
+          aria-label={t("upload_attachment_aria")}
+          className="hidden"
+          disabled={submitting}
+          onChange={(event) => {
+            addFiles(Array.from(event.target.files ?? []));
+            event.target.value = "";
+          }}
+        />
+      </div>
       <textarea
         ref={textareaRef}
         value={draft}

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -188,7 +188,7 @@ function MessageEditor({
     addFiles,
     removeImage,
     invalidatePendingReaders,
-  } = useImageAttachments(initialImages.map(imagePayloadToAttachment));
+  } = useImageAttachments(() => initialImages.map(imagePayloadToAttachment));
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // 部分输入法在组合确认的那次 keydown 上不置 isComposing，靠组合事件补齐
@@ -260,7 +260,7 @@ function MessageEditor({
       <div className="mb-2 flex items-center gap-2">
         <button
           type="button"
-          disabled={submitting || images.length >= MAX_ATTACHED_IMAGES}
+          disabled={submitting || isReadingImages || images.length >= MAX_ATTACHED_IMAGES}
           onClick={() => fileInputRef.current?.click()}
           className="focus-ring flex items-center gap-1 rounded-md px-2 py-1 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           style={{ color: "var(--color-text-3)", border: "1px solid var(--color-hairline-soft)" }}

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -184,6 +184,7 @@ function MessageEditor({
   const {
     images,
     error: attachError,
+    isReading: isReadingImages,
     addFiles,
     removeImage,
     invalidatePendingReaders,
@@ -206,10 +207,19 @@ function MessageEditor({
   const hasContent = Boolean(draft.trim()) || images.length > 0;
 
   const submit = useCallback(() => {
-    if (submitting || !canSubmit || !hasContent) return;
+    if (submitting || !canSubmit || !hasContent || isReadingImages) return;
     invalidatePendingReaders();
     onSubmit(draft, images.map(attachmentToImagePayload));
-  }, [draft, images, hasContent, submitting, canSubmit, onSubmit, invalidatePendingReaders]);
+  }, [
+    draft,
+    images,
+    hasContent,
+    isReadingImages,
+    submitting,
+    canSubmit,
+    onSubmit,
+    invalidatePendingReaders,
+  ]);
 
   return (
     <div className={`${USER_BUBBLE_LAYOUT_CLASS} ${BUBBLE_SHELL_CLASS}`} style={USER_BUBBLE_STYLE}>
@@ -329,7 +339,7 @@ function MessageEditor({
         </button>
         <button
           type="button"
-          disabled={submitting || !canSubmit || !hasContent}
+          disabled={submitting || !canSubmit || !hasContent || isReadingImages}
           onClick={submit}
           title={t("message_edit_resend_hint")}
           className="focus-ring rounded-md px-2.5 py-1 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/components/copilot/chat/utils.test.ts
+++ b/frontend/src/components/copilot/chat/utils.test.ts
@@ -129,13 +129,13 @@ describe("canEditUserTurn", () => {
     expect(canEditUserTurn(answerTurn, idle)).toBe(false);
   });
 
-  it("rejects a turn with no plain text", () => {
+  it("allows a user turn with an image attachment and no plain text", () => {
     const imageOnly: Turn = {
       type: "user",
       uuid: "u-3",
       content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "x" } }],
     };
-    expect(canEditUserTurn(imageOnly, idle)).toBe(false);
+    expect(canEditUserTurn(imageOnly, idle)).toBe(true);
   });
 
   it("hides the entry while the agent is running", () => {

--- a/frontend/src/components/copilot/chat/utils.ts
+++ b/frontend/src/components/copilot/chat/utils.ts
@@ -101,7 +101,7 @@ export function canEditUserTurn(
   // 问答答复是智能体问卷的回执，不是用户自己写的消息。投影产出的 Turn 不带
   // subtype，按内容块类型识别。
   if ((turn.content ?? []).some((block) => block.type === "question_answer")) return false;
-  if (!turnPlainText(turn).trim()) return false;
+  if (!turnPlainText(turn).trim() && turnImageAttachments(turn).length === 0) return false;
   if (context.sessionStatus === "running") return false;
   if (context.hasPendingQuestion) return false;
   // 已有发送或改写在途：此刻放行别处的编辑入口，点下去会顶掉正在提交的编辑器，

--- a/frontend/src/hooks/useAssistantSession.ts
+++ b/frontend/src/hooks/useAssistantSession.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { errMsg, voidCall } from "@/utils/async";
 import { AgentFailureError, API } from "@/api";
 import { uid } from "@/utils/id";
+import type { AttachedImage } from "@/hooks/useImageAttachments";
 import { useAssistantStore } from "@/stores/assistant-store";
 import type {
   DraftDeltaPayload,
@@ -12,12 +13,6 @@ import type {
   SessionMeta,
   TimelineEntry,
 } from "@/types";
-
-export interface AttachedImage {
-  id: string;
-  dataUrl: string;
-  mimeType: string;
-}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/src/hooks/useImageAttachments.test.tsx
+++ b/frontend/src/hooks/useImageAttachments.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useImageAttachments } from "./useImageAttachments";
+
+class DeferredFileReader {
+  static instances: DeferredFileReader[] = [];
+
+  result: string | ArrayBuffer | null = null;
+  onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+
+  constructor() {
+    DeferredFileReader.instances.push(this);
+  }
+
+  readAsDataURL() {}
+
+  finish(dataUrl: string) {
+    this.result = dataUrl;
+    this.onload?.({ target: this } as unknown as ProgressEvent<FileReader>);
+  }
+}
+
+describe("useImageAttachments", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    DeferredFileReader.instances = [];
+  });
+
+  it("reports image reads as pending until the reader completes", () => {
+    vi.stubGlobal("FileReader", DeferredFileReader);
+    const { result } = renderHook(() => useImageAttachments());
+
+    act(() => {
+      result.current.addFiles([new File(["image"], "image.png", { type: "image/png" })]);
+    });
+    expect(result.current.isReading).toBe(true);
+
+    act(() => {
+      DeferredFileReader.instances[0].finish("data:image/png;base64,aW1hZ2U=");
+    });
+    expect(result.current.isReading).toBe(false);
+    expect(result.current.images).toHaveLength(1);
+  });
+
+  it("does not let an invalidated reader change the next generation's pending state", () => {
+    vi.stubGlobal("FileReader", DeferredFileReader);
+    const { result } = renderHook(() => useImageAttachments());
+
+    act(() => {
+      result.current.addFiles([new File(["old"], "old.png", { type: "image/png" })]);
+      result.current.resetImages();
+      result.current.addFiles([new File(["new"], "new.png", { type: "image/png" })]);
+    });
+    expect(result.current.isReading).toBe(true);
+
+    act(() => {
+      DeferredFileReader.instances[0].finish("data:image/png;base64,b2xk");
+    });
+    expect(result.current.isReading).toBe(true);
+
+    act(() => {
+      DeferredFileReader.instances[1].finish("data:image/png;base64,bmV3");
+    });
+    expect(result.current.isReading).toBe(false);
+    expect(result.current.images).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/useImageAttachments.test.tsx
+++ b/frontend/src/hooks/useImageAttachments.test.tsx
@@ -66,4 +66,26 @@ describe("useImageAttachments", () => {
     expect(result.current.isReading).toBe(false);
     expect(result.current.images).toHaveLength(1);
   });
+
+  it("reserves pending capacity across consecutive additions", () => {
+    vi.stubGlobal("FileReader", DeferredFileReader);
+    const initialImages = Array.from({ length: 4 }, (_, index) => ({
+      id: String(index),
+      dataUrl: `data:image/png;base64,${index}`,
+      mimeType: "image/png",
+    }));
+    const { result } = renderHook(() => useImageAttachments(initialImages));
+
+    act(() => {
+      result.current.addFiles([new File(["first"], "first.png", { type: "image/png" })]);
+      result.current.addFiles([new File(["second"], "second.png", { type: "image/png" })]);
+    });
+    expect(DeferredFileReader.instances).toHaveLength(1);
+
+    act(() => {
+      DeferredFileReader.instances[0].finish("data:image/png;base64,Zmlyc3Q=");
+    });
+    expect(DeferredFileReader.instances).toHaveLength(1);
+    expect(result.current.images).toHaveLength(5);
+  });
 });

--- a/frontend/src/hooks/useImageAttachments.ts
+++ b/frontend/src/hooks/useImageAttachments.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { ImagePayload } from "@/types";
+import { uid } from "@/utils/id";
+
+export const MAX_ATTACHED_IMAGES = 5;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export interface AttachedImage {
+  id: string;
+  dataUrl: string;
+  mimeType: string;
+}
+
+export function imagePayloadToAttachment(image: ImagePayload): AttachedImage {
+  return {
+    id: uid(),
+    dataUrl: `data:${image.media_type};base64,${image.data}`,
+    mimeType: image.media_type,
+  };
+}
+
+export function attachmentToImagePayload(image: AttachedImage): ImagePayload {
+  return {
+    data: image.dataUrl.split(",")[1] ?? "",
+    media_type: image.mimeType,
+  };
+}
+
+export function useImageAttachments(initialImages: AttachedImage[] = []) {
+  const { t } = useTranslation("dashboard");
+  const [images, setImages] = useState<AttachedImage[]>(initialImages);
+  const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
+
+  useEffect(() => () => {
+    generationRef.current += 1;
+  }, []);
+
+  const addFiles = useCallback((files: File[]) => {
+    setError(null);
+    const generation = generationRef.current;
+    for (const file of files) {
+      if (!file.type.startsWith("image/")) continue;
+      if (file.size > MAX_IMAGE_BYTES) {
+        setError(t("image_too_large_hint", { name: file.name }));
+        continue;
+      }
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        if (generationRef.current !== generation) return;
+        const dataUrl = event.target?.result;
+        if (typeof dataUrl !== "string") return;
+        setImages((current) => {
+          if (current.length >= MAX_ATTACHED_IMAGES) return current;
+          return [...current, { id: uid(), dataUrl, mimeType: file.type }];
+        });
+      };
+      reader.readAsDataURL(file);
+    }
+  }, [t]);
+
+  const removeImage = useCallback((id: string) => {
+    setImages((current) => current.filter((image) => image.id !== id));
+    setError(null);
+  }, []);
+
+  const resetImages = useCallback(() => {
+    generationRef.current += 1;
+    setImages([]);
+    setError(null);
+  }, []);
+
+  const invalidatePendingReaders = useCallback(() => {
+    generationRef.current += 1;
+  }, []);
+
+  return { images, error, addFiles, removeImage, resetImages, invalidatePendingReaders };
+}

--- a/frontend/src/hooks/useImageAttachments.ts
+++ b/frontend/src/hooks/useImageAttachments.ts
@@ -31,6 +31,7 @@ export function useImageAttachments(initialImages: AttachedImage[] = []) {
   const { t } = useTranslation("dashboard");
   const [images, setImages] = useState<AttachedImage[]>(initialImages);
   const [error, setError] = useState<string | null>(null);
+  const [pendingReads, setPendingReads] = useState(0);
   const generationRef = useRef(0);
 
   useEffect(() => () => {
@@ -47,15 +48,24 @@ export function useImageAttachments(initialImages: AttachedImage[] = []) {
         continue;
       }
       const reader = new FileReader();
+      setPendingReads((current) => current + 1);
+      const finishRead = () => {
+        if (generationRef.current !== generation) return;
+        setPendingReads((current) => Math.max(0, current - 1));
+      };
       reader.onload = (event) => {
         if (generationRef.current !== generation) return;
         const dataUrl = event.target?.result;
-        if (typeof dataUrl !== "string") return;
-        setImages((current) => {
-          if (current.length >= MAX_ATTACHED_IMAGES) return current;
-          return [...current, { id: uid(), dataUrl, mimeType: file.type }];
-        });
+        if (typeof dataUrl === "string") {
+          setImages((current) => {
+            if (current.length >= MAX_ATTACHED_IMAGES) return current;
+            return [...current, { id: uid(), dataUrl, mimeType: file.type }];
+          });
+        }
+        finishRead();
       };
+      reader.onerror = finishRead;
+      reader.onabort = finishRead;
       reader.readAsDataURL(file);
     }
   }, [t]);
@@ -69,11 +79,21 @@ export function useImageAttachments(initialImages: AttachedImage[] = []) {
     generationRef.current += 1;
     setImages([]);
     setError(null);
+    setPendingReads(0);
   }, []);
 
   const invalidatePendingReaders = useCallback(() => {
     generationRef.current += 1;
+    setPendingReads(0);
   }, []);
 
-  return { images, error, addFiles, removeImage, resetImages, invalidatePendingReaders };
+  return {
+    images,
+    error,
+    isReading: pendingReads > 0,
+    addFiles,
+    removeImage,
+    resetImages,
+    invalidatePendingReaders,
+  };
 }

--- a/frontend/src/hooks/useImageAttachments.ts
+++ b/frontend/src/hooks/useImageAttachments.ts
@@ -21,13 +21,14 @@ export function imagePayloadToAttachment(image: ImagePayload): AttachedImage {
 }
 
 export function attachmentToImagePayload(image: AttachedImage): ImagePayload {
+  const separatorIndex = image.dataUrl.indexOf(",");
   return {
-    data: image.dataUrl.split(",")[1] ?? "",
+    data: separatorIndex >= 0 ? image.dataUrl.slice(separatorIndex + 1) : "",
     media_type: image.mimeType,
   };
 }
 
-export function useImageAttachments(initialImages: AttachedImage[] = []) {
+export function useImageAttachments(initialImages: AttachedImage[] | (() => AttachedImage[]) = []) {
   const { t } = useTranslation("dashboard");
   const [images, setImages] = useState<AttachedImage[]>(initialImages);
   const [error, setError] = useState<string | null>(null);
@@ -41,8 +42,12 @@ export function useImageAttachments(initialImages: AttachedImage[] = []) {
   const addFiles = useCallback((files: File[]) => {
     setError(null);
     const generation = generationRef.current;
-    for (const file of files) {
-      if (!file.type.startsWith("image/")) continue;
+    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+    const remainingCapacity = MAX_ATTACHED_IMAGES - images.length;
+    if (imageFiles.length > remainingCapacity) {
+      setError(t("max_images_hint", { count: MAX_ATTACHED_IMAGES }));
+    }
+    for (const file of imageFiles.slice(0, remainingCapacity)) {
       if (file.size > MAX_IMAGE_BYTES) {
         setError(t("image_too_large_hint", { name: file.name }));
         continue;
@@ -68,7 +73,7 @@ export function useImageAttachments(initialImages: AttachedImage[] = []) {
       reader.onabort = finishRead;
       reader.readAsDataURL(file);
     }
-  }, [t]);
+  }, [images.length, t]);
 
   const removeImage = useCallback((id: string) => {
     setImages((current) => current.filter((image) => image.id !== id));

--- a/frontend/src/hooks/useImageAttachments.ts
+++ b/frontend/src/hooks/useImageAttachments.ts
@@ -12,6 +12,11 @@ export interface AttachedImage {
   mimeType: string;
 }
 
+interface PendingImageRead {
+  file: File;
+  generation: number;
+}
+
 export function imagePayloadToAttachment(image: ImagePayload): AttachedImage {
   return {
     id: uid(),
@@ -34,6 +39,9 @@ export function useImageAttachments(initialImages: AttachedImage[] | (() => Atta
   const [error, setError] = useState<string | null>(null);
   const [pendingReads, setPendingReads] = useState(0);
   const generationRef = useRef(0);
+  const pendingSlotsRef = useRef(0);
+  const readQueueRef = useRef<PendingImageRead[]>([]);
+  const readingRef = useRef(false);
 
   useEffect(() => () => {
     generationRef.current += 1;
@@ -42,37 +50,57 @@ export function useImageAttachments(initialImages: AttachedImage[] | (() => Atta
   const addFiles = useCallback((files: File[]) => {
     setError(null);
     const generation = generationRef.current;
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    const remainingCapacity = MAX_ATTACHED_IMAGES - images.length;
+    const imageFiles = files.filter((file) => {
+      if (!file.type.startsWith("image/")) return false;
+      if (file.size <= MAX_IMAGE_BYTES) return true;
+      setError(t("image_too_large_hint", { name: file.name }));
+      return false;
+    });
+    const remainingCapacity = Math.max(
+      0,
+      MAX_ATTACHED_IMAGES - images.length - pendingSlotsRef.current,
+    );
     if (imageFiles.length > remainingCapacity) {
       setError(t("max_images_hint", { count: MAX_ATTACHED_IMAGES }));
     }
-    for (const file of imageFiles.slice(0, remainingCapacity)) {
-      if (file.size > MAX_IMAGE_BYTES) {
-        setError(t("image_too_large_hint", { name: file.name }));
-        continue;
-      }
+    const filesToRead = imageFiles.slice(0, remainingCapacity);
+    pendingSlotsRef.current += filesToRead.length;
+    setPendingReads((current) => current + filesToRead.length);
+    readQueueRef.current.push(...filesToRead.map((file) => ({ file, generation })));
+
+    const processNext = () => {
+      if (readingRef.current) return;
+      const pending = readQueueRef.current.shift();
+      if (!pending) return;
+      readingRef.current = true;
       const reader = new FileReader();
-      setPendingReads((current) => current + 1);
       const finishRead = () => {
-        if (generationRef.current !== generation) return;
-        setPendingReads((current) => Math.max(0, current - 1));
+        if (generationRef.current === pending.generation) {
+          pendingSlotsRef.current = Math.max(0, pendingSlotsRef.current - 1);
+          setPendingReads((current) => Math.max(0, current - 1));
+        }
+        readingRef.current = false;
+        processNext();
       };
       reader.onload = (event) => {
-        if (generationRef.current !== generation) return;
+        if (generationRef.current !== pending.generation) {
+          finishRead();
+          return;
+        }
         const dataUrl = event.target?.result;
         if (typeof dataUrl === "string") {
           setImages((current) => {
             if (current.length >= MAX_ATTACHED_IMAGES) return current;
-            return [...current, { id: uid(), dataUrl, mimeType: file.type }];
+            return [...current, { id: uid(), dataUrl, mimeType: pending.file.type }];
           });
         }
         finishRead();
       };
       reader.onerror = finishRead;
       reader.onabort = finishRead;
-      reader.readAsDataURL(file);
-    }
+      reader.readAsDataURL(pending.file);
+    };
+    processNext();
   }, [images.length, t]);
 
   const removeImage = useCallback((id: string) => {
@@ -85,11 +113,15 @@ export function useImageAttachments(initialImages: AttachedImage[] | (() => Atta
     setImages([]);
     setError(null);
     setPendingReads(0);
+    pendingSlotsRef.current = 0;
+    readQueueRef.current = [];
   }, []);
 
   const invalidatePendingReaders = useCallback(() => {
     generationRef.current += 1;
     setPendingReads(0);
+    pendingSlotsRef.current = 0;
+    readQueueRef.current = [];
   }, []);
 
   return {


### PR DESCRIPTION
## 变更

- 抽取共享图片附件 hook，在主输入框与消息改写编辑器复用 5MB / 5 张采集限制
- 支持改写时新增、保留和移除图片
- 为纯图用户消息显示改写入口，并在无正文时隐藏复制按钮
- 补充编辑载荷、纯图入口和可编辑判据测试

## 验证

- pnpm lint
- pnpm check（146 个测试文件，1759 个测试通过）

Closes #1813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持在聊天消息发送和编辑时添加、预览及删除图片附件。
  - 支持仅包含图片的消息进入编辑流程。
  - 图片附件最多 5 张，单张不超过 5 MiB，并提供格式及大小错误提示。
  - 图片发送成功后自动清空附件。

- **体验优化**
  - 无正文消息不再显示复制按钮，图片消息操作更清晰。
  - 图片读取完成前，添加和发送操作会自动禁用。
  - 编辑提交时会正确携带图片数据，提升附件处理稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->