### PR TITLE
chore(skills): 长等待期间即时感知 PR 审查变化

### DIFF
--- a/.agents/skills/pr-ai-review-loop/SKILL.md
+++ b/.agents/skills/pr-ai-review-loop/SKILL.md
@@ -80,13 +80,7 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 
 ## 轮询节奏
 
-每轮 poll 与决策完成后,立即运行 `bash scripts/wait.sh --repo-root <repo-root> <PR_NUMBER> --max <延迟秒数>`,允许命令执行至少比 `--max` 多 30 秒;命令返回后继续步骤 1。每轮都由 `wait.sh` 保持主动等待,不得结束回合被动等待外部探活。延迟取值:
-
-| 场景 | 延迟 | 备注 |
-|---|---|---|
-| 新 HEAD 后首次 poll | 360s | reviewer cold-start |
-| 其余等待(触发命令后、reviewer 响应中、仅剩 CodeQL 分析未完成) | 180s | |
-| 超过 30 分钟无响应 | 暂停并询问用户,不再等待 | 见「故障处理」 |
+每轮 poll 与决策后运行 `bash scripts/wait.sh --repo-root <repo-root> <PR_NUMBER>`并等待返回,命令执行上限设为 1800 秒;返回后回到步骤 1。`WAIT_TIMEOUT` 后仍无可执行动作时,按「故障处理」的 30 分钟无响应条目暂停。
 
 ## 收敛兜底
 
@@ -108,5 +102,6 @@ GitHub code scanning 两家(quality / security)的评论并入同一批,处置�
 - **`quota_alerts` 非空**:alert 之后该家已有成功审查(更晚的 review 或 walkthrough 更新)的视为已恢复,忽略残留 banner;真实受阻时,reviewers.md 该家有专项配额处置段的(如 CodeRabbit)按其规则自行处置,不暂停;其余家贴出 `body_head`,询问停用该家继续其他家,还是等 quota 恢复后再 push
 - **`codeql_checks.failing` 非空**(失败态集合见 poll.sh header `checks_failing` 条):分析失败,alerts 数据停留在上次成功分析,不能做终核;询问是否重跑失败的 workflow
 - **`security_alerts.available == false`**:贴出 `unavailable_hint`,按 reviewers.md「仓库未接入」段判别权限问题与未接入——两种情形都需用户确认,不得自动跳过 security 门槛
+- **`wait.sh` 返回 `WAIT_ERROR`**:401/403 按下条处理;其余贴出 stderr 暂停
 - **`gh` 401/403**:请用户运行 `gh auth refresh -s repo`
 - **review 评论语义模糊**,按 `receiving-code-review` 的纪律仍无法判定是否 pushback:贴出原文请用户定夺

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -18,40 +18,121 @@ mkdir "$TMP_ROOT/repo"
 git -C "$TMP_ROOT/repo" init -q
 REPO_ARGS=(--repo-root "$TMP_ROOT/repo")
 export TMPDIR="$TMP_ROOT/tmp"
+
 cat > "$TMP_ROOT/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$WAIT_TEST_ROOT/gh-args"
+
+mode=${WAIT_TEST_MODE:-review_change}
+if [[ "$mode" == "slow_probe" ]]; then
+  clock=$(<"$WAIT_TEST_ROOT/clock")
+  printf '%s\n' "$((clock + 5))" > "$WAIT_TEST_ROOT/clock"
+fi
+
+next_count() {
+  local name="$1"
+  local count_file="$WAIT_TEST_ROOT/${name}-count"
+  local count=0
+  [[ ! -f "$count_file" ]] || count=$(<"$count_file")
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$count_file"
+  printf '%s\n' "$count"
+}
+
 if [[ "$1 $2" == "repo view" ]]; then
   printf '%s\n' 'ArcReel/ArcReel'
 elif [[ "$*" == *'reviews(first:100'* ]]; then
-  count_file="$WAIT_TEST_ROOT/review-count"
-  count=0
-  [[ ! -f "$count_file" ]] || count=$(<"$count_file")
-  count=$((count + 1))
-  printf '%s\n' "$count" > "$count_file"
-  if [[ "${WAIT_TEST_MODE:-change}" == "http_error" && "$count" -gt 1 ]]; then
-    echo "HTTP ${WAIT_TEST_HTTP_CODE:-500}: probe failed" >&2
-    exit 1
-  elif (( count == 1 )) || [[ "${WAIT_TEST_MODE:-change}" =~ ^(flat|reaction_change)$ ]]; then
-    submitted_at='2026-08-11T00:00:00Z'
-  else
+  count=$(next_count review)
+  if [[ "$count" -gt 1 ]]; then
+    case "$mode" in
+      http_500_once)
+        if [[ "$count" -eq 2 ]]; then
+          echo 'HTTP 500: probe failed' >&2
+          exit 1
+        fi
+        ;;
+      http_500_always)
+        echo 'HTTP 500: probe failed' >&2
+        exit 1
+        ;;
+      auth_403)
+        echo 'HTTP 403: Resource not accessible by personal access token' >&2
+        exit 1
+        ;;
+      rate_limit_once)
+        if [[ "$count" -eq 2 ]]; then
+          echo 'HTTP 429: secondary rate limit; Retry-After: 7' >&2
+          exit 1
+        fi
+        ;;
+    esac
+  fi
+  submitted_at='2026-08-11T00:00:00Z'
+  if [[ "$mode" == "review_change" && "$count" -gt 1 ]]; then
     submitted_at='2026-08-11T00:01:00Z'
   fi
-  printf '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"submittedAt":"%s"}]}}}}}\n' "$submitted_at"
+  printf '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"id":"R1","submittedAt":"%s","updatedAt":"%s","state":"COMMENTED","commit":{"oid":"abc"}}]}}}}}\n' "$submitted_at" "$submitted_at"
+elif [[ "$*" == *'comments(first:100'* ]]; then
+  count=$(next_count issue_comment)
+  head_sha=${WAIT_TEST_HEAD:-abc}
+  updated_at='2026-08-11T00:00:00Z'
+  reaction_count=0
+  if [[ "$mode" == "head_change" && "$count" -gt 1 ]]; then
+    head_sha=def
+  fi
+  if [[ "$mode" == "issue_comment_change" && "$count" -gt 1 ]]; then
+    updated_at='2026-08-11T00:01:00Z'
+  fi
+  if [[ "$mode" == "comment_reaction_change" && "$count" -gt 1 ]]; then
+    reaction_count=1
+  fi
+  printf '{"data":{"repository":{"pullRequest":{"headRefOid":"%s","comments":{"nodes":[{"id":"C1","updatedAt":"%s","reactionGroups":[{"content":"EYES","reactors":{"totalCount":%s}}]}]}}}}}\n' \
+    "$head_sha" "$updated_at" "$reaction_count"
 elif [[ "$*" == *'/issues/1767/reactions'* ]]; then
-  count_file="$WAIT_TEST_ROOT/reaction-count"
-  count=0
-  [[ ! -f "$count_file" ]] || count=$(<"$count_file")
-  count=$((count + 1))
-  printf '%s\n' "$count" > "$count_file"
+  count=$(next_count reaction)
   content=eyes
-  if [[ "${WAIT_TEST_MODE:-change}" == "reaction_change" && "$count" -gt 1 ]]; then
+  if [[ "$mode" == "reaction_change" && "$count" -gt 1 ]]; then
     content='+1'
   fi
-  printf '[{"content":"%s","user":{"login":"chatgpt-codex-connector[bot]"}}]\n' "$content"
+  printf '[{"id":1,"content":"%s","user":{"login":"chatgpt-codex-connector[bot]"}}]\n' "$content"
+elif [[ "$*" == *'/pulls/1767/comments'* ]]; then
+  count=$(next_count inline)
+  if [[ "$mode" == "eof_once" && "$count" -eq 1 ]]; then
+    printf '%s' '[{"id":'
+    exit 0
+  fi
+  updated_at='2026-08-11T00:00:00Z'
+  if [[ "$mode" == "inline_change" && "$count" -gt 1 ]]; then
+    updated_at='2026-08-11T00:01:00Z'
+  fi
+  printf '[{"id":2,"updated_at":"%s","commit_id":"abc","in_reply_to_id":null,"user":{"login":"github-code-quality[bot]"}}]\n' "$updated_at"
+elif [[ "$*" == *'/check-runs?per_page=100'* ]]; then
+  count=$(next_count checks)
+  status=queued
+  conclusion=null
+  completed_at=null
+  if [[ "$mode" == "check_change" && "$count" -gt 1 ]]; then
+    status=completed
+    conclusion='"success"'
+    completed_at='"2026-08-11T00:01:00Z"'
+  fi
+  printf '{"check_runs":[{"id":3,"name":"CodeQL","app":{"slug":"github-advanced-security"},"status":"%s","conclusion":%s,"started_at":"2026-08-11T00:00:00Z","completed_at":%s}]}\n' \
+    "$status" "$conclusion" "$completed_at"
+elif [[ "$*" == *'/code-scanning/alerts?'* ]]; then
+  count=$(next_count security)
+  if [[ "$mode" == "security_unavailable" ]]; then
+    echo 'HTTP 404: no analysis found' >&2
+    exit 1
+  fi
+  if [[ "$mode" == "security_change" && "$count" -gt 1 ]]; then
+    printf '[{"number":4,"state":"open","rule":{"id":"py/test"},"tool":{"name":"CodeQL"},"most_recent_instance":{"ref":"refs/pull/1767/merge","analysis_key":".github/workflows/codeql.yml","location":{"path":"server/app.py","start_line":10}}}]\n'
+  else
+    printf '[]\n'
+  fi
 else
-  printf '{"data":{"repository":{"pullRequest":{"headRefOid":"%s","comments":{"nodes":[{"updatedAt":"2026-08-11T00:00:00Z"}]}}}}}\n' "${WAIT_TEST_HEAD:-abc}"
+  echo "unexpected gh invocation: $*" >&2
+  exit 99
 fi
 EOF
 chmod +x "$TMP_ROOT/bin/gh"
@@ -60,64 +141,100 @@ cat > "$TMP_ROOT/bin/sleep" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$1" >> "$WAIT_TEST_ROOT/sleeps"
+clock=$(<"$WAIT_TEST_ROOT/clock")
+printf '%s\n' "$((clock + $1))" > "$WAIT_TEST_ROOT/clock"
 EOF
 chmod +x "$TMP_ROOT/bin/sleep"
 
-WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 --max 180
+cat > "$TMP_ROOT/bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "+%s" ]]
+printf '%s\n' "$(<"$WAIT_TEST_ROOT/clock")"
+EOF
+chmod +x "$TMP_ROOT/bin/date"
 
-[[ "$(<"$TMP_ROOT/review-count")" == "2" ]] || fail "expected baseline plus one changed probe"
-[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected one 60-second probe interval"
-grep -q 'headRefOid' "$TMP_ROOT/gh-args" || fail "probe did not request the head SHA"
-grep -q 'submittedAt' "$TMP_ROOT/gh-args" || fail "probe did not request review submitted_at"
-grep -q 'updatedAt' "$TMP_ROOT/gh-args" || fail "probe did not request comment updated_at"
+reset_case() {
+  rm -f "$TMP_ROOT"/*-count "$TMP_ROOT/sleeps" "$TMP_ROOT/result.out" "$TMP_ROOT/result.err"
+  printf '0\n' > "$TMP_ROOT/clock"
+}
 
-echo "PASS: wait exits early when a probe signal changes"
+run_wait() {
+  local mode="$1"
+  shift
+  WAIT_TEST_MODE="$mode" WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
+    bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 "$@" \
+    > "$TMP_ROOT/result.out" 2> "$TMP_ROOT/result.err"
+}
 
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-WAIT_TEST_MODE=reaction_change WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
-  bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 --max 180
-[[ "$(<"$TMP_ROOT/reaction-count")" == "2" ]] || fail "expected two Codex reaction probes"
-[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected reaction-only completion after one interval"
-echo "PASS: wait exits early when the Codex PR reaction changes"
-
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
-  bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 --max 125
-[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,5" ]] || fail "expected 60-second probes capped at --max"
-echo "PASS: wait respects the maximum delay"
-
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-rm -f "$TMP_ROOT/tmp/pr-ai-review-loop-$(id -u)/wait-ArcReel-ArcReel-1767.head"
-WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
-  bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767
-[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
-  || fail "expected the first wait on a head to default to 360 seconds"
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-WAIT_TEST_MODE=flat WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
-  bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767
-[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60" ]] \
-  || fail "expected later waits on the same head to default to 180 seconds"
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-WAIT_TEST_MODE=flat WAIT_TEST_HEAD=def WAIT_TEST_ROOT="$TMP_ROOT" PATH="$TMP_ROOT/bin:$PATH" \
-  bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767
-[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,60,60,60,60" ]] \
-  || fail "expected a changed head to restore the 360-second default"
-echo "PASS: wait defaults to 360 seconds on a new head and 180 seconds thereafter"
-
-for code in 403 429; do
-  rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-  WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE="$code" WAIT_TEST_ROOT="$TMP_ROOT" \
-    PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 --max 180
-  [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,120" ]] \
-    || fail "expected HTTP $code to degrade to sleep-only mode"
+for signal in head review issue_comment reaction comment_reaction inline check security; do
+  reset_case
+  run_wait "${signal}_change" --max 180
+  [[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected $signal change after one interval"
+  grep -q '^WAIT_CHANGE:' "$TMP_ROOT/result.out" || fail "expected an explicit change result for $signal"
 done
-echo "PASS: rate-limit responses degrade to sleep-only mode"
+grep -q '/pulls/1767/comments' "$TMP_ROOT/gh-args" || fail "probe did not request inline review comments"
+grep -q '/check-runs?per_page=100' "$TMP_ROOT/gh-args" || fail "probe did not request check runs"
+grep -q '/code-scanning/alerts?' "$TMP_ROOT/gh-args" || fail "probe did not request code-scanning alerts"
+echo "PASS: every decision-relevant signal wakes the wait early"
 
-rm -f "$TMP_ROOT/review-count" "$TMP_ROOT/reaction-count" "$TMP_ROOT/sleeps"
-if WAIT_TEST_MODE=http_error WAIT_TEST_HTTP_CODE=500 WAIT_TEST_ROOT="$TMP_ROOT" \
-  PATH="$TMP_ROOT/bin:$PATH" bash "$WAIT_SH" "${REPO_ARGS[@]}" 1767 --max 180 \
-  >"$TMP_ROOT/error.out" 2>"$TMP_ROOT/error.err"; then
-  fail "expected a non-rate-limit GitHub error to fail"
+reset_case
+run_wait flat --max 125
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,5" ]] || fail "expected 60-second probes capped at --max"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected an explicit timeout result"
+echo "PASS: wait respects an explicit maximum and reports timeout"
+
+reset_case
+run_wait flat
+[[ "$(wc -l < "$TMP_ROOT/sleeps" | tr -d ' ')" == "30" ]] || fail "expected 30 one-minute-or-less intervals"
+[[ "$(head -n 29 "$TMP_ROOT/sleeps" | sort -u)" == "60" ]] || fail "expected one-minute polling intervals"
+[[ "$(tail -n 1 "$TMP_ROOT/sleeps")" == "30" ]] || fail "expected a 30-second execution reserve"
+grep -q '^WAIT_TIMEOUT:.*1770' "$TMP_ROOT/result.out" || fail "expected the default timeout to reserve 30 seconds"
+echo "PASS: wait fills a 30-minute command budget with setup reserve"
+
+reset_case
+run_wait slow_probe --max 125
+[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected API time to reduce the remaining sleep budget"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected probe time to count toward timeout"
+echo "PASS: API latency counts against the wait budget"
+
+reset_case
+run_wait eof_once --max 65
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "2,60,3" ]] || fail "expected EOF retry to consume the same wait budget"
+[[ "$(<"$TMP_ROOT/review-count")" == "4" ]] || fail "expected the whole baseline probe to restart after EOF"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected successful recovery after EOF"
+echo "PASS: truncated JSON retries the entire probe"
+
+reset_case
+run_wait http_500_once --max 70
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,2,8" ]] || fail "expected one bounded retry after HTTP 500"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected successful recovery after HTTP 500"
+echo "PASS: a transient HTTP failure recovers"
+
+reset_case
+if run_wait http_500_always --max 180; then
+  fail "expected persistent HTTP 500 failures to fail"
 fi
-grep -q '^WAIT_ERROR:' "$TMP_ROOT/error.err" || fail "expected a loud WAIT_ERROR prefix"
-echo "PASS: non-rate-limit probe errors fail loudly"
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,2,5,10" ]] || fail "expected three bounded retries"
+grep -q '^WAIT_ERROR:' "$TMP_ROOT/result.err" || fail "expected a loud WAIT_ERROR after retry exhaustion"
+echo "PASS: persistent transient failures exhaust a bounded retry budget"
+
+reset_case
+if run_wait auth_403 --max 180; then
+  fail "expected a permission error to fail"
+fi
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60" ]] || fail "expected permission errors to skip retries"
+grep -q '^WAIT_ERROR:' "$TMP_ROOT/result.err" || fail "expected a loud permission WAIT_ERROR"
+echo "PASS: permission failures fail immediately"
+
+reset_case
+run_wait rate_limit_once --max 70
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,7,3" ]] || fail "expected Retry-After to control rate-limit backoff"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected rate-limit recovery"
+echo "PASS: rate limits honor the server retry hint"
+
+reset_case
+run_wait security_unavailable --max 60
+[[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected unavailable code scanning to remain a stable signal"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected unavailable code scanning not to abort waiting"
+echo "PASS: an unavailable code-scanning endpoint remains observable without blocking the loop"

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -44,6 +44,9 @@ if [[ "$1 $2" == "repo view" ]]; then
   printf '%s\n' 'ArcReel/ArcReel'
 elif [[ "$*" == *'reviews(first:100'* ]]; then
   count=$(next_count review)
+  if [[ "$mode" == "hung_probe" ]]; then
+    exec /bin/sleep 2
+  fi
   if [[ "$count" -gt 1 ]]; then
     case "$mode" in
       http_500_once)
@@ -221,6 +224,12 @@ run_wait slow_probe --max 125
 [[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected API time to reduce the remaining sleep budget"
 grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected probe time to count toward timeout"
 echo "PASS: API latency counts against the wait budget"
+
+reset_case
+run_wait hung_probe --max 1
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected a hung request to end as a clean timeout"
+[[ ! -s "$TMP_ROOT/result.err" ]] || fail "expected no process-termination diagnostic on timeout"
+echo "PASS: an in-flight GitHub request cannot outlive the wait deadline"
 
 reset_case
 run_wait eof_once --max 65

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -62,7 +62,14 @@ elif [[ "$*" == *'reviews(first:100'* ]]; then
         ;;
       rate_limit_once)
         if [[ "$count" -eq 2 ]]; then
-          echo 'HTTP 429: secondary rate limit; Retry-After: 7' >&2
+          printf 'HTTP/2.0 429 Too Many Requests\nRetry-After: 7\n\n'
+          echo 'gh: secondary rate limit (HTTP 429)' >&2
+          exit 1
+        fi
+        ;;
+      network_once)
+        if [[ "$count" -eq 2 ]]; then
+          echo 'dial tcp: lookup api.github.com: no such host' >&2
           exit 1
         fi
         ;;
@@ -106,7 +113,11 @@ elif [[ "$*" == *'/pulls/1767/comments'* ]]; then
   if [[ "$mode" == "inline_change" && "$count" -gt 1 ]]; then
     updated_at='2026-08-11T00:01:00Z'
   fi
-  printf '[{"id":2,"updated_at":"%s","commit_id":"abc","in_reply_to_id":null,"user":{"login":"github-code-quality[bot]"}}]\n' "$updated_at"
+  if [[ "$mode" == "null_nested_fields" ]]; then
+    printf '[{"id":1,"updated_at":"%s","commit_id":"abc","in_reply_to_id":null,"user":null},{"id":2,"updated_at":"%s","commit_id":"abc","in_reply_to_id":null,"user":{"login":"github-code-quality[bot]"}}]\n' "$updated_at" "$updated_at"
+  else
+    printf '[{"id":2,"updated_at":"%s","commit_id":"abc","in_reply_to_id":null,"user":{"login":"github-code-quality[bot]"}}]\n' "$updated_at"
+  fi
 elif [[ "$*" == *'/check-runs?per_page=100'* ]]; then
   count=$(next_count checks)
   status=queued
@@ -117,15 +128,22 @@ elif [[ "$*" == *'/check-runs?per_page=100'* ]]; then
     conclusion='"success"'
     completed_at='"2026-08-11T00:01:00Z"'
   fi
-  printf '{"check_runs":[{"id":3,"name":"CodeQL","app":{"slug":"github-advanced-security"},"status":"%s","conclusion":%s,"started_at":"2026-08-11T00:00:00Z","completed_at":%s}]}\n' \
-    "$status" "$conclusion" "$completed_at"
+  if [[ "$mode" == "null_nested_fields" ]]; then
+    app=null
+  else
+    app='{"slug":"github-advanced-security"}'
+  fi
+  printf '{"check_runs":[{"id":3,"name":"CodeQL","app":%s,"status":"%s","conclusion":%s,"started_at":"2026-08-11T00:00:00Z","completed_at":%s}]}\n' \
+    "$app" "$status" "$conclusion" "$completed_at"
 elif [[ "$*" == *'/code-scanning/alerts?'* ]]; then
   count=$(next_count security)
   if [[ "$mode" == "security_unavailable" ]]; then
     echo 'HTTP 404: no analysis found' >&2
     exit 1
   fi
-  if [[ "$mode" == "security_change" && "$count" -gt 1 ]]; then
+  if [[ "$mode" == "null_nested_fields" ]]; then
+    printf '[{"number":4,"state":"open","rule":null,"tool":null,"most_recent_instance":null}]\n'
+  elif [[ "$mode" == "security_change" && "$count" -gt 1 ]]; then
     printf '[{"number":4,"state":"open","rule":{"id":"py/test"},"tool":{"name":"CodeQL"},"most_recent_instance":{"ref":"refs/pull/1767/merge","analysis_key":".github/workflows/codeql.yml","location":{"path":"server/app.py","start_line":10}}}]\n'
   else
     printf '[]\n'
@@ -181,6 +199,7 @@ echo "PASS: every decision-relevant signal wakes the wait early"
 reset_case
 run_wait flat --max 125
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,60,5" ]] || fail "expected 60-second probes capped at --max"
+[[ "$(<"$TMP_ROOT/review-count")" == "3" ]] || fail "expected no probe after the deadline"
 grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected an explicit timeout result"
 echo "PASS: wait respects an explicit maximum and reports timeout"
 
@@ -201,7 +220,7 @@ echo "PASS: API latency counts against the wait budget"
 reset_case
 run_wait eof_once --max 65
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "2,60,3" ]] || fail "expected EOF retry to consume the same wait budget"
-[[ "$(<"$TMP_ROOT/review-count")" == "4" ]] || fail "expected the whole baseline probe to restart after EOF"
+[[ "$(<"$TMP_ROOT/review-count")" == "3" ]] || fail "expected the whole baseline probe to restart after EOF"
 grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected successful recovery after EOF"
 echo "PASS: truncated JSON retries the entire probe"
 
@@ -210,6 +229,12 @@ run_wait http_500_once --max 70
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,2,8" ]] || fail "expected one bounded retry after HTTP 500"
 grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected successful recovery after HTTP 500"
 echo "PASS: a transient HTTP failure recovers"
+
+reset_case
+run_wait network_once --max 70
+[[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,2,8" ]] || fail "expected one bounded retry after a Go network error"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected network recovery"
+echo "PASS: common GitHub CLI network failures recover"
 
 reset_case
 if run_wait http_500_always --max 180; then
@@ -232,6 +257,12 @@ run_wait rate_limit_once --max 70
 [[ "$(paste -sd, "$TMP_ROOT/sleeps")" == "60,7,3" ]] || fail "expected Retry-After to control rate-limit backoff"
 grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected rate-limit recovery"
 echo "PASS: rate limits honor the server retry hint"
+
+reset_case
+run_wait null_nested_fields --max 1
+[[ "$(<"$TMP_ROOT/review-count")" == "1" ]] || fail "expected a valid baseline with null nested fields"
+grep -q '^WAIT_TIMEOUT:' "$TMP_ROOT/result.out" || fail "expected null nested fields to remain observable"
+echo "PASS: nullable GitHub response fields do not invalidate a probe"
 
 reset_case
 run_wait security_unavailable --max 60

--- a/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/test_wait.sh
@@ -136,14 +136,19 @@ elif [[ "$*" == *'/check-runs?per_page=100'* ]]; then
   printf '{"check_runs":[{"id":3,"name":"CodeQL","app":%s,"status":"%s","conclusion":%s,"started_at":"2026-08-11T00:00:00Z","completed_at":%s}]}\n' \
     "$app" "$status" "$conclusion" "$completed_at"
 elif [[ "$*" == *'/code-scanning/alerts?'* ]]; then
-  count=$(next_count security)
+  if [[ "$*" == *'ref=refs/pull/'* ]]; then
+    alert_scope=security
+  else
+    alert_scope=base_security
+  fi
+  count=$(next_count "$alert_scope")
   if [[ "$mode" == "security_unavailable" ]]; then
     echo 'HTTP 404: no analysis found' >&2
     exit 1
   fi
   if [[ "$mode" == "null_nested_fields" ]]; then
     printf '[{"number":4,"state":"open","rule":null,"tool":null,"most_recent_instance":null}]\n'
-  elif [[ "$mode" == "security_change" && "$count" -gt 1 ]]; then
+  elif [[ "$mode" == "${alert_scope}_change" && "$count" -gt 1 ]]; then
     printf '[{"number":4,"state":"open","rule":{"id":"py/test"},"tool":{"name":"CodeQL"},"most_recent_instance":{"ref":"refs/pull/1767/merge","analysis_key":".github/workflows/codeql.yml","location":{"path":"server/app.py","start_line":10}}}]\n'
   else
     printf '[]\n'
@@ -185,7 +190,7 @@ run_wait() {
     > "$TMP_ROOT/result.out" 2> "$TMP_ROOT/result.err"
 }
 
-for signal in head review issue_comment reaction comment_reaction inline check security; do
+for signal in head review issue_comment reaction comment_reaction inline check security base_security; do
   reset_case
   run_wait "${signal}_change" --max 180
   [[ "$(<"$TMP_ROOT/sleeps")" == "60" ]] || fail "expected $signal change after one interval"

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -7,8 +7,8 @@
 # The default wait uses 1770 seconds of a 30-minute command budget, leaving 30 seconds
 # for setup and result delivery. --max is an override for tests and manual diagnostics.
 # Every probe is an atomic fingerprint of reviews, comments, reactions, inline comments,
-# check runs, and PR code-scanning alerts. Truncated output, network errors, rate limits,
-# and HTTP 5xx responses retry the whole probe up to three times. Authentication,
+# check runs, and the PR/base code-scanning alert sets. Truncated output, network errors,
+# rate limits, and HTTP 5xx responses retry the whole probe up to three times. Authentication,
 # permission, and other request errors fail loudly with WAIT_ERROR.
 
 set -euo pipefail
@@ -239,12 +239,22 @@ probe_once() {
   fetch_json "$WORKDIR/check-runs.json" "$WORKDIR/check-runs.err" required \
     gh api --include "repos/${REPO_SLUG}/commits/${head_sha}/check-runs?per_page=100" --paginate || return 1
 
-  if fetch_json "$WORKDIR/security-alerts.json" "$WORKDIR/security-alerts.err" optional \
+  if fetch_json "$WORKDIR/security-alerts-pr.json" "$WORKDIR/security-alerts-pr.err" optional \
     gh api --include "repos/${REPO_SLUG}/code-scanning/alerts?ref=refs/pull/${PR}/merge&state=open&per_page=100" --paginate; then
     :
   elif [[ "$FAILURE_KIND" == "unavailable" ]]; then
     security_available=false
-    printf '[]\n' > "$WORKDIR/security-alerts.json"
+    printf '[]\n' > "$WORKDIR/security-alerts-pr.json"
+  else
+    return 1
+  fi
+
+  if fetch_json "$WORKDIR/security-alerts-base.json" "$WORKDIR/security-alerts-base.err" optional \
+    gh api --include "repos/${REPO_SLUG}/code-scanning/alerts?state=open&per_page=100" --paginate; then
+    :
+  elif [[ "$FAILURE_KIND" == "unavailable" ]]; then
+    security_available=false
+    printf '[]\n' > "$WORKDIR/security-alerts-base.json"
   else
     return 1
   fi
@@ -257,7 +267,8 @@ probe_once() {
     --slurpfile reactions "$WORKDIR/reactions.json" \
     --slurpfile inline_comments "$WORKDIR/inline-comments.json" \
     --slurpfile check_runs "$WORKDIR/check-runs.json" \
-    --slurpfile security_alerts "$WORKDIR/security-alerts.json" \
+    --slurpfile security_alerts_pr "$WORKDIR/security-alerts-pr.json" \
+    --slurpfile security_alerts_base "$WORKDIR/security-alerts-base.json" \
     --argjson security_available "$security_available" \
     '
     if any($reviews[]; .errors? != null) or any($comments[]; .errors? != null) then
@@ -295,8 +306,16 @@ probe_once() {
            | sort_by(.id)),
         security_alerts: {
           available: $security_available,
-          open:
-            ([$security_alerts[][]?
+          pr_open:
+            ([$security_alerts_pr[][]?
+              | {number, state, rule_id: .rule.id, tool: .tool.name,
+                 ref: .most_recent_instance.ref,
+                 analysis_key: .most_recent_instance.analysis_key,
+                 path: .most_recent_instance.location.path,
+                 start_line: .most_recent_instance.location.start_line}]
+             | sort_by(.number)),
+          base_open:
+            ([$security_alerts_base[][]?
               | {number, state, rule_id: .rule.id, tool: .tool.name,
                  ref: .most_recent_instance.ref,
                  analysis_key: .most_recent_instance.analysis_key,

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -52,6 +52,7 @@ command -v jq >/dev/null 2>&1 || {
 
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/pr-ai-review-wait.XXXXXX")
 trap 'rm -rf "$WORKDIR"' EXIT
+WATCHDOG_SEQUENCE=0
 
 STARTED_AT=$(date +%s)
 DEADLINE=$((STARTED_AT + MAX_WAIT))
@@ -61,6 +62,52 @@ RETRY_AFTER=0
 
 report_timeout() {
   printf 'WAIT_TIMEOUT: no relevant PR state change within %s seconds\n' "$MAX_WAIT"
+}
+
+run_until_deadline() {
+  local output_file="$1"
+  local error_file="$2"
+  local now remaining command_pid watchdog_pid status watchdog_fifo
+  shift 2
+
+  now=$(date +%s)
+  remaining=$((DEADLINE - now))
+  (( remaining > 0 )) || {
+    printf 'GitHub request skipped because the wait deadline elapsed\n' > "$error_file"
+    return 124
+  }
+
+  rm -f "$WORKDIR/request-timed-out"
+  WATCHDOG_SEQUENCE=$((WATCHDOG_SEQUENCE + 1))
+  watchdog_fifo="$WORKDIR/watchdog-${WATCHDOG_SEQUENCE}.fifo"
+  mkfifo "$watchdog_fifo"
+  exec 9<> "$watchdog_fifo"
+  "$@" > "$output_file" 2> "$error_file" &
+  command_pid=$!
+  (
+    IFS= read -r -t "$remaining" -u 9 && exit 0
+    if kill -0 "$command_pid" 2>/dev/null; then
+      printf 'GitHub request exceeded the wait deadline\n' > "$WORKDIR/request-timed-out"
+      kill -TERM "$command_pid" 2>/dev/null || true
+    fi
+  ) &
+  watchdog_pid=$!
+
+  if wait "$command_pid" 2>/dev/null; then
+    status=0
+  else
+    status=$?
+  fi
+  printf '\n' >&9
+  wait "$watchdog_pid" 2>/dev/null || true
+  exec 9>&-
+  rm -f "$watchdog_fifo"
+
+  if [[ -f "$WORKDIR/request-timed-out" ]]; then
+    cat "$WORKDIR/request-timed-out" >> "$error_file"
+    return 124
+  fi
+  return "$status"
 }
 
 classify_failure() {
@@ -97,16 +144,25 @@ fetch_json() {
   local error_file="$2"
   local availability="$3"
   local raw_output="${output_file}.raw"
+  local command_status
   shift 3
 
   LAST_ERROR_FILE="$error_file"
   : > "$error_file"
-  if "$@" > "$raw_output" 2> "$error_file"; then
+  if run_until_deadline "$raw_output" "$error_file" "$@"; then
     strip_http_headers "$raw_output" > "$output_file"
     if jq -e -s 'length > 0' "$output_file" >/dev/null 2> "$error_file"; then
       return 0
     fi
     printf 'GitHub returned truncated or invalid JSON\n' >> "$error_file"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    return 1
+  else
+    command_status=$?
+  fi
+
+  if [[ "$command_status" -eq 124 ]]; then
     FAILURE_KIND="transient"
     RETRY_AFTER=0
     return 1
@@ -166,15 +222,25 @@ repo_view_once() {
   local output_file="$1"
   local error_file="$WORKDIR/repo-view.err"
   local repo_slug
+  local command_status
 
   LAST_ERROR_FILE="$error_file"
   : > "$error_file"
-  if gh repo view --json nameWithOwner --jq .nameWithOwner > "$output_file" 2> "$error_file"; then
+  if run_until_deadline "$output_file" "$error_file" \
+    gh repo view --json nameWithOwner --jq .nameWithOwner; then
     repo_slug=$(<"$output_file")
     if [[ "$repo_slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
       return 0
     fi
     printf 'GitHub returned a truncated or invalid repository slug\n' > "$error_file"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    return 1
+  else
+    command_status=$?
+  fi
+
+  if [[ "$command_status" -eq 124 ]]; then
     FAILURE_KIND="transient"
     RETRY_AFTER=0
     return 1

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# wait.sh — wait for one lightweight PR-state change, or until the polling delay expires.
+# wait.sh — wait for one decision-relevant PR-state change or the fixed safety timeout.
 #
 # USAGE
 #   bash wait.sh --repo-root <path> <PR_NUMBER> [--max <seconds>]
 #
-# Without --max, the first wait observed for a HEAD is 360 seconds and later waits on the
-# same HEAD are 180 seconds.
-#
-# The probe reads only the PR head SHA, review submittedAt values, issue-comment
-# updatedAt values, and Codex PR reactions. Any change returns immediately. GitHub
-# 403/429 responses switch the remainder of this wait to sleep-only mode; other errors
-# fail loudly with WAIT_ERROR.
+# The default wait uses 1770 seconds of a 30-minute command budget, leaving 30 seconds
+# for setup and result delivery. --max is an override for tests and manual diagnostics.
+# Every probe is an atomic fingerprint of reviews, comments, reactions, inline comments,
+# check runs, and PR code-scanning alerts. Truncated output, network errors, rate limits,
+# and HTTP 5xx responses retry the whole probe up to three times. Authentication,
+# permission, and other request errors fail loudly with WAIT_ERROR.
 
 set -euo pipefail
 
@@ -20,6 +19,10 @@ source "$SCRIPT_DIR/repo-context.sh"
 enter_repo_root "WAIT_ERROR" "$@"
 shift "$REPO_CONTEXT_SHIFT"
 
+DEFAULT_MAX_WAIT=1770
+POLL_INTERVAL=60
+RETRY_DELAYS=(2 5 10)
+
 usage() {
   echo "WAIT_ERROR: Usage: bash wait.sh [--repo-root <path>] <PR_NUMBER> [--max <seconds>]" >&2
   exit 2
@@ -28,7 +31,7 @@ usage() {
 [[ $# -ge 1 ]] || usage
 PR="$1"
 shift
-MAX_WAIT=""
+MAX_WAIT="$DEFAULT_MAX_WAIT"
 
 if [[ $# -gt 0 ]]; then
   [[ $# -eq 2 && "$1" == "--max" ]] || usage
@@ -36,7 +39,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 [[ "$PR" =~ ^[0-9]+$ ]] || usage
-[[ -z "$MAX_WAIT" || ("$MAX_WAIT" =~ ^[0-9]+$ && "$MAX_WAIT" -gt 0) ]] || usage
+[[ "$MAX_WAIT" =~ ^[0-9]+$ && "$MAX_WAIT" -gt 0 ]] || usage
 
 command -v gh >/dev/null 2>&1 || {
   echo "WAIT_ERROR: gh CLI not found on PATH" >&2
@@ -47,142 +50,301 @@ command -v jq >/dev/null 2>&1 || {
   exit 3
 }
 
-REPO_SLUG=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>&1) || {
-  if grep -Eq '(^|[^0-9])(403|429)([^0-9]|$)' <<<"$REPO_SLUG"; then
-    sleep "${MAX_WAIT:-180}"
-    exit 0
-  fi
-  echo "WAIT_ERROR: gh repo view failed" >&2
-  echo "$REPO_SLUG" >&2
-  exit 4
-}
-OWNER=${REPO_SLUG%%/*}
-REPO=${REPO_SLUG#*/}
-[[ "$REPO_SLUG" == */* && -n "$OWNER" && -n "$REPO" ]] || {
-  echo "WAIT_ERROR: gh repo view returned an invalid repository slug: $REPO_SLUG" >&2
-  exit 4
-}
-
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/pr-ai-review-wait.XXXXXX")
 trap 'rm -rf "$WORKDIR"' EXIT
-RATE_LIMITED=75
 
-# GraphQL variable names are literals consumed by GitHub, not shell expansions.
-# shellcheck disable=SC2016
-REVIEWS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviews(first:100,after:$endCursor){nodes{submittedAt}pageInfo{hasNextPage endCursor}}}}}'
-# shellcheck disable=SC2016
-COMMENTS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){headRefOid comments(first:100,after:$endCursor){nodes{updatedAt}pageInfo{hasNextPage endCursor}}}}}'
+STARTED_AT=$(date +%s)
+DEADLINE=$((STARTED_AT + MAX_WAIT))
+FAILURE_KIND=""
+LAST_ERROR_FILE="$WORKDIR/probe.err"
+RETRY_AFTER=0
 
-is_rate_limited() {
-  grep -Eq '(^|[^0-9])(403|429)([^0-9]|$)' "$1"
+report_timeout() {
+  printf 'WAIT_TIMEOUT: no relevant PR state change within %s seconds\n' "$MAX_WAIT"
 }
 
-probe() {
-  local reviews_json comments_json reactions_json
+classify_failure() {
+  local error_file="$1"
+  local retry_hint
 
-  if ! reviews_json=$(gh api graphql --paginate \
-    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
-    -f query="$REVIEWS_QUERY" 2>"$WORKDIR/probe.err"); then
-    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
-    return 1
-  fi
-  if ! comments_json=$(gh api graphql --paginate \
-    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
-    -f query="$COMMENTS_QUERY" 2>"$WORKDIR/probe.err"); then
-    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
-    return 1
-  fi
-  if ! reactions_json=$(gh api "repos/${REPO_SLUG}/issues/${PR}/reactions" --paginate \
-    2>"$WORKDIR/probe.err"); then
-    is_rate_limited "$WORKDIR/probe.err" && return "$RATE_LIMITED"
-    return 1
-  fi
+  FAILURE_KIND="fatal"
+  RETRY_AFTER=0
 
-  jq -n \
-    --slurpfile reviews <(printf '%s\n' "$reviews_json") \
-    --slurpfile comments <(printf '%s\n' "$comments_json") \
-    --slurpfile reactions <(printf '%s\n' "$reactions_json") \
-    '{
-      head: $comments[0].data.repository.pullRequest.headRefOid,
-      review_submitted_at:
-        ([$reviews[].data.repository.pullRequest.reviews.nodes[]?.submittedAt] | max // null),
-      comment_updated_at:
-        ([$comments[].data.repository.pullRequest.comments.nodes[]?.updatedAt] | max // null),
-      codex_reactions:
-        ([$reactions[][]
-          | select(.user.login == "chatgpt-codex-connector[bot]")
-          | .content]
-         | sort)
-    }'
+  if grep -Eiq 'rate[ -]?limit|secondary rate|abuse detection' "$error_file" \
+    || grep -Eiq '(^|[^0-9])429([^0-9]|$)' "$error_file"; then
+    FAILURE_KIND="transient"
+    retry_hint=$(sed -nE 's/.*[Rr]etry-[Aa]fter[:= ]+([0-9]+).*/\1/p' "$error_file" | head -n 1)
+    if [[ "$retry_hint" =~ ^[0-9]+$ ]]; then
+      RETRY_AFTER="$retry_hint"
+    fi
+  elif grep -Eiq '(^|[^0-9])5[0-9]{2}([^0-9]|$)' "$error_file" \
+    || grep -Eiq 'unexpected.*(EOF|end of)|(^|[^a-z])EOF([^a-z]|$)|timed? out|timeout|connection.*(reset|closed|refused)|TLS|temporary|temporarily unavailable|network is unreachable|could not resolve' "$error_file"; then
+    FAILURE_KIND="transient"
+  fi
 }
 
-BASELINE_FILE="$WORKDIR/baseline.json"
-if probe > "$BASELINE_FILE"; then
+fetch_json() {
+  local output_file="$1"
+  local error_file="$2"
+  local availability="$3"
+  shift 3
+
+  LAST_ERROR_FILE="$error_file"
+  : > "$error_file"
+  if "$@" > "$output_file" 2> "$error_file"; then
+    if jq -e -s 'length > 0' "$output_file" >/dev/null 2> "$error_file"; then
+      return 0
+    fi
+    printf 'GitHub returned truncated or invalid JSON\n' >> "$error_file"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    return 1
+  fi
+
+  if [[ "$availability" == "optional" ]] \
+    && grep -Eq '(^|[^0-9])(404|422)([^0-9]|$)' "$error_file"; then
+    FAILURE_KIND="unavailable"
+    RETRY_AFTER=0
+    return 1
+  fi
+
+  classify_failure "$error_file"
+  return 1
+}
+
+sleep_for_retry() {
+  local requested="$1"
+  local now remaining
+
+  now=$(date +%s)
+  remaining=$((DEADLINE - now))
+  (( remaining > 0 )) || return 1
+  if (( requested >= remaining )); then
+    sleep "$remaining"
+    return 1
+  fi
+  sleep "$requested"
+}
+
+retry_operation() {
+  local operation="$1"
+  local output_file="$2"
+  local attempt delay
+
+  for attempt in 0 1 2 3; do
+    if (( attempt > 0 )); then
+      delay="${RETRY_DELAYS[attempt - 1]}"
+      if (( RETRY_AFTER > delay )); then
+        delay="$RETRY_AFTER"
+      fi
+      sleep_for_retry "$delay" || return 124
+    fi
+
+    FAILURE_KIND=""
+    RETRY_AFTER=0
+    if "$operation" "$output_file"; then
+      return 0
+    fi
+    [[ "$FAILURE_KIND" == "transient" ]] || return 1
+  done
+  return 1
+}
+
+repo_view_once() {
+  local output_file="$1"
+  local error_file="$WORKDIR/repo-view.err"
+  local repo_slug
+
+  LAST_ERROR_FILE="$error_file"
+  : > "$error_file"
+  if gh repo view --json nameWithOwner --jq .nameWithOwner > "$output_file" 2> "$error_file"; then
+    repo_slug=$(<"$output_file")
+    if [[ "$repo_slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+      return 0
+    fi
+    printf 'GitHub returned a truncated or invalid repository slug\n' > "$error_file"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    return 1
+  fi
+
+  classify_failure "$error_file"
+  return 1
+}
+
+if retry_operation repo_view_once "$WORKDIR/repo-slug"; then
   :
 else
   status=$?
-  if [[ "$status" -eq "$RATE_LIMITED" ]]; then
-    sleep "${MAX_WAIT:-180}"
+  if [[ "$status" -eq 124 ]]; then
+    report_timeout
+    exit 0
+  fi
+  echo "WAIT_ERROR: gh repo view failed" >&2
+  cat "$LAST_ERROR_FILE" >&2
+  exit 4
+fi
+
+REPO_SLUG=$(<"$WORKDIR/repo-slug")
+OWNER=${REPO_SLUG%%/*}
+REPO=${REPO_SLUG#*/}
+
+# GraphQL variable names are literals consumed by GitHub, not shell expansions.
+# shellcheck disable=SC2016
+REVIEWS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviews(first:100,after:$endCursor){nodes{id submittedAt updatedAt state commit{oid}}pageInfo{hasNextPage endCursor}}}}}'
+# shellcheck disable=SC2016
+COMMENTS_QUERY='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){headRefOid comments(first:100,after:$endCursor){nodes{id updatedAt reactionGroups{content reactors(first:1){totalCount}}}pageInfo{hasNextPage endCursor}}}}}'
+
+probe_once() {
+  local output_file="$1"
+  local security_available=true
+
+  fetch_json "$WORKDIR/reviews.json" "$WORKDIR/reviews.err" required \
+    gh api graphql --paginate \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+    -f query="$REVIEWS_QUERY" || return 1
+
+  fetch_json "$WORKDIR/comments.json" "$WORKDIR/comments.err" required \
+    gh api graphql --paginate \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+    -f query="$COMMENTS_QUERY" || return 1
+
+  fetch_json "$WORKDIR/reactions.json" "$WORKDIR/reactions.err" required \
+    gh api "repos/${REPO_SLUG}/issues/${PR}/reactions" --paginate || return 1
+
+  fetch_json "$WORKDIR/inline-comments.json" "$WORKDIR/inline-comments.err" required \
+    gh api "repos/${REPO_SLUG}/pulls/${PR}/comments" --paginate || return 1
+
+  local head_sha
+  head_sha=$(jq -er -s '.[0].data.repository.pullRequest.headRefOid' "$WORKDIR/comments.json" 2> "$WORKDIR/head.err") || {
+    LAST_ERROR_FILE="$WORKDIR/head.err"
+    printf 'GitHub probe returned no head SHA\n' >> "$LAST_ERROR_FILE"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    return 1
+  }
+
+  fetch_json "$WORKDIR/check-runs.json" "$WORKDIR/check-runs.err" required \
+    gh api "repos/${REPO_SLUG}/commits/${head_sha}/check-runs?per_page=100" --paginate || return 1
+
+  if fetch_json "$WORKDIR/security-alerts.json" "$WORKDIR/security-alerts.err" optional \
+    gh api "repos/${REPO_SLUG}/code-scanning/alerts?ref=refs/pull/${PR}/merge&state=open&per_page=100" --paginate; then
+    :
+  elif [[ "$FAILURE_KIND" == "unavailable" ]]; then
+    security_available=false
+    printf '[]\n' > "$WORKDIR/security-alerts.json"
+  else
+    return 1
+  fi
+
+  LAST_ERROR_FILE="$WORKDIR/probe.err"
+  : > "$LAST_ERROR_FILE"
+  if ! jq -n \
+    --slurpfile reviews "$WORKDIR/reviews.json" \
+    --slurpfile comments "$WORKDIR/comments.json" \
+    --slurpfile reactions "$WORKDIR/reactions.json" \
+    --slurpfile inline_comments "$WORKDIR/inline-comments.json" \
+    --slurpfile check_runs "$WORKDIR/check-runs.json" \
+    --slurpfile security_alerts "$WORKDIR/security-alerts.json" \
+    --argjson security_available "$security_available" \
+    '
+    if any($reviews[]; .errors? != null) or any($comments[]; .errors? != null) then
+      error("GraphQL response contains errors")
+    else
+      {
+        head: $comments[0].data.repository.pullRequest.headRefOid,
+        reviews:
+          ([$reviews[].data.repository.pullRequest.reviews.nodes[]?
+            | {id, submitted_at: .submittedAt, updated_at: .updatedAt,
+               state, commit_oid: .commit.oid}]
+           | sort_by(.id)),
+        issue_comments:
+          ([$comments[].data.repository.pullRequest.comments.nodes[]?
+            | {id, updated_at: .updatedAt,
+               reactions:
+                 ([.reactionGroups[]?
+                   | {content, total_count: .reactors.totalCount}]
+                  | sort_by(.content))}]
+           | sort_by(.id)),
+        codex_reactions:
+          ([$reactions[][]?
+            | select(.user.login == "chatgpt-codex-connector[bot]")
+            | {id, content}]
+           | sort_by(.id)),
+        inline_comments:
+          ([$inline_comments[][]?
+            | select(.user.login
+                | test("(coderabbitai|gemini-code-assist|chatgpt-codex-connector|github-code-quality|github-advanced-security)\\[bot\\]$"))
+            | {id, updated_at, commit_id, in_reply_to_id, user: .user.login}]
+           | sort_by(.id)),
+        check_runs:
+          ([$check_runs[].check_runs[]?
+            | {id, name, app: .app.slug, status, conclusion, started_at, completed_at}]
+           | sort_by(.id)),
+        security_alerts: {
+          available: $security_available,
+          open:
+            ([$security_alerts[][]?
+              | {number, state, rule_id: .rule.id, tool: .tool.name,
+                 ref: .most_recent_instance.ref,
+                 analysis_key: .most_recent_instance.analysis_key,
+                 path: .most_recent_instance.location.path,
+                 start_line: .most_recent_instance.location.start_line}]
+             | sort_by(.number))
+        }
+      }
+    end
+    ' > "$output_file.next" 2> "$LAST_ERROR_FILE"; then
+    printf 'GitHub probe could not assemble a complete state fingerprint\n' >> "$LAST_ERROR_FILE"
+    FAILURE_KIND="transient"
+    RETRY_AFTER=0
+    rm -f "$output_file.next"
+    return 1
+  fi
+
+  mv "$output_file.next" "$output_file"
+}
+
+BASELINE_FILE="$WORKDIR/baseline.json"
+if retry_operation probe_once "$BASELINE_FILE"; then
+  :
+else
+  status=$?
+  if [[ "$status" -eq 124 ]]; then
+    report_timeout
     exit 0
   fi
   echo "WAIT_ERROR: GitHub probe failed" >&2
-  cat "$WORKDIR/probe.err" >&2
+  cat "$LAST_ERROR_FILE" >&2
   exit 5
 fi
 
-CURRENT_HEAD=$(jq -er '.head' "$BASELINE_FILE") || {
-  echo "WAIT_ERROR: GitHub probe returned no head SHA" >&2
-  exit 5
-}
-STATE_DIR="${TMPDIR:-/tmp}/pr-ai-review-loop-$(id -u)"
-if [[ -L "$STATE_DIR" ]]; then
-  echo "WAIT_ERROR: state dir is a symlink: $STATE_DIR" >&2
-  exit 4
-fi
-if ! mkdir "$STATE_DIR" 2>/dev/null; then
-  if [[ -L "$STATE_DIR" || ! -d "$STATE_DIR" || ! -O "$STATE_DIR" ]]; then
-    echo "WAIT_ERROR: state dir is missing or not owned by the current user: $STATE_DIR" >&2
-    exit 4
-  fi
-fi
-chmod 700 "$STATE_DIR"
-HEAD_STATE="$STATE_DIR/wait-${OWNER}-${REPO}-${PR}.head"
-PREVIOUS_HEAD=""
-[[ ! -f "$HEAD_STATE" ]] || PREVIOUS_HEAD=$(<"$HEAD_STATE")
-if [[ -z "$MAX_WAIT" ]]; then
-  if [[ "$PREVIOUS_HEAD" == "$CURRENT_HEAD" ]]; then
-    MAX_WAIT=180
-  else
-    MAX_WAIT=360
-  fi
-fi
-printf '%s\n' "$CURRENT_HEAD" > "$WORKDIR/head-state"
-mv "$WORKDIR/head-state" "$HEAD_STATE"
-
-elapsed=0
-while (( elapsed < MAX_WAIT )); do
-  interval=60
-  remaining=$((MAX_WAIT - elapsed))
-  (( remaining >= interval )) || interval=$remaining
+while true; do
+  now=$(date +%s)
+  remaining=$((DEADLINE - now))
+  (( remaining > 0 )) || break
+  interval="$POLL_INTERVAL"
+  (( remaining >= interval )) || interval="$remaining"
   sleep "$interval"
-  elapsed=$((elapsed + interval))
 
   CURRENT_FILE="$WORKDIR/current.json"
-  if probe > "$CURRENT_FILE"; then
+  if retry_operation probe_once "$CURRENT_FILE"; then
     :
   else
     status=$?
-    if [[ "$status" -eq "$RATE_LIMITED" ]]; then
-      remaining=$((MAX_WAIT - elapsed))
-      (( remaining == 0 )) || sleep "$remaining"
+    if [[ "$status" -eq 124 ]]; then
+      report_timeout
       exit 0
     fi
-    echo "WAIT_ERROR: GitHub probe failed" >&2
-    cat "$WORKDIR/probe.err" >&2
+    echo "WAIT_ERROR: GitHub probe failed after transient retries" >&2
+    cat "$LAST_ERROR_FILE" >&2
     exit 5
   fi
 
   if ! cmp -s "$BASELINE_FILE" "$CURRENT_FILE"; then
+    echo "WAIT_CHANGE: relevant PR state changed"
     exit 0
   fi
 done
+
+report_timeout

--- a/.agents/skills/pr-ai-review-loop/scripts/wait.sh
+++ b/.agents/skills/pr-ai-review-loop/scripts/wait.sh
@@ -78,20 +78,31 @@ classify_failure() {
       RETRY_AFTER="$retry_hint"
     fi
   elif grep -Eiq '(^|[^0-9])5[0-9]{2}([^0-9]|$)' "$error_file" \
-    || grep -Eiq 'unexpected.*(EOF|end of)|(^|[^a-z])EOF([^a-z]|$)|timed? out|timeout|connection.*(reset|closed|refused)|TLS|temporary|temporarily unavailable|network is unreachable|could not resolve' "$error_file"; then
+    || grep -Eiq 'unexpected.*(EOF|end of)|(^|[^a-z])EOF([^a-z]|$)|timed? out|timeout|connection.*(reset|closed|refused)|connect:.*refused|TLS|temporary|temporarily unavailable|network is unreachable|could not resolve|no such host|dial tcp' "$error_file"; then
     FAILURE_KIND="transient"
   fi
+}
+
+strip_http_headers() {
+  awk '
+    /^HTTP\/[0-9.]+ [0-9][0-9][0-9]/ { in_headers = 1; next }
+    in_headers && ($0 == "" || $0 == "\r") { in_headers = 0; next }
+    in_headers { next }
+    { print }
+  ' "$1"
 }
 
 fetch_json() {
   local output_file="$1"
   local error_file="$2"
   local availability="$3"
+  local raw_output="${output_file}.raw"
   shift 3
 
   LAST_ERROR_FILE="$error_file"
   : > "$error_file"
-  if "$@" > "$output_file" 2> "$error_file"; then
+  if "$@" > "$raw_output" 2> "$error_file"; then
+    strip_http_headers "$raw_output" > "$output_file"
     if jq -e -s 'length > 0' "$output_file" >/dev/null 2> "$error_file"; then
       return 0
     fi
@@ -101,6 +112,7 @@ fetch_json() {
     return 1
   fi
 
+  grep -Ei '^(HTTP/|Retry-After:)' "$raw_output" >> "$error_file" || true
   if [[ "$availability" == "optional" ]] \
     && grep -Eq '(^|[^0-9])(404|422)([^0-9]|$)' "$error_file"; then
     FAILURE_KIND="unavailable"
@@ -200,20 +212,20 @@ probe_once() {
   local security_available=true
 
   fetch_json "$WORKDIR/reviews.json" "$WORKDIR/reviews.err" required \
-    gh api graphql --paginate \
+    gh api --include graphql --paginate \
     -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
     -f query="$REVIEWS_QUERY" || return 1
 
   fetch_json "$WORKDIR/comments.json" "$WORKDIR/comments.err" required \
-    gh api graphql --paginate \
+    gh api --include graphql --paginate \
     -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
     -f query="$COMMENTS_QUERY" || return 1
 
   fetch_json "$WORKDIR/reactions.json" "$WORKDIR/reactions.err" required \
-    gh api "repos/${REPO_SLUG}/issues/${PR}/reactions" --paginate || return 1
+    gh api --include "repos/${REPO_SLUG}/issues/${PR}/reactions" --paginate || return 1
 
   fetch_json "$WORKDIR/inline-comments.json" "$WORKDIR/inline-comments.err" required \
-    gh api "repos/${REPO_SLUG}/pulls/${PR}/comments" --paginate || return 1
+    gh api --include "repos/${REPO_SLUG}/pulls/${PR}/comments" --paginate || return 1
 
   local head_sha
   head_sha=$(jq -er -s '.[0].data.repository.pullRequest.headRefOid' "$WORKDIR/comments.json" 2> "$WORKDIR/head.err") || {
@@ -225,10 +237,10 @@ probe_once() {
   }
 
   fetch_json "$WORKDIR/check-runs.json" "$WORKDIR/check-runs.err" required \
-    gh api "repos/${REPO_SLUG}/commits/${head_sha}/check-runs?per_page=100" --paginate || return 1
+    gh api --include "repos/${REPO_SLUG}/commits/${head_sha}/check-runs?per_page=100" --paginate || return 1
 
   if fetch_json "$WORKDIR/security-alerts.json" "$WORKDIR/security-alerts.err" optional \
-    gh api "repos/${REPO_SLUG}/code-scanning/alerts?ref=refs/pull/${PR}/merge&state=open&per_page=100" --paginate; then
+    gh api --include "repos/${REPO_SLUG}/code-scanning/alerts?ref=refs/pull/${PR}/merge&state=open&per_page=100" --paginate; then
     :
   elif [[ "$FAILURE_KIND" == "unavailable" ]]; then
     security_available=false
@@ -273,7 +285,7 @@ probe_once() {
            | sort_by(.id)),
         inline_comments:
           ([$inline_comments[][]?
-            | select(.user.login
+            | select((.user.login // "")
                 | test("(coderabbitai|gemini-code-assist|chatgpt-codex-connector|github-code-quality|github-advanced-security)\\[bot\\]$"))
             | {id, updated_at, commit_id, in_reply_to_id, user: .user.login}]
            | sort_by(.id)),
@@ -326,6 +338,9 @@ while true; do
   interval="$POLL_INTERVAL"
   (( remaining >= interval )) || interval="$remaining"
   sleep "$interval"
+
+  now=$(date +%s)
+  (( now < DEADLINE )) || break
 
   CURRENT_FILE="$WORKDIR/current.json"
   if retry_operation probe_once "$CURRENT_FILE"; then


### PR DESCRIPTION
## 改动

- 将 AI review loop 的单次主动等待扩展到 30 分钟命令预算，并保留收尾余量
- 在等待脚本中监听 HEAD、review、顶层评论与 reaction、inline comment、check run 和 code-scanning alert
- 对截断 JSON、网络异常、5xx 与限流执行有界整轮重试，权限错误继续响亮失败
- 精简 skill 的轮询契约，只保留会改变 agent 编排行为的指令

## 原因与影响

原来的 3/6 分钟短等待会反复唤醒 agent 做机械 poll，同时轻量探测遗漏 CodeQL、inline comment 等状态。延长等待窗口后，如果不补齐这些信号，review 变化可能延迟到超时才被发现。

现在无状态变化时由脚本持续等待；相关状态变化会即时唤醒 agent。瞬时 EOF 或 GitHub API 故障不会直接终止循环，持续故障仍会明确失败。

## 验证

- 运行 `pr-ai-review-loop/scripts/test_*.sh` 全部测试
- `shellcheck` 与 `bash -n`
- `git diff --check`
- 使用真实 GitHub PR 执行 1 秒只读 smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化自动评审状态轮询，统一检查评审、评论、代码扫描和检查运行状态。
  * 增加状态变化、超时及网络错误提示，提升异常情况下的可见性与稳定性。
  * 支持临时错误自动重试及服务端建议的重试等待时间。
  * 权限错误将按现有认证流程处理；部分安全告警接口不可用时可安全降级。
  * 优化轮询超时后的处理，无法继续执行时将暂停并提示故障。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->