### PR TITLE
fix(助手): 改写消息可粘贴图片

### DIFF
--- a/frontend/src/components/copilot/chat/MessageRow.test.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.test.tsx
@@ -36,6 +36,15 @@ const imageOnlyTurn: Turn = {
   content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } }],
 };
 
+const fullImageTurn: Turn = {
+  ...userTurn,
+  uuid: "u-4",
+  content: Array.from({ length: 5 }, (_, index) => ({
+    type: "image" as const,
+    source: { type: "base64" as const, media_type: "image/png", data: `IMAGE-${index}` },
+  })),
+};
+
 describe("MessageRow", () => {
   it("renders the edit entry on an editable user message", () => {
     render(<MessageRow turn={userTurn} editable />);
@@ -128,6 +137,98 @@ describe("MessageRow", () => {
       { data: "AAAA", media_type: "image/png" },
       { data: "bmV3LWltYWdl", media_type: "image/png" },
     ]);
+  });
+
+  it("adds a pasted image and includes it in the rewrite payload", async () => {
+    const onSubmitEdit = vi.fn();
+    render(<MessageRow turn={userTurn} editable editing onSubmitEdit={onSubmitEdit} />);
+
+    const pasted = new File(["pasted-image"], "paste.png", { type: "image/png" });
+    const defaultWasPrevented = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+      clipboardData: {
+        items: [{ type: "image/png", getAsFile: () => pasted }],
+      },
+    });
+
+    expect(defaultWasPrevented).toBe(false);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "编辑中的附件 1/1" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "重新发送" }));
+
+    expect(onSubmitEdit).toHaveBeenCalledWith("u-1", "只改第 3 集", [
+      { data: "cGFzdGVkLWltYWdl", media_type: "image/png" },
+    ]);
+  });
+
+  it("keeps the browser's default paste behavior for text-only clipboard data", () => {
+    render(<MessageRow turn={userTurn} editable editing />);
+
+    const defaultWasAllowed = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+      clipboardData: {
+        items: [{ type: "text/plain", getAsFile: () => null }],
+      },
+    });
+
+    expect(defaultWasAllowed).toBe(true);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("does not intercept image paste while a rewrite is submitting", () => {
+    render(<MessageRow turn={userTurn} editable editing submitting />);
+
+    const defaultWasAllowed = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+      clipboardData: {
+        items: [{ type: "image/png", getAsFile: () => new File(["image"], "paste.png", { type: "image/png" }) }],
+      },
+    });
+
+    expect(defaultWasAllowed).toBe(true);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("does not intercept image paste while another image is being read", () => {
+    const originalFileReader = globalThis.FileReader;
+    class DeferredReader {
+      onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+
+      readAsDataURL() {}
+    }
+    vi.stubGlobal("FileReader", DeferredReader);
+
+    try {
+      render(<MessageRow turn={userTurn} editable editing />);
+      fireEvent.change(screen.getByLabelText("上传附件图片"), {
+        target: { files: [new File(["reading"], "reading.png", { type: "image/png" })] },
+      });
+
+      const defaultWasAllowed = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+        clipboardData: {
+          items: [{ type: "image/png", getAsFile: () => new File(["image"], "paste.png", { type: "image/png" }) }],
+        },
+      });
+
+      expect(defaultWasAllowed).toBe(true);
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    } finally {
+      vi.stubGlobal("FileReader", originalFileReader);
+    }
+  });
+
+  it("does not intercept image paste once five attachments are present", () => {
+    render(<MessageRow turn={fullImageTurn} editable editing />);
+
+    const defaultWasAllowed = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+      clipboardData: {
+        items: [{ type: "image/png", getAsFile: () => new File(["image"], "paste.png", { type: "image/png" }) }],
+      },
+    });
+
+    expect(defaultWasAllowed).toBe(true);
+    expect(screen.getAllByRole("img")).toHaveLength(5);
   });
 
   it("keeps resend disabled until a newly selected image finishes loading", () => {

--- a/frontend/src/components/copilot/chat/MessageRow.test.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.test.tsx
@@ -175,6 +175,19 @@ describe("MessageRow", () => {
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
+  it("keeps the browser's default paste behavior when an image clipboard item has no file", () => {
+    render(<MessageRow turn={userTurn} editable editing />);
+
+    const defaultWasAllowed = fireEvent.paste(screen.getByLabelText("改写消息内容"), {
+      clipboardData: {
+        items: [{ type: "image/png", getAsFile: () => null }],
+      },
+    });
+
+    expect(defaultWasAllowed).toBe(true);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
   it("does not intercept image paste while a rewrite is submitting", () => {
     render(<MessageRow turn={userTurn} editable editing submitting />);
 

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -205,6 +205,7 @@ function MessageEditor({
   }, []);
 
   const hasContent = Boolean(draft.trim()) || images.length > 0;
+  const attachDisabled = submitting || isReadingImages || images.length >= MAX_ATTACHED_IMAGES;
 
   const submit = useCallback(() => {
     if (submitting || !canSubmit || !hasContent || isReadingImages) return;
@@ -220,6 +221,14 @@ function MessageEditor({
     onSubmit,
     invalidatePendingReaders,
   ]);
+
+  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (attachDisabled) return;
+    const imageItems = Array.from(event.clipboardData.items).filter((item) => item.type.startsWith("image/"));
+    if (imageItems.length === 0) return;
+    event.preventDefault();
+    addFiles(imageItems.map((item) => item.getAsFile()).filter(Boolean) as File[]);
+  }, [addFiles, attachDisabled]);
 
   return (
     <div className={`${USER_BUBBLE_LAYOUT_CLASS} ${BUBBLE_SHELL_CLASS}`} style={USER_BUBBLE_STYLE}>
@@ -260,7 +269,7 @@ function MessageEditor({
       <div className="mb-2 flex items-center gap-2">
         <button
           type="button"
-          disabled={submitting || isReadingImages || images.length >= MAX_ATTACHED_IMAGES}
+          disabled={attachDisabled}
           onClick={() => fileInputRef.current?.click()}
           className="focus-ring flex items-center gap-1 rounded-md px-2 py-1 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           style={{ color: "var(--color-text-3)", border: "1px solid var(--color-hairline-soft)" }}
@@ -297,6 +306,7 @@ function MessageEditor({
           e.currentTarget.style.height = "auto";
           e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
         }}
+        onPaste={handlePaste}
         onCompositionStart={() => {
           isComposingRef.current = true;
         }}

--- a/frontend/src/components/copilot/chat/MessageRow.tsx
+++ b/frontend/src/components/copilot/chat/MessageRow.tsx
@@ -224,10 +224,13 @@ function MessageEditor({
 
   const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     if (attachDisabled) return;
-    const imageItems = Array.from(event.clipboardData.items).filter((item) => item.type.startsWith("image/"));
-    if (imageItems.length === 0) return;
+    const imageFiles = Array.from(event.clipboardData.items)
+      .filter((item) => item.type.startsWith("image/"))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null);
+    if (imageFiles.length === 0) return;
     event.preventDefault();
-    addFiles(imageItems.map((item) => item.getAsFile()).filter(Boolean) as File[]);
+    addFiles(imageFiles);
   }, [addFiles, attachDisabled]);
 
   return (


### PR DESCRIPTION
## Summary

- 让历史消息改写编辑器支持粘贴剪贴板图片
- 复用共享附件 hook 的容量、大小、顺序与提交锁约束
- 覆盖图片提交载荷、纯文本默认粘贴和三种禁用态

## Validation

- `cd frontend && pnpm lint`
- `cd frontend && pnpm check`（147 files / 1768 tests passed）
- Standards review: 0 findings
- Spec review: 0 findings

Closes #1820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持在聊天输入框中直接粘贴图片并添加为附件。
  * 当附件达到五个上限或已有附件正在读取时，自动忽略新的图片粘贴。
  * 粘贴文本时保留默认行为，不影响正常输入。
  * 附件按钮会根据当前状态自动启用或禁用。

* **测试**
  * 新增图片、文本及多附件场景测试，覆盖最多五个附件的处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->