### PR TITLE
feat(minimax): add voice design client

### DIFF
--- a/lib/audio_backends/__init__.py
+++ b/lib/audio_backends/__init__.py
@@ -7,6 +7,12 @@ from lib.audio_backends.base import (
     AudioSynthesisResult,
     VoiceOption,
 )
+from lib.audio_backends.minimax import (
+    MiniMaxVoiceDesignClient,
+    VoiceDesignRequest,
+    VoiceDesignResult,
+    extract_voice_design_id,
+)
 from lib.audio_backends.registry import create_backend, get_registered_backends, register_backend
 
 __all__ = [
@@ -14,8 +20,12 @@ __all__ = [
     "AudioCapability",
     "AudioSynthesisRequest",
     "AudioSynthesisResult",
+    "MiniMaxVoiceDesignClient",
     "VoiceOption",
+    "VoiceDesignRequest",
+    "VoiceDesignResult",
     "create_backend",
+    "extract_voice_design_id",
     "get_registered_backends",
     "register_backend",
 ]

--- a/lib/audio_backends/minimax.py
+++ b/lib/audio_backends/minimax.py
@@ -1,0 +1,103 @@
+"""MiniMax voice design client for the synchronous ``/v1/voice_design`` operation."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from lib.minimax_shared import (
+    minimax_headers,
+    minimax_voice_base_url,
+    resolve_minimax_api_key,
+)
+from lib.providers import PROVIDER_MINIMAX
+from lib.retry import with_retry_async
+from lib.video_backends.base import should_retry_submit, submit_post
+
+logger = logging.getLogger(__name__)
+
+_VOICE_DESIGN_ENDPOINT = "/voice_design"
+
+
+@dataclass(frozen=True)
+class VoiceDesignRequest:
+    """Inputs accepted by the MiniMax voice design operation."""
+
+    prompt: str
+    voice_id: str
+
+
+@dataclass(frozen=True)
+class VoiceDesignResult:
+    """The voice identifier confirmed by MiniMax."""
+
+    provider: str
+    voice_id: str
+
+
+def extract_voice_design_id(payload: object) -> str:
+    """Return ``voice_id`` from a successful response and surface business errors."""
+    if not isinstance(payload, dict):
+        raise RuntimeError("MiniMax voice design response must be an object")
+
+    base_resp = payload.get("base_resp")
+    if isinstance(base_resp, dict):
+        status_code = base_resp.get("status_code")
+        if status_code is not None and status_code != 0:
+            status_msg = base_resp.get("status_msg") or ""
+            raise RuntimeError(f"MiniMax voice design failed status_code={status_code}: {status_msg}".strip())
+
+    voice_id = payload.get("voice_id")
+    if not isinstance(voice_id, str) or not voice_id.strip():
+        raise RuntimeError("MiniMax voice design response is missing voice_id")
+    return voice_id
+
+
+class MiniMaxVoiceDesignClient:
+    """Create reusable voice identifiers from natural-language voice prompts."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        http_timeout: float = 60.0,
+    ) -> None:
+        self._api_key = resolve_minimax_api_key(api_key)
+        self._base_url = minimax_voice_base_url(base_url)
+        self._http_timeout = http_timeout
+
+    async def design_voice(self, request: VoiceDesignRequest) -> VoiceDesignResult:
+        prompt = request.prompt.strip()
+        voice_id = request.voice_id.strip()
+        if not prompt:
+            raise ValueError("voice design prompt must not be blank")
+        if not voice_id:
+            raise ValueError("voice design voice_id must not be blank")
+
+        payload = {"prompt": prompt, "voice_id": voice_id}
+        response = await self._submit(payload)
+        return VoiceDesignResult(
+            provider=PROVIDER_MINIMAX,
+            voice_id=extract_voice_design_id(response),
+        )
+
+    @with_retry_async(retry_if=should_retry_submit)
+    async def _submit(self, payload: dict[str, str]) -> object:
+        logger.info(
+            "Calling MiniMax voice design API voice_id=%s prompt_chars=%d",
+            payload["voice_id"],
+            len(payload["prompt"]),
+        )
+        async with httpx.AsyncClient(timeout=self._http_timeout) as client:
+            response = await submit_post(
+                lambda: client.post(
+                    f"{self._base_url}{_VOICE_DESIGN_ENDPOINT}",
+                    json=payload,
+                    headers=minimax_headers(self._api_key),
+                ),
+                provider=PROVIDER_MINIMAX,
+            )
+            return response.json()

--- a/lib/minimax_shared.py
+++ b/lib/minimax_shared.py
@@ -82,6 +82,11 @@ def minimax_text_base_url(configured: str | None = None) -> str:
     return f"{_minimax_host(configured)}{_V1_SUFFIX}"
 
 
+def minimax_voice_base_url(configured: str | None = None) -> str:
+    """Voice operation base: {host}/v1."""
+    return f"{_minimax_host(configured)}{_V1_SUFFIX}"
+
+
 def minimax_video_base_url(configured: str | None = None) -> str:
     """原生视频端点 base：{host}/v1。与文本共用单一 /v1 base，仅命名区分用途。"""
     return f"{_minimax_host(configured)}{_V1_SUFFIX}"

--- a/tests/test_minimax_voice_design.py
+++ b/tests/test_minimax_voice_design.py
@@ -1,0 +1,86 @@
+"""Unit tests for the MiniMax voice design operation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.audio_backends import (
+    MiniMaxVoiceDesignClient,
+    VoiceDesignRequest,
+    extract_voice_design_id,
+)
+from lib.providers import PROVIDER_MINIMAX
+
+pytestmark = pytest.mark.unit
+
+
+def _response(payload: object) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def _client(response: MagicMock) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+class TestVoiceDesignResponse:
+    def test_extracts_voice_id(self):
+        assert extract_voice_design_id({"voice_id": "narrator-01", "base_resp": {"status_code": 0}}) == "narrator-01"
+
+    def test_surfaces_business_error(self):
+        with pytest.raises(RuntimeError, match="status_code=1004.*invalid voice"):
+            extract_voice_design_id({"voice_id": "", "base_resp": {"status_code": 1004, "status_msg": "invalid voice"}})
+
+    @pytest.mark.parametrize("payload", [None, [], {}, {"voice_id": "   "}])
+    def test_rejects_malformed_response(self, payload):
+        with pytest.raises(RuntimeError):
+            extract_voice_design_id(payload)
+
+
+class TestMiniMaxVoiceDesignClient:
+    async def test_posts_prompt_and_voice_id_to_domestic_endpoint(self):
+        client = _client(_response({"voice_id": "narrator-01", "base_resp": {"status_code": 0}}))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await MiniMaxVoiceDesignClient(api_key="sk-test").design_voice(
+                VoiceDesignRequest(prompt="A calm documentary narrator", voice_id="narrator-01")
+            )
+
+        assert client.post.call_args.args[0] == "https://api.minimaxi.com/v1/voice_design"
+        assert client.post.call_args.kwargs["json"] == {
+            "prompt": "A calm documentary narrator",
+            "voice_id": "narrator-01",
+        }
+        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        assert result.provider == PROVIDER_MINIMAX
+        assert result.voice_id == "narrator-01"
+
+    async def test_uses_configured_international_endpoint(self):
+        client = _client(_response({"voice_id": "voice-02", "base_resp": {"status_code": 0}}))
+        with patch("httpx.AsyncClient", return_value=client):
+            await MiniMaxVoiceDesignClient(
+                api_key="sk-test",
+                base_url="https://api.minimax.io/v1",
+            ).design_voice(VoiceDesignRequest(prompt="Bright and energetic", voice_id="voice-02"))
+
+        assert client.post.call_args.args[0] == "https://api.minimax.io/v1/voice_design"
+
+    @pytest.mark.parametrize(
+        "design_request",
+        [
+            VoiceDesignRequest(prompt="", voice_id="voice-01"),
+            VoiceDesignRequest(prompt="A narrator", voice_id=" "),
+        ],
+    )
+    async def test_rejects_blank_required_fields_before_http(self, design_request):
+        with patch("httpx.AsyncClient") as async_client:
+            with pytest.raises(ValueError, match="must not be blank"):
+                await MiniMaxVoiceDesignClient(api_key="sk-test").design_voice(design_request)
+        async_client.assert_not_called()


### PR DESCRIPTION
Reason: ArcReel has executable MiniMax providers and an audio-generation pipeline, but lacks the `/v1/voice_design` operation for handling `prompt` and `voice_id` requests and parsing `voice_id` responses.

This adds a public MiniMax voice-design client that uses the configured regional API base, validates required inputs, safely submits the synchronous request, and surfaces business-level response errors. It also exports typed request and result values and covers both supported regional endpoints and malformed responses with unit tests.

Checks:

- `uv run ruff check .`
- `uv run basedpyright lib/audio_backends/minimax.py lib/audio_backends/__init__.py lib/minimax_shared.py tests/test_minimax_voice_design.py`
- `uv run lint-imports`
- `uv run pytest -q tests/test_minimax_voice_design.py tests/test_minimax_shared.py tests/test_minimax_integration.py tests/test_audio_backends.py` (107 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 MiniMax 音色设计能力，可根据文本描述生成音色。
  - 支持配置国内或国际服务地址，并自动处理身份认证与请求超时。
  - 返回生成后的音色标识，便于后续语音合成使用。
  - 增加输入校验和错误提示，帮助识别无效请求及异常响应。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->