### PR TITLE
feat(text): support video URL input

### DIFF
--- a/docs/api-docs/providers/minimax.md
+++ b/docs/api-docs/providers/minimax.md
@@ -1,8 +1,8 @@
 # minimax
 
-MiniMax 文本、图片与视频媒体 provider。
+MiniMax text, image, and video media provider.
 
-- 总入口：[MiniMax API overview](https://platform.minimax.io/docs/api-reference/api-overview)
-- 接口与能力：[Text generation](https://platform.minimax.io/docs/guides/text-generation)、[Image generation](https://platform.minimax.io/docs/guides/image-generation)、[Video generation](https://platform.minimax.io/docs/guides/video-generation)、[Video generation V2](https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md)
-- 计费：[Pay-as-you-go pricing](https://platform.minimaxi.com/docs/guides/pricing-paygo.md)
-- 代码：`lib/config/registry.py::PROVIDER_REGISTRY["minimax"]`、`lib/text_backends/openai.py::OpenAITextBackend`、`lib/image_backends/minimax.py::MiniMaxImageBackend`、`lib/video_backends/minimax.py::MiniMaxVideoBackend`
+- Overview: [MiniMax API overview](https://platform.minimax.io/docs/api-reference/api-overview)
+- APIs and capabilities: [Text generation and multimodal chat input](https://platform.minimax.io/docs/guides/text-generation), [Image generation](https://platform.minimax.io/docs/guides/image-generation), [Video generation](https://platform.minimax.io/docs/guides/video-generation), [Video generation V2](https://platform.minimaxi.com/docs/api-reference/video-generation-v2-create.md)
+- Pricing: [Pay-as-you-go pricing](https://platform.minimaxi.com/docs/guides/pricing-paygo.md)
+- Code: `lib/config/registry.py::PROVIDER_REGISTRY["minimax"]`, `lib/text_backends/base.py::VideoInput`, `lib/text_backends/openai.py::OpenAITextBackend`, `lib/image_backends/minimax.py::MiniMaxImageBackend`, `lib/video_backends/minimax.py::MiniMaxVideoBackend`

--- a/lib/text_backends/__init__.py
+++ b/lib/text_backends/__init__.py
@@ -10,6 +10,7 @@ from lib.text_backends.base import (
     TextGenerationResult,
     TextTaskTier,
     TextTaskType,
+    VideoInput,
 )
 from lib.text_backends.registry import create_backend, get_registered_backends, register_backend
 
@@ -23,6 +24,7 @@ __all__ = [
     "TextGenerationResult",
     "TextTaskTier",
     "TextTaskType",
+    "VideoInput",
     "create_backend",
     "get_registered_backends",
     "register_backend",

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -198,12 +198,20 @@ class ImageInput:
 
 
 @dataclass
+class VideoInput:
+    """Remote video input for multimodal text models."""
+
+    url: str
+
+
+@dataclass
 class TextGenerationRequest:
     """通用文本生成请求。各 Backend 忽略不支持的字段。"""
 
     prompt: str
     response_schema: dict | type | None = None
     images: list[ImageInput] | None = None
+    videos: list[VideoInput] | None = None
     system_prompt: str | None = None
     max_output_tokens: int | None = None
 

--- a/lib/text_backends/openai.py
+++ b/lib/text_backends/openai.py
@@ -178,16 +178,20 @@ def _build_messages(request: TextGenerationRequest) -> list[dict]:
         messages.append({"role": "system", "content": request.system_prompt})
 
     # 构建 user message
-    if request.images:
-        from lib.image_backends.base import image_to_base64_data_uri
-
+    if request.images or request.videos:
         content: list[dict] = []
-        for img in request.images:
-            if img.path:
-                data_uri = image_to_base64_data_uri(img.path)
-                content.append({"type": "image_url", "image_url": {"url": data_uri}})
-            elif img.url:
-                content.append({"type": "image_url", "image_url": {"url": img.url}})
+        if request.images:
+            from lib.image_backends.base import image_to_base64_data_uri
+
+            for img in request.images:
+                if img.path:
+                    data_uri = image_to_base64_data_uri(img.path)
+                    content.append({"type": "image_url", "image_url": {"url": data_uri}})
+                elif img.url:
+                    content.append({"type": "image_url", "image_url": {"url": img.url}})
+        if request.videos:
+            for video in request.videos:
+                content.append({"type": "video_url", "video_url": {"url": video.url}})
         content.append({"type": "text", "text": request.prompt})
         messages.append({"role": "user", "content": content})
     else:

--- a/tests/test_openai_text_backend.py
+++ b/tests/test_openai_text_backend.py
@@ -16,6 +16,7 @@ from lib.text_backends.base import (
     ImageInput,
     TextCapability,
     TextGenerationRequest,
+    VideoInput,
 )
 from tests.fakes import instructor_api_call_exhausted
 
@@ -131,6 +132,30 @@ class TestOpenAITextBackend:
         types = [part["type"] for part in user_msg["content"]]
         assert "image_url" in types
         assert "text" in types
+
+    async def test_generate_with_video_url(self):
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("I see a video"))
+
+        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.text_backends.openai import OpenAITextBackend
+
+            backend = OpenAITextBackend(api_key="test-key", model="MiniMax-M3", provider_name="minimax")
+            request = TextGenerationRequest(
+                prompt="Describe this video",
+                videos=[VideoInput(url="https://example.com/video.mp4")],
+            )
+            result = await backend.generate(request)
+
+        assert result.text == "I see a video"
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["messages"][-1]["content"] == [
+            {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/video.mp4"},
+            },
+            {"type": "text", "text": "Describe this video"},
+        ]
 
     async def test_generate_structured_output(self):
         schema_response = json.dumps({"name": "Alice", "age": 30})

--- a/tests/test_text_backends/test_base.py
+++ b/tests/test_text_backends/test_base.py
@@ -15,6 +15,7 @@ from lib.text_backends.base import (
     TextGenerationResult,
     TextTaskTier,
     TextTaskType,
+    VideoInput,
     resolve_schema,
 )
 
@@ -65,12 +66,19 @@ class TestImageInput:
         assert inp.url == "https://example.com/img.png"
 
 
+class TestVideoInput:
+    def test_url(self):
+        inp = VideoInput(url="https://example.com/video.mp4")
+        assert inp.url == "https://example.com/video.mp4"
+
+
 class TestTextGenerationRequest:
     def test_minimal(self):
         req = TextGenerationRequest(prompt="hello")
         assert req.prompt == "hello"
         assert req.response_schema is None
         assert req.images is None
+        assert req.videos is None
         assert req.system_prompt is None
 
     def test_full(self):
@@ -78,10 +86,12 @@ class TestTextGenerationRequest:
             prompt="analyze",
             response_schema={"type": "object"},
             images=[ImageInput(path=Path("/tmp/img.png"))],
+            videos=[VideoInput(url="https://example.com/video.mp4")],
             system_prompt="You are a helpful assistant.",
         )
         assert req.response_schema == {"type": "object"}
         assert len(req.images) == 1
+        assert len(req.videos) == 1
         assert req.system_prompt == "You are a helpful assistant."
 
 


### PR DESCRIPTION
Reason: ArcReel declares image vision for MiniMax-M3, but its executable text request schema and OpenAI-compatible serializer accept only ImageInput/image_url parts and cannot send the target video input modality; merged PR #1298 covers image input only.

Summary:
- Expose a `VideoInput` request field and serialize remote videos as OpenAI-compatible `video_url` content parts.
- Cover request defaults and the MiniMax-M3 video payload with focused tests.
- Refresh the MiniMax official documentation and code index in English.

Checks:
- `uv run --project . --frozen ruff format --check lib/text_backends/base.py lib/text_backends/__init__.py lib/text_backends/openai.py tests/test_text_backends/test_base.py tests/test_openai_text_backend.py`
- `uv run --project . --frozen ruff check lib/text_backends/base.py lib/text_backends/__init__.py lib/text_backends/openai.py tests/test_text_backends/test_base.py tests/test_openai_text_backend.py`
- `uv run --project . --frozen pytest -q tests/test_text_backends/test_base.py tests/test_openai_text_backend.py tests/test_minimax_integration.py`
- `uv run --project . --frozen basedpyright --project pyproject.toml lib/text_backends/base.py lib/text_backends/__init__.py lib/text_backends/openai.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 文本生成请求现支持通过视频 URL 携带视频输入。
  - OpenAI 文本后端支持同时处理文本、图片和视频内容，并返回相应文本结果。
  - 新增公开的视频输入类型，便于构建包含视频的请求。

- **文档**
  - 更新 MiniMax 提供商文档，改为英文并补充多模态聊天输入能力说明。

- **测试**
  - 增加视频输入及多模态消息处理的覆盖验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->