### PR TITLE
feat(workflow): 准确识别视觉产物的内容变化

### DIFF
--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -803,6 +803,84 @@ class ArtifactBasis:
 
 
 @dataclass(frozen=True, slots=True)
+class ArtifactBasisDescriptor:
+    """Strict, portable identity for a canonical basis used as source evidence."""
+
+    kind: str
+    kind_version: int
+    digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, str) or not self.kind:
+            raise ValueError("artifact basis descriptor kind must be a non-empty string")
+        if type(self.kind_version) is not int or self.kind_version < 1:
+            raise ValueError("artifact basis descriptor kind_version must be a positive integer")
+        if not isinstance(self.digest, str) or _DIGEST_RE.fullmatch(self.digest) is None:
+            raise ValueError("artifact basis descriptor digest must be a canonical sha256-v1 digest")
+
+    @classmethod
+    def from_basis(cls, basis: ArtifactBasis) -> Self:
+        if not isinstance(basis, ArtifactBasis):
+            raise TypeError("basis must be an ArtifactBasis")
+        return cls(kind=basis.kind, kind_version=basis.kind_version, digest=basis.digest)
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        if not isinstance(value, Mapping):
+            raise ValueError("artifact basis descriptor must be an object")
+        if set(value) != {"kind", "kind_version", "digest"}:
+            raise ValueError("artifact basis descriptor has an invalid schema")
+        return cls(
+            kind=cast(str, value["kind"]),
+            kind_version=cast(int, value["kind_version"]),
+            digest=cast(str, value["digest"]),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "kind_version": self.kind_version,
+            "digest": self.digest,
+        }
+
+
+def compose_video_artifact_basis(
+    *,
+    visual: ArtifactBasis,
+    speech: ArtifactBasis | None = None,
+    duration: ArtifactBasis | None = None,
+) -> ArtifactBasis:
+    """Compose independently owned video inputs into one manifest basis.
+
+    The resulting basis is registered under the existing episode-video key. A
+    change in any present component consequently produces one stale comparison,
+    rather than parallel visual/speech/duration artifact states.
+    """
+
+    if not isinstance(visual, ArtifactBasis):
+        raise TypeError("visual must be an ArtifactBasis")
+    if speech is not None and not isinstance(speech, ArtifactBasis):
+        raise TypeError("speech must be an ArtifactBasis or null")
+    if duration is not None and not isinstance(duration, ArtifactBasis):
+        raise TypeError("duration must be an ArtifactBasis or null")
+    return ArtifactBasis.build(
+        "artifact-components/video",
+        kind_version=1,
+        inputs={
+            "components": {
+                "visual": _artifact_basis_descriptor(visual),
+                "speech": _artifact_basis_descriptor(speech) if speech is not None else None,
+                "duration": _artifact_basis_descriptor(duration) if duration is not None else None,
+            }
+        },
+    )
+
+
+def _artifact_basis_descriptor(basis: ArtifactBasis) -> dict[str, object]:
+    return ArtifactBasisDescriptor.from_basis(basis).to_dict()
+
+
+@dataclass(frozen=True, slots=True)
 class ArtifactKey:
     """Typed artifact identity with a canonical reversible wire representation."""
 

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -528,6 +528,7 @@ class _VideoSubmissionCheckpoint:
     """Strict, versioned identity shared by both video execution routes."""
 
     CHECKPOINT_KIND: ClassVar[str]
+    ARTIFACT_VISUAL_BASIS_KIND: ClassVar[str]
 
     schema_version: int
     kind: str
@@ -628,6 +629,8 @@ class _VideoSubmissionCheckpoint:
         if self.schema_version == _SCHEMA_VERSION:
             if not isinstance(self.artifact_visual_basis, ArtifactBasisDescriptor):
                 raise ValueError("artifact_visual_basis must be a strict artifact basis descriptor")
+            if self.artifact_visual_basis.kind != self.ARTIFACT_VISUAL_BASIS_KIND:
+                raise ValueError("artifact_visual_basis kind does not match checkpoint kind")
         elif self.artifact_visual_basis is not None:
             raise ValueError("legacy checkpoint cannot carry artifact_visual_basis")
         if tuple(item.index for item in self.media) != tuple(range(len(self.media))):
@@ -866,6 +869,7 @@ class ReferenceSubmissionCheckpoint(_VideoSubmissionCheckpoint):
 
     __slots__ = ()
     CHECKPOINT_KIND = _CHECKPOINT_KIND
+    ARTIFACT_VISUAL_BASIS_KIND = "artifact-visual/video-reference"
 
 
 class StoryboardSubmissionCheckpoint(_VideoSubmissionCheckpoint):
@@ -873,6 +877,7 @@ class StoryboardSubmissionCheckpoint(_VideoSubmissionCheckpoint):
 
     __slots__ = ()
     CHECKPOINT_KIND = _STORYBOARD_CHECKPOINT_KIND
+    ARTIFACT_VISUAL_BASIS_KIND = "artifact-visual/video-storyboard"
 
 
 VideoSubmissionCheckpoint = ReferenceSubmissionCheckpoint | StoryboardSubmissionCheckpoint

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -703,6 +703,9 @@ class _VideoSubmissionCheckpoint:
 
         payload = self._request_payload()
         del payload["api_call_id"]
+        # Artifact currency is independent source evidence, not part of provider
+        # execution identity. Keep the existing request digest's meaning stable.
+        payload.pop("artifact_visual_basis", None)
         return payload
 
     def to_dict(self) -> dict[str, object]:
@@ -766,7 +769,9 @@ class _VideoSubmissionCheckpoint:
             "media": [item.to_dict() for item in media],
             "reference_audio_targets": list(reference_audio_targets) if reference_audio_targets is not None else None,
         }
-        digest_values = {key: value for key, value in values.items() if key != "api_call_id"}
+        digest_values = {
+            key: value for key, value in values.items() if key not in {"api_call_id", "artifact_visual_basis"}
+        }
         request_digest = _sha256_bytes(_canonical_json(digest_values).encode("utf-8"))
         return cls(
             schema_version=_SCHEMA_VERSION,

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -18,6 +18,7 @@ from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal, Self, cast
 
+from lib.artifact_manifest import ArtifactBasisDescriptor
 from lib.json_io import atomic_write_json, load_json
 from lib.path_safety import safe_join
 
@@ -26,7 +27,8 @@ logger = logging.getLogger(__name__)
 ProviderMediaRole = Literal["reference_image", "reference_audio", "start_image", "end_image"]
 ReferenceCapability = Literal["i2v", "r2v"]
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
+_LEGACY_SCHEMA_VERSION = 1
 _CHECKPOINT_KIND = "reference_video_submit"
 _STORYBOARD_CHECKPOINT_KIND = "storyboard_video_submit"
 _STAGING_MANIFEST_VERSION = 1
@@ -548,12 +550,13 @@ class _VideoSubmissionCheckpoint:
     service_tier: str
     seed: int | None
     visual_basis_digest: str
+    artifact_visual_basis: ArtifactBasisDescriptor | None
     narration: NarrationExecutionFacts
     media: tuple[StagedProviderMedia, ...]
     reference_audio_targets: tuple[int, ...] | None
     request_digest: str
 
-    _FIELDS = frozenset(
+    _LEGACY_FIELDS = frozenset(
         {
             "schema_version",
             "kind",
@@ -582,12 +585,13 @@ class _VideoSubmissionCheckpoint:
             "request_digest",
         }
     )
+    _FIELDS = _LEGACY_FIELDS | {"artifact_visual_basis"}
 
     def __post_init__(self) -> None:
         if (
             not isinstance(self.schema_version, int)
             or isinstance(self.schema_version, bool)
-            or self.schema_version != _SCHEMA_VERSION
+            or self.schema_version not in {_LEGACY_SCHEMA_VERSION, _SCHEMA_VERSION}
             or self.kind != self.CHECKPOINT_KIND
         ):
             raise ValueError("unsupported video submission checkpoint version or kind")
@@ -621,6 +625,11 @@ class _VideoSubmissionCheckpoint:
         if self.seed is not None and (not isinstance(self.seed, int) or isinstance(self.seed, bool)):
             raise ValueError("seed must be an integer or null")
         _require_basis_digest(self.visual_basis_digest, "visual_basis_digest")
+        if self.schema_version == _SCHEMA_VERSION:
+            if not isinstance(self.artifact_visual_basis, ArtifactBasisDescriptor):
+                raise ValueError("artifact_visual_basis must be a strict artifact basis descriptor")
+        elif self.artifact_visual_basis is not None:
+            raise ValueError("legacy checkpoint cannot carry artifact_visual_basis")
         if tuple(item.index for item in self.media) != tuple(range(len(self.media))):
             raise ValueError("provider media indexes must be contiguous and ordered")
         expected_prefix = f".arcreel/tasks/{self.task_id}/provider_media/"
@@ -657,7 +666,7 @@ class _VideoSubmissionCheckpoint:
             raise ValueError("request_digest does not match checkpoint request")
 
     def _request_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "kind": self.kind,
             "task_id": self.task_id,
@@ -685,6 +694,9 @@ class _VideoSubmissionCheckpoint:
                 list(self.reference_audio_targets) if self.reference_audio_targets is not None else None
             ),
         }
+        if self.artifact_visual_basis is not None:
+            payload["artifact_visual_basis"] = self.artifact_visual_basis.to_dict()
+        return payload
 
     def _request_digest_payload(self) -> dict[str, object]:
         """Return frozen request facts without the local accounting coordinate."""
@@ -721,6 +733,7 @@ class _VideoSubmissionCheckpoint:
         service_tier: str,
         seed: int | None,
         visual_basis_digest: str,
+        artifact_visual_basis: ArtifactBasisDescriptor,
         narration: NarrationExecutionFacts,
         media: tuple[StagedProviderMedia, ...],
         reference_audio_targets: tuple[int, ...] | None,
@@ -748,6 +761,7 @@ class _VideoSubmissionCheckpoint:
             "service_tier": service_tier,
             "seed": seed,
             "visual_basis_digest": visual_basis_digest,
+            "artifact_visual_basis": artifact_visual_basis.to_dict(),
             "narration": narration.to_dict(),
             "media": [item.to_dict() for item in media],
             "reference_audio_targets": list(reference_audio_targets) if reference_audio_targets is not None else None,
@@ -776,6 +790,7 @@ class _VideoSubmissionCheckpoint:
             service_tier=service_tier,
             seed=seed,
             visual_basis_digest=visual_basis_digest,
+            artifact_visual_basis=artifact_visual_basis,
             narration=narration,
             media=media,
             reference_audio_targets=reference_audio_targets,
@@ -793,7 +808,14 @@ class _VideoSubmissionCheckpoint:
         if not isinstance(decoded, dict):
             raise ValueError("execution checkpoint must be a JSON object")
         raw = cast(dict[str, Any], decoded)
-        _require_exact_keys(raw, cls._FIELDS, "checkpoint")
+        schema_version = raw.get("schema_version")
+        if type(schema_version) is not int or schema_version not in {_LEGACY_SCHEMA_VERSION, _SCHEMA_VERSION}:
+            raise ValueError("unsupported video submission checkpoint version or kind")
+        _require_exact_keys(
+            raw,
+            cls._LEGACY_FIELDS if schema_version == _LEGACY_SCHEMA_VERSION else cls._FIELDS,
+            "checkpoint",
+        )
         targets = raw["reference_audio_targets"]
         if targets is not None and not isinstance(targets, list):
             raise ValueError("reference_audio_targets must be an array or null")
@@ -822,6 +844,11 @@ class _VideoSubmissionCheckpoint:
             service_tier=raw["service_tier"],
             seed=raw["seed"],
             visual_basis_digest=raw["visual_basis_digest"],
+            artifact_visual_basis=(
+                ArtifactBasisDescriptor.from_dict(raw["artifact_visual_basis"])
+                if schema_version == _SCHEMA_VERSION
+                else None
+            ),
             narration=NarrationExecutionFacts.from_dict(raw["narration"]),
             media=tuple(StagedProviderMedia.from_dict(item) for item in media),
             reference_audio_targets=tuple(targets) if targets is not None else None,
@@ -849,7 +876,7 @@ VideoSubmissionCheckpoint = ReferenceSubmissionCheckpoint | StoryboardSubmission
 def checkpoint_version_metadata(checkpoint: VideoSubmissionCheckpoint) -> dict[str, object]:
     """Source facts shared by normal and resumed paid-version registration."""
 
-    return {
+    metadata: dict[str, object] = {
         "execution_checkpoint_schema_version": checkpoint.schema_version,
         "execution_task_id": checkpoint.task_id,
         "execution_api_call_id": checkpoint.api_call_id,
@@ -874,6 +901,9 @@ def checkpoint_version_metadata(checkpoint: VideoSubmissionCheckpoint) -> dict[s
             list(checkpoint.reference_audio_targets) if checkpoint.reference_audio_targets is not None else None
         ),
     }
+    if checkpoint.artifact_visual_basis is not None:
+        metadata["artifact_visual_basis"] = checkpoint.artifact_visual_basis.to_dict()
+    return metadata
 
 
 def load_task_video_checkpoint(task: dict[str, Any]) -> VideoSubmissionCheckpoint:

--- a/lib/video_visual_provenance.py
+++ b/lib/video_visual_provenance.py
@@ -1,4 +1,10 @@
-"""Read-only provenance for deciding whether a selected video is still current."""
+"""Execution-sensitive fingerprints for exact video-request reuse.
+
+These digests intentionally include provider request configuration and sound
+inputs. They support same-tier reuse and immutable execution checkpoints; they are
+not canonical visual-content bases for the Artifact Manifest. That separate
+contract lives in :mod:`lib.visual_artifact_provenance`.
+"""
 
 from __future__ import annotations
 

--- a/lib/visual_artifact_provenance.py
+++ b/lib/visual_artifact_provenance.py
@@ -91,7 +91,8 @@ def build_asset_sheet_visual_basis(
     if asset_type not in ASSET_TYPES:
         raise ValueError(f"unsupported asset type: {asset_type!r}")
     canonical_id = normalize_asset_name(_require_non_empty("asset_id", asset_id))
-    normalized_description = _require_non_empty("description", description).strip()
+    normalized_description = _require_string("description", description).strip()
+    _require_non_empty("description", normalized_description)
     _require_string("style", style)
     _require_string("style_description", style_description)
     canvas_ratio = _require_non_empty("aspect_ratio", aspect_ratio)
@@ -288,10 +289,13 @@ def build_reference_video_artifact_visual_basis(
         raw_text = raw_shot.get("text")
         if not isinstance(raw_text, str):
             raise ValueError(f"unit.shots[{index}].text must be a string")
+        visual_lines = _reference_visual_lines(raw_text)
+        if not visual_lines:
+            continue
         visual_shots.append(
             {
-                "shot_index": index,
-                "lines": _reference_visual_lines(raw_text),
+                "shot_index": len(visual_shots),
+                "lines": visual_lines,
             }
         )
     references: list[VisualReference] = []

--- a/lib/visual_artifact_provenance.py
+++ b/lib/visual_artifact_provenance.py
@@ -152,7 +152,6 @@ def build_grid_composite_visual_basis(
     columns: int,
     style: str,
     grid_aspect_ratio: str,
-    member_aspect_ratio: str,
     references: Sequence[VisualReference] = (),
 ) -> ArtifactBasis:
     """Describe one grid composite without hashing its rendered provider prompt."""
@@ -169,7 +168,6 @@ def build_grid_composite_visual_basis(
                 "rows": rows,
                 "columns": columns,
                 "grid_aspect_ratio": _require_non_empty("grid_aspect_ratio", grid_aspect_ratio),
-                "member_aspect_ratio": _require_non_empty("member_aspect_ratio", member_aspect_ratio),
             },
             "style": style,
             "references": _reference_evidence(references),

--- a/lib/visual_artifact_provenance.py
+++ b/lib/visual_artifact_provenance.py
@@ -1,0 +1,473 @@
+"""Canonical visual-content provenance for Artifact Manifest currency.
+
+The builders in this module describe formal visual content. They deliberately do
+not describe provider request equivalence: provider/model selection, credentials,
+pixel resolution, seeds, audio controls, and prompt-renderer revisions are not
+Artifact Manifest currency inputs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from lib.artifact_manifest import ArtifactBasis
+from lib.asset_types import ASSET_TYPES, normalize_asset_name
+from lib.prompt_utils import normalize_style
+from lib.reference_video.request_projection import ResolvedReferenceAsset
+from lib.reference_video.shot_parser import match_dialogue_line, match_voiceover_line, strip_shot_header
+
+
+@dataclass(frozen=True, slots=True)
+class VisualReference:
+    """One ordered image actually supplied while producing formal visual content.
+
+    Filesystem locations are transport details. The canonical evidence therefore
+    records logical identity, role, variant, and content bytes, but not the path.
+    """
+
+    path: Path
+    role: str
+    logical_type: str | None = None
+    logical_id: str | None = None
+    kind: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path):
+            raise TypeError("visual reference path must be a Path")
+        _require_non_empty("visual reference role", self.role)
+        if (self.logical_type is None) != (self.logical_id is None):
+            raise ValueError("visual reference logical_type and logical_id must be provided together")
+        if self.logical_type is not None:
+            _require_non_empty("visual reference logical_type", self.logical_type)
+            logical_id = _require_non_empty("visual reference logical_id", self.logical_id)
+            object.__setattr__(self, "logical_id", normalize_asset_name(logical_id))
+        if self.kind is not None:
+            _require_non_empty("visual reference kind", self.kind)
+
+    def evidence(self) -> dict[str, object]:
+        """Return path-independent, content-addressed manifest evidence."""
+
+        evidence: dict[str, object] = {
+            "role": self.role,
+            "sha256": _file_digest(self.path),
+        }
+        if self.logical_type is not None:
+            evidence["logical_identity"] = {
+                "type": self.logical_type,
+                "id": self.logical_id,
+            }
+        if self.kind is not None:
+            evidence["kind"] = self.kind
+        return evidence
+
+
+@dataclass(frozen=True, slots=True)
+class GridStoryboardVisual:
+    """Stable visual facts for one storyboard item participating in a grid."""
+
+    resource_id: str
+    image_prompt: object
+    video_prompt: object
+
+    def __post_init__(self) -> None:
+        _require_non_empty("grid member resource_id", self.resource_id)
+
+
+def build_asset_sheet_visual_basis(
+    *,
+    asset_type: str,
+    asset_id: str,
+    description: str,
+    style: str,
+    style_description: str,
+    aspect_ratio: str,
+    references: Sequence[VisualReference] = (),
+) -> ArtifactBasis:
+    """Describe one character, scene, prop, or product design sheet."""
+
+    if asset_type not in ASSET_TYPES:
+        raise ValueError(f"unsupported asset type: {asset_type!r}")
+    canonical_id = normalize_asset_name(_require_non_empty("asset_id", asset_id))
+    normalized_description = _require_non_empty("description", description).strip()
+    _require_string("style", style)
+    _require_string("style_description", style_description)
+    canvas_ratio = _require_non_empty("aspect_ratio", aspect_ratio)
+    inputs: dict[str, object] = {
+        "asset": {
+            "type": asset_type,
+            "id": canonical_id,
+            "description": normalized_description,
+        },
+        "canvas": {"aspect_ratio": canvas_ratio},
+        "references": _reference_evidence(references),
+    }
+    if asset_type != "product":
+        inputs["style"] = {
+            "name": style,
+            "description": style_description,
+        }
+    return ArtifactBasis.build(
+        "artifact-visual/asset-sheet",
+        kind_version=1,
+        inputs=inputs,
+    )
+
+
+def build_storyboard_image_visual_basis(
+    *,
+    resource_id: str,
+    image_prompt: object,
+    style: str,
+    aspect_ratio: str,
+    references: Sequence[VisualReference] = (),
+) -> ArtifactBasis:
+    """Describe one ordinary storyboard image and its actual ordered image inputs."""
+
+    identity = _require_non_empty("resource_id", resource_id)
+    _require_string("style", style)
+    prompt, style_input = _project_storyboard_image_prompt(image_prompt, style)
+    inputs: dict[str, object] = {
+        "resource_id": identity,
+        "image_prompt": prompt,
+        "canvas": {"aspect_ratio": _require_non_empty("aspect_ratio", aspect_ratio)},
+        "references": _reference_evidence(references),
+    }
+    if style_input is not None:
+        inputs["style"] = style_input
+    return ArtifactBasis.build(
+        "artifact-visual/storyboard-image",
+        kind_version=1,
+        inputs=inputs,
+    )
+
+
+def build_grid_composite_visual_basis(
+    *,
+    group_id: str,
+    members: Sequence[GridStoryboardVisual],
+    rows: int,
+    columns: int,
+    style: str,
+    grid_aspect_ratio: str,
+    member_aspect_ratio: str,
+    references: Sequence[VisualReference] = (),
+) -> ArtifactBasis:
+    """Describe one grid composite without hashing its rendered provider prompt."""
+
+    member_tuple = _validate_grid_members(members, rows=rows, columns=columns)
+    _require_string("style", style)
+    return ArtifactBasis.build(
+        "artifact-visual/grid-composite",
+        kind_version=1,
+        inputs={
+            "group_id": _require_non_empty("group_id", group_id),
+            "cells": _project_grid_cells(member_tuple),
+            "layout": {
+                "rows": rows,
+                "columns": columns,
+                "grid_aspect_ratio": _require_non_empty("grid_aspect_ratio", grid_aspect_ratio),
+                "member_aspect_ratio": _require_non_empty("member_aspect_ratio", member_aspect_ratio),
+            },
+            "style": style,
+            "references": _reference_evidence(references),
+        },
+    )
+
+
+def build_grid_member_storyboard_visual_basis(
+    *,
+    group_id: str,
+    members: Sequence[GridStoryboardVisual],
+    cell_index: int,
+    composite_image: Path,
+    rows: int,
+    columns: int,
+    style: str,
+    member_aspect_ratio: str,
+    references: Sequence[VisualReference] = (),
+) -> ArtifactBasis:
+    """Describe one split cell while preserving grid dependency locality.
+
+    The member does not embed the composite's target basis. It records only the
+    selected cell's semantic inputs plus the actual composite bytes it was split
+    from. Editing a different cell therefore leaves this member current until a
+    replacement composite is really produced.
+    """
+
+    member_tuple = _validate_grid_members(members, rows=rows, columns=columns)
+    if type(cell_index) is not int or not 0 <= cell_index < len(member_tuple):
+        raise ValueError("cell_index must identify a content cell")
+    _require_string("style", style)
+    return ArtifactBasis.build(
+        "artifact-visual/grid-member",
+        kind_version=1,
+        inputs={
+            "group_id": _require_non_empty("group_id", group_id),
+            "cell": _project_grid_cells(member_tuple)[cell_index],
+            "layout": {
+                "rows": rows,
+                "columns": columns,
+                "member_aspect_ratio": _require_non_empty("member_aspect_ratio", member_aspect_ratio),
+            },
+            "style": style,
+            "references": _reference_evidence(references),
+            "source_composite": {"sha256": _file_digest(composite_image)},
+        },
+    )
+
+
+def build_storyboard_video_artifact_visual_basis(
+    *,
+    resource_id: str,
+    visual_prompt: object,
+    storyboard_image: Path,
+    end_frame_image: Path | None,
+    aspect_ratio: str,
+) -> ArtifactBasis:
+    """Describe the visual component of one storyboard-driven video.
+
+    Sound design, dialogue, voice profiles, duration, and execution options are
+    intentionally absent. They either belong to later video components or are not
+    Artifact Manifest currency at all.
+    """
+
+    if isinstance(visual_prompt, str):
+        visual_text = visual_prompt.strip()
+        if not visual_text:
+            raise ValueError("visual_prompt must not be empty")
+        projected_prompt: object = visual_text
+    elif isinstance(visual_prompt, Mapping):
+        action = str(visual_prompt.get("action") or "").strip()
+        if not action:
+            raise ValueError("visual_prompt.action must be a non-empty string")
+        projected_prompt = {
+            "action": action,
+            "camera_motion": str(visual_prompt.get("camera_motion") or "Static"),
+        }
+    else:
+        raise ValueError("visual_prompt must be a string or structured object")
+    frame_evidence: list[dict[str, object]] = [{"role": "storyboard", "sha256": _file_digest(storyboard_image)}]
+    if end_frame_image is not None:
+        frame_evidence.append({"role": "end_frame", "sha256": _file_digest(end_frame_image)})
+    return ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": _require_non_empty("resource_id", resource_id),
+            "visual_prompt": projected_prompt,
+            "canvas": {"aspect_ratio": _require_non_empty("aspect_ratio", aspect_ratio)},
+            "frames": frame_evidence,
+        },
+    )
+
+
+def build_reference_video_artifact_visual_basis(
+    *,
+    unit: Mapping[str, object],
+    request_assets: Sequence[ResolvedReferenceAsset],
+    style: str | None,
+    aspect_ratio: str,
+) -> ArtifactBasis:
+    """Describe one canonical ``video_unit`` and the images actually sent for it.
+
+    Only ``unit_id`` and visual lines from ``shots`` are projected. Legacy grouping
+    fields and speech-only lines never enter the basis. ``request_assets`` must be
+    the already-clamped request projection, so unavailable or provider-truncated
+    declarations cannot make the formal video stale.
+    """
+
+    unit_id = _require_non_empty("unit.unit_id", unit.get("unit_id"))
+    raw_shots = unit.get("shots")
+    if not isinstance(raw_shots, (list, tuple)):
+        raise ValueError("unit.shots must be an array")
+    visual_shots: list[dict[str, object]] = []
+    for index, raw_shot in enumerate(raw_shots):
+        if not isinstance(raw_shot, Mapping):
+            raise ValueError(f"unit.shots[{index}] must be an object")
+        raw_text = raw_shot.get("text")
+        if not isinstance(raw_text, str):
+            raise ValueError(f"unit.shots[{index}].text must be a string")
+        visual_shots.append(
+            {
+                "shot_index": index,
+                "lines": _reference_visual_lines(raw_text),
+            }
+        )
+    references: list[VisualReference] = []
+    for asset in request_assets:
+        if not isinstance(asset, ResolvedReferenceAsset):
+            raise TypeError("request_assets must contain ResolvedReferenceAsset values")
+        references.append(
+            VisualReference(
+                path=asset.path,
+                role="reference_image",
+                logical_type=asset.reference.type,
+                logical_id=asset.reference.name,
+                kind=asset.kind,
+            )
+        )
+    return ArtifactBasis.build(
+        "artifact-visual/video-reference",
+        kind_version=1,
+        inputs={
+            "unit_id": unit_id,
+            "visual_shots": visual_shots,
+            "style": normalize_style(style),
+            "canvas": {"aspect_ratio": _require_non_empty("aspect_ratio", aspect_ratio)},
+            "request_references": _reference_evidence(references),
+        },
+    )
+
+
+def _reference_visual_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = strip_shot_header(raw_line).strip()
+        if not line:
+            continue
+        if match_dialogue_line(line) is not None or match_voiceover_line(line) is not None:
+            continue
+        lines.append(line)
+    return lines
+
+
+def _project_storyboard_image_prompt(image_prompt: object, style: str) -> tuple[object, str | None]:
+    if isinstance(image_prompt, str):
+        prompt = image_prompt.strip()
+        if not prompt:
+            raise ValueError("image_prompt must not be empty")
+        return prompt, None
+    if not isinstance(image_prompt, Mapping):
+        raise ValueError("image_prompt must be a string or object")
+    scene = image_prompt.get("scene")
+    if not isinstance(scene, str) or not scene.strip():
+        raise ValueError("image_prompt.scene must be a non-empty string")
+    raw_composition = image_prompt.get("composition")
+    composition = raw_composition if isinstance(raw_composition, Mapping) else {}
+    return (
+        {
+            "scene": scene.strip(),
+            "composition": {
+                "shot_type": str(composition.get("shot_type") or "Medium Shot"),
+                "lighting": str(composition.get("lighting") or ""),
+                "ambiance": str(composition.get("ambiance") or ""),
+            },
+        },
+        normalize_style(style),
+    )
+
+
+def _validate_grid_members(
+    members: Sequence[GridStoryboardVisual],
+    *,
+    rows: int,
+    columns: int,
+) -> tuple[GridStoryboardVisual, ...]:
+    if type(rows) is not int or rows < 1 or type(columns) is not int or columns < 1:
+        raise ValueError("grid rows and columns must be positive integers")
+    member_tuple = tuple(members)
+    if not member_tuple:
+        raise ValueError("grid must contain at least one member")
+    if len(member_tuple) > rows * columns:
+        raise ValueError("grid members exceed the declared layout capacity")
+    if any(not isinstance(member, GridStoryboardVisual) for member in member_tuple):
+        raise TypeError("grid members must be GridStoryboardVisual values")
+    identities = [member.resource_id for member in member_tuple]
+    if len(set(identities)) != len(identities):
+        raise ValueError("grid member resource_id values must be unique")
+    return member_tuple
+
+
+def _project_grid_cells(members: Sequence[GridStoryboardVisual]) -> list[dict[str, object]]:
+    cells: list[dict[str, object]] = []
+    for index, member in enumerate(members):
+        transition: dict[str, object] | None = None
+        if index:
+            previous = members[index - 1]
+            transition = {
+                "from_resource_id": previous.resource_id,
+                "action": _project_grid_action(previous.video_prompt),
+            }
+        cells.append(
+            {
+                "cell_index": index,
+                "resource_id": member.resource_id,
+                "image_prompt": _project_grid_image_prompt(member.image_prompt),
+                "transition": transition,
+            }
+        )
+    return cells
+
+
+def _project_grid_image_prompt(image_prompt: object) -> object:
+    if not isinstance(image_prompt, Mapping):
+        return str(image_prompt)
+    scene = image_prompt.get("scene")
+    if scene is None:
+        scene = ""
+    if not isinstance(scene, str):
+        raise ValueError("grid image_prompt.scene must be a string")
+    raw_composition = image_prompt.get("composition")
+    if raw_composition is None:
+        raw_composition = {}
+    if not isinstance(raw_composition, Mapping):
+        raise ValueError("grid image_prompt.composition must be an object")
+    projected_composition: dict[str, str] = {}
+    for key, value in raw_composition.items():
+        if not isinstance(key, str):
+            raise ValueError("grid image_prompt.composition keys must be strings")
+        if value:
+            projected_composition[key] = str(value)
+    return {
+        "scene": scene,
+        "composition": projected_composition,
+    }
+
+
+def _project_grid_action(video_prompt: object) -> str:
+    if isinstance(video_prompt, Mapping):
+        return str(video_prompt.get("action") or "")
+    return str(video_prompt)
+
+
+def _reference_evidence(references: Sequence[VisualReference]) -> list[dict[str, object]]:
+    if any(not isinstance(reference, VisualReference) for reference in references):
+        raise TypeError("visual references must be VisualReference values")
+    return [reference.evidence() for reference in references]
+
+
+def _file_digest(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_non_empty(field: str, value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_string(field: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+__all__ = [
+    "GridStoryboardVisual",
+    "VisualReference",
+    "build_asset_sheet_visual_basis",
+    "build_grid_composite_visual_basis",
+    "build_grid_member_storyboard_visual_basis",
+    "build_reference_video_artifact_visual_basis",
+    "build_storyboard_image_visual_basis",
+    "build_storyboard_video_artifact_visual_basis",
+]

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -13,7 +13,12 @@ from pathlib import Path
 from typing import Any
 
 from lib.api_errors import ConflictError
-from lib.artifact_manifest import ArtifactKey, ArtifactManifestEntry, ProjectArtifactManifestAdapter
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifestEntry,
+    ProjectArtifactManifestAdapter,
+)
 from lib.asset_types import (
     ASSET_SPECS,
     normalize_asset_bucket,
@@ -98,6 +103,7 @@ from lib.storyboard_sequence import (
 from lib.thumbnail import extract_video_thumbnail
 from lib.video_backends.base import VideoCapabilityError
 from lib.video_visual_provenance import build_storyboard_video_visual_basis, resolve_video_aspect_ratio
+from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
 from server.services.generation_context import (
     AudioLaneRequest,
     ImageLaneRequest,
@@ -1432,6 +1438,17 @@ async def execute_video_task(
                     ).digest
                 )
             )
+            artifact_visual_basis = await asyncio.to_thread(
+                lambda: ArtifactBasisDescriptor.from_basis(
+                    build_storyboard_video_artifact_visual_basis(
+                        resource_id=resource_id,
+                        visual_prompt=requested_visual_prompt,
+                        storyboard_image=provider_start_image,
+                        end_frame_image=provider_end_image,
+                        aspect_ratio=aspect_ratio,
+                    )
+                )
+            )
             narration = delivery_projection.narration if delivery_projection is not None else None
             narration_facts = NarrationExecutionFacts(
                 delivery=delivery_options.narration_delivery,
@@ -1461,6 +1478,7 @@ async def execute_video_task(
                     service_tier=service_tier,
                     seed=seed,
                     visual_basis_digest=visual_basis_digest,
+                    artifact_visual_basis=artifact_visual_basis,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=None,

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from lib.artifact_manifest import ArtifactBasisDescriptor
 from lib.config.resolver import (
     ConfigResolver,
     VideoCapability,
@@ -66,6 +67,7 @@ from lib.speech_composition import video_unit_replan_problems
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import VersionManager
 from lib.video_visual_provenance import resolve_video_aspect_ratio
+from lib.visual_artifact_provenance import build_reference_video_artifact_visual_basis
 from server.services.generation_context import AudioLaneRequest, VideoLaneRequest, resolve_generation_context
 from server.services.generation_tasks import get_project_manager
 from server.services.narration_delivery_tasks import (
@@ -749,6 +751,19 @@ async def execute_reference_video_task(
                 reference_audio_targets=reference_audio_targets,
                 candidate=candidate,
             )
+            staged_request_assets = tuple(
+                replace(entry, path=path) for entry, path in zip(constrained_entries, provider_refs, strict=True)
+            )
+            artifact_visual_basis = await asyncio.to_thread(
+                lambda: ArtifactBasisDescriptor.from_basis(
+                    build_reference_video_artifact_visual_basis(
+                        unit=unit,
+                        request_assets=staged_request_assets,
+                        style=project.get("style"),
+                        aspect_ratio=aspect_ratio,
+                    )
+                )
+            )
 
             def _build_checkpoint(api_call_id: int) -> ReferenceSubmissionCheckpoint:
                 return ReferenceSubmissionCheckpoint.create(
@@ -770,6 +785,7 @@ async def execute_reference_video_task(
                     service_tier="default",
                     seed=None,
                     visual_basis_digest=visual_basis_digest,
+                    artifact_visual_basis=artifact_visual_basis,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=audio_targets_tuple,

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -2711,11 +2711,15 @@ async def test_execute_reference_video_task_stages_actual_request_and_checkpoint
     assert checkpoint.prompt == submitted["prompt"]
     assert [media.role for media in checkpoint.media] == ["reference_image", "reference_image"]
     assert all(media.source_locator != "audio/segment_E1U1.wav" for media in checkpoint.media)
+    assert checkpoint.artifact_visual_basis is not None
+    assert checkpoint.artifact_visual_basis.kind == "artifact-visual/video-reference"
     metadata = submitted["checkpoint_metadata"]
     assert metadata["execution_api_call_id"] == checkpoint.api_call_id
     assert metadata["execution_request_digest"] == checkpoint.request_digest
     assert metadata["execution_prompt_sha256"] == checkpoint.prompt_sha256
     assert metadata["execution_visual_basis_digest"] == checkpoint.visual_basis_digest
+    assert metadata["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
+    assert not (proj_dir / ".arcreel_artifacts.json").exists()
     assert not (proj_dir / ".arcreel" / "tasks" / "task-submit" / "provider_media").exists()
 
     async def _cancel_after_staging(**_kwargs):

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from lib.artifact_manifest import ArtifactBasis
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
 from lib.artifact_provenance import build_episode_script_basis, build_step1_basis
 
 pytestmark = pytest.mark.unit
@@ -26,6 +26,34 @@ def test_artifact_basis_has_deterministic_canonical_json() -> None:
     )
     assert second.normalized_bytes() == first.normalized_bytes()
     assert second.digest == first.digest
+
+
+def test_artifact_basis_descriptor_round_trips_strict_source_fact() -> None:
+    basis = ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=3, inputs={"frame": "v1"})
+
+    descriptor = ArtifactBasisDescriptor.from_basis(basis)
+
+    assert descriptor.to_dict() == {
+        "kind": "artifact-visual/video-storyboard",
+        "kind_version": 3,
+        "digest": basis.digest,
+    }
+    assert ArtifactBasisDescriptor.from_dict(descriptor.to_dict()) == descriptor
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {},
+        {"kind": "visual", "kind_version": 1, "digest": "sha256-v1:" + "a" * 64, "extra": True},
+        {"kind": "", "kind_version": 1, "digest": "sha256-v1:" + "a" * 64},
+        {"kind": "visual", "kind_version": True, "digest": "sha256-v1:" + "a" * 64},
+        {"kind": "visual", "kind_version": 1, "digest": "a" * 64},
+    ],
+)
+def test_artifact_basis_descriptor_rejects_noncanonical_source_fact(value: object) -> None:
+    with pytest.raises(ValueError):
+        ArtifactBasisDescriptor.from_dict(value)
 
 
 def test_structured_content_basis_tracks_only_the_direct_formal_chain() -> None:

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -737,7 +737,7 @@ class TestGenerationTasks:
         current_prompt = {"action": "current action", "camera_motion": "Static", "dialogue": []}
         item["video_prompt"] = current_prompt
         item["duration_seconds"] = 8
-        manifest = project_path / ".artifact_manifest.json"
+        manifest = project_path / ".arcreel_artifacts.json"
         manifest.write_bytes(b'{"unchanged":true}')
         submitted: dict[str, Mapping[str, object]] = {}
 
@@ -788,6 +788,9 @@ class TestGenerationTasks:
         assert checkpoint.duration_seconds == 8
         assert checkpoint.provider_id == "ark"
         assert [media.role for media in checkpoint.media] == ["start_image"]
+        assert checkpoint.artifact_visual_basis is not None
+        assert checkpoint.artifact_visual_basis.kind == "artifact-visual/video-storyboard"
+        assert submitted["metadata"]["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
         assert call["formal_output"] is True
         assert submitted["metadata"]["execution_request_digest"] == checkpoint.request_digest
         assert manifest.read_bytes() == b'{"unchanged":true}'

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
 from lib.db import Base
 from lib.generation_worker import (
     _ORPHAN_RESCAN_LEASE_LOST_MULT,
@@ -57,6 +58,9 @@ def _worker_reference_checkpoint(task_id: str, *, provider_id: str = "ark") -> s
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        ),
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -95,6 +99,9 @@ def _worker_storyboard_checkpoint(task_id: str, *, provider_id: str = "ark") -> 
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        ),
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",

--- a/tests/test_reference_video_execution_checkpoint.py
+++ b/tests/test_reference_video_execution_checkpoint.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import errno
+import hashlib
 import json
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+from lib.artifact_manifest import MANIFEST_FILENAME, ArtifactBasis, ArtifactBasisDescriptor
 from lib.path_safety import PathTraversalError
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
@@ -18,6 +20,7 @@ from lib.reference_video.execution_checkpoint import (
     ReferenceSubmissionCheckpoint,
     StoryboardSubmissionCheckpoint,
     VideoResumeState,
+    checkpoint_version_metadata,
     classify_reference_resume_state,
     classify_video_resume_state,
     cleanup_staged_provider_media,
@@ -75,6 +78,9 @@ def _checkpoint(project_path: Path) -> ReferenceSubmissionCheckpoint:
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        ),
         narration=NarrationExecutionFacts(
             delivery="use_tts",
             tts_status="current",
@@ -244,6 +250,13 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     assert len(restored.request_digest) == 64
     assert restored.media[0].source_locator == "characters/Alice.png"
     assert restored.narration.actual_duration_seconds == 6.25
+    assert restored.artifact_visual_basis == checkpoint.artifact_visual_basis
+    assert checkpoint_version_metadata(restored)["artifact_visual_basis"] == {
+        "kind": "artifact-visual/video-reference",
+        "kind_version": 1,
+        "digest": checkpoint.artifact_visual_basis.digest,
+    }
+    assert not (tmp_path / "demo" / MANIFEST_FILENAME).exists()
 
     raw = json.loads(checkpoint.to_json())
     raw["unexpected"] = True
@@ -265,6 +278,17 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     with pytest.raises(ValueError, match="canonical"):
         ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
 
+    for invalid in (
+        {"kind": "", "kind_version": 1, "digest": "sha256-v1:" + "a" * 64},
+        {"kind": "visual", "kind_version": True, "digest": "sha256-v1:" + "a" * 64},
+        {"kind": "visual", "kind_version": 1, "digest": "a" * 64},
+        {**checkpoint.artifact_visual_basis.to_dict(), "extra": True},
+    ):
+        raw = json.loads(checkpoint.to_json())
+        raw["artifact_visual_basis"] = invalid
+        with pytest.raises(ValueError, match="artifact basis descriptor"):
+            ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
+
 
 def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
@@ -272,6 +296,27 @@ def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -
     replay = replace(checkpoint, api_call_id=checkpoint.api_call_id + 1)
 
     assert replay.request_digest == checkpoint.request_digest
+
+
+def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tmp_path: Path) -> None:
+    raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
+    raw["schema_version"] = 1
+    raw.pop("artifact_visual_basis")
+    digest_payload = {key: value for key, value in raw.items() if key not in {"api_call_id", "request_digest"}}
+    raw["request_digest"] = hashlib.sha256(
+        json.dumps(
+            digest_payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    restored = ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
+
+    assert restored.schema_version == 1
+    assert restored.artifact_visual_basis is None
+    assert "artifact_visual_basis" not in checkpoint_version_metadata(restored)
 
 
 def test_checkpoint_rejects_incoherent_narration_and_media_facts(tmp_path: Path) -> None:
@@ -321,6 +366,7 @@ def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_p
             service_tier=checkpoint.service_tier,
             seed=checkpoint.seed,
             visual_basis_digest=checkpoint.visual_basis_digest,
+            artifact_visual_basis=checkpoint.artifact_visual_basis,
             narration=checkpoint.narration,
             media=(wrong_task, *checkpoint.media[1:]),
             reference_audio_targets=checkpoint.reference_audio_targets,
@@ -408,6 +454,9 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
         service_tier="default",
         seed=123,
         visual_basis_digest="c" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        ),
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",

--- a/tests/test_reference_video_execution_checkpoint.py
+++ b/tests/test_reference_video_execution_checkpoint.py
@@ -242,6 +242,8 @@ def test_cleanup_does_not_traverse_a_symlinked_task_ancestor(tmp_path: Path) -> 
 
 def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
+    artifact_visual_basis = checkpoint.artifact_visual_basis
+    assert artifact_visual_basis is not None
 
     restored = ReferenceSubmissionCheckpoint.from_json(checkpoint.to_json())
 
@@ -250,11 +252,11 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     assert len(restored.request_digest) == 64
     assert restored.media[0].source_locator == "characters/Alice.png"
     assert restored.narration.actual_duration_seconds == 6.25
-    assert restored.artifact_visual_basis == checkpoint.artifact_visual_basis
+    assert restored.artifact_visual_basis == artifact_visual_basis
     assert checkpoint_version_metadata(restored)["artifact_visual_basis"] == {
         "kind": "artifact-visual/video-reference",
         "kind_version": 1,
-        "digest": checkpoint.artifact_visual_basis.digest,
+        "digest": artifact_visual_basis.digest,
     }
     assert not (tmp_path / "demo" / MANIFEST_FILENAME).exists()
 
@@ -282,7 +284,7 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
         {"kind": "", "kind_version": 1, "digest": "sha256-v1:" + "a" * 64},
         {"kind": "visual", "kind_version": True, "digest": "sha256-v1:" + "a" * 64},
         {"kind": "visual", "kind_version": 1, "digest": "a" * 64},
-        {**checkpoint.artifact_visual_basis.to_dict(), "extra": True},
+        {**artifact_visual_basis.to_dict(), "extra": True},
     ):
         raw = json.loads(checkpoint.to_json())
         raw["artifact_visual_basis"] = invalid
@@ -307,6 +309,16 @@ def test_artifact_visual_basis_does_not_change_execution_request_digest(tmp_path
     with_changed_artifact_basis = replace(checkpoint, artifact_visual_basis=changed_artifact_basis)
 
     assert with_changed_artifact_basis.request_digest == checkpoint.request_digest
+
+
+def test_reference_checkpoint_rejects_storyboard_artifact_visual_basis(tmp_path: Path) -> None:
+    checkpoint = _checkpoint(tmp_path / "demo")
+    storyboard_basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    )
+
+    with pytest.raises(ValueError, match="artifact_visual_basis kind"):
+        replace(checkpoint, artifact_visual_basis=storyboard_basis)
 
 
 def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tmp_path: Path) -> None:
@@ -350,6 +362,8 @@ def test_checkpoint_rejects_incoherent_narration_and_media_facts(tmp_path: Path)
 
 def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
+    artifact_visual_basis = checkpoint.artifact_visual_basis
+    assert artifact_visual_basis is not None
     with pytest.raises(ValueError, match="staged_locator"):
         replace(checkpoint.media[0], staged_locator="../outside.png")
 
@@ -377,7 +391,7 @@ def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_p
             service_tier=checkpoint.service_tier,
             seed=checkpoint.seed,
             visual_basis_digest=checkpoint.visual_basis_digest,
-            artifact_visual_basis=checkpoint.artifact_visual_basis,
+            artifact_visual_basis=artifact_visual_basis,
             narration=checkpoint.narration,
             media=(wrong_task, *checkpoint.media[1:]),
             reference_audio_targets=checkpoint.reference_audio_targets,
@@ -478,6 +492,12 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
         media=staged,
         reference_audio_targets=None,
     )
+    reference_basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U01"})
+    )
+    with pytest.raises(ValueError, match="artifact_visual_basis kind"):
+        replace(checkpoint, artifact_visual_basis=reference_basis)
+
     restored = StoryboardSubmissionCheckpoint.from_json(checkpoint.to_json())
     assert restored == checkpoint
     assert restored.media[0].role == "start_image"

--- a/tests/test_reference_video_execution_checkpoint.py
+++ b/tests/test_reference_video_execution_checkpoint.py
@@ -298,6 +298,17 @@ def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -
     assert replay.request_digest == checkpoint.request_digest
 
 
+def test_artifact_visual_basis_does_not_change_execution_request_digest(tmp_path: Path) -> None:
+    checkpoint = _checkpoint(tmp_path / "demo")
+    changed_artifact_basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U2"})
+    )
+
+    with_changed_artifact_basis = replace(checkpoint, artifact_visual_basis=changed_artifact_basis)
+
+    assert with_changed_artifact_basis.request_digest == checkpoint.request_digest
+
+
 def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tmp_path: Path) -> None:
     raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
     raw["schema_version"] = 1

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
     StagedProviderMedia,
@@ -127,6 +128,9 @@ def _storyboard_checkpoint_json(
         service_tier="default",
         seed=None,
         visual_basis_digest="b" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        ),
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -261,6 +265,9 @@ async def test_execute_resume_video_calls_backend_resume_directly(monkeypatch, f
     assert call["execution_provider_model_id"] == "sora-2"
     assert call["execution_backend_model_id"] == "sora-2"
     assert call["execution_visual_basis_digest"] == "b" * 64
+    checkpoint = StoryboardSubmissionCheckpoint.from_json(video_task["execution_checkpoint_json"])
+    assert checkpoint.artifact_visual_basis is not None
+    assert call["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
     assert call["execution_provider_media"][0]["source_locator"] == "storyboards/scene_E1S01.png"
     # 返回结果带 file_path / resource_type，供 worker mark_succeeded
     assert result["resource_type"] == "videos"
@@ -469,6 +476,9 @@ def _reference_checkpoint(
         service_tier="pro",
         seed=123,
         visual_basis_digest="sha256-v1:" + "a" * 64,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        ),
         narration=(
             NarrationExecutionFacts(
                 delivery="use_tts",
@@ -564,6 +574,8 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
     assert call["execution_request_digest"] == checkpoint.request_digest
     assert call["execution_provider_media"] == []
     assert call["visual_basis_digest"] == checkpoint.visual_basis_digest
+    assert checkpoint.artifact_visual_basis is not None
+    assert call["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
     output_guard.assert_awaited_once_with(
         project_name="demo",
         script_file="scripts/frozen.json",

--- a/tests/test_visual_artifact_provenance.py
+++ b/tests/test_visual_artifact_provenance.py
@@ -29,7 +29,7 @@ from lib.visual_artifact_provenance import (
     build_storyboard_video_artifact_visual_basis,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 
 @pytest.mark.parametrize("asset_type", ["character", "scene", "prop", "product"])
@@ -247,7 +247,6 @@ def test_grid_composite_and_member_bases_keep_member_changes_local(tmp_path: Pat
             columns=2,
             style="水墨",
             grid_aspect_ratio="1:1",
-            member_aspect_ratio="16:9",
             references=references,
         )
 
@@ -317,11 +316,28 @@ def test_grid_composite_ignores_last_action_that_is_not_rendered(tmp_path: Path)
             columns=2,
             style="水墨",
             grid_aspect_ratio="1:1",
-            member_aspect_ratio="16:9",
             references=(VisualReference(path=reference, role="asset_sheet"),),
         )
 
     assert build(changed_last).digest == build(members).digest
+
+
+def test_grid_composite_tracks_only_the_aspect_ratio_sent_for_the_composite(tmp_path: Path) -> None:
+    reference = tmp_path / "reference.png"
+    reference.write_bytes(b"visual")
+    common = {
+        "group_id": "grid_1",
+        "members": _grid_members(),
+        "rows": 2,
+        "columns": 2,
+        "style": "水墨",
+        "references": (VisualReference(path=reference, role="asset_sheet"),),
+    }
+
+    landscape = build_grid_composite_visual_basis(grid_aspect_ratio="16:9", **common)
+    portrait = build_grid_composite_visual_basis(grid_aspect_ratio="9:16", **common)
+
+    assert portrait.digest != landscape.digest
 
 
 def test_storyboard_video_visual_basis_excludes_sound_execution_and_duration(tmp_path: Path) -> None:

--- a/tests/test_visual_artifact_provenance.py
+++ b/tests/test_visual_artifact_provenance.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import unicodedata
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactKey,
+    ArtifactManifest,
+    ArtifactStatus,
+    ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
+)
+from lib.reference_video.request_projection import ResolvedReferenceAsset
+from lib.script_models import ReferenceResource
+from lib.visual_artifact_provenance import (
+    GridStoryboardVisual,
+    VisualReference,
+    build_asset_sheet_visual_basis,
+    build_grid_composite_visual_basis,
+    build_grid_member_storyboard_visual_basis,
+    build_reference_video_artifact_visual_basis,
+    build_storyboard_image_visual_basis,
+    build_storyboard_video_artifact_visual_basis,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("asset_type", ["character", "scene", "prop", "product"])
+def test_asset_sheet_visual_basis_tracks_only_formal_visual_inputs(tmp_path: Path, asset_type: str) -> None:
+    first_reference = tmp_path / "first.png"
+    same_reference = tmp_path / "same.png"
+    changed_reference = tmp_path / "changed.png"
+    first_reference.write_bytes(b"same visual bytes")
+    same_reference.write_bytes(b"same visual bytes")
+    changed_reference.write_bytes(b"changed visual bytes")
+
+    def build(reference: Path, *, description: str = "银发旅人", aspect_ratio: str = "16:9", style: str = "水墨"):
+        return build_asset_sheet_visual_basis(
+            asset_type=asset_type,
+            asset_id="Hiếu",
+            description=description,
+            style=style,
+            style_description="淡彩",
+            aspect_ratio=aspect_ratio,
+            references=(
+                VisualReference(
+                    path=reference,
+                    role="source",
+                    logical_type=asset_type,
+                    logical_id="Hiếu",
+                    kind="original",
+                ),
+            ),
+        )
+
+    baseline = build(first_reference)
+
+    assert build(same_reference).digest == baseline.digest
+    assert build(changed_reference).digest != baseline.digest
+    assert build(first_reference, description="黑发旅人").digest != baseline.digest
+    assert build(first_reference, aspect_ratio="9:16").digest != baseline.digest
+    if asset_type == "product":
+        assert build(first_reference, style="写实摄影").digest == baseline.digest
+    else:
+        assert build(first_reference, style="写实摄影").digest != baseline.digest
+
+
+def test_asset_sheet_visual_basis_uses_canonical_asset_identity(tmp_path: Path) -> None:
+    reference = tmp_path / "reference.png"
+    reference.write_bytes(b"visual")
+    nfc_name = unicodedata.normalize("NFC", "Hiếu")
+    nfd_name = unicodedata.normalize("NFD", nfc_name)
+
+    first = build_asset_sheet_visual_basis(
+        asset_type="character",
+        asset_id=nfc_name,
+        description="主角",
+        style="",
+        style_description="",
+        aspect_ratio="16:9",
+        references=(
+            VisualReference(
+                path=reference,
+                role="source",
+                logical_type="character",
+                logical_id=nfc_name,
+            ),
+        ),
+    )
+    same = build_asset_sheet_visual_basis(
+        asset_type="character",
+        asset_id=nfd_name,
+        description="主角",
+        style="",
+        style_description="",
+        aspect_ratio="16:9",
+        references=(
+            VisualReference(
+                path=reference,
+                role="source",
+                logical_type="character",
+                logical_id=nfd_name,
+            ),
+        ),
+    )
+
+    assert nfc_name != nfd_name
+    assert same.digest == first.digest
+
+
+def test_visual_reference_requires_real_image_evidence(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.png"
+    reference = VisualReference(path=missing, role="source")
+
+    with pytest.raises(FileNotFoundError):
+        build_asset_sheet_visual_basis(
+            asset_type="character",
+            asset_id="阿黎",
+            description="主角",
+            style="",
+            style_description="",
+            aspect_ratio="16:9",
+            references=(reference,),
+        )
+
+
+def test_storyboard_image_basis_projects_content_canvas_and_actual_references(tmp_path: Path) -> None:
+    character_sheet = tmp_path / "character.png"
+    changed_sheet = tmp_path / "changed-character.png"
+    character_sheet.write_bytes(b"character-v1")
+    changed_sheet.write_bytes(b"character-v2")
+
+    def build(
+        *,
+        image_prompt: object | None = None,
+        style: str = "画风：水墨",
+        aspect_ratio: str = "16:9",
+        sheet: Path = character_sheet,
+    ):
+        return build_storyboard_image_visual_basis(
+            resource_id="E1S01",
+            image_prompt=image_prompt
+            or {
+                "scene": "阿黎站在雨中",
+                "composition": {
+                    "shot_type": "Medium Shot",
+                    "lighting": "冷光",
+                    "ambiance": "压抑",
+                },
+            },
+            style=style,
+            aspect_ratio=aspect_ratio,
+            references=(
+                VisualReference(
+                    path=sheet,
+                    role="asset_sheet",
+                    logical_type="character",
+                    logical_id="阿黎",
+                ),
+            ),
+        )
+
+    baseline = build()
+
+    assert build(style="水墨").digest == baseline.digest
+    assert build(sheet=changed_sheet).digest != baseline.digest
+    assert build(aspect_ratio="9:16").digest != baseline.digest
+    assert (
+        build(
+            image_prompt={
+                "scene": "阿黎走出雨幕",
+                "composition": {
+                    "shot_type": "Medium Shot",
+                    "lighting": "冷光",
+                    "ambiance": "压抑",
+                },
+            }
+        ).digest
+        != baseline.digest
+    )
+
+
+def test_legacy_storyboard_text_ignores_style_that_is_not_sent_to_the_request(tmp_path: Path) -> None:
+    reference = tmp_path / "reference.png"
+    reference.write_bytes(b"visual")
+    kwargs = {
+        "resource_id": "E1S01",
+        "image_prompt": "阿黎站在雨中",
+        "aspect_ratio": "16:9",
+        "references": (VisualReference(path=reference, role="asset_sheet"),),
+    }
+
+    first = build_storyboard_image_visual_basis(style="水墨", **kwargs)
+    changed_style = build_storyboard_image_visual_basis(style="写实", **kwargs)
+
+    assert changed_style.digest == first.digest
+
+
+def _grid_members(*, second_image: str = "雨巷", first_action: str = "阿黎转身") -> tuple[GridStoryboardVisual, ...]:
+    return (
+        GridStoryboardVisual(
+            resource_id="E1S01",
+            image_prompt={"scene": "屋顶", "composition": {"shot_type": "Wide Shot"}},
+            video_prompt={"action": first_action, "camera_motion": "Pan Left", "ambiance_audio": "雨声"},
+        ),
+        GridStoryboardVisual(
+            resource_id="E1S02",
+            image_prompt={"scene": second_image, "composition": {"shot_type": "Medium Shot"}},
+            video_prompt={"action": "推门", "camera_motion": "Static", "ambiance_audio": "脚步声"},
+        ),
+        GridStoryboardVisual(
+            resource_id="E1S03",
+            image_prompt={"scene": "门厅", "composition": {"shot_type": "Close-up"}},
+            video_prompt={"action": "灯熄灭", "camera_motion": "Static", "ambiance_audio": "钟声"},
+        ),
+    )
+
+
+def test_grid_composite_and_member_bases_keep_member_changes_local(tmp_path: Path) -> None:
+    group_reference = tmp_path / "character.png"
+    composite = tmp_path / "grid.png"
+    group_reference.write_bytes(b"character")
+    composite.write_bytes(b"grid-v1")
+    references = (
+        VisualReference(
+            path=group_reference,
+            role="asset_sheet",
+            logical_type="character",
+            logical_id="阿黎",
+        ),
+    )
+    members = _grid_members()
+    changed_second = _grid_members(second_image="雪巷")
+
+    def composite_basis(current_members: tuple[GridStoryboardVisual, ...]):
+        return build_grid_composite_visual_basis(
+            group_id="grid_1",
+            members=current_members,
+            rows=2,
+            columns=2,
+            style="水墨",
+            grid_aspect_ratio="1:1",
+            member_aspect_ratio="16:9",
+            references=references,
+        )
+
+    def member_basis(current_members: tuple[GridStoryboardVisual, ...], cell_index: int):
+        return build_grid_member_storyboard_visual_basis(
+            group_id="grid_1",
+            members=current_members,
+            cell_index=cell_index,
+            composite_image=composite,
+            rows=2,
+            columns=2,
+            style="水墨",
+            member_aspect_ratio="16:9",
+            references=references,
+        )
+
+    group = composite_basis(members)
+    first = member_basis(members, 0)
+    second = member_basis(members, 1)
+
+    assert composite_basis(changed_second).digest != group.digest
+    assert member_basis(changed_second, 0).digest == first.digest
+    assert member_basis(changed_second, 1).digest != second.digest
+
+
+def test_grid_member_tracks_transition_source_and_replaced_composite(tmp_path: Path) -> None:
+    composite = tmp_path / "grid.png"
+    composite.write_bytes(b"grid-v1")
+    members = _grid_members()
+
+    def build(current_members: tuple[GridStoryboardVisual, ...], cell_index: int):
+        return build_grid_member_storyboard_visual_basis(
+            group_id="grid_1",
+            members=current_members,
+            cell_index=cell_index,
+            composite_image=composite,
+            rows=2,
+            columns=2,
+            style="水墨",
+            member_aspect_ratio="16:9",
+        )
+
+    first = build(members, 0)
+    second = build(members, 1)
+    changed_transition = _grid_members(first_action="阿黎跃下屋顶")
+
+    assert build(changed_transition, 0).digest == first.digest
+    assert build(changed_transition, 1).digest != second.digest
+
+    composite.write_bytes(b"grid-v2")
+
+    assert build(members, 0).digest != first.digest
+    assert build(members, 1).digest != second.digest
+
+
+def test_grid_composite_ignores_last_action_that_is_not_rendered(tmp_path: Path) -> None:
+    reference = tmp_path / "reference.png"
+    reference.write_bytes(b"visual")
+    members = _grid_members()
+    changed_last = (*members[:2], replace(members[2], video_prompt={"action": "另一动作"}))
+
+    def build(current_members: tuple[GridStoryboardVisual, ...]):
+        return build_grid_composite_visual_basis(
+            group_id="grid_1",
+            members=current_members,
+            rows=2,
+            columns=2,
+            style="水墨",
+            grid_aspect_ratio="1:1",
+            member_aspect_ratio="16:9",
+            references=(VisualReference(path=reference, role="asset_sheet"),),
+        )
+
+    assert build(changed_last).digest == build(members).digest
+
+
+def test_storyboard_video_visual_basis_excludes_sound_execution_and_duration(tmp_path: Path) -> None:
+    start = tmp_path / "start.png"
+    end = tmp_path / "end.png"
+    start.write_bytes(b"start-frame")
+    end.write_bytes(b"end-frame")
+    prompt = {
+        "action": "阿黎推开门",
+        "camera_motion": "Push In",
+        "ambiance_audio": "雨声",
+        "dialogue": [{"speaker": "阿黎", "line": "有人吗"}],
+        "voice_profiles": [{"Speaker": "阿黎", "Voice_Style": "低沉"}],
+        "provider": "ignored-provider",
+        "resolution": "1080p",
+        "seed": 7,
+        "duration_seconds": 8,
+    }
+
+    def build(*, current_prompt: object = prompt, current_start: Path = start, aspect_ratio: str = "16:9"):
+        return build_storyboard_video_artifact_visual_basis(
+            resource_id="E1S01",
+            visual_prompt=current_prompt,
+            storyboard_image=current_start,
+            end_frame_image=end,
+            aspect_ratio=aspect_ratio,
+        )
+
+    baseline = build()
+    changed_sound_and_execution = build(
+        current_prompt={
+            **prompt,
+            "ambiance_audio": "钟声",
+            "dialogue": [{"speaker": "阿黎", "line": "快走"}],
+            "voice_profiles": [{"Speaker": "阿黎", "Voice_Style": "尖细"}],
+            "provider": "other-provider",
+            "resolution": "4k",
+            "seed": 99,
+            "duration_seconds": 12,
+        }
+    )
+
+    assert changed_sound_and_execution.digest == baseline.digest
+    assert build(current_prompt={**prompt, "action": "阿黎关上门"}).digest != baseline.digest
+    assert build(current_prompt={**prompt, "camera_motion": "Pan Left"}).digest != baseline.digest
+    assert build(aspect_ratio="9:16").digest != baseline.digest
+
+    start.write_bytes(b"changed-start-frame")
+
+    assert build().digest != baseline.digest
+
+
+def test_storyboard_video_visual_basis_tracks_end_frame_presence_and_bytes(tmp_path: Path) -> None:
+    start = tmp_path / "start.png"
+    end = tmp_path / "end.png"
+    start.write_bytes(b"start")
+    end.write_bytes(b"end-v1")
+
+    def build(current_end: Path | None):
+        return build_storyboard_video_artifact_visual_basis(
+            resource_id="E1S01",
+            visual_prompt={"action": "起身", "camera_motion": "Static"},
+            storyboard_image=start,
+            end_frame_image=current_end,
+            aspect_ratio="16:9",
+        )
+
+    without_end = build(None)
+    with_end = build(end)
+
+    assert with_end.digest != without_end.digest
+
+    end.write_bytes(b"end-v2")
+
+    assert build(end).digest != with_end.digest
+
+
+def test_storyboard_video_visual_basis_accepts_legacy_visual_text(tmp_path: Path) -> None:
+    start = tmp_path / "start.png"
+    start.write_bytes(b"start")
+
+    first = build_storyboard_video_artifact_visual_basis(
+        resource_id="E1S01",
+        visual_prompt="阿黎沿雨巷奔跑，镜头向前跟随",
+        storyboard_image=start,
+        end_frame_image=None,
+        aspect_ratio="16:9",
+    )
+    changed = build_storyboard_video_artifact_visual_basis(
+        resource_id="E1S01",
+        visual_prompt="阿黎停在雨巷尽头，镜头缓慢推近",
+        storyboard_image=start,
+        end_frame_image=None,
+        aspect_ratio="16:9",
+    )
+
+    assert changed.digest != first.digest
+
+
+def _request_asset(
+    path: Path,
+    *,
+    asset_type: Literal["product", "character", "scene", "prop"],
+    name: str,
+    kind: str = "asset",
+) -> ResolvedReferenceAsset:
+    return ResolvedReferenceAsset(
+        path=path,
+        reference=ReferenceResource(type=asset_type, name=name),
+        kind=kind,
+    )
+
+
+def test_reference_video_visual_basis_uses_unit_visual_text_and_actual_request_assets(tmp_path: Path) -> None:
+    character = tmp_path / "character.png"
+    scene = tmp_path / "scene.png"
+    clamped = tmp_path / "clamped.png"
+    character.write_bytes(b"character")
+    scene.write_bytes(b"scene")
+    clamped.write_bytes(b"unused")
+    unit = {
+        "unit_id": "E1U01",
+        "shots": [
+            {"text": "镜头1：中景，@[阿黎]站在屋檐下\n@[阿黎]：{快走。}"},
+            {"text": "特写，雨滴划过窗面\n{夜色吞没街道。}"},
+        ],
+        "references": [
+            {"type": "character", "name": "阿黎"},
+            {"type": "scene", "name": "雨巷"},
+            {"type": "prop", "name": "被裁掉的伞"},
+        ],
+        "shot_ids": ["legacy-shot"],
+        "source_signature": "legacy-source",
+        "derived_group": "legacy-group",
+        "duration_seconds": 8,
+        "utterances": [{"kind": "voiceover", "text": "声音事实"}],
+    }
+    request_assets = (
+        _request_asset(character, asset_type="character", name="阿黎", kind="sheet"),
+        _request_asset(scene, asset_type="scene", name="雨巷", kind="sheet"),
+    )
+
+    def build(
+        *,
+        current_unit: dict[str, object] = unit,
+        current_assets: tuple[ResolvedReferenceAsset, ...] = request_assets,
+        style: str = "画风：水墨",
+        aspect_ratio: str = "9:16",
+    ):
+        return build_reference_video_artifact_visual_basis(
+            unit=current_unit,
+            request_assets=current_assets,
+            style=style,
+            aspect_ratio=aspect_ratio,
+        )
+
+    baseline = build()
+    changed_speech_and_legacy = build(
+        current_unit={
+            **unit,
+            "shots": [
+                {"text": "镜头1：中景，@[阿黎]站在屋檐下\n@[阿黎]：{别走。}"},
+                {"text": "特写，雨滴划过窗面\n{另一句画外音。}"},
+            ],
+            "shot_ids": ["other-legacy-shot"],
+            "source_signature": "other-source",
+            "derived_group": "other-group",
+            "duration_seconds": 12,
+            "utterances": [{"kind": "dialogue", "text": "另一声音事实"}],
+        }
+    )
+
+    assert changed_speech_and_legacy.digest == baseline.digest
+    assert (
+        build(
+            current_unit={
+                **unit,
+                "shots": [
+                    {"text": "镜头1：近景，@[阿黎]跑出屋檐\n@[阿黎]：{快走。}"},
+                    unit["shots"][1],
+                ],
+            }
+        ).digest
+        != baseline.digest
+    )
+    assert build(current_unit={**unit, "unit_id": "E1U02"}).digest != baseline.digest
+    assert build(style="写实").digest != baseline.digest
+    assert build(aspect_ratio="16:9").digest != baseline.digest
+
+    clamped.write_bytes(b"changed-but-still-clamped")
+
+    assert build().digest == baseline.digest
+
+
+def test_reference_video_visual_basis_tracks_request_asset_identity_order_and_bytes(tmp_path: Path) -> None:
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    unit = {"unit_id": "E1U01", "shots": [{"text": "阿黎走入雨巷"}]}
+    assets = (
+        _request_asset(first, asset_type="character", name="阿黎"),
+        _request_asset(second, asset_type="scene", name="雨巷"),
+    )
+
+    def build(current_assets: tuple[ResolvedReferenceAsset, ...]):
+        return build_reference_video_artifact_visual_basis(
+            unit=unit,
+            request_assets=current_assets,
+            style="水墨",
+            aspect_ratio="9:16",
+        )
+
+    baseline = build(assets)
+
+    assert build(tuple(reversed(assets))).digest != baseline.digest
+    assert (
+        build((_request_asset(first, asset_type="character", name="另一个角色"), assets[1])).digest != baseline.digest
+    )
+
+    first.write_bytes(b"changed-first")
+
+    assert build(assets).digest != baseline.digest
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        {"unit_id": "", "shots": [{"text": "visual"}]},
+        {"shots": [{"text": "visual"}]},
+        {"unit_id": "E1U01", "shots": "not-an-array"},
+    ],
+)
+def test_reference_video_visual_basis_requires_canonical_video_unit(unit: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        build_reference_video_artifact_visual_basis(
+            unit=unit,
+            request_assets=(),
+            style="",
+            aspect_ratio="9:16",
+        )
+
+
+def test_video_components_compare_through_one_manifest_entry(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    video_path = project_path / "videos" / "scene_E1S01.mp4"
+    paid_version = project_path / "versions" / "videos" / "E1S01" / "1.mp4"
+    video_path.parent.mkdir(parents=True)
+    paid_version.parent.mkdir(parents=True)
+    video_path.write_bytes(b"selected-video")
+    paid_version.write_bytes(b"paid-version")
+    generated_assets = {
+        "video_clip": "videos/scene_E1S01.mp4",
+        "video_uri": "provider://paid-job",
+        "versions": ["versions/videos/E1S01/1.mp4"],
+    }
+    untouched_assets = deepcopy(generated_assets)
+    key = ArtifactKey.episode_video(1, "E1S01")
+    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project_path))
+    visual = ArtifactBasis.build("test/video-visual", kind_version=1, inputs={"frame": "v1"})
+    speech = ArtifactBasis.build("test/video-speech", kind_version=1, inputs={"line": "v1"})
+    duration = ArtifactBasis.build("test/video-duration", kind_version=1, inputs={"seconds": 8})
+    baseline = compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+    manifest.register(key, artifact_path="videos/scene_E1S01.mp4", basis=baseline)
+
+    variants = (
+        compose_video_artifact_basis(
+            visual=ArtifactBasis.build("test/video-visual", kind_version=1, inputs={"frame": "v2"}),
+            speech=speech,
+            duration=duration,
+        ),
+        compose_video_artifact_basis(
+            visual=visual,
+            speech=ArtifactBasis.build("test/video-speech", kind_version=1, inputs={"line": "v2"}),
+            duration=duration,
+        ),
+        compose_video_artifact_basis(
+            visual=visual,
+            speech=speech,
+            duration=ArtifactBasis.build("test/video-duration", kind_version=1, inputs={"seconds": 12}),
+        ),
+    )
+
+    assert (
+        manifest.compare(key, artifact_path="videos/scene_E1S01.mp4", basis=baseline).status is ArtifactStatus.CURRENT
+    )
+    for changed in variants:
+        comparison = manifest.compare(key, artifact_path="videos/scene_E1S01.mp4", basis=changed)
+        assert comparison.status is ArtifactStatus.STALE
+        assert comparison.usable
+    assert generated_assets == untouched_assets
+    assert video_path.read_bytes() == b"selected-video"
+    assert paid_version.read_bytes() == b"paid-version"
+    assert ProjectArtifactManifestAdapter(project_path).get_entry(ArtifactKey.episode_audio(1, "E1S01")) is None
+
+
+def test_video_component_composition_names_absent_future_components() -> None:
+    visual = ArtifactBasis.build("test/video-visual", kind_version=1, inputs={"frame": "v1"})
+
+    visual_only = compose_video_artifact_basis(visual=visual)
+    explicit_none = compose_video_artifact_basis(visual=visual, speech=None, duration=None)
+    with_speech = compose_video_artifact_basis(
+        visual=visual,
+        speech=ArtifactBasis.build("test/video-speech", kind_version=1, inputs={"line": "v1"}),
+    )
+
+    assert explicit_none.digest == visual_only.digest
+    assert with_speech.digest != visual_only.digest

--- a/tests/test_visual_artifact_provenance.py
+++ b/tests/test_visual_artifact_provenance.py
@@ -115,6 +115,18 @@ def test_asset_sheet_visual_basis_uses_canonical_asset_identity(tmp_path: Path) 
     assert same.digest == first.digest
 
 
+def test_asset_sheet_visual_basis_rejects_whitespace_only_description() -> None:
+    with pytest.raises(ValueError, match="description"):
+        build_asset_sheet_visual_basis(
+            asset_type="character",
+            asset_id="阿黎",
+            description="   ",
+            style="",
+            style_description="",
+            aspect_ratio="16:9",
+        )
+
+
 def test_visual_reference_requires_real_image_evidence(tmp_path: Path) -> None:
     missing = tmp_path / "missing.png"
     reference = VisualReference(path=missing, role="source")
@@ -509,8 +521,19 @@ def test_reference_video_visual_basis_uses_unit_visual_text_and_actual_request_a
             "utterances": [{"kind": "dialogue", "text": "另一声音事实"}],
         }
     )
+    with_speech_only_shot = build(
+        current_unit={
+            **unit,
+            "shots": [
+                unit["shots"][0],
+                {"text": "@[阿黎]：{新插入的台词。}\n{新插入的画外音。}"},
+                unit["shots"][1],
+            ],
+        }
+    )
 
     assert changed_speech_and_legacy.digest == baseline.digest
+    assert with_speech_only_shot.digest == baseline.digest
     assert (
         build(
             current_unit={


### PR DESCRIPTION
## 范围

为资产图、普通/宫格分镜、storyboard video 与 reference video 定义 canonical visual basis，并为视频 checkpoint 记录独立的视觉来源 descriptor。不激活 Manifest/current，也不改变既有执行复用指纹语义。

Closes #1673

## 变更

- 增加四类资产 sheet、普通分镜、宫格 composite/member、两条视频路线的 typed visual basis builder，以及单一 video entry 的 visual/speech/duration 组合缝
- checkpoint schema v2 严格保存 artifact_visual_basis，normal/resume 版本 metadata 同源；v1 继续只读兼容，descriptor 不参与 replay 或 execution request digest
- 审查修正 composite 画幅边界，并把真实文件系统/Manifest 测试归入 integration

## 验收清单

- [x] 本地已跑相关测试：全量后端 9500 passed、2 skipped；受影响套件 341 passed
- [x] 手动核对 canonical digest、checkpoint JSON、normal/resume metadata 与 Manifest 隔离行为
- [x] 新增面向用户文案已加 zh/en 翻译（不适用：无用户文案）
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求

## 验证

- uv run pytest -q（隔离且已迁移的 SQLite）：9500 passed, 2 skipped
- uv run ruff check .；uv run ruff format --check .
- uv run basedpyright：0 errors
- uv run lint-imports：1 contract kept
- uv run alembic heads：单一 head f6a41746c0de
- frontend: pnpm lint；pnpm check（149 files / 1792 tests）；pnpm build

## 已知 defer

- Manifest 激活与旧项目回填由 #1748 承接；本 PR 按 #1673 的 checkpoint/Manifest 隔离约束不提前写 Manifest/current。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增统一的视频素材依据标识，可组合视觉、语音和时长信息。
  - 支持为图片、视频、参考素材及合成内容生成可验证的内容依据。
- **改进**
  - 执行检查点新增视觉依据记录，并支持规范化序列化与严格校验。
  - 保持旧版检查点的恢复兼容性。
  - 内容依据变化可准确识别视频是否需要重新生成。
- **测试**
  - 增加对依据生成、非法数据校验、检查点兼容性及恢复流程的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->