### PR TITLE
feat(media): 统一追踪发声媒体来源与付费历史

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -283,6 +283,8 @@ export interface VersionInfo {
   created_at: string;
   file_size: number;
   is_current: boolean;
+  /** Whether this history record carries verified provenance for restore. */
+  restorable?: boolean;
   file_url?: string;
   prompt?: string;
   restored_from?: number;

--- a/frontend/src/components/canvas/timeline/NarrationAudioCard.test.tsx
+++ b/frontend/src/components/canvas/timeline/NarrationAudioCard.test.tsx
@@ -41,6 +41,12 @@ describe("NarrationAudioCard", () => {
     expect(screen.getByText("尚未生成")).toBeInTheDocument();
   });
 
+  it("keeps paid history reachable when no narration audio is currently selected", () => {
+    renderCard();
+
+    expect(screen.getByRole("button", { name: /版本/ })).toBeInTheDocument();
+  });
+
   it("invokes onGenerate when the generate button is clicked", () => {
     const onGenerate = vi.fn();
     renderCard({ onGenerate });

--- a/frontend/src/components/canvas/timeline/NarrationAudioCard.tsx
+++ b/frontend/src/components/canvas/timeline/NarrationAudioCard.tsx
@@ -67,7 +67,7 @@ export function NarrationAudioCard({
               resourceType="audio"
               resourceId={segmentId}
               iconOnly
-              readOnly
+              busy={Boolean(generating)}
             />
           </div>
         )}

--- a/frontend/src/components/canvas/timeline/NarrationAudioCard.tsx
+++ b/frontend/src/components/canvas/timeline/NarrationAudioCard.tsx
@@ -60,17 +60,15 @@ export function NarrationAudioCard({
         >
           {t("media_narration_title")}
         </span>
-        {assetPath && (
-          <div className="ml-auto">
-            <VersionTimeMachine
-              projectName={projectName}
-              resourceType="audio"
-              resourceId={segmentId}
-              iconOnly
-              busy={Boolean(generating)}
-            />
-          </div>
-        )}
+        <div className="ml-auto">
+          <VersionTimeMachine
+            projectName={projectName}
+            resourceType="audio"
+            resourceId={segmentId}
+            iconOnly
+            busy={Boolean(generating)}
+          />
+        </div>
       </div>
 
       {/* 只读原文 + 播放器并排 */}

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
@@ -144,7 +144,7 @@ describe("VersionTimeMachine", () => {
     expect(previewImage.parentElement).toHaveClass("h-80");
   });
 
-  it("previews, downloads, and restores historical narration audio", async () => {
+  it("previews, downloads, and restores verified historical narration audio", async () => {
     vi.spyOn(API, "getVersions").mockResolvedValue({
       resource_type: "audio",
       resource_id: "E1S01",
@@ -156,6 +156,7 @@ describe("VersionTimeMachine", () => {
           created_at: "2026-02-01T00:00:00Z",
           file_size: 10,
           is_current: false,
+          restorable: true,
           file_url: "/api/v1/files/demo/versions/audio/E1S01_v1.wav",
         },
         {
@@ -190,6 +191,49 @@ describe("VersionTimeMachine", () => {
     await waitFor(() => {
       expect(restore).toHaveBeenCalledWith("demo", "audio", "E1S01", 1);
     });
+  });
+
+  it("does not offer restore for history-only narration audio", async () => {
+    vi.spyOn(API, "getVersions").mockResolvedValue({
+      resource_type: "audio",
+      resource_id: "E1S01",
+      current_version: 2,
+      versions: [
+        {
+          version: 1,
+          filename: "E1S01_v1.wav",
+          created_at: "2026-02-01T00:00:00Z",
+          file_size: 10,
+          is_current: false,
+          restorable: false,
+          file_url: "/api/v1/files/demo/versions/audio/E1S01_v1.wav",
+        },
+        {
+          version: 2,
+          filename: "E1S01_v2.wav",
+          created_at: "2026-02-01T01:00:00Z",
+          file_size: 12,
+          is_current: true,
+          restorable: true,
+          file_url: "/api/v1/files/demo/versions/audio/E1S01_v2.wav",
+        },
+      ],
+    });
+    const restore = vi.spyOn(API, "restoreVersion").mockResolvedValue({ success: true });
+
+    render(
+      <VersionTimeMachine
+        projectName="demo"
+        resourceType="audio"
+        resourceId="E1S01"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /版本/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "v1" }));
+
+    expect(await screen.findByLabelText("旁白音频版本 v1")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /切换到此版本/ })).not.toBeInTheDocument();
+    expect(restore).not.toHaveBeenCalled();
   });
 
   it("disables version restore while the resource is busy (image_edit in flight)", async () => {

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.test.tsx
@@ -144,7 +144,7 @@ describe("VersionTimeMachine", () => {
     expect(previewImage.parentElement).toHaveClass("h-80");
   });
 
-  it("previews and downloads historical narration audio without offering restore", async () => {
+  it("previews, downloads, and restores historical narration audio", async () => {
     vi.spyOn(API, "getVersions").mockResolvedValue({
       resource_type: "audio",
       resource_id: "E1S01",
@@ -168,14 +168,13 @@ describe("VersionTimeMachine", () => {
         },
       ],
     });
-    const restore = vi.spyOn(API, "restoreVersion");
+    const restore = vi.spyOn(API, "restoreVersion").mockResolvedValue({ success: true });
 
     render(
       <VersionTimeMachine
         projectName="demo"
         resourceType="audio"
         resourceId="E1S01"
-        readOnly
       />,
     );
 
@@ -187,8 +186,10 @@ describe("VersionTimeMachine", () => {
       "/api/v1/files/demo/versions/audio/E1S01_v1.wav",
     );
     expect(screen.getByRole("link", { name: /下载音频/ })).toHaveAttribute("download");
-    expect(screen.queryByRole("button", { name: /切换到此版本/ })).not.toBeInTheDocument();
-    expect(restore).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /切换到此版本/ }));
+    await waitFor(() => {
+      expect(restore).toHaveBeenCalledWith("demo", "audio", "E1S01", 1);
+    });
   });
 
   it("disables version restore while the resource is busy (image_edit in flight)", async () => {

--- a/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
+++ b/frontend/src/components/canvas/timeline/VersionTimeMachine.tsx
@@ -346,7 +346,7 @@ export function VersionTimeMachine({
                         <span className="shrink-0 rounded-full bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium text-indigo-300">
                           {t("current_version_badge")}
                         </span>
-                      ) : !readOnly ? (
+                      ) : !readOnly && selectedInfo.restorable !== false ? (
                         <button
                           type="button"
                           disabled={restoringVersion !== null || busy}

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -51,6 +51,8 @@ class ArtifactKind(StrEnum):
     EPISODE_STORYBOARD = "episode-storyboard"
     EPISODE_VIDEO = "episode-video"
     EPISODE_AUDIO = "episode-audio"
+    EPISODE_SUBTITLE = "episode-subtitle"
+    EPISODE_PRESENTATION = "episode-presentation"
 
 
 class ArtifactStatus(StrEnum):
@@ -124,6 +126,30 @@ class ArtifactManifest:
         self._adapter = adapter
 
     def register(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> bool:
+        if not isinstance(basis, ArtifactBasis):
+            raise TypeError("basis must be an ArtifactBasis")
+        return self.register_descriptor(
+            key,
+            artifact_path=artifact_path,
+            basis=ArtifactBasisDescriptor.from_basis(basis),
+        )
+
+    def register_descriptor(
+        self,
+        key: ArtifactKey,
+        *,
+        artifact_path: str,
+        basis: ArtifactBasisDescriptor,
+    ) -> bool:
+        """Register source evidence frozen before the formal artifact commit.
+
+        Checkpoints and version metadata intentionally carry only strict
+        descriptors. Accepting that portable form avoids reconstructing or
+        guessing the original input payload during resume and restore.
+        """
+
+        if not isinstance(basis, ArtifactBasisDescriptor):
+            raise TypeError("basis must be an ArtifactBasisDescriptor")
         observation = self._adapter.inspect_artifact(artifact_path)
         if observation.blocker is not None:
             raise ArtifactRegistrationError(observation.blocker.detail)
@@ -136,6 +162,36 @@ class ArtifactManifest:
                 basis_digest=basis.digest,
             ),
         )
+
+    def register_descriptor_transactionally(
+        self,
+        key: ArtifactKey,
+        *,
+        artifact_path: str,
+        basis: ArtifactBasisDescriptor,
+    ) -> bool:
+        """Register a descriptor while restoring the exact prior entry on error."""
+
+        if not isinstance(basis, ArtifactBasisDescriptor):
+            raise TypeError("basis must be an ArtifactBasisDescriptor")
+        previous = self._adapter.get_entry(key)
+        expected = ArtifactManifestEntry(
+            artifact_path=_normalize_relative_path(artifact_path),
+            basis_digest=basis.digest,
+        )
+        try:
+            return self.register_descriptor(key, artifact_path=artifact_path, basis=basis)
+        except BaseException:
+            try:
+                current = self._adapter.get_entry(key)
+                if current == expected:
+                    if previous is None:
+                        self._adapter.delete_entry(key)
+                    else:
+                        self._adapter.put_entry(key, previous)
+            except BaseException as rollback_error:
+                raise RuntimeError("artifact basis registration failed and rollback was incomplete") from rollback_error
+            raise
 
     def compare(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> ArtifactComparison:
         observation = self._adapter.inspect_artifact(artifact_path)
@@ -846,9 +902,9 @@ class ArtifactBasisDescriptor:
 
 def compose_video_artifact_basis(
     *,
-    visual: ArtifactBasis,
-    speech: ArtifactBasis | None = None,
-    duration: ArtifactBasis | None = None,
+    visual: ArtifactBasis | ArtifactBasisDescriptor,
+    speech: ArtifactBasis | ArtifactBasisDescriptor | None = None,
+    duration: ArtifactBasis | ArtifactBasisDescriptor | None = None,
 ) -> ArtifactBasis:
     """Compose independently owned video inputs into one manifest basis.
 
@@ -857,27 +913,40 @@ def compose_video_artifact_basis(
     rather than parallel visual/speech/duration artifact states.
     """
 
-    if not isinstance(visual, ArtifactBasis):
-        raise TypeError("visual must be an ArtifactBasis")
-    if speech is not None and not isinstance(speech, ArtifactBasis):
-        raise TypeError("speech must be an ArtifactBasis or null")
-    if duration is not None and not isinstance(duration, ArtifactBasis):
-        raise TypeError("duration must be an ArtifactBasis or null")
+    visual_descriptor = _coerce_artifact_basis_descriptor("visual", visual)
+    speech_descriptor = _coerce_optional_artifact_basis_descriptor("speech", speech)
+    duration_descriptor = _coerce_optional_artifact_basis_descriptor("duration", duration)
     return ArtifactBasis.build(
         "artifact-components/video",
         kind_version=1,
         inputs={
             "components": {
-                "visual": _artifact_basis_descriptor(visual),
-                "speech": _artifact_basis_descriptor(speech) if speech is not None else None,
-                "duration": _artifact_basis_descriptor(duration) if duration is not None else None,
+                "visual": visual_descriptor.to_dict(),
+                "speech": speech_descriptor.to_dict() if speech_descriptor is not None else None,
+                "duration": duration_descriptor.to_dict() if duration_descriptor is not None else None,
             }
         },
     )
 
 
-def _artifact_basis_descriptor(basis: ArtifactBasis) -> dict[str, object]:
-    return ArtifactBasisDescriptor.from_basis(basis).to_dict()
+def _coerce_artifact_basis_descriptor(
+    field: str,
+    value: ArtifactBasis | ArtifactBasisDescriptor,
+) -> ArtifactBasisDescriptor:
+    if isinstance(value, ArtifactBasis):
+        return ArtifactBasisDescriptor.from_basis(value)
+    if isinstance(value, ArtifactBasisDescriptor):
+        return value
+    raise TypeError(f"{field} must be an ArtifactBasis or ArtifactBasisDescriptor")
+
+
+def _coerce_optional_artifact_basis_descriptor(
+    field: str,
+    value: ArtifactBasis | ArtifactBasisDescriptor | None,
+) -> ArtifactBasisDescriptor | None:
+    if value is None:
+        return None
+    return _coerce_artifact_basis_descriptor(field, value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -914,6 +983,18 @@ class ArtifactKey:
         ):
             episode, resource_id = self.components
             valid = type(episode) is int and episode > 0 and isinstance(resource_id, str) and bool(resource_id)
+        elif (
+            self.kind in {ArtifactKind.EPISODE_SUBTITLE, ArtifactKind.EPISODE_PRESENTATION}
+            and len(self.components) == 3
+        ):
+            episode, resource_id, variant = self.components
+            valid = (
+                type(episode) is int
+                and episode > 0
+                and isinstance(resource_id, str)
+                and bool(resource_id)
+                and variant in {"post_production", "use_tts"}
+            )
         if not valid:
             raise ValueError(f"artifact key components do not match {self.kind!r}: {self.components!r}")
 
@@ -956,6 +1037,32 @@ class ArtifactKey:
         return cls(
             ArtifactKind.EPISODE_AUDIO,
             (_episode_number(episode), _non_empty("resource_id", resource_id)),
+        )
+
+    @classmethod
+    def episode_subtitle(cls, episode: int, resource_id: str, variant: str) -> Self:
+        """Identify one rendition variant's mechanical subtitle artifact."""
+
+        return cls(
+            ArtifactKind.EPISODE_SUBTITLE,
+            (
+                _episode_number(episode),
+                _non_empty("resource_id", resource_id),
+                _rendition_variant(variant),
+            ),
+        )
+
+    @classmethod
+    def episode_presentation(cls, episode: int, resource_id: str, variant: str) -> Self:
+        """Identify one independently current final-presentation variant."""
+
+        return cls(
+            ArtifactKind.EPISODE_PRESENTATION,
+            (
+                _episode_number(episode),
+                _non_empty("resource_id", resource_id),
+                _rendition_variant(variant),
+            ),
         )
 
     def encode(self) -> str:
@@ -1006,6 +1113,12 @@ def _non_empty(field: str, value: object) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{field} must be a non-empty string")
     return value
+
+
+def _rendition_variant(value: object) -> str:
+    if value not in {"post_production", "use_tts"}:
+        raise ValueError(f"variant must be 'post_production' or 'use_tts', got {value!r}")
+    return cast(str, value)
 
 
 def _normalize_json(value: object) -> object:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -181,7 +181,7 @@ class ArtifactManifest:
         )
         try:
             return self.register_descriptor(key, artifact_path=artifact_path, basis=basis)
-        except BaseException:
+        except BaseException as original_error:
             try:
                 current = self._adapter.get_entry(key)
                 if current == expected:
@@ -190,6 +190,7 @@ class ArtifactManifest:
                     else:
                         self._adapter.put_entry(key, previous)
             except BaseException as rollback_error:
+                rollback_error.__cause__ = original_error
                 raise RuntimeError("artifact basis registration failed and rollback was incomplete") from rollback_error
             raise
 

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -857,6 +857,31 @@ class ArtifactBasis:
     def normalized_bytes(self) -> bytes:
         return self._normalized
 
+    def to_evidence_dict(self) -> dict[str, object]:
+        """Return the complete canonical basis together with its verified digest."""
+
+        payload = json.loads(self._normalized)
+        if not isinstance(payload, dict):  # pragma: no cover - constructor invariant
+            raise RuntimeError("canonical artifact basis is not an object")
+        return {**payload, "digest": self.digest}
+
+    @classmethod
+    def from_evidence_dict(cls, value: object) -> Self:
+        """Parse complete portable evidence and verify its canonical digest."""
+
+        if not isinstance(value, Mapping) or set(value) != {"kind", "kind_version", "inputs", "digest"}:
+            raise ValueError("artifact basis evidence has an invalid schema")
+        kind = value["kind"]
+        kind_version = value["kind_version"]
+        inputs = value["inputs"]
+        digest = value["digest"]
+        if not isinstance(kind, str) or not isinstance(inputs, Mapping):
+            raise ValueError("artifact basis evidence has invalid canonical inputs")
+        basis = cls(kind, kind_version=cast(int, kind_version), inputs=cast(Mapping[str, object], inputs))
+        if not isinstance(digest, str) or basis.digest != digest:
+            raise ValueError("artifact basis evidence digest does not match its canonical inputs")
+        return basis
+
 
 @dataclass(frozen=True, slots=True)
 class ArtifactBasisDescriptor:

--- a/lib/async_thread.py
+++ b/lib/async_thread.py
@@ -1,0 +1,64 @@
+"""Bridges for non-interruptible synchronous transactions in async workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable, Coroutine
+from typing import Any, Self
+
+
+class EventLoopBridge:
+    """Run an async observation on the captured loop from a worker thread.
+
+    File transactions sometimes need to hold a synchronous cross-process lock
+    while consulting async database-backed state.  The transaction runs in a
+    worker thread and uses this bridge so the observation happens inside the
+    lock-held decision seam without blocking the event loop.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, loop_thread_id: int) -> None:
+        self._loop = loop
+        self._loop_thread_id = loop_thread_id
+
+    @classmethod
+    def capture(cls) -> Self:
+        """Capture the currently running loop and its owner thread."""
+
+        return cls(asyncio.get_running_loop(), threading.get_ident())
+
+    def run[T](self, coroutine: Coroutine[Any, Any, T]) -> T:
+        """Synchronously wait for *coroutine* from a non-loop worker thread."""
+
+        if threading.get_ident() == self._loop_thread_id:
+            coroutine.close()
+            raise RuntimeError("EventLoopBridge.run must be called from a worker thread")
+        if self._loop.is_closed():
+            coroutine.close()
+            raise RuntimeError("captured event loop is closed")
+        return asyncio.run_coroutine_threadsafe(coroutine, self._loop).result()
+
+
+async def run_noninterruptible_sync[**P, T](
+    func: Callable[P, T],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    """Finish one synchronous transaction even if its awaiting task is cancelled.
+
+    A thread cannot be stopped safely after it starts mutating files.  Cancellation
+    is therefore deferred until the caller's normal terminal-state gate can observe
+    the completed result and compensate it when necessary.
+    """
+
+    task = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.done():
+                return task.result()
+
+
+__all__ = ["EventLoopBridge", "run_noninterruptible_sync"]

--- a/lib/async_thread.py
+++ b/lib/async_thread.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, Self
 
 
@@ -39,6 +39,18 @@ class EventLoopBridge:
         return asyncio.run_coroutine_threadsafe(coroutine, self._loop).result()
 
 
+async def run_noninterruptible_async[T](awaitable: Awaitable[T], /) -> T:
+    """Finish one async transaction boundary even if its awaiting task is cancelled."""
+
+    task = asyncio.ensure_future(awaitable)
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.done():
+                return task.result()
+
+
 async def run_noninterruptible_sync[**P, T](
     func: Callable[P, T],
     /,
@@ -52,13 +64,7 @@ async def run_noninterruptible_sync[**P, T](
     the completed result and compensate it when necessary.
     """
 
-    task = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
-    while True:
-        try:
-            return await asyncio.shield(task)
-        except asyncio.CancelledError:
-            if task.done():
-                return task.result()
+    return await run_noninterruptible_async(asyncio.to_thread(func, *args, **kwargs))
 
 
-__all__ = ["EventLoopBridge", "run_noninterruptible_sync"]
+__all__ = ["EventLoopBridge", "run_noninterruptible_async", "run_noninterruptible_sync"]

--- a/lib/generation_admission.py
+++ b/lib/generation_admission.py
@@ -1,0 +1,68 @@
+"""Cross-process admission guard for generation and media selection."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import posixpath
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import portalocker
+
+from lib.app_data_dir import app_data_dir
+
+_POLL_SECONDS = 0.05
+
+
+def _normalized_script_locator(script_file: str) -> str:
+    normalized = posixpath.normpath(script_file.replace("\\", "/"))
+    return normalized.removeprefix("scripts/")
+
+
+def _lock_path(*, project_name: str, script_file: str, resource_id: str) -> Path:
+    identity = json.dumps(
+        [project_name, _normalized_script_locator(script_file), resource_id],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(identity).hexdigest()
+    root = app_data_dir() / ".generation-admission-locks"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{digest}.lock"
+
+
+@asynccontextmanager
+async def generation_admission_lock(
+    *,
+    project_name: str,
+    script_file: str,
+    resource_id: str,
+) -> AsyncIterator[None]:
+    """Serialize task admission with guarded media selection for one unit.
+
+    Non-blocking lock attempts keep the event loop responsive and cancellation
+    safe: no background thread can acquire the lock after the awaiting task has
+    already exited.
+    """
+
+    path = _lock_path(project_name=project_name, script_file=script_file, resource_id=resource_id)
+    handle = path.open("a+b")
+    acquired = False
+    try:
+        while not acquired:
+            try:
+                portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                acquired = True
+            except (portalocker.AlreadyLocked, portalocker.LockException):
+                await asyncio.sleep(_POLL_SECONDS)
+        yield
+    finally:
+        if acquired:
+            portalocker.unlock(handle)
+        handle.close()
+
+
+__all__ = ["generation_admission_lock"]

--- a/lib/generation_admission.py
+++ b/lib/generation_admission.py
@@ -60,9 +60,11 @@ async def generation_admission_lock(
                 await asyncio.sleep(_POLL_SECONDS)
         yield
     finally:
-        if acquired:
-            portalocker.unlock(handle)
-        handle.close()
+        try:
+            if acquired:
+                portalocker.unlock(handle)
+        finally:
+            handle.close()
 
 
 __all__ = ["generation_admission_lock"]

--- a/lib/generation_admission.py
+++ b/lib/generation_admission.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import posixpath
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 
 import portalocker
@@ -17,14 +16,9 @@ from lib.app_data_dir import app_data_dir
 _POLL_SECONDS = 0.05
 
 
-def _normalized_script_locator(script_file: str) -> str:
-    normalized = posixpath.normpath(script_file.replace("\\", "/"))
-    return normalized.removeprefix("scripts/")
-
-
-def _lock_path(*, project_name: str, script_file: str, resource_id: str) -> Path:
+def _lock_path(*, project_name: str, resource_id: str) -> Path:
     identity = json.dumps(
-        [project_name, _normalized_script_locator(script_file), resource_id],
+        [project_name, resource_id],
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
@@ -48,7 +42,9 @@ async def generation_admission_lock(
     already exited.
     """
 
-    path = _lock_path(project_name=project_name, script_file=script_file, resource_id=resource_id)
+    # The script locator is deliberately absent from the key. Rebinding an episode must not let
+    # a new task select the same resource while compensation for the former binding is in flight.
+    path = _lock_path(project_name=project_name, resource_id=resource_id)
     handle = path.open("a+b")
     acquired = False
     try:
@@ -67,4 +63,28 @@ async def generation_admission_lock(
             handle.close()
 
 
-__all__ = ["generation_admission_lock"]
+@contextmanager
+def generation_admission_lock_sync(
+    *,
+    project_name: str,
+    script_file: str,
+    resource_id: str,
+) -> Iterator[None]:
+    """Blocking counterpart for synchronous compensation after the async guard is released."""
+
+    path = _lock_path(project_name=project_name, resource_id=resource_id)
+    handle = path.open("a+b")
+    acquired = False
+    try:
+        portalocker.lock(handle, portalocker.LOCK_EX)
+        acquired = True
+        yield
+    finally:
+        try:
+            if acquired:
+                portalocker.unlock(handle)
+        finally:
+            handle.close()
+
+
+__all__ = ["generation_admission_lock", "generation_admission_lock_sync"]

--- a/lib/generation_admission.py
+++ b/lib/generation_admission.py
@@ -56,7 +56,7 @@ async def generation_admission_lock(
             try:
                 portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
                 acquired = True
-            except (portalocker.AlreadyLocked, portalocker.LockException):
+            except portalocker.AlreadyLocked:
                 await asyncio.sleep(_POLL_SECONDS)
         yield
     finally:

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from lib.db import safe_session_factory
 from lib.db.base import DEFAULT_USER_ID
 from lib.db.repositories.task_repo import TaskRepository
+from lib.generation_admission import generation_admission_lock
 from lib.task_terminal_events import emit_task_terminal_events
 
 if TYPE_CHECKING:
@@ -363,22 +364,36 @@ class GenerationQueue:
                 # Video provider/model is only an advisory claim projection until the worker materializes the
                 # current request and persists its pre-submit checkpoint. Enqueue payload never freezes identity.
 
-        async with self._task_repo() as repo:
-            result = await repo.enqueue(
+        async def _enqueue() -> dict[str, Any]:
+            async with self._task_repo() as repo:
+                return await repo.enqueue(
+                    project_name=project_name,
+                    task_type=task_type,
+                    media_type=media_type,
+                    resource_id=resource_id,
+                    payload=payload,
+                    script_file=script_file,
+                    resource_type=resource_type,
+                    source=source,
+                    dependency_task_id=dependency_task_id,
+                    dependency_group=dependency_group,
+                    dependency_index=dependency_index,
+                    user_id=user_id,
+                    provider_id=provider_id,
+                )
+
+        # Audio restoration observes active TTS/video consumers while holding the
+        # same per-unit admission guard.  Keeping the guard here makes every Web,
+        # Agent, and batch enqueue entry participate without duplicating checks.
+        if task_type in {"tts", "video", "reference_video"} and script_file:
+            async with generation_admission_lock(
                 project_name=project_name,
-                task_type=task_type,
-                media_type=media_type,
-                resource_id=resource_id,
-                payload=payload,
                 script_file=script_file,
-                resource_type=resource_type,
-                source=source,
-                dependency_task_id=dependency_task_id,
-                dependency_group=dependency_group,
-                dependency_index=dependency_index,
-                user_id=user_id,
-                provider_id=provider_id,
-            )
+                resource_id=resource_id,
+            ):
+                result = await _enqueue()
+        else:
+            result = await _enqueue()
         # The unique index intentionally protects one active task per resource. A matching
         # video task is reusable only when its durable narration request facts also match;
         # current TTS evidence and other mutable generation intent are re-read by the worker.

--- a/lib/i18n/en/errors.py
+++ b/lib/i18n/en/errors.py
@@ -362,6 +362,7 @@ MESSAGES = {
     "video_prompt_too_long": "{provider}/{model} accepts prompts of at most {limit} characters but received {count}; the provider would silently truncate the excess, so generation was aborted. Shorten the prompt",
     "video_request_conflicts_with_active_task": "Unit '{resource_id}' already has a video task using different narration delivery options; wait for it to finish or cancel it before retrying.",
     "tts_conflicts_with_active_narrated_video": "Unit '{resource_id}' has an active video task using the current TTS; wait for it to finish or cancel it before regenerating narration.",
+    "audio_restore_conflicts_with_active_task": "Unit '{resource_id}' has narration being generated or consumed by a video task; wait for it to finish or cancel it before switching audio versions.",
     # Agent credentials
     "agent_preset_unknown": "Unknown preset provider: {preset_id}",
     "agent_base_url_required_custom": "base_url is required for custom configuration",

--- a/lib/i18n/vi/errors.py
+++ b/lib/i18n/vi/errors.py
@@ -364,6 +364,7 @@ MESSAGES = {
     "video_prompt_too_long": "{provider}/{model} chỉ chấp nhận câu lệnh tối đa {limit} ký tự nhưng nhận được {count}; phần vượt quá sẽ bị nhà cung cấp cắt bỏ âm thầm nên đã hủy tạo. Hãy rút ngắn câu lệnh",
     "video_request_conflicts_with_active_task": "Đơn vị '{resource_id}' đã có tác vụ video đang xử lý với lựa chọn bàn giao lời dẫn hoặc thời lượng xác nhận khác; hãy đợi tác vụ hoàn tất hoặc hủy rồi thử lại.",
     "tts_conflicts_with_active_narrated_video": "Đơn vị '{resource_id}' có tác vụ video đang dùng TTS hiện tại; hãy đợi tác vụ hoàn tất hoặc hủy trước khi tạo lại lời dẫn.",
+    "audio_restore_conflicts_with_active_task": "Đơn vị '{resource_id}' đang tạo lời dẫn hoặc lời dẫn đang được tác vụ video sử dụng; hãy đợi hoàn tất hoặc hủy trước khi chuyển phiên bản âm thanh.",
     # Agent credentials
     "agent_preset_unknown": "Nhà cung cấp đặt sẵn không xác định: {preset_id}",
     "agent_base_url_required_custom": "Cấu hình tuỳ chỉnh yêu cầu base_url",

--- a/lib/i18n/zh/errors.py
+++ b/lib/i18n/zh/errors.py
@@ -315,6 +315,7 @@ MESSAGES = {
     "video_prompt_too_long": "{provider}/{model} 的提示词最多 {limit} 个字符，当前 {count} 个；超出部分会被供应商静默截断，已中止生成。请缩短提示词",
     "video_request_conflicts_with_active_task": "单元「{resource_id}」已有使用不同旁白交付方式或确认时长的视频任务在处理中；请等待完成或取消任务后重试",
     "tts_conflicts_with_active_narrated_video": "单元「{resource_id}」已有使用当前 TTS 的视频任务在处理中；请等待完成或取消任务后再重新生成旁白",
+    "audio_restore_conflicts_with_active_task": "单元「{resource_id}」的旁白正在生成或被视频任务使用；请等待完成或取消任务后再切换音频版本",
     # Agent credentials
     "agent_preset_unknown": "未知预设供应商: {preset_id}",
     "agent_base_url_required_custom": "自定义配置需要填写 base_url",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from lib.image_backends.base import ImageBackend
     from lib.reference_compression import CompressedRef, PayloadLimits, ReferenceSpec
 
+from lib.async_thread import run_noninterruptible_sync
 from lib.audio_utils import probe_reference_audio_total_seconds
 from lib.db.base import DEFAULT_USER_ID
 from lib.gemini_shared import RateLimiter
@@ -282,25 +283,17 @@ class MediaGenerator:
         compensates a selected result when cancellation already won.
         """
 
-        commit_task = asyncio.create_task(
-            asyncio.to_thread(
-                self._commit_video_output_version_sync,
-                resource_type=resource_type,
-                resource_id=resource_id,
-                prompt=prompt,
-                output_path=output_path,
-                staged_output_path=staged_output_path,
-                duration_seconds=duration_seconds,
-                version_metadata=version_metadata,
-                commit_formal_output=commit_formal_output,
-            )
+        return await run_noninterruptible_sync(
+            self._commit_video_output_version_sync,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            output_path=output_path,
+            staged_output_path=staged_output_path,
+            duration_seconds=duration_seconds,
+            version_metadata=version_metadata,
+            commit_formal_output=commit_formal_output,
         )
-        while True:
-            try:
-                return await asyncio.shield(commit_task)
-            except asyncio.CancelledError:
-                if commit_task.done():
-                    return commit_task.result()
 
     async def _prepare_formal_video_commit(
         self,
@@ -700,7 +693,7 @@ class MediaGenerator:
                     **version_metadata,
                 )
             else:
-                committed = commit(staged_path, output_path)
+                committed = await run_noninterruptible_sync(commit, staged_path, output_path)
                 if isinstance(committed, PaidVersionCommit):
                     version = committed.version
                     selected_current = committed.selected

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -317,7 +317,8 @@ class MediaGenerator:
             await before_formal_commit(staged_output_path, duration_seconds, version_metadata)
         except (Exception, asyncio.CancelledError) as failure:
             try:
-                self.versions.commit_staged_paid_version(
+                await run_noninterruptible_sync(
+                    self.versions.commit_staged_paid_version,
                     resource_type=resource_type,
                     resource_id=resource_id,
                     prompt=prompt,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -38,7 +38,7 @@ from lib.ledger import Ledger
 from lib.path_safety import PathTraversalError, safe_join
 from lib.providers import CallType, require_provider_pair
 from lib.resource_paths import resource_relative_path
-from lib.version_manager import VersionManager
+from lib.version_manager import PaidVersionCommit, VersionManager
 
 logger = logging.getLogger(__name__)
 
@@ -224,28 +224,41 @@ class MediaGenerator:
         staged_output_path: Path | None,
         duration_seconds: int,
         version_metadata: Mapping[str, Any],
-    ) -> int:
+        commit_formal_output: Callable[[Path, Path, int, Mapping[str, Any]], PaidVersionCommit] | None = None,
+    ) -> PaidVersionCommit:
         """Register a normal or resumed video through one identical formal-output commit path."""
 
         if staged_output_path is None:
-            return self.versions.add_version(
-                resource_type=resource_type,
-                resource_id=resource_id,
-                prompt=prompt,
-                source_file=output_path,
-                duration_seconds=duration_seconds,
-                **version_metadata,
+            return PaidVersionCommit(
+                version=self.versions.add_version(
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    prompt=prompt,
+                    source_file=output_path,
+                    duration_seconds=duration_seconds,
+                    **version_metadata,
+                ),
+                selected=True,
             )
         try:
-            return self.versions.commit_staged_version(
+            if commit_formal_output is not None:
+                return commit_formal_output(
+                    staged_output_path,
+                    output_path,
+                    duration_seconds,
+                    version_metadata,
+                )
+            self.versions.commit_staged_paid_version(
                 resource_type=resource_type,
                 resource_id=resource_id,
                 prompt=prompt,
                 staged_file=staged_output_path,
                 current_file=output_path,
+                select_current=False,
                 duration_seconds=duration_seconds,
                 **version_metadata,
             )
+            raise RuntimeError("formal video output requires an artifact commit callback")
         finally:
             staged_output_path.unlink(missing_ok=True)
 
@@ -532,7 +545,7 @@ class MediaGenerator:
         language_type: str = "Chinese",
         speed: float | None = None,
         before_commit: Callable[[Path], Awaitable[None]] | None = None,
-        commit_staged: Callable[[Path, Path], int] | None = None,
+        commit_staged: Callable[[Path, Path], int | PaidVersionCommit] | None = None,
         **version_metadata,
     ) -> tuple[Path, int]:
         """
@@ -600,6 +613,7 @@ class MediaGenerator:
             if before_commit is not None:
                 await before_commit(staged_path)
             commit = commit_staged
+            selected_current = True
             if commit is None:
                 version = self.versions.commit_staged_version(
                     resource_type=resource_type,
@@ -610,8 +624,13 @@ class MediaGenerator:
                     **version_metadata,
                 )
             else:
-                version = commit(staged_path, output_path)
-            if not output_path.is_file():
+                committed = commit(staged_path, output_path)
+                if isinstance(committed, PaidVersionCommit):
+                    version = committed.version
+                    selected_current = committed.selected
+                else:
+                    version = committed
+            if selected_current and not output_path.is_file():
                 raise RuntimeError("audio commit completed without a regular formal output file")
             return output_path, version
         finally:
@@ -687,6 +706,8 @@ class MediaGenerator:
         task_id: str | None = None,
         before_submit: Callable[[int], Awaitable[Mapping[str, object] | None]] | None = None,
         formal_output: bool = False,
+        before_formal_commit: Callable[[Path, int, Mapping[str, Any]], Awaitable[None]] | None = None,
+        commit_formal_output: Callable[[Path, Path, int, Mapping[str, Any]], PaidVersionCommit] | None = None,
         **version_metadata,
     ) -> tuple[Path, int, Any, str | None]:
         """
@@ -814,6 +835,8 @@ class MediaGenerator:
             formal_output=formal_output,
             task_id=task_id,
         )
+        if before_formal_commit is not None and staged_output_path is None:
+            raise ValueError("before_formal_commit requires formal video output")
 
         # video 实际计费时长（result.duration_seconds）覆盖请求时长的语义转写已收进 ledger union
         # 分发（_settlement_from_result），此处仅递交 backend 结果对象。
@@ -916,8 +939,12 @@ class MediaGenerator:
             video_uri = result.video_uri
             call.success(result)
 
+        if before_formal_commit is not None:
+            assert staged_output_path is not None
+            await before_formal_commit(staged_output_path, duration_int, version_metadata)
+
         # 5. 记录新版本
-        new_version = self._commit_video_output_version(
+        committed = self._commit_video_output_version(
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt,
@@ -925,9 +952,10 @@ class MediaGenerator:
             staged_output_path=staged_output_path,
             duration_seconds=duration_int,
             version_metadata=version_metadata,
+            commit_formal_output=commit_formal_output,
         )
 
-        return output_path, new_version, video_ref, video_uri
+        return output_path, committed.version, video_ref, video_uri
 
     async def resume_video_async(
         self,
@@ -943,6 +971,8 @@ class MediaGenerator:
         api_call_id: int | None = None,
         submitted_base_url: str | None = None,
         formal_output: bool = False,
+        before_formal_commit: Callable[[Path, int, Mapping[str, Any]], Awaitable[None]] | None = None,
+        commit_formal_output: Callable[[Path, Path, int, Mapping[str, Any]], PaidVersionCommit] | None = None,
         **version_metadata,
     ) -> tuple[Path, int, Any, str | None]:
         """接续 provider 上已发起的 video job：调 backend.resume_video 而非 generate。
@@ -987,6 +1017,8 @@ class MediaGenerator:
             formal_output=formal_output,
             task_id=task_id,
         )
+        if before_formal_commit is not None and staged_output_path is None:
+            raise ValueError("before_formal_commit requires formal video output")
 
         from lib.video_backends.base import ResumeExpiredError, VideoGenerationRequest
 
@@ -1051,7 +1083,11 @@ class MediaGenerator:
         # - versions.json 空时（submit→poll 中崩）add_version 直接登记 v1，避免下游 versions[-1] IndexError；
         # - versions.json 已有 v_n（覆盖式重新生成）时 add_version 登记 v_(n+1)，避免 output_path
         #   被新内容覆盖却仍报旧版本号导致 versions.json 与磁盘文件错位。
-        new_version = self._commit_video_output_version(
+        if before_formal_commit is not None:
+            assert staged_output_path is not None
+            await before_formal_commit(staged_output_path, duration_int, version_metadata)
+
+        committed = self._commit_video_output_version(
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt,
@@ -1059,6 +1095,7 @@ class MediaGenerator:
             staged_output_path=staged_output_path,
             duration_seconds=duration_int,
             version_metadata=version_metadata,
+            commit_formal_output=commit_formal_output,
         )
 
-        return output_path, new_version, video_ref, video_uri
+        return output_path, committed.version, video_ref, video_uri

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -262,6 +262,42 @@ class MediaGenerator:
         finally:
             staged_output_path.unlink(missing_ok=True)
 
+    async def _prepare_formal_video_commit(
+        self,
+        *,
+        resource_type: str,
+        resource_id: str,
+        prompt: str,
+        output_path: Path,
+        staged_output_path: Path | None,
+        duration_seconds: int,
+        version_metadata: Mapping[str, Any],
+        before_formal_commit: Callable[[Path, int, Mapping[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """Run paid-output validation without losing history when validation aborts."""
+
+        if before_formal_commit is None:
+            return
+        if staged_output_path is None:
+            raise ValueError("before_formal_commit requires formal video output")
+        try:
+            await before_formal_commit(staged_output_path, duration_seconds, version_metadata)
+        except (Exception, asyncio.CancelledError) as failure:
+            try:
+                self.versions.commit_staged_paid_version(
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    prompt=prompt,
+                    staged_file=staged_output_path,
+                    current_file=output_path,
+                    select_current=False,
+                    duration_seconds=duration_seconds,
+                    **version_metadata,
+                )
+            except (Exception, asyncio.CancelledError) as archive_failure:
+                failure.add_note(f"paid video history archival also failed: {archive_failure}")
+            raise
+
     @staticmethod
     def _sync(coro):
         """Run an async coroutine from synchronous code (e.g. inside to_thread)."""
@@ -939,9 +975,16 @@ class MediaGenerator:
             video_uri = result.video_uri
             call.success(result)
 
-        if before_formal_commit is not None:
-            assert staged_output_path is not None
-            await before_formal_commit(staged_output_path, duration_int, version_metadata)
+        await self._prepare_formal_video_commit(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            output_path=output_path,
+            staged_output_path=staged_output_path,
+            duration_seconds=duration_int,
+            version_metadata=version_metadata,
+            before_formal_commit=before_formal_commit,
+        )
 
         # 5. 记录新版本
         committed = self._commit_video_output_version(
@@ -1081,9 +1124,16 @@ class MediaGenerator:
 
         # backend.resume_video 已将付费结果下载到请求路径。正式媒体请求写入 staging，随后由
         # commit callback 在一个受控事务内保存历史并决定是否选中；非正式请求直接追加版本。
-        if before_formal_commit is not None:
-            assert staged_output_path is not None
-            await before_formal_commit(staged_output_path, duration_int, version_metadata)
+        await self._prepare_formal_video_commit(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            output_path=output_path,
+            staged_output_path=staged_output_path,
+            duration_seconds=duration_int,
+            version_metadata=version_metadata,
+            before_formal_commit=before_formal_commit,
+        )
 
         committed = self._commit_video_output_version(
             resource_type=resource_type,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -214,7 +214,7 @@ class MediaGenerator:
         _remove_task_video_staging_path(staged_output_path)
         return staged_output_path, staged_output_path
 
-    def _commit_video_output_version(
+    def _commit_video_output_version_sync(
         self,
         *,
         resource_type: str,
@@ -261,6 +261,46 @@ class MediaGenerator:
             raise RuntimeError("formal video output requires an artifact commit callback")
         finally:
             staged_output_path.unlink(missing_ok=True)
+
+    async def _commit_video_output_version(
+        self,
+        *,
+        resource_type: str,
+        resource_id: str,
+        prompt: str,
+        output_path: Path,
+        staged_output_path: Path | None,
+        duration_seconds: int,
+        version_metadata: Mapping[str, Any],
+        commit_formal_output: Callable[[Path, Path, int, Mapping[str, Any]], PaidVersionCommit] | None = None,
+    ) -> PaidVersionCommit:
+        """Run the shared normal/resume disk transaction without blocking the event loop.
+
+        User cancellation first marks the queue row as cancelling and then cancels
+        this coroutine. The sync transaction cannot be interrupted safely, so wait
+        for its thread before continuing to the queue's terminal row gate; that gate
+        compensates a selected result when cancellation already won.
+        """
+
+        commit_task = asyncio.create_task(
+            asyncio.to_thread(
+                self._commit_video_output_version_sync,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                prompt=prompt,
+                output_path=output_path,
+                staged_output_path=staged_output_path,
+                duration_seconds=duration_seconds,
+                version_metadata=version_metadata,
+                commit_formal_output=commit_formal_output,
+            )
+        )
+        while True:
+            try:
+                return await asyncio.shield(commit_task)
+            except asyncio.CancelledError:
+                if commit_task.done():
+                    return commit_task.result()
 
     async def _prepare_formal_video_commit(
         self,
@@ -987,7 +1027,7 @@ class MediaGenerator:
         )
 
         # 5. 记录新版本
-        committed = self._commit_video_output_version(
+        committed = await self._commit_video_output_version(
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt,
@@ -1135,7 +1175,7 @@ class MediaGenerator:
             before_formal_commit=before_formal_commit,
         )
 
-        committed = self._commit_video_output_version(
+        committed = await self._commit_video_output_version(
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt,

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -1079,10 +1079,8 @@ class MediaGenerator:
                 job_id,
             )
 
-        # backend.resume_video 已下载新视频并覆盖 output_path，必须 bump 一个新版本号：
-        # - versions.json 空时（submit→poll 中崩）add_version 直接登记 v1，避免下游 versions[-1] IndexError；
-        # - versions.json 已有 v_n（覆盖式重新生成）时 add_version 登记 v_(n+1)，避免 output_path
-        #   被新内容覆盖却仍报旧版本号导致 versions.json 与磁盘文件错位。
+        # backend.resume_video 已将付费结果下载到请求路径。正式媒体请求写入 staging，随后由
+        # commit callback 在一个受控事务内保存历史并决定是否选中；非正式请求直接追加版本。
         if before_formal_commit is not None:
             assert staged_output_path is not None
             await before_formal_commit(staged_output_path, duration_int, version_metadata)

--- a/lib/narration_delivery.py
+++ b/lib/narration_delivery.py
@@ -318,6 +318,21 @@ def build_narration_audio_basis(
     text = canonical_narration_text(preparation)
     if not text:
         raise ValueError("narration audio basis requires non-empty narrator text")
+    return build_narration_audio_basis_from_canonical_text(text, settings)
+
+
+def build_narration_audio_basis_from_canonical_text(
+    text: str,
+    settings: TtsSynthesisSettings,
+) -> ArtifactBasis:
+    """Build a TTS basis from already-canonical synthesis facts.
+
+    Version restore uses this seam to verify persisted execution facts without
+    reconstructing a synthetic script unit or duplicating the basis schema.
+    """
+
+    if not text:
+        raise ValueError("narration audio basis requires non-empty canonical text")
     return ArtifactBasis.build(
         "narration-delivery/tts-audio",
         kind_version=1,
@@ -824,6 +839,7 @@ __all__ = [
     "TtsSynthesisSettings",
     "VideoRequestCostFacts",
     "build_narration_audio_basis",
+    "build_narration_audio_basis_from_canonical_text",
     "canonical_narration_text",
     "prepare_current_narration_delivery",
     "prepare_current_narrated_video_duration",

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -359,7 +359,7 @@ class ProjectManager:
     _DELETE_RETRYABLE_ERRNOS = (errno.ENOTEMPTY, errno.EACCES)
 
     def delete_project_directory(self, name: str) -> None:
-        """删除项目目录，容忍并发扫描与本次删除竞态产生的临时性错误。"""
+        """删除项目目录，容忍并发扫描与删除操作竞态产生的临时性错误。"""
         project_dir = self.get_project_path(name)
         attempts = 5
         for attempt in range(attempts):
@@ -673,7 +673,7 @@ class ProjectManager:
         再次获取 `_project_lock`，故已持有项目锁的调用方（见 `locked_episode_script`）须传 False
         以免同进程自死锁。仅写脚本内容、不改 episode 元数据的场景跳过同步无副作用。
 
-        `validate=True`（默认，fail-safe）时按「不更坏」语义做结构校验：仅当本次写入把一个
+        `validate=True`（默认，fail-safe）时按「不更坏」语义做结构校验：仅当待写数据把一个
         原本合法的剧本改成非法时才 `raise ScriptStructureValidationError`，改前就已非法的旧
         剧本照常放行。读-改-写流程（`locked_script` 一族）已持有改前剧本，应作 `before` 传入
         以零额外读盘；直连保存不传 `before`，由本函数按需读盘取改前（无改前则按严格校验）。
@@ -925,7 +925,7 @@ class ProjectManager:
 
     @staticmethod
     def _guard_no_worse(before: dict | None, after: dict) -> None:
-        """「不更坏」守卫：仅当本次写入引入新结构错误时拒绝。
+        """「不更坏」守卫：仅当待写数据引入新结构错误时拒绝。
 
         改后合法 → 放行；改后非法时：改前合法或无改前 → 拒绝（`raise`）；改前已非法 → 放行
         （不为历史遗留背锅）。校验器经函数内延迟 import，打破 project_manager → 校验器 →
@@ -2046,7 +2046,7 @@ class ProjectManager:
         """按 table（characters/scenes/props/products）+ name upsert 资产：不存在则新增、存在则改字段。
 
         在 `update_project` 的单一文件锁内完成 read-modify-write；apply 后、落盘前对结果
-        project dict 做 payload 级结构校验，按**「不更坏」语义**裁决：仅当本次 upsert 把原本
+        project dict 做 payload 级结构校验，按**「不更坏」语义**裁决：仅当该 upsert 把原本
         合法的 project 改成非法时才 raise 且**不落盘**（mutation 抛错时 `update_project` 不执行
         atomic_write）；改前已非法（历史遗留脏数据，如空 `style`）则照常放行——否则带历史问题的
         项目会整条 patch_project 路径不可用（旧 `add_assets.py` 报告校验错误也不阻断写入）。
@@ -2163,7 +2163,7 @@ class ProjectManager:
             # 「不更坏」按 error set diff 判定：after 不应比 before 多任何 errors。
             #   - 改前合法、改后非法 → new_errors=全部 after errors → 拒
             #   - 改前已脏、改后相同脏 → new_errors=∅ → 放行（允许带历史脏数据的项目继续 patch）
-            #   - 改前已脏、改后引入新错误（如本次 entries 缺 description）→ new_errors≠∅ → 拒
+            #   - 改前已脏、改后引入新错误（如 entries 缺 description）→ new_errors≠∅ → 拒
             #   - 改前已脏、改后修复了部分 → new_errors=∅ → 放行（允许 patch 改进历史脏数据）
             # 比单纯比 valid 标志更严：堵住「带历史脏数据的项目里新 entry 的结构错误 piggyback 落盘」。
             new_errors = after_errors - before_errors

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -46,6 +46,7 @@ from lib.asset_types import (
     resolve_asset_key,
     validate_asset_name,
 )
+from lib.audio_utils import discard_stale_reference_audio, resolve_audio_ref_path, resolve_stale_reference_audio
 from lib.episode_ledger import SOURCE_TEXT_SUFFIXES
 from lib.episode_paths import (
     REFERENCE_VIDEO_STEP1_FILENAME,
@@ -1700,14 +1701,32 @@ class ProjectManager:
         mutate_fn: Callable[[dict], None],
         copies: list[tuple[Path, Path]],
     ) -> dict:
-        """在项目锁内把文件替换与 project.json 写回作为一个可回滚事务提交。
+        """在项目锁内把文件复制与 project.json 写回作为一个可回滚事务提交。"""
 
-        ``copies`` 的目标路径必须互不重复；``mutate_fn`` 可在锁内完成最终名称规划并向
-        该列表追加拷贝。回调抛错时不会安装任何文件；
-        所有源文件先完成暂存，再逐个替换目标。安装或 JSON 写回失败时按相反顺序恢复
-        已替换目标，恢复失败仅记录日志并保留原始异常；提交成功后清理备份。
+        return self._update_project_with_files(
+            project_name,
+            mutate_fn,
+            copies=copies,
+        )
+
+    def _update_project_with_files(
+        self,
+        project_name: str,
+        mutate_fn: Callable[[dict], None],
+        *,
+        copies: list[tuple[Path, Path]] | None = None,
+        writes: list[tuple[bytes, Path]] | None = None,
+    ) -> dict:
+        """在项目锁内把文件变更与 project.json 写回作为一个可回滚事务提交。
+
+        ``mutate_fn`` 可在锁内完成最终名称规划并向两个列表追加操作。回调抛错时不会安装
+        任何文件；所有复制/字节写入先完成暂存，再逐个替换目标。安装或 JSON 写回失败时按
+        相反顺序恢复，恢复失败仅记录日志并保留原始异常；提交成功后清理备份。全部目标必须
+        互不重复，避免同一事务内操作顺序产生歧义。
         """
         project_file = self._get_project_file_path(project_name)
+        copies = copies if copies is not None else []
+        writes = writes if writes is not None else []
 
         token = secrets.token_hex(8)
         staged: list[tuple[Path, Path]] = []
@@ -1728,13 +1747,20 @@ class ProjectManager:
 
                 # mutate_fn 可在锁内完成最终名称规划并填充 copies；因此目标唯一性也必须
                 # 在回调之后、仍持有同一把项目锁时校验。
-                destinations = [destination for _source, destination in copies]
-                if len(set(destinations)) != len(destinations):
+                replacement_destinations = [destination for _source, destination in copies] + [
+                    destination for _content, destination in writes
+                ]
+                if len(set(replacement_destinations)) != len(replacement_destinations):
                     raise ValueError("项目文件事务包含重复目标路径")
                 for index, (source, destination) in enumerate(copies):
                     destination.parent.mkdir(parents=True, exist_ok=True)
                     temporary = destination.with_name(f".{destination.name}.{token}-{index}.tmp")
                     shutil.copyfile(source, temporary)
+                    staged.append((temporary, destination))
+                for offset, (content, destination) in enumerate(writes, start=len(staged)):
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    temporary = destination.with_name(f".{destination.name}.{token}-{offset}.tmp")
+                    atomic_write_bytes(temporary, content)
                     staged.append((temporary, destination))
 
                 for index, (temporary, destination) in enumerate(staged):
@@ -2499,11 +2525,105 @@ class ProjectManager:
         """
 
         def _mutate(project: dict) -> None:
+            self._set_character_reference_audio(project, char_name, ref_path)
+
+        return self.update_project(project_name, _mutate)
+
+    @staticmethod
+    def _set_character_reference_audio(project: dict, char_name: str, ref_path: str) -> None:
+        key = resolve_asset_key(project.get("characters"), char_name)
+        if key is None:
+            raise KeyError(f"角色 '{char_name}' 不存在")
+        project["characters"][key]["reference_audio"] = ref_path
+        project["characters"][key]["voice_updated_at"] = datetime.now(UTC).isoformat()
+
+    def install_character_reference_audio(
+        self,
+        project_name: str,
+        char_name: str,
+        ref_path: str,
+        content: bytes,
+    ) -> dict:
+        """Atomically install reference-audio bytes and point the character at them.
+
+        Video currency selection hashes reference-audio bytes while holding the project lock.  Keeping every
+        physical replacement in that same lock makes the project pointer and the bytes one coherent input snapshot.
+        A replaced file with a different extension is best-effort cleanup after the new pointer commits; it is no
+        longer an input then, so cleanup does not need to prolong the selection-critical section.
+        """
+
+        project_dir = self.get_project_path(project_name)
+        refs_audio_dir = project_dir / "characters" / "refs_audio"
+        target = Path(self._safe_subpath(project_dir, ref_path))
+        if os.path.realpath(target.parent) != os.path.realpath(refs_audio_dir):
+            raise ValueError("reference audio target must be inside characters/refs_audio")
+        stale_audio: Path | None = None
+
+        def _mutate(project: dict) -> None:
+            nonlocal stale_audio
             key = resolve_asset_key(project.get("characters"), char_name)
             if key is None:
                 raise KeyError(f"角色 '{char_name}' 不存在")
-            project["characters"][key]["reference_audio"] = ref_path
-            project["characters"][key]["voice_updated_at"] = datetime.now(UTC).isoformat()
+            old_audio = project["characters"][key].get("reference_audio")
+            stale_audio = resolve_stale_reference_audio(project_dir, refs_audio_dir, old_audio, target)
+            self._set_character_reference_audio(project, char_name, ref_path)
+
+        project = self._update_project_with_files(
+            project_name,
+            _mutate,
+            writes=[(content, target)],
+        )
+        self._discard_stale_reference_audio_if_unreferenced(project_name, stale_audio)
+        return project
+
+    def _discard_stale_reference_audio_if_unreferenced(
+        self,
+        project_name: str,
+        stale_audio: Path | None,
+    ) -> None:
+        """Best-effort cleanup that cannot delete a newer concurrent selection of the same path."""
+
+        if stale_audio is None:
+            return
+        project_dir = self.get_project_path(project_name)
+        refs_audio_dir = project_dir / "characters" / "refs_audio"
+        stale_identity = os.path.realpath(stale_audio)
+        with self._project_lock(project_name):
+            project = self._read_project_raw_unlocked(project_name)
+            characters = project.get("characters")
+            if isinstance(characters, dict):
+                for character in characters.values():
+                    if not isinstance(character, dict):
+                        continue
+                    reference_audio = character.get("reference_audio")
+                    current = resolve_audio_ref_path(
+                        project_dir,
+                        refs_audio_dir,
+                        reference_audio if isinstance(reference_audio, str) else None,
+                    )
+                    if current is not None and os.path.realpath(current) == stale_identity:
+                        return
+            discard_stale_reference_audio(stale_audio)
+
+    def clear_character_reference_audio(self, project_name: str, char_name: str) -> dict:
+        """Remove the referenced audio file and clear its pointer under the shared project lock."""
+
+        project_dir = self.get_project_path(project_name)
+        refs_audio_dir = project_dir / "characters" / "refs_audio"
+
+        def _mutate(project: dict) -> None:
+            key = resolve_asset_key(project.get("characters"), char_name)
+            if key is None:
+                raise KeyError(f"角色 '{char_name}' 不存在")
+            old_audio = project["characters"][key].get("reference_audio")
+            stale = resolve_audio_ref_path(
+                project_dir,
+                refs_audio_dir,
+                old_audio if isinstance(old_audio, str) else None,
+            )
+            if stale is not None:
+                stale.unlink(missing_ok=True)
+            self._set_character_reference_audio(project, char_name, "")
 
         return self.update_project(project_name, _mutate)
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -123,6 +123,30 @@ def find_episode(project: dict[str, Any], episode: int | None) -> dict[str, Any]
     return None
 
 
+def resolve_episode_script_binding(
+    project: dict[str, Any],
+    episode: int,
+    expected_script_file: str,
+) -> str | None:
+    """Return the live binding when it still denotes the expected episode script.
+
+    Legacy projects without an ``episodes`` index use the submitted script as
+    their binding. Indexed projects must retain a matching normalized binding;
+    a missing episode or a concurrent rebind returns ``None``.
+    """
+
+    entry = find_episode(project, episode)
+    current_binding = entry.get("script_file") if isinstance(entry, dict) else None
+    if current_binding is None and not (project.get("episodes") or []):
+        return expected_script_file
+    if isinstance(current_binding, str) and (
+        ProjectManager.normalize_script_filename(current_binding)
+        == ProjectManager.normalize_script_filename(expected_script_file)
+    ):
+        return current_binding
+    return None
+
+
 def is_reference_video_project(project: Mapping[str, Any]) -> bool:
     """项目是否走参考生视频路线。
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -2606,26 +2606,28 @@ class ProjectManager:
             discard_stale_reference_audio(stale_audio)
 
     def clear_character_reference_audio(self, project_name: str, char_name: str) -> dict:
-        """Remove the referenced audio file and clear its pointer under the shared project lock."""
+        """Clear the reference first, then best-effort delete the now-unreferenced audio file."""
 
         project_dir = self.get_project_path(project_name)
         refs_audio_dir = project_dir / "characters" / "refs_audio"
+        stale_audio: Path | None = None
 
         def _mutate(project: dict) -> None:
+            nonlocal stale_audio
             key = resolve_asset_key(project.get("characters"), char_name)
             if key is None:
                 raise KeyError(f"角色 '{char_name}' 不存在")
             old_audio = project["characters"][key].get("reference_audio")
-            stale = resolve_audio_ref_path(
+            stale_audio = resolve_audio_ref_path(
                 project_dir,
                 refs_audio_dir,
                 old_audio if isinstance(old_audio, str) else None,
             )
-            if stale is not None:
-                stale.unlink(missing_ok=True)
             self._set_character_reference_audio(project, char_name, "")
 
-        return self.update_project(project_name, _mutate)
+        project = self.update_project(project_name, _mutate)
+        self._discard_stale_reference_audio_if_unreferenced(project_name, stale_audio)
+        return project
 
     def get_project_character(self, project_name: str, name: str) -> dict:
         """获取项目级角色定义"""

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -780,6 +780,26 @@ class ProjectManager:
             yield script
             self._write_script_unlocked(project_name, script, norm, validate=validate, before=before)
 
+    @contextmanager
+    def locked_project_script_snapshot(self, project_name: str, script_filename: str):
+        """Yield a read-only project/script snapshot under the canonical write locks.
+
+        Artifact selection must compare execution-frozen inputs with one coherent
+        current snapshot, but a read-only comparison must not rewrite the script
+        or touch project metadata.  The lock order mirrors
+        :meth:`locked_episode_script` (script, then project), so callers can keep
+        the comparison and a guarded downstream commit serialized with both
+        source edit paths.
+        """
+
+        norm = self.normalize_script_filename(script_filename)
+        with self._script_lock(project_name, norm):
+            with self._project_lock(project_name):
+                project = self._read_project_raw_unlocked(project_name)
+                self._migrate_legacy_style(project)
+                script, _migrated = self._read_script_unlocked(project_name, norm)
+                yield project, script
+
     def _read_project_raw_unlocked(self, project_name: str) -> dict:
         """裸读 project.json（不取锁、不迁移）。仅供已持 `_project_lock` 的复核调用。"""
         project_file = self._get_project_file_path(project_name)

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -18,7 +18,8 @@ from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal, Self, cast
 
-from lib.artifact_manifest import ArtifactBasisDescriptor
+from lib.artifact_manifest import ArtifactBasisDescriptor, compose_video_artifact_basis
+from lib.asset_types import asset_name_comparison_key
 from lib.json_io import atomic_write_json, load_json
 from lib.path_safety import safe_join
 
@@ -27,7 +28,8 @@ logger = logging.getLogger(__name__)
 ProviderMediaRole = Literal["reference_image", "reference_audio", "start_image", "end_image"]
 ReferenceCapability = Literal["i2v", "r2v"]
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
+_VISUAL_BASIS_SCHEMA_VERSION = 2
 _LEGACY_SCHEMA_VERSION = 1
 _CHECKPOINT_KIND = "reference_video_submit"
 _STORYBOARD_CHECKPOINT_KIND = "storyboard_video_submit"
@@ -551,7 +553,14 @@ class _VideoSubmissionCheckpoint:
     service_tier: str
     seed: int | None
     visual_basis_digest: str
+    artifact_episode: int | None
     artifact_visual_basis: ArtifactBasisDescriptor | None
+    artifact_speech_basis: ArtifactBasisDescriptor | None
+    artifact_duration_basis: ArtifactBasisDescriptor | None
+    artifact_video_basis: ArtifactBasisDescriptor | None
+    artifact_voice_style_speakers: tuple[str, ...]
+    artifact_duration_tiers: tuple[int, ...]
+    artifact_reference_image_limit: int | None
     narration: NarrationExecutionFacts
     media: tuple[StagedProviderMedia, ...]
     reference_audio_targets: tuple[int, ...] | None
@@ -586,13 +595,22 @@ class _VideoSubmissionCheckpoint:
             "request_digest",
         }
     )
-    _FIELDS = _LEGACY_FIELDS | {"artifact_visual_basis"}
+    _VISUAL_BASIS_FIELDS = _LEGACY_FIELDS | {"artifact_visual_basis"}
+    _FIELDS = _VISUAL_BASIS_FIELDS | {
+        "artifact_episode",
+        "artifact_speech_basis",
+        "artifact_duration_basis",
+        "artifact_video_basis",
+        "artifact_voice_style_speakers",
+        "artifact_duration_tiers",
+        "artifact_reference_image_limit",
+    }
 
     def __post_init__(self) -> None:
         if (
             not isinstance(self.schema_version, int)
             or isinstance(self.schema_version, bool)
-            or self.schema_version not in {_LEGACY_SCHEMA_VERSION, _SCHEMA_VERSION}
+            or self.schema_version not in {_LEGACY_SCHEMA_VERSION, _VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}
             or self.kind != self.CHECKPOINT_KIND
         ):
             raise ValueError("unsupported video submission checkpoint version or kind")
@@ -626,13 +644,64 @@ class _VideoSubmissionCheckpoint:
         if self.seed is not None and (not isinstance(self.seed, int) or isinstance(self.seed, bool)):
             raise ValueError("seed must be an integer or null")
         _require_basis_digest(self.visual_basis_digest, "visual_basis_digest")
-        if self.schema_version == _SCHEMA_VERSION:
+        if self.schema_version in {_VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}:
             if not isinstance(self.artifact_visual_basis, ArtifactBasisDescriptor):
                 raise ValueError("artifact_visual_basis must be a strict artifact basis descriptor")
             if self.artifact_visual_basis.kind != self.ARTIFACT_VISUAL_BASIS_KIND:
                 raise ValueError("artifact_visual_basis kind does not match checkpoint kind")
         elif self.artifact_visual_basis is not None:
             raise ValueError("legacy checkpoint cannot carry artifact_visual_basis")
+        if self.schema_version == _SCHEMA_VERSION:
+            if type(self.artifact_episode) is not int or self.artifact_episode < 1:
+                raise ValueError("artifact_episode must be a positive integer")
+            if not isinstance(self.artifact_speech_basis, ArtifactBasisDescriptor):
+                raise ValueError("artifact_speech_basis must be a strict artifact basis descriptor")
+            if self.artifact_speech_basis.kind != "artifact-speech/video":
+                raise ValueError("artifact_speech_basis kind does not describe video speech")
+            if not isinstance(self.artifact_duration_basis, ArtifactBasisDescriptor):
+                raise ValueError("artifact_duration_basis must be a strict artifact basis descriptor")
+            if self.artifact_duration_basis.kind != "artifact-speech/video-duration":
+                raise ValueError("artifact_duration_basis kind does not describe a video duration tier")
+            if not isinstance(self.artifact_video_basis, ArtifactBasisDescriptor):
+                raise ValueError("artifact_video_basis must be a strict artifact basis descriptor")
+            expected_video = ArtifactBasisDescriptor.from_basis(
+                compose_video_artifact_basis(
+                    visual=cast(ArtifactBasisDescriptor, self.artifact_visual_basis),
+                    speech=self.artifact_speech_basis,
+                    duration=self.artifact_duration_basis,
+                )
+            )
+            if self.artifact_video_basis != expected_video:
+                raise ValueError("artifact_video_basis does not compose the checkpoint components")
+            if any(
+                not isinstance(speaker, str) or not speaker or asset_name_comparison_key(speaker) != speaker
+                for speaker in self.artifact_voice_style_speakers
+            ):
+                raise ValueError("artifact_voice_style_speakers must contain canonical non-empty names")
+            if len(set(self.artifact_voice_style_speakers)) != len(self.artifact_voice_style_speakers):
+                raise ValueError("artifact_voice_style_speakers must be unique")
+            if (
+                not self.artifact_duration_tiers
+                or tuple(sorted(set(self.artifact_duration_tiers))) != self.artifact_duration_tiers
+                or any(type(tier) is not int or tier <= 0 for tier in self.artifact_duration_tiers)
+                or self.duration_seconds not in self.artifact_duration_tiers
+            ):
+                raise ValueError("artifact_duration_tiers must be sorted positive tiers containing the request tier")
+            limit = self.artifact_reference_image_limit
+            if limit is not None and (type(limit) is not int or limit < 0):
+                raise ValueError("artifact_reference_image_limit must be a non-negative integer or null")
+            if self.kind == _STORYBOARD_CHECKPOINT_KIND and limit is not None:
+                raise ValueError("storyboard checkpoint cannot carry an artifact reference-image limit")
+        elif (
+            self.artifact_episode is not None
+            or self.artifact_speech_basis is not None
+            or self.artifact_duration_basis is not None
+            or self.artifact_video_basis is not None
+            or self.artifact_voice_style_speakers
+            or self.artifact_duration_tiers
+            or self.artifact_reference_image_limit is not None
+        ):
+            raise ValueError("older checkpoint cannot carry complete artifact currency facts")
         if tuple(item.index for item in self.media) != tuple(range(len(self.media))):
             raise ValueError("provider media indexes must be contiguous and ordered")
         expected_prefix = f".arcreel/tasks/{self.task_id}/provider_media/"
@@ -699,6 +768,22 @@ class _VideoSubmissionCheckpoint:
         }
         if self.artifact_visual_basis is not None:
             payload["artifact_visual_basis"] = self.artifact_visual_basis.to_dict()
+        if self.schema_version == _SCHEMA_VERSION:
+            assert self.artifact_episode is not None
+            assert self.artifact_speech_basis is not None
+            assert self.artifact_duration_basis is not None
+            assert self.artifact_video_basis is not None
+            payload.update(
+                {
+                    "artifact_episode": self.artifact_episode,
+                    "artifact_speech_basis": self.artifact_speech_basis.to_dict(),
+                    "artifact_duration_basis": self.artifact_duration_basis.to_dict(),
+                    "artifact_video_basis": self.artifact_video_basis.to_dict(),
+                    "artifact_voice_style_speakers": list(self.artifact_voice_style_speakers),
+                    "artifact_duration_tiers": list(self.artifact_duration_tiers),
+                    "artifact_reference_image_limit": self.artifact_reference_image_limit,
+                }
+            )
         return payload
 
     def _request_digest_payload(self) -> dict[str, object]:
@@ -708,7 +793,17 @@ class _VideoSubmissionCheckpoint:
         del payload["api_call_id"]
         # Artifact currency is independent source evidence, not part of provider
         # execution identity. Keep the existing request digest's meaning stable.
-        payload.pop("artifact_visual_basis", None)
+        for field in (
+            "artifact_episode",
+            "artifact_visual_basis",
+            "artifact_speech_basis",
+            "artifact_duration_basis",
+            "artifact_video_basis",
+            "artifact_voice_style_speakers",
+            "artifact_duration_tiers",
+            "artifact_reference_image_limit",
+        ):
+            payload.pop(field, None)
         return payload
 
     def to_dict(self) -> dict[str, object]:
@@ -739,7 +834,14 @@ class _VideoSubmissionCheckpoint:
         service_tier: str,
         seed: int | None,
         visual_basis_digest: str,
+        artifact_episode: int,
         artifact_visual_basis: ArtifactBasisDescriptor,
+        artifact_speech_basis: ArtifactBasisDescriptor,
+        artifact_duration_basis: ArtifactBasisDescriptor,
+        artifact_video_basis: ArtifactBasisDescriptor,
+        artifact_voice_style_speakers: tuple[str, ...],
+        artifact_duration_tiers: tuple[int, ...],
+        artifact_reference_image_limit: int | None,
         narration: NarrationExecutionFacts,
         media: tuple[StagedProviderMedia, ...],
         reference_audio_targets: tuple[int, ...] | None,
@@ -767,13 +869,33 @@ class _VideoSubmissionCheckpoint:
             "service_tier": service_tier,
             "seed": seed,
             "visual_basis_digest": visual_basis_digest,
+            "artifact_episode": artifact_episode,
             "artifact_visual_basis": artifact_visual_basis.to_dict(),
+            "artifact_speech_basis": artifact_speech_basis.to_dict(),
+            "artifact_duration_basis": artifact_duration_basis.to_dict(),
+            "artifact_video_basis": artifact_video_basis.to_dict(),
+            "artifact_voice_style_speakers": list(artifact_voice_style_speakers),
+            "artifact_duration_tiers": list(artifact_duration_tiers),
+            "artifact_reference_image_limit": artifact_reference_image_limit,
             "narration": narration.to_dict(),
             "media": [item.to_dict() for item in media],
             "reference_audio_targets": list(reference_audio_targets) if reference_audio_targets is not None else None,
         }
         digest_values = {
-            key: value for key, value in values.items() if key not in {"api_call_id", "artifact_visual_basis"}
+            key: value
+            for key, value in values.items()
+            if key
+            not in {
+                "api_call_id",
+                "artifact_episode",
+                "artifact_visual_basis",
+                "artifact_speech_basis",
+                "artifact_duration_basis",
+                "artifact_video_basis",
+                "artifact_voice_style_speakers",
+                "artifact_duration_tiers",
+                "artifact_reference_image_limit",
+            }
         }
         request_digest = _sha256_bytes(_canonical_json(digest_values).encode("utf-8"))
         return cls(
@@ -798,7 +920,14 @@ class _VideoSubmissionCheckpoint:
             service_tier=service_tier,
             seed=seed,
             visual_basis_digest=visual_basis_digest,
+            artifact_episode=artifact_episode,
             artifact_visual_basis=artifact_visual_basis,
+            artifact_speech_basis=artifact_speech_basis,
+            artifact_duration_basis=artifact_duration_basis,
+            artifact_video_basis=artifact_video_basis,
+            artifact_voice_style_speakers=artifact_voice_style_speakers,
+            artifact_duration_tiers=artifact_duration_tiers,
+            artifact_reference_image_limit=artifact_reference_image_limit,
             narration=narration,
             media=media,
             reference_audio_targets=reference_audio_targets,
@@ -817,11 +946,21 @@ class _VideoSubmissionCheckpoint:
             raise ValueError("execution checkpoint must be a JSON object")
         raw = cast(dict[str, Any], decoded)
         schema_version = raw.get("schema_version")
-        if type(schema_version) is not int or schema_version not in {_LEGACY_SCHEMA_VERSION, _SCHEMA_VERSION}:
+        if type(schema_version) is not int or schema_version not in {
+            _LEGACY_SCHEMA_VERSION,
+            _VISUAL_BASIS_SCHEMA_VERSION,
+            _SCHEMA_VERSION,
+        }:
             raise ValueError("unsupported video submission checkpoint version or kind")
         _require_exact_keys(
             raw,
-            cls._LEGACY_FIELDS if schema_version == _LEGACY_SCHEMA_VERSION else cls._FIELDS,
+            (
+                cls._LEGACY_FIELDS
+                if schema_version == _LEGACY_SCHEMA_VERSION
+                else cls._VISUAL_BASIS_FIELDS
+                if schema_version == _VISUAL_BASIS_SCHEMA_VERSION
+                else cls._FIELDS
+            ),
             "checkpoint",
         )
         targets = raw["reference_audio_targets"]
@@ -830,6 +969,12 @@ class _VideoSubmissionCheckpoint:
         media = raw["media"]
         if not isinstance(media, list):
             raise ValueError("checkpoint media must be an array")
+        voice_style_speakers = raw.get("artifact_voice_style_speakers", [])
+        if not isinstance(voice_style_speakers, list):
+            raise ValueError("artifact_voice_style_speakers must be an array")
+        duration_tiers = raw.get("artifact_duration_tiers", [])
+        if not isinstance(duration_tiers, list):
+            raise ValueError("artifact_duration_tiers must be an array")
         return cls(
             schema_version=raw["schema_version"],
             kind=raw["kind"],
@@ -852,11 +997,30 @@ class _VideoSubmissionCheckpoint:
             service_tier=raw["service_tier"],
             seed=raw["seed"],
             visual_basis_digest=raw["visual_basis_digest"],
+            artifact_episode=raw.get("artifact_episode"),
             artifact_visual_basis=(
                 ArtifactBasisDescriptor.from_dict(raw["artifact_visual_basis"])
+                if schema_version in {_VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}
+                else None
+            ),
+            artifact_speech_basis=(
+                ArtifactBasisDescriptor.from_dict(raw["artifact_speech_basis"])
                 if schema_version == _SCHEMA_VERSION
                 else None
             ),
+            artifact_duration_basis=(
+                ArtifactBasisDescriptor.from_dict(raw["artifact_duration_basis"])
+                if schema_version == _SCHEMA_VERSION
+                else None
+            ),
+            artifact_video_basis=(
+                ArtifactBasisDescriptor.from_dict(raw["artifact_video_basis"])
+                if schema_version == _SCHEMA_VERSION
+                else None
+            ),
+            artifact_voice_style_speakers=tuple(voice_style_speakers),
+            artifact_duration_tiers=tuple(duration_tiers),
+            artifact_reference_image_limit=raw.get("artifact_reference_image_limit"),
             narration=NarrationExecutionFacts.from_dict(raw["narration"]),
             media=tuple(StagedProviderMedia.from_dict(item) for item in media),
             reference_audio_targets=tuple(targets) if targets is not None else None,
@@ -913,6 +1077,21 @@ def checkpoint_version_metadata(checkpoint: VideoSubmissionCheckpoint) -> dict[s
     }
     if checkpoint.artifact_visual_basis is not None:
         metadata["artifact_visual_basis"] = checkpoint.artifact_visual_basis.to_dict()
+    if checkpoint.artifact_video_basis is not None:
+        assert checkpoint.artifact_episode is not None
+        assert checkpoint.artifact_speech_basis is not None
+        assert checkpoint.artifact_duration_basis is not None
+        metadata.update(
+            {
+                "artifact_episode": checkpoint.artifact_episode,
+                "artifact_speech_basis": checkpoint.artifact_speech_basis.to_dict(),
+                "artifact_duration_basis": checkpoint.artifact_duration_basis.to_dict(),
+                "artifact_video_basis": checkpoint.artifact_video_basis.to_dict(),
+                "artifact_voice_style_speakers": list(checkpoint.artifact_voice_style_speakers),
+                "artifact_duration_tiers": list(checkpoint.artifact_duration_tiers),
+                "artifact_reference_image_limit": checkpoint.artifact_reference_image_limit,
+            }
+        )
     return metadata
 
 

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -18,10 +18,10 @@ from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal, Self, cast
 
-from lib.artifact_manifest import ArtifactBasisDescriptor, compose_video_artifact_basis
-from lib.asset_types import asset_name_comparison_key
+from lib.artifact_manifest import ArtifactBasisDescriptor
 from lib.json_io import atomic_write_json, load_json
 from lib.path_safety import safe_join
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 logger = logging.getLogger(__name__)
 
@@ -553,14 +553,8 @@ class _VideoSubmissionCheckpoint:
     service_tier: str
     seed: int | None
     visual_basis_digest: str
-    artifact_episode: int | None
-    artifact_visual_basis: ArtifactBasisDescriptor | None
-    artifact_speech_basis: ArtifactBasisDescriptor | None
-    artifact_duration_basis: ArtifactBasisDescriptor | None
-    artifact_video_basis: ArtifactBasisDescriptor | None
-    artifact_voice_style_speakers: tuple[str, ...]
-    artifact_duration_tiers: tuple[int, ...]
-    artifact_reference_image_limit: int | None
+    legacy_artifact_visual_basis: ArtifactBasisDescriptor | None
+    artifact_currency: VideoArtifactCurrencyFacts | None
     narration: NarrationExecutionFacts
     media: tuple[StagedProviderMedia, ...]
     reference_audio_targets: tuple[int, ...] | None
@@ -596,15 +590,41 @@ class _VideoSubmissionCheckpoint:
         }
     )
     _VISUAL_BASIS_FIELDS = _LEGACY_FIELDS | {"artifact_visual_basis"}
-    _FIELDS = _VISUAL_BASIS_FIELDS | {
-        "artifact_episode",
-        "artifact_speech_basis",
-        "artifact_duration_basis",
-        "artifact_video_basis",
-        "artifact_voice_style_speakers",
-        "artifact_duration_tiers",
-        "artifact_reference_image_limit",
-    }
+    _FIELDS = _LEGACY_FIELDS | {"artifact_currency"}
+
+    @property
+    def artifact_episode(self) -> int | None:
+        return self.artifact_currency.episode if self.artifact_currency is not None else None
+
+    @property
+    def artifact_visual_basis(self) -> ArtifactBasisDescriptor | None:
+        if self.artifact_currency is not None:
+            return self.artifact_currency.visual_descriptor
+        return self.legacy_artifact_visual_basis
+
+    @property
+    def artifact_speech_basis(self) -> ArtifactBasisDescriptor | None:
+        return self.artifact_currency.speech_descriptor if self.artifact_currency is not None else None
+
+    @property
+    def artifact_duration_basis(self) -> ArtifactBasisDescriptor | None:
+        return self.artifact_currency.duration_descriptor if self.artifact_currency is not None else None
+
+    @property
+    def artifact_video_basis(self) -> ArtifactBasisDescriptor | None:
+        return self.artifact_currency.video_descriptor if self.artifact_currency is not None else None
+
+    @property
+    def artifact_voice_style_speakers(self) -> tuple[str, ...]:
+        return self.artifact_currency.voice_style_speakers if self.artifact_currency is not None else ()
+
+    @property
+    def artifact_duration_tiers(self) -> tuple[int, ...]:
+        return self.artifact_currency.duration_tiers if self.artifact_currency is not None else ()
+
+    @property
+    def artifact_reference_image_limit(self) -> int | None:
+        return self.artifact_currency.reference_image_limit if self.artifact_currency is not None else None
 
     def __post_init__(self) -> None:
         if (
@@ -644,63 +664,21 @@ class _VideoSubmissionCheckpoint:
         if self.seed is not None and (not isinstance(self.seed, int) or isinstance(self.seed, bool)):
             raise ValueError("seed must be an integer or null")
         _require_basis_digest(self.visual_basis_digest, "visual_basis_digest")
-        if self.schema_version in {_VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}:
-            if not isinstance(self.artifact_visual_basis, ArtifactBasisDescriptor):
+        if self.schema_version == _VISUAL_BASIS_SCHEMA_VERSION:
+            if not isinstance(self.legacy_artifact_visual_basis, ArtifactBasisDescriptor):
                 raise ValueError("artifact_visual_basis must be a strict artifact basis descriptor")
-            if self.artifact_visual_basis.kind != self.ARTIFACT_VISUAL_BASIS_KIND:
+            if self.legacy_artifact_visual_basis.kind != self.ARTIFACT_VISUAL_BASIS_KIND:
                 raise ValueError("artifact_visual_basis kind does not match checkpoint kind")
-        elif self.artifact_visual_basis is not None:
-            raise ValueError("legacy checkpoint cannot carry artifact_visual_basis")
+        elif self.legacy_artifact_visual_basis is not None:
+            raise ValueError("checkpoint schema cannot carry a legacy artifact_visual_basis")
         if self.schema_version == _SCHEMA_VERSION:
-            if type(self.artifact_episode) is not int or self.artifact_episode < 1:
-                raise ValueError("artifact_episode must be a positive integer")
-            if not isinstance(self.artifact_speech_basis, ArtifactBasisDescriptor):
-                raise ValueError("artifact_speech_basis must be a strict artifact basis descriptor")
-            if self.artifact_speech_basis.kind != "artifact-speech/video":
-                raise ValueError("artifact_speech_basis kind does not describe video speech")
-            if not isinstance(self.artifact_duration_basis, ArtifactBasisDescriptor):
-                raise ValueError("artifact_duration_basis must be a strict artifact basis descriptor")
-            if self.artifact_duration_basis.kind != "artifact-speech/video-duration":
-                raise ValueError("artifact_duration_basis kind does not describe a video duration tier")
-            if not isinstance(self.artifact_video_basis, ArtifactBasisDescriptor):
-                raise ValueError("artifact_video_basis must be a strict artifact basis descriptor")
-            expected_video = ArtifactBasisDescriptor.from_basis(
-                compose_video_artifact_basis(
-                    visual=cast(ArtifactBasisDescriptor, self.artifact_visual_basis),
-                    speech=self.artifact_speech_basis,
-                    duration=self.artifact_duration_basis,
-                )
-            )
-            if self.artifact_video_basis != expected_video:
-                raise ValueError("artifact_video_basis does not compose the checkpoint components")
-            if any(
-                not isinstance(speaker, str) or not speaker or asset_name_comparison_key(speaker) != speaker
-                for speaker in self.artifact_voice_style_speakers
-            ):
-                raise ValueError("artifact_voice_style_speakers must contain canonical non-empty names")
-            if len(set(self.artifact_voice_style_speakers)) != len(self.artifact_voice_style_speakers):
-                raise ValueError("artifact_voice_style_speakers must be unique")
-            if (
-                not self.artifact_duration_tiers
-                or tuple(sorted(set(self.artifact_duration_tiers))) != self.artifact_duration_tiers
-                or any(type(tier) is not int or tier <= 0 for tier in self.artifact_duration_tiers)
-                or self.duration_seconds not in self.artifact_duration_tiers
-            ):
-                raise ValueError("artifact_duration_tiers must be sorted positive tiers containing the request tier")
-            limit = self.artifact_reference_image_limit
-            if limit is not None and (type(limit) is not int or limit < 0):
-                raise ValueError("artifact_reference_image_limit must be a non-negative integer or null")
-            if self.kind == _STORYBOARD_CHECKPOINT_KIND and limit is not None:
-                raise ValueError("storyboard checkpoint cannot carry an artifact reference-image limit")
-        elif (
-            self.artifact_episode is not None
-            or self.artifact_speech_basis is not None
-            or self.artifact_duration_basis is not None
-            or self.artifact_video_basis is not None
-            or self.artifact_voice_style_speakers
-            or self.artifact_duration_tiers
-            or self.artifact_reference_image_limit is not None
-        ):
+            if not isinstance(self.artifact_currency, VideoArtifactCurrencyFacts):
+                raise ValueError("schema v3 checkpoint requires complete artifact currency facts")
+            if self.artifact_currency.request_duration_seconds != self.duration_seconds:
+                raise ValueError("artifact currency request duration does not match checkpoint request")
+            if self.artifact_currency.visual_basis.kind != self.ARTIFACT_VISUAL_BASIS_KIND:
+                raise ValueError("artifact currency visual kind does not match checkpoint kind")
+        elif self.artifact_currency is not None:
             raise ValueError("older checkpoint cannot carry complete artifact currency facts")
         if tuple(item.index for item in self.media) != tuple(range(len(self.media))):
             raise ValueError("provider media indexes must be contiguous and ordered")
@@ -766,24 +744,12 @@ class _VideoSubmissionCheckpoint:
                 list(self.reference_audio_targets) if self.reference_audio_targets is not None else None
             ),
         }
-        if self.artifact_visual_basis is not None:
-            payload["artifact_visual_basis"] = self.artifact_visual_basis.to_dict()
-        if self.schema_version == _SCHEMA_VERSION:
-            assert self.artifact_episode is not None
-            assert self.artifact_speech_basis is not None
-            assert self.artifact_duration_basis is not None
-            assert self.artifact_video_basis is not None
-            payload.update(
-                {
-                    "artifact_episode": self.artifact_episode,
-                    "artifact_speech_basis": self.artifact_speech_basis.to_dict(),
-                    "artifact_duration_basis": self.artifact_duration_basis.to_dict(),
-                    "artifact_video_basis": self.artifact_video_basis.to_dict(),
-                    "artifact_voice_style_speakers": list(self.artifact_voice_style_speakers),
-                    "artifact_duration_tiers": list(self.artifact_duration_tiers),
-                    "artifact_reference_image_limit": self.artifact_reference_image_limit,
-                }
-            )
+        if self.schema_version == _VISUAL_BASIS_SCHEMA_VERSION:
+            assert self.legacy_artifact_visual_basis is not None
+            payload["artifact_visual_basis"] = self.legacy_artifact_visual_basis.to_dict()
+        elif self.schema_version == _SCHEMA_VERSION:
+            assert self.artifact_currency is not None
+            payload["artifact_currency"] = self.artifact_currency.to_dict()
         return payload
 
     def _request_digest_payload(self) -> dict[str, object]:
@@ -791,19 +757,11 @@ class _VideoSubmissionCheckpoint:
 
         payload = self._request_payload()
         del payload["api_call_id"]
-        # Artifact currency is independent source evidence, not part of provider
-        # execution identity. Keep the existing request digest's meaning stable.
-        for field in (
-            "artifact_episode",
-            "artifact_visual_basis",
-            "artifact_speech_basis",
-            "artifact_duration_basis",
-            "artifact_video_basis",
-            "artifact_voice_style_speakers",
-            "artifact_duration_tiers",
-            "artifact_reference_image_limit",
-        ):
-            payload.pop(field, None)
+        # Schema v2 preserved its historical provider-request digest semantics.
+        # Schema v3 binds complete artifact currency evidence into the immutable
+        # checkpoint so a version cannot replace typed components independently.
+        if self.schema_version == _VISUAL_BASIS_SCHEMA_VERSION:
+            payload.pop("artifact_visual_basis", None)
         return payload
 
     def to_dict(self) -> dict[str, object]:
@@ -834,14 +792,7 @@ class _VideoSubmissionCheckpoint:
         service_tier: str,
         seed: int | None,
         visual_basis_digest: str,
-        artifact_episode: int,
-        artifact_visual_basis: ArtifactBasisDescriptor,
-        artifact_speech_basis: ArtifactBasisDescriptor,
-        artifact_duration_basis: ArtifactBasisDescriptor,
-        artifact_video_basis: ArtifactBasisDescriptor,
-        artifact_voice_style_speakers: tuple[str, ...],
-        artifact_duration_tiers: tuple[int, ...],
-        artifact_reference_image_limit: int | None,
+        artifact_currency: VideoArtifactCurrencyFacts,
         narration: NarrationExecutionFacts,
         media: tuple[StagedProviderMedia, ...],
         reference_audio_targets: tuple[int, ...] | None,
@@ -869,34 +820,12 @@ class _VideoSubmissionCheckpoint:
             "service_tier": service_tier,
             "seed": seed,
             "visual_basis_digest": visual_basis_digest,
-            "artifact_episode": artifact_episode,
-            "artifact_visual_basis": artifact_visual_basis.to_dict(),
-            "artifact_speech_basis": artifact_speech_basis.to_dict(),
-            "artifact_duration_basis": artifact_duration_basis.to_dict(),
-            "artifact_video_basis": artifact_video_basis.to_dict(),
-            "artifact_voice_style_speakers": list(artifact_voice_style_speakers),
-            "artifact_duration_tiers": list(artifact_duration_tiers),
-            "artifact_reference_image_limit": artifact_reference_image_limit,
+            "artifact_currency": artifact_currency.to_dict(),
             "narration": narration.to_dict(),
             "media": [item.to_dict() for item in media],
             "reference_audio_targets": list(reference_audio_targets) if reference_audio_targets is not None else None,
         }
-        digest_values = {
-            key: value
-            for key, value in values.items()
-            if key
-            not in {
-                "api_call_id",
-                "artifact_episode",
-                "artifact_visual_basis",
-                "artifact_speech_basis",
-                "artifact_duration_basis",
-                "artifact_video_basis",
-                "artifact_voice_style_speakers",
-                "artifact_duration_tiers",
-                "artifact_reference_image_limit",
-            }
-        }
+        digest_values = {key: value for key, value in values.items() if key != "api_call_id"}
         request_digest = _sha256_bytes(_canonical_json(digest_values).encode("utf-8"))
         return cls(
             schema_version=_SCHEMA_VERSION,
@@ -920,14 +849,8 @@ class _VideoSubmissionCheckpoint:
             service_tier=service_tier,
             seed=seed,
             visual_basis_digest=visual_basis_digest,
-            artifact_episode=artifact_episode,
-            artifact_visual_basis=artifact_visual_basis,
-            artifact_speech_basis=artifact_speech_basis,
-            artifact_duration_basis=artifact_duration_basis,
-            artifact_video_basis=artifact_video_basis,
-            artifact_voice_style_speakers=artifact_voice_style_speakers,
-            artifact_duration_tiers=artifact_duration_tiers,
-            artifact_reference_image_limit=artifact_reference_image_limit,
+            legacy_artifact_visual_basis=None,
+            artifact_currency=artifact_currency,
             narration=narration,
             media=media,
             reference_audio_targets=reference_audio_targets,
@@ -969,12 +892,6 @@ class _VideoSubmissionCheckpoint:
         media = raw["media"]
         if not isinstance(media, list):
             raise ValueError("checkpoint media must be an array")
-        voice_style_speakers = raw.get("artifact_voice_style_speakers", [])
-        if not isinstance(voice_style_speakers, list):
-            raise ValueError("artifact_voice_style_speakers must be an array")
-        duration_tiers = raw.get("artifact_duration_tiers", [])
-        if not isinstance(duration_tiers, list):
-            raise ValueError("artifact_duration_tiers must be an array")
         return cls(
             schema_version=raw["schema_version"],
             kind=raw["kind"],
@@ -997,30 +914,16 @@ class _VideoSubmissionCheckpoint:
             service_tier=raw["service_tier"],
             seed=raw["seed"],
             visual_basis_digest=raw["visual_basis_digest"],
-            artifact_episode=raw.get("artifact_episode"),
-            artifact_visual_basis=(
+            legacy_artifact_visual_basis=(
                 ArtifactBasisDescriptor.from_dict(raw["artifact_visual_basis"])
-                if schema_version in {_VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}
+                if schema_version == _VISUAL_BASIS_SCHEMA_VERSION
                 else None
             ),
-            artifact_speech_basis=(
-                ArtifactBasisDescriptor.from_dict(raw["artifact_speech_basis"])
+            artifact_currency=(
+                VideoArtifactCurrencyFacts.from_dict(raw["artifact_currency"])
                 if schema_version == _SCHEMA_VERSION
                 else None
             ),
-            artifact_duration_basis=(
-                ArtifactBasisDescriptor.from_dict(raw["artifact_duration_basis"])
-                if schema_version == _SCHEMA_VERSION
-                else None
-            ),
-            artifact_video_basis=(
-                ArtifactBasisDescriptor.from_dict(raw["artifact_video_basis"])
-                if schema_version == _SCHEMA_VERSION
-                else None
-            ),
-            artifact_voice_style_speakers=tuple(voice_style_speakers),
-            artifact_duration_tiers=tuple(duration_tiers),
-            artifact_reference_image_limit=raw.get("artifact_reference_image_limit"),
             narration=NarrationExecutionFacts.from_dict(raw["narration"]),
             media=tuple(StagedProviderMedia.from_dict(item) for item in media),
             reference_audio_targets=tuple(targets) if targets is not None else None,
@@ -1075,23 +978,11 @@ def checkpoint_version_metadata(checkpoint: VideoSubmissionCheckpoint) -> dict[s
             list(checkpoint.reference_audio_targets) if checkpoint.reference_audio_targets is not None else None
         ),
     }
-    if checkpoint.artifact_visual_basis is not None:
-        metadata["artifact_visual_basis"] = checkpoint.artifact_visual_basis.to_dict()
-    if checkpoint.artifact_video_basis is not None:
-        assert checkpoint.artifact_episode is not None
-        assert checkpoint.artifact_speech_basis is not None
-        assert checkpoint.artifact_duration_basis is not None
-        metadata.update(
-            {
-                "artifact_episode": checkpoint.artifact_episode,
-                "artifact_speech_basis": checkpoint.artifact_speech_basis.to_dict(),
-                "artifact_duration_basis": checkpoint.artifact_duration_basis.to_dict(),
-                "artifact_video_basis": checkpoint.artifact_video_basis.to_dict(),
-                "artifact_voice_style_speakers": list(checkpoint.artifact_voice_style_speakers),
-                "artifact_duration_tiers": list(checkpoint.artifact_duration_tiers),
-                "artifact_reference_image_limit": checkpoint.artifact_reference_image_limit,
-            }
-        )
+    if checkpoint.schema_version == _VISUAL_BASIS_SCHEMA_VERSION:
+        assert checkpoint.legacy_artifact_visual_basis is not None
+        metadata["artifact_visual_basis"] = checkpoint.legacy_artifact_visual_basis.to_dict()
+    elif checkpoint.artifact_currency is not None:
+        metadata["artifact_video_currency"] = checkpoint.artifact_currency.to_dict()
     return metadata
 
 

--- a/lib/speech_artifact_provenance.py
+++ b/lib/speech_artifact_provenance.py
@@ -1,0 +1,348 @@
+"""Canonical sound-owned provenance for video, subtitles, and presentations.
+
+The builders describe artifact currency only. They do not persist a narration
+delivery choice, generate subtitle timing, mix audio, submit provider work, or
+own a second stale store beside :mod:`lib.artifact_manifest`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
+from lib.asset_types import asset_name_comparison_key, normalize_asset_bucket
+from lib.narration_delivery import POST_PRODUCTION, USE_TTS
+from lib.speech_composition import SpeechMode, SpeechOwner, SpeechPreparation
+
+RenditionVariant = Literal["post_production", "use_tts"]
+_DIGEST_RE = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True, slots=True)
+class CharacterVoiceEvidence:
+    """Effective voice facts for one speaking character in a paid video request."""
+
+    speaker: str
+    voice_style: str = ""
+    reference_audio: Path | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.speaker, str) or not self.speaker.strip():
+            raise ValueError("speaker must be a non-empty string")
+        if not isinstance(self.voice_style, str):
+            raise ValueError("voice_style must be a string")
+        if self.reference_audio is not None and not isinstance(self.reference_audio, Path):
+            raise TypeError("reference_audio must be a Path or null")
+        object.__setattr__(self, "speaker", asset_name_comparison_key(self.speaker))
+        object.__setattr__(self, "voice_style", _canonical_text(self.voice_style))
+
+    def basis_input(self) -> dict[str, object]:
+        return {
+            "speaker": self.speaker,
+            "voice_style": self.voice_style,
+            "reference_audio_digest": (
+                _file_content_digest(self.reference_audio) if self.reference_audio is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedMediaEvidence:
+    """Identity and observed boundary of one selected formal upstream medium."""
+
+    basis: ArtifactBasisDescriptor
+    content_digest: str
+    actual_duration_seconds: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.basis, ArtifactBasisDescriptor):
+            raise TypeError("basis must be an ArtifactBasisDescriptor")
+        if not isinstance(self.content_digest, str) or _DIGEST_RE.fullmatch(self.content_digest) is None:
+            raise ValueError("content_digest must be a canonical sha256-v1 digest")
+        duration = self.actual_duration_seconds
+        if isinstance(duration, bool) or not isinstance(duration, (int, float)) or not math.isfinite(duration):
+            raise ValueError("actual_duration_seconds must be positive and finite")
+        if duration <= 0:
+            raise ValueError("actual_duration_seconds must be positive and finite")
+        object.__setattr__(self, "actual_duration_seconds", float(duration))
+
+    @classmethod
+    def from_file(
+        cls,
+        *,
+        basis: ArtifactBasis | ArtifactBasisDescriptor,
+        path: Path,
+        actual_duration_seconds: float,
+    ) -> SelectedMediaEvidence:
+        return cls(
+            basis=_basis_descriptor("basis", basis),
+            content_digest=_file_content_digest(path),
+            actual_duration_seconds=actual_duration_seconds,
+        )
+
+    def basis_input(self) -> dict[str, object]:
+        return {
+            "basis": self.basis.to_dict(),
+            "content_digest": self.content_digest,
+            "actual_duration_seconds": self.actual_duration_seconds,
+        }
+
+
+def project_character_voice_evidence(
+    preparation: SpeechPreparation,
+    *,
+    characters: object,
+    voice_style_speakers: Sequence[str] = (),
+    reference_audio_paths: Mapping[str, Path] | None = None,
+) -> tuple[CharacterVoiceEvidence, ...]:
+    """Adapt current character assets to an execution-frozen dependency shape.
+
+    ``voice_style_speakers`` and ``reference_audio_paths`` name only facts that
+    were actually wired into the paid request. Rebuilding later uses those same
+    logical speakers, so a provider/config change cannot retroactively widen or
+    shrink the artifact basis.
+    """
+
+    _require_prepared_speech(preparation)
+    if preparation.mode is not SpeechMode.CHARACTER_SPEECH:
+        return ()
+    style_names = {asset_name_comparison_key(name) for name in voice_style_speakers}
+    audio_paths = {asset_name_comparison_key(name): path for name, path in (reference_audio_paths or {}).items()}
+    if any(not isinstance(path, Path) for path in audio_paths.values()):
+        raise TypeError("reference_audio_paths values must be Paths")
+    character_bucket = normalize_asset_bucket(characters)
+    ordered_speakers = list(
+        dict.fromkeys(
+            asset_name_comparison_key(utterance.speaker or "")
+            for utterance in preparation.utterances
+            if utterance.owner is SpeechOwner.CHARACTER
+        )
+    )
+    evidence: list[CharacterVoiceEvidence] = []
+    for speaker in ordered_speakers:
+        if speaker not in style_names and speaker not in audio_paths:
+            continue
+        character = character_bucket.get(speaker)
+        voice_style = ""
+        if speaker in style_names and isinstance(character, Mapping):
+            raw_style = character.get("voice_style")
+            voice_style = raw_style if isinstance(raw_style, str) else ""
+        evidence.append(
+            CharacterVoiceEvidence(
+                speaker=speaker,
+                voice_style=voice_style,
+                reference_audio=audio_paths.get(speaker),
+            )
+        )
+    return tuple(evidence)
+
+
+def build_video_speech_basis(
+    preparation: SpeechPreparation,
+    *,
+    voices: Sequence[CharacterVoiceEvidence] = (),
+) -> ArtifactBasis:
+    """Describe the speech facts carried by a provider video audio track.
+
+    Narrator text belongs to the independent TTS/post-production paths and is
+    intentionally omitted. Character speech includes only effective profiles for
+    speakers that occur in this unit, keeping unrelated character edits local.
+    """
+
+    mode = _require_prepared_speech(preparation)
+    if any(not isinstance(voice, CharacterVoiceEvidence) for voice in voices):
+        raise TypeError("voices must contain CharacterVoiceEvidence values")
+    profiles: dict[str, CharacterVoiceEvidence] = {}
+    for voice in voices:
+        if voice.speaker in profiles:
+            raise ValueError(f"duplicate voice evidence for speaker: {voice.speaker!r}")
+        profiles[voice.speaker] = voice
+
+    if mode is not SpeechMode.CHARACTER_SPEECH:
+        return ArtifactBasis.build(
+            "artifact-speech/video",
+            kind_version=1,
+            inputs={"mode": mode.value},
+        )
+
+    utterances: list[dict[str, str]] = []
+    speaker_order: list[str] = []
+    for utterance in preparation.utterances:
+        if utterance.owner is not SpeechOwner.CHARACTER:
+            raise ValueError("character speech preparation contains a non-character utterance")
+        speaker = asset_name_comparison_key(utterance.speaker or "")
+        text = _canonical_text(utterance.text)
+        if not speaker or not text:
+            raise ValueError("character speech basis requires non-empty speaker and text")
+        utterances.append({"speaker": speaker, "text": text})
+        if speaker not in speaker_order:
+            speaker_order.append(speaker)
+
+    return ArtifactBasis.build(
+        "artifact-speech/video",
+        kind_version=1,
+        inputs={
+            "mode": mode.value,
+            "utterances": utterances,
+            "voices": [
+                profiles[speaker].basis_input()
+                if speaker in profiles
+                else {
+                    "speaker": speaker,
+                    "voice_style": "",
+                    "reference_audio_digest": None,
+                }
+                for speaker in speaker_order
+            ],
+        },
+    )
+
+
+def build_video_duration_basis(request_duration_seconds: int) -> ArtifactBasis:
+    """Describe the paid video request tier, not an observed TTS duration."""
+
+    if type(request_duration_seconds) is not int or request_duration_seconds <= 0:
+        raise ValueError("request_duration_seconds must be a positive integer")
+    return ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": request_duration_seconds},
+    )
+
+
+def build_mechanical_subtitle_basis(
+    preparation: SpeechPreparation,
+    *,
+    variant: RenditionVariant,
+    video: SelectedMediaEvidence,
+    narration_audio: SelectedMediaEvidence | None = None,
+) -> ArtifactBasis:
+    """Describe a mechanical subtitle draft without materializing its timeline."""
+
+    mode = _require_prepared_speech(preparation)
+    normalized_variant = _variant(variant)
+    if not isinstance(video, SelectedMediaEvidence):
+        raise TypeError("video must be SelectedMediaEvidence")
+    if narration_audio is not None and not isinstance(narration_audio, SelectedMediaEvidence):
+        raise TypeError("narration_audio must be SelectedMediaEvidence or null")
+
+    narrator_uses_tts = mode is SpeechMode.NARRATOR_VOICEOVER and normalized_variant == USE_TTS
+    if narrator_uses_tts and narration_audio is None:
+        raise ValueError("use_tts narrator subtitle basis requires narration audio")
+    boundary = narration_audio if narrator_uses_tts else video
+    assert boundary is not None
+
+    return ArtifactBasis.build(
+        "artifact-speech/mechanical-subtitle",
+        kind_version=1,
+        inputs={
+            "variant": normalized_variant,
+            "mode": mode.value,
+            "utterances": _subtitle_utterances(preparation),
+            "boundary_media": boundary.basis_input(),
+        },
+    )
+
+
+def build_presentation_basis(
+    *,
+    variant: RenditionVariant,
+    video: SelectedMediaEvidence,
+    subtitle: ArtifactBasis | ArtifactBasisDescriptor,
+    narration_audio: SelectedMediaEvidence | None = None,
+) -> ArtifactBasis:
+    """Describe a final-presentation variant without performing media mixing."""
+
+    normalized_variant = _variant(variant)
+    if not isinstance(video, SelectedMediaEvidence):
+        raise TypeError("video must be SelectedMediaEvidence")
+    subtitle_descriptor = _basis_descriptor("subtitle", subtitle)
+    if narration_audio is not None and not isinstance(narration_audio, SelectedMediaEvidence):
+        raise TypeError("narration_audio must be SelectedMediaEvidence or null")
+    if normalized_variant == USE_TTS and narration_audio is None:
+        raise ValueError("use_tts presentation basis requires narration audio")
+    if normalized_variant == POST_PRODUCTION and narration_audio is not None:
+        raise ValueError("post_production presentation basis cannot include narration audio")
+
+    return ArtifactBasis.build(
+        "artifact-speech/presentation",
+        kind_version=1,
+        inputs={
+            "variant": normalized_variant,
+            "video": video.basis_input(),
+            "subtitle": subtitle_descriptor.to_dict(),
+            "narration_audio": narration_audio.basis_input() if narration_audio is not None else None,
+        },
+    )
+
+
+def _subtitle_utterances(preparation: SpeechPreparation) -> list[dict[str, object]]:
+    values: list[dict[str, object]] = []
+    for utterance in preparation.utterances:
+        text = _canonical_text(utterance.text)
+        if not text:
+            continue
+        speaker = (
+            asset_name_comparison_key(utterance.speaker or "") if utterance.owner is SpeechOwner.CHARACTER else None
+        )
+        if utterance.owner is SpeechOwner.CHARACTER and not speaker:
+            raise ValueError("character subtitle utterance requires a speaker")
+        values.append({"owner": utterance.owner.value, "speaker": speaker, "text": text})
+    return values
+
+
+def _require_prepared_speech(preparation: SpeechPreparation) -> SpeechMode:
+    if not isinstance(preparation, SpeechPreparation):
+        raise TypeError("preparation must be a SpeechPreparation")
+    if preparation.problems or preparation.mode is None:
+        raise ValueError("cannot build artifact basis from blocked speech preparation")
+    return preparation.mode
+
+
+def _basis_descriptor(field: str, value: ArtifactBasis | ArtifactBasisDescriptor) -> ArtifactBasisDescriptor:
+    if isinstance(value, ArtifactBasis):
+        return ArtifactBasisDescriptor.from_basis(value)
+    if isinstance(value, ArtifactBasisDescriptor):
+        return value
+    raise TypeError(f"{field} must be an ArtifactBasis or ArtifactBasisDescriptor")
+
+
+def _variant(value: object) -> RenditionVariant:
+    if value not in (POST_PRODUCTION, USE_TTS):
+        raise ValueError(f"unsupported rendition variant: {value!r}")
+    return value  # type: ignore[return-value]
+
+
+def _canonical_text(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("speech text must be a string")
+    return unicodedata.normalize("NFC", value.replace("\r\n", "\n").replace("\r", "\n")).strip()
+
+
+def _file_content_digest(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256-v1:{digest.hexdigest()}"
+
+
+__all__ = [
+    "CharacterVoiceEvidence",
+    "RenditionVariant",
+    "SelectedMediaEvidence",
+    "build_mechanical_subtitle_basis",
+    "build_presentation_basis",
+    "build_video_duration_basis",
+    "build_video_speech_basis",
+    "project_character_voice_evidence",
+]

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -330,7 +330,6 @@ class VersionManager:
                         current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
-                        current_backup = None
                 except OSError as exc:
                     rollback_errors.append(exc)
                 try:
@@ -507,7 +506,6 @@ class VersionManager:
                         current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
-                        current_backup = None
                 except OSError as exc:
                     selection_rollback_errors.append(exc)
                 resource_data["current_version"] = prior_current
@@ -644,7 +642,6 @@ class VersionManager:
                         current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
-                        current_backup = None
                 except OSError as exc:
                     rollback_errors.append(exc)
                 try:
@@ -860,7 +857,6 @@ class VersionManager:
                         current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
-                        current_backup = None
                 except OSError as exc:
                     rollback_errors.append(exc)
                 try:

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -74,6 +74,24 @@ def _report_cleanup_failures(
             logger.warning("failed to remove temporary version file %s: %s", path, cleanup_failure)
 
 
+def _create_rollback_backup(current_file: Path) -> Path:
+    """Copy current media to a valid rollback file, removing an incomplete candidate on failure."""
+
+    fd, backup_name = tempfile.mkstemp(
+        prefix=f".{current_file.stem}.",
+        suffix=f"{current_file.suffix}.rollback",
+        dir=current_file.parent,
+    )
+    os.close(fd)
+    candidate = Path(backup_name)
+    try:
+        shutil.copy2(current_file, candidate)
+    except BaseException as failure:
+        _report_cleanup_failures(_unlink_paths(candidate), active_failure=failure)
+        raise
+    return candidate
+
+
 class VersionManager:
     """版本管理器"""
 
@@ -274,6 +292,7 @@ class VersionManager:
             records = resource_data.setdefault("versions", [])
             created_snapshots: list[Path] = []
             current_backup: Path | None = None
+            current_existed = current_file.is_file()
             activation_succeeded = False
 
             def _append_version(source: Path, version_prompt: str, version_metadata: dict) -> int:
@@ -304,15 +323,8 @@ class VersionManager:
 
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
-                if current_file.is_file():
-                    fd, backup_name = tempfile.mkstemp(
-                        prefix=f".{current_file.stem}.",
-                        suffix=f"{current_file.suffix}.rollback",
-                        dir=current_file.parent,
-                    )
-                    os.close(fd)
-                    current_backup = Path(backup_name)
-                    shutil.copy2(current_file, current_backup)
+                if current_existed:
+                    current_backup = _create_rollback_backup(current_file)
                     if not resource_data.get("current_version"):
                         _append_version(current_file, "", {})
 
@@ -327,7 +339,8 @@ class VersionManager:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
-                        current_file.unlink(missing_ok=True)
+                        if not current_existed:
+                            current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
                 except OSError as exc:
@@ -480,18 +493,12 @@ class VersionManager:
                 return PaidVersionCommit(version=version, selected=False)
 
             current_backup: Path | None = None
+            current_existed = current_file.is_file()
             selection_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
-                if current_file.is_file():
-                    fd, backup_name = tempfile.mkstemp(
-                        prefix=f".{current_file.stem}.",
-                        suffix=f"{current_file.suffix}.rollback",
-                        dir=current_file.parent,
-                    )
-                    os.close(fd)
-                    current_backup = Path(backup_name)
-                    shutil.copy2(current_file, current_backup)
+                if current_existed:
+                    current_backup = _create_rollback_backup(current_file)
                 os.replace(staged_file, current_file)
                 resource_data["current_version"] = version
                 self._save_versions(data)
@@ -503,7 +510,8 @@ class VersionManager:
                 selection_rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
-                        current_file.unlink(missing_ok=True)
+                        if not current_existed:
+                            current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
                 except OSError as exc:
@@ -599,19 +607,13 @@ class VersionManager:
                 raise ValueError(f"restore version does not exist: {restore_version}")
             versions_snapshot = self.versions_file.read_bytes()
             current_backup: Path | None = None
+            current_existed = current_file.is_file()
             replacement: Path | None = None
             rejection_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
-                if current_file.is_file():
-                    fd, backup_name = tempfile.mkstemp(
-                        prefix=f".{current_file.stem}.",
-                        suffix=f"{current_file.suffix}.rollback",
-                        dir=current_file.parent,
-                    )
-                    os.close(fd)
-                    current_backup = Path(backup_name)
-                    shutil.copy2(current_file, current_backup)
+                if current_existed:
+                    current_backup = _create_rollback_backup(current_file)
                 if previous is None:
                     current_file.unlink(missing_ok=True)
                     resource_data["current_version"] = 0
@@ -639,7 +641,8 @@ class VersionManager:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
-                        current_file.unlink(missing_ok=True)
+                        if not current_existed:
+                            current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
                 except OSError as exc:
@@ -832,18 +835,12 @@ class VersionManager:
             versions_existed = self.versions_file.is_file()
             versions_snapshot = self.versions_file.read_bytes() if versions_existed else None
             current_backup: Path | None = None
+            current_existed = current_file.is_file()
             restore_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
-                if current_file.is_file():
-                    fd, backup_name = tempfile.mkstemp(
-                        prefix=f".{current_file.stem}.",
-                        suffix=f"{current_file.suffix}.rollback",
-                        dir=current_file.parent,
-                    )
-                    os.close(fd)
-                    current_backup = Path(backup_name)
-                    shutil.copy2(current_file, current_backup)
+                if current_existed:
+                    current_backup = _create_rollback_backup(current_file)
                 shutil.copy2(target_file, current_file)
                 resource_data["current_version"] = version
                 self._save_versions(data)
@@ -854,7 +851,8 @@ class VersionManager:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
-                        current_file.unlink(missing_ok=True)
+                        if not current_existed:
+                            current_file.unlink(missing_ok=True)
                     else:
                         os.replace(current_backup, current_file)
                 except OSError as exc:

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -331,6 +331,7 @@ class VersionManager:
         staged_file: Path,
         current_file: Path,
         select_current: bool | Callable[[], bool],
+        expected_current_version: int | None = None,
         on_select: Callable[[], None] | None = None,
         **metadata,
     ) -> PaidVersionCommit:
@@ -349,6 +350,10 @@ class VersionManager:
             raise ValueError(f"不支持的资源类型: {resource_type}")
         if not isinstance(select_current, bool) and not callable(select_current):
             raise TypeError("select_current must be a boolean or a callable returning one")
+        if expected_current_version is not None and (
+            type(expected_current_version) is not int or expected_current_version < 0
+        ):
+            raise ValueError("expected_current_version must be a non-negative integer or null")
         staged_file = Path(staged_file)
         current_file = Path(current_file)
         if not staged_file.is_file():
@@ -420,7 +425,13 @@ class VersionManager:
                 raise
 
             try:
-                should_select = select_current() if callable(select_current) else select_current
+                should_select = (
+                    False
+                    if expected_current_version is not None and prior_current != expected_current_version
+                    else select_current()
+                    if callable(select_current)
+                    else select_current
+                )
                 if not isinstance(should_select, bool):
                     raise TypeError("select_current callback must return a boolean")
             except BaseException:

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -6,8 +6,10 @@
 """
 
 import json
+import logging
 import os
 import shutil
+import sys
 import tempfile
 import threading
 from collections.abc import Callable
@@ -24,6 +26,7 @@ from lib.resource_paths import resource_extension
 _LOCKS_GUARD = threading.Lock()
 _LOCKS_BY_VERSIONS_FILE: dict[str, threading.RLock] = {}
 _PREVIOUS_CURRENT_VERSION = "_previous_current_version"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +45,33 @@ def _get_versions_file_lock(versions_file: Path) -> threading.RLock:
             lock = threading.RLock()
             _LOCKS_BY_VERSIONS_FILE[key] = lock
         return lock
+
+
+def _unlink_paths(*paths: Path | None) -> list[tuple[Path, OSError]]:
+    """Attempt every unlink and return failures without masking an active operation."""
+
+    failures: list[tuple[Path, OSError]] = []
+    for path in paths:
+        if path is None:
+            continue
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            failures.append((path, exc))
+    return failures
+
+
+def _report_cleanup_failures(
+    failures: list[tuple[Path, OSError]],
+    *,
+    active_failure: BaseException | None,
+) -> None:
+    for path, cleanup_failure in failures:
+        message = f"failed to remove temporary version file {path}: {cleanup_failure}"
+        if active_failure is not None:
+            active_failure.add_note(message)
+        else:
+            logger.warning("failed to remove temporary version file %s: %s", path, cleanup_failure)
 
 
 class VersionManager:
@@ -410,7 +440,7 @@ class VersionManager:
                 version = _append_snapshot(staged_file, prompt, metadata)
                 # Persist paid history before any selection callback can fail.
                 self._save_versions(data)
-            except BaseException:
+            except BaseException as failure:
                 history_rollback_errors: list[OSError] = []
                 try:
                     if versions_snapshot is None:
@@ -419,13 +449,11 @@ class VersionManager:
                         atomic_write_bytes(self.versions_file, versions_snapshot)
                 except OSError as exc:
                     history_rollback_errors.append(exc)
-                for path in created_snapshots:
-                    try:
-                        path.unlink(missing_ok=True)
-                    except OSError as exc:
-                        history_rollback_errors.append(exc)
-                staged_file.unlink(missing_ok=True)
+                history_rollback_errors.extend(
+                    cleanup_failure for _path, cleanup_failure in _unlink_paths(*created_snapshots, staged_file)
+                )
                 if history_rollback_errors:
+                    history_rollback_errors[0].__cause__ = failure
                     raise RuntimeError(
                         "paid version history commit failed and rollback was incomplete"
                     ) from history_rollback_errors[0]
@@ -441,15 +469,16 @@ class VersionManager:
                 )
                 if not isinstance(should_select, bool):
                     raise TypeError("select_current callback must return a boolean")
-            except BaseException:
-                staged_file.unlink(missing_ok=True)
+            except BaseException as failure:
+                _report_cleanup_failures(_unlink_paths(staged_file), active_failure=failure)
                 raise
 
             if not should_select:
-                staged_file.unlink(missing_ok=True)
+                _report_cleanup_failures(_unlink_paths(staged_file), active_failure=None)
                 return PaidVersionCommit(version=version, selected=False)
 
             current_backup: Path | None = None
+            selection_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
                 if current_file.is_file():
@@ -466,8 +495,9 @@ class VersionManager:
                 self._save_versions(data)
                 if on_select is not None:
                     on_select()
+                selection_succeeded = True
                 return PaidVersionCommit(version=version, selected=True)
-            except BaseException:
+            except BaseException as failure:
                 selection_rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
@@ -483,14 +513,14 @@ class VersionManager:
                 except OSError as exc:
                     selection_rollback_errors.append(exc)
                 if selection_rollback_errors:
+                    selection_rollback_errors[0].__cause__ = failure
                     raise RuntimeError(
                         "paid version selection failed and durable rollback was incomplete"
                     ) from selection_rollback_errors[0]
                 raise
             finally:
-                staged_file.unlink(missing_ok=True)
-                if current_backup is not None:
-                    current_backup.unlink(missing_ok=True)
+                cleanup_failures = _unlink_paths(staged_file, current_backup if selection_succeeded else None)
+                _report_cleanup_failures(cleanup_failures, active_failure=sys.exception())
 
     def reject_current_version(
         self,

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -23,6 +24,14 @@ from lib.resource_paths import resource_extension
 _LOCKS_GUARD = threading.Lock()
 _LOCKS_BY_VERSIONS_FILE: dict[str, threading.RLock] = {}
 _PREVIOUS_CURRENT_VERSION = "_previous_current_version"
+
+
+@dataclass(frozen=True, slots=True)
+class PaidVersionCommit:
+    """Outcome of recording paid media and optionally selecting it as current."""
+
+    version: int
+    selected: bool
 
 
 def _get_versions_file_lock(versions_file: Path) -> threading.RLock:
@@ -313,6 +322,158 @@ class VersionManager:
                 if current_backup is not None:
                     current_backup.unlink(missing_ok=True)
 
+    def commit_staged_paid_version(
+        self,
+        resource_type: str,
+        resource_id: str,
+        prompt: str,
+        *,
+        staged_file: Path,
+        current_file: Path,
+        select_current: bool | Callable[[], bool],
+        on_select: Callable[[], None] | None = None,
+        **metadata,
+    ) -> PaidVersionCommit:
+        """Record paid output and decide current selection inside one version lock.
+
+        A non-selected result is copied into history without changing the formal
+        file or current pointer. A callable selection guard runs after the paid
+        snapshot is durable and while the version lock remains held. When
+        selection is requested, the formal file, pointer, and ``on_select``
+        registration form one guarded transition. A selection failure restores
+        the old formal selection while retaining the paid result as a
+        non-current historical version.
+        """
+
+        if resource_type not in self.RESOURCE_TYPES:
+            raise ValueError(f"不支持的资源类型: {resource_type}")
+        if not isinstance(select_current, bool) and not callable(select_current):
+            raise TypeError("select_current must be a boolean or a callable returning one")
+        staged_file = Path(staged_file)
+        current_file = Path(current_file)
+        if not staged_file.is_file():
+            raise FileNotFoundError(f"staged version file does not exist: {staged_file}")
+
+        with self._lock:
+            versions_existed = self.versions_file.is_file()
+            versions_snapshot = self.versions_file.read_bytes() if versions_existed else None
+            data = self._load_versions()
+            bucket = data.setdefault(resource_type, {})
+            resource_data = bucket.setdefault(resource_id, {"current_version": 0, "versions": []})
+            records = resource_data.setdefault("versions", [])
+            created_snapshots: list[Path] = []
+
+            def _append_snapshot(source: Path, version_prompt: str, version_metadata: dict) -> int:
+                previous = resource_data.get("current_version", 0)
+                if not isinstance(previous, int) or isinstance(previous, bool) or previous < 0:
+                    previous = 0
+                version = max((item.get("version", 0) for item in records), default=0) + 1
+                timestamp = self._generate_timestamp()
+                ext = self.EXTENSIONS.get(resource_type, ".png")
+                rel_path = f"versions/{resource_type}/{resource_id}_v{version}_{timestamp}{ext}"
+                abs_path = self.project_path / rel_path
+                self._ensure_dirs()
+                shutil.copy2(source, abs_path)
+                created_snapshots.append(abs_path)
+                records.append(
+                    {
+                        "version": version,
+                        "file": rel_path,
+                        "prompt": version_prompt,
+                        "created_at": self._generate_iso_timestamp(),
+                        **version_metadata,
+                        _PREVIOUS_CURRENT_VERSION: previous,
+                    }
+                )
+                return version
+
+            try:
+                if current_file.is_file() and not resource_data.get("current_version"):
+                    tracked = _append_snapshot(current_file, "", {})
+                    resource_data["current_version"] = tracked
+                prior_current = resource_data.get("current_version", 0)
+                if not isinstance(prior_current, int) or isinstance(prior_current, bool) or prior_current < 0:
+                    prior_current = 0
+                    resource_data["current_version"] = 0
+                version = _append_snapshot(staged_file, prompt, metadata)
+                # Persist paid history before any selection callback can fail.
+                self._save_versions(data)
+            except BaseException:
+                history_rollback_errors: list[OSError] = []
+                try:
+                    if versions_snapshot is None:
+                        self.versions_file.unlink(missing_ok=True)
+                    else:
+                        atomic_write_bytes(self.versions_file, versions_snapshot)
+                except OSError as exc:
+                    history_rollback_errors.append(exc)
+                for path in created_snapshots:
+                    try:
+                        path.unlink(missing_ok=True)
+                    except OSError as exc:
+                        history_rollback_errors.append(exc)
+                staged_file.unlink(missing_ok=True)
+                if history_rollback_errors:
+                    raise RuntimeError(
+                        "paid version history commit failed and rollback was incomplete"
+                    ) from history_rollback_errors[0]
+                raise
+
+            try:
+                should_select = select_current() if callable(select_current) else select_current
+                if not isinstance(should_select, bool):
+                    raise TypeError("select_current callback must return a boolean")
+            except BaseException:
+                staged_file.unlink(missing_ok=True)
+                raise
+
+            if not should_select:
+                staged_file.unlink(missing_ok=True)
+                return PaidVersionCommit(version=version, selected=False)
+
+            current_backup: Path | None = None
+            try:
+                current_file.parent.mkdir(parents=True, exist_ok=True)
+                if current_file.is_file():
+                    fd, backup_name = tempfile.mkstemp(
+                        prefix=f".{current_file.stem}.",
+                        suffix=f"{current_file.suffix}.rollback",
+                        dir=current_file.parent,
+                    )
+                    os.close(fd)
+                    current_backup = Path(backup_name)
+                    shutil.copy2(current_file, current_backup)
+                os.replace(staged_file, current_file)
+                resource_data["current_version"] = version
+                self._save_versions(data)
+                if on_select is not None:
+                    on_select()
+                return PaidVersionCommit(version=version, selected=True)
+            except BaseException:
+                selection_rollback_errors: list[OSError] = []
+                try:
+                    if current_backup is None:
+                        current_file.unlink(missing_ok=True)
+                    else:
+                        os.replace(current_backup, current_file)
+                        current_backup = None
+                except OSError as exc:
+                    selection_rollback_errors.append(exc)
+                resource_data["current_version"] = prior_current
+                try:
+                    self._save_versions(data)
+                except OSError as exc:
+                    selection_rollback_errors.append(exc)
+                if selection_rollback_errors:
+                    raise RuntimeError(
+                        "paid version selection failed and durable rollback was incomplete"
+                    ) from selection_rollback_errors[0]
+                raise
+            finally:
+                staged_file.unlink(missing_ok=True)
+                if current_backup is not None:
+                    current_backup.unlink(missing_ok=True)
+
     def reject_current_version(
         self,
         resource_type: str,
@@ -568,7 +729,15 @@ class VersionManager:
                 **metadata,
             )
 
-    def restore_version(self, resource_type: str, resource_id: str, version: int, current_file: Path) -> dict:
+    def restore_version(
+        self,
+        resource_type: str,
+        resource_id: str,
+        version: int,
+        current_file: Path,
+        *,
+        on_restore: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict:
         """
         切换到指定版本
 
@@ -608,11 +777,50 @@ class VersionManager:
             if not target_file.exists():
                 raise FileNotFoundError(f"版本文件不存在: {target_file}")
 
-            current_file.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(target_file, current_file)
-
-            resource_data["current_version"] = version
-            self._save_versions(data)
+            versions_existed = self.versions_file.is_file()
+            versions_snapshot = self.versions_file.read_bytes() if versions_existed else None
+            current_backup: Path | None = None
+            try:
+                current_file.parent.mkdir(parents=True, exist_ok=True)
+                if current_file.is_file():
+                    fd, backup_name = tempfile.mkstemp(
+                        prefix=f".{current_file.stem}.",
+                        suffix=f"{current_file.suffix}.rollback",
+                        dir=current_file.parent,
+                    )
+                    os.close(fd)
+                    current_backup = Path(backup_name)
+                    shutil.copy2(current_file, current_backup)
+                shutil.copy2(target_file, current_file)
+                resource_data["current_version"] = version
+                self._save_versions(data)
+                if on_restore is not None:
+                    on_restore(dict(target_version))
+            except BaseException:
+                rollback_errors: list[OSError] = []
+                try:
+                    if current_backup is None:
+                        current_file.unlink(missing_ok=True)
+                    else:
+                        os.replace(current_backup, current_file)
+                        current_backup = None
+                except OSError as exc:
+                    rollback_errors.append(exc)
+                try:
+                    if versions_snapshot is None:
+                        self.versions_file.unlink(missing_ok=True)
+                    else:
+                        atomic_write_bytes(self.versions_file, versions_snapshot)
+                except OSError as exc:
+                    rollback_errors.append(exc)
+                if rollback_errors:
+                    raise RuntimeError(
+                        "version restore failed and durable rollback was incomplete"
+                    ) from rollback_errors[0]
+                raise
+            finally:
+                if current_backup is not None:
+                    current_backup.unlink(missing_ok=True)
 
         restored_prompt = target_version.get("prompt", "")
         return {

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -274,6 +274,7 @@ class VersionManager:
             records = resource_data.setdefault("versions", [])
             created_snapshots: list[Path] = []
             current_backup: Path | None = None
+            activation_succeeded = False
 
             def _append_version(source: Path, version_prompt: str, version_metadata: dict) -> int:
                 previous_current_version = resource_data.get("current_version", 0)
@@ -320,8 +321,9 @@ class VersionManager:
                 self._save_versions(data)
                 if on_commit is not None:
                     on_commit()
+                activation_succeeded = True
                 return new_version
-            except BaseException:
+            except BaseException as failure:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
@@ -344,13 +346,14 @@ class VersionManager:
                     except OSError as exc:
                         rollback_errors.append(exc)
                 if rollback_errors:
+                    rollback_errors[0].__cause__ = failure
                     raise RuntimeError(
                         "version activation failed and durable rollback was incomplete"
                     ) from rollback_errors[0]
                 raise
             finally:
-                if current_backup is not None:
-                    current_backup.unlink(missing_ok=True)
+                if activation_succeeded:
+                    _report_cleanup_failures(_unlink_paths(current_backup), active_failure=sys.exception())
 
     def commit_staged_paid_version(
         self,
@@ -599,6 +602,7 @@ class VersionManager:
             versions_snapshot = self.versions_file.read_bytes()
             current_backup: Path | None = None
             replacement: Path | None = None
+            rejection_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
                 if current_file.is_file():
@@ -631,8 +635,9 @@ class VersionManager:
                 self._save_versions(data)
                 if on_reject is not None:
                     on_reject()
+                rejection_succeeded = True
                 return True
-            except BaseException:
+            except BaseException as failure:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
@@ -647,15 +652,17 @@ class VersionManager:
                 except OSError as exc:
                     rollback_errors.append(exc)
                 if rollback_errors:
+                    rollback_errors[0].__cause__ = failure
                     raise RuntimeError(
                         "version rejection failed and durable rollback was incomplete"
                     ) from rollback_errors[0]
                 raise
             finally:
-                if current_backup is not None:
-                    current_backup.unlink(missing_ok=True)
-                if replacement is not None:
-                    replacement.unlink(missing_ok=True)
+                cleanup_failures = _unlink_paths(
+                    replacement,
+                    current_backup if rejection_succeeded else None,
+                )
+                _report_cleanup_failures(cleanup_failures, active_failure=sys.exception())
 
     def rename_resource(self, resource_type: str, old_id: str, new_id: str, *, dry_run: bool = False) -> int:
         """把资源的版本历史整体迁移到新 id：re-key 元数据、重命名快照文件、改写记录内路径。
@@ -828,6 +835,7 @@ class VersionManager:
             versions_existed = self.versions_file.is_file()
             versions_snapshot = self.versions_file.read_bytes() if versions_existed else None
             current_backup: Path | None = None
+            restore_succeeded = False
             try:
                 current_file.parent.mkdir(parents=True, exist_ok=True)
                 if current_file.is_file():
@@ -844,7 +852,8 @@ class VersionManager:
                 self._save_versions(data)
                 if on_restore is not None:
                     on_restore(dict(target_version))
-            except BaseException:
+                restore_succeeded = True
+            except BaseException as failure:
                 rollback_errors: list[OSError] = []
                 try:
                     if current_backup is None:
@@ -862,13 +871,14 @@ class VersionManager:
                 except OSError as exc:
                     rollback_errors.append(exc)
                 if rollback_errors:
+                    rollback_errors[0].__cause__ = failure
                     raise RuntimeError(
                         "version restore failed and durable rollback was incomplete"
                     ) from rollback_errors[0]
                 raise
             finally:
-                if current_backup is not None:
-                    current_backup.unlink(missing_ok=True)
+                if restore_succeeded:
+                    _report_cleanup_failures(_unlink_paths(current_backup), active_failure=sys.exception())
 
         restored_prompt = target_version.get("prompt", "")
         return {

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -393,6 +393,13 @@ class VersionManager:
                 return version
 
             try:
+                submitted_current = resource_data.get("current_version", 0)
+                if (
+                    not isinstance(submitted_current, int)
+                    or isinstance(submitted_current, bool)
+                    or submitted_current < 0
+                ):
+                    submitted_current = 0
                 if current_file.is_file() and not resource_data.get("current_version"):
                     tracked = _append_snapshot(current_file, "", {})
                     resource_data["current_version"] = tracked
@@ -427,7 +434,7 @@ class VersionManager:
             try:
                 should_select = (
                     False
-                    if expected_current_version is not None and prior_current != expected_current_version
+                    if expected_current_version is not None and submitted_current != expected_current_version
                     else select_current()
                     if callable(select_current)
                     else select_current

--- a/lib/video_artifact_commit.py
+++ b/lib/video_artifact_commit.py
@@ -1,0 +1,149 @@
+"""Atomic paid-video history and Artifact Manifest selection.
+
+This module owns the commit decision only.  Callers supply a current-basis
+projection and the guard that serializes that projection with script edits.
+Provider execution, prompt rendering, thumbnail extraction, and post-production
+remain outside this boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager, nullcontext
+from pathlib import Path
+from typing import Any
+
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ArtifactManifestEntry,
+    ProjectArtifactManifestAdapter,
+)
+from lib.version_manager import PaidVersionCommit, VersionManager
+
+SelectionGuard = Callable[[], AbstractContextManager[object]]
+CurrentBasisResolver = Callable[[Mapping[str, Any]], ArtifactBasisDescriptor | None]
+
+
+def commit_paid_video_artifact(
+    *,
+    project_path: Path,
+    versions: VersionManager,
+    resource_type: str,
+    resource_id: str,
+    prompt: str,
+    staged_file: Path,
+    current_file: Path,
+    duration_seconds: int,
+    version_metadata: Mapping[str, Any],
+    resolve_current_basis: CurrentBasisResolver,
+    selection_guard: SelectionGuard | None = None,
+    capture_prior_manifest: Callable[[ArtifactManifestEntry | None], None] | None = None,
+) -> PaidVersionCommit:
+    """Record paid output, then select only a provably current typed artifact.
+
+    The selection predicate runs inside ``VersionManager``'s lock and, when a
+    caller supplies ``selection_guard``, inside that outer guard as well.  The
+    formal file, version pointer, and Manifest registration therefore become one
+    guarded transition.  Missing or malformed typed facts are deliberately
+    history-only instead of being inferred from a legacy path or prompt.
+    """
+
+    metadata = dict(version_metadata)
+    episode, frozen_basis = _typed_video_identity(metadata)
+    guard_factory = selection_guard or nullcontext
+
+    def _archive_paid_history() -> PaidVersionCommit:
+        return versions.commit_staged_paid_version(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            staged_file=staged_file,
+            current_file=current_file,
+            select_current=False,
+            duration_seconds=duration_seconds,
+            **metadata,
+        )
+
+    try:
+        artifact_path = _relative_artifact_path(project_path, current_file)
+    except BaseException as failure:
+        try:
+            _archive_paid_history()
+        except BaseException as archive_failure:
+            failure.add_note(f"paid video history archival also failed: {archive_failure}")
+        raise
+
+    def _select_if_current() -> bool:
+        if episode is None or frozen_basis is None:
+            return False
+        try:
+            current_basis = resolve_current_basis(metadata)
+        except (FileNotFoundError, KeyError, TypeError, ValueError):
+            return False
+        return current_basis == frozen_basis
+
+    def _register_selected_basis() -> None:
+        assert episode is not None
+        assert frozen_basis is not None
+        adapter = ProjectArtifactManifestAdapter(project_path)
+        if capture_prior_manifest is not None:
+            capture_prior_manifest(adapter.get_entry(ArtifactKey.episode_video(episode, resource_id)))
+        ArtifactManifest(adapter).register_descriptor_transactionally(
+            ArtifactKey.episode_video(episode, resource_id),
+            artifact_path=artifact_path,
+            basis=frozen_basis,
+        )
+
+    try:
+        with guard_factory():
+            return versions.commit_staged_paid_version(
+                resource_type=resource_type,
+                resource_id=resource_id,
+                prompt=prompt,
+                staged_file=staged_file,
+                current_file=current_file,
+                select_current=_select_if_current,
+                on_select=_register_selected_basis,
+                duration_seconds=duration_seconds,
+                **metadata,
+            )
+    except BaseException as failure:
+        if staged_file.is_file():
+            try:
+                _archive_paid_history()
+            except BaseException as archive_failure:
+                failure.add_note(f"paid video history archival also failed: {archive_failure}")
+        raise
+
+
+def _typed_video_identity(
+    metadata: Mapping[str, Any],
+) -> tuple[int | None, ArtifactBasisDescriptor | None]:
+    episode = metadata.get("artifact_episode")
+    raw_basis = metadata.get("artifact_video_basis")
+    if type(episode) is not int or episode < 1 or not isinstance(raw_basis, Mapping):
+        return None, None
+    try:
+        descriptor = ArtifactBasisDescriptor.from_dict(raw_basis)
+    except (TypeError, ValueError):
+        return None, None
+    if descriptor.kind != "artifact-components/video":
+        return None, None
+    return episode, descriptor
+
+
+def _relative_artifact_path(project_path: Path, current_file: Path) -> str:
+    root = project_path.resolve(strict=True)
+    resolved = current_file.resolve(strict=False)
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("formal video path must stay inside the project") from exc
+    if not relative.parts:
+        raise ValueError("formal video path must identify a file")
+    return relative.as_posix()
+
+
+__all__ = ["CurrentBasisResolver", "SelectionGuard", "commit_paid_video_artifact"]

--- a/lib/video_artifact_commit.py
+++ b/lib/video_artifact_commit.py
@@ -21,6 +21,7 @@ from lib.artifact_manifest import (
     ProjectArtifactManifestAdapter,
 )
 from lib.version_manager import PaidVersionCommit, VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 SelectionGuard = Callable[[], AbstractContextManager[object]]
 CurrentBasisResolver = Callable[[Mapping[str, Any]], ArtifactBasisDescriptor | None]
@@ -51,7 +52,9 @@ def commit_paid_video_artifact(
     """
 
     metadata = dict(version_metadata)
-    episode, frozen_basis = _typed_video_identity(metadata)
+    artifact_currency = _typed_video_identity(metadata)
+    episode = artifact_currency.episode if artifact_currency is not None else None
+    frozen_basis = artifact_currency.video_descriptor if artifact_currency is not None else None
     guard_factory = selection_guard or nullcontext
 
     def _archive_paid_history() -> PaidVersionCommit:
@@ -105,6 +108,7 @@ def commit_paid_video_artifact(
                 staged_file=staged_file,
                 current_file=current_file,
                 select_current=_select_if_current,
+                expected_current_version=(artifact_currency.parent_version if artifact_currency is not None else None),
                 on_select=_register_selected_basis,
                 duration_seconds=duration_seconds,
                 **metadata,
@@ -120,18 +124,11 @@ def commit_paid_video_artifact(
 
 def _typed_video_identity(
     metadata: Mapping[str, Any],
-) -> tuple[int | None, ArtifactBasisDescriptor | None]:
-    episode = metadata.get("artifact_episode")
-    raw_basis = metadata.get("artifact_video_basis")
-    if type(episode) is not int or episode < 1 or not isinstance(raw_basis, Mapping):
-        return None, None
+) -> VideoArtifactCurrencyFacts | None:
     try:
-        descriptor = ArtifactBasisDescriptor.from_dict(raw_basis)
+        return VideoArtifactCurrencyFacts.from_dict(metadata.get("artifact_video_currency"))
     except (TypeError, ValueError):
-        return None, None
-    if descriptor.kind != "artifact-components/video":
-        return None, None
-    return episode, descriptor
+        return None
 
 
 def _relative_artifact_path(project_path: Path, current_file: Path) -> str:

--- a/lib/video_artifact_facts.py
+++ b/lib/video_artifact_facts.py
@@ -17,10 +17,10 @@ _SCHEMA_VERSION = 1
 _STORYBOARD_VISUAL_KIND = "artifact-visual/video-storyboard"
 _REFERENCE_VISUAL_KIND = "artifact-visual/video-reference"
 _SPEECH_KIND = "artifact-speech/video"
-_DURATION_KIND = "artifact-speech/video-duration"
 _VIDEO_KIND = "artifact-components/video"
 _HEX_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _BASIS_DIGEST = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
+VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD = "artifact_video_restore_blocker"
 
 
 def _canonical_json(value: object) -> str:
@@ -105,8 +105,8 @@ class VideoArtifactCurrencyFacts:
             raise ValueError("voice_style_speakers must be unique")
         if (
             not self.duration_tiers
-            or tuple(sorted(set(self.duration_tiers))) != self.duration_tiers
             or any(type(tier) is not int or tier <= 0 for tier in self.duration_tiers)
+            or tuple(sorted(set(self.duration_tiers))) != self.duration_tiers
             or self.request_duration_seconds not in self.duration_tiers
         ):
             raise ValueError("duration_tiers must be sorted positive tiers containing the paid request tier")
@@ -189,7 +189,7 @@ class VideoArtifactCurrencyFacts:
         return facts
 
 
-__all__ = ["VideoArtifactCurrencyFacts"]
+__all__ = ["VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD", "VideoArtifactCurrencyFacts"]
 
 
 def _basis_inputs(basis: ArtifactBasis) -> Mapping[str, Any]:

--- a/lib/video_artifact_facts.py
+++ b/lib/video_artifact_facts.py
@@ -1,0 +1,322 @@
+"""Self-verifying typed currency facts for one paid video request."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Self, cast
+
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
+from lib.asset_types import asset_name_comparison_key
+from lib.speech_artifact_provenance import build_video_duration_basis
+
+_SCHEMA_VERSION = 1
+_STORYBOARD_VISUAL_KIND = "artifact-visual/video-storyboard"
+_REFERENCE_VISUAL_KIND = "artifact-visual/video-reference"
+_SPEECH_KIND = "artifact-speech/video"
+_DURATION_KIND = "artifact-speech/video-duration"
+_VIDEO_KIND = "artifact-components/video"
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_BASIS_DIGEST = re.compile(r"sha256-v1:[0-9a-f]{64}\Z")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+@dataclass(frozen=True, slots=True)
+class VideoArtifactCurrencyFacts:
+    """Complete execution-frozen facts required to select or restore a video.
+
+    Descriptors alone cannot prove which canonical inputs produced their digest.
+    Each component therefore carries its normalized input document, while the
+    aggregate digest protects the route knobs and selection parent token as one
+    value.  Consumers parse this object once and use its derived descriptors.
+    """
+
+    episode: int
+    request_duration_seconds: int
+    visual_basis: ArtifactBasis
+    speech_basis: ArtifactBasis
+    duration_basis: ArtifactBasis
+    video_basis: ArtifactBasis
+    voice_style_speakers: tuple[str, ...]
+    duration_tiers: tuple[int, ...]
+    reference_image_limit: int | None
+    parent_version: int
+
+    _FIELDS = frozenset(
+        {
+            "schema_version",
+            "episode",
+            "request_duration_seconds",
+            "visual_basis",
+            "speech_basis",
+            "duration_basis",
+            "video_basis",
+            "voice_style_speakers",
+            "duration_tiers",
+            "reference_image_limit",
+            "parent_version",
+            "currency_digest",
+        }
+    )
+
+    def __post_init__(self) -> None:
+        if type(self.episode) is not int or self.episode < 1:
+            raise ValueError("video artifact episode must be a positive integer")
+        if type(self.request_duration_seconds) is not int or self.request_duration_seconds <= 0:
+            raise ValueError("video artifact request duration must be a positive integer")
+        for field, value in (
+            ("visual_basis", self.visual_basis),
+            ("speech_basis", self.speech_basis),
+            ("duration_basis", self.duration_basis),
+            ("video_basis", self.video_basis),
+        ):
+            if not isinstance(value, ArtifactBasis):
+                raise TypeError(f"{field} must be an ArtifactBasis")
+            if value.kind_version != 1:
+                raise ValueError(f"{field} must use the supported kind version")
+        if self.visual_basis.kind not in {_STORYBOARD_VISUAL_KIND, _REFERENCE_VISUAL_KIND}:
+            raise ValueError("visual_basis does not describe a supported video route")
+        _validate_visual_inputs(self.visual_basis)
+        if self.speech_basis.kind != _SPEECH_KIND:
+            raise ValueError("speech_basis does not describe video speech")
+        _validate_speech_inputs(self.speech_basis)
+        expected_duration = build_video_duration_basis(self.request_duration_seconds)
+        if self.duration_basis != expected_duration:
+            raise ValueError("duration_basis does not describe the paid request tier")
+        expected_video = compose_video_artifact_basis(
+            visual=self.visual_basis,
+            speech=self.speech_basis,
+            duration=self.duration_basis,
+        )
+        if self.video_basis != expected_video or self.video_basis.kind != _VIDEO_KIND:
+            raise ValueError("video_basis does not compose the frozen video components")
+        if any(
+            not isinstance(speaker, str) or not speaker or asset_name_comparison_key(speaker) != speaker
+            for speaker in self.voice_style_speakers
+        ):
+            raise ValueError("voice_style_speakers must contain canonical non-empty names")
+        if len(set(self.voice_style_speakers)) != len(self.voice_style_speakers):
+            raise ValueError("voice_style_speakers must be unique")
+        if (
+            not self.duration_tiers
+            or tuple(sorted(set(self.duration_tiers))) != self.duration_tiers
+            or any(type(tier) is not int or tier <= 0 for tier in self.duration_tiers)
+            or self.request_duration_seconds not in self.duration_tiers
+        ):
+            raise ValueError("duration_tiers must be sorted positive tiers containing the paid request tier")
+        limit = self.reference_image_limit
+        if self.visual_basis.kind == _STORYBOARD_VISUAL_KIND:
+            if limit is not None:
+                raise ValueError("storyboard video facts cannot carry a reference-image limit")
+        elif limit is not None and (type(limit) is not int or limit < 0):
+            raise ValueError("reference video facts require an unlimited or non-negative reference-image limit")
+        if type(self.parent_version) is not int or self.parent_version < 0:
+            raise ValueError("parent_version must be a non-negative current-version token")
+
+    @property
+    def visual_descriptor(self) -> ArtifactBasisDescriptor:
+        return ArtifactBasisDescriptor.from_basis(self.visual_basis)
+
+    @property
+    def speech_descriptor(self) -> ArtifactBasisDescriptor:
+        return ArtifactBasisDescriptor.from_basis(self.speech_basis)
+
+    @property
+    def duration_descriptor(self) -> ArtifactBasisDescriptor:
+        return ArtifactBasisDescriptor.from_basis(self.duration_basis)
+
+    @property
+    def video_descriptor(self) -> ArtifactBasisDescriptor:
+        return ArtifactBasisDescriptor.from_basis(self.video_basis)
+
+    @property
+    def currency_digest(self) -> str:
+        payload = self._payload()
+        return f"sha256-v1:{hashlib.sha256(_canonical_json(payload).encode('utf-8')).hexdigest()}"
+
+    def _payload(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "episode": self.episode,
+            "request_duration_seconds": self.request_duration_seconds,
+            "visual_basis": self.visual_basis.to_evidence_dict(),
+            "speech_basis": self.speech_basis.to_evidence_dict(),
+            "duration_basis": self.duration_basis.to_evidence_dict(),
+            "video_basis": self.video_basis.to_evidence_dict(),
+            "voice_style_speakers": list(self.voice_style_speakers),
+            "duration_tiers": list(self.duration_tiers),
+            "reference_image_limit": self.reference_image_limit,
+            "parent_version": self.parent_version,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self._payload(), "currency_digest": self.currency_digest}
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        if not isinstance(value, Mapping) or set(value) != cls._FIELDS:
+            raise ValueError("video artifact currency facts have an invalid schema")
+        raw = cast(Mapping[str, Any], value)
+        if raw["schema_version"] != _SCHEMA_VERSION:
+            raise ValueError("unsupported video artifact currency schema")
+        speakers = raw["voice_style_speakers"]
+        tiers = raw["duration_tiers"]
+        if not isinstance(speakers, list) or not isinstance(tiers, list):
+            raise ValueError("video artifact currency collections must be arrays")
+        try:
+            facts = cls(
+                episode=raw["episode"],
+                request_duration_seconds=raw["request_duration_seconds"],
+                visual_basis=ArtifactBasis.from_evidence_dict(raw["visual_basis"]),
+                speech_basis=ArtifactBasis.from_evidence_dict(raw["speech_basis"]),
+                duration_basis=ArtifactBasis.from_evidence_dict(raw["duration_basis"]),
+                video_basis=ArtifactBasis.from_evidence_dict(raw["video_basis"]),
+                voice_style_speakers=tuple(speakers),
+                duration_tiers=tuple(tiers),
+                reference_image_limit=raw["reference_image_limit"],
+                parent_version=raw["parent_version"],
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("video artifact currency facts are not self-verifying") from exc
+        if raw["currency_digest"] != facts.currency_digest:
+            raise ValueError("video artifact currency digest does not match its canonical facts")
+        return facts
+
+
+__all__ = ["VideoArtifactCurrencyFacts"]
+
+
+def _basis_inputs(basis: ArtifactBasis) -> Mapping[str, Any]:
+    evidence = basis.to_evidence_dict()
+    inputs = evidence.get("inputs")
+    if not isinstance(inputs, Mapping):  # pragma: no cover - ArtifactBasis invariant
+        raise ValueError("artifact basis inputs must be an object")
+    return cast(Mapping[str, Any], inputs)
+
+
+def _nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _canvas_is_valid(value: object) -> bool:
+    return isinstance(value, Mapping) and set(value) == {"aspect_ratio"} and _nonempty(value["aspect_ratio"])
+
+
+def _validate_visual_inputs(basis: ArtifactBasis) -> None:
+    inputs = _basis_inputs(basis)
+    if basis.kind == _STORYBOARD_VISUAL_KIND:
+        if set(inputs) != {"resource_id", "visual_prompt", "canvas", "frames"}:
+            raise ValueError("storyboard visual basis has invalid canonical inputs")
+        prompt = inputs["visual_prompt"]
+        prompt_valid = (_nonempty(prompt)) or (
+            isinstance(prompt, Mapping)
+            and set(prompt) == {"action", "camera_motion"}
+            and _nonempty(prompt["action"])
+            and isinstance(prompt["camera_motion"], str)
+        )
+        frames = inputs["frames"]
+        frames_valid = (
+            isinstance(frames, list)
+            and len(frames) in {1, 2}
+            and [frame.get("role") for frame in frames if isinstance(frame, Mapping)]
+            == (["storyboard"] if len(frames) == 1 else ["storyboard", "end_frame"])
+            and all(
+                isinstance(frame, Mapping)
+                and set(frame) == {"role", "sha256"}
+                and isinstance(frame["sha256"], str)
+                and _HEX_DIGEST.fullmatch(frame["sha256"]) is not None
+                for frame in frames
+            )
+        )
+        if not _nonempty(inputs["resource_id"]) or not prompt_valid or not _canvas_is_valid(inputs["canvas"]):
+            raise ValueError("storyboard visual basis has invalid canonical inputs")
+        if not frames_valid:
+            raise ValueError("storyboard visual basis has invalid frame evidence")
+        return
+
+    if set(inputs) != {"unit_id", "visual_shots", "style", "canvas", "request_references"}:
+        raise ValueError("reference visual basis has invalid canonical inputs")
+    shots = inputs["visual_shots"]
+    shots_valid = isinstance(shots, list) and all(
+        isinstance(shot, Mapping)
+        and set(shot) == {"shot_index", "lines"}
+        and shot["shot_index"] == index
+        and isinstance(shot["lines"], list)
+        and bool(shot["lines"])
+        and all(_nonempty(line) for line in shot["lines"])
+        for index, shot in enumerate(shots)
+    )
+    references = inputs["request_references"]
+    references_valid = isinstance(references, list) and all(_reference_evidence_is_valid(item) for item in references)
+    if (
+        not _nonempty(inputs["unit_id"])
+        or not isinstance(inputs["style"], str)
+        or not _canvas_is_valid(inputs["canvas"])
+        or not shots_valid
+        or not references_valid
+    ):
+        raise ValueError("reference visual basis has invalid canonical inputs")
+
+
+def _reference_evidence_is_valid(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    allowed = {"role", "sha256", "logical_identity", "kind"}
+    identity = value.get("logical_identity")
+    return (
+        set(value) <= allowed
+        and {"role", "sha256", "logical_identity"} <= set(value)
+        and value["role"] == "reference_image"
+        and isinstance(value["sha256"], str)
+        and _HEX_DIGEST.fullmatch(value["sha256"]) is not None
+        and isinstance(identity, Mapping)
+        and set(identity) == {"type", "id"}
+        and _nonempty(identity["type"])
+        and _nonempty(identity["id"])
+        and ("kind" not in value or _nonempty(value["kind"]))
+    )
+
+
+def _validate_speech_inputs(basis: ArtifactBasis) -> None:
+    inputs = _basis_inputs(basis)
+    mode = inputs.get("mode")
+    if mode in {"silent", "narrator_voiceover"}:
+        if set(inputs) != {"mode"}:
+            raise ValueError("non-character video speech basis has invalid canonical inputs")
+        return
+    if mode != "character_speech" or set(inputs) != {"mode", "utterances", "voices"}:
+        raise ValueError("video speech basis has invalid canonical inputs")
+    utterances = inputs["utterances"]
+    voices = inputs["voices"]
+    if not isinstance(utterances, list) or not utterances or not isinstance(voices, list):
+        raise ValueError("character video speech basis requires utterances and voices")
+    speaker_order: list[str] = []
+    for utterance in utterances:
+        if (
+            not isinstance(utterance, Mapping)
+            or set(utterance) != {"speaker", "text"}
+            or not _nonempty(utterance["speaker"])
+            or asset_name_comparison_key(utterance["speaker"]) != utterance["speaker"]
+            or not _nonempty(utterance["text"])
+        ):
+            raise ValueError("character video speech utterance is not canonical")
+        if utterance["speaker"] not in speaker_order:
+            speaker_order.append(utterance["speaker"])
+    if len(voices) != len(speaker_order):
+        raise ValueError("character video speech voices do not match ordered speakers")
+    for speaker, voice in zip(speaker_order, voices, strict=True):
+        digest = voice.get("reference_audio_digest") if isinstance(voice, Mapping) else object()
+        if (
+            not isinstance(voice, Mapping)
+            or set(voice) != {"speaker", "voice_style", "reference_audio_digest"}
+            or voice["speaker"] != speaker
+            or not isinstance(voice["voice_style"], str)
+            or (digest is not None and (not isinstance(digest, str) or _BASIS_DIGEST.fullmatch(digest) is None))
+        ):
+            raise ValueError("character video speech voice evidence is not canonical")

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -116,6 +116,8 @@ class UploadSpec:
         # 宿主约束与其 404 文案必须成对登记，否则拒收路径会拿空 key 去取翻译
         if (self.host_bucket is None) != (not self.host_not_found_key):
             raise ValueError("host_bucket 与 host_not_found_key 必须成对登记")
+        if self.tracks_stale_audio and self.host_bucket is None:
+            raise ValueError("tracks_stale_audio 必须登记宿主约束")
 
 
 UPLOAD_SPECS: dict[str, UploadSpec] = {
@@ -147,6 +149,8 @@ UPLOAD_SPECS: dict[str, UploadSpec] = {
         unsupported_ext_key="unsupported_audio_type",
         max_bytes=AUDIO_REFERENCE_MAX_BYTES,
         metadata_setter=ProjectManager.update_character_reference_audio,
+        host_bucket=ASSET_SPECS["character"].bucket_key,
+        host_not_found_key="character_not_found",
         tracks_stale_audio=True,
     ),
     "scene": UploadSpec(

--- a/server/routers/files.py
+++ b/server/routers/files.py
@@ -25,10 +25,7 @@ from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
     AUDIO_REFERENCE_MIN_SECONDS,
-    discard_stale_reference_audio,
     probe_audio_duration_seconds,
-    resolve_audio_ref_path,
-    resolve_stale_reference_audio,
 )
 from lib.config.resolver import VisionCapabilityError
 from lib.episode_paths import (
@@ -112,7 +109,7 @@ class UploadSpec:
     # 可容忍资产后建，不设此约束。
     host_bucket: str | None = None
     host_not_found_key: str = ""
-    # 替换参考音频时先解析旧文件路径，等新文件与字段写入成功后再删除
+    # 参考音频的字节替换与字段写回须走 ProjectManager 的项目锁事务；提交后再清理旧扩展名文件
     tracks_stale_audio: bool = False
 
     def __post_init__(self) -> None:
@@ -363,37 +360,31 @@ async def upload_file(
                         seq += 1
                 filename = candidate.name
 
-            stale_audio_path: Path | None = None
-            if spec.tracks_stale_audio and name:
-                # 实际删除推迟到新文件与字段写入成功之后（见 discard_stale_reference_audio）。
-                characters = manager.load_project(project_name).get("characters", {})
-                char_key = resolve_asset_key(characters, name)
-                old_audio = (characters.get(char_key, {}) if char_key else {}).get("reference_audio")
-                stale_audio_path = resolve_stale_reference_audio(
-                    project_dir, target_dir, old_audio, target_dir / filename
-                )
-
             target_path = target_dir / filename
-            with open(target_path, "wb") as f:
-                f.write(content)
-
             relative_path = "/".join((*spec.subdir, filename))
 
-            # 更新元数据
-            if spec.metadata_setter is not None and name:
+            if spec.tracks_stale_audio and name:
                 try:
                     with project_change_source("webui"):
-                        spec.metadata_setter(manager, project_name, name, relative_path)
+                        manager.install_character_reference_audio(project_name, name, relative_path, content)
                 except KeyError:
-                    if spec.host_bucket is not None:
-                        # 入口已校验宿主存在；并发删除导致的窗口期竞态按 404 处理，
-                        # 已落盘的文件一并清理避免孤儿
-                        target_path.unlink(missing_ok=True)
-                        raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name))
-                    # 单图类型：资产不存在时忽略，文件路径确定，资产后建仍可引用
-                else:
-                    if spec.tracks_stale_audio:
-                        discard_stale_reference_audio(stale_audio_path)
+                    raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name))
+            else:
+                with open(target_path, "wb") as f:
+                    f.write(content)
+
+                # 更新元数据
+                if spec.metadata_setter is not None and name:
+                    try:
+                        with project_change_source("webui"):
+                            spec.metadata_setter(manager, project_name, name, relative_path)
+                    except KeyError:
+                        if spec.host_bucket is not None:
+                            # 入口已校验宿主存在；并发删除导致的窗口期竞态按 404 处理，
+                            # 已落盘的文件一并清理避免孤儿
+                            target_path.unlink(missing_ok=True)
+                            raise HTTPException(status_code=404, detail=_t(spec.host_not_found_key, name=name))
+                        # 单图类型：资产不存在时忽略，文件路径确定，资产后建仍可引用
 
             return {
                 "success": True,
@@ -420,28 +411,11 @@ async def delete_character_reference_audio(project_name: str, name: str, _t: Tra
 
         def _sync():
             manager = get_project_manager()
-            project_dir = manager.get_project_path(project_name)
-            project = manager.load_project(project_name)
-            characters = project.get("characters") or {}
-            char_key = resolve_asset_key(characters, name)
-            character = characters.get(char_key) if char_key else None
-            if character is None:
+            try:
+                with project_change_source("webui"):
+                    manager.clear_character_reference_audio(project_name, name)
+            except KeyError:
                 raise HTTPException(status_code=404, detail=_t("character_not_found", name=name))
-
-            old_audio = character.get("reference_audio")
-            # 字段值来自 project.json，可被 PATCH 写成任意字符串；经 resolve_audio_ref_path
-            # 确认落在 refs_audio 目录内才允许删除，否则只清字段不碰文件系统
-            audio_refs_dir = project_dir / "characters" / "refs_audio"
-            stale_path = (
-                resolve_audio_ref_path(project_dir, audio_refs_dir, old_audio) if isinstance(old_audio, str) else None
-            )
-            # 先删文件、后清字段：权限/IO 错误（含 Windows 文件被占用的共享冲突）导致
-            # unlink 失败时,字段仍指向该文件,可重试删除;顺序反过来会在物理删除失败时
-            # 留下「字段已清空但文件仍在」的孤儿,且没有指针可供重试发现它。
-            if stale_path is not None:
-                stale_path.unlink(missing_ok=True)
-            with project_change_source("webui"):
-                manager.update_character_reference_audio(project_name, name, "")
 
             return {"success": True}
 

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, Field
 
 from lib.api_errors import BadRequestError, ConflictError, NotFoundError
 from lib.asset_types import ASSET_SPECS, resolve_asset_key, validate_asset_name
-from lib.audio_utils import discard_stale_reference_audio, resolve_stale_reference_audio
 from lib.config.resolver import ConfigResolver, video_bucket_for_generation_mode
 from lib.generation_queue import get_generation_queue
 from lib.generation_queue_client import TaskSpec
@@ -663,35 +662,20 @@ async def confirm_character_voice_sample(
 
     def _sync() -> dict:
         pm_local = get_project_manager()
-        project = pm_local.load_project(project_name)
-        char_key = resolve_asset_key(project.get("characters"), char_name)
-        if char_key is None:
-            raise NotFoundError("character_not_found", name=char_name)
-
         project_dir = pm_local.get_project_path(project_name)
         if not safe_exists(project_dir, sample_rel):
             raise NotFoundError("voice_sample_file_missing")
         sample_abs = safe_join(project_dir, sample_rel)
         content = sample_abs.read_bytes()
 
-        refs_audio_dir = project_dir / "characters" / "refs_audio"
-        refs_audio_dir.mkdir(parents=True, exist_ok=True)
         filename = f"{char_name}.wav"
-        target_path = refs_audio_dir / filename
-
-        old_audio = ((project.get("characters") or {}).get(char_key) or {}).get("reference_audio")
-        stale_audio_path = resolve_stale_reference_audio(project_dir, refs_audio_dir, old_audio, target_path)
-
-        target_path.write_bytes(content)
-
         ref_audio_rel = f"characters/refs_audio/{filename}"
+        target_path = project_dir / ref_audio_rel
         try:
             with project_change_source("webui"):
-                pm_local.update_character_reference_audio(project_name, char_name, ref_audio_rel)
+                pm_local.install_character_reference_audio(project_name, char_name, ref_audio_rel, content)
         except KeyError:
             raise NotFoundError("character_not_found", name=char_name)
-
-        discard_stale_reference_audio(stale_audio_path)
 
         # 目标文件名固定为 {char_name}.wav：重新生成后再次确认时 reference_audio 字段值
         # 不变（同一路径字符串），project.json 的字段级 diff 因此检测不到变化、不会自动

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -220,7 +220,7 @@ async def restore_version(
     """
     try:
         target: TypedMediaRestoreTarget | None = None
-        if resource_type == "audio":
+        if is_typed_media_restore_resource(resource_type):
             target = await asyncio.to_thread(
                 get_typed_media_restore_target,
                 get_version_manager(project_name),
@@ -292,27 +292,27 @@ async def restore_version(
                 "asset_fingerprints": asset_fingerprints,
             }
 
-        if resource_type == "audio":
-            assert target is not None
+        if target is not None:
             async with generation_admission_lock(
                 project_name=project_name,
                 script_file=target.script_file,
                 resource_id=resource_id,
             ):
-                active_tts, active_video = await asyncio.gather(
-                    active_tts_resource_ids(
-                        project_name=project_name,
-                        resource_ids=(resource_id,),
-                        script_file=target.script_file,
-                    ),
-                    active_narrated_video_resource_ids(
-                        project_name=project_name,
-                        resource_ids=(resource_id,),
-                        script_file=target.script_file,
-                    ),
-                )
-                if resource_id in active_tts or resource_id in active_video:
-                    raise ConflictError("audio_restore_conflicts_with_active_task", resource_id=resource_id)
+                if resource_type == "audio":
+                    active_tts, active_video = await asyncio.gather(
+                        active_tts_resource_ids(
+                            project_name=project_name,
+                            resource_ids=(resource_id,),
+                            script_file=target.script_file,
+                        ),
+                        active_narrated_video_resource_ids(
+                            project_name=project_name,
+                            resource_ids=(resource_id,),
+                            script_file=target.script_file,
+                        ),
+                    )
+                    if resource_id in active_tts or resource_id in active_video:
+                        raise ConflictError("audio_restore_conflicts_with_active_task", resource_id=resource_id)
                 return await run_noninterruptible_sync(_sync)
         return await asyncio.to_thread(_sync)
 

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -13,14 +13,16 @@ from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 
-from lib.api_errors import BadRequestError
+from lib.api_errors import BadRequestError, ConflictError
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
 from lib.project_manager import get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
+from server.services.artifact_version_restore import get_typed_media_restore_target, restore_typed_media_version
 from server.services.grid_access import ensure_grid_writable
+from server.services.narration_delivery_tasks import active_narrated_video_resource_ids, active_tts_resource_ids
 from server.services.reference_video_tasks import apply_unit_video_assets
 
 router = APIRouter()
@@ -29,8 +31,9 @@ router = APIRouter()
 # 仅放行有还原后元数据同步分支的这几类。grids 的还原只换回联合图文件并复位宫格记录的
 # 切分态，不触发切分、不碰任何分镜图——落格由宫格切分端点显式执行。
 _RESTORABLE_RESOURCE_TYPES = frozenset(
-    {"storyboards", "videos", "characters", "scenes", "props", "products", "reference_videos", "grids"}
+    {"storyboards", "videos", "audio", "characters", "scenes", "props", "products", "reference_videos", "grids"}
 )
+_TYPED_MEDIA_RESOURCE_TYPES = frozenset({"audio", "videos", "reference_videos"})
 
 
 def get_version_manager(project_name: str) -> VersionManager:
@@ -272,6 +275,28 @@ async def restore_version(
         version: 要还原的版本号
     """
     try:
+        if resource_type == "audio":
+            target = await asyncio.to_thread(
+                get_typed_media_restore_target,
+                get_version_manager(project_name),
+                resource_type=resource_type,
+                resource_id=resource_id,
+                version=version,
+            )
+            active_tts, active_video = await asyncio.gather(
+                active_tts_resource_ids(
+                    project_name=project_name,
+                    resource_ids=(resource_id,),
+                    script_file=target.script_file,
+                ),
+                active_narrated_video_resource_ids(
+                    project_name=project_name,
+                    resource_ids=(resource_id,),
+                    script_file=target.script_file,
+                ),
+            )
+            if resource_id in active_tts or resource_id in active_video:
+                raise ConflictError("audio_restore_conflicts_with_active_task", resource_id=resource_id)
 
         def _sync():
             # 还原同样是一条联合图写入路径（换回历史联合图 + 复位宫格记录），
@@ -283,12 +308,25 @@ async def restore_version(
             project_path = get_project_manager().get_project_path(project_name)
             current_file, file_path = _resolve_resource_path(resource_type, resource_id, project_path)
 
-            result = vm.restore_version(
-                resource_type=resource_type,
-                resource_id=resource_id,
-                version=version,
-                current_file=current_file,
-            )
+            if resource_type in _TYPED_MEDIA_RESOURCE_TYPES:
+                result = restore_typed_media_version(
+                    project_manager=get_project_manager(),
+                    project_name=project_name,
+                    project_path=project_path,
+                    versions=vm,
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    version=version,
+                    current_file=current_file,
+                    artifact_path=file_path,
+                )
+            else:
+                result = vm.restore_version(
+                    resource_type=resource_type,
+                    resource_id=resource_id,
+                    version=version,
+                    current_file=current_file,
+                )
 
             # 还原参考视频时把该版本的原始入库时间一并写回，
             # 避免存量声音判定被还原动作洗新。
@@ -296,14 +334,15 @@ async def restore_version(
                 restored_created_at = vm.get_version_created_at(resource_type, resource_id, version)
             else:
                 restored_created_at = None
-            _sync_metadata(
-                resource_type,
-                project_name,
-                resource_id,
-                file_path,
-                project_path,
-                restored_created_at,
-            )
+            if resource_type not in _TYPED_MEDIA_RESOURCE_TYPES:
+                _sync_metadata(
+                    resource_type,
+                    project_name,
+                    resource_id,
+                    file_path,
+                    project_path,
+                    restored_created_at,
+                )
 
             # 计算还原后文件的 fingerprint；视频还原时同步删除缩略图（内容已失效）
             asset_fingerprints: dict[str, int] = {}

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -14,6 +14,8 @@ from fastapi import APIRouter
 logger = logging.getLogger(__name__)
 
 from lib.api_errors import BadRequestError, ConflictError
+from lib.async_thread import run_noninterruptible_sync
+from lib.generation_admission import generation_admission_lock
 from lib.path_safety import PathTraversalError, safe_join
 from lib.project_change_hints import project_change_source
 from lib.project_manager import get_project_manager
@@ -21,6 +23,7 @@ from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
 from server.services.artifact_version_restore import (
+    TypedMediaRestoreTarget,
     get_typed_media_restore_target,
     is_typed_media_restore_resource,
     is_typed_media_version_restorable,
@@ -216,6 +219,7 @@ async def restore_version(
         version: 要还原的版本号
     """
     try:
+        target: TypedMediaRestoreTarget | None = None
         if resource_type == "audio":
             target = await asyncio.to_thread(
                 get_typed_media_restore_target,
@@ -224,20 +228,6 @@ async def restore_version(
                 resource_id=resource_id,
                 version=version,
             )
-            active_tts, active_video = await asyncio.gather(
-                active_tts_resource_ids(
-                    project_name=project_name,
-                    resource_ids=(resource_id,),
-                    script_file=target.script_file,
-                ),
-                active_narrated_video_resource_ids(
-                    project_name=project_name,
-                    resource_ids=(resource_id,),
-                    script_file=target.script_file,
-                ),
-            )
-            if resource_id in active_tts or resource_id in active_video:
-                raise ConflictError("audio_restore_conflicts_with_active_task", resource_id=resource_id)
 
         def _sync():
             # 还原同样是一条联合图写入路径（换回历史联合图 + 复位宫格记录），
@@ -302,6 +292,28 @@ async def restore_version(
                 "asset_fingerprints": asset_fingerprints,
             }
 
+        if resource_type == "audio":
+            assert target is not None
+            async with generation_admission_lock(
+                project_name=project_name,
+                script_file=target.script_file,
+                resource_id=resource_id,
+            ):
+                active_tts, active_video = await asyncio.gather(
+                    active_tts_resource_ids(
+                        project_name=project_name,
+                        resource_ids=(resource_id,),
+                        script_file=target.script_file,
+                    ),
+                    active_narrated_video_resource_ids(
+                        project_name=project_name,
+                        resource_ids=(resource_id,),
+                        script_file=target.script_file,
+                    ),
+                )
+                if resource_id in active_tts or resource_id in active_video:
+                    raise ConflictError("audio_restore_conflicts_with_active_task", resource_id=resource_id)
+                return await run_noninterruptible_sync(_sync)
         return await asyncio.to_thread(_sync)
 
     except ValueError as e:

--- a/server/routers/versions.py
+++ b/server/routers/versions.py
@@ -20,10 +20,14 @@ from lib.project_manager import get_project_manager
 from lib.resource_paths import resource_relative_path
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
-from server.services.artifact_version_restore import get_typed_media_restore_target, restore_typed_media_version
+from server.services.artifact_version_restore import (
+    get_typed_media_restore_target,
+    is_typed_media_restore_resource,
+    is_typed_media_version_restorable,
+    restore_typed_media_version,
+)
 from server.services.grid_access import ensure_grid_writable
 from server.services.narration_delivery_tasks import active_narrated_video_resource_ids, active_tts_resource_ids
-from server.services.reference_video_tasks import apply_unit_video_assets
 
 router = APIRouter()
 
@@ -33,7 +37,6 @@ router = APIRouter()
 _RESTORABLE_RESOURCE_TYPES = frozenset(
     {"storyboards", "videos", "audio", "characters", "scenes", "props", "products", "reference_videos", "grids"}
 )
-_TYPED_MEDIA_RESOURCE_TYPES = frozenset({"audio", "videos", "reference_videos"})
 
 
 def get_version_manager(project_name: str) -> VersionManager:
@@ -104,63 +107,6 @@ def _sync_storyboard_metadata(
     _sync_scripts_best_effort(project_path, _apply)
 
 
-def _sync_video_metadata(
-    project_name: str,
-    resource_id: str,
-    file_path: str,
-    project_path: Path,
-) -> None:
-    """还原镜头视频后同步 generated_assets。
-
-    还原的是历史本地文件，旧 provider URI / 缩略图与之不再对应，一并清空
-    （缩略图文件本身由 restore 端点删除，同步路径无法内联 async ffmpeg 重新抽帧）。
-    """
-
-    def _apply(script_name: str) -> None:
-        get_project_manager().batch_update_scene_assets(
-            project_name=project_name,
-            script_filename=script_name,
-            updates=[
-                (resource_id, "video_clip", file_path),
-                (resource_id, "video_uri", None),
-                (resource_id, "video_thumbnail", None),
-            ],
-        )
-
-    _sync_scripts_best_effort(project_path, _apply)
-
-
-def _sync_reference_video_metadata(
-    project_name: str,
-    resource_id: str,
-    project_path: Path,
-    generated_at: str | None = None,
-) -> None:
-    """还原参考视频单元后同步 unit.generated_assets（写回口径与生成 finalize 共用）。
-
-    还原的是历史本地文件，旧 provider URI / 缩略图与之不再对应，一并清空；
-    缩略图文件本身由 restore 端点删除（同步路径无法内联 async ffmpeg 重新抽帧）。
-
-    ``generated_at`` 传被还原版本的入库时间：还原回来的是旧内容，其 video_generated_at
-    应当是那一版的生成时间，否则「早于当前参考音频设置」的存量片段会被还原动作洗成最新。
-
-    """
-
-    def _apply(script_name: str) -> None:
-        # 资产回写热路径：只动 unit.generated_assets，豁免结构校验（与 update_scene_asset 对齐）。
-        # 该集脚本不含此 unit 时 apply_unit_video_assets 抛 KeyError，锁内冒出即跳过写回。
-        with get_project_manager().locked_script(project_name, script_name, validate=False) as script:
-            apply_unit_video_assets(
-                script,
-                resource_id,
-                video_uri=None,
-                thumb_rel=None,
-                generated_at=generated_at,
-            )
-
-    _sync_scripts_best_effort(project_path, _apply)
-
-
 def _sync_grid_record(project_path: Path, resource_id: str) -> None:
     """还原联合图后复位宫格记录：内容已换回历史版本，旧的落格结果不再对应当前图。
 
@@ -198,12 +144,8 @@ def _sync_metadata(
     resource_id: str,
     file_path: str,
     project_path: Path,
-    restored_created_at: str | None = None,
 ) -> None:
-    """还原后同步元数据，确保引用指向统一文件路径。
-
-    ``restored_created_at`` 为被还原版本的入库时间，仅参考视频写回时需要。
-    """
+    """还原非 typed 资源后同步元数据，确保引用指向统一文件路径。"""
     asset_type = _RESOURCE_TO_ASSET_TYPE.get(resource_type)
     if asset_type is not None:
         try:
@@ -213,10 +155,6 @@ def _sync_metadata(
             pass  # 资产条目可能已从 project.json 删除，跳过元数据同步
     elif resource_type == "storyboards":
         _sync_storyboard_metadata(project_name, resource_id, file_path, project_path)
-    elif resource_type == "videos":
-        _sync_video_metadata(project_name, resource_id, file_path, project_path)
-    elif resource_type == "reference_videos":
-        _sync_reference_video_metadata(project_name, resource_id, project_path, restored_created_at)
     elif resource_type == "grids":
         _sync_grid_record(project_path, resource_id)
 
@@ -243,6 +181,9 @@ async def get_versions(
         def _sync():
             vm = get_version_manager(project_name)
             versions_info = vm.get_versions(resource_type, resource_id)
+            for record in versions_info.get("versions", []):
+                if isinstance(record, dict):
+                    record["restorable"] = is_typed_media_version_restorable(resource_type, record)
             return {"resource_type": resource_type, "resource_id": resource_id, **versions_info}
 
         return await asyncio.to_thread(_sync)
@@ -308,7 +249,7 @@ async def restore_version(
             project_path = get_project_manager().get_project_path(project_name)
             current_file, file_path = _resolve_resource_path(resource_type, resource_id, project_path)
 
-            if resource_type in _TYPED_MEDIA_RESOURCE_TYPES:
+            if is_typed_media_restore_resource(resource_type):
                 result = restore_typed_media_version(
                     project_manager=get_project_manager(),
                     project_name=project_name,
@@ -328,20 +269,13 @@ async def restore_version(
                     current_file=current_file,
                 )
 
-            # 还原参考视频时把该版本的原始入库时间一并写回，
-            # 避免存量声音判定被还原动作洗新。
-            if resource_type == "reference_videos":
-                restored_created_at = vm.get_version_created_at(resource_type, resource_id, version)
-            else:
-                restored_created_at = None
-            if resource_type not in _TYPED_MEDIA_RESOURCE_TYPES:
+            if not is_typed_media_restore_resource(resource_type):
                 _sync_metadata(
                     resource_type,
                     project_name,
                     resource_id,
                     file_path,
                     project_path,
-                    restored_created_at,
                 )
 
             # 计算还原后文件的 fingerprint；视频还原时同步删除缩略图（内容已失效）

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -19,7 +19,7 @@ from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_b
 from lib.project_manager import ProjectManager, find_episode
 from lib.script_editor import resolve_items
 from lib.version_manager import VersionManager
-from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+from lib.video_artifact_facts import VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD, VideoArtifactCurrencyFacts
 from server.services.reference_video_tasks import apply_unit_video_assets
 
 
@@ -248,6 +248,8 @@ def _validate_video_basis(
     record: Mapping[str, Any],
     spec: _TypedMediaRestoreSpec,
 ) -> VideoArtifactCurrencyFacts:
+    if record.get(VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD) is not None:
+        raise ValueError("version failed paid video output validation")
     schema_version = record.get("execution_checkpoint_schema_version")
     duration_seconds = record.get("execution_duration_seconds")
     request_digest = record.get("execution_request_digest")

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -127,6 +127,8 @@ def restore_typed_media_version(
     def _same_script(project: dict[str, Any]) -> str:
         episode_entry = find_episode(project, target.episode)
         current_binding = episode_entry.get("script_file") if isinstance(episode_entry, dict) else None
+        if current_binding is None and not (project.get("episodes") or []):
+            return target.script_file
         if not isinstance(current_binding, str) or (
             ProjectManager.normalize_script_filename(current_binding)
             != ProjectManager.normalize_script_filename(target.script_file)

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -1,0 +1,207 @@
+"""Typed media-version restore coordinated with script and Artifact Manifest state."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.api_errors import NotFoundError
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ProjectArtifactManifestAdapter,
+)
+from lib.project_manager import ProjectManager, find_episode
+from lib.script_editor import resolve_items
+from lib.version_manager import VersionManager
+from server.services.reference_video_tasks import apply_unit_video_assets
+
+_TYPED_MEDIA_RESOURCE_TYPES = frozenset({"audio", "videos", "reference_videos"})
+
+
+@dataclass(frozen=True, slots=True)
+class TypedMediaRestoreTarget:
+    episode: int
+    script_file: str
+    basis: ArtifactBasisDescriptor
+    created_at: str | None
+
+
+def get_typed_media_restore_target(
+    versions: VersionManager,
+    *,
+    resource_type: str,
+    resource_id: str,
+    version: int,
+) -> TypedMediaRestoreTarget:
+    """Read and validate the complete typed identity carried by one version."""
+
+    if resource_type not in _TYPED_MEDIA_RESOURCE_TYPES:
+        raise ValueError(f"resource type does not carry typed artifact restore metadata: {resource_type}")
+    records = versions.get_versions(resource_type, resource_id).get("versions", [])
+    record = next(
+        (candidate for candidate in records if isinstance(candidate, Mapping) and candidate.get("version") == version),
+        None,
+    )
+    if record is None:
+        raise NotFoundError("version_not_found", version=version)
+    return _target_from_record(resource_type, record)
+
+
+def restore_typed_media_version(
+    *,
+    project_manager: ProjectManager,
+    project_name: str,
+    project_path: Path,
+    versions: VersionManager,
+    resource_type: str,
+    resource_id: str,
+    version: int,
+    current_file: Path,
+    artifact_path: str,
+) -> dict[str, Any]:
+    """Restore a typed version as one script/media/pointer/Manifest transition.
+
+    Historical versions without a complete descriptor are rejected.  Their
+    provenance cannot be reconstructed from a path, prompt, or current project
+    state without making an unprovable selection claim.
+    """
+
+    target = get_typed_media_restore_target(
+        versions,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        version=version,
+    )
+    restored: dict[str, Any] | None = None
+
+    def _same_script(project: dict[str, Any]) -> str:
+        episode_entry = find_episode(project, target.episode)
+        current_binding = episode_entry.get("script_file") if isinstance(episode_entry, dict) else None
+        if not isinstance(current_binding, str) or (
+            ProjectManager.normalize_script_filename(current_binding)
+            != ProjectManager.normalize_script_filename(target.script_file)
+        ):
+            raise ValueError("typed artifact version no longer matches the episode script binding")
+        return current_binding
+
+    def _restore_and_register(_script_path: Path) -> None:
+        nonlocal restored
+
+        def _register(record: dict[str, Any]) -> None:
+            committed_target = _target_from_record(resource_type, record)
+            if committed_target != target:
+                raise RuntimeError("typed artifact version metadata changed during restore")
+            key = (
+                ArtifactKey.episode_audio(target.episode, resource_id)
+                if resource_type == "audio"
+                else ArtifactKey.episode_video(target.episode, resource_id)
+            )
+            ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor_transactionally(
+                key,
+                artifact_path=artifact_path,
+                basis=target.basis,
+            )
+
+        restored = versions.restore_version(
+            resource_type,
+            resource_id,
+            version,
+            current_file,
+            on_restore=_register,
+        )
+
+    with project_manager.locked_episode_script(
+        project_name,
+        _same_script,
+        validate=False,
+        on_commit=_restore_and_register,
+    ) as script:
+        _apply_restored_asset(
+            project_manager=project_manager,
+            script=script,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            artifact_path=artifact_path,
+            created_at=target.created_at,
+        )
+
+    if restored is None:
+        raise RuntimeError("typed artifact restore completed without selecting a version")
+    return restored
+
+
+def _target_from_record(resource_type: str, record: Mapping[str, Any]) -> TypedMediaRestoreTarget:
+    episode = record.get("artifact_episode")
+    script_file = record.get("execution_script_file")
+    basis_field = "artifact_audio_basis" if resource_type == "audio" else "artifact_video_basis"
+    raw_basis = record.get(basis_field)
+    if type(episode) is not int or episode < 1 or not isinstance(script_file, str) or not script_file.strip():
+        raise ValueError("version does not contain complete typed artifact metadata")
+    try:
+        basis = ArtifactBasisDescriptor.from_dict(raw_basis)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("version does not contain complete typed artifact metadata") from exc
+    expected_kind = "narration-delivery/tts-audio" if resource_type == "audio" else "artifact-components/video"
+    if basis.kind != expected_kind:
+        raise ValueError("version does not contain complete typed artifact metadata")
+    created_at = record.get("created_at")
+    return TypedMediaRestoreTarget(
+        episode=episode,
+        script_file=script_file,
+        basis=basis,
+        created_at=created_at if isinstance(created_at, str) else None,
+    )
+
+
+def _apply_restored_asset(
+    *,
+    project_manager: ProjectManager,
+    script: dict[str, Any],
+    resource_type: str,
+    resource_id: str,
+    artifact_path: str,
+    created_at: str | None,
+) -> None:
+    if resource_type == "reference_videos":
+        apply_unit_video_assets(
+            script,
+            resource_id,
+            video_uri=None,
+            thumb_rel=None,
+            generated_at=created_at,
+        )
+        return
+
+    items, id_field, _kind = resolve_items(script)
+    item = next(
+        (
+            candidate
+            for candidate in items
+            if isinstance(candidate, dict) and str(candidate.get(id_field)) == str(resource_id)
+        ),
+        None,
+    )
+    if item is None:
+        raise KeyError(resource_id)
+    assets = item.get("generated_assets")
+    if not isinstance(assets, dict):
+        assets = ProjectManager.create_generated_assets(str(script.get("content_mode") or "narration"))
+        item["generated_assets"] = assets
+    if resource_type == "audio":
+        assets["narration_audio"] = artifact_path
+    else:
+        assets["video_clip"] = artifact_path
+        assets["video_uri"] = None
+        assets["video_thumbnail"] = None
+    project_manager.update_scene_status(item)
+
+
+__all__ = [
+    "TypedMediaRestoreTarget",
+    "get_typed_media_restore_target",
+    "restore_typed_media_version",
+]

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -16,7 +16,7 @@ from lib.artifact_manifest import (
     ProjectArtifactManifestAdapter,
 )
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis_from_canonical_text
-from lib.project_manager import ProjectManager, find_episode
+from lib.project_manager import ProjectManager, resolve_episode_script_binding
 from lib.script_editor import resolve_items
 from lib.version_manager import VersionManager
 from lib.video_artifact_facts import VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD, VideoArtifactCurrencyFacts
@@ -125,14 +125,8 @@ def restore_typed_media_version(
     restored: dict[str, Any] | None = None
 
     def _same_script(project: dict[str, Any]) -> str:
-        episode_entry = find_episode(project, target.episode)
-        current_binding = episode_entry.get("script_file") if isinstance(episode_entry, dict) else None
-        if current_binding is None and not (project.get("episodes") or []):
-            return target.script_file
-        if not isinstance(current_binding, str) or (
-            ProjectManager.normalize_script_filename(current_binding)
-            != ProjectManager.normalize_script_filename(target.script_file)
-        ):
+        current_binding = resolve_episode_script_binding(project, target.episode, target.script_file)
+        if current_binding is None:
             raise ValueError("typed artifact version no longer matches the episode script binding")
         return current_binding
 

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import math
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from lib.api_errors import NotFoundError
 from lib.artifact_manifest import (
+    ArtifactBasis,
     ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifest,
@@ -17,9 +19,53 @@ from lib.artifact_manifest import (
 from lib.project_manager import ProjectManager, find_episode
 from lib.script_editor import resolve_items
 from lib.version_manager import VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from server.services.reference_video_tasks import apply_unit_video_assets
 
-_TYPED_MEDIA_RESOURCE_TYPES = frozenset({"audio", "videos", "reference_videos"})
+
+@dataclass(frozen=True, slots=True)
+class _TypedMediaRestoreSpec:
+    basis_field: str | None
+    basis_kind: str
+    artifact_key: Callable[[int, str], ArtifactKey]
+    visual_kind: str | None = None
+
+
+_TYPED_MEDIA_RESTORE_SPECS = {
+    "audio": _TypedMediaRestoreSpec(
+        basis_field="artifact_audio_basis",
+        basis_kind="narration-delivery/tts-audio",
+        artifact_key=ArtifactKey.episode_audio,
+    ),
+    "videos": _TypedMediaRestoreSpec(
+        basis_field=None,
+        basis_kind="artifact-components/video",
+        artifact_key=ArtifactKey.episode_video,
+        visual_kind="artifact-visual/video-storyboard",
+    ),
+    "reference_videos": _TypedMediaRestoreSpec(
+        basis_field=None,
+        basis_kind="artifact-components/video",
+        artifact_key=ArtifactKey.episode_video,
+        visual_kind="artifact-visual/video-reference",
+    ),
+}
+
+
+def is_typed_media_restore_resource(resource_type: str) -> bool:
+    return resource_type in _TYPED_MEDIA_RESTORE_SPECS
+
+
+def is_typed_media_version_restorable(resource_type: str, record: Mapping[str, Any]) -> bool:
+    """Whether one API version record carries a complete verified restore target."""
+
+    if not is_typed_media_restore_resource(resource_type):
+        return True
+    try:
+        _target_from_record(resource_type, record)
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,7 +85,7 @@ def get_typed_media_restore_target(
 ) -> TypedMediaRestoreTarget:
     """Read and validate the complete typed identity carried by one version."""
 
-    if resource_type not in _TYPED_MEDIA_RESOURCE_TYPES:
+    if not is_typed_media_restore_resource(resource_type):
         raise ValueError(f"resource type does not carry typed artifact restore metadata: {resource_type}")
     records = versions.get_versions(resource_type, resource_id).get("versions", [])
     record = next(
@@ -95,11 +141,7 @@ def restore_typed_media_version(
             committed_target = _target_from_record(resource_type, record)
             if committed_target != target:
                 raise RuntimeError("typed artifact version metadata changed during restore")
-            key = (
-                ArtifactKey.episode_audio(target.episode, resource_id)
-                if resource_type == "audio"
-                else ArtifactKey.episode_video(target.episode, resource_id)
-            )
+            key = _TYPED_MEDIA_RESTORE_SPECS[resource_type].artifact_key(target.episode, resource_id)
             ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor_transactionally(
                 key,
                 artifact_path=artifact_path,
@@ -135,19 +177,25 @@ def restore_typed_media_version(
 
 
 def _target_from_record(resource_type: str, record: Mapping[str, Any]) -> TypedMediaRestoreTarget:
-    episode = record.get("artifact_episode")
+    spec = _TYPED_MEDIA_RESTORE_SPECS[resource_type]
     script_file = record.get("execution_script_file")
-    basis_field = "artifact_audio_basis" if resource_type == "audio" else "artifact_video_basis"
-    raw_basis = record.get(basis_field)
-    if type(episode) is not int or episode < 1 or not isinstance(script_file, str) or not script_file.strip():
+    if not isinstance(script_file, str) or not script_file.strip():
         raise ValueError("version does not contain complete typed artifact metadata")
-    try:
-        basis = ArtifactBasisDescriptor.from_dict(raw_basis)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("version does not contain complete typed artifact metadata") from exc
-    expected_kind = "narration-delivery/tts-audio" if resource_type == "audio" else "artifact-components/video"
-    if basis.kind != expected_kind:
-        raise ValueError("version does not contain complete typed artifact metadata")
+    if resource_type == "audio":
+        episode = record.get("artifact_episode")
+        if type(episode) is not int or episode < 1 or spec.basis_field is None:
+            raise ValueError("version does not contain complete typed artifact metadata")
+        try:
+            basis = ArtifactBasisDescriptor.from_dict(record.get(spec.basis_field))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("version does not contain complete typed artifact metadata") from exc
+        if basis.kind != spec.basis_kind:
+            raise ValueError("version does not contain complete typed artifact metadata")
+        _validate_audio_basis(record, basis)
+    else:
+        facts = _validate_video_basis(record, spec)
+        episode = facts.episode
+        basis = facts.video_descriptor
     created_at = record.get("created_at")
     return TypedMediaRestoreTarget(
         episode=episode,
@@ -155,6 +203,75 @@ def _target_from_record(resource_type: str, record: Mapping[str, Any]) -> TypedM
         basis=basis,
         created_at=created_at if isinstance(created_at, str) else None,
     )
+
+
+def _validate_audio_basis(record: Mapping[str, Any], basis: ArtifactBasisDescriptor) -> None:
+    text = record.get("prompt")
+    provider_id = record.get("tts_provider_id")
+    model_id = record.get("tts_model_id")
+    voice = record.get("tts_voice")
+    speed = record.get("tts_speed")
+    duration = record.get("tts_actual_duration_seconds")
+    if (
+        not isinstance(text, str)
+        or not text
+        or not isinstance(provider_id, str)
+        or not provider_id.strip()
+        or not isinstance(model_id, str)
+        or not model_id.strip()
+        or not isinstance(voice, str)
+        or not voice.strip()
+        or (
+            speed is not None
+            and (
+                isinstance(speed, bool) or not isinstance(speed, (int, float)) or not math.isfinite(speed) or speed <= 0
+            )
+        )
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration <= 0
+    ):
+        raise ValueError("version does not contain complete typed artifact metadata")
+    expected = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build(
+            "narration-delivery/tts-audio",
+            kind_version=1,
+            inputs={
+                "text": text,
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "voice": voice,
+                "speed": speed,
+            },
+        )
+    )
+    if basis != expected or record.get("tts_basis_digest") != expected.digest:
+        raise ValueError("version does not contain complete typed artifact metadata")
+
+
+def _validate_video_basis(
+    record: Mapping[str, Any],
+    spec: _TypedMediaRestoreSpec,
+) -> VideoArtifactCurrencyFacts:
+    schema_version = record.get("execution_checkpoint_schema_version")
+    duration_seconds = record.get("execution_duration_seconds")
+    request_digest = record.get("execution_request_digest")
+    if (
+        type(schema_version) is not int
+        or schema_version != 3
+        or type(duration_seconds) is not int
+        or not isinstance(request_digest, str)
+        or len(request_digest) != 64
+    ):
+        raise ValueError("version does not contain complete typed artifact metadata")
+    try:
+        facts = VideoArtifactCurrencyFacts.from_dict(record.get("artifact_video_currency"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("version does not contain complete typed artifact metadata") from exc
+    if facts.visual_basis.kind != spec.visual_kind or facts.request_duration_seconds != duration_seconds:
+        raise ValueError("version does not contain complete typed artifact metadata")
+    return facts
 
 
 def _apply_restored_asset(
@@ -203,5 +320,7 @@ def _apply_restored_asset(
 __all__ = [
     "TypedMediaRestoreTarget",
     "get_typed_media_restore_target",
+    "is_typed_media_restore_resource",
+    "is_typed_media_version_restorable",
     "restore_typed_media_version",
 ]

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -10,12 +10,12 @@ from typing import Any
 
 from lib.api_errors import NotFoundError
 from lib.artifact_manifest import (
-    ArtifactBasis,
     ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifest,
     ProjectArtifactManifestAdapter,
 )
+from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis_from_canonical_text
 from lib.project_manager import ProjectManager, find_episode
 from lib.script_editor import resolve_items
 from lib.version_manager import VersionManager
@@ -233,19 +233,13 @@ def _validate_audio_basis(record: Mapping[str, Any], basis: ArtifactBasisDescrip
         or duration <= 0
     ):
         raise ValueError("version does not contain complete typed artifact metadata")
-    expected = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build(
-            "narration-delivery/tts-audio",
-            kind_version=1,
-            inputs={
-                "text": text,
-                "provider_id": provider_id,
-                "model_id": model_id,
-                "voice": voice,
-                "speed": speed,
-            },
-        )
+    settings = TtsSynthesisSettings(
+        provider_id=provider_id,
+        model_id=model_id,
+        voice=voice,
+        speed=speed,
     )
+    expected = ArtifactBasisDescriptor.from_basis(build_narration_audio_basis_from_canonical_text(text, settings))
     if basis != expected or record.get("tts_basis_digest") != expected.digest:
         raise ValueError("version does not contain complete typed artifact metadata")
 

--- a/server/services/generation_context.py
+++ b/server/services/generation_context.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from lib.audio_backends.base import VoiceOption
@@ -302,6 +303,7 @@ async def resolve_generation_context(
     payload: dict | None,
     *,
     project: dict,
+    project_path: Path | None = None,
     user_id: str = DEFAULT_USER_ID,
     image: ImageLaneRequest | None = None,
     video: VideoLaneRequest | None = None,
@@ -311,7 +313,8 @@ async def resolve_generation_context(
 
     lane 传即声明、None 跳过，任务只为用到的 lane 付出配置要求与构造成本。任一声明 lane
     的解析或构造失败即原样上抛、整次调用失败——无部分结果、无跨 provider 兜底；仅能力
-    查询失败降级空值放行。``project`` 是调用方已加载的项目快照，本函数不读盘。
+    查询失败降级空值放行。``project`` 是调用方已加载的项目快照；``project_path`` 可由已经
+    持有项目路径的事务传入，避免同步事务解析当前配置时嵌套占用默认线程池。本函数不读项目。
 
     video lane 的定桶随 ``VideoLaneRequest.capability``：None 时按项目生成路线解析（见
     ``lib.config.resolver.caps_generation_mode``）——路线创建即定、整个项目按同一条路径生成，
@@ -320,7 +323,11 @@ async def resolve_generation_context(
     """
     from lib.db import async_session_factory
 
-    project_path = await asyncio.to_thread(get_project_manager().get_project_path, project_name)
+    resolved_project_path = (
+        project_path
+        if project_path is not None
+        else await asyncio.to_thread(get_project_manager().get_project_path, project_name)
+    )
     resolver = ConfigResolver(async_session_factory)
 
     image_result: ImageLaneResult | None = None
@@ -419,7 +426,7 @@ async def resolve_generation_context(
             )
 
     generator = MediaGenerator(
-        project_path,
+        resolved_project_path,
         rate_limiter=rate_limiter,
         image_backend=image_backend,
         video_backend=video_backend,

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -18,9 +18,11 @@ from lib.artifact_manifest import (
     ArtifactKey,
     ArtifactManifestEntry,
     ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
 )
 from lib.asset_types import (
     ASSET_SPECS,
+    asset_name_comparison_key,
     normalize_asset_bucket,
     normalize_asset_name,
     resolve_asset_key,
@@ -92,7 +94,12 @@ from lib.resource_paths import resource_relative_path
 from lib.script_editor import resolve_items
 from lib.script_models import resolve_content_mode
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
-from lib.speech_composition import SpeechAdmissionError, admit_script_unit
+from lib.speech_artifact_provenance import (
+    build_video_duration_basis,
+    build_video_speech_basis,
+    project_character_voice_evidence,
+)
+from lib.speech_composition import SpeechAdmissionError, SpeechMode, admit_script_unit
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
@@ -101,6 +108,7 @@ from lib.storyboard_sequence import (
     resolve_previous_storyboard_path,
 )
 from lib.thumbnail import extract_video_thumbnail
+from lib.version_manager import PaidVersionCommit
 from lib.video_backends.base import VideoCapabilityError
 from lib.video_visual_provenance import build_storyboard_video_visual_basis, resolve_video_aspect_ratio
 from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
@@ -114,10 +122,14 @@ from server.services.narration_delivery_tasks import (
     ResolvedTtsSettingsResolver,
     active_narrated_video_resource_ids,
     current_selected_video_tier,
-    require_generated_video_covers_current_tts,
     resolve_storyboard_video_inputs,
     reuse_current_video_for_tier,
     tts_task_in_progress,
+)
+from server.services.video_artifact_currency import (
+    VideoArtifactCommitter,
+    finalize_selected_video_result,
+    paid_video_history_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -800,19 +812,47 @@ async def execute_tts_task(
 
     audio_rel = resource_relative_path("audio", resource_id)
     duration_seconds: float | None = None
+    current_commit_settings = settings
+    tts_selection_error: BaseException | None = None
+    selected_current = True
     missing_narration_audio = object()
     prior_narration_audio: object = missing_narration_audio
     prior_manifest_entry: ArtifactManifestEntry | None = None
     prior_manifest_captured = False
 
     async def _measure_staged(staged_path: Path) -> None:
-        nonlocal duration_seconds
-        duration_seconds = await probe_existing_audio_duration_seconds(staged_path)
-        if duration_seconds is None or not math.isfinite(duration_seconds) or duration_seconds <= 0:
-            raise RuntimeError("generated narration audio duration is unavailable")
+        nonlocal current_commit_settings, duration_seconds, tts_selection_error
+        try:
+            measured_duration = await probe_existing_audio_duration_seconds(staged_path)
+        except BaseException as exc:
+            tts_selection_error = exc
+            return
+        if measured_duration is None or not math.isfinite(measured_duration) or measured_duration <= 0:
+            tts_selection_error = RuntimeError("generated narration audio duration is unavailable")
+            return
+        duration_seconds = float(measured_duration)
+        if preparation is None:
+            return
+        try:
+            current_project = await asyncio.to_thread(get_project_manager().load_project, project_name)
+            current_ctx = await resolve_generation_context(
+                project_name,
+                None,
+                project=current_project,
+                user_id=user_id,
+                audio=AudioLaneRequest(),
+            )
+            current_commit_settings = TtsSynthesisSettings(
+                provider_id=current_ctx.audio.provider_model.provider_id,
+                model_id=current_ctx.audio.backend_model,
+                voice=current_ctx.audio.narration_voice,
+                speed=current_ctx.audio.narration_speed,
+            )
+        except BaseException as exc:
+            tts_selection_error = exc
 
-    def _commit_staged(staged_path: Path, output_path: Path) -> int:
-        nonlocal prior_narration_audio
+    def _commit_staged(staged_path: Path, output_path: Path) -> int | PaidVersionCommit:
+        nonlocal prior_narration_audio, selected_current
         if script_file is None or preparation is None or episode is None or basis is None:
             return generator.versions.commit_staged_version(
                 resource_type="audio",
@@ -831,7 +871,36 @@ async def execute_tts_task(
         committed_episode = episode
         committed_basis = basis
         pm = get_project_manager()
-        committed_version: int | None = None
+        committed_outcome: PaidVersionCommit | None = None
+        should_select = False
+
+        version_metadata = {
+            "tts_provider_id": settings.provider_id,
+            "tts_model_id": settings.model_id,
+            "tts_voice": settings.voice,
+            "tts_speed": settings.speed,
+            "tts_basis_digest": committed_basis.digest,
+            "artifact_episode": committed_episode,
+            "artifact_audio_basis": ArtifactBasisDescriptor.from_basis(committed_basis).to_dict(),
+            "tts_actual_duration_seconds": duration_seconds,
+            "execution_script_file": str(script_file),
+        }
+
+        def _archive_paid_history() -> PaidVersionCommit:
+            return generator.versions.commit_staged_paid_version(
+                resource_type="audio",
+                resource_id=resource_id,
+                prompt=text,
+                staged_file=staged_path,
+                current_file=output_path,
+                select_current=False,
+                **version_metadata,
+            )
+
+        if tts_selection_error is not None:
+            committed_outcome = _archive_paid_history()
+            selected_current = False
+            return committed_outcome
 
         def _register_basis() -> None:
             register_narration_audio_transactionally(
@@ -842,22 +911,22 @@ async def execute_tts_task(
             )
 
         def _activate(_script_path: Path) -> None:
-            nonlocal committed_version, prior_manifest_captured, prior_manifest_entry
-            manifest_adapter = ProjectArtifactManifestAdapter(project_path)
-            prior_manifest_entry = manifest_adapter.get_entry(ArtifactKey.episode_audio(committed_episode, resource_id))
-            prior_manifest_captured = True
-            committed_version = generator.versions.commit_staged_version(
+            nonlocal committed_outcome, prior_manifest_captured, prior_manifest_entry
+            if should_select:
+                manifest_adapter = ProjectArtifactManifestAdapter(project_path)
+                prior_manifest_entry = manifest_adapter.get_entry(
+                    ArtifactKey.episode_audio(committed_episode, resource_id)
+                )
+                prior_manifest_captured = True
+            committed_outcome = generator.versions.commit_staged_paid_version(
                 resource_type="audio",
                 resource_id=resource_id,
                 prompt=text,
                 staged_file=staged_path,
                 current_file=output_path,
-                on_commit=_register_basis,
-                tts_provider_id=settings.provider_id,
-                tts_model_id=settings.model_id,
-                tts_voice=settings.voice,
-                tts_speed=settings.speed,
-                tts_basis_digest=committed_basis.digest,
+                select_current=lambda: should_select,
+                on_select=_register_basis,
+                **version_metadata,
             )
 
         def _same_script(_project: dict) -> str:
@@ -872,48 +941,65 @@ async def execute_tts_task(
                 raise EpisodeScriptReboundError(f"episode {committed_episode} script binding changed before TTS commit")
             return current_binding
 
-        with pm.locked_episode_script(
-            project_name,
-            _same_script,
-            validate=False,
-            on_commit=_activate,
-        ) as current_script:
-            items, id_field, current_kind = _resolve_tts_task_items(
-                current_script,
-                reference_video_route=reference_video_route,
-            )
-            item = next(
-                (
-                    candidate
-                    for candidate in items
-                    if isinstance(candidate, dict) and str(candidate.get(id_field)) == str(resource_id)
-                ),
-                None,
-            )
-            if item is None:
-                raise ValueError(f"segment not found: {resource_id}")
-            current_admission = admit_script_unit(current_kind, item)
-            try:
-                current_basis = build_narration_audio_basis(current_admission.preparation, settings)
-            except ValueError as exc:
-                raise RuntimeError("narration changed before TTS commit") from exc
-            if current_basis.digest != committed_basis.digest:
-                raise RuntimeError("narration changed before TTS commit")
-            assets = item.get("generated_assets")
-            prior_narration_audio = (
-                copy.deepcopy(assets["narration_audio"])
-                if isinstance(assets, dict) and "narration_audio" in assets
-                else missing_narration_audio
-            )
-            if not isinstance(assets, dict):
-                assets = ProjectManager.create_generated_assets(str(current_script.get("content_mode") or "narration"))
-                item["generated_assets"] = assets
-            assets["narration_audio"] = audio_rel
-            pm.update_scene_status(item)
+        try:
+            with pm.locked_episode_script(
+                project_name,
+                _same_script,
+                validate=False,
+                on_commit=_activate,
+            ) as current_script:
+                items, id_field, current_kind = _resolve_tts_task_items(
+                    current_script,
+                    reference_video_route=reference_video_route,
+                )
+                item = next(
+                    (
+                        candidate
+                        for candidate in items
+                        if isinstance(candidate, dict) and str(candidate.get(id_field)) == str(resource_id)
+                    ),
+                    None,
+                )
+                current_basis = None
+                if item is not None:
+                    current_admission = admit_script_unit(current_kind, item)
+                    try:
+                        current_basis = build_narration_audio_basis(
+                            current_admission.preparation,
+                            current_commit_settings,
+                        )
+                    except ValueError:
+                        current_basis = None
+                should_select = current_basis is not None and current_basis.digest == committed_basis.digest
+                if should_select:
+                    assert item is not None
+                    assets = item.get("generated_assets")
+                    prior_narration_audio = (
+                        copy.deepcopy(assets["narration_audio"])
+                        if isinstance(assets, dict) and "narration_audio" in assets
+                        else missing_narration_audio
+                    )
+                    if not isinstance(assets, dict):
+                        assets = ProjectManager.create_generated_assets(
+                            str(current_script.get("content_mode") or "narration")
+                        )
+                        item["generated_assets"] = assets
+                    assets["narration_audio"] = audio_rel
+                    pm.update_scene_status(item)
+        except EpisodeScriptReboundError:
+            committed_outcome = _archive_paid_history()
+        except BaseException as failure:
+            if staged_path.is_file():
+                try:
+                    _archive_paid_history()
+                except BaseException as archive_failure:
+                    failure.add_note(f"paid TTS history archival also failed: {archive_failure}")
+            raise
 
-        if committed_version is None:
+        if committed_outcome is None:
             raise RuntimeError("TTS commit completed without a version")
-        return committed_version
+        selected_current = committed_outcome.selected
+        return committed_outcome
 
     output_path, version = await generator.generate_audio_async(
         text=text,
@@ -929,8 +1015,16 @@ async def execute_tts_task(
         tts_basis_digest=basis.digest if basis is not None else None,
     )
 
+    if tts_selection_error is not None:
+        raise tts_selection_error
+
+    version_record: dict[str, Any] | None = None
     try:
         records = generator.versions.get_versions("audio", resource_id)["versions"]
+        version_record = next(
+            (record for record in reversed(records) if record.get("version") == version),
+            None,
+        )
         created_at = next(
             (record.get("created_at") for record in reversed(records) if record.get("version") == version),
             records[-1].get("created_at") if records else None,
@@ -941,14 +1035,17 @@ async def execute_tts_task(
 
     result = {
         "version": version,
-        "file_path": audio_rel,
+        "file_path": (
+            audio_rel if selected_current else version_record.get("file") if isinstance(version_record, dict) else None
+        ),
         "created_at": created_at,
         "resource_type": "audio",
         "resource_id": resource_id,
         "duration_seconds": duration_seconds,
         "tts_basis_digest": basis.digest if basis is not None else None,
+        "selected_current": selected_current,
     }
-    if task_id is None:
+    if task_id is None or not selected_current:
         return result
 
     def _compensate_cancelled_tts() -> None:
@@ -1385,6 +1482,41 @@ async def execute_video_task(
     checkpoint_hook: Callable[[int], Awaitable[Mapping[str, object] | None]] | None = None
     staged_media: tuple[StagedProviderMedia, ...] = ()
     if task_id is not None:
+        artifact_episode = ProjectManager.resolve_episode_from_script(script, str(script_file))
+        artifact_speech_preparation = admit_script_unit(script_kind, item).preparation
+        artifact_voice_style_speakers = (
+            tuple(
+                dict.fromkeys(
+                    asset_name_comparison_key(str(utterance.speaker))
+                    for utterance in artifact_speech_preparation.utterances
+                    if utterance.speaker
+                )
+            )
+            if artifact_speech_preparation.mode is SpeechMode.CHARACTER_SPEECH and not ctx.video.is_silent
+            else ()
+        )
+        artifact_speech_basis = build_video_speech_basis(
+            artifact_speech_preparation,
+            voices=project_character_voice_evidence(
+                artifact_speech_preparation,
+                characters=project.get("characters"),
+                voice_style_speakers=artifact_voice_style_speakers,
+            ),
+        )
+        artifact_duration_basis = build_video_duration_basis(duration_seconds)
+        artifact_duration_tiers = tuple(
+            sorted(
+                {
+                    duration_seconds,
+                    *constrain_durations(
+                        registry_provider_id,
+                        model_name,
+                        supported_durations,
+                        resolution=resolution,
+                    ),
+                }
+            )
+        )
         media_inputs = [
             ProviderMediaInput(
                 path=storyboard_file,
@@ -1449,6 +1581,13 @@ async def execute_video_task(
                     )
                 )
             )
+            artifact_video_basis = ArtifactBasisDescriptor.from_basis(
+                compose_video_artifact_basis(
+                    visual=artifact_visual_basis,
+                    speech=artifact_speech_basis,
+                    duration=artifact_duration_basis,
+                )
+            )
             narration = delivery_projection.narration if delivery_projection is not None else None
             narration_facts = NarrationExecutionFacts(
                 delivery=delivery_options.narration_delivery,
@@ -1478,7 +1617,14 @@ async def execute_video_task(
                     service_tier=service_tier,
                     seed=seed,
                     visual_basis_digest=visual_basis_digest,
+                    artifact_episode=artifact_episode,
                     artifact_visual_basis=artifact_visual_basis,
+                    artifact_speech_basis=ArtifactBasisDescriptor.from_basis(artifact_speech_basis),
+                    artifact_duration_basis=ArtifactBasisDescriptor.from_basis(artifact_duration_basis),
+                    artifact_video_basis=artifact_video_basis,
+                    artifact_voice_style_speakers=artifact_voice_style_speakers,
+                    artifact_duration_tiers=artifact_duration_tiers,
+                    artifact_reference_image_limit=None,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=None,
@@ -1495,6 +1641,19 @@ async def execute_video_task(
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)
             raise
 
+    artifact_committer = (
+        VideoArtifactCommitter(
+            project_manager=get_project_manager(),
+            project_name=project_name,
+            project_path=project_path,
+            versions=generator.versions,
+            resource_type="videos",
+            resource_id=resource_id,
+            prompt=prompt_text,
+        )
+        if task_id is not None
+        else None
+    )
     try:
         output_path, version, _, video_uri = await generator.generate_video_async(
             prompt=prompt_text,
@@ -1508,33 +1667,43 @@ async def execute_video_task(
             task_id=task_id,
             before_submit=checkpoint_hook,
             formal_output=task_id is not None,
+            before_formal_commit=artifact_committer.prepare_selection if artifact_committer is not None else None,
+            commit_formal_output=artifact_committer,
             seed=seed,
             service_tier=service_tier,
             visual_basis_digest=visual_basis_digest,
             generate_audio=ctx.video.requested_generate_audio,
         )
 
-        if delivery_projection is not None:
-            await require_generated_video_covers_current_tts(
+        if artifact_committer is not None:
+            if artifact_committer.outcome is None:
+                raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
+            if artifact_committer.selection_error is not None:
+                raise artifact_committer.selection_error
+            if not artifact_committer.outcome.selected:
+                return await asyncio.to_thread(
+                    paid_video_history_result,
+                    versions=generator.versions,
+                    resource_type="videos",
+                    resource_id=resource_id,
+                    version=version,
+                    video_uri=video_uri,
+                )
+
+        async def _finalize() -> dict[str, Any]:
+            return await _finalize_video_task(
                 project_name=project_name,
-                script_file=str(script_file),
-                request_duration_seconds=duration_seconds,
-                output_path=output_path,
-                versions=generator.versions,
-                resource_type="videos",
+                script_file=script_file,
+                project_path=project_path,
                 resource_id=resource_id,
                 version=version,
+                video_uri=video_uri,
+                generator=generator,
             )
 
-        return await _finalize_video_task(
-            project_name=project_name,
-            script_file=script_file,
-            project_path=project_path,
-            resource_id=resource_id,
-            version=version,
-            video_uri=video_uri,
-            generator=generator,
-        )
+        if artifact_committer is not None:
+            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
+        return await _finalize()
     finally:
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)
@@ -2103,10 +2272,15 @@ async def execute_generation_task(task: dict[str, Any], *, claimed_provider_id: 
             )
         else:
             result = await executor(project_name, resource_id, payload, user_id=user_id, task_id=queue_task_id)
-        emit_generation_success_batch(
-            task_type=task_type,
-            project_name=project_name,
-            resource_id=resource_id,
-            payload=payload,
-        )
+        try:
+            emit_generation_success_batch(
+                task_type=task_type,
+                project_name=project_name,
+                resource_id=resource_id,
+                payload=payload,
+            )
+        except BaseException:
+            if isinstance(result, CompensableGenerationResult):
+                result.compensate_cancelled()
+            raise
         return result

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -27,6 +27,7 @@ from lib.asset_types import (
     resolve_asset_key,
     validate_asset_name,
 )
+from lib.async_thread import EventLoopBridge
 from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
@@ -115,6 +116,7 @@ from server.services.generation_context import (
     resolve_generation_context,
 )
 from server.services.narration_delivery_tasks import (
+    CurrentTtsSettingsResolver,
     ResolvedTtsSettingsResolver,
     active_narrated_video_resource_ids,
     current_selected_video_tier,
@@ -808,16 +810,19 @@ async def execute_tts_task(
 
     audio_rel = resource_relative_path("audio", resource_id)
     duration_seconds: float | None = None
-    current_commit_settings = settings
     tts_selection_error: BaseException | None = None
+    tts_settings_bridge = EventLoopBridge.capture()
     selected_current = True
     missing_narration_audio = object()
     prior_narration_audio: object = missing_narration_audio
     prior_manifest_entry: ArtifactManifestEntry | None = None
     prior_manifest_captured = False
 
+    class _TtsSelectionResolutionFailed(RuntimeError):
+        pass
+
     async def _measure_staged(staged_path: Path) -> None:
-        nonlocal current_commit_settings, duration_seconds, tts_selection_error
+        nonlocal duration_seconds, tts_selection_error
         try:
             measured_duration = await probe_existing_audio_duration_seconds(staged_path)
         except (Exception, asyncio.CancelledError) as exc:
@@ -827,28 +832,9 @@ async def execute_tts_task(
             tts_selection_error = RuntimeError("generated narration audio duration is unavailable")
             return
         duration_seconds = float(measured_duration)
-        if preparation is None:
-            return
-        try:
-            current_project = await asyncio.to_thread(get_project_manager().load_project, project_name)
-            current_ctx = await resolve_generation_context(
-                project_name,
-                None,
-                project=current_project,
-                user_id=user_id,
-                audio=AudioLaneRequest(),
-            )
-            current_commit_settings = TtsSynthesisSettings(
-                provider_id=current_ctx.audio.provider_model.provider_id,
-                model_id=current_ctx.audio.backend_model,
-                voice=current_ctx.audio.narration_voice,
-                speed=current_ctx.audio.narration_speed,
-            )
-        except (Exception, asyncio.CancelledError) as exc:
-            tts_selection_error = exc
 
     def _commit_staged(staged_path: Path, output_path: Path) -> int | PaidVersionCommit:
-        nonlocal prior_narration_audio, selected_current
+        nonlocal prior_narration_audio, selected_current, tts_selection_error
         if script_file is None or preparation is None or episode is None or basis is None:
             selected_current = False
             return generator.versions.commit_staged_paid_version(
@@ -872,6 +858,7 @@ async def execute_tts_task(
         pm = get_project_manager()
         committed_outcome: PaidVersionCommit | None = None
         should_select = False
+        guarded_project: dict[str, Any] | None = None
 
         version_metadata = {
             "tts_provider_id": settings.provider_id,
@@ -929,6 +916,8 @@ async def execute_tts_task(
             )
 
         def _same_script(_project: dict) -> str:
+            nonlocal guarded_project
+            guarded_project = _project
             entry = find_episode(_project, committed_episode)
             current_binding = entry.get("script_file") if isinstance(entry, dict) else None
             if current_binding is None and not (_project.get("episodes") or []):
@@ -947,6 +936,19 @@ async def execute_tts_task(
                 validate=False,
                 on_commit=_activate,
             ) as current_script:
+                if guarded_project is None:
+                    raise RuntimeError("TTS commit guard did not expose the current project")
+                try:
+                    current_commit_settings = tts_settings_bridge.run(
+                        CurrentTtsSettingsResolver(
+                            project_name,
+                            user_id=user_id,
+                            context_resolver=resolve_generation_context,
+                        ).resolve_tts_synthesis_settings(guarded_project)
+                    )
+                except (Exception, asyncio.CancelledError) as exc:
+                    tts_selection_error = exc
+                    raise _TtsSelectionResolutionFailed from exc
                 items, id_field, current_kind = _resolve_tts_task_items(
                     current_script,
                     reference_video_route=reference_video_route,
@@ -960,7 +962,7 @@ async def execute_tts_task(
                     None,
                 )
                 current_basis = None
-                if item is not None:
+                if tts_selection_error is None and item is not None:
                     current_admission = admit_script_unit(current_kind, item)
                     try:
                         current_basis = build_narration_audio_basis(
@@ -985,7 +987,7 @@ async def execute_tts_task(
                         item["generated_assets"] = assets
                     assets["narration_audio"] = audio_rel
                     pm.update_scene_status(item)
-        except EpisodeScriptReboundError:
+        except (EpisodeScriptReboundError, _TtsSelectionResolutionFailed):
             committed_outcome = _archive_paid_history()
         except BaseException as failure:
             if staged_path.is_file():

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -820,7 +820,7 @@ async def execute_tts_task(
         nonlocal current_commit_settings, duration_seconds, tts_selection_error
         try:
             measured_duration = await probe_existing_audio_duration_seconds(staged_path)
-        except BaseException as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             tts_selection_error = exc
             return
         if measured_duration is None or not math.isfinite(measured_duration) or measured_duration <= 0:
@@ -844,7 +844,7 @@ async def execute_tts_task(
                 voice=current_ctx.audio.narration_voice,
                 speed=current_ctx.audio.narration_speed,
             )
-        except BaseException as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             tts_selection_error = exc
 
     def _commit_staged(staged_path: Path, output_path: Path) -> int | PaidVersionCommit:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -943,6 +943,7 @@ async def execute_tts_task(
                         CurrentTtsSettingsResolver(
                             project_name,
                             user_id=user_id,
+                            project_path=project_path,
                             context_resolver=resolve_generation_context,
                         ).resolve_tts_synthesis_settings(guarded_project)
                     )
@@ -1111,21 +1112,20 @@ async def execute_tts_task(
                     ),
                     None,
                 )
-                if item is None:
-                    raise ValueError(f"segment not found during TTS cancellation: {resource_id}")
-                assets = item.get("generated_assets")
-                if not isinstance(assets, dict):
-                    assets = ProjectManager.create_generated_assets(
-                        str(current_script.get("content_mode") or "narration")
-                    )
-                    item["generated_assets"] = assets
-                if assets.get("narration_audio") != audio_rel:
-                    raise RuntimeError("narration audio changed before cancellation compensation")
-                if prior_narration_audio is missing_narration_audio:
-                    assets.pop("narration_audio", None)
-                else:
-                    assets["narration_audio"] = copy.deepcopy(prior_narration_audio)
-                pm.update_scene_status(item)
+                if item is not None:
+                    assets = item.get("generated_assets")
+                    if not isinstance(assets, dict):
+                        assets = ProjectManager.create_generated_assets(
+                            str(current_script.get("content_mode") or "narration")
+                        )
+                        item["generated_assets"] = assets
+                    if assets.get("narration_audio") != audio_rel:
+                        raise RuntimeError("narration audio changed before cancellation compensation")
+                    if prior_narration_audio is missing_narration_audio:
+                        assets.pop("narration_audio", None)
+                    else:
+                        assets["narration_audio"] = copy.deepcopy(prior_narration_audio)
+                    pm.update_scene_status(item)
         except EpisodeScriptReboundError:
             # The old script is no longer the episode's current edit target, but
             # cancellation must still revoke this task's formal media selection.

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -60,9 +60,9 @@ from lib.project_change_hints import emit_project_change_batch, project_change_s
 from lib.project_manager import (
     EpisodeScriptReboundError,
     ProjectManager,
-    find_episode,
     get_project_manager,
     is_reference_video_project,
+    resolve_episode_script_binding,
 )
 from lib.prompt_builders import (
     append_product_fidelity_tail,
@@ -918,14 +918,8 @@ async def execute_tts_task(
         def _same_script(_project: dict) -> str:
             nonlocal guarded_project
             guarded_project = _project
-            entry = find_episode(_project, committed_episode)
-            current_binding = entry.get("script_file") if isinstance(entry, dict) else None
-            if current_binding is None and not (_project.get("episodes") or []):
-                return str(script_file)
-            if not isinstance(current_binding, str) or (
-                ProjectManager.normalize_script_filename(current_binding)
-                != ProjectManager.normalize_script_filename(str(script_file))
-            ):
+            current_binding = resolve_episode_script_binding(_project, committed_episode, str(script_file))
+            if current_binding is None:
                 raise EpisodeScriptReboundError(f"episode {committed_episode} script binding changed before TTS commit")
             return current_binding
 
@@ -1080,17 +1074,14 @@ async def execute_tts_task(
             return
 
         pm = get_project_manager()
+        cancelled_episode = episode
 
         def _same_script(_project: dict) -> str:
-            entry = find_episode(_project, episode)
-            current_binding = entry.get("script_file") if isinstance(entry, dict) else None
-            if current_binding is None and not (_project.get("episodes") or []):
-                return str(script_file)
-            if not isinstance(current_binding, str) or (
-                ProjectManager.normalize_script_filename(current_binding)
-                != ProjectManager.normalize_script_filename(str(script_file))
-            ):
-                raise EpisodeScriptReboundError(f"episode {episode} script binding changed before TTS cancellation")
+            current_binding = resolve_episode_script_binding(_project, cancelled_episode, str(script_file))
+            if current_binding is None:
+                raise EpisodeScriptReboundError(
+                    f"episode {cancelled_episode} script binding changed before TTS cancellation"
+                )
             return current_binding
 
         try:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -1682,6 +1682,8 @@ async def execute_video_task(
             finalize=_finalize,
         )
     finally:
+        if artifact_committer is not None:
+            await artifact_committer.release_admission_guard()
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)
 

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -22,7 +22,6 @@ from lib.artifact_manifest import (
 )
 from lib.asset_types import (
     ASSET_SPECS,
-    asset_name_comparison_key,
     normalize_asset_bucket,
     normalize_asset_name,
     resolve_asset_key,
@@ -94,12 +93,8 @@ from lib.resource_paths import resource_relative_path
 from lib.script_editor import resolve_items
 from lib.script_models import resolve_content_mode
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_NOUNS, resolve_script_kind
-from lib.speech_artifact_provenance import (
-    build_video_duration_basis,
-    build_video_speech_basis,
-    project_character_voice_evidence,
-)
-from lib.speech_composition import SpeechAdmissionError, SpeechMode, admit_script_unit
+from lib.speech_artifact_provenance import build_video_duration_basis
+from lib.speech_composition import SpeechAdmissionError, admit_script_unit
 from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
@@ -109,6 +104,7 @@ from lib.storyboard_sequence import (
 )
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import PaidVersionCommit
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_backends.base import VideoCapabilityError
 from lib.video_visual_provenance import build_storyboard_video_visual_basis, resolve_video_aspect_ratio
 from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
@@ -128,8 +124,8 @@ from server.services.narration_delivery_tasks import (
 )
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
-    finalize_selected_video_result,
-    paid_video_history_result,
+    complete_video_artifact_commit,
+    freeze_video_speech_facts,
 )
 
 logger = logging.getLogger(__name__)
@@ -854,17 +850,20 @@ async def execute_tts_task(
     def _commit_staged(staged_path: Path, output_path: Path) -> int | PaidVersionCommit:
         nonlocal prior_narration_audio, selected_current
         if script_file is None or preparation is None or episode is None or basis is None:
-            return generator.versions.commit_staged_version(
+            selected_current = False
+            return generator.versions.commit_staged_paid_version(
                 resource_type="audio",
                 resource_id=resource_id,
                 prompt=text,
                 staged_file=staged_path,
                 current_file=output_path,
+                select_current=False,
                 tts_provider_id=settings.provider_id,
                 tts_model_id=settings.model_id,
                 tts_voice=settings.voice,
                 tts_speed=settings.speed,
                 tts_basis_digest=None,
+                tts_actual_duration_seconds=duration_seconds,
             )
 
         committed_preparation = preparation
@@ -1484,24 +1483,10 @@ async def execute_video_task(
     if task_id is not None:
         artifact_episode = ProjectManager.resolve_episode_from_script(script, str(script_file))
         artifact_speech_preparation = admit_script_unit(script_kind, item).preparation
-        artifact_voice_style_speakers = (
-            tuple(
-                dict.fromkeys(
-                    asset_name_comparison_key(str(utterance.speaker))
-                    for utterance in artifact_speech_preparation.utterances
-                    if utterance.speaker
-                )
-            )
-            if artifact_speech_preparation.mode is SpeechMode.CHARACTER_SPEECH and not ctx.video.is_silent
-            else ()
-        )
-        artifact_speech_basis = build_video_speech_basis(
+        artifact_speech = freeze_video_speech_facts(
             artifact_speech_preparation,
-            voices=project_character_voice_evidence(
-                artifact_speech_preparation,
-                characters=project.get("characters"),
-                voice_style_speakers=artifact_voice_style_speakers,
-            ),
+            characters=project.get("characters"),
+            include_voice_styles=not ctx.video.is_silent,
         )
         artifact_duration_basis = build_video_duration_basis(duration_seconds)
         artifact_duration_tiers = tuple(
@@ -1571,22 +1556,18 @@ async def execute_video_task(
                 )
             )
             artifact_visual_basis = await asyncio.to_thread(
-                lambda: ArtifactBasisDescriptor.from_basis(
-                    build_storyboard_video_artifact_visual_basis(
-                        resource_id=resource_id,
-                        visual_prompt=requested_visual_prompt,
-                        storyboard_image=provider_start_image,
-                        end_frame_image=provider_end_image,
-                        aspect_ratio=aspect_ratio,
-                    )
+                lambda: build_storyboard_video_artifact_visual_basis(
+                    resource_id=resource_id,
+                    visual_prompt=requested_visual_prompt,
+                    storyboard_image=provider_start_image,
+                    end_frame_image=provider_end_image,
+                    aspect_ratio=aspect_ratio,
                 )
             )
-            artifact_video_basis = ArtifactBasisDescriptor.from_basis(
-                compose_video_artifact_basis(
-                    visual=artifact_visual_basis,
-                    speech=artifact_speech_basis,
-                    duration=artifact_duration_basis,
-                )
+            artifact_video_basis = compose_video_artifact_basis(
+                visual=artifact_visual_basis,
+                speech=artifact_speech.basis,
+                duration=artifact_duration_basis,
             )
             narration = delivery_projection.narration if delivery_projection is not None else None
             narration_facts = NarrationExecutionFacts(
@@ -1598,6 +1579,18 @@ async def execute_video_task(
             )
 
             async def _checkpoint_before_submit(api_call_id: int) -> Mapping[str, object]:
+                artifact_currency = VideoArtifactCurrencyFacts(
+                    episode=artifact_episode,
+                    request_duration_seconds=duration_seconds,
+                    visual_basis=artifact_visual_basis,
+                    speech_basis=artifact_speech.basis,
+                    duration_basis=artifact_duration_basis,
+                    video_basis=artifact_video_basis,
+                    voice_style_speakers=artifact_speech.voice_style_speakers,
+                    duration_tiers=artifact_duration_tiers,
+                    reference_image_limit=None,
+                    parent_version=generator.versions.get_current_version("videos", resource_id),
+                )
                 checkpoint = StoryboardSubmissionCheckpoint.create(
                     task_id=task_id,
                     project_name=project_name,
@@ -1617,14 +1610,7 @@ async def execute_video_task(
                     service_tier=service_tier,
                     seed=seed,
                     visual_basis_digest=visual_basis_digest,
-                    artifact_episode=artifact_episode,
-                    artifact_visual_basis=artifact_visual_basis,
-                    artifact_speech_basis=ArtifactBasisDescriptor.from_basis(artifact_speech_basis),
-                    artifact_duration_basis=ArtifactBasisDescriptor.from_basis(artifact_duration_basis),
-                    artifact_video_basis=artifact_video_basis,
-                    artifact_voice_style_speakers=artifact_voice_style_speakers,
-                    artifact_duration_tiers=artifact_duration_tiers,
-                    artifact_reference_image_limit=None,
+                    artifact_currency=artifact_currency,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=None,
@@ -1650,6 +1636,11 @@ async def execute_video_task(
             resource_type="videos",
             resource_id=resource_id,
             prompt=prompt_text,
+            current_tts_settings=(
+                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
+                if delivery_projection is not None
+                else None
+            ),
         )
         if task_id is not None
         else None
@@ -1675,21 +1666,6 @@ async def execute_video_task(
             generate_audio=ctx.video.requested_generate_audio,
         )
 
-        if artifact_committer is not None:
-            if artifact_committer.outcome is None:
-                raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
-            if artifact_committer.selection_error is not None:
-                raise artifact_committer.selection_error
-            if not artifact_committer.outcome.selected:
-                return await asyncio.to_thread(
-                    paid_video_history_result,
-                    versions=generator.versions,
-                    resource_type="videos",
-                    resource_id=resource_id,
-                    version=version,
-                    video_uri=video_uri,
-                )
-
         async def _finalize() -> dict[str, Any]:
             return await _finalize_video_task(
                 project_name=project_name,
@@ -1701,9 +1677,15 @@ async def execute_video_task(
                 generator=generator,
             )
 
-        if artifact_committer is not None:
-            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
-        return await _finalize()
+        return await complete_video_artifact_commit(
+            committer=artifact_committer,
+            versions=generator.versions,
+            resource_type="videos",
+            resource_id=resource_id,
+            version=version,
+            video_uri=video_uri,
+            finalize=_finalize,
+        )
     finally:
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -27,7 +27,7 @@ from lib.asset_types import (
     resolve_asset_key,
     validate_asset_name,
 )
-from lib.async_thread import EventLoopBridge
+from lib.async_thread import EventLoopBridge, run_noninterruptible_sync
 from lib.audio_utils import (
     AUDIO_REFERENCE_MAX_BYTES,
     AUDIO_REFERENCE_MAX_SECONDS,
@@ -2260,6 +2260,6 @@ async def execute_generation_task(task: dict[str, Any], *, claimed_provider_id: 
             )
         except BaseException:
             if isinstance(result, CompensableGenerationResult):
-                result.compensate_cancelled()
+                await run_noninterruptible_sync(result.compensate_cancelled)
             raise
         return result

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -1090,37 +1090,44 @@ async def execute_tts_task(
                 raise EpisodeScriptReboundError(f"episode {episode} script binding changed before TTS cancellation")
             return current_binding
 
-        with pm.locked_episode_script(
-            project_name,
-            _same_script,
-            validate=False,
-            on_commit=lambda _script_path: _reject_with_manifest_restore(),
-        ) as current_script:
-            items, id_field, _kind = _resolve_tts_task_items(
-                current_script,
-                reference_video_route=reference_video_route,
-            )
-            item = next(
-                (
-                    candidate
-                    for candidate in items
-                    if isinstance(candidate, dict) and str(candidate.get(id_field)) == str(resource_id)
-                ),
-                None,
-            )
-            if item is None:
-                raise ValueError(f"segment not found during TTS cancellation: {resource_id}")
-            assets = item.get("generated_assets")
-            if not isinstance(assets, dict):
-                assets = ProjectManager.create_generated_assets(str(current_script.get("content_mode") or "narration"))
-                item["generated_assets"] = assets
-            if assets.get("narration_audio") != audio_rel:
-                raise RuntimeError("narration audio changed before cancellation compensation")
-            if prior_narration_audio is missing_narration_audio:
-                assets.pop("narration_audio", None)
-            else:
-                assets["narration_audio"] = copy.deepcopy(prior_narration_audio)
-            pm.update_scene_status(item)
+        try:
+            with pm.locked_episode_script(
+                project_name,
+                _same_script,
+                validate=False,
+                on_commit=lambda _script_path: _reject_with_manifest_restore(),
+            ) as current_script:
+                items, id_field, _kind = _resolve_tts_task_items(
+                    current_script,
+                    reference_video_route=reference_video_route,
+                )
+                item = next(
+                    (
+                        candidate
+                        for candidate in items
+                        if isinstance(candidate, dict) and str(candidate.get(id_field)) == str(resource_id)
+                    ),
+                    None,
+                )
+                if item is None:
+                    raise ValueError(f"segment not found during TTS cancellation: {resource_id}")
+                assets = item.get("generated_assets")
+                if not isinstance(assets, dict):
+                    assets = ProjectManager.create_generated_assets(
+                        str(current_script.get("content_mode") or "narration")
+                    )
+                    item["generated_assets"] = assets
+                if assets.get("narration_audio") != audio_rel:
+                    raise RuntimeError("narration audio changed before cancellation compensation")
+                if prior_narration_audio is missing_narration_audio:
+                    assets.pop("narration_audio", None)
+                else:
+                    assets["narration_audio"] = copy.deepcopy(prior_narration_audio)
+                pm.update_scene_status(item)
+        except EpisodeScriptReboundError:
+            # The old script is no longer the episode's current edit target, but
+            # cancellation must still revoke this task's formal media selection.
+            _reject_with_manifest_restore()
 
     return CompensableGenerationResult(result, cancel_compensation=_compensate_cancelled_tts)
 
@@ -1636,11 +1643,6 @@ async def execute_video_task(
             resource_type="videos",
             resource_id=resource_id,
             prompt=prompt_text,
-            current_tts_settings=(
-                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
-                if delivery_projection is not None
-                else None
-            ),
         )
         if task_id is not None
         else None

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -15,6 +15,13 @@ from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifestEntry,
+    ArtifactManifestError,
+    ProjectArtifactManifestAdapter,
+)
 from lib.audio_utils import probe_existing_media_duration_seconds
 from lib.config.resolver import ConfigResolver, VideoCapability
 from lib.db import async_session_factory
@@ -108,14 +115,8 @@ def _selected_current_video_record(
     resource_id: str,
     visual_basis_digest: str | None,
 ) -> tuple[str, Path, dict[str, Any], int] | None:
-    if item.get("stale"):
-        return None
-    assets = item.get("generated_assets")
-    if not isinstance(assets, dict) or assets.get("status") != "completed":
-        return None
+    del item  # Script path/status fields are presentation metadata, not artifact currency.
     canonical_rel = resource_relative_path(resource_type, resource_id)
-    if assets.get("video_clip") != canonical_rel:
-        return None
 
     formal_file = try_safe_join(project_path, canonical_rel, require_file=True)
     if formal_file is None:
@@ -138,6 +139,24 @@ def _selected_current_video_record(
         None,
     )
     if current_record is None:
+        return None
+    episode = current_record.get("artifact_episode")
+    try:
+        recorded_basis = ArtifactBasisDescriptor.from_dict(current_record.get("artifact_video_basis"))
+    except (TypeError, ValueError):
+        return None
+    if type(episode) is not int or episode < 1 or recorded_basis.kind != "artifact-components/video":
+        return None
+    try:
+        manifest_entry = ProjectArtifactManifestAdapter(project_path).get_entry(
+            ArtifactKey.episode_video(episode, resource_id)
+        )
+    except ArtifactManifestError:
+        return None
+    if manifest_entry != ArtifactManifestEntry(
+        artifact_path=canonical_rel,
+        basis_digest=recorded_basis.digest,
+    ):
         return None
     if not visual_basis_digest or current_record.get("visual_basis_digest") != visual_basis_digest:
         return None
@@ -785,6 +804,37 @@ async def require_generated_video_covers_current_tts(
 ) -> None:
     """Reject a paid video unless it covers the latest current TTS in full."""
 
+    try:
+        await validate_generated_video_covers_current_tts(
+            project_name=project_name,
+            script_file=script_file,
+            request_duration_seconds=request_duration_seconds,
+            output_path=output_path,
+            resource_type=resource_type,
+            resource_id=resource_id,
+        )
+    except NarratedVideoDurationBlockedError:
+        await asyncio.to_thread(
+            versions.reject_current_version,
+            resource_type,
+            resource_id,
+            rejected_version=version,
+            current_file=output_path,
+        )
+        raise
+
+
+async def validate_generated_video_covers_current_tts(
+    *,
+    project_name: str,
+    script_file: str,
+    request_duration_seconds: int,
+    output_path: Path,
+    resource_type: str,
+    resource_id: str,
+) -> None:
+    """Validate staged paid media before it can become the formal selection."""
+
     narration = await _prepare_current_task_narration_delivery(
         project_name=project_name,
         script_file=script_file,
@@ -806,13 +856,6 @@ async def require_generated_video_covers_current_tts(
     )
     if checked.allowed:
         return
-    await asyncio.to_thread(
-        versions.reject_current_version,
-        resource_type,
-        resource_id,
-        rejected_version=version,
-        current_file=output_path,
-    )
     raise NarratedVideoDurationBlockedError(checked)
 
 
@@ -878,6 +921,7 @@ __all__ = [
     "prepare_current_reference_video_request_options",
     "ResolvedTtsSettingsResolver",
     "require_generated_video_covers_current_tts",
+    "validate_generated_video_covers_current_tts",
     "reuse_current_video_for_tier",
     "tts_task_in_progress",
 ]

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -30,6 +30,7 @@ from lib.narration_delivery import (
     NarratedVideoDurationPreparation,
     NarrationDeliveryPreparation,
     NarrationDeliveryRequestOptions,
+    NarrationTtsStatus,
     TtsSettingsResolver,
     TtsSynthesisSettings,
     VideoRequestCostFacts,
@@ -840,6 +841,47 @@ async def validate_generated_video_covers_current_tts(
         resource_type=resource_type,
         resource_id=resource_id,
     )
+    await _validate_generated_video_covers_narration(
+        narration=narration,
+        request_duration_seconds=request_duration_seconds,
+        output_path=output_path,
+    )
+
+
+async def validate_generated_video_covers_tts_duration(
+    *,
+    resource_id: str,
+    request_duration_seconds: int,
+    output_path: Path,
+    tts_actual_duration_seconds: float,
+) -> None:
+    """Validate paid media against the immutable TTS duration accepted at submit."""
+
+    if not math.isfinite(tts_actual_duration_seconds) or tts_actual_duration_seconds <= 0:
+        raise ValueError("execution TTS duration must be positive and finite")
+    narration = NarrationDeliveryPreparation(
+        delivery=USE_TTS,
+        unit_id=resource_id,
+        speech_mode=None,
+        tts_status=NarrationTtsStatus.CURRENT,
+        artifact_path="",
+        basis_digest=None,
+        actual_duration_seconds=tts_actual_duration_seconds,
+        problems=(),
+    )
+    await _validate_generated_video_covers_narration(
+        narration=narration,
+        request_duration_seconds=request_duration_seconds,
+        output_path=output_path,
+    )
+
+
+async def _validate_generated_video_covers_narration(
+    *,
+    narration: NarrationDeliveryPreparation,
+    request_duration_seconds: int,
+    output_path: Path,
+) -> None:
     actual_duration = await probe_existing_media_duration_seconds(output_path)
     preparation = NarratedVideoDurationPreparation(
         narration=narration,
@@ -920,6 +962,7 @@ __all__ = [
     "prepare_current_reference_video_request_options",
     "ResolvedTtsSettingsResolver",
     "require_generated_video_covers_current_tts",
+    "validate_generated_video_covers_tts_duration",
     "validate_generated_video_covers_current_tts",
     "reuse_current_video_for_tier",
     "tts_task_in_progress",

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import filecmp
 import math
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -24,6 +24,7 @@ from lib.artifact_manifest import (
 from lib.audio_utils import probe_existing_media_duration_seconds
 from lib.config.resolver import ConfigResolver, VideoCapability
 from lib.db import async_session_factory
+from lib.db.base import DEFAULT_USER_ID
 from lib.generation_queue import GenerationQueue, get_generation_queue
 from lib.narration_delivery import (
     NarratedVideoDurationBlockedError,
@@ -94,14 +95,23 @@ class ResolvedTtsSettingsResolver:
 class CurrentTtsSettingsResolver:
     """Resolve freshness inputs through the same assembled audio lane as synthesis."""
 
-    def __init__(self, project_name: str) -> None:
+    def __init__(
+        self,
+        project_name: str,
+        *,
+        user_id: str = DEFAULT_USER_ID,
+        context_resolver: Callable[..., Awaitable[Any]] | None = None,
+    ) -> None:
         self._project_name = project_name
+        self._user_id = user_id
+        self._context_resolver = context_resolver or resolve_generation_context
 
     async def resolve_tts_synthesis_settings(self, project: dict) -> TtsSynthesisSettings:
-        ctx = await resolve_generation_context(
+        ctx = await self._context_resolver(
             self._project_name,
             None,
             project=project,
+            user_id=self._user_id,
             audio=AudioLaneRequest(),
         )
         return ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -100,19 +100,26 @@ class CurrentTtsSettingsResolver:
         project_name: str,
         *,
         user_id: str = DEFAULT_USER_ID,
+        project_path: Path | None = None,
         context_resolver: Callable[..., Awaitable[Any]] | None = None,
     ) -> None:
         self._project_name = project_name
         self._user_id = user_id
+        self._project_path = project_path
         self._context_resolver = context_resolver or resolve_generation_context
 
     async def resolve_tts_synthesis_settings(self, project: dict) -> TtsSynthesisSettings:
+        context_kwargs: dict[str, Any] = {
+            "project": project,
+            "user_id": self._user_id,
+            "audio": AudioLaneRequest(),
+        }
+        if self._project_path is not None:
+            context_kwargs["project_path"] = self._project_path
         ctx = await self._context_resolver(
             self._project_name,
             None,
-            project=project,
-            user_id=self._user_id,
-            audio=AudioLaneRequest(),
+            **context_kwargs,
         )
         return ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
 

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -16,7 +16,6 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from lib.artifact_manifest import (
-    ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifestEntry,
     ArtifactManifestError,
@@ -60,6 +59,7 @@ from lib.script_skeleton import resolve_script_kind
 from lib.speech_composition import admit_script_unit
 from lib.storyboard_sequence import resolve_storyboard_image_ref
 from lib.version_manager import VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_visual_provenance import (
     build_reference_video_visual_basis,
     build_storyboard_video_visual_basis,
@@ -140,13 +140,12 @@ def _selected_current_video_record(
     )
     if current_record is None:
         return None
-    episode = current_record.get("artifact_episode")
     try:
-        recorded_basis = ArtifactBasisDescriptor.from_dict(current_record.get("artifact_video_basis"))
+        artifact_currency = VideoArtifactCurrencyFacts.from_dict(current_record.get("artifact_video_currency"))
     except (TypeError, ValueError):
         return None
-    if type(episode) is not int or episode < 1 or recorded_basis.kind != "artifact-components/video":
-        return None
+    episode = artifact_currency.episode
+    recorded_basis = artifact_currency.video_descriptor
     try:
         manifest_entry = ProjectArtifactManifestAdapter(project_path).get_entry(
             ArtifactKey.episode_video(episode, resource_id)

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -12,7 +12,8 @@ from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from lib.artifact_manifest import ArtifactBasisDescriptor
+from lib.artifact_manifest import ArtifactBasisDescriptor, compose_video_artifact_basis
+from lib.asset_types import asset_name_comparison_key
 from lib.config.resolver import (
     ConfigResolver,
     VideoCapability,
@@ -28,6 +29,7 @@ from lib.generation_queue import (
 )
 from lib.narration_delivery import USE_TTS
 from lib.path_safety import safe_join
+from lib.project_manager import ProjectManager
 from lib.reference_video.duration_slots import DurationSlot, resolve_duration_slot
 from lib.reference_video.errors import MissingReferenceError
 from lib.reference_video.execution_checkpoint import (
@@ -63,7 +65,12 @@ from lib.reference_video.units import reference_video_bucket
 from lib.reference_video.voice_settings import VoiceRenderSettings
 from lib.script_editor import ScriptEditError
 from lib.script_models import ReferenceResource
-from lib.speech_composition import video_unit_replan_problems
+from lib.speech_artifact_provenance import (
+    build_video_duration_basis,
+    build_video_speech_basis,
+    project_character_voice_evidence,
+)
+from lib.speech_composition import SpeechMode, admit_script_unit, video_unit_replan_problems
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import VersionManager
 from lib.video_visual_provenance import resolve_video_aspect_ratio
@@ -75,9 +82,13 @@ from server.services.narration_delivery_tasks import (
     materialized_reference_video_visual_basis_digest,
     prepare_current_reference_video_request_options,
     reference_video_visual_basis_digest,
-    require_generated_video_covers_current_tts,
     reuse_current_video_for_tier,
     tts_task_in_progress,
+)
+from server.services.video_artifact_currency import (
+    VideoArtifactCommitter,
+    finalize_selected_video_result,
+    paid_video_history_result,
 )
 from server.services.video_caps import project_video_caps
 
@@ -681,6 +692,20 @@ async def execute_reference_video_task(
     staged_media: tuple[StagedProviderMedia, ...] = ()
     checkpoint_hook: Callable[[int], Awaitable[Mapping[str, object] | None]] | None = None
     if task_id is not None:
+        artifact_episode = ProjectManager.resolve_episode_from_script(script, str(script_file))
+        artifact_speech_preparation = admit_script_unit("video_units", unit).preparation
+        artifact_voice_style_speakers = (
+            tuple(
+                dict.fromkeys(
+                    asset_name_comparison_key(str(utterance.speaker))
+                    for utterance in artifact_speech_preparation.utterances
+                    if utterance.speaker
+                )
+            )
+            if artifact_speech_preparation.mode is SpeechMode.CHARACTER_SPEECH and not voice_settings.is_silent
+            else ()
+        )
+        artifact_duration_basis = build_video_duration_basis(effective_duration)
         image_inputs = tuple(
             ProviderMediaInput(
                 path=entry.path,
@@ -764,6 +789,23 @@ async def execute_reference_video_task(
                     )
                 )
             )
+            artifact_speech_basis = await asyncio.to_thread(
+                build_video_speech_basis,
+                artifact_speech_preparation,
+                voices=project_character_voice_evidence(
+                    artifact_speech_preparation,
+                    characters=project.get("characters"),
+                    voice_style_speakers=artifact_voice_style_speakers,
+                    reference_audio_paths=dict(zip(audio_names, reference_audio_files, strict=True)),
+                ),
+            )
+            artifact_video_basis = ArtifactBasisDescriptor.from_basis(
+                compose_video_artifact_basis(
+                    visual=artifact_visual_basis,
+                    speech=artifact_speech_basis,
+                    duration=artifact_duration_basis,
+                )
+            )
 
             def _build_checkpoint(api_call_id: int) -> ReferenceSubmissionCheckpoint:
                 return ReferenceSubmissionCheckpoint.create(
@@ -785,7 +827,14 @@ async def execute_reference_video_task(
                     service_tier="default",
                     seed=None,
                     visual_basis_digest=visual_basis_digest,
+                    artifact_episode=artifact_episode,
                     artifact_visual_basis=artifact_visual_basis,
+                    artifact_speech_basis=ArtifactBasisDescriptor.from_basis(artifact_speech_basis),
+                    artifact_duration_basis=ArtifactBasisDescriptor.from_basis(artifact_duration_basis),
+                    artifact_video_basis=artifact_video_basis,
+                    artifact_voice_style_speakers=artifact_voice_style_speakers,
+                    artifact_duration_tiers=candidate.supported_durations,
+                    artifact_reference_image_limit=candidate.max_reference_images,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=audio_targets_tuple,
@@ -809,6 +858,19 @@ async def execute_reference_video_task(
             )
             raise
 
+    artifact_committer = (
+        VideoArtifactCommitter(
+            project_manager=get_project_manager(),
+            project_name=project_name,
+            project_path=project_path,
+            versions=generator.versions,
+            resource_type="reference_videos",
+            resource_id=resource_id,
+            prompt=rendered_prompt,
+        )
+        if task_id is not None
+        else None
+    )
     try:
         # MediaGenerator compresses only transient derivatives of the immutable staged images. A 413 retry keeps
         # the same high-level media identities and cannot rewrite the once-only checkpoint.
@@ -825,36 +887,44 @@ async def execute_reference_video_task(
             task_id=task_id,
             before_submit=checkpoint_hook,
             formal_output=task_id is not None,
+            before_formal_commit=artifact_committer.prepare_selection if artifact_committer is not None else None,
+            commit_formal_output=artifact_committer,
             visual_basis_digest=visual_basis_digest,
             generate_audio=video.requested_generate_audio,
         )
 
-        if request_options.narration_delivery == USE_TTS:
-            narration = options.narration_preparation
-            if narration is None:
-                raise RuntimeError("allowed TTS reference request is missing current narration preparation")
-            await require_generated_video_covers_current_tts(
+        if artifact_committer is not None:
+            if artifact_committer.outcome is None:
+                raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
+            if artifact_committer.selection_error is not None:
+                raise artifact_committer.selection_error
+            if not artifact_committer.outcome.selected:
+                return await asyncio.to_thread(
+                    paid_video_history_result,
+                    versions=generator.versions,
+                    resource_type="reference_videos",
+                    resource_id=resource_id,
+                    version=version,
+                    video_uri=video_uri,
+                    warnings=warnings,
+                )
+
+        async def _finalize() -> dict[str, Any]:
+            return await _finalize_reference_video_unit(
                 project_name=project_name,
-                script_file=str(script_file),
-                request_duration_seconds=effective_duration,
-                output_path=output_path,
-                versions=generator.versions,
-                resource_type="reference_videos",
+                script_file=script_file,
+                project_path=project_path,
                 resource_id=resource_id,
+                output_path=output_path,
                 version=version,
+                video_uri=video_uri,
+                versions=generator.versions,
+                warnings=warnings,
             )
 
-        return await _finalize_reference_video_unit(
-            project_name=project_name,
-            script_file=script_file,
-            project_path=project_path,
-            resource_id=resource_id,
-            output_path=output_path,
-            version=version,
-            video_uri=video_uri,
-            versions=generator.versions,
-            warnings=warnings,
-        )
+        if artifact_committer is not None:
+            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
+        return await _finalize()
     finally:
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)
@@ -901,7 +971,6 @@ def apply_unit_video_assets(
         else:
             ga.pop("video_thumbnail", None)
         ga["status"] = "completed"
-        u.pop("stale", None)
         return None
     raise KeyError(resource_id)
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -12,8 +12,7 @@ from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from lib.artifact_manifest import ArtifactBasisDescriptor, compose_video_artifact_basis
-from lib.asset_types import asset_name_comparison_key
+from lib.artifact_manifest import compose_video_artifact_basis
 from lib.config.resolver import (
     ConfigResolver,
     VideoCapability,
@@ -65,14 +64,11 @@ from lib.reference_video.units import reference_video_bucket
 from lib.reference_video.voice_settings import VoiceRenderSettings
 from lib.script_editor import ScriptEditError
 from lib.script_models import ReferenceResource
-from lib.speech_artifact_provenance import (
-    build_video_duration_basis,
-    build_video_speech_basis,
-    project_character_voice_evidence,
-)
-from lib.speech_composition import SpeechMode, admit_script_unit, video_unit_replan_problems
+from lib.speech_artifact_provenance import build_video_duration_basis
+from lib.speech_composition import admit_script_unit, video_unit_replan_problems
 from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_visual_provenance import resolve_video_aspect_ratio
 from lib.visual_artifact_provenance import build_reference_video_artifact_visual_basis
 from server.services.generation_context import AudioLaneRequest, VideoLaneRequest, resolve_generation_context
@@ -87,8 +83,8 @@ from server.services.narration_delivery_tasks import (
 )
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
-    finalize_selected_video_result,
-    paid_video_history_result,
+    complete_video_artifact_commit,
+    freeze_video_speech_facts,
 )
 from server.services.video_caps import project_video_caps
 
@@ -694,17 +690,6 @@ async def execute_reference_video_task(
     if task_id is not None:
         artifact_episode = ProjectManager.resolve_episode_from_script(script, str(script_file))
         artifact_speech_preparation = admit_script_unit("video_units", unit).preparation
-        artifact_voice_style_speakers = (
-            tuple(
-                dict.fromkeys(
-                    asset_name_comparison_key(str(utterance.speaker))
-                    for utterance in artifact_speech_preparation.utterances
-                    if utterance.speaker
-                )
-            )
-            if artifact_speech_preparation.mode is SpeechMode.CHARACTER_SPEECH and not voice_settings.is_silent
-            else ()
-        )
         artifact_duration_basis = build_video_duration_basis(effective_duration)
         image_inputs = tuple(
             ProviderMediaInput(
@@ -780,34 +765,39 @@ async def execute_reference_video_task(
                 replace(entry, path=path) for entry, path in zip(constrained_entries, provider_refs, strict=True)
             )
             artifact_visual_basis = await asyncio.to_thread(
-                lambda: ArtifactBasisDescriptor.from_basis(
-                    build_reference_video_artifact_visual_basis(
-                        unit=unit,
-                        request_assets=staged_request_assets,
-                        style=project.get("style"),
-                        aspect_ratio=aspect_ratio,
-                    )
+                lambda: build_reference_video_artifact_visual_basis(
+                    unit=unit,
+                    request_assets=staged_request_assets,
+                    style=project.get("style"),
+                    aspect_ratio=aspect_ratio,
                 )
             )
-            artifact_speech_basis = await asyncio.to_thread(
-                build_video_speech_basis,
+            artifact_speech = await asyncio.to_thread(
+                freeze_video_speech_facts,
                 artifact_speech_preparation,
-                voices=project_character_voice_evidence(
-                    artifact_speech_preparation,
-                    characters=project.get("characters"),
-                    voice_style_speakers=artifact_voice_style_speakers,
-                    reference_audio_paths=dict(zip(audio_names, reference_audio_files, strict=True)),
-                ),
+                characters=project.get("characters"),
+                include_voice_styles=not voice_settings.is_silent,
+                reference_audio_paths=dict(zip(audio_names, staged_audio_paths, strict=True)),
             )
-            artifact_video_basis = ArtifactBasisDescriptor.from_basis(
-                compose_video_artifact_basis(
-                    visual=artifact_visual_basis,
-                    speech=artifact_speech_basis,
-                    duration=artifact_duration_basis,
-                )
+            artifact_video_basis = compose_video_artifact_basis(
+                visual=artifact_visual_basis,
+                speech=artifact_speech.basis,
+                duration=artifact_duration_basis,
             )
 
             def _build_checkpoint(api_call_id: int) -> ReferenceSubmissionCheckpoint:
+                artifact_currency = VideoArtifactCurrencyFacts(
+                    episode=artifact_episode,
+                    request_duration_seconds=effective_duration,
+                    visual_basis=artifact_visual_basis,
+                    speech_basis=artifact_speech.basis,
+                    duration_basis=artifact_duration_basis,
+                    video_basis=artifact_video_basis,
+                    voice_style_speakers=artifact_speech.voice_style_speakers,
+                    duration_tiers=candidate.supported_durations,
+                    reference_image_limit=candidate.max_reference_images,
+                    parent_version=generator.versions.get_current_version("reference_videos", resource_id),
+                )
                 return ReferenceSubmissionCheckpoint.create(
                     task_id=task_id,
                     project_name=project_name,
@@ -827,14 +817,7 @@ async def execute_reference_video_task(
                     service_tier="default",
                     seed=None,
                     visual_basis_digest=visual_basis_digest,
-                    artifact_episode=artifact_episode,
-                    artifact_visual_basis=artifact_visual_basis,
-                    artifact_speech_basis=ArtifactBasisDescriptor.from_basis(artifact_speech_basis),
-                    artifact_duration_basis=ArtifactBasisDescriptor.from_basis(artifact_duration_basis),
-                    artifact_video_basis=artifact_video_basis,
-                    artifact_voice_style_speakers=artifact_voice_style_speakers,
-                    artifact_duration_tiers=candidate.supported_durations,
-                    artifact_reference_image_limit=candidate.max_reference_images,
+                    artifact_currency=artifact_currency,
                     narration=narration_facts,
                     media=staged_media,
                     reference_audio_targets=audio_targets_tuple,
@@ -867,6 +850,11 @@ async def execute_reference_video_task(
             resource_type="reference_videos",
             resource_id=resource_id,
             prompt=rendered_prompt,
+            current_tts_settings=(
+                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
+                if options.narration_delivery == USE_TTS
+                else None
+            ),
         )
         if task_id is not None
         else None
@@ -893,22 +881,6 @@ async def execute_reference_video_task(
             generate_audio=video.requested_generate_audio,
         )
 
-        if artifact_committer is not None:
-            if artifact_committer.outcome is None:
-                raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
-            if artifact_committer.selection_error is not None:
-                raise artifact_committer.selection_error
-            if not artifact_committer.outcome.selected:
-                return await asyncio.to_thread(
-                    paid_video_history_result,
-                    versions=generator.versions,
-                    resource_type="reference_videos",
-                    resource_id=resource_id,
-                    version=version,
-                    video_uri=video_uri,
-                    warnings=warnings,
-                )
-
         async def _finalize() -> dict[str, Any]:
             return await _finalize_reference_video_unit(
                 project_name=project_name,
@@ -922,9 +894,16 @@ async def execute_reference_video_task(
                 warnings=warnings,
             )
 
-        if artifact_committer is not None:
-            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
-        return await _finalize()
+        return await complete_video_artifact_commit(
+            committer=artifact_committer,
+            versions=generator.versions,
+            resource_type="reference_videos",
+            resource_id=resource_id,
+            version=version,
+            video_uri=video_uri,
+            finalize=_finalize,
+            warnings=warnings,
+        )
     finally:
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -900,6 +900,8 @@ async def execute_reference_video_task(
             warnings=warnings,
         )
     finally:
+        if artifact_committer is not None:
+            await artifact_committer.release_admission_guard()
         if task_id is not None:
             await asyncio.to_thread(cleanup_staged_provider_media, project_path, task_id)
 

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -850,11 +850,6 @@ async def execute_reference_video_task(
             resource_type="reference_videos",
             resource_id=resource_id,
             prompt=rendered_prompt,
-            current_tts_settings=(
-                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
-                if options.narration_delivery == USE_TTS
-                else None
-            ),
         )
         if task_id is not None
         else None

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -11,7 +11,6 @@ import asyncio
 import logging
 from typing import Any
 
-from lib.narration_delivery import USE_TTS
 from lib.project_change_hints import project_change_source
 from lib.reference_video.execution_checkpoint import (
     ReferenceExecutionIdentityError,
@@ -28,8 +27,12 @@ from server.services.generation_tasks import (
     emit_generation_success_batch,
     get_project_manager,
 )
-from server.services.narration_delivery_tasks import require_generated_video_covers_current_tts
 from server.services.reference_video_tasks import _finalize_reference_video_unit
+from server.services.video_artifact_currency import (
+    VideoArtifactCommitter,
+    finalize_selected_video_result,
+    paid_video_history_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +162,15 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         script_file = checkpoint.script_file
         api_call_id: int | None = checkpoint.api_call_id
         event_payload: dict[str, Any] = {"script_file": checkpoint.script_file}
+        artifact_committer = VideoArtifactCommitter(
+            project_manager=get_project_manager(),
+            project_name=project_name,
+            project_path=project_path,
+            versions=generator.versions,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt_text,
+        )
 
         with project_change_source("worker"):
             output_path, version, _, video_uri = await generator.resume_video_async(
@@ -174,48 +186,62 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                 submitted_base_url=_submitted_base_url(task, ctx.video.endpoint),
                 seed=seed,
                 service_tier=service_tier,
+                before_formal_commit=artifact_committer.prepare_selection,
+                commit_formal_output=artifact_committer,
                 **optional_kwargs,
             )
 
-            if checkpoint.narration.delivery == USE_TTS:
-                await require_generated_video_covers_current_tts(
-                    project_name=project_name,
-                    script_file=script_file,
-                    request_duration_seconds=duration_seconds,
-                    output_path=output_path,
+            if artifact_committer.outcome is None:
+                raise RuntimeError("formal video resume returned without invoking the artifact commit callback")
+            if artifact_committer.selection_error is not None:
+                raise artifact_committer.selection_error
+            if not artifact_committer.outcome.selected:
+                result = await asyncio.to_thread(
+                    paid_video_history_result,
                     versions=generator.versions,
                     resource_type=resource_type,
                     resource_id=resource_id,
                     version=version,
-                )
-            if task_type == "reference_video":
-                result = await _finalize_reference_video_unit(
-                    project_name=project_name,
-                    script_file=script_file,
-                    project_path=project_path,
-                    resource_id=resource_id,
-                    output_path=output_path,
-                    version=version,
                     video_uri=video_uri,
-                    versions=generator.versions,
                 )
-            else:
-                result = await _finalize_video_task(
+                emit_generation_success_batch(
+                    task_type=task_type,
                     project_name=project_name,
-                    script_file=script_file,
-                    project_path=project_path,
                     resource_id=resource_id,
-                    version=version,
-                    video_uri=video_uri,
-                    generator=generator,
+                    payload=event_payload,
                 )
+                return result
 
-            emit_generation_success_batch(
-                task_type=task_type,
-                project_name=project_name,
-                resource_id=resource_id,
-                payload=event_payload,
-            )
-            return result
+            async def _finalize() -> dict[str, Any]:
+                if task_type == "reference_video":
+                    selected_result = await _finalize_reference_video_unit(
+                        project_name=project_name,
+                        script_file=script_file,
+                        project_path=project_path,
+                        resource_id=resource_id,
+                        output_path=output_path,
+                        version=version,
+                        video_uri=video_uri,
+                        versions=generator.versions,
+                    )
+                else:
+                    selected_result = await _finalize_video_task(
+                        project_name=project_name,
+                        script_file=script_file,
+                        project_path=project_path,
+                        resource_id=resource_id,
+                        version=version,
+                        video_uri=video_uri,
+                        generator=generator,
+                    )
+                emit_generation_success_batch(
+                    task_type=task_type,
+                    project_name=project_name,
+                    resource_id=resource_id,
+                    payload=event_payload,
+                )
+                return selected_result
+
+            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
     finally:
         await asyncio.to_thread(cleanup_staged_provider_media, project_path, checkpoint.task_id)

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -131,6 +131,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
         )
     )
 
+    artifact_committer: VideoArtifactCommitter | None = None
     try:
         # Only the project snapshot remains live here, and solely to resolve credentials/backend construction.
         # A submitted reference job's prompt, duration, script locator, endpoint and model all come from checkpoint.
@@ -234,4 +235,8 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                 on_completed=_emit_success,
             )
     finally:
-        await asyncio.to_thread(cleanup_staged_provider_media, project_path, checkpoint.task_id)
+        try:
+            if artifact_committer is not None:
+                await artifact_committer.release_admission_guard()
+        finally:
+            await asyncio.to_thread(cleanup_staged_provider_media, project_path, checkpoint.task_id)

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -27,7 +27,6 @@ from server.services.generation_tasks import (
     emit_generation_success_batch,
     get_project_manager,
 )
-from server.services.narration_delivery_tasks import ResolvedTtsSettingsResolver
 from server.services.reference_video_tasks import _finalize_reference_video_unit
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
@@ -171,11 +170,6 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt_text,
-            current_tts_settings=(
-                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
-                if checkpoint.narration.delivery == "use_tts"
-                else None
-            ),
         )
 
         with project_change_source("worker"):

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -20,18 +20,18 @@ from lib.reference_video.execution_checkpoint import (
     load_task_video_checkpoint,
 )
 from lib.video_backends.base import ResumeEndpointChangedError
-from server.services.generation_context import VideoLaneRequest, resolve_generation_context
+from server.services.generation_context import AudioLaneRequest, VideoLaneRequest, resolve_generation_context
 from server.services.generation_tasks import (
     DEFAULT_USER_ID,
     _finalize_video_task,
     emit_generation_success_batch,
     get_project_manager,
 )
+from server.services.narration_delivery_tasks import ResolvedTtsSettingsResolver
 from server.services.reference_video_tasks import _finalize_reference_video_unit
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
-    finalize_selected_video_result,
-    paid_video_history_result,
+    complete_video_artifact_commit,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,6 +141,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
             project=project,
             user_id=user_id,
             video=video_request,
+            audio=(AudioLaneRequest() if checkpoint.narration.delivery == "use_tts" else None),
         )
         generator = ctx.generator
 
@@ -170,6 +171,11 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
             resource_type=resource_type,
             resource_id=resource_id,
             prompt=prompt_text,
+            current_tts_settings=(
+                ResolvedTtsSettingsResolver.from_audio_lane(ctx.audio).settings
+                if checkpoint.narration.delivery == "use_tts"
+                else None
+            ),
         )
 
         with project_change_source("worker"):
@@ -191,26 +197,13 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                 **optional_kwargs,
             )
 
-            if artifact_committer.outcome is None:
-                raise RuntimeError("formal video resume returned without invoking the artifact commit callback")
-            if artifact_committer.selection_error is not None:
-                raise artifact_committer.selection_error
-            if not artifact_committer.outcome.selected:
-                result = await asyncio.to_thread(
-                    paid_video_history_result,
-                    versions=generator.versions,
-                    resource_type=resource_type,
-                    resource_id=resource_id,
-                    version=version,
-                    video_uri=video_uri,
-                )
+            def _emit_success() -> None:
                 emit_generation_success_batch(
                     task_type=task_type,
                     project_name=project_name,
                     resource_id=resource_id,
                     payload=event_payload,
                 )
-                return result
 
             async def _finalize() -> dict[str, Any]:
                 if task_type == "reference_video":
@@ -234,14 +227,17 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                         video_uri=video_uri,
                         generator=generator,
                     )
-                emit_generation_success_batch(
-                    task_type=task_type,
-                    project_name=project_name,
-                    resource_id=resource_id,
-                    payload=event_payload,
-                )
                 return selected_result
 
-            return await finalize_selected_video_result(committer=artifact_committer, finalize=_finalize)
+            return await complete_video_artifact_commit(
+                committer=artifact_committer,
+                versions=generator.versions,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                version=version,
+                video_uri=video_uri,
+                finalize=_finalize,
+                on_completed=_emit_success,
+            )
     finally:
         await asyncio.to_thread(cleanup_staged_provider_media, project_path, checkpoint.task_id)

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -19,7 +19,7 @@ from lib.artifact_manifest import (
     compose_video_artifact_basis,
 )
 from lib.asset_types import asset_name_comparison_key
-from lib.async_thread import EventLoopBridge
+from lib.async_thread import EventLoopBridge, run_noninterruptible_async
 from lib.generation_admission import generation_admission_lock
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
@@ -163,7 +163,7 @@ class VideoArtifactCommitter:
                 script_file=script_file,
                 resource_id=self._resource_id,
             )
-            await guard.__aenter__()
+            await run_noninterruptible_async(guard.__aenter__())
             self._admission_guard = guard
 
         raw_narration = version_metadata.get("execution_narration")

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -697,26 +697,6 @@ def _restore_file(path: Path, present: bool, content: bytes | None) -> None:
         path.unlink(missing_ok=True)
 
 
-def _string_sequence(value: object) -> tuple[str, ...] | None:
-    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
-        return None
-    canonical = tuple(asset_name_comparison_key(item) for item in value)
-    if len(set(canonical)) != len(canonical):
-        return None
-    return canonical
-
-
-def _positive_integer_tiers(value: object) -> tuple[int, ...] | None:
-    if not isinstance(value, list):
-        return None
-    tiers = tuple(value)
-    if not tiers or any(type(tier) is not int or tier <= 0 for tier in tiers):
-        return None
-    if tuple(sorted(set(tiers))) != tiers:
-        return None
-    return tiers
-
-
 def paid_video_history_result(
     *,
     versions: VersionManager,

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -598,9 +598,8 @@ def _current_duration_tier_basis(
             preparation=preparation,
             current_tts_settings=current_tts_settings,
         )
-        if actual is None:
-            return artifact_currency.duration_basis
-        duration_input = max(duration_input, actual)
+        if actual is not None:
+            duration_input = max(duration_input, actual)
     slot = resolve_duration_slot(duration_input, tiers)
     if slot.adjustment == "down" and duration_input > slot.seconds:
         return None

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -19,6 +19,7 @@ from lib.artifact_manifest import (
     compose_video_artifact_basis,
 )
 from lib.asset_types import asset_name_comparison_key
+from lib.async_thread import EventLoopBridge
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
@@ -134,6 +135,7 @@ class VideoArtifactCommitter:
         self._prior_thumbnail: tuple[Path, bool, bytes | None] | None = None
         self._current_tts_settings: TtsSynthesisSettings | None = None
         self._current_tts_basis_resolved = False
+        self._tts_settings_bridge: EventLoopBridge | None = None
         self._restore_blocker: str | None = None
 
     async def prepare_selection(
@@ -153,6 +155,7 @@ class VideoArtifactCommitter:
         raw_narration = version_metadata.get("execution_narration")
         if not isinstance(raw_narration, Mapping) or raw_narration.get("delivery") != "use_tts":
             return
+        self._tts_settings_bridge = EventLoopBridge.capture()
         try:
             narration = NarrationExecutionFacts.from_dict(dict(raw_narration))
             if narration.actual_duration_seconds is None:
@@ -173,19 +176,6 @@ class VideoArtifactCommitter:
             VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
         except (TypeError, ValueError):
             return
-        try:
-            current_project = await asyncio.to_thread(self._project_manager.load_project, self._project_name)
-            self._current_tts_settings = await CurrentTtsSettingsResolver(
-                self._project_name
-            ).resolve_tts_synthesis_settings(current_project)
-        except ValueError:
-            # No configured current TTS means there is no fresh duration that can
-            # invalidate the execution-frozen video tier.
-            self._current_tts_settings = None
-        except (Exception, asyncio.CancelledError) as exc:
-            self.selection_error = exc
-            return
-        self._current_tts_basis_resolved = True
 
     def __call__(
         self,
@@ -218,16 +208,31 @@ class VideoArtifactCommitter:
             if self.selection_error is not None:
                 return None
             narration = metadata.get("execution_narration")
+            project = snapshot["project"]
+            script = snapshot["script"]
+            if project is None or script is None:
+                return None
             if (
                 isinstance(narration, Mapping)
                 and narration.get("delivery") == "use_tts"
                 and not self._current_tts_basis_resolved
             ):
-                return None
-            project = snapshot["project"]
-            script = snapshot["script"]
-            if project is None or script is None:
-                return None
+                bridge = self._tts_settings_bridge
+                if bridge is None:
+                    self.selection_error = RuntimeError("current TTS selection was not prepared on an event loop")
+                    return None
+                try:
+                    self._current_tts_settings = bridge.run(
+                        CurrentTtsSettingsResolver(self._project_name).resolve_tts_synthesis_settings(project)
+                    )
+                except ValueError:
+                    # No configured current TTS means there is no fresh duration
+                    # that can invalidate the execution-frozen video tier.
+                    self._current_tts_settings = None
+                except (Exception, asyncio.CancelledError) as exc:
+                    self.selection_error = exc
+                    return None
+                self._current_tts_basis_resolved = True
             return build_current_video_artifact_basis(
                 project_path=self._project_path,
                 project=project,

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -1,0 +1,629 @@
+"""Project-state adapter for typed video Artifact Manifest currency."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifestEntry,
+    ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
+)
+from lib.asset_types import asset_name_comparison_key
+from lib.generation_queue import CompensableGenerationResult
+from lib.json_io import atomic_write_bytes
+from lib.project_manager import ProjectManager, find_episode
+from lib.reference_video.duration_slots import resolve_duration_slot
+from lib.reference_video.prompt_render import resolve_reference_audio_paths
+from lib.reference_video.request_projection import (
+    FilesystemReferenceAssets,
+    canonicalize_references,
+    clamp_reference_assets,
+    hydrate_reference_assets,
+    resolve_reference_assets,
+)
+from lib.resource_paths import resource_relative_path
+from lib.script_editor import resolve_items
+from lib.speech_artifact_provenance import (
+    build_video_duration_basis,
+    build_video_speech_basis,
+    project_character_voice_evidence,
+)
+from lib.speech_composition import admit_script_unit
+from lib.version_manager import PaidVersionCommit, VersionManager
+from lib.video_artifact_commit import commit_paid_video_artifact
+from lib.video_visual_provenance import resolve_video_aspect_ratio
+from lib.visual_artifact_provenance import (
+    build_reference_video_artifact_visual_basis,
+    build_storyboard_video_artifact_visual_basis,
+)
+from server.services.narration_delivery_tasks import (
+    resolve_storyboard_video_inputs,
+    validate_generated_video_covers_current_tts,
+)
+
+
+class VideoArtifactCommitter:
+    """Callable formal-output hook shared by normal and resume execution."""
+
+    def __init__(
+        self,
+        *,
+        project_manager: ProjectManager,
+        project_name: str,
+        project_path: Path,
+        versions: VersionManager,
+        resource_type: str,
+        resource_id: str,
+        prompt: str,
+    ) -> None:
+        if resource_type not in {"videos", "reference_videos"}:
+            raise ValueError(f"unsupported video artifact resource type: {resource_type!r}")
+        self._project_manager = project_manager
+        self._project_name = project_name
+        self._project_path = project_path
+        self._versions = versions
+        self._resource_type = resource_type
+        self._resource_id = resource_id
+        self._prompt = prompt
+        self.outcome: PaidVersionCommit | None = None
+        self.selection_error: BaseException | None = None
+        self._current_file: Path | None = None
+        self._selected_episode: int | None = None
+        self._selected_script_file: str | None = None
+        self._selected_basis: ArtifactBasisDescriptor | None = None
+        self._selected_artifact_path: str | None = None
+        self._prior_manifest_entry: ArtifactManifestEntry | None = None
+        self._prior_assets: dict[str, tuple[bool, Any]] | None = None
+        self._prior_thumbnail: tuple[Path, bool, bytes | None] | None = None
+
+    async def prepare_selection(
+        self,
+        staged_file: Path,
+        duration_seconds: int,
+        version_metadata: Mapping[str, Any],
+    ) -> None:
+        """Validate paid bytes before the synchronous lock-held selection decision.
+
+        Validation failures are retained instead of raised here.  The ensuing
+        formal callback can then archive the paid bytes history-only, after
+        which the executor re-raises the stored failure without ever exposing
+        the invalid media as current.
+        """
+
+        narration = version_metadata.get("execution_narration")
+        if not isinstance(narration, Mapping) or narration.get("delivery") != "use_tts":
+            return
+        script_file = version_metadata.get("execution_script_file")
+        if not isinstance(script_file, str) or not script_file:
+            return
+        try:
+            await validate_generated_video_covers_current_tts(
+                project_name=self._project_name,
+                script_file=script_file,
+                request_duration_seconds=duration_seconds,
+                output_path=staged_file,
+                resource_type=self._resource_type,
+                resource_id=self._resource_id,
+            )
+        except BaseException as exc:
+            self.selection_error = exc
+
+    def __call__(
+        self,
+        staged_file: Path,
+        current_file: Path,
+        duration_seconds: int,
+        version_metadata: Mapping[str, Any],
+    ) -> PaidVersionCommit:
+        snapshot: dict[str, dict[str, Any] | None] = {"project": None, "script": None}
+        script_file = version_metadata.get("execution_script_file")
+
+        @contextmanager
+        def _selection_guard():
+            if not isinstance(script_file, str) or not script_file:
+                yield
+                return
+            with self._project_manager.locked_project_script_snapshot(
+                self._project_name,
+                script_file,
+            ) as (project, script):
+                snapshot["project"] = project
+                snapshot["script"] = script
+                self._capture_prior_assets(script)
+                yield
+
+        def _current_basis(metadata: Mapping[str, Any]) -> ArtifactBasisDescriptor | None:
+            if self.selection_error is not None:
+                return None
+            project = snapshot["project"]
+            script = snapshot["script"]
+            if project is None or script is None:
+                return None
+            return build_current_video_artifact_basis(
+                project_path=self._project_path,
+                project=project,
+                script=script,
+                resource_type=self._resource_type,
+                resource_id=self._resource_id,
+                versions=self._versions,
+                version_metadata=metadata,
+            )
+
+        self._current_file = current_file
+        episode = version_metadata.get("artifact_episode")
+        raw_basis = version_metadata.get("artifact_video_basis")
+        self._selected_episode = episode if type(episode) is int and episode > 0 else None
+        self._selected_script_file = script_file if isinstance(script_file, str) and script_file else None
+        try:
+            self._selected_basis = ArtifactBasisDescriptor.from_dict(raw_basis)
+        except (TypeError, ValueError):
+            self._selected_basis = None
+        try:
+            self._selected_artifact_path = (
+                current_file.resolve(strict=False).relative_to(self._project_path.resolve(strict=True)).as_posix()
+            )
+        except (FileNotFoundError, ValueError):
+            self._selected_artifact_path = None
+
+        outcome = commit_paid_video_artifact(
+            project_path=self._project_path,
+            versions=self._versions,
+            resource_type=self._resource_type,
+            resource_id=self._resource_id,
+            prompt=self._prompt,
+            staged_file=staged_file,
+            current_file=current_file,
+            duration_seconds=duration_seconds,
+            version_metadata=version_metadata,
+            resolve_current_basis=_current_basis,
+            selection_guard=_selection_guard,
+            capture_prior_manifest=self._capture_prior_manifest,
+        )
+        self.outcome = outcome
+        return outcome
+
+    def compensate_selection(self) -> bool:
+        """Undo this committer's selected formal version after task failure/cancellation."""
+
+        outcome = self.outcome
+        episode = self._selected_episode
+        script_file = self._selected_script_file
+        basis = self._selected_basis
+        current_file = self._current_file
+        artifact_path = self._selected_artifact_path
+        prior_assets = self._prior_assets
+        prior_thumbnail = self._prior_thumbnail
+        if (
+            outcome is None
+            or not outcome.selected
+            or episode is None
+            or script_file is None
+            or basis is None
+            or current_file is None
+            or artifact_path is None
+            or prior_assets is None
+            or prior_thumbnail is None
+        ):
+            return False
+
+        class _SelectionChanged(RuntimeError):
+            pass
+
+        def _same_script(project: dict[str, Any]) -> str:
+            entry = find_episode(project, episode)
+            current_binding = entry.get("script_file") if isinstance(entry, dict) else None
+            if not isinstance(current_binding, str) or (
+                ProjectManager.normalize_script_filename(current_binding)
+                != ProjectManager.normalize_script_filename(script_file)
+            ):
+                raise _SelectionChanged("episode script binding changed before video compensation")
+            return current_binding
+
+        def _restore_manifest_and_thumbnail() -> None:
+            adapter = ProjectArtifactManifestAdapter(self._project_path)
+            key = ArtifactKey.episode_video(episode, self._resource_id)
+            expected = ArtifactManifestEntry(
+                artifact_path=artifact_path,
+                basis_digest=basis.digest,
+            )
+            if adapter.get_entry(key) != expected:
+                raise _SelectionChanged("video artifact selection changed before compensation")
+            thumbnail_path, prior_thumbnail_present, prior_thumbnail_bytes = prior_thumbnail
+            selected_thumbnail_present, selected_thumbnail_bytes = _snapshot_file(thumbnail_path)
+            try:
+                _restore_file(thumbnail_path, prior_thumbnail_present, prior_thumbnail_bytes)
+                if self._prior_manifest_entry is None:
+                    adapter.delete_entry(key)
+                else:
+                    adapter.put_entry(key, self._prior_manifest_entry)
+            except BaseException:
+                rollback_failures: list[BaseException] = []
+                try:
+                    _restore_file(thumbnail_path, selected_thumbnail_present, selected_thumbnail_bytes)
+                except BaseException as exc:
+                    rollback_failures.append(exc)
+                try:
+                    if adapter.get_entry(key) != expected:
+                        adapter.put_entry(key, expected)
+                except BaseException as exc:
+                    rollback_failures.append(exc)
+                if rollback_failures:
+                    raise RuntimeError(
+                        "video compensation failed and thumbnail/Manifest rollback was incomplete"
+                    ) from rollback_failures[0]
+                raise
+
+        def _reject(_script_path: Path) -> None:
+            restored = self._versions.reject_current_version(
+                self._resource_type,
+                self._resource_id,
+                rejected_version=outcome.version,
+                current_file=current_file,
+                on_reject=_restore_manifest_and_thumbnail,
+            )
+            if not restored:
+                raise _SelectionChanged("video version selection changed before compensation")
+
+        try:
+            with self._project_manager.locked_episode_script(
+                self._project_name,
+                _same_script,
+                validate=False,
+                on_commit=_reject,
+            ) as script:
+                item = _find_script_item(script, self._resource_id)
+                assets = item.get("generated_assets")
+                if not isinstance(assets, dict):
+                    assets = {}
+                    item["generated_assets"] = assets
+                for field, (present, value) in prior_assets.items():
+                    if present:
+                        assets[field] = copy.deepcopy(value)
+                    else:
+                        assets.pop(field, None)
+        except _SelectionChanged:
+            return False
+        return True
+
+    def _capture_prior_manifest(self, entry: ArtifactManifestEntry | None) -> None:
+        self._prior_manifest_entry = entry
+
+    def _capture_prior_assets(self, script: dict[str, Any]) -> None:
+        thumbnail = (
+            self._project_path / "thumbnails" / f"scene_{self._resource_id}.jpg"
+            if self._resource_type == "videos"
+            else self._project_path / "reference_videos" / "thumbnails" / f"{self._resource_id}.jpg"
+        )
+        present, content = _snapshot_file(thumbnail)
+        self._prior_thumbnail = (thumbnail, present, content)
+        try:
+            item = _find_script_item(script, self._resource_id)
+        except (KeyError, TypeError, ValueError):
+            self._prior_assets = None
+            return
+        assets = item.get("generated_assets")
+        if not isinstance(assets, dict):
+            assets = {}
+        self._prior_assets = {
+            field: (field in assets, copy.deepcopy(assets.get(field)))
+            for field in ("video_clip", "video_uri", "video_thumbnail", "video_generated_at", "status")
+        }
+
+
+async def finalize_selected_video_result(
+    *,
+    committer: VideoArtifactCommitter,
+    finalize: Callable[[], Awaitable[dict[str, Any]]],
+) -> CompensableGenerationResult:
+    """Finalize a selected video and span the task terminal-update window.
+
+    Selection precedes script/thumbnails finalization because paid media must be
+    committed through the version lock first.  Any failure in that remaining
+    work compensates the selection synchronously before it is re-raised.  A
+    successful result carries the same idempotent compensation into
+    ``GenerationQueue.mark_task_succeeded`` so an already-cancelled row cannot
+    leave the media selected.
+    """
+
+    outcome = committer.outcome
+    if outcome is None or not outcome.selected:
+        raise RuntimeError("selected video finalization requires a selected artifact commit")
+    try:
+        result = await finalize()
+    except BaseException as failure:
+        try:
+            committer.compensate_selection()
+        except BaseException as compensation_failure:
+            failure.add_note(f"video selection compensation also failed: {compensation_failure}")
+        raise
+
+    def _compensate_cancelled() -> None:
+        committer.compensate_selection()
+
+    return CompensableGenerationResult(result, cancel_compensation=_compensate_cancelled)
+
+
+def build_current_video_artifact_basis(
+    *,
+    project_path: Path,
+    project: dict[str, Any],
+    script: dict[str, Any],
+    resource_type: str,
+    resource_id: str,
+    versions: VersionManager,
+    version_metadata: Mapping[str, Any],
+) -> ArtifactBasisDescriptor | None:
+    """Rebuild current input basis using only frozen execution dependency shape."""
+
+    episode = version_metadata.get("artifact_episode")
+    if type(episode) is not int or episode < 1:
+        return None
+    script_file = version_metadata.get("execution_script_file")
+    if not isinstance(script_file, str) or not script_file:
+        return None
+    try:
+        current_episode = ProjectManager.resolve_episode_from_script(script, script_file)
+    except ValueError:
+        return None
+    if current_episode != episode:
+        return None
+
+    items, id_field, kind = resolve_items(script)
+    item = next(
+        (
+            candidate
+            for candidate in items
+            if isinstance(candidate, dict) and str(candidate.get(id_field)) == resource_id
+        ),
+        None,
+    )
+    if item is None:
+        return None
+    admission = admit_script_unit(kind, item)
+    if not admission.allowed:
+        return None
+
+    style_speakers = _string_sequence(version_metadata.get("artifact_voice_style_speakers"))
+    if style_speakers is None:
+        return None
+    audio_speakers = _execution_reference_audio_speakers(version_metadata.get("execution_provider_media"))
+    if audio_speakers is None:
+        return None
+    available_audio = resolve_reference_audio_paths(project, project_path)
+    selected_audio = {speaker: available_audio[speaker] for speaker in audio_speakers if speaker in available_audio}
+    speech = build_video_speech_basis(
+        admission.preparation,
+        voices=project_character_voice_evidence(
+            admission.preparation,
+            characters=project.get("characters"),
+            voice_style_speakers=style_speakers,
+            reference_audio_paths=selected_audio,
+        ),
+    )
+
+    if resource_type == "videos":
+        prompt = item.get("video_prompt")
+        storyboard, end_frame = resolve_storyboard_video_inputs(
+            project_path=project_path,
+            resource_id=resource_id,
+            item=item,
+        )
+        visual = build_storyboard_video_artifact_visual_basis(
+            resource_id=resource_id,
+            visual_prompt=prompt,
+            storyboard_image=storyboard,
+            end_frame_image=end_frame,
+            aspect_ratio=resolve_video_aspect_ratio(project),
+        )
+    elif resource_type == "reference_videos":
+        limit = version_metadata.get("artifact_reference_image_limit")
+        if limit is not None and (type(limit) is not int or limit < 0):
+            return None
+        declared = canonicalize_references(item.get("references"))
+        resolved = resolve_reference_assets(project, project_path, item)
+        hydration = hydrate_reference_assets(declared, resolved, FilesystemReferenceAssets(project_path))
+        if hydration.missing:
+            return None
+        visual = build_reference_video_artifact_visual_basis(
+            unit=item,
+            request_assets=clamp_reference_assets(hydration.available, limit),
+            style=project.get("style") if isinstance(project.get("style"), str) else None,
+            aspect_ratio=resolve_video_aspect_ratio(project),
+        )
+    else:
+        return None
+
+    duration = _current_duration_tier_basis(
+        project_path=project_path,
+        project=project,
+        item=item,
+        resource_id=resource_id,
+        episode=episode,
+        versions=versions,
+        version_metadata=version_metadata,
+    )
+    if duration is None:
+        return None
+    return ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+    )
+
+
+def _current_duration_tier_basis(
+    *,
+    project_path: Path,
+    project: Mapping[str, Any],
+    item: Mapping[str, Any],
+    resource_id: str,
+    episode: int,
+    versions: VersionManager,
+    version_metadata: Mapping[str, Any],
+):
+    tiers = _positive_integer_tiers(version_metadata.get("artifact_duration_tiers"))
+    if tiers is None:
+        return None
+    planned = item.get("duration_seconds")
+    if type(planned) is not int or planned <= 0:
+        planned = project.get("default_duration")
+    if type(planned) is not int or planned <= 0:
+        return None
+    duration_input: int | float = planned
+    narration = version_metadata.get("execution_narration")
+    if isinstance(narration, Mapping) and narration.get("delivery") == "use_tts":
+        actual = _selected_current_tts_duration(
+            project_path=project_path,
+            versions=versions,
+            episode=episode,
+            resource_id=resource_id,
+        )
+        if actual is not None:
+            duration_input = max(duration_input, actual)
+    slot = resolve_duration_slot(duration_input, tiers)
+    if slot.adjustment == "down" and duration_input > slot.seconds:
+        return None
+    return build_video_duration_basis(slot.seconds)
+
+
+def _selected_current_tts_duration(
+    *,
+    project_path: Path,
+    versions: VersionManager,
+    episode: int,
+    resource_id: str,
+) -> float | None:
+    history = versions.get_versions("audio", resource_id)
+    selected = next((record for record in history["versions"] if record.get("is_current")), None)
+    if not isinstance(selected, dict):
+        return None
+    raw_basis = selected.get("artifact_audio_basis")
+    actual = selected.get("tts_actual_duration_seconds")
+    if not isinstance(raw_basis, Mapping) or isinstance(actual, bool) or not isinstance(actual, (int, float)):
+        return None
+    try:
+        descriptor = ArtifactBasisDescriptor.from_dict(raw_basis)
+    except ValueError:
+        return None
+    if descriptor.kind != "narration-delivery/tts-audio" or actual <= 0:
+        return None
+    entry = ProjectArtifactManifestAdapter(project_path).get_entry(ArtifactKey.episode_audio(episode, resource_id))
+    expected_path = resource_relative_path("audio", resource_id)
+    if entry is None or entry.artifact_path != expected_path or entry.basis_digest != descriptor.digest:
+        return None
+    if not (project_path / expected_path).is_file():
+        return None
+    return float(actual)
+
+
+def _execution_reference_audio_speakers(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, list):
+        return None
+    speakers: list[str] = []
+    for raw in value:
+        if not isinstance(raw, Mapping):
+            return None
+        if raw.get("role") != "reference_audio":
+            continue
+        name = raw.get("logical_name")
+        if not isinstance(name, str) or not name:
+            return None
+        canonical = asset_name_comparison_key(name)
+        if canonical not in speakers:
+            speakers.append(canonical)
+    return tuple(speakers)
+
+
+def _find_script_item(script: dict[str, Any], resource_id: str) -> dict[str, Any]:
+    items, id_field, _kind = resolve_items(script)
+    item = next(
+        (
+            candidate
+            for candidate in items
+            if isinstance(candidate, dict) and str(candidate.get(id_field)) == resource_id
+        ),
+        None,
+    )
+    if item is None:
+        raise KeyError(f"script unit not found: {resource_id}")
+    return item
+
+
+def _snapshot_file(path: Path) -> tuple[bool, bytes | None]:
+    if path.is_file():
+        return True, path.read_bytes()
+    if path.exists():
+        raise OSError(f"expected a regular file: {path}")
+    return False, None
+
+
+def _restore_file(path: Path, present: bool, content: bytes | None) -> None:
+    if present:
+        if content is None:
+            raise RuntimeError("present file snapshot is missing bytes")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_bytes(path, content)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _string_sequence(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        return None
+    canonical = tuple(asset_name_comparison_key(item) for item in value)
+    if len(set(canonical)) != len(canonical):
+        return None
+    return canonical
+
+
+def _positive_integer_tiers(value: object) -> tuple[int, ...] | None:
+    if not isinstance(value, list):
+        return None
+    tiers = tuple(value)
+    if not tiers or any(type(tier) is not int or tier <= 0 for tier in tiers):
+        return None
+    if tuple(sorted(set(tiers))) != tiers:
+        return None
+    return tiers
+
+
+def paid_video_history_result(
+    *,
+    versions: VersionManager,
+    resource_type: str,
+    resource_id: str,
+    version: int,
+    video_uri: str | None,
+    warnings: Sequence[dict[str, Any]] = (),
+) -> dict[str, Any]:
+    """Return a successful paid-history result without claiming a formal path."""
+
+    records = versions.get_versions(resource_type, resource_id)["versions"]
+    record = next((item for item in records if item.get("version") == version), None)
+    if not isinstance(record, dict):
+        raise RuntimeError("committed paid video version is missing from history")
+    result: dict[str, Any] = {
+        "version": version,
+        "file_path": record.get("file"),
+        "created_at": record.get("created_at"),
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "video_uri": video_uri,
+        "selected_current": False,
+    }
+    if resource_type == "reference_videos":
+        result["warnings"] = list(warnings)
+    return result
+
+
+__all__ = [
+    "VideoArtifactCommitter",
+    "build_current_video_artifact_basis",
+    "finalize_selected_video_result",
+    "paid_video_history_result",
+]

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -23,7 +23,7 @@ from lib.async_thread import EventLoopBridge
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
-from lib.project_manager import ProjectManager, find_episode
+from lib.project_manager import ProjectManager, resolve_episode_script_binding
 from lib.reference_video.duration_slots import resolve_duration_slot
 from lib.reference_video.execution_checkpoint import NarrationExecutionFacts
 from lib.reference_video.prompt_render import resolve_reference_audio_paths
@@ -310,12 +310,8 @@ class VideoArtifactCommitter:
             pass
 
         def _same_script(project: dict[str, Any]) -> str:
-            entry = find_episode(project, episode)
-            current_binding = entry.get("script_file") if isinstance(entry, dict) else None
-            if not isinstance(current_binding, str) or (
-                ProjectManager.normalize_script_filename(current_binding)
-                != ProjectManager.normalize_script_filename(script_file)
-            ):
+            current_binding = resolve_episode_script_binding(project, episode, script_file)
+            if current_binding is None:
                 raise _ScriptBindingChanged("episode script binding changed before video compensation")
             return current_binding
 
@@ -492,13 +488,7 @@ def build_current_video_artifact_basis(
         return None
     if current_episode != episode:
         return None
-    episode_entry = find_episode(project, episode)
-    current_binding = episode_entry.get("script_file") if isinstance(episode_entry, dict) else None
-    if not (current_binding is None and not (project.get("episodes") or [])) and (
-        not isinstance(current_binding, str)
-        or ProjectManager.normalize_script_filename(current_binding)
-        != ProjectManager.normalize_script_filename(script_file)
-    ):
+    if resolve_episode_script_binding(project, episode, script_file) is None:
         return None
 
     items, id_field, kind = resolve_items(script)

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import copy
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractAsyncContextManager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +20,7 @@ from lib.artifact_manifest import (
 )
 from lib.asset_types import asset_name_comparison_key
 from lib.async_thread import EventLoopBridge
+from lib.generation_admission import generation_admission_lock
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
@@ -137,6 +138,7 @@ class VideoArtifactCommitter:
         self._current_tts_basis_resolved = False
         self._tts_settings_bridge: EventLoopBridge | None = None
         self._restore_blocker: str | None = None
+        self._admission_guard: AbstractAsyncContextManager[None] | None = None
 
     async def prepare_selection(
         self,
@@ -151,6 +153,18 @@ class VideoArtifactCommitter:
         which the executor re-raises the stored failure without ever exposing
         the invalid media as current.
         """
+
+        script_file = version_metadata.get("execution_script_file")
+        if isinstance(script_file, str) and script_file:
+            if self._admission_guard is not None:
+                raise RuntimeError("video artifact selection guard was already acquired")
+            guard = generation_admission_lock(
+                project_name=self._project_name,
+                script_file=script_file,
+                resource_id=self._resource_id,
+            )
+            await guard.__aenter__()
+            self._admission_guard = guard
 
         raw_narration = version_metadata.get("execution_narration")
         if not isinstance(raw_narration, Mapping) or raw_narration.get("delivery") != "use_tts":
@@ -176,6 +190,15 @@ class VideoArtifactCommitter:
             VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
         except (TypeError, ValueError):
             return
+
+    async def release_admission_guard(self) -> None:
+        """Release the selection/finalization guard, if formal preparation acquired it."""
+
+        guard = self._admission_guard
+        if guard is None:
+            return
+        self._admission_guard = None
+        await guard.__aexit__(None, None, None)
 
     def __call__(
         self,
@@ -751,24 +774,27 @@ async def complete_video_artifact_commit(
 
     if committer is None:
         return await _finalize_and_complete()
-    if committer.outcome is None:
-        raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
-    if committer.selection_error is not None:
-        raise committer.selection_error
-    if not committer.outcome.selected:
-        result = await asyncio.to_thread(
-            paid_video_history_result,
-            versions=versions,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            version=version,
-            video_uri=video_uri,
-            warnings=warnings,
-        )
-        if on_completed is not None:
-            on_completed()
-        return result
-    return await finalize_selected_video_result(committer=committer, finalize=_finalize_and_complete)
+    try:
+        if committer.outcome is None:
+            raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
+        if committer.selection_error is not None:
+            raise committer.selection_error
+        if not committer.outcome.selected:
+            result = await asyncio.to_thread(
+                paid_video_history_result,
+                versions=versions,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                version=version,
+                video_uri=video_uri,
+                warnings=warnings,
+            )
+            if on_completed is not None:
+                on_completed()
+            return result
+        return await finalize_selected_video_result(committer=committer, finalize=_finalize_and_complete)
+    finally:
+        await committer.release_admission_guard()
 
 
 __all__ = [

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -223,7 +223,10 @@ class VideoArtifactCommitter:
                     return None
                 try:
                     self._current_tts_settings = bridge.run(
-                        CurrentTtsSettingsResolver(self._project_name).resolve_tts_synthesis_settings(project)
+                        CurrentTtsSettingsResolver(
+                            self._project_name,
+                            project_path=self._project_path,
+                        ).resolve_tts_synthesis_settings(project)
                     )
                 except ValueError:
                     # No configured current TTS means there is no fresh duration
@@ -369,16 +372,20 @@ class VideoArtifactCommitter:
                 validate=False,
                 on_commit=_reject,
             ) as script:
-                item = _find_script_item(script, self._resource_id)
-                assets = item.get("generated_assets")
-                if not isinstance(assets, dict):
-                    assets = {}
-                    item["generated_assets"] = assets
-                for field, (present, value) in prior_assets.items():
-                    if present:
-                        assets[field] = copy.deepcopy(value)
-                    else:
-                        assets.pop(field, None)
+                try:
+                    item = _find_script_item(script, self._resource_id)
+                except KeyError:
+                    pass
+                else:
+                    assets = item.get("generated_assets")
+                    if not isinstance(assets, dict):
+                        assets = {}
+                        item["generated_assets"] = assets
+                    for field, (present, value) in prior_assets.items():
+                        if present:
+                            assets[field] = copy.deepcopy(value)
+                        else:
+                            assets.pop(field, None)
         except _ScriptBindingChanged:
             restored = self._versions.reject_current_version(
                 self._resource_type,

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -333,7 +333,7 @@ class VideoArtifactCommitter:
                     adapter.delete_entry(key)
                 else:
                     adapter.put_entry(key, self._prior_manifest_entry)
-            except BaseException:
+            except BaseException as original_error:
                 rollback_failures: list[BaseException] = []
                 try:
                     _restore_file(thumbnail_path, selected_thumbnail_present, selected_thumbnail_bytes)
@@ -345,6 +345,7 @@ class VideoArtifactCommitter:
                 except BaseException as exc:
                     rollback_failures.append(exc)
                 if rollback_failures:
+                    rollback_failures[0].__cause__ = original_error
                     raise RuntimeError(
                         "video compensation failed and thumbnail/Manifest rollback was incomplete"
                     ) from rollback_failures[0]

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from lib.artifact_manifest import (
+    ArtifactBasis,
     ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifestEntry,
@@ -18,6 +21,7 @@ from lib.artifact_manifest import (
 from lib.asset_types import asset_name_comparison_key
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
+from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
 from lib.project_manager import ProjectManager, find_episode
 from lib.reference_video.duration_slots import resolve_duration_slot
 from lib.reference_video.prompt_render import resolve_reference_audio_paths
@@ -35,18 +39,63 @@ from lib.speech_artifact_provenance import (
     build_video_speech_basis,
     project_character_voice_evidence,
 )
-from lib.speech_composition import admit_script_unit
+from lib.speech_composition import SpeechMode, SpeechPreparation, admit_script_unit
 from lib.version_manager import PaidVersionCommit, VersionManager
 from lib.video_artifact_commit import commit_paid_video_artifact
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_visual_provenance import resolve_video_aspect_ratio
 from lib.visual_artifact_provenance import (
     build_reference_video_artifact_visual_basis,
     build_storyboard_video_artifact_visual_basis,
 )
 from server.services.narration_delivery_tasks import (
+    CurrentTtsSettingsResolver,
     resolve_storyboard_video_inputs,
     validate_generated_video_covers_current_tts,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenVideoSpeechFacts:
+    """Canonical speech component and the execution-local voice dependencies it used."""
+
+    basis: ArtifactBasis
+    voice_style_speakers: tuple[str, ...]
+
+
+def freeze_video_speech_facts(
+    preparation: SpeechPreparation,
+    *,
+    characters: object,
+    include_voice_styles: bool,
+    reference_audio_paths: Mapping[str, Path] | None = None,
+) -> FrozenVideoSpeechFacts:
+    """Freeze route-independent character speech evidence for a paid video request."""
+
+    speakers = (
+        tuple(
+            dict.fromkeys(
+                asset_name_comparison_key(str(utterance.speaker))
+                for utterance in preparation.utterances
+                if utterance.speaker
+            )
+        )
+        if preparation.mode is SpeechMode.CHARACTER_SPEECH and include_voice_styles
+        else ()
+    )
+    basis = build_video_speech_basis(
+        preparation,
+        voices=project_character_voice_evidence(
+            preparation,
+            characters=characters,
+            voice_style_speakers=speakers,
+            reference_audio_paths=reference_audio_paths,
+        ),
+    )
+    return FrozenVideoSpeechFacts(
+        basis=basis,
+        voice_style_speakers=speakers,
+    )
 
 
 class VideoArtifactCommitter:
@@ -62,6 +111,7 @@ class VideoArtifactCommitter:
         resource_type: str,
         resource_id: str,
         prompt: str,
+        current_tts_settings: TtsSynthesisSettings | None = None,
     ) -> None:
         if resource_type not in {"videos", "reference_videos"}:
             raise ValueError(f"unsupported video artifact resource type: {resource_type!r}")
@@ -82,6 +132,7 @@ class VideoArtifactCommitter:
         self._prior_manifest_entry: ArtifactManifestEntry | None = None
         self._prior_assets: dict[str, tuple[bool, Any]] | None = None
         self._prior_thumbnail: tuple[Path, bool, bytes | None] | None = None
+        self._current_tts_settings = current_tts_settings
 
     async def prepare_selection(
         self,
@@ -104,6 +155,15 @@ class VideoArtifactCommitter:
         if not isinstance(script_file, str) or not script_file:
             return
         try:
+            current_project = await asyncio.to_thread(self._project_manager.load_project, self._project_name)
+            try:
+                frozen_currency = VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
+            except (TypeError, ValueError):
+                frozen_currency = None
+            if frozen_currency is not None and self._current_tts_settings is None:
+                self._current_tts_settings = await CurrentTtsSettingsResolver(
+                    self._project_name
+                ).resolve_tts_synthesis_settings(current_project)
             await validate_generated_video_covers_current_tts(
                 project_name=self._project_name,
                 script_file=script_file,
@@ -154,17 +214,17 @@ class VideoArtifactCommitter:
                 resource_id=self._resource_id,
                 versions=self._versions,
                 version_metadata=metadata,
+                current_tts_settings=self._current_tts_settings,
             )
 
         self._current_file = current_file
-        episode = version_metadata.get("artifact_episode")
-        raw_basis = version_metadata.get("artifact_video_basis")
-        self._selected_episode = episode if type(episode) is int and episode > 0 else None
-        self._selected_script_file = script_file if isinstance(script_file, str) and script_file else None
         try:
-            self._selected_basis = ArtifactBasisDescriptor.from_dict(raw_basis)
+            artifact_currency = VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
         except (TypeError, ValueError):
-            self._selected_basis = None
+            artifact_currency = None
+        self._selected_episode = artifact_currency.episode if artifact_currency is not None else None
+        self._selected_script_file = script_file if isinstance(script_file, str) and script_file else None
+        self._selected_basis = artifact_currency.video_descriptor if artifact_currency is not None else None
         try:
             self._selected_artifact_path = (
                 current_file.resolve(strict=False).relative_to(self._project_path.resolve(strict=True)).as_posix()
@@ -359,12 +419,15 @@ def build_current_video_artifact_basis(
     resource_id: str,
     versions: VersionManager,
     version_metadata: Mapping[str, Any],
+    current_tts_settings: TtsSynthesisSettings | None = None,
 ) -> ArtifactBasisDescriptor | None:
     """Rebuild current input basis using only frozen execution dependency shape."""
 
-    episode = version_metadata.get("artifact_episode")
-    if type(episode) is not int or episode < 1:
+    try:
+        artifact_currency = VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
+    except (TypeError, ValueError):
         return None
+    episode = artifact_currency.episode
     script_file = version_metadata.get("execution_script_file")
     if not isinstance(script_file, str) or not script_file:
         return None
@@ -390,9 +453,7 @@ def build_current_video_artifact_basis(
     if not admission.allowed:
         return None
 
-    style_speakers = _string_sequence(version_metadata.get("artifact_voice_style_speakers"))
-    if style_speakers is None:
-        return None
+    style_speakers = artifact_currency.voice_style_speakers
     audio_speakers = _execution_reference_audio_speakers(version_metadata.get("execution_provider_media"))
     if audio_speakers is None:
         return None
@@ -423,9 +484,7 @@ def build_current_video_artifact_basis(
             aspect_ratio=resolve_video_aspect_ratio(project),
         )
     elif resource_type == "reference_videos":
-        limit = version_metadata.get("artifact_reference_image_limit")
-        if limit is not None and (type(limit) is not int or limit < 0):
-            return None
+        limit = artifact_currency.reference_image_limit
         declared = canonicalize_references(item.get("references"))
         resolved = resolve_reference_assets(project, project_path, item)
         hydration = hydrate_reference_assets(declared, resolved, FilesystemReferenceAssets(project_path))
@@ -448,6 +507,9 @@ def build_current_video_artifact_basis(
         episode=episode,
         versions=versions,
         version_metadata=version_metadata,
+        artifact_currency=artifact_currency,
+        preparation=admission.preparation,
+        current_tts_settings=current_tts_settings,
     )
     if duration is None:
         return None
@@ -465,10 +527,11 @@ def _current_duration_tier_basis(
     episode: int,
     versions: VersionManager,
     version_metadata: Mapping[str, Any],
+    artifact_currency: VideoArtifactCurrencyFacts,
+    preparation: SpeechPreparation,
+    current_tts_settings: TtsSynthesisSettings | None,
 ):
-    tiers = _positive_integer_tiers(version_metadata.get("artifact_duration_tiers"))
-    if tiers is None:
-        return None
+    tiers = artifact_currency.duration_tiers
     planned = item.get("duration_seconds")
     if type(planned) is not int or planned <= 0:
         planned = project.get("default_duration")
@@ -482,9 +545,12 @@ def _current_duration_tier_basis(
             versions=versions,
             episode=episode,
             resource_id=resource_id,
+            preparation=preparation,
+            current_tts_settings=current_tts_settings,
         )
-        if actual is not None:
-            duration_input = max(duration_input, actual)
+        if actual is None:
+            return artifact_currency.duration_basis
+        duration_input = max(duration_input, actual)
     slot = resolve_duration_slot(duration_input, tiers)
     if slot.adjustment == "down" and duration_input > slot.seconds:
         return None
@@ -497,6 +563,8 @@ def _selected_current_tts_duration(
     versions: VersionManager,
     episode: int,
     resource_id: str,
+    preparation: SpeechPreparation,
+    current_tts_settings: TtsSynthesisSettings | None,
 ) -> float | None:
     history = versions.get_versions("audio", resource_id)
     selected = next((record for record in history["versions"] if record.get("is_current")), None)
@@ -511,6 +579,14 @@ def _selected_current_tts_duration(
     except ValueError:
         return None
     if descriptor.kind != "narration-delivery/tts-audio" or actual <= 0:
+        return None
+    if current_tts_settings is None:
+        return None
+    try:
+        expected = ArtifactBasisDescriptor.from_basis(build_narration_audio_basis(preparation, current_tts_settings))
+    except (TypeError, ValueError):
+        return None
+    if descriptor != expected:
         return None
     entry = ProjectArtifactManifestAdapter(project_path).get_entry(ArtifactKey.episode_audio(episode, resource_id))
     expected_path = resource_relative_path("audio", resource_id)
@@ -621,9 +697,54 @@ def paid_video_history_result(
     return result
 
 
+async def complete_video_artifact_commit(
+    *,
+    committer: VideoArtifactCommitter | None,
+    versions: VersionManager,
+    resource_type: str,
+    resource_id: str,
+    version: int,
+    video_uri: str | None,
+    finalize: Callable[[], Awaitable[dict[str, Any]]],
+    warnings: Sequence[dict[str, Any]] = (),
+    on_completed: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    """Finish normal and resumed video generation through one selection seam."""
+
+    async def _finalize_and_complete() -> dict[str, Any]:
+        result = await finalize()
+        if on_completed is not None:
+            on_completed()
+        return result
+
+    if committer is None:
+        return await _finalize_and_complete()
+    if committer.outcome is None:
+        raise RuntimeError("formal video generator returned without invoking the artifact commit callback")
+    if committer.selection_error is not None:
+        raise committer.selection_error
+    if not committer.outcome.selected:
+        result = await asyncio.to_thread(
+            paid_video_history_result,
+            versions=versions,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            version=version,
+            video_uri=video_uri,
+            warnings=warnings,
+        )
+        if on_completed is not None:
+            on_completed()
+        return result
+    return await finalize_selected_video_result(committer=committer, finalize=_finalize_and_complete)
+
+
 __all__ = [
     "VideoArtifactCommitter",
+    "FrozenVideoSpeechFacts",
     "build_current_video_artifact_basis",
+    "complete_video_artifact_commit",
     "finalize_selected_video_result",
+    "freeze_video_speech_facts",
     "paid_video_history_result",
 ]

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import copy
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import AbstractAsyncContextManager, contextmanager
+from contextlib import AbstractAsyncContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,7 +20,7 @@ from lib.artifact_manifest import (
 )
 from lib.asset_types import asset_name_comparison_key
 from lib.async_thread import EventLoopBridge, run_noninterruptible_async
-from lib.generation_admission import generation_admission_lock
+from lib.generation_admission import generation_admission_lock, generation_admission_lock_sync
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
@@ -384,42 +384,52 @@ class VideoArtifactCommitter:
             if not restored:
                 raise _SelectionChanged("video version selection changed before compensation")
 
-        try:
-            with self._project_manager.locked_episode_script(
-                self._project_name,
-                _same_script,
-                validate=False,
-                on_commit=_reject,
-            ) as script:
-                try:
-                    item = _find_script_item(script, self._resource_id)
-                except KeyError:
-                    pass
-                else:
-                    assets = item.get("generated_assets")
-                    if not isinstance(assets, dict):
-                        assets = {}
-                        item["generated_assets"] = assets
-                    for field, (present, value) in prior_assets.items():
-                        if present:
-                            assets[field] = copy.deepcopy(value)
-                        else:
-                            assets.pop(field, None)
-        except _ScriptBindingChanged:
-            restored = self._versions.reject_current_version(
-                self._resource_type,
-                self._resource_id,
-                rejected_version=outcome.version,
-                current_file=current_file,
-                on_reject=_restore_manifest_and_thumbnail,
+        admission_guard = (
+            nullcontext()
+            if self._admission_guard is not None
+            else generation_admission_lock_sync(
+                project_name=self._project_name,
+                script_file=script_file,
+                resource_id=self._resource_id,
             )
-            return (
-                restored
-                or self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
-            )
-        except _SelectionChanged:
-            return self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
-        return True
+        )
+        with admission_guard:
+            try:
+                with self._project_manager.locked_episode_script(
+                    self._project_name,
+                    _same_script,
+                    validate=False,
+                    on_commit=_reject,
+                ) as script:
+                    try:
+                        item = _find_script_item(script, self._resource_id)
+                    except KeyError:
+                        pass
+                    else:
+                        assets = item.get("generated_assets")
+                        if not isinstance(assets, dict):
+                            assets = {}
+                            item["generated_assets"] = assets
+                        for field, (present, value) in prior_assets.items():
+                            if present:
+                                assets[field] = copy.deepcopy(value)
+                            else:
+                                assets.pop(field, None)
+            except _ScriptBindingChanged:
+                restored = self._versions.reject_current_version(
+                    self._resource_type,
+                    self._resource_id,
+                    rejected_version=outcome.version,
+                    current_file=current_file,
+                    on_reject=_restore_manifest_and_thumbnail,
+                )
+                return (
+                    restored
+                    or self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
+                )
+            except _SelectionChanged:
+                return self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
+            return True
 
     def _capture_prior_manifest(self, entry: ArtifactManifestEntry | None) -> None:
         self._prior_manifest_entry = entry

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -43,7 +43,7 @@ from lib.speech_artifact_provenance import (
 from lib.speech_composition import SpeechMode, SpeechPreparation, admit_script_unit
 from lib.version_manager import PaidVersionCommit, VersionManager
 from lib.video_artifact_commit import commit_paid_video_artifact
-from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+from lib.video_artifact_facts import VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD, VideoArtifactCurrencyFacts
 from lib.video_visual_provenance import resolve_video_aspect_ratio
 from lib.visual_artifact_provenance import (
     build_reference_video_artifact_visual_basis,
@@ -134,6 +134,7 @@ class VideoArtifactCommitter:
         self._prior_thumbnail: tuple[Path, bool, bytes | None] | None = None
         self._current_tts_settings: TtsSynthesisSettings | None = None
         self._current_tts_basis_resolved = False
+        self._restore_blocker: str | None = None
 
     async def prepare_selection(
         self,
@@ -162,8 +163,10 @@ class VideoArtifactCommitter:
                 output_path=staged_file,
                 tts_actual_duration_seconds=narration.actual_duration_seconds,
             )
-        except BaseException as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             self.selection_error = exc
+            code = getattr(exc, "code", None)
+            self._restore_blocker = code if isinstance(code, str) and code else "output_duration_unverified"
             return
 
         try:
@@ -179,7 +182,7 @@ class VideoArtifactCommitter:
             # No configured current TTS means there is no fresh duration that can
             # invalidate the execution-frozen video tier.
             self._current_tts_settings = None
-        except BaseException as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             self.selection_error = exc
             return
         self._current_tts_basis_resolved = True
@@ -192,7 +195,10 @@ class VideoArtifactCommitter:
         version_metadata: Mapping[str, Any],
     ) -> PaidVersionCommit:
         snapshot: dict[str, dict[str, Any] | None] = {"project": None, "script": None}
-        script_file = version_metadata.get("execution_script_file")
+        metadata = dict(version_metadata)
+        if self._restore_blocker is not None:
+            metadata[VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD] = self._restore_blocker
+        script_file = metadata.get("execution_script_file")
 
         @contextmanager
         def _selection_guard():
@@ -235,7 +241,7 @@ class VideoArtifactCommitter:
 
         self._current_file = current_file
         try:
-            artifact_currency = VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
+            artifact_currency = VideoArtifactCurrencyFacts.from_dict(metadata.get("artifact_video_currency"))
         except (TypeError, ValueError):
             artifact_currency = None
         self._selected_episode = artifact_currency.episode if artifact_currency is not None else None
@@ -257,7 +263,7 @@ class VideoArtifactCommitter:
             staged_file=staged_file,
             current_file=current_file,
             duration_seconds=duration_seconds,
-            version_metadata=version_metadata,
+            version_metadata=metadata,
             resolve_current_basis=_current_basis,
             selection_guard=_selection_guard,
             capture_prior_manifest=self._capture_prior_manifest,

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -24,6 +24,7 @@ from lib.json_io import atomic_write_bytes
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
 from lib.project_manager import ProjectManager, find_episode
 from lib.reference_video.duration_slots import resolve_duration_slot
+from lib.reference_video.execution_checkpoint import NarrationExecutionFacts
 from lib.reference_video.prompt_render import resolve_reference_audio_paths
 from lib.reference_video.request_projection import (
     FilesystemReferenceAssets,
@@ -51,7 +52,7 @@ from lib.visual_artifact_provenance import (
 from server.services.narration_delivery_tasks import (
     CurrentTtsSettingsResolver,
     resolve_storyboard_video_inputs,
-    validate_generated_video_covers_current_tts,
+    validate_generated_video_covers_tts_duration,
 )
 
 
@@ -111,7 +112,6 @@ class VideoArtifactCommitter:
         resource_type: str,
         resource_id: str,
         prompt: str,
-        current_tts_settings: TtsSynthesisSettings | None = None,
     ) -> None:
         if resource_type not in {"videos", "reference_videos"}:
             raise ValueError(f"unsupported video artifact resource type: {resource_type!r}")
@@ -132,7 +132,8 @@ class VideoArtifactCommitter:
         self._prior_manifest_entry: ArtifactManifestEntry | None = None
         self._prior_assets: dict[str, tuple[bool, Any]] | None = None
         self._prior_thumbnail: tuple[Path, bool, bytes | None] | None = None
-        self._current_tts_settings = current_tts_settings
+        self._current_tts_settings: TtsSynthesisSettings | None = None
+        self._current_tts_basis_resolved = False
 
     async def prepare_selection(
         self,
@@ -148,32 +149,40 @@ class VideoArtifactCommitter:
         the invalid media as current.
         """
 
-        narration = version_metadata.get("execution_narration")
-        if not isinstance(narration, Mapping) or narration.get("delivery") != "use_tts":
-            return
-        script_file = version_metadata.get("execution_script_file")
-        if not isinstance(script_file, str) or not script_file:
+        raw_narration = version_metadata.get("execution_narration")
+        if not isinstance(raw_narration, Mapping) or raw_narration.get("delivery") != "use_tts":
             return
         try:
-            current_project = await asyncio.to_thread(self._project_manager.load_project, self._project_name)
-            try:
-                frozen_currency = VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
-            except (TypeError, ValueError):
-                frozen_currency = None
-            if frozen_currency is not None and self._current_tts_settings is None:
-                self._current_tts_settings = await CurrentTtsSettingsResolver(
-                    self._project_name
-                ).resolve_tts_synthesis_settings(current_project)
-            await validate_generated_video_covers_current_tts(
-                project_name=self._project_name,
-                script_file=script_file,
+            narration = NarrationExecutionFacts.from_dict(dict(raw_narration))
+            if narration.actual_duration_seconds is None:
+                raise ValueError("use_tts execution facts are missing actual duration")
+            await validate_generated_video_covers_tts_duration(
+                resource_id=self._resource_id,
                 request_duration_seconds=duration_seconds,
                 output_path=staged_file,
-                resource_type=self._resource_type,
-                resource_id=self._resource_id,
+                tts_actual_duration_seconds=narration.actual_duration_seconds,
             )
         except BaseException as exc:
             self.selection_error = exc
+            return
+
+        try:
+            VideoArtifactCurrencyFacts.from_dict(version_metadata.get("artifact_video_currency"))
+        except (TypeError, ValueError):
+            return
+        try:
+            current_project = await asyncio.to_thread(self._project_manager.load_project, self._project_name)
+            self._current_tts_settings = await CurrentTtsSettingsResolver(
+                self._project_name
+            ).resolve_tts_synthesis_settings(current_project)
+        except ValueError:
+            # No configured current TTS means there is no fresh duration that can
+            # invalidate the execution-frozen video tier.
+            self._current_tts_settings = None
+        except BaseException as exc:
+            self.selection_error = exc
+            return
+        self._current_tts_basis_resolved = True
 
     def __call__(
         self,
@@ -201,6 +210,13 @@ class VideoArtifactCommitter:
 
         def _current_basis(metadata: Mapping[str, Any]) -> ArtifactBasisDescriptor | None:
             if self.selection_error is not None:
+                return None
+            narration = metadata.get("execution_narration")
+            if (
+                isinstance(narration, Mapping)
+                and narration.get("delivery") == "use_tts"
+                and not self._current_tts_basis_resolved
+            ):
                 return None
             project = snapshot["project"]
             script = snapshot["script"]
@@ -276,6 +292,9 @@ class VideoArtifactCommitter:
         class _SelectionChanged(RuntimeError):
             pass
 
+        class _ScriptBindingChanged(_SelectionChanged):
+            pass
+
         def _same_script(project: dict[str, Any]) -> str:
             entry = find_episode(project, episode)
             current_binding = entry.get("script_file") if isinstance(entry, dict) else None
@@ -283,7 +302,7 @@ class VideoArtifactCommitter:
                 ProjectManager.normalize_script_filename(current_binding)
                 != ProjectManager.normalize_script_filename(script_file)
             ):
-                raise _SelectionChanged("episode script binding changed before video compensation")
+                raise _ScriptBindingChanged("episode script binding changed before video compensation")
             return current_binding
 
         def _restore_manifest_and_thumbnail() -> None:
@@ -348,8 +367,20 @@ class VideoArtifactCommitter:
                         assets[field] = copy.deepcopy(value)
                     else:
                         assets.pop(field, None)
+        except _ScriptBindingChanged:
+            restored = self._versions.reject_current_version(
+                self._resource_type,
+                self._resource_id,
+                rejected_version=outcome.version,
+                current_file=current_file,
+                on_reject=_restore_manifest_and_thumbnail,
+            )
+            return (
+                restored
+                or self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
+            )
         except _SelectionChanged:
-            return False
+            return self._versions.get_current_version(self._resource_type, self._resource_id) != outcome.version
         return True
 
     def _capture_prior_manifest(self, entry: ArtifactManifestEntry | None) -> None:
@@ -399,15 +430,20 @@ async def finalize_selected_video_result(
         result = await finalize()
     except BaseException as failure:
         try:
-            committer.compensate_selection()
+            _require_video_selection_compensation(committer)
         except BaseException as compensation_failure:
             failure.add_note(f"video selection compensation also failed: {compensation_failure}")
         raise
 
     def _compensate_cancelled() -> None:
-        committer.compensate_selection()
+        _require_video_selection_compensation(committer)
 
     return CompensableGenerationResult(result, cancel_compensation=_compensate_cancelled)
+
+
+def _require_video_selection_compensation(committer: VideoArtifactCommitter) -> None:
+    if not committer.compensate_selection():
+        raise RuntimeError("video artifact remains selected after compensation")
 
 
 def build_current_video_artifact_basis(
@@ -436,6 +472,14 @@ def build_current_video_artifact_basis(
     except ValueError:
         return None
     if current_episode != episode:
+        return None
+    episode_entry = find_episode(project, episode)
+    current_binding = episode_entry.get("script_file") if isinstance(episode_entry, dict) else None
+    if not (current_binding is None and not (project.get("episodes") or [])) and (
+        not isinstance(current_binding, str)
+        or ProjectManager.normalize_script_filename(current_binding)
+        != ProjectManager.normalize_script_filename(script_file)
+    ):
         return None
 
     items, id_field, kind = resolve_items(script)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,13 +7,45 @@ Single-file fakes stay in their respective test modules.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from instructor.core import InstructorRetryException
 
 if TYPE_CHECKING:
+    from lib.media_generator import MediaGenerator
     from lib.reference_video.voice_settings import VoiceRenderSettings
+    from lib.version_manager import PaidVersionCommit
+
+
+def select_formal_video(
+    generator: MediaGenerator,
+    *,
+    resource_type: str = "reference_videos",
+    resource_id: str = "E1U1",
+    prompt: str = "",
+) -> Callable[[Path, Path, int, Mapping[str, Any]], PaidVersionCommit]:
+    """Build the minimal paid-video formal commit callback used by generator tests."""
+
+    def _commit(
+        staged_file: Path,
+        current_file: Path,
+        duration_seconds: int,
+        version_metadata: Mapping[str, Any],
+    ) -> PaidVersionCommit:
+        return generator.versions.commit_staged_paid_version(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            prompt=prompt,
+            staged_file=staged_file,
+            current_file=current_file,
+            select_current=True,
+            duration_seconds=duration_seconds,
+            **version_metadata,
+        )
+
+    return _commit
 
 
 class FakeSDKClient:

--- a/tests/server/test_generation_context.py
+++ b/tests/server/test_generation_context.py
@@ -178,6 +178,31 @@ class TestLaneDeclaration:
             _ = ctx.image
 
     @pytest.mark.unit
+    async def test_preloaded_project_path_avoids_the_default_executor(
+        self,
+        session_factory,
+        project_env,
+        fake_assemble,
+        monkeypatch,
+    ):
+        project_path = project_env.get_project_path("demo")
+
+        async def _unexpected_to_thread(*_args, **_kwargs):
+            pytest.fail("a preloaded project path must not re-enter the default executor")
+
+        monkeypatch.setattr(generation_context.asyncio, "to_thread", _unexpected_to_thread)
+
+        ctx = await resolve_generation_context(
+            "demo",
+            None,
+            project={"audio_backend": "dashscope/tts-model-x"},
+            project_path=project_path,
+            audio=AudioLaneRequest(),
+        )
+
+        assert ctx.generator.project_path == project_path
+
+    @pytest.mark.unit
     async def test_i2i_capability_selects_i2i_slot(self, session_factory, project_env, fake_assemble):
         project = {
             "image_provider_t2i": "ark/img-t2i",

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -138,6 +138,9 @@ def _wire_context(
         async def prepare_selection(self, *_args, **_kwargs):
             return None
 
+        async def release_admission_guard(self):
+            return None
+
         def __call__(self, *_args, **_kwargs):
             return self.outcome
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -142,6 +142,8 @@ def _wire_context(
             return self.outcome
 
     monkeypatch.setattr(rvt, "VideoArtifactCommitter", _SelectedArtifactCommitter)
+    if isinstance(fake_generator.versions, MagicMock):
+        fake_generator.versions.get_current_version.return_value = 0
 
     lane = VideoLaneResult(
         provider_model=ProviderModel(provider_id=registry_provider_id or backend_name, model_id=backend_model),
@@ -962,7 +964,7 @@ async def test_execute_reference_video_task_bucket_follows_resolved_references(
     assert "video_provider_r2v" not in captured["payload"]
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_sends_reference_audio_in_prompt_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1039,6 +1041,34 @@ async def test_execute_reference_video_task_sends_reference_audio_in_prompt_orde
     # speaker 位不产生参考图：李四没有 @图片N 绑定
     assert "<张三>@图片1。" in prompt
     assert "<李四>@图片" not in prompt
+
+    frozen_speech_paths: dict[str, Path] = {}
+    submitted_audio_paths: list[Path] = []
+    real_freeze_speech = rvt.freeze_video_speech_facts
+
+    def _capture_frozen_speech(*args, **kwargs):
+        frozen_speech_paths.update(kwargs.get("reference_audio_paths") or {})
+        return real_freeze_speech(*args, **kwargs)
+
+    async def _stop_after_currency_freeze(**kwargs):
+        submitted_audio_paths.extend(kwargs["reference_audio_files"] or [])
+        raise RuntimeError("stop after frozen speech evidence")
+
+    monkeypatch.setattr(rvt, "freeze_video_speech_facts", _capture_frozen_speech)
+    fake_generator.generate_video_async = AsyncMock(side_effect=_stop_after_currency_freeze)
+    with pytest.raises(RuntimeError, match="stop after frozen speech evidence"):
+        await rvt.execute_reference_video_task(
+            "demo",
+            "E1U1",
+            {"script_file": "episode_1.json"},
+            user_id="u1",
+            task_id="task-audio-evidence",
+        )
+
+    assert list(frozen_speech_paths.values()) == submitted_audio_paths
+    assert all(
+        ".arcreel/tasks/task-audio-evidence/provider_media/" in path.as_posix() for path in submitted_audio_paths
+    )
 
 
 @pytest.mark.asyncio
@@ -2278,13 +2308,12 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
     monkeypatch: pytest.MonkeyPatch,
 ):
     from lib.artifact_manifest import (
-        ArtifactBasis,
-        ArtifactBasisDescriptor,
         ArtifactComparison,
         ArtifactKey,
         ArtifactManifest,
         ArtifactStatus,
         ProjectArtifactManifestAdapter,
+        compose_video_artifact_basis,
     )
     from lib.narration_delivery import NarrationAudioEvidence, TtsSynthesisSettings, prepare_narration_delivery
     from lib.reference_video.request_projection import (
@@ -2292,8 +2321,11 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         reference_audio_model_facts,
         resolve_reference_assets,
     )
+    from lib.speech_artifact_provenance import build_video_duration_basis, build_video_speech_basis
     from lib.speech_composition import admit_script_unit
     from lib.version_manager import VersionManager
+    from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+    from lib.visual_artifact_provenance import build_reference_video_artifact_visual_basis
     from server.services import reference_video_tasks as rvt
     from server.services.narration_delivery_tasks import reference_video_visual_basis_digest
 
@@ -2333,15 +2365,37 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         has_audio_track=has_audio_track,
         audio_switch_controllable=audio_switch_controllable,
     )
+    request_assets = resolve_reference_assets(project, proj_dir, unit)
     visual_basis_digest = reference_video_visual_basis_digest(
         project=project,
         project_path=proj_dir,
         unit=unit,
-        request_assets=resolve_reference_assets(project, proj_dir, unit),
+        request_assets=request_assets,
         candidate=candidate,
     )
-    artifact_video_basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"unit": "E1U1"})
+    artifact_visual_basis = build_reference_video_artifact_visual_basis(
+        unit=unit,
+        request_assets=request_assets,
+        style=project.get("style"),
+        aspect_ratio="9:16",
+    )
+    artifact_speech_basis = build_video_speech_basis(admit_script_unit("video_units", unit).preparation)
+    artifact_duration_basis = build_video_duration_basis(8)
+    artifact_currency = VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=8,
+        visual_basis=artifact_visual_basis,
+        speech_basis=artifact_speech_basis,
+        duration_basis=artifact_duration_basis,
+        video_basis=compose_video_artifact_basis(
+            visual=artifact_visual_basis,
+            speech=artifact_speech_basis,
+            duration=artifact_duration_basis,
+        ),
+        voice_style_speakers=(),
+        duration_tiers=(4, 8, 12),
+        reference_image_limit=9,
+        parent_version=0,
     )
     selected_version = versions.add_version(
         "reference_videos",
@@ -2350,13 +2404,17 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         source_file=current,
         duration_seconds=8,
         visual_basis_digest=visual_basis_digest,
-        artifact_episode=1,
-        artifact_video_basis=artifact_video_basis.to_dict(),
+        execution_checkpoint_schema_version=3,
+        execution_script_file="scripts/episode_1.json",
+        execution_duration_seconds=8,
+        execution_request_digest="d" * 64,
+        execution_provider_media=[],
+        artifact_video_currency=artifact_currency.to_dict(),
     )
     ArtifactManifest(ProjectArtifactManifestAdapter(proj_dir)).register_descriptor(
         ArtifactKey.episode_video(1, "E1U1"),
         artifact_path="reference_videos/E1U1.mp4",
-        basis=artifact_video_basis,
+        basis=artifact_currency.video_descriptor,
     )
     versions_before = (proj_dir / "versions" / "versions.json").read_bytes()
 
@@ -2745,7 +2803,8 @@ async def test_execute_reference_video_task_stages_actual_request_and_checkpoint
     assert metadata["execution_request_digest"] == checkpoint.request_digest
     assert metadata["execution_prompt_sha256"] == checkpoint.prompt_sha256
     assert metadata["execution_visual_basis_digest"] == checkpoint.visual_basis_digest
-    assert metadata["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
+    assert checkpoint.artifact_currency is not None
+    assert metadata["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
     assert not (proj_dir / ".arcreel_artifacts.json").exists()
     assert not (proj_dir / ".arcreel" / "tasks" / "task-submit" / "provider_media").exists()
 

--- a/tests/server/test_reference_video_tasks.py
+++ b/tests/server/test_reference_video_tasks.py
@@ -127,7 +127,21 @@ def _wire_context(
     （如 ark-agent-plan 族复用 Ark backend）两者不同，需显式区分以覆盖 registry 查表路径。
     """
     from lib.config.resolver import ProviderModel
+    from lib.version_manager import PaidVersionCommit
     from server.services.generation_context import AudioLaneResult, GenerationContext, VideoLaneResult
+
+    class _SelectedArtifactCommitter:
+        def __init__(self, **_kwargs):
+            self.outcome = PaidVersionCommit(version=1, selected=True)
+            self.selection_error = None
+
+        async def prepare_selection(self, *_args, **_kwargs):
+            return None
+
+        def __call__(self, *_args, **_kwargs):
+            return self.outcome
+
+    monkeypatch.setattr(rvt, "VideoArtifactCommitter", _SelectedArtifactCommitter)
 
     lane = VideoLaneResult(
         provider_model=ProviderModel(provider_id=registry_provider_id or backend_name, model_id=backend_model),
@@ -2204,8 +2218,6 @@ async def test_execute_reference_video_task_reprojects_fresh_tts_duration_and_co
         "server.services.narration_delivery_tasks.probe_existing_media_duration_seconds",
         AsyncMock(return_value=8.0),
     )
-    output_guard = AsyncMock()
-    monkeypatch.setattr(rvt, "require_generated_video_covers_current_tts", output_guard)
     fake_queue = MagicMock()
     fake_queue.persist_execution_checkpoint = AsyncMock()
     monkeypatch.setattr(rvt, "get_generation_queue", lambda: fake_queue)
@@ -2232,7 +2244,7 @@ async def test_execute_reference_video_task_reprojects_fresh_tts_duration_and_co
     assert checkpoint.narration.basis_digest
     assert checkpoint.narration.actual_duration_seconds == 6.2
     assert all(media.source_locator != "audio/segment_E1U1.wav" for media in checkpoint.media)
-    output_guard.assert_awaited_once()
+    assert callable(captured["before_formal_commit"])
     assert len(seen_lane_requests) == 1
     assert seen_lane_requests[0]["video"] is not None
     assert seen_lane_requests[0]["audio"] is not None
@@ -2265,7 +2277,15 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    from lib.artifact_manifest import ArtifactComparison, ArtifactStatus
+    from lib.artifact_manifest import (
+        ArtifactBasis,
+        ArtifactBasisDescriptor,
+        ArtifactComparison,
+        ArtifactKey,
+        ArtifactManifest,
+        ArtifactStatus,
+        ProjectArtifactManifestAdapter,
+    )
     from lib.narration_delivery import NarrationAudioEvidence, TtsSynthesisSettings, prepare_narration_delivery
     from lib.reference_video.request_projection import (
         ProviderProjectionCandidate,
@@ -2320,6 +2340,9 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         request_assets=resolve_reference_assets(project, proj_dir, unit),
         candidate=candidate,
     )
+    artifact_video_basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"unit": "E1U1"})
+    )
     selected_version = versions.add_version(
         "reference_videos",
         "E1U1",
@@ -2327,6 +2350,13 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         source_file=current,
         duration_seconds=8,
         visual_basis_digest=visual_basis_digest,
+        artifact_episode=1,
+        artifact_video_basis=artifact_video_basis.to_dict(),
+    )
+    ArtifactManifest(ProjectArtifactManifestAdapter(proj_dir)).register_descriptor(
+        ArtifactKey.episode_video(1, "E1U1"),
+        artifact_path="reference_videos/E1U1.mp4",
+        basis=artifact_video_basis,
     )
     versions_before = (proj_dir / "versions" / "versions.json").read_bytes()
 
@@ -2380,8 +2410,6 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
         "server.services.narration_delivery_tasks.probe_existing_media_duration_seconds",
         AsyncMock(return_value=8.0),
     )
-    output_guard = AsyncMock()
-    monkeypatch.setattr(rvt, "require_generated_video_covers_current_tts", output_guard)
     fake_queue = MagicMock()
     monkeypatch.setattr(rvt, "get_generation_queue", lambda: fake_queue)
 
@@ -2403,7 +2431,6 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
     assert result["version"] == selected_version
     assert result["request_duration_seconds"] == 8
     fake_generator.generate_video_async.assert_not_awaited()
-    output_guard.assert_not_awaited()
     assert script_path.read_bytes() == script_before
     assert (proj_dir / "versions" / "versions.json").read_bytes() == versions_before
     assert current.read_bytes() == b"existing-paid-video"

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -6,6 +6,7 @@ import pytest
 
 from lib.artifact_manifest import (
     ArtifactBasis,
+    ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactKind,
     ArtifactManifest,
@@ -29,6 +30,8 @@ pytestmark = pytest.mark.unit
         ArtifactKey.episode_storyboard(12, "E12S03:/"),
         ArtifactKey.episode_video(12, "unit:/3"),
         ArtifactKey.episode_audio(12, "segment:/3"),
+        ArtifactKey.episode_subtitle(12, "segment:/3", "use_tts"),
+        ArtifactKey.episode_presentation(12, "segment:/3", "post_production"),
     ],
 )
 def test_artifact_key_round_trips_without_display_string_parsing(key: ArtifactKey) -> None:
@@ -36,6 +39,12 @@ def test_artifact_key_round_trips_without_display_string_parsing(key: ArtifactKe
 
     assert encoded.startswith("artifact-key-v1:")
     assert ArtifactKey.decode(encoded) == key
+
+
+@pytest.mark.parametrize("variant", ["", "automatic", "USE_TTS", 1])
+def test_rendition_artifact_keys_reject_unknown_variants(variant: object) -> None:
+    with pytest.raises(ValueError, match="variant"):
+        ArtifactKey.episode_presentation(1, "E1U01", variant)  # type: ignore[arg-type]
 
 
 def test_artifact_key_rejects_direct_construction_that_cannot_round_trip() -> None:
@@ -85,6 +94,52 @@ def test_manifest_compares_registered_basis_without_mutating_the_artifact() -> N
     assert blocked.blocker is not None
     assert blocked.blocker.code == "artifact_symlink"
     assert not blocked.usable
+
+
+def test_manifest_registers_a_strict_frozen_basis_descriptor_after_artifact_exists() -> None:
+    path = "videos/scene_E1S01.mp4"
+    adapter = InMemoryArtifactManifestAdapter(artifacts={path})
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_video(1, "E1S01")
+    basis = ArtifactBasis.build("test/video", kind_version=1, inputs={"source": "frozen"})
+
+    assert manifest.register_descriptor(
+        key,
+        artifact_path=path,
+        basis=ArtifactBasisDescriptor.from_basis(basis),
+    )
+    assert manifest.compare(key, artifact_path=path, basis=basis).status is ArtifactStatus.CURRENT
+
+
+def test_transactional_descriptor_registration_restores_previous_entry_after_partial_write(monkeypatch) -> None:
+    path = "videos/scene_E1S01.mp4"
+    adapter = InMemoryArtifactManifestAdapter(artifacts={path})
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_video(1, "E1S01")
+    old = ArtifactBasis.build("test/video", kind_version=1, inputs={"source": "old"})
+    new = ArtifactBasis.build("test/video", kind_version=1, inputs={"source": "new"})
+    manifest.register(key, artifact_path=path, basis=old)
+    original_put = adapter.put_entry
+    calls = 0
+
+    def _write_then_fail(write_key, entry):
+        nonlocal calls
+        calls += 1
+        changed = original_put(write_key, entry)
+        if calls == 1:
+            raise RuntimeError("manifest write failed")
+        return changed
+
+    monkeypatch.setattr(adapter, "put_entry", _write_then_fail)
+
+    with pytest.raises(RuntimeError, match="manifest write failed"):
+        manifest.register_descriptor_transactionally(
+            key,
+            artifact_path=path,
+            basis=ArtifactBasisDescriptor.from_basis(new),
+        )
+
+    assert manifest.compare(key, artifact_path=path, basis=old).status is ArtifactStatus.CURRENT
 
 
 def test_manifest_blocks_windows_drive_like_artifact_path() -> None:

--- a/tests/test_artifact_manifest.py
+++ b/tests/test_artifact_manifest.py
@@ -142,6 +142,49 @@ def test_transactional_descriptor_registration_restores_previous_entry_after_par
     assert manifest.compare(key, artifact_path=path, basis=old).status is ArtifactStatus.CURRENT
 
 
+def test_transactional_descriptor_registration_preserves_original_and_rollback_failures(monkeypatch) -> None:
+    path = "videos/scene_E1S01.mp4"
+    adapter = InMemoryArtifactManifestAdapter(artifacts={path})
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_video(1, "E1S01")
+    old = ArtifactBasis.build("test/video", kind_version=1, inputs={"source": "old"})
+    new = ArtifactBasis.build("test/video", kind_version=1, inputs={"source": "new"})
+    manifest.register(key, artifact_path=path, basis=old)
+    original_put = adapter.put_entry
+    original_error = RuntimeError("manifest write failed")
+    rollback_error = OSError("manifest rollback failed")
+    calls = 0
+
+    def _fail_write_and_rollback(write_key, entry):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            original_put(write_key, entry)
+            raise original_error
+        raise rollback_error
+
+    monkeypatch.setattr(adapter, "put_entry", _fail_write_and_rollback)
+
+    with pytest.raises(RuntimeError, match="rollback was incomplete") as exc_info:
+        manifest.register_descriptor_transactionally(
+            key,
+            artifact_path=path,
+            basis=ArtifactBasisDescriptor.from_basis(new),
+        )
+
+    assert exc_info.value.__cause__ is rollback_error
+    assert rollback_error.__cause__ is original_error
+
+
+@pytest.mark.parametrize("kind_version", ["1", True, 1.0])
+def test_artifact_basis_evidence_rejects_non_integer_kind_version(kind_version: object) -> None:
+    evidence = ArtifactBasis.build("test/video", kind_version=1, inputs={}).to_evidence_dict()
+    evidence["kind_version"] = kind_version
+
+    with pytest.raises(ValueError, match="kind_version"):
+        ArtifactBasis.from_evidence_dict(evidence)
+
+
 def test_manifest_blocks_windows_drive_like_artifact_path() -> None:
     manifest = ArtifactManifest(InMemoryArtifactManifestAdapter())
     comparison = manifest.compare(

--- a/tests/test_artifact_version_restore.py
+++ b/tests/test_artifact_version_restore.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ArtifactManifestEntry,
+    ProjectArtifactManifestAdapter,
+)
+from lib.project_manager import ProjectManager
+from lib.version_manager import VersionManager
+from server.services.artifact_version_restore import restore_typed_media_version
+
+pytestmark = pytest.mark.unit
+
+
+def _descriptor(seed: str, *, kind: str = "narration-delivery/tts-audio") -> ArtifactBasisDescriptor:
+    return ArtifactBasisDescriptor.from_basis(ArtifactBasis.build(kind, kind_version=1, inputs={"seed": seed}))
+
+
+def _project(tmp_path: Path) -> tuple[ProjectManager, Path]:
+    pm = ProjectManager(tmp_path)
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    pm.save_script(
+        "demo",
+        {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [
+                {
+                    "segment_id": "E1S01",
+                    "novel_text": "旁白",
+                    "generated_assets": {
+                        "narration_audio": "audio/segment_E1S01.wav",
+                        "status": "pending",
+                    },
+                }
+            ],
+        },
+        "episode_1.json",
+        validate=False,
+    )
+    return pm, pm.get_project_path("demo")
+
+
+def _add_audio_version(
+    vm: VersionManager,
+    current: Path,
+    *,
+    content: bytes,
+    basis: ArtifactBasisDescriptor | None,
+) -> int:
+    current.parent.mkdir(parents=True, exist_ok=True)
+    current.write_bytes(content)
+    metadata = (
+        {
+            "artifact_episode": 1,
+            "artifact_audio_basis": basis.to_dict(),
+            "execution_script_file": "episode_1.json",
+            "tts_actual_duration_seconds": 5.0,
+        }
+        if basis is not None
+        else {}
+    )
+    return vm.add_version("audio", "E1S01", content.decode(), source_file=current, **metadata)
+
+
+def test_typed_audio_restore_selects_media_script_pointer_and_manifest_together(tmp_path):
+    pm, project_path = _project(tmp_path)
+    vm = VersionManager(project_path)
+    current = project_path / "audio" / "segment_E1S01.wav"
+    old_basis = _descriptor("old")
+    current_basis = _descriptor("current")
+    old_version = _add_audio_version(vm, current, content=b"old", basis=old_basis)
+    _add_audio_version(vm, current, content=b"current", basis=current_basis)
+    adapter = ProjectArtifactManifestAdapter(project_path)
+    ArtifactManifest(adapter).register_descriptor(
+        ArtifactKey.episode_audio(1, "E1S01"),
+        artifact_path="audio/segment_E1S01.wav",
+        basis=current_basis,
+    )
+
+    result = restore_typed_media_version(
+        project_manager=pm,
+        project_name="demo",
+        project_path=project_path,
+        versions=vm,
+        resource_type="audio",
+        resource_id="E1S01",
+        version=old_version,
+        current_file=current,
+        artifact_path="audio/segment_E1S01.wav",
+    )
+
+    assert result["restored_version"] == old_version
+    assert current.read_bytes() == b"old"
+    assert vm.get_current_version("audio", "E1S01") == old_version
+    assets = pm.load_script("demo", "episode_1.json")["segments"][0]["generated_assets"]
+    assert assets["narration_audio"] == "audio/segment_E1S01.wav"
+    assert adapter.get_entry(ArtifactKey.episode_audio(1, "E1S01")) == ArtifactManifestEntry(
+        artifact_path="audio/segment_E1S01.wav",
+        basis_digest=old_basis.digest,
+    )
+
+
+def test_restore_registration_failure_rolls_back_media_pointer_and_script(tmp_path, monkeypatch):
+    pm, project_path = _project(tmp_path)
+    vm = VersionManager(project_path)
+    current = project_path / "audio" / "segment_E1S01.wav"
+    old_basis = _descriptor("old")
+    current_basis = _descriptor("current")
+    old_version = _add_audio_version(vm, current, content=b"old", basis=old_basis)
+    current_version = _add_audio_version(vm, current, content=b"current", basis=current_basis)
+    adapter = ProjectArtifactManifestAdapter(project_path)
+    ArtifactManifest(adapter).register_descriptor(
+        ArtifactKey.episode_audio(1, "E1S01"),
+        artifact_path="audio/segment_E1S01.wav",
+        basis=current_basis,
+    )
+    before_script = (project_path / "scripts" / "episode_1.json").read_bytes()
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("injected manifest failure")
+
+    monkeypatch.setattr(ArtifactManifest, "register_descriptor_transactionally", _fail)
+
+    with pytest.raises(RuntimeError, match="injected manifest failure"):
+        restore_typed_media_version(
+            project_manager=pm,
+            project_name="demo",
+            project_path=project_path,
+            versions=vm,
+            resource_type="audio",
+            resource_id="E1S01",
+            version=old_version,
+            current_file=current,
+            artifact_path="audio/segment_E1S01.wav",
+        )
+
+    assert current.read_bytes() == b"current"
+    assert vm.get_current_version("audio", "E1S01") == current_version
+    assert (project_path / "scripts" / "episode_1.json").read_bytes() == before_script
+    assert adapter.get_entry(ArtifactKey.episode_audio(1, "E1S01")).basis_digest == current_basis.digest
+
+
+def test_legacy_audio_restore_without_typed_basis_is_rejected_without_mutation(tmp_path):
+    pm, project_path = _project(tmp_path)
+    vm = VersionManager(project_path)
+    current = project_path / "audio" / "segment_E1S01.wav"
+    legacy_version = _add_audio_version(vm, current, content=b"legacy", basis=None)
+    current_basis = _descriptor("current")
+    current_version = _add_audio_version(vm, current, content=b"current", basis=current_basis)
+
+    with pytest.raises(ValueError, match="typed artifact metadata"):
+        restore_typed_media_version(
+            project_manager=pm,
+            project_name="demo",
+            project_path=project_path,
+            versions=vm,
+            resource_type="audio",
+            resource_id="E1S01",
+            version=legacy_version,
+            current_file=current,
+            artifact_path="audio/segment_E1S01.wav",
+        )
+
+    assert current.read_bytes() == b"current"
+    assert vm.get_current_version("audio", "E1S01") == current_version

--- a/tests/test_artifact_version_restore.py
+++ b/tests/test_artifact_version_restore.py
@@ -126,6 +126,31 @@ def test_typed_audio_restore_selects_media_script_pointer_and_manifest_together(
     )
 
 
+def test_typed_audio_restore_accepts_legacy_project_without_episode_index(tmp_path):
+    pm, project_path = _project(tmp_path)
+    vm = VersionManager(project_path)
+    current = project_path / "audio" / "segment_E1S01.wav"
+    old_basis = _descriptor("old")
+    old_version = _add_audio_version(vm, current, content=b"old", basis=old_basis)
+    _add_audio_version(vm, current, content=b"current", basis=_descriptor("current"))
+    pm.update_project("demo", lambda project: project.pop("episodes", None))
+
+    result = restore_typed_media_version(
+        project_manager=pm,
+        project_name="demo",
+        project_path=project_path,
+        versions=vm,
+        resource_type="audio",
+        resource_id="E1S01",
+        version=old_version,
+        current_file=current,
+        artifact_path="audio/segment_E1S01.wav",
+    )
+
+    assert result["restored_version"] == old_version
+    assert current.read_bytes() == b"old"
+
+
 def test_restore_registration_failure_rolls_back_media_pointer_and_script(tmp_path, monkeypatch):
     pm, project_path = _project(tmp_path)
     vm = VersionManager(project_path)

--- a/tests/test_artifact_version_restore.py
+++ b/tests/test_artifact_version_restore.py
@@ -14,13 +14,24 @@ from lib.artifact_manifest import (
 )
 from lib.project_manager import ProjectManager
 from lib.version_manager import VersionManager
-from server.services.artifact_version_restore import restore_typed_media_version
+from server.services.artifact_version_restore import get_typed_media_restore_target, restore_typed_media_version
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 
 def _descriptor(seed: str, *, kind: str = "narration-delivery/tts-audio") -> ArtifactBasisDescriptor:
-    return ArtifactBasisDescriptor.from_basis(ArtifactBasis.build(kind, kind_version=1, inputs={"seed": seed}))
+    inputs = (
+        {
+            "text": seed,
+            "provider_id": "dashscope",
+            "model_id": "qwen3-tts-flash",
+            "voice": "Cherry",
+            "speed": None,
+        }
+        if kind == "narration-delivery/tts-audio"
+        else {"seed": seed}
+    )
+    return ArtifactBasisDescriptor.from_basis(ArtifactBasis.build(kind, kind_version=1, inputs=inputs))
 
 
 def _project(tmp_path: Path) -> tuple[ProjectManager, Path]:
@@ -65,6 +76,11 @@ def _add_audio_version(
             "artifact_audio_basis": basis.to_dict(),
             "execution_script_file": "episode_1.json",
             "tts_actual_duration_seconds": 5.0,
+            "tts_provider_id": "dashscope",
+            "tts_model_id": "qwen3-tts-flash",
+            "tts_voice": "Cherry",
+            "tts_speed": None,
+            "tts_basis_digest": basis.digest,
         }
         if basis is not None
         else {}
@@ -173,3 +189,54 @@ def test_legacy_audio_restore_without_typed_basis_is_rejected_without_mutation(t
 
     assert current.read_bytes() == b"current"
     assert vm.get_current_version("audio", "E1S01") == current_version
+
+
+def test_audio_restore_rejects_kind_only_descriptor_that_metadata_cannot_verify(tmp_path):
+    pm, project_path = _project(tmp_path)
+    vm = VersionManager(project_path)
+    current = project_path / "audio" / "segment_E1S01.wav"
+    unverifiable = _descriptor("different prompt")
+    invalid_version = _add_audio_version(vm, current, content=b"old", basis=unverifiable)
+    current_version = _add_audio_version(vm, current, content=b"current", basis=_descriptor("current"))
+
+    with pytest.raises(ValueError, match="typed artifact metadata"):
+        restore_typed_media_version(
+            project_manager=pm,
+            project_name="demo",
+            project_path=project_path,
+            versions=vm,
+            resource_type="audio",
+            resource_id="E1S01",
+            version=invalid_version,
+            current_file=current,
+            artifact_path="audio/segment_E1S01.wav",
+        )
+
+    assert current.read_bytes() == b"current"
+    assert vm.get_current_version("audio", "E1S01") == current_version
+
+
+def test_video_restore_rejects_composite_kind_without_complete_v3_components(tmp_path):
+    project_path = tmp_path / "demo"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"video")
+    vm = VersionManager(project_path)
+    kind_only = _descriptor("video", kind="artifact-components/video")
+    version = vm.add_version(
+        "videos",
+        "E1S01",
+        "video",
+        source_file=current,
+        artifact_episode=1,
+        execution_script_file="episode_1.json",
+        artifact_video_basis=kind_only.to_dict(),
+    )
+
+    with pytest.raises(ValueError, match="typed artifact metadata"):
+        get_typed_media_restore_target(
+            vm,
+            resource_type="videos",
+            resource_id="E1S01",
+            version=version,
+        )

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -277,19 +277,21 @@ class TestExecuteTtsTask:
         result = await generation_tasks.execute_tts_task("demo", "E1S01", {"text": "你好世界"})
         assert result == {
             "version": 3,
-            "file_path": "audio/segment_E1S01.wav",
+            "file_path": "versions/audio/E1S01_v3.wav",
             "created_at": "2026-06-01T00:00:00Z",
             "resource_type": "audio",
             "resource_id": "E1S01",
             "duration_seconds": 5.25,
             "tts_basis_digest": None,
-            "selected_current": True,
+            "selected_current": False,
         }
         call = gen.audio_calls[0]
         assert call["text"] == "你好世界"
         assert call["voice"] == "Cherry"
         assert call["resource_id"] == "E1S01"
-        # 无 script_file → 不写回 narration_audio
+        assert not (pm.project_path / "audio" / "segment_E1S01.wav").exists()
+        assert gen.version_records[-1]["tts_basis_digest"] is None
+        # 无 script_file → 只保存付费历史，不写回 narration_audio 或抢占 current
         assert pm.updated_assets == []
 
     async def test_text_from_script_segment_and_writeback(self, tts_env):

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -79,6 +79,7 @@ class _FakePM:
         }
         self.updated_assets = []
         self.rebind_on_next_lock: str | None = None
+        self.episode_lock_active = False
 
     def load_project(self, project_name):
         return self.project
@@ -101,12 +102,15 @@ class _FakePM:
         resolve_script_file(self.project)
         before = copy.deepcopy(self.script)
         try:
+            self.episode_lock_active = True
             yield self.script
             if on_commit is not None:
                 on_commit(self.project_path / "scripts" / "episode_1.json")
         except BaseException:
             self.script = before
             raise
+        finally:
+            self.episode_lock_active = False
 
     @staticmethod
     def update_scene_status(item):
@@ -133,7 +137,7 @@ class _FakeAudioGenerator:
         if before_commit := kwargs.get("before_commit"):
             await before_commit(staged)
         if commit_staged := kwargs.get("commit_staged"):
-            committed = commit_staged(staged, output)
+            committed = await asyncio.to_thread(commit_staged, staged, output)
             version = committed.version if isinstance(committed, PaidVersionCommit) else committed
         else:
             staged.replace(output)
@@ -467,6 +471,8 @@ class TestExecuteTtsTask:
         async def _settings_change(*args, **kwargs):
             nonlocal calls
             calls += 1
+            if calls == 2:
+                assert pm.episode_lock_active
             resolver = initial_resolver if calls == 1 else changed_resolver
             return await resolver(*args, **kwargs)
 

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -473,6 +473,7 @@ class TestExecuteTtsTask:
             calls += 1
             if calls == 2:
                 assert pm.episode_lock_active
+                assert kwargs["project_path"] == pm.project_path
             resolver = initial_resolver if calls == 1 else changed_resolver
             return await resolver(*args, **kwargs)
 
@@ -766,6 +767,25 @@ class TestExecuteTtsTask:
         assert gen.rejected_versions == [3]
         assert not (pm.project_path / "audio" / "segment_E1S01.wav").exists()
         assert ProjectArtifactManifestAdapter(pm.project_path).get_entry(ArtifactKey.episode_audio(1, "E1S01")) is None
+
+    async def test_cancel_after_unit_removal_still_rejects_selected_tts(self, tts_env):
+        pm, gen = tts_env
+
+        result = await generation_tasks.execute_tts_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json"},
+            task_id="removed-unit-tts-task",
+        )
+        pm.script["segments"].clear()
+
+        assert isinstance(result, CompensableGenerationResult)
+        result.compensate_cancelled()
+
+        assert gen.rejected_versions == [3]
+        assert not (pm.project_path / "audio" / "segment_E1S01.wav").exists()
+        assert ProjectArtifactManifestAdapter(pm.project_path).get_entry(ArtifactKey.episode_audio(1, "E1S01")) is None
+        assert pm.script["segments"] == []
 
     async def test_narration_speed_passed_to_generator(self, tts_env, monkeypatch):
         pm, gen = tts_env

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -743,6 +743,24 @@ class TestExecuteTtsTask:
         assert not (pm.project_path / "audio" / "segment_E1S01.wav").exists()
         assert "narration_audio" not in pm.script["segments"][0]["generated_assets"]
 
+    async def test_cancel_after_episode_rebind_still_rejects_selected_tts(self, tts_env):
+        pm, gen = tts_env
+
+        result = await generation_tasks.execute_tts_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json"},
+            task_id="rebound-tts-task",
+        )
+        pm.project["episodes"] = [{"episode": 1, "script_file": "scripts/rebound_episode_1.json"}]
+
+        assert isinstance(result, CompensableGenerationResult)
+        result.compensate_cancelled()
+
+        assert gen.rejected_versions == [3]
+        assert not (pm.project_path / "audio" / "segment_E1S01.wav").exists()
+        assert ProjectArtifactManifestAdapter(pm.project_path).get_entry(ArtifactKey.episode_audio(1, "E1S01")) is None
+
     async def test_narration_speed_passed_to_generator(self, tts_env, monkeypatch):
         pm, gen = tts_env
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _audio_ctx(gen, speed=1.5))

--- a/tests/test_execute_tts_task.py
+++ b/tests/test_execute_tts_task.py
@@ -25,6 +25,7 @@ from lib.generation_queue import CompensableGenerationResult
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis, register_narration_audio
 from lib.script_editor import resolve_items
 from lib.speech_composition import admit_script_unit
+from lib.version_manager import PaidVersionCommit
 from server.services import generation_context, generation_tasks
 from server.services.generation_context import AudioLaneResult, GenerationContext
 
@@ -120,6 +121,8 @@ class _FakeAudioGenerator:
         self.versions = self
         self.previous_formal: bytes | None = None
         self.rejected_versions: list[int] = []
+        self.version_records: list[dict[str, Any]] = []
+        self.current_version = 0
 
     async def generate_audio_async(self, **kwargs):
         self.audio_calls.append(kwargs)
@@ -130,7 +133,8 @@ class _FakeAudioGenerator:
         if before_commit := kwargs.get("before_commit"):
             await before_commit(staged)
         if commit_staged := kwargs.get("commit_staged"):
-            version = commit_staged(staged, output)
+            committed = commit_staged(staged, output)
+            version = committed.version if isinstance(committed, PaidVersionCommit) else committed
         else:
             staged.replace(output)
             version = 3
@@ -152,6 +156,53 @@ class _FakeAudioGenerator:
             raise
         return 3
 
+    def commit_staged_paid_version(
+        self,
+        *,
+        resource_type,
+        resource_id,
+        prompt,
+        staged_file,
+        current_file,
+        select_current,
+        on_select=None,
+        **metadata,
+    ):
+        assert resource_type == "audio"
+        previous = current_file.read_bytes() if current_file.is_file() else None
+        self.previous_formal = previous
+        version = max((record["version"] for record in self.version_records), default=2) + 1
+        version_rel = f"versions/audio/{resource_id}_v{version}.wav"
+        version_file = self.project_path / version_rel
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.write_bytes(staged_file.read_bytes())
+        record = {
+            "version": version,
+            "file": version_rel,
+            "prompt": prompt,
+            "created_at": "2026-06-01T00:00:00Z",
+            **metadata,
+        }
+        self.version_records.append(record)
+
+        should_select = select_current() if callable(select_current) else select_current
+        if not should_select:
+            staged_file.unlink(missing_ok=True)
+            return PaidVersionCommit(version=version, selected=False)
+
+        staged_file.replace(current_file)
+        try:
+            if on_select is not None:
+                on_select()
+        except BaseException:
+            if previous is None:
+                current_file.unlink(missing_ok=True)
+            else:
+                current_file.write_bytes(previous)
+            raise
+        self.current_version = version
+        return PaidVersionCommit(version=version, selected=True)
+
     def reject_current_version(self, resource_type, resource_id, *, rejected_version, current_file, **kwargs):
         del resource_type, resource_id
         self.rejected_versions.append(rejected_version)
@@ -168,7 +219,16 @@ class _FakeAudioGenerator:
         return {"restored_version": 3}
 
     def get_versions(self, resource_type, resource_id):
-        return {"versions": [{"created_at": "2026-06-01T00:00:00Z"}]}
+        del resource_type, resource_id
+        if self.version_records:
+            return {
+                "current_version": self.current_version,
+                "versions": [
+                    {**record, "is_current": record["version"] == self.current_version}
+                    for record in self.version_records
+                ],
+            }
+        return {"current_version": 3, "versions": [{"version": 3, "created_at": "2026-06-01T00:00:00Z"}]}
 
 
 @pytest.fixture
@@ -223,6 +283,7 @@ class TestExecuteTtsTask:
             "resource_id": "E1S01",
             "duration_seconds": 5.25,
             "tts_basis_digest": None,
+            "selected_current": True,
         }
         call = gen.audio_calls[0]
         assert call["text"] == "你好世界"
@@ -233,9 +294,13 @@ class TestExecuteTtsTask:
 
     async def test_text_from_script_segment_and_writeback(self, tts_env):
         pm, gen = tts_env
-        await generation_tasks.execute_tts_task("demo", "E1S01", {"script_file": "episode_1.json"})
+        result = await generation_tasks.execute_tts_task("demo", "E1S01", {"script_file": "episode_1.json"})
         assert gen.audio_calls[0]["text"] == "却说天下大势，分久必合，合久必分。"
         assert pm.script["segments"][0]["generated_assets"]["narration_audio"] == "audio/segment_E1S01.wav"
+        assert gen.version_records[-1]["artifact_episode"] == 1
+        assert gen.version_records[-1]["artifact_audio_basis"]["digest"] == result["tts_basis_digest"]
+        assert gen.version_records[-1]["tts_actual_duration_seconds"] == 5.25
+        assert gen.version_records[-1]["execution_script_file"] == "episode_1.json"
 
         settings = TtsSynthesisSettings(
             provider_id="dashscope",
@@ -274,7 +339,37 @@ class TestExecuteTtsTask:
 
         pm.rebind_on_next_lock = "scripts/episode_1_rebound.json"
 
-        with pytest.raises(RuntimeError, match="script binding changed"):
+        result = await generation_tasks.execute_tts_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json"},
+            task_id="tts-task",
+        )
+
+        assert formal.read_bytes() == b"paid-old-audio"
+        assert result["selected_current"] is False
+        assert (pm.project_path / result["file_path"]).read_bytes() == b"RIFF-current-audio"
+        assert "generated_assets" not in pm.script["segments"][0]
+
+    async def test_project_transaction_failure_still_archives_paid_audio(
+        self,
+        tts_env,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        pm, gen = tts_env
+        formal = pm.project_path / "audio" / "segment_E1S01.wav"
+        formal.parent.mkdir(parents=True, exist_ok=True)
+        formal.write_bytes(b"paid-old-audio")
+        pm.project["episodes"] = [{"episode": 1, "script_file": "scripts/episode_1.json"}]
+
+        @contextmanager
+        def _failed_transaction(*_args, **_kwargs):
+            raise OSError("project snapshot unavailable")
+            yield
+
+        monkeypatch.setattr(pm, "locked_episode_script", _failed_transaction)
+
+        with pytest.raises(OSError, match="project snapshot unavailable"):
             await generation_tasks.execute_tts_task(
                 "demo",
                 "E1S01",
@@ -283,9 +378,11 @@ class TestExecuteTtsTask:
             )
 
         assert formal.read_bytes() == b"paid-old-audio"
-        assert "generated_assets" not in pm.script["segments"][0]
+        assert len(gen.version_records) == 1
+        assert (pm.project_path / gen.version_records[0]["file"]).read_bytes() == b"RIFF-current-audio"
+        assert gen.current_version == 0
 
-    async def test_narration_change_before_commit_preserves_old_formal_audio_and_basis(
+    async def test_narration_change_before_commit_keeps_paid_history_without_taking_current(
         self,
         tts_env,
         monkeypatch: pytest.MonkeyPatch,
@@ -321,19 +418,69 @@ class TestExecuteTtsTask:
 
         monkeypatch.setattr(gen, "generate_audio_async", _edit_before_commit)
 
-        with pytest.raises(RuntimeError, match="narration changed before TTS commit"):
-            await generation_tasks.execute_tts_task(
-                "demo",
-                "E1S01",
-                {"script_file": "episode_1.json"},
-            )
+        result = await generation_tasks.execute_tts_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json"},
+        )
 
         assert formal.read_bytes() == b"paid-old-audio"
+        assert result["selected_current"] is False
+        assert result["file_path"].startswith("versions/audio/")
+        assert (pm.project_path / result["file_path"]).read_bytes() == b"RIFF-current-audio"
         assert pm.script["segments"][0]["novel_text"] == "合成期间并发改写的旁白。"
         assert pm.script["segments"][0]["generated_assets"] == {
             "narration_audio": "audio/segment_E1S01.wav",
             "status": "pending",
         }
+        assert adapter.get_entry(ArtifactKey.episode_audio(1, "E1S01")) == prior_entry
+
+    async def test_tts_settings_change_before_commit_keeps_paid_history_without_taking_current(
+        self,
+        tts_env,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        pm, gen = tts_env
+        formal = pm.project_path / "audio" / "segment_E1S01.wav"
+        formal.parent.mkdir(parents=True, exist_ok=True)
+        formal.write_bytes(b"paid-old-audio")
+        pm.script["segments"][0]["generated_assets"] = {
+            "narration_audio": "audio/segment_E1S01.wav",
+            "status": "pending",
+        }
+        items, _id_field, kind = resolve_items(pm.script)
+        initial_settings = TtsSynthesisSettings("dashscope", "qwen3-tts-flash", "Cherry", None)
+        register_narration_audio(
+            project_path=pm.project_path,
+            episode=1,
+            preparation=admit_script_unit(kind, items[0]).preparation,
+            settings=initial_settings,
+        )
+        adapter = ProjectArtifactManifestAdapter(pm.project_path)
+        prior_entry = adapter.get_entry(ArtifactKey.episode_audio(1, "E1S01"))
+        initial_resolver = _audio_ctx(gen, voice="Cherry")
+        changed_resolver = _audio_ctx(gen, voice="Ada")
+        calls = 0
+
+        async def _settings_change(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            resolver = initial_resolver if calls == 1 else changed_resolver
+            return await resolver(*args, **kwargs)
+
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _settings_change)
+
+        result = await generation_tasks.execute_tts_task(
+            "demo",
+            "E1S01",
+            {"script_file": "episode_1.json"},
+        )
+
+        assert calls == 2
+        assert result["selected_current"] is False
+        assert formal.read_bytes() == b"paid-old-audio"
+        assert (pm.project_path / result["file_path"]).read_bytes() == b"RIFF-current-audio"
+        assert gen.version_records[-1]["tts_voice"] == "Cherry"
         assert adapter.get_entry(ArtifactKey.episode_audio(1, "E1S01")) == prior_entry
 
     async def test_reference_video_unit_uses_its_own_narrator_text_and_manifest_key(self, tts_env):
@@ -451,7 +598,7 @@ class TestExecuteTtsTask:
         monkeypatch,
         measured_duration: float | None,
     ):
-        pm, _gen = tts_env
+        pm, gen = tts_env
         formal = pm.project_path / "audio" / "segment_E1S01.wav"
         formal.parent.mkdir(parents=True, exist_ok=True)
         formal.write_bytes(b"paid-old-audio")
@@ -480,6 +627,9 @@ class TestExecuteTtsTask:
 
         assert formal.read_bytes() == b"paid-old-audio"
         assert pm.script["segments"][0]["generated_assets"]["narration_audio"] == "audio/segment_E1S01.wav"
+        assert len(gen.version_records) == 1
+        assert (pm.project_path / gen.version_records[0]["file"]).read_bytes() == b"RIFF-current-audio"
+        assert gen.current_version == 0
         comparison = ArtifactManifest(ProjectArtifactManifestAdapter(pm.project_path)).compare(
             ArtifactKey.episode_audio(1, "E1S01"),
             artifact_path="audio/segment_E1S01.wav",

--- a/tests/test_files_router.py
+++ b/tests/test_files_router.py
@@ -9,11 +9,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
 
+import lib.project_manager as project_manager_module
 from lib.i18n.en import assets as en_assets
 from lib.i18n.vi import assets as vi_assets
 from lib.i18n.zh import assets as zh_assets
 from lib.i18n.zh import errors as zh_errors
-from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import files
@@ -51,7 +51,7 @@ def _img_bytes(fmt="JPEG"):
 
 
 def _client(monkeypatch, tmp_path):
-    pm = ProjectManager(tmp_path / "projects")
+    pm = project_manager_module.ProjectManager(tmp_path / "projects")
     pm.create_project("demo")
     pm.create_project_metadata("demo", "Demo", "Anime", "narration")
     pm.add_character("demo", "Alice", "desc")
@@ -238,6 +238,19 @@ class TestFilesRouter:
             assert project["characters"]["Alice"]["reference_audio"] == "characters/refs_audio/Alice.wav"
 
     @pytest.mark.unit
+    def test_character_audio_ref_without_name_is_rejected_without_writing_an_orphan(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        with client:
+            resp = client.post(
+                "/api/v1/projects/demo/upload/character_audio_ref",
+                files={"file": ("orphan.wav", _wav_bytes(3), "audio/wav")},
+            )
+
+            assert resp.status_code == 404
+            refs_dir = pm.get_project_path("demo") / "characters" / "refs_audio"
+            assert not refs_dir.exists() or not any(refs_dir.iterdir())
+
+    @pytest.mark.unit
     def test_character_audio_ref_rejects_bad_extension(self, tmp_path, monkeypatch):
         client, _ = _client(monkeypatch, tmp_path)
         with client:
@@ -373,8 +386,8 @@ class TestFilesRouter:
             assert pm.load_project("demo")["characters"]["Alice"].get("reference_audio") == ""
 
     @pytest.mark.unit
-    def test_delete_character_reference_audio_preserves_pointer_on_unlink_failure(self, tmp_path, monkeypatch):
-        """物理删除失败（权限/IO 错误，含 Windows 文件占用）时保留字段指针，允许重试发现并清理该文件。"""
+    def test_delete_character_reference_audio_succeeds_when_cleanup_fails(self, tmp_path, monkeypatch):
+        """字段已提交清空后，物理删除失败只残留无引用文件，不应让请求误报失败。"""
         client, pm = _client(monkeypatch, tmp_path)
         with client:
             upload = client.post(
@@ -394,6 +407,32 @@ class TestFilesRouter:
                 return original_unlink(self, *args, **kwargs)
 
             monkeypatch.setattr(Path, "unlink", _boom)
+
+            resp = client.delete("/api/v1/projects/demo/characters/Alice/reference-audio")
+            assert resp.status_code == 200
+            assert pm.load_project("demo")["characters"]["Alice"]["reference_audio"] == ""
+            assert audio_path.exists()
+
+    @pytest.mark.unit
+    def test_delete_character_reference_audio_preserves_file_when_project_commit_fails(self, tmp_path, monkeypatch):
+        client, pm = _client(monkeypatch, tmp_path)
+        with client:
+            upload = client.post(
+                "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
+                files={"file": ("alice_voice.wav", _wav_bytes(3), "audio/wav")},
+            )
+            assert upload.status_code == 200
+            project_dir = pm.get_project_path("demo")
+            project_file = project_dir / "project.json"
+            audio_path = project_dir / "characters" / "refs_audio" / "Alice.wav"
+            real_atomic_write = project_manager_module.atomic_write_json
+
+            def _fail_project_write(path, data):
+                if path == project_file:
+                    raise OSError("injected project write failure")
+                return real_atomic_write(path, data)
+
+            monkeypatch.setattr(project_manager_module, "atomic_write_json", _fail_project_write)
 
             resp = client.delete("/api/v1/projects/demo/characters/Alice/reference-audio")
             assert resp.status_code == 500
@@ -822,6 +861,16 @@ class TestFilesRouter:
                 naming="stable_png",
                 content_check="validate_image",
                 host_not_found_key="product_not_found",
+            )
+
+        # 参考音频的元数据字段是文件唯一指针；清理旧文件的类型不能漏掉宿主存在性约束。
+        with pytest.raises(ValueError):
+            files.UploadSpec(
+                allowed_exts=(".wav",),
+                subdir=("x",),
+                naming="keep_ext",
+                content_check="audio",
+                tracks_stale_audio=True,
             )
 
     @pytest.mark.integration

--- a/tests/test_generate_router_voice_sample.py
+++ b/tests/test_generate_router_voice_sample.py
@@ -1,13 +1,17 @@
 """角色 TTS 参考音频试听样本端点测试：音色列表 / 生成入队 / confirm 落资产。"""
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import lib.project_manager as project_manager_module
 from lib.audio_backends.base import VoiceOption
 from lib.config.resolver import ConfigResolver, ProviderModel
+from lib.project_manager import ProjectManager
 from lib.resource_paths import resource_relative_path
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -49,6 +53,16 @@ class _FakePM:
         self.project["characters"][char_name]["reference_audio"] = ref_path
         self.updated_audio_refs.append((char_name, ref_path))
         return self.project
+
+    def install_character_reference_audio(self, project_name, char_name, ref_path, content):
+        old_ref = self.project["characters"].get(char_name, {}).get("reference_audio")
+        project = self.update_character_reference_audio(project_name, char_name, ref_path)
+        target = self.project_path / ref_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        if old_ref and old_ref != ref_path:
+            (self.project_path / old_ref).unlink(missing_ok=True)
+        return project
 
 
 def _app(monkeypatch, fake_pm, fake_queue, *, audio_provider_ready=True):
@@ -283,6 +297,75 @@ class TestConfirmCharacterVoiceSample:
         assert body["path"] == "characters/refs_audio/艾莉.wav"
         assert fake_pm.updated_audio_refs == [("艾莉", "characters/refs_audio/艾莉.wav")]
         assert (project_path / "characters" / "refs_audio" / "艾莉.wav").read_bytes() == b"fake-wav"
+
+    def test_confirm_waits_for_video_selection_before_replacing_reference_audio(self, tmp_path, monkeypatch):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+        pm.add_character("demo", "艾莉", "desc")
+        project_path = pm.get_project_path("demo")
+        script_file = project_path / "scripts" / "episode_1.json"
+        script_file.write_text(
+            '{"episode": 1, "content_mode": "narration", "segments": []}',
+            encoding="utf-8",
+        )
+        target = project_path / "characters" / "refs_audio" / "艾莉.wav"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"old-reference-audio")
+        pm.update_character_reference_audio("demo", "艾莉", "characters/refs_audio/艾莉.wav")
+        sample_rel = self._write_sample(project_path, "艾莉", b"new-reference-audio")
+        fake_queue = _FakeQueue(
+            {
+                "task-1": {
+                    "project_name": "demo",
+                    "task_type": "voice_sample",
+                    "resource_id": "艾莉",
+                    "status": "succeeded",
+                    "result": {"file_path": sample_rel},
+                }
+            }
+        )
+        client = _client(monkeypatch, pm, fake_queue)
+
+        sample = project_path / sample_rel
+        sample_read = Event()
+        continue_confirm = Event()
+        target_install_started = Event()
+        original_read_bytes = Path.read_bytes
+        original_replace = project_manager_module.os.replace
+
+        def _paused_sample_read(path: Path) -> bytes:
+            content = original_read_bytes(path)
+            if path == sample:
+                sample_read.set()
+                assert continue_confirm.wait(timeout=2)
+            return content
+
+        def _observe_target_install(source, destination) -> None:
+            if Path(destination) == target:
+                target_install_started.set()
+            original_replace(source, destination)
+
+        monkeypatch.setattr(Path, "read_bytes", _paused_sample_read)
+        monkeypatch.setattr(project_manager_module.os, "replace", _observe_target_install)
+
+        with client, ThreadPoolExecutor(max_workers=1) as executor:
+            request = executor.submit(
+                client.post,
+                "/api/v1/projects/demo/characters/艾莉/voice-sample/confirm",
+                json={"task_id": "task-1"},
+            )
+            assert sample_read.wait(timeout=2)
+            with pm.locked_project_script_snapshot("demo", "episode_1.json"):
+                continue_confirm.set()
+                assert not target_install_started.wait(timeout=0.5)
+                assert original_read_bytes(target) == b"old-reference-audio"
+
+            response = request.result(timeout=2)
+
+        assert response.status_code == 200
+        assert target_install_started.is_set()
+        assert original_read_bytes(target) == b"new-reference-audio"
 
     def test_confirm_invalid_character_name_400_not_500(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path / "projects" / "demo")

--- a/tests/test_generate_router_voice_sample.py
+++ b/tests/test_generate_router_voice_sample.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 import lib.project_manager as project_manager_module
 from lib.audio_backends.base import VoiceOption
 from lib.config.resolver import ConfigResolver, ProviderModel
-from lib.project_manager import ProjectManager
 from lib.resource_paths import resource_relative_path
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -299,7 +298,7 @@ class TestConfirmCharacterVoiceSample:
         assert (project_path / "characters" / "refs_audio" / "艾莉.wav").read_bytes() == b"fake-wav"
 
     def test_confirm_waits_for_video_selection_before_replacing_reference_audio(self, tmp_path, monkeypatch):
-        pm = ProjectManager(tmp_path / "projects")
+        pm = project_manager_module.ProjectManager(tmp_path / "projects")
         pm.create_project("demo")
         pm.create_project_metadata("demo", "Demo", "Anime", "narration")
         pm.add_character("demo", "艾莉", "desc")

--- a/tests/test_generation_admission.py
+++ b/tests/test_generation_admission.py
@@ -1,10 +1,35 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
+import portalocker
 import pytest
 
 from lib import generation_admission
 
 pytestmark = pytest.mark.unit
+
+
+async def test_admission_guard_propagates_non_contention_lock_failures(tmp_path, monkeypatch):
+    failure = portalocker.LockException("lock backend failed")
+    sleep = AsyncMock(side_effect=AssertionError("non-contention failures must not be polled"))
+
+    def _fail_lock(*_args):
+        raise failure
+
+    monkeypatch.setattr(generation_admission, "app_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(generation_admission.portalocker, "lock", _fail_lock)
+    monkeypatch.setattr(generation_admission.asyncio, "sleep", sleep)
+
+    with pytest.raises(portalocker.LockException, match="lock backend failed"):
+        async with generation_admission.generation_admission_lock(
+            project_name="demo",
+            script_file="episode_01.json",
+            resource_id="E1S01",
+        ):
+            pass
+
+    sleep.assert_not_awaited()
 
 
 async def test_admission_guard_closes_its_file_when_unlock_fails(tmp_path, monkeypatch):

--- a/tests/test_generation_admission.py
+++ b/tests/test_generation_admission.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock
 
 import portalocker
@@ -8,6 +10,56 @@ import pytest
 from lib import generation_admission
 
 pytestmark = pytest.mark.unit
+
+
+async def test_admission_guard_serializes_one_resource_across_script_rebinds(tmp_path, monkeypatch):
+    monkeypatch.setattr(generation_admission, "app_data_dir", lambda: tmp_path)
+    acquired = asyncio.Event()
+
+    async def _acquire_rebound_binding() -> None:
+        async with generation_admission.generation_admission_lock(
+            project_name="demo",
+            script_file="rebound_episode_01.json",
+            resource_id="E1S01",
+        ):
+            acquired.set()
+
+    async with generation_admission.generation_admission_lock(
+        project_name="demo",
+        script_file="episode_01.json",
+        resource_id="E1S01",
+    ):
+        rebound = asyncio.create_task(_acquire_rebound_binding())
+        await asyncio.sleep(0.1)
+        assert not acquired.is_set()
+
+    await rebound
+    assert acquired.is_set()
+
+
+async def test_sync_compensation_guard_shares_the_async_resource_lock(tmp_path, monkeypatch):
+    monkeypatch.setattr(generation_admission, "app_data_dir", lambda: tmp_path)
+    acquired = threading.Event()
+
+    def _acquire_for_compensation() -> None:
+        with generation_admission.generation_admission_lock_sync(
+            project_name="demo",
+            script_file="rebound_episode_01.json",
+            resource_id="E1S01",
+        ):
+            acquired.set()
+
+    async with generation_admission.generation_admission_lock(
+        project_name="demo",
+        script_file="episode_01.json",
+        resource_id="E1S01",
+    ):
+        compensation = asyncio.create_task(asyncio.to_thread(_acquire_for_compensation))
+        await asyncio.sleep(0.1)
+        assert not acquired.is_set()
+
+    await compensation
+    assert acquired.is_set()
 
 
 async def test_admission_guard_propagates_non_contention_lock_failures(tmp_path, monkeypatch):

--- a/tests/test_generation_admission.py
+++ b/tests/test_generation_admission.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from lib import generation_admission
+
+pytestmark = pytest.mark.unit
+
+
+async def test_admission_guard_closes_its_file_when_unlock_fails(tmp_path, monkeypatch):
+    captured_handle = None
+
+    def _fail_unlock(handle):
+        nonlocal captured_handle
+        captured_handle = handle
+        raise OSError("unlock failed")
+
+    monkeypatch.setattr(generation_admission, "app_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(generation_admission.portalocker, "unlock", _fail_unlock)
+
+    with pytest.raises(OSError, match="unlock failed"):
+        async with generation_admission.generation_admission_lock(
+            project_name="demo",
+            script_file="episode_01.json",
+            resource_id="E1S01",
+        ):
+            pass
+
+    assert captured_handle is not None and captured_handle.closed

--- a/tests/test_generation_queue.py
+++ b/tests/test_generation_queue.py
@@ -27,7 +27,16 @@ async def queue():
 
 
 class TestGenerationQueue:
-    async def test_narration_task_admission_waits_for_the_shared_restore_guard(self, queue):
+    async def test_narration_task_admission_waits_for_the_shared_restore_guard(
+        self,
+        queue,
+        tmp_path,
+        monkeypatch,
+    ):
+        from lib.app_data_dir import _reset_for_tests
+
+        monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path / "app-data"))
+        _reset_for_tests()
         async with generation_admission_lock(
             project_name="admission-demo",
             script_file="scripts/episode_01.json",

--- a/tests/test_generation_queue.py
+++ b/tests/test_generation_queue.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db.base import Base
+from lib.generation_admission import generation_admission_lock
 from lib.generation_queue import CompensableGenerationResult, GenerationQueue, reference_projection_for_queued_task
 from lib.task_failure import encode_failure
 
@@ -26,6 +27,28 @@ async def queue():
 
 
 class TestGenerationQueue:
+    async def test_narration_task_admission_waits_for_the_shared_restore_guard(self, queue):
+        async with generation_admission_lock(
+            project_name="admission-demo",
+            script_file="scripts/episode_01.json",
+            resource_id="E1S01",
+        ):
+            enqueue = asyncio.create_task(
+                queue.enqueue_task(
+                    project_name="admission-demo",
+                    task_type="tts",
+                    media_type="audio",
+                    resource_id="E1S01",
+                    script_file="episode_01.json",
+                    provider_id="audio-provider",
+                )
+            )
+            await asyncio.sleep(0.1)
+            assert not enqueue.done()
+
+        result = await enqueue
+        assert result["deduped"] is False
+
     async def test_enqueue_dedupe_claim_and_succeed(self, queue):
         first = await queue.enqueue_task(
             project_name="demo",

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -734,6 +734,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         item = fake_pm.script["segments"][0]
+        item["novel_text"] = "旁白正文"
         current_prompt = {"action": "current action", "camera_motion": "Static", "dialogue": []}
         item["video_prompt"] = current_prompt
         item["duration_seconds"] = 8
@@ -751,6 +752,9 @@ class TestGenerationTasks:
                 metadata = await kwargs["before_submit"](41)
                 assert metadata is not None
                 submitted["metadata"] = metadata
+                from lib.version_manager import PaidVersionCommit
+
+                kwargs["commit_formal_output"].outcome = PaidVersionCommit(version=2, selected=True)
                 return project_path / "videos" / "scene_E1S01.mp4", 2, "ref", "uri"
 
         fake_generator = _CheckpointingGenerator()
@@ -940,8 +944,6 @@ class TestGenerationTasks:
             fake_prepare_current_narrated_video_duration,
         )
         monkeypatch.setattr(generation_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
-        output_guard = AsyncMock()
-        monkeypatch.setattr(generation_tasks, "require_generated_video_covers_current_tts", output_guard)
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
         payload = {
@@ -955,7 +957,6 @@ class TestGenerationTasks:
 
         await generation_tasks.execute_video_task("demo", "E1S01", payload)
         assert fake_generator.video_calls[0]["duration_seconds"] == 8
-        output_guard.assert_awaited_once()
         assert len(seen_lane_requests) == 1
         assert seen_lane_requests[0]["video"] is not None
         assert seen_lane_requests[0]["audio"] is not None
@@ -977,6 +978,13 @@ class TestGenerationTasks:
         monkeypatch,
         tmp_path,
     ):
+        from lib.artifact_manifest import (
+            ArtifactBasis,
+            ArtifactBasisDescriptor,
+            ArtifactKey,
+            ArtifactManifest,
+            ProjectArtifactManifestAdapter,
+        )
         from lib.version_manager import VersionManager
 
         project_path = _prepare_files(tmp_path)
@@ -1010,6 +1018,9 @@ class TestGenerationTasks:
             has_utterances=False,
             voice_characters=None,
         )
+        artifact_video_basis = ArtifactBasisDescriptor.from_basis(
+            ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"unit": "E1S01"})
+        )
         selected_version = fake_generator.versions.add_version(
             "videos",
             "E1S01",
@@ -1017,6 +1028,13 @@ class TestGenerationTasks:
             source_file=current,
             duration_seconds=8,
             visual_basis_digest=visual_basis.digest,
+            artifact_episode=1,
+            artifact_video_basis=artifact_video_basis.to_dict(),
+        )
+        ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
+            ArtifactKey.episode_video(1, "E1S01"),
+            artifact_path="videos/scene_E1S01.mp4",
+            basis=artifact_video_basis,
         )
         script_before = copy.deepcopy(fake_pm.script)
         history_before = copy.deepcopy(fake_generator.versions.get_versions("videos", "E1S01"))
@@ -1056,10 +1074,8 @@ class TestGenerationTasks:
             "server.services.narration_delivery_tasks.probe_existing_media_duration_seconds",
             AsyncMock(return_value=8.0),
         )
-        output_guard = AsyncMock()
         fake_queue = type("Queue", (), {})()
         fake_queue.persist_execution_checkpoint = AsyncMock()
-        monkeypatch.setattr(generation_tasks, "require_generated_video_covers_current_tts", output_guard)
         monkeypatch.setattr(generation_tasks, "get_generation_queue", lambda: fake_queue)
 
         result = await generation_tasks.execute_video_task(
@@ -1082,7 +1098,6 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
         fake_queue.persist_execution_checkpoint.assert_not_awaited()
         assert not (project_path / ".arcreel" / "tasks" / "task-reuse" / "provider_media").exists()
-        output_guard.assert_not_awaited()
         assert fake_pm.script == script_before
         assert fake_generator.versions.get_versions("videos", "E1S01") == history_before
         assert current.read_bytes() == b"existing-paid-video"

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -1,5 +1,6 @@
 import copy
 import re
+import threading
 from collections.abc import Mapping
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from lib.config.resolver import ProviderModel
+from lib.generation_queue import CompensableGenerationResult
 from lib.narration_delivery import (
     USE_TTS,
     NarratedVideoDurationBlockedError,
@@ -622,6 +624,36 @@ class TestGenerationTasks:
                 "payload": {"script_file": "episode_1.json"},
             }
         ]
+
+    @pytest.mark.unit
+    async def test_generation_event_failure_runs_media_compensation_off_the_event_loop(self, monkeypatch):
+        event_loop_thread = threading.get_ident()
+        compensation_threads: list[int] = []
+
+        async def _executor(*_args, **_kwargs):
+            return CompensableGenerationResult(
+                {"resource_type": "storyboards", "resource_id": "E1S01"},
+                cancel_compensation=lambda: compensation_threads.append(threading.get_ident()),
+            )
+
+        def _fail_event(**_kwargs):
+            raise RuntimeError("event emission failed")
+
+        monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "storyboard", _executor)
+        monkeypatch.setattr(generation_tasks, "emit_generation_success_batch", _fail_event)
+
+        with pytest.raises(RuntimeError, match="event emission failed"):
+            await generation_tasks.execute_generation_task(
+                {
+                    "task_type": "storyboard",
+                    "project_name": "demo",
+                    "resource_id": "E1S01",
+                    "payload": {},
+                }
+            )
+
+        assert len(compensation_threads) == 1
+        assert compensation_threads[0] != event_loop_thread
 
     @pytest.mark.unit
     async def test_execute_product_task_injects_reference_images(self, tmp_path, monkeypatch):

--- a/tests/test_generation_tasks_service.py
+++ b/tests/test_generation_tasks_service.py
@@ -407,6 +407,9 @@ class _FakeGenerator:
     def get_versions(self, resource_type, resource_id):
         return {"versions": [{"created_at": "2026-01-01T00:00:00Z"}]}
 
+    def get_current_version(self, resource_type, resource_id):
+        return 0
+
 
 def _prepare_files(tmp_path: Path):
     project_path = tmp_path / "projects" / "demo"
@@ -794,7 +797,8 @@ class TestGenerationTasks:
         assert [media.role for media in checkpoint.media] == ["start_image"]
         assert checkpoint.artifact_visual_basis is not None
         assert checkpoint.artifact_visual_basis.kind == "artifact-visual/video-storyboard"
-        assert submitted["metadata"]["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
+        assert checkpoint.artifact_currency is not None
+        assert submitted["metadata"]["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
         assert call["formal_output"] is True
         assert submitted["metadata"]["execution_request_digest"] == checkpoint.request_digest
         assert manifest.read_bytes() == b'{"unchanged":true}'
@@ -979,13 +983,16 @@ class TestGenerationTasks:
         tmp_path,
     ):
         from lib.artifact_manifest import (
-            ArtifactBasis,
-            ArtifactBasisDescriptor,
             ArtifactKey,
             ArtifactManifest,
             ProjectArtifactManifestAdapter,
+            compose_video_artifact_basis,
         )
+        from lib.speech_artifact_provenance import build_video_duration_basis, build_video_speech_basis
+        from lib.speech_composition import admit_script_unit
         from lib.version_manager import VersionManager
+        from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+        from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
 
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
@@ -1018,8 +1025,30 @@ class TestGenerationTasks:
             has_utterances=False,
             voice_characters=None,
         )
-        artifact_video_basis = ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"unit": "E1S01"})
+        artifact_visual_basis = build_storyboard_video_artifact_visual_basis(
+            resource_id="E1S01",
+            visual_prompt=visual_prompt,
+            storyboard_image=project_path / "storyboards" / "scene_E1S01.png",
+            end_frame_image=None,
+            aspect_ratio="9:16",
+        )
+        artifact_speech_basis = build_video_speech_basis(admit_script_unit("segments", item).preparation)
+        artifact_duration_basis = build_video_duration_basis(8)
+        artifact_currency = VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=artifact_visual_basis,
+            speech_basis=artifact_speech_basis,
+            duration_basis=artifact_duration_basis,
+            video_basis=compose_video_artifact_basis(
+                visual=artifact_visual_basis,
+                speech=artifact_speech_basis,
+                duration=artifact_duration_basis,
+            ),
+            voice_style_speakers=(),
+            duration_tiers=(4, 8, 12),
+            reference_image_limit=None,
+            parent_version=0,
         )
         selected_version = fake_generator.versions.add_version(
             "videos",
@@ -1028,13 +1057,17 @@ class TestGenerationTasks:
             source_file=current,
             duration_seconds=8,
             visual_basis_digest=visual_basis.digest,
-            artifact_episode=1,
-            artifact_video_basis=artifact_video_basis.to_dict(),
+            execution_checkpoint_schema_version=3,
+            execution_script_file="episode_1.json",
+            execution_duration_seconds=8,
+            execution_request_digest="d" * 64,
+            execution_provider_media=[],
+            artifact_video_currency=artifact_currency.to_dict(),
         )
         ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
             ArtifactKey.episode_video(1, "E1S01"),
             artifact_path="videos/scene_E1S01.mp4",
-            basis=artifact_video_basis,
+            basis=artifact_currency.video_descriptor,
         )
         script_before = copy.deepcopy(fake_pm.script)
         history_before = copy.deepcopy(fake_generator.versions.get_versions("videos", "E1S01"))
@@ -1046,7 +1079,7 @@ class TestGenerationTasks:
                 speech_mode=None,
                 tts_status=NarrationTtsStatus.CURRENT,
                 artifact_path="audio/segment_E1S01.wav",
-                basis_digest="current-basis",
+                basis_digest="sha256-v1:" + "c" * 64,
                 actual_duration_seconds=6.2,
                 problems=(),
             )

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
+from lib.artifact_manifest import ArtifactBasis, compose_video_artifact_basis
 from lib.db import Base
 from lib.generation_worker import (
     _ORPHAN_RESCAN_LEASE_LOST_MULT,
@@ -17,6 +17,7 @@ from lib.generation_worker import (
     _read_int_env,
 )
 from lib.script_editor import ScriptEditError
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 
 def _cap(limits: dict[str, dict[str, int]] | None = None, *, image: int = 5, video: int = 3) -> CapacityTable:
@@ -39,18 +40,22 @@ def _phase_ids(slots: SlotTable, provider: str, media: str) -> tuple[set[str], s
 def _worker_reference_checkpoint(task_id: str, *, provider_id: str = "ark") -> str:
     from lib.reference_video.execution_checkpoint import NarrationExecutionFacts, ReferenceSubmissionCheckpoint
 
-    visual = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-reference",
+        kind_version=1,
+        inputs={
+            "unit_id": "E1U1",
+            "visual_shots": [{"shot_index": 0, "lines": ["Run."]}],
+            "style": "cinematic",
+            "canvas": {"aspect_ratio": "9:16"},
+            "request_references": [],
+        },
     )
-    speech = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
-    )
-    duration = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build(
-            "artifact-speech/video-duration",
-            kind_version=1,
-            inputs={"request_duration_seconds": 8},
-        )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": 8},
     )
     return ReferenceSubmissionCheckpoint.create(
         task_id=task_id,
@@ -71,16 +76,18 @@ def _worker_reference_checkpoint(task_id: str, *, provider_id: str = "ark") -> s
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=visual,
-        artifact_speech_basis=speech,
-        artifact_duration_basis=duration,
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=visual,
+            speech_basis=speech,
+            duration_basis=duration,
+            video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+            voice_style_speakers=(),
+            duration_tiers=(8,),
+            reference_image_limit=1,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=(),
-        artifact_duration_tiers=(8,),
-        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -100,18 +107,21 @@ def _worker_storyboard_checkpoint(task_id: str, *, provider_id: str = "ark") -> 
         StoryboardSubmissionCheckpoint,
     )
 
-    visual = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": "E1S01",
+            "visual_prompt": {"action": "Run.", "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
     )
-    speech = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
-    )
-    duration = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build(
-            "artifact-speech/video-duration",
-            kind_version=1,
-            inputs={"request_duration_seconds": 8},
-        )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": 8},
     )
     return StoryboardSubmissionCheckpoint.create(
         task_id=task_id,
@@ -132,16 +142,18 @@ def _worker_storyboard_checkpoint(task_id: str, *, provider_id: str = "ark") -> 
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=visual,
-        artifact_speech_basis=speech,
-        artifact_duration_basis=duration,
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=visual,
+            speech_basis=speech,
+            duration_basis=duration,
+            video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+            voice_style_speakers=(),
+            duration_tiers=(8,),
+            reference_image_limit=None,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=(),
-        artifact_duration_tiers=(8,),
-        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",

--- a/tests/test_generation_worker_module.py
+++ b/tests/test_generation_worker_module.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
 from lib.db import Base
 from lib.generation_worker import (
     _ORPHAN_RESCAN_LEASE_LOST_MULT,
@@ -39,6 +39,19 @@ def _phase_ids(slots: SlotTable, provider: str, media: str) -> tuple[set[str], s
 def _worker_reference_checkpoint(task_id: str, *, provider_id: str = "ark") -> str:
     from lib.reference_video.execution_checkpoint import NarrationExecutionFacts, ReferenceSubmissionCheckpoint
 
+    visual = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+    )
+    speech = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    )
+    duration = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build(
+            "artifact-speech/video-duration",
+            kind_version=1,
+            inputs={"request_duration_seconds": 8},
+        )
+    )
     return ReferenceSubmissionCheckpoint.create(
         task_id=task_id,
         project_name="demo",
@@ -58,9 +71,16 @@ def _worker_reference_checkpoint(task_id: str, *, provider_id: str = "ark") -> s
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        artifact_episode=1,
+        artifact_visual_basis=visual,
+        artifact_speech_basis=speech,
+        artifact_duration_basis=duration,
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
         ),
+        artifact_voice_style_speakers=(),
+        artifact_duration_tiers=(8,),
+        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -80,6 +100,19 @@ def _worker_storyboard_checkpoint(task_id: str, *, provider_id: str = "ark") -> 
         StoryboardSubmissionCheckpoint,
     )
 
+    visual = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    )
+    speech = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    )
+    duration = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build(
+            "artifact-speech/video-duration",
+            kind_version=1,
+            inputs={"request_duration_seconds": 8},
+        )
+    )
     return StoryboardSubmissionCheckpoint.create(
         task_id=task_id,
         project_name="demo",
@@ -99,9 +132,16 @@ def _worker_storyboard_checkpoint(task_id: str, *, provider_id: str = "ark") -> 
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        artifact_episode=1,
+        artifact_visual_basis=visual,
+        artifact_speech_basis=speech,
+        artifact_duration_basis=duration,
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
         ),
+        artifact_voice_style_speakers=(),
+        artifact_duration_tiers=(8,),
+        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -9,6 +9,22 @@ from lib.image_backends.base import ImageCapability, ImageGenerationResult
 from lib.media_generator import MediaGenerator, cleanup_staged_video_output, segment_id_for, task_video_staging_path
 
 
+def _select_formal_video(gen: MediaGenerator, prompt: str = "paid request"):
+    def _commit(staged_file, current_file, duration_seconds, version_metadata):
+        return gen.versions.commit_staged_paid_version(
+            resource_type="reference_videos",
+            resource_id="E1U1",
+            prompt=prompt,
+            staged_file=staged_file,
+            current_file=current_file,
+            select_current=True,
+            duration_seconds=duration_seconds,
+            **version_metadata,
+        )
+
+    return _commit
+
+
 class _FakeImageBackend:
     """Fake ImageBackend conforming to the protocol."""
 
@@ -462,12 +478,26 @@ class TestMediaGenerator:
         gen = _build_generator(tmp_path)
         gen.versions = VersionManager(gen.project_path)
 
+        events = []
+
+        async def _prepare(staged_file, duration_seconds, version_metadata):
+            assert staged_file.read_bytes() == b"fake-video-data"
+            assert duration_seconds == 8
+            assert version_metadata["execution_request_digest"] == "d" * 64
+            events.append("prepared")
+
+        def _commit(*args):
+            events.append("committed")
+            return _select_formal_video(gen)(*args)
+
         output, version, _, _ = await gen.generate_video_async(
             prompt="paid request",
             resource_type="reference_videos",
             resource_id="E1U1",
             formal_output=True,
             task_id="task-output-success",
+            before_formal_commit=_prepare,
+            commit_formal_output=_commit,
             execution_request_digest="d" * 64,
         )
 
@@ -476,6 +506,39 @@ class TestMediaGenerator:
         history = gen.versions.get_versions("reference_videos", "E1U1")
         assert history["versions"][0]["execution_request_digest"] == "d" * 64
         assert Path(gen.project_path / history["versions"][0]["file"]).read_bytes() == b"fake-video-data"
+        assert events == ["prepared", "committed"]
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_formal_video_without_commit_callback_keeps_paid_history_but_never_selects_it(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from lib.version_manager import VersionManager
+
+        monkeypatch.setattr("lib.video_backends.base.persist_api_call_id", AsyncMock())
+        gen = _build_generator(tmp_path)
+        gen.versions = VersionManager(gen.project_path)
+        current = gen._get_output_path("reference_videos", "E1U1")
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"old-current")
+
+        with pytest.raises(RuntimeError, match="commit callback"):
+            await gen.generate_video_async(
+                prompt="paid request",
+                resource_type="reference_videos",
+                resource_id="E1U1",
+                formal_output=True,
+                task_id="task-missing-callback",
+            )
+
+        assert current.read_bytes() == b"old-current"
+        history = gen.versions.get_versions("reference_videos", "E1U1")
+        assert history["current_version"] == 1
+        assert len(history["versions"]) == 2
+        assert history["versions"][-1]["is_current"] is False
+        assert (gen.project_path / history["versions"][-1]["file"]).read_bytes() == b"fake-video-data"
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -503,6 +566,7 @@ class TestMediaGenerator:
             resource_id="E1U1",
             formal_output=True,
             task_id="task-restarted",
+            commit_formal_output=_select_formal_video(gen),
         )
 
         assert current.read_bytes() == b"fake-video-data"

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -7,6 +7,7 @@ import pytest
 
 from lib.image_backends.base import ImageCapability, ImageGenerationResult
 from lib.media_generator import MediaGenerator, cleanup_staged_video_output, segment_id_for, task_video_staging_path
+from lib.version_manager import PaidVersionCommit
 from tests.fakes import select_formal_video
 
 
@@ -562,6 +563,47 @@ class TestMediaGenerator:
         assert len(history["versions"]) == 2
         assert history["versions"][-1]["is_current"] is False
         assert (gen.project_path / history["versions"][-1]["file"]).read_bytes() == b"fake-video-data"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_video_commit_thread_keeps_event_loop_responsive_and_defers_cancellation(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import threading
+
+        gen = _build_generator(tmp_path)
+        started = threading.Event()
+        release = threading.Event()
+        expected = PaidVersionCommit(version=7, selected=True)
+
+        def _blocked_commit(**_kwargs):
+            started.set()
+            assert release.wait(timeout=5)
+            return expected
+
+        monkeypatch.setattr(gen, "_commit_video_output_version_sync", _blocked_commit)
+        commit_task = asyncio.create_task(
+            gen._commit_video_output_version(
+                resource_type="videos",
+                resource_id="E1S01",
+                prompt="paid request",
+                output_path=tmp_path / "current.mp4",
+                staged_output_path=tmp_path / "staged.mp4",
+                duration_seconds=8,
+                version_metadata={},
+            )
+        )
+
+        assert await asyncio.to_thread(started.wait, 5)
+        await asyncio.sleep(0)
+        commit_task.cancel()
+        await asyncio.sleep(0)
+        assert not commit_task.done()
+
+        release.set()
+        assert await commit_task == expected
 
     @pytest.mark.integration
     @pytest.mark.asyncio

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -527,6 +527,44 @@ class TestMediaGenerator:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", [RuntimeError("paid output validation failed"), asyncio.CancelledError()])
+    async def test_formal_video_prepare_failure_or_cancellation_archives_paid_history_without_selecting_it(
+        self,
+        tmp_path,
+        monkeypatch,
+        failure: BaseException,
+    ):
+        from lib.version_manager import VersionManager
+
+        monkeypatch.setattr("lib.video_backends.base.persist_api_call_id", AsyncMock())
+        gen = _build_generator(tmp_path)
+        gen.versions = VersionManager(gen.project_path)
+        current = gen._get_output_path("reference_videos", "E1U1")
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"old-current")
+
+        async def _fail_prepare(*_args):
+            raise failure
+
+        with pytest.raises(type(failure)):
+            await gen.generate_video_async(
+                prompt="paid request",
+                resource_type="reference_videos",
+                resource_id="E1U1",
+                formal_output=True,
+                task_id="task-prepare-failure",
+                before_formal_commit=_fail_prepare,
+            )
+
+        assert current.read_bytes() == b"old-current"
+        history = gen.versions.get_versions("reference_videos", "E1U1")
+        assert history["current_version"] == 1
+        assert len(history["versions"]) == 2
+        assert history["versions"][-1]["is_current"] is False
+        assert (gen.project_path / history["versions"][-1]["file"]).read_bytes() == b"fake-video-data"
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
     async def test_formal_video_output_reclaims_the_same_task_path_after_interruption(self, tmp_path, monkeypatch):
         from lib.version_manager import VersionManager
 

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -7,22 +7,7 @@ import pytest
 
 from lib.image_backends.base import ImageCapability, ImageGenerationResult
 from lib.media_generator import MediaGenerator, cleanup_staged_video_output, segment_id_for, task_video_staging_path
-
-
-def _select_formal_video(gen: MediaGenerator, prompt: str = "paid request"):
-    def _commit(staged_file, current_file, duration_seconds, version_metadata):
-        return gen.versions.commit_staged_paid_version(
-            resource_type="reference_videos",
-            resource_id="E1U1",
-            prompt=prompt,
-            staged_file=staged_file,
-            current_file=current_file,
-            select_current=True,
-            duration_seconds=duration_seconds,
-            **version_metadata,
-        )
-
-    return _commit
+from tests.fakes import select_formal_video
 
 
 class _FakeImageBackend:
@@ -488,7 +473,7 @@ class TestMediaGenerator:
 
         def _commit(*args):
             events.append("committed")
-            return _select_formal_video(gen)(*args)
+            return select_formal_video(gen, prompt="paid request")(*args)
 
         output, version, _, _ = await gen.generate_video_async(
             prompt="paid request",
@@ -566,7 +551,7 @@ class TestMediaGenerator:
             resource_id="E1U1",
             formal_output=True,
             task_id="task-restarted",
-            commit_formal_output=_select_formal_video(gen),
+            commit_formal_output=select_formal_video(gen, prompt="paid request"),
         )
 
         assert current.read_bytes() == b"fake-video-data"

--- a/tests/test_media_generator_module.py
+++ b/tests/test_media_generator_module.py
@@ -566,6 +566,44 @@ class TestMediaGenerator:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", [RuntimeError("validation failed"), asyncio.CancelledError()])
+    async def test_formal_video_prepare_failure_archives_paid_history_off_the_event_loop(
+        self,
+        tmp_path,
+        monkeypatch,
+        failure: BaseException,
+    ):
+        import threading
+
+        gen = _build_generator(tmp_path)
+        event_loop_thread = threading.get_ident()
+        archive_threads: list[int] = []
+
+        def _archive(**_kwargs):
+            archive_threads.append(threading.get_ident())
+
+        monkeypatch.setattr(gen.versions, "commit_staged_paid_version", _archive, raising=False)
+
+        async def _fail_prepare(*_args):
+            raise failure
+
+        with pytest.raises(type(failure)):
+            await gen._prepare_formal_video_commit(
+                resource_type="reference_videos",
+                resource_id="E1U1",
+                prompt="paid request",
+                output_path=tmp_path / "current.mp4",
+                staged_output_path=tmp_path / "staged.mp4",
+                duration_seconds=8,
+                version_metadata={},
+                before_formal_commit=_fail_prepare,
+            )
+
+        assert archive_threads
+        assert archive_threads[0] != event_loop_thread
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_video_commit_thread_keeps_event_loop_responsive_and_defers_cancellation(
         self,
         tmp_path,

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -352,6 +352,38 @@ async def test_resume_formal_output_uses_same_staged_version_transaction(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_resume_formal_prepare_failure_archives_paid_history_without_selecting_it(tmp_path):
+    from lib.version_manager import VersionManager
+
+    gen = _build_generator(tmp_path)
+    gen.versions = VersionManager(gen.project_path)
+    current = gen._get_output_path("reference_videos", "E1U1")
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+
+    async def _fail_prepare(*_args):
+        raise RuntimeError("resume paid output validation failed")
+
+    with pytest.raises(RuntimeError, match="resume paid output validation failed"):
+        await gen.resume_video_async(
+            job_id="provider-job-1",
+            resource_type="reference_videos",
+            resource_id="E1U1",
+            task_id="T-1",
+            api_call_id=42,
+            formal_output=True,
+            before_formal_commit=_fail_prepare,
+        )
+
+    assert current.read_bytes() == b"old-current"
+    history = gen.versions.get_versions("reference_videos", "E1U1")
+    assert history["current_version"] == 1
+    assert len(history["versions"]) == 2
+    assert history["versions"][-1]["is_current"] is False
+    assert (gen.project_path / history["versions"][-1]["file"]).read_bytes() == b"fake-resume-video"
+
+
+@pytest.mark.asyncio
 async def test_resume_handles_float_string_duration(tmp_path):
     """duration_seconds 传浮点字符串（如 "10.0"）时应解析为 int(10)，
     不能被 try/except 静默吞成兜底值 8（int("10.0") 会 ValueError）。

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -3,8 +3,8 @@
 关注点：
 - resume 路径不落新 pending 行（不开记账括号）
 - ledger.resume_success / resume_failed 按 api_call_id 精准翻 pending → success/failed
-- 版本管理用 add_version：resume 成功后总是 bump 新版本，让 versions.json 与磁盘文件一致
-  （submit→poll 崩 → 登记 v1；已有 v_n 的覆盖式重新生成 → 登记 v_(n+1)）
+- resume 成功后保存一个付费版本；正式媒体经 staging callback 原子决定 current，
+  非正式请求直接追加并选中新版本
 - ResumeExpiredError 沿调用链上抛，pending 翻 failed
 """
 
@@ -19,24 +19,9 @@ import pytest
 
 from lib.media_generator import MediaGenerator
 from lib.video_backends.base import ResumeExpiredError
+from tests.fakes import select_formal_video
 
 pytestmark = pytest.mark.unit
-
-
-def _select_formal_video(gen: MediaGenerator):
-    def _commit(staged_file, current_file, duration_seconds, version_metadata):
-        return gen.versions.commit_staged_paid_version(
-            resource_type="reference_videos",
-            resource_id="E1U1",
-            prompt="",
-            staged_file=staged_file,
-            current_file=current_file,
-            select_current=True,
-            duration_seconds=duration_seconds,
-            **version_metadata,
-        )
-
-    return _commit
 
 
 class _FakeVideoResult:
@@ -344,7 +329,7 @@ async def test_resume_formal_output_uses_same_staged_version_transaction(tmp_pat
 
     def _commit(*args):
         events.append("committed")
-        return _select_formal_video(gen)(*args)
+        return select_formal_video(gen)(*args)
 
     output, version, _, _ = await gen.resume_video_async(
         job_id="provider-job-1",

--- a/tests/test_media_generator_resume.py
+++ b/tests/test_media_generator_resume.py
@@ -23,6 +23,22 @@ from lib.video_backends.base import ResumeExpiredError
 pytestmark = pytest.mark.unit
 
 
+def _select_formal_video(gen: MediaGenerator):
+    def _commit(staged_file, current_file, duration_seconds, version_metadata):
+        return gen.versions.commit_staged_paid_version(
+            resource_type="reference_videos",
+            resource_id="E1U1",
+            prompt="",
+            staged_file=staged_file,
+            current_file=current_file,
+            select_current=True,
+            duration_seconds=duration_seconds,
+            **version_metadata,
+        )
+
+    return _commit
+
+
 class _FakeVideoResult:
     def __init__(self) -> None:
         self.video_uri = "video-uri-resume"
@@ -319,6 +335,17 @@ async def test_resume_formal_output_uses_same_staged_version_transaction(tmp_pat
     current.parent.mkdir(parents=True)
     current.write_bytes(b"old-current")
 
+    events = []
+
+    async def _prepare(staged_file, duration_seconds, version_metadata):
+        assert staged_file.read_bytes() == b"fake-resume-video"
+        assert duration_seconds == 8
+        events.append("prepared")
+
+    def _commit(*args):
+        events.append("committed")
+        return _select_formal_video(gen)(*args)
+
     output, version, _, _ = await gen.resume_video_async(
         job_id="provider-job-1",
         resource_type="reference_videos",
@@ -326,6 +353,8 @@ async def test_resume_formal_output_uses_same_staged_version_transaction(tmp_pat
         task_id="T-1",
         api_call_id=42,
         formal_output=True,
+        before_formal_commit=_prepare,
+        commit_formal_output=_commit,
         execution_request_digest="d" * 64,
     )
 
@@ -334,6 +363,7 @@ async def test_resume_formal_output_uses_same_staged_version_transaction(tmp_pat
     history = gen.versions.get_versions("reference_videos", "E1U1")
     assert [item["prompt"] for item in history["versions"]] == ["", ""]
     assert history["versions"][-1]["execution_request_digest"] == "d" * 64
+    assert events == ["prepared", "committed"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_narration_delivery.py
+++ b/tests/test_narration_delivery.py
@@ -23,6 +23,7 @@ from lib.narration_delivery import (
     NarrationTtsStatus,
     TtsSynthesisSettings,
     build_narration_audio_basis,
+    build_narration_audio_basis_from_canonical_text,
     canonical_narration_text,
     prepare_current_narration_delivery,
     prepare_narrated_video_duration,
@@ -95,6 +96,16 @@ def test_tts_basis_changes_for_each_paid_synthesis_input() -> None:
     assert base != build_narration_audio_basis(preparation, _settings(voice="Ethan"))
     assert base != build_narration_audio_basis(preparation, _settings(model_id="cosyvoice-v3.5-flash"))
     assert base != build_narration_audio_basis(preparation, _settings(speed=1.2))
+
+
+def test_tts_basis_raw_facts_builder_matches_preparation_builder() -> None:
+    preparation = _narrator_preparation("E1U1", "正文")
+    settings = _settings()
+
+    assert build_narration_audio_basis(preparation, settings) == build_narration_audio_basis_from_canonical_text(
+        "正文",
+        settings,
+    )
 
 
 def test_registration_failure_restores_the_previous_current_basis(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_narration_delivery_tasks.py
+++ b/tests/test_narration_delivery_tasks.py
@@ -77,7 +77,7 @@ def _typed_video_metadata(
 
 
 @pytest.mark.unit
-async def test_current_settings_use_canonical_provider_and_actual_backend_model(monkeypatch) -> None:
+async def test_current_settings_use_canonical_provider_and_actual_backend_model(monkeypatch, tmp_path: Path) -> None:
     from lib.config.resolver import ProviderModel
     from server.services.generation_context import AudioLaneResult, GenerationContext
 
@@ -95,14 +95,26 @@ async def test_current_settings_use_canonical_provider_and_actual_backend_model(
     resolve = AsyncMock(return_value=ctx)
     monkeypatch.setattr(narration_delivery_tasks, "resolve_generation_context", resolve)
 
-    settings = await narration_delivery_tasks.CurrentTtsSettingsResolver("demo").resolve_tts_synthesis_settings(
-        {"name": "demo"}
-    )
+    project = {"name": "demo"}
+    project_path = tmp_path / "demo"
+    settings = await narration_delivery_tasks.CurrentTtsSettingsResolver(
+        "demo",
+        user_id="owner",
+        project_path=project_path,
+    ).resolve_tts_synthesis_settings(project)
 
     assert settings.provider_id == "custom-7"
     assert settings.model_id == "fallback-model"
     assert settings.voice == "alloy"
     assert settings.speed == 1.2
+    resolve.assert_awaited_once_with(
+        "demo",
+        None,
+        project=project,
+        project_path=project_path,
+        user_id="owner",
+        audio=narration_delivery_tasks.AudioLaneRequest(),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_narration_delivery_tasks.py
+++ b/tests/test_narration_delivery_tasks.py
@@ -3,7 +3,38 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ProjectArtifactManifestAdapter,
+)
 from server.services import narration_delivery_tasks
+
+
+def _typed_video_metadata(
+    project_path: Path,
+    *,
+    resource_id: str,
+    artifact_path: str,
+    visual_basis_digest: str,
+    register: bool = True,
+) -> dict[str, object]:
+    descriptor = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"resource_id": resource_id})
+    )
+    if register:
+        ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
+            ArtifactKey.episode_video(1, resource_id),
+            artifact_path=artifact_path,
+            basis=descriptor,
+        )
+    return {
+        "artifact_episode": 1,
+        "artifact_video_basis": descriptor.to_dict(),
+        "visual_basis_digest": visual_basis_digest,
+    }
 
 
 @pytest.mark.unit
@@ -265,14 +296,20 @@ async def test_current_visual_is_reused_only_for_the_selected_trusted_duration_t
         "prompt",
         source_file=current,
         duration_seconds=8,
-        visual_basis_digest="current-visual-basis",
+        **_typed_video_metadata(
+            tmp_path,
+            resource_id="E1S01",
+            artifact_path="videos/scene_E1S01.mp4",
+            visual_basis_digest="current-visual-basis",
+        ),
     )
     item = {
         "generated_assets": {
-            "status": "completed",
-            "video_clip": "videos/scene_E1S01.mp4",
+            "status": "pending",
+            "video_clip": "legacy/wrong-path.mp4",
             "video_uri": "provider://video/1",
-        }
+        },
+        "stale": True,
     }
 
     monkeypatch.setattr(
@@ -352,7 +389,12 @@ async def test_current_visual_tier_is_retained_when_media_is_too_short_for_curre
         "prompt",
         source_file=current,
         duration_seconds=4,
-        visual_basis_digest="current-visual-basis",
+        **_typed_video_metadata(
+            tmp_path,
+            resource_id="E1S01",
+            artifact_path="videos/scene_E1S01.mp4",
+            visual_basis_digest="current-visual-basis",
+        ),
     )
     item = {
         "generated_assets": {
@@ -399,7 +441,7 @@ async def test_current_visual_tier_is_retained_when_media_is_too_short_for_curre
     "unsafe_state",
     [
         "missing_metadata",
-        "stale",
+        "missing_manifest",
         "wrong_tier",
         "unselected_bytes",
         "short_media",
@@ -421,15 +463,23 @@ async def test_current_visual_without_reusable_current_media_is_not_reused(
     metadata = (
         {}
         if unsafe_state == "missing_metadata"
-        else {"duration_seconds": 8, "visual_basis_digest": "recorded-visual-basis"}
+        else {
+            "duration_seconds": 8,
+            **_typed_video_metadata(
+                tmp_path,
+                resource_id="E1U1",
+                artifact_path="reference_videos/E1U1.mp4",
+                visual_basis_digest="recorded-visual-basis",
+                register=unsafe_state != "missing_manifest",
+            ),
+        }
     )
     versions.add_version("reference_videos", "E1U1", "prompt", source_file=current, **metadata)
     item = {
         "generated_assets": {
             "status": "completed",
             "video_clip": "reference_videos/E1U1.mp4",
-        },
-        "stale": unsafe_state == "stale",
+        }
     }
     request_duration = 12 if unsafe_state == "wrong_tier" else 8
     if unsafe_state == "unselected_bytes":

--- a/tests/test_narration_delivery_tasks.py
+++ b/tests/test_narration_delivery_tasks.py
@@ -5,11 +5,13 @@ import pytest
 
 from lib.artifact_manifest import (
     ArtifactBasis,
-    ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifest,
     ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
 )
+from lib.speech_artifact_provenance import build_video_duration_basis
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from server.services import narration_delivery_tasks
 
 
@@ -19,20 +21,57 @@ def _typed_video_metadata(
     resource_id: str,
     artifact_path: str,
     visual_basis_digest: str,
+    request_duration_seconds: int = 8,
     register: bool = True,
 ) -> dict[str, object]:
-    descriptor = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"resource_id": resource_id})
+    is_reference = artifact_path.startswith("reference_videos/")
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-reference" if is_reference else "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs=(
+            {
+                "unit_id": resource_id,
+                "visual_shots": [{"shot_index": 0, "lines": ["Run."]}],
+                "style": "cinematic",
+                "canvas": {"aspect_ratio": "9:16"},
+                "request_references": [],
+            }
+            if is_reference
+            else {
+                "resource_id": resource_id,
+                "visual_prompt": {"action": "Run.", "camera_motion": "Static"},
+                "canvas": {"aspect_ratio": "9:16"},
+                "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+            }
+        ),
+    )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = build_video_duration_basis(request_duration_seconds)
+    currency = VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=request_duration_seconds,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=(),
+        duration_tiers=(4, 8, 12),
+        reference_image_limit=0 if is_reference else None,
+        parent_version=0,
     )
     if register:
         ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
             ArtifactKey.episode_video(1, resource_id),
             artifact_path=artifact_path,
-            basis=descriptor,
+            basis=currency.video_descriptor,
         )
     return {
-        "artifact_episode": 1,
-        "artifact_video_basis": descriptor.to_dict(),
+        "execution_checkpoint_schema_version": 3,
+        "execution_script_file": "episode_1.json",
+        "execution_duration_seconds": request_duration_seconds,
+        "execution_request_digest": "d" * 64,
+        "execution_provider_media": [],
+        "artifact_video_currency": currency.to_dict(),
         "visual_basis_digest": visual_basis_digest,
     }
 
@@ -301,6 +340,7 @@ async def test_current_visual_is_reused_only_for_the_selected_trusted_duration_t
             resource_id="E1S01",
             artifact_path="videos/scene_E1S01.mp4",
             visual_basis_digest="current-visual-basis",
+            request_duration_seconds=4,
         ),
     )
     item = {

--- a/tests/test_project_manager_more.py
+++ b/tests/test_project_manager_more.py
@@ -1,6 +1,8 @@
 import json
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -595,6 +597,48 @@ class TestProjectManagerMore:
             pm.get_prop("demo", "none")
         with pytest.raises(KeyError):
             pm.update_prop_sheet("demo", "none", "x")
+
+    @pytest.mark.integration
+    def test_reference_audio_cleanup_cannot_delete_a_newer_concurrent_selection(self, tmp_path, monkeypatch):
+        pm = ProjectManager(tmp_path / "projects")
+        pm.create_project("demo")
+        pm.create_project_metadata("demo", "Demo")
+        pm.add_project_character("demo", "Alice", "hero", "soft")
+        wav_rel = "characters/refs_audio/Alice.wav"
+        mp3_rel = "characters/refs_audio/Alice.mp3"
+        pm.install_character_reference_audio("demo", "Alice", wav_rel, b"old-wav")
+
+        first_cleanup_ready = Event()
+        continue_first_cleanup = Event()
+        original_cleanup = pm._discard_stale_reference_audio_if_unreferenced
+
+        def _delay_first_cleanup(project_name: str, stale_audio: Path | None) -> None:
+            if stale_audio is not None and stale_audio.name == "Alice.wav" and not first_cleanup_ready.is_set():
+                first_cleanup_ready.set()
+                assert continue_first_cleanup.wait(timeout=2)
+            original_cleanup(project_name, stale_audio)
+
+        monkeypatch.setattr(pm, "_discard_stale_reference_audio_if_unreferenced", _delay_first_cleanup)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            first = executor.submit(
+                pm.install_character_reference_audio,
+                "demo",
+                "Alice",
+                mp3_rel,
+                b"intermediate-mp3",
+            )
+            try:
+                assert first_cleanup_ready.wait(timeout=2)
+                pm.install_character_reference_audio("demo", "Alice", wav_rel, b"new-wav")
+            finally:
+                continue_first_cleanup.set()
+            first.result(timeout=2)
+
+        project_dir = pm.get_project_path("demo")
+        assert pm.load_project("demo")["characters"]["Alice"]["reference_audio"] == wav_rel
+        assert (project_dir / wav_rel).read_bytes() == b"new-wav"
+        assert not (project_dir / mp3_rel).exists()
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/test_reference_video_execution_checkpoint.py
+++ b/tests/test_reference_video_execution_checkpoint.py
@@ -13,7 +13,6 @@ import pytest
 from lib.artifact_manifest import (
     MANIFEST_FILENAME,
     ArtifactBasis,
-    ArtifactBasisDescriptor,
     compose_video_artifact_basis,
 )
 from lib.path_safety import PathTraversalError
@@ -32,8 +31,37 @@ from lib.reference_video.execution_checkpoint import (
     load_task_reference_checkpoint,
     stage_provider_media,
 )
+from lib.speech_artifact_provenance import build_video_duration_basis
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 pytestmark = pytest.mark.integration
+
+
+def _reference_visual_basis(unit_id: str) -> ArtifactBasis:
+    return ArtifactBasis.build(
+        "artifact-visual/video-reference",
+        kind_version=1,
+        inputs={
+            "unit_id": unit_id,
+            "visual_shots": [{"shot_index": 0, "lines": ["Alice crosses the room."]}],
+            "style": "cinematic",
+            "canvas": {"aspect_ratio": "9:16"},
+            "request_references": [],
+        },
+    )
+
+
+def _storyboard_visual_basis(resource_id: str) -> ArtifactBasis:
+    return ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": resource_id,
+            "visual_prompt": {"action": "Alice crosses the room.", "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
+    )
 
 
 def _stage_inputs(project_path: Path) -> tuple[ProviderMediaInput, ...]:
@@ -64,8 +92,16 @@ def _stage_inputs(project_path: Path) -> tuple[ProviderMediaInput, ...]:
 
 def _checkpoint(project_path: Path) -> ReferenceSubmissionCheckpoint:
     staged = stage_provider_media(project_path, "task-1", _stage_inputs(project_path))
-    visual = ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
-    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"speaker": "Alice"})
+    visual = _reference_visual_basis("E1U1")
+    speech = ArtifactBasis.build(
+        "artifact-speech/video",
+        kind_version=1,
+        inputs={
+            "mode": "character_speech",
+            "utterances": [{"speaker": "Alice", "text": "Move."}],
+            "voices": [{"speaker": "Alice", "voice_style": "", "reference_audio_digest": None}],
+        },
+    )
     duration = ArtifactBasis.build(
         "artifact-speech/video-duration",
         kind_version=1,
@@ -90,16 +126,18 @@ def _checkpoint(project_path: Path) -> ReferenceSubmissionCheckpoint:
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(visual),
-        artifact_speech_basis=ArtifactBasisDescriptor.from_basis(speech),
-        artifact_duration_basis=ArtifactBasisDescriptor.from_basis(duration),
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=visual,
+            speech_basis=speech,
+            duration_basis=duration,
+            video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+            voice_style_speakers=("Alice",),
+            duration_tiers=(4, 8, 12),
+            reference_image_limit=3,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=("Alice",),
-        artifact_duration_tiers=(4, 8, 12),
-        artifact_reference_image_limit=3,
         narration=NarrationExecutionFacts(
             delivery="use_tts",
             tts_status="current",
@@ -279,12 +317,8 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     assert restored.artifact_voice_style_speakers == ("Alice",)
     assert restored.artifact_duration_tiers == (4, 8, 12)
     assert restored.artifact_reference_image_limit == 3
-    assert checkpoint_version_metadata(restored)["artifact_visual_basis"] == {
-        "kind": "artifact-visual/video-reference",
-        "kind_version": 1,
-        "digest": artifact_visual_basis.digest,
-    }
-    assert checkpoint_version_metadata(restored)["artifact_video_basis"] == restored.artifact_video_basis.to_dict()
+    assert restored.artifact_currency is not None
+    assert checkpoint_version_metadata(restored)["artifact_video_currency"] == restored.artifact_currency.to_dict()
     assert not (tmp_path / "demo" / MANIFEST_FILENAME).exists()
 
     raw = json.loads(checkpoint.to_json())
@@ -293,7 +327,7 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
         ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
 
     raw = json.loads(checkpoint.to_json())
-    raw["duration_seconds"] = 12
+    raw["service_tier"] = "priority"
     with pytest.raises(ValueError, match="request_digest"):
         ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
 
@@ -307,16 +341,10 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     with pytest.raises(ValueError, match="canonical"):
         ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
 
-    for invalid in (
-        {"kind": "", "kind_version": 1, "digest": "sha256-v1:" + "a" * 64},
-        {"kind": "visual", "kind_version": True, "digest": "sha256-v1:" + "a" * 64},
-        {"kind": "visual", "kind_version": 1, "digest": "a" * 64},
-        {**artifact_visual_basis.to_dict(), "extra": True},
-    ):
-        raw = json.loads(checkpoint.to_json())
-        raw["artifact_visual_basis"] = invalid
-        with pytest.raises(ValueError, match="artifact basis descriptor"):
-            ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
+    raw = json.loads(checkpoint.to_json())
+    raw["artifact_currency"]["visual_basis"]["inputs"]["unit_id"] = "tampered"
+    with pytest.raises(ValueError, match="self-verifying"):
+        ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
 
 
 def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -> None:
@@ -327,54 +355,65 @@ def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -
     assert replay.request_digest == checkpoint.request_digest
 
 
-def test_artifact_currency_facts_do_not_change_execution_request_digest(tmp_path: Path) -> None:
+def test_artifact_currency_facts_are_bound_to_execution_request_digest(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
-    changed_artifact_basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U2"})
-    )
-
-    with_changed_artifact_basis = replace(
-        checkpoint,
-        artifact_visual_basis=changed_artifact_basis,
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(
-                visual=changed_artifact_basis,
-                speech=checkpoint.artifact_speech_basis,
-                duration=checkpoint.artifact_duration_basis,
-            )
+    changed_artifact_basis = _reference_visual_basis("E1U2")
+    assert checkpoint.artifact_currency is not None
+    changed_currency = replace(
+        checkpoint.artifact_currency,
+        visual_basis=changed_artifact_basis,
+        video_basis=compose_video_artifact_basis(
+            visual=changed_artifact_basis,
+            speech=checkpoint.artifact_currency.speech_basis,
+            duration=checkpoint.artifact_currency.duration_basis,
         ),
-        artifact_voice_style_speakers=("Bob",),
-        artifact_duration_tiers=(8, 16),
-        artifact_reference_image_limit=1,
     )
 
-    assert with_changed_artifact_basis.request_digest == checkpoint.request_digest
+    with pytest.raises(ValueError, match="request_digest"):
+        replace(checkpoint, artifact_currency=changed_currency)
 
 
 def test_reference_checkpoint_rejects_storyboard_artifact_visual_basis(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
-    storyboard_basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    storyboard_basis = _storyboard_visual_basis("E1S01")
+    assert checkpoint.artifact_currency is not None
+    changed = replace(
+        checkpoint.artifact_currency,
+        visual_basis=storyboard_basis,
+        video_basis=compose_video_artifact_basis(
+            visual=storyboard_basis,
+            speech=checkpoint.artifact_currency.speech_basis,
+            duration=checkpoint.artifact_currency.duration_basis,
+        ),
+        reference_image_limit=None,
     )
 
-    with pytest.raises(ValueError, match="artifact_visual_basis kind"):
-        replace(checkpoint, artifact_visual_basis=storyboard_basis)
+    with pytest.raises(ValueError, match="visual kind"):
+        replace(checkpoint, artifact_currency=changed)
+
+
+def test_checkpoint_rejects_duration_basis_that_does_not_describe_the_request_tier(tmp_path: Path) -> None:
+    checkpoint = _checkpoint(tmp_path / "demo")
+    assert checkpoint.artifact_currency is not None
+    wrong_duration = build_video_duration_basis(4)
+    wrong_video = compose_video_artifact_basis(
+        visual=checkpoint.artifact_currency.visual_basis,
+        speech=checkpoint.artifact_currency.speech_basis,
+        duration=wrong_duration,
+    )
+
+    with pytest.raises(ValueError, match="paid request tier"):
+        replace(
+            checkpoint.artifact_currency,
+            duration_basis=wrong_duration,
+            video_basis=wrong_video,
+        )
 
 
 def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tmp_path: Path) -> None:
     raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
     raw["schema_version"] = 1
-    for field in (
-        "artifact_episode",
-        "artifact_visual_basis",
-        "artifact_speech_basis",
-        "artifact_duration_basis",
-        "artifact_video_basis",
-        "artifact_voice_style_speakers",
-        "artifact_duration_tiers",
-        "artifact_reference_image_limit",
-    ):
-        raw.pop(field)
+    raw.pop("artifact_currency")
     digest_payload = {key: value for key, value in raw.items() if key not in {"api_call_id", "request_digest"}}
     raw["request_digest"] = hashlib.sha256(
         json.dumps(
@@ -394,17 +433,14 @@ def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tm
 
 def test_visual_only_checkpoint_remains_resumable_but_cannot_claim_complete_video_basis(tmp_path: Path) -> None:
     raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
+    artifact_visual_basis = raw["artifact_currency"]["visual_basis"]
     raw["schema_version"] = 2
-    for field in (
-        "artifact_episode",
-        "artifact_speech_basis",
-        "artifact_duration_basis",
-        "artifact_video_basis",
-        "artifact_voice_style_speakers",
-        "artifact_duration_tiers",
-        "artifact_reference_image_limit",
-    ):
-        raw.pop(field)
+    raw.pop("artifact_currency")
+    raw["artifact_visual_basis"] = {
+        "kind": artifact_visual_basis["kind"],
+        "kind_version": artifact_visual_basis["kind_version"],
+        "digest": artifact_visual_basis["digest"],
+    }
     digest_payload = {
         key: value
         for key, value in raw.items()
@@ -444,6 +480,7 @@ def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_p
     checkpoint = _checkpoint(tmp_path / "demo")
     artifact_visual_basis = checkpoint.artifact_visual_basis
     assert artifact_visual_basis is not None
+    assert checkpoint.artifact_currency is not None
     with pytest.raises(ValueError, match="staged_locator"):
         replace(checkpoint.media[0], staged_locator="../outside.png")
 
@@ -471,14 +508,7 @@ def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_p
             service_tier=checkpoint.service_tier,
             seed=checkpoint.seed,
             visual_basis_digest=checkpoint.visual_basis_digest,
-            artifact_episode=checkpoint.artifact_episode,
-            artifact_visual_basis=artifact_visual_basis,
-            artifact_speech_basis=checkpoint.artifact_speech_basis,
-            artifact_duration_basis=checkpoint.artifact_duration_basis,
-            artifact_video_basis=checkpoint.artifact_video_basis,
-            artifact_voice_style_speakers=checkpoint.artifact_voice_style_speakers,
-            artifact_duration_tiers=checkpoint.artifact_duration_tiers,
-            artifact_reference_image_limit=checkpoint.artifact_reference_image_limit,
+            artifact_currency=checkpoint.artifact_currency,
             narration=checkpoint.narration,
             media=(wrong_task, *checkpoint.media[1:]),
             reference_audio_targets=checkpoint.reference_audio_targets,
@@ -547,6 +577,9 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
             ),
         ),
     )
+    storyboard_visual = _storyboard_visual_basis("E1S01")
+    storyboard_speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    storyboard_duration = build_video_duration_basis(8)
     checkpoint = StoryboardSubmissionCheckpoint.create(
         task_id="task-storyboard",
         project_name="demo",
@@ -566,36 +599,22 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
         service_tier="default",
         seed=123,
         visual_basis_digest="c" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=(
-            storyboard_visual := ArtifactBasisDescriptor.from_basis(
-                ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
-            )
-        ),
-        artifact_speech_basis=(
-            storyboard_speech := ArtifactBasisDescriptor.from_basis(
-                ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
-            )
-        ),
-        artifact_duration_basis=(
-            storyboard_duration := ArtifactBasisDescriptor.from_basis(
-                ArtifactBasis.build(
-                    "artifact-speech/video-duration",
-                    kind_version=1,
-                    inputs={"request_duration_seconds": 8},
-                )
-            )
-        ),
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=storyboard_visual,
+            speech_basis=storyboard_speech,
+            duration_basis=storyboard_duration,
+            video_basis=compose_video_artifact_basis(
                 visual=storyboard_visual,
                 speech=storyboard_speech,
                 duration=storyboard_duration,
-            )
+            ),
+            voice_style_speakers=(),
+            duration_tiers=(4, 8, 12),
+            reference_image_limit=None,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=(),
-        artifact_duration_tiers=(4, 8, 12),
-        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -606,11 +625,20 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
         media=staged,
         reference_audio_targets=None,
     )
-    reference_basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U01"})
+    reference_basis = _reference_visual_basis("E1U01")
+    assert checkpoint.artifact_currency is not None
+    reference_currency = replace(
+        checkpoint.artifact_currency,
+        visual_basis=reference_basis,
+        video_basis=compose_video_artifact_basis(
+            visual=reference_basis,
+            speech=checkpoint.artifact_currency.speech_basis,
+            duration=checkpoint.artifact_currency.duration_basis,
+        ),
+        reference_image_limit=1,
     )
-    with pytest.raises(ValueError, match="artifact_visual_basis kind"):
-        replace(checkpoint, artifact_visual_basis=reference_basis)
+    with pytest.raises(ValueError, match="visual kind"):
+        replace(checkpoint, artifact_currency=reference_currency)
 
     restored = StoryboardSubmissionCheckpoint.from_json(checkpoint.to_json())
     assert restored == checkpoint

--- a/tests/test_reference_video_execution_checkpoint.py
+++ b/tests/test_reference_video_execution_checkpoint.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 import pytest
 
-from lib.artifact_manifest import MANIFEST_FILENAME, ArtifactBasis, ArtifactBasisDescriptor
+from lib.artifact_manifest import (
+    MANIFEST_FILENAME,
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    compose_video_artifact_basis,
+)
 from lib.path_safety import PathTraversalError
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
@@ -59,6 +64,13 @@ def _stage_inputs(project_path: Path) -> tuple[ProviderMediaInput, ...]:
 
 def _checkpoint(project_path: Path) -> ReferenceSubmissionCheckpoint:
     staged = stage_provider_media(project_path, "task-1", _stage_inputs(project_path))
+    visual = ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"speaker": "Alice"})
+    duration = ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": 8},
+    )
     return ReferenceSubmissionCheckpoint.create(
         task_id="task-1",
         project_name="demo",
@@ -78,9 +90,16 @@ def _checkpoint(project_path: Path) -> ReferenceSubmissionCheckpoint:
         service_tier="default",
         seed=None,
         visual_basis_digest="a" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        artifact_episode=1,
+        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(visual),
+        artifact_speech_basis=ArtifactBasisDescriptor.from_basis(speech),
+        artifact_duration_basis=ArtifactBasisDescriptor.from_basis(duration),
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
         ),
+        artifact_voice_style_speakers=("Alice",),
+        artifact_duration_tiers=(4, 8, 12),
+        artifact_reference_image_limit=3,
         narration=NarrationExecutionFacts(
             delivery="use_tts",
             tts_status="current",
@@ -253,11 +272,19 @@ def test_checkpoint_round_trip_is_versioned_strict_and_self_authenticating(tmp_p
     assert restored.media[0].source_locator == "characters/Alice.png"
     assert restored.narration.actual_duration_seconds == 6.25
     assert restored.artifact_visual_basis == artifact_visual_basis
+    assert restored.artifact_speech_basis is not None
+    assert restored.artifact_duration_basis is not None
+    assert restored.artifact_video_basis is not None
+    assert restored.artifact_episode == 1
+    assert restored.artifact_voice_style_speakers == ("Alice",)
+    assert restored.artifact_duration_tiers == (4, 8, 12)
+    assert restored.artifact_reference_image_limit == 3
     assert checkpoint_version_metadata(restored)["artifact_visual_basis"] == {
         "kind": "artifact-visual/video-reference",
         "kind_version": 1,
         "digest": artifact_visual_basis.digest,
     }
+    assert checkpoint_version_metadata(restored)["artifact_video_basis"] == restored.artifact_video_basis.to_dict()
     assert not (tmp_path / "demo" / MANIFEST_FILENAME).exists()
 
     raw = json.loads(checkpoint.to_json())
@@ -300,13 +327,26 @@ def test_request_digest_is_stable_across_local_ledger_call_ids(tmp_path: Path) -
     assert replay.request_digest == checkpoint.request_digest
 
 
-def test_artifact_visual_basis_does_not_change_execution_request_digest(tmp_path: Path) -> None:
+def test_artifact_currency_facts_do_not_change_execution_request_digest(tmp_path: Path) -> None:
     checkpoint = _checkpoint(tmp_path / "demo")
     changed_artifact_basis = ArtifactBasisDescriptor.from_basis(
         ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U2"})
     )
 
-    with_changed_artifact_basis = replace(checkpoint, artifact_visual_basis=changed_artifact_basis)
+    with_changed_artifact_basis = replace(
+        checkpoint,
+        artifact_visual_basis=changed_artifact_basis,
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(
+                visual=changed_artifact_basis,
+                speech=checkpoint.artifact_speech_basis,
+                duration=checkpoint.artifact_duration_basis,
+            )
+        ),
+        artifact_voice_style_speakers=("Bob",),
+        artifact_duration_tiers=(8, 16),
+        artifact_reference_image_limit=1,
+    )
 
     assert with_changed_artifact_basis.request_digest == checkpoint.request_digest
 
@@ -324,7 +364,17 @@ def test_reference_checkpoint_rejects_storyboard_artifact_visual_basis(tmp_path:
 def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tmp_path: Path) -> None:
     raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
     raw["schema_version"] = 1
-    raw.pop("artifact_visual_basis")
+    for field in (
+        "artifact_episode",
+        "artifact_visual_basis",
+        "artifact_speech_basis",
+        "artifact_duration_basis",
+        "artifact_video_basis",
+        "artifact_voice_style_speakers",
+        "artifact_duration_tiers",
+        "artifact_reference_image_limit",
+    ):
+        raw.pop(field)
     digest_payload = {key: value for key, value in raw.items() if key not in {"api_call_id", "request_digest"}}
     raw["request_digest"] = hashlib.sha256(
         json.dumps(
@@ -340,6 +390,36 @@ def test_legacy_checkpoint_remains_resumable_without_inventing_artifact_basis(tm
     assert restored.schema_version == 1
     assert restored.artifact_visual_basis is None
     assert "artifact_visual_basis" not in checkpoint_version_metadata(restored)
+
+
+def test_visual_only_checkpoint_remains_resumable_but_cannot_claim_complete_video_basis(tmp_path: Path) -> None:
+    raw = json.loads(_checkpoint(tmp_path / "demo").to_json())
+    raw["schema_version"] = 2
+    for field in (
+        "artifact_episode",
+        "artifact_speech_basis",
+        "artifact_duration_basis",
+        "artifact_video_basis",
+        "artifact_voice_style_speakers",
+        "artifact_duration_tiers",
+        "artifact_reference_image_limit",
+    ):
+        raw.pop(field)
+    digest_payload = {
+        key: value
+        for key, value in raw.items()
+        if key not in {"api_call_id", "request_digest", "artifact_visual_basis"}
+    }
+    raw["request_digest"] = hashlib.sha256(
+        json.dumps(digest_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    restored = ReferenceSubmissionCheckpoint.from_json(json.dumps(raw))
+
+    assert restored.schema_version == 2
+    assert restored.artifact_visual_basis is not None
+    assert restored.artifact_video_basis is None
+    assert "artifact_video_basis" not in checkpoint_version_metadata(restored)
 
 
 def test_checkpoint_rejects_incoherent_narration_and_media_facts(tmp_path: Path) -> None:
@@ -391,7 +471,14 @@ def test_checkpoint_rejects_noncanonical_staged_locator_and_wrong_identity(tmp_p
             service_tier=checkpoint.service_tier,
             seed=checkpoint.seed,
             visual_basis_digest=checkpoint.visual_basis_digest,
+            artifact_episode=checkpoint.artifact_episode,
             artifact_visual_basis=artifact_visual_basis,
+            artifact_speech_basis=checkpoint.artifact_speech_basis,
+            artifact_duration_basis=checkpoint.artifact_duration_basis,
+            artifact_video_basis=checkpoint.artifact_video_basis,
+            artifact_voice_style_speakers=checkpoint.artifact_voice_style_speakers,
+            artifact_duration_tiers=checkpoint.artifact_duration_tiers,
+            artifact_reference_image_limit=checkpoint.artifact_reference_image_limit,
             narration=checkpoint.narration,
             media=(wrong_task, *checkpoint.media[1:]),
             reference_audio_targets=checkpoint.reference_audio_targets,
@@ -479,9 +566,36 @@ def test_storyboard_checkpoint_round_trip_and_four_resume_states(tmp_path: Path)
         service_tier="default",
         seed=123,
         visual_basis_digest="c" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        artifact_episode=1,
+        artifact_visual_basis=(
+            storyboard_visual := ArtifactBasisDescriptor.from_basis(
+                ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+            )
         ),
+        artifact_speech_basis=(
+            storyboard_speech := ArtifactBasisDescriptor.from_basis(
+                ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+            )
+        ),
+        artifact_duration_basis=(
+            storyboard_duration := ArtifactBasisDescriptor.from_basis(
+                ArtifactBasis.build(
+                    "artifact-speech/video-duration",
+                    kind_version=1,
+                    inputs={"request_duration_seconds": 8},
+                )
+            )
+        ),
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(
+                visual=storyboard_visual,
+                speech=storyboard_speech,
+                duration=storyboard_duration,
+            )
+        ),
+        artifact_voice_style_speakers=(),
+        artifact_duration_tiers=(4, 8, 12),
+        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -16,12 +16,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
     StagedProviderMedia,
     StoryboardSubmissionCheckpoint,
 )
+from lib.version_manager import PaidVersionCommit
 from lib.video_backends.base import ResumeExpiredError
 
 pytestmark = pytest.mark.unit
@@ -55,7 +56,20 @@ class _FakeGenerator:
         self.resume_calls.append(kwargs)
         if self.raises is not None:
             raise self.raises
-        output_path = kwargs["output_path"] if "output_path" in kwargs else Path(tempfile.gettempdir()) / "video.mp4"
+        output_path = kwargs.get("output_path") or Path(tempfile.gettempdir()) / "video.mp4"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"paid-resume-video")
+        prepare = kwargs.get("before_formal_commit")
+        if prepare is not None:
+            metadata = {
+                key: value
+                for key, value in kwargs.items()
+                if key.startswith("execution_") or key.startswith("artifact_")
+            }
+            await prepare(output_path, int(kwargs.get("duration_seconds") or 8), metadata)
+        commit = kwargs.get("commit_formal_output")
+        if commit is not None:
+            commit.outcome = PaidVersionCommit(version=3, selected=True)
         return output_path, 3, None, "video-uri-xyz"
 
     def get_versions(self, _resource_type: str, _resource_id: str) -> dict[str, Any]:
@@ -109,6 +123,19 @@ def _storyboard_checkpoint_json(
         sha256="a" * 64,
         size_bytes=1,
     )
+    visual = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    )
+    speech = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    )
+    duration = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build(
+            "artifact-speech/video-duration",
+            kind_version=1,
+            inputs={"request_duration_seconds": 8},
+        )
+    )
     return StoryboardSubmissionCheckpoint.create(
         task_id=task_id,
         project_name="demo",
@@ -128,9 +155,16 @@ def _storyboard_checkpoint_json(
         service_tier="default",
         seed=None,
         visual_basis_digest="b" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+        artifact_episode=1,
+        artifact_visual_basis=visual,
+        artifact_speech_basis=speech,
+        artifact_duration_basis=duration,
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
         ),
+        artifact_voice_style_speakers=(),
+        artifact_duration_tiers=(8,),
+        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -457,6 +491,19 @@ def _reference_checkpoint(
     staging = project_path / ".arcreel" / "tasks" / "T-ref" / "provider_media"
     staging.mkdir(parents=True, exist_ok=True)
     (staging / "crash-leftover").write_bytes(b"staged")
+    visual = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+    )
+    speech = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    )
+    duration = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build(
+            "artifact-speech/video-duration",
+            kind_version=1,
+            inputs={"request_duration_seconds": 12},
+        )
+    )
     return ReferenceSubmissionCheckpoint.create(
         task_id="T-ref",
         project_name="demo",
@@ -476,9 +523,16 @@ def _reference_checkpoint(
         service_tier="pro",
         seed=123,
         visual_basis_digest="sha256-v1:" + "a" * 64,
-        artifact_visual_basis=ArtifactBasisDescriptor.from_basis(
-            ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+        artifact_episode=1,
+        artifact_visual_basis=visual,
+        artifact_speech_basis=speech,
+        artifact_duration_basis=duration,
+        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
+            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
         ),
+        artifact_voice_style_speakers=(),
+        artifact_duration_tiers=(12,),
+        artifact_reference_image_limit=None,
         narration=(
             NarrationExecutionFacts(
                 delivery="use_tts",
@@ -523,7 +577,10 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
 
     monkeypatch.setattr(resume_executor, "resolve_generation_context", _resolve)
     output_guard = AsyncMock()
-    monkeypatch.setattr(resume_executor, "require_generated_video_covers_current_tts", output_guard)
+    monkeypatch.setattr(
+        "server.services.video_artifact_currency.validate_generated_video_covers_current_tts",
+        output_guard,
+    )
     finalize = AsyncMock(return_value={"resource_type": "reference_videos", "resource_id": "E1U1"})
     monkeypatch.setattr(resume_executor, "_finalize_reference_video_unit", finalize)
     monkeypatch.setattr(resume_executor, "emit_generation_success_batch", lambda **_kwargs: None)
@@ -581,10 +638,8 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
         script_file="scripts/frozen.json",
         request_duration_seconds=12,
         output_path=Path(tempfile.gettempdir()) / "video.mp4",
-        versions=fake_gen.versions,
         resource_type="reference_videos",
         resource_id="E1U1",
-        version=3,
     )
     finalize.assert_awaited_once()
     assert finalize.await_args.kwargs["script_file"] == "scripts/frozen.json"
@@ -611,7 +666,10 @@ async def test_reference_resume_post_production_does_not_reproject_tts(monkeypat
         ),
     )
     output_guard = AsyncMock()
-    monkeypatch.setattr(resume_executor, "require_generated_video_covers_current_tts", output_guard)
+    monkeypatch.setattr(
+        "server.services.video_artifact_currency.validate_generated_video_covers_current_tts",
+        output_guard,
+    )
     monkeypatch.setattr(
         resume_executor,
         "_finalize_reference_video_unit",

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -449,6 +449,50 @@ async def test_execute_resume_failure_does_not_emit(monkeypatch, fake_pm, video_
 
 
 @pytest.mark.asyncio
+async def test_execute_resume_releases_selection_guard_when_generator_fails_after_prepare(
+    monkeypatch,
+    fake_pm,
+    video_task,
+):
+    from server.services import resume_executor
+    from server.services.resume_executor import execute_resume_video_task
+
+    class _FailAfterPrepareGenerator(_FakeGenerator):
+        async def resume_video_async(self, **kwargs: Any) -> tuple[Path, int, Any, str | None]:
+            self.resume_calls.append(kwargs)
+            prepare = kwargs["before_formal_commit"]
+            await prepare(
+                Path(tempfile.gettempdir()) / "video.mp4",
+                int(kwargs["duration_seconds"]),
+                {"execution_script_file": kwargs["execution_script_file"]},
+            )
+            raise RuntimeError("commit failed after selection preparation")
+
+    class _GuardedCommitter:
+        instance: _GuardedCommitter | None = None
+
+        def __init__(self, **_kwargs: Any) -> None:
+            self.guard_active = False
+            type(self).instance = self
+
+        async def prepare_selection(self, *_args: Any, **_kwargs: Any) -> None:
+            self.guard_active = True
+
+        async def release_admission_guard(self) -> None:
+            self.guard_active = False
+
+    fake_gen = _FailAfterPrepareGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen)
+    monkeypatch.setattr(resume_executor, "VideoArtifactCommitter", _GuardedCommitter)
+
+    with pytest.raises(RuntimeError, match="commit failed after selection preparation"):
+        await execute_resume_video_task(video_task, job_id="openai-job-1")
+
+    assert _GuardedCommitter.instance is not None
+    assert not _GuardedCommitter.instance.guard_active
+
+
+@pytest.mark.asyncio
 async def test_execute_resume_accepts_float_string_duration(monkeypatch, fake_pm):
     """Resume ignores legacy payload duration and uses the strict checkpoint value."""
     from server.services.resume_executor import execute_resume_video_task

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from lib.artifact_manifest import ArtifactBasis, compose_video_artifact_basis
+from lib.narration_delivery import TtsSynthesisSettings
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
     StagedProviderMedia,
@@ -599,8 +600,12 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
     monkeypatch.setattr(resume_executor, "resolve_generation_context", _resolve)
     output_guard = AsyncMock()
     monkeypatch.setattr(
-        "server.services.video_artifact_currency.validate_generated_video_covers_current_tts",
+        "server.services.video_artifact_currency.validate_generated_video_covers_tts_duration",
         output_guard,
+    )
+    monkeypatch.setattr(
+        "server.services.video_artifact_currency.CurrentTtsSettingsResolver.resolve_tts_synthesis_settings",
+        AsyncMock(return_value=TtsSynthesisSettings("dashscope", "tts-model", "Cherry", None)),
     )
     finalize = AsyncMock(return_value={"resource_type": "reference_videos", "resource_id": "E1U1"})
     monkeypatch.setattr(resume_executor, "_finalize_reference_video_unit", finalize)
@@ -656,12 +661,10 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
     assert checkpoint.artifact_currency is not None
     assert call["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
     output_guard.assert_awaited_once_with(
-        project_name="demo",
-        script_file="scripts/frozen.json",
+        resource_id="E1U1",
         request_duration_seconds=12,
         output_path=Path(tempfile.gettempdir()) / "video.mp4",
-        resource_type="reference_videos",
-        resource_id="E1U1",
+        tts_actual_duration_seconds=10.5,
     )
     finalize.assert_awaited_once()
     assert finalize.await_args.kwargs["script_file"] == "scripts/frozen.json"
@@ -689,7 +692,7 @@ async def test_reference_resume_post_production_does_not_reproject_tts(monkeypat
     )
     output_guard = AsyncMock()
     monkeypatch.setattr(
-        "server.services.video_artifact_currency.validate_generated_video_covers_current_tts",
+        "server.services.video_artifact_currency.validate_generated_video_covers_tts_duration",
         output_guard,
     )
     monkeypatch.setattr(

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -16,13 +16,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
+from lib.artifact_manifest import ArtifactBasis, compose_video_artifact_basis
 from lib.reference_video.execution_checkpoint import (
     NarrationExecutionFacts,
     StagedProviderMedia,
     StoryboardSubmissionCheckpoint,
 )
 from lib.version_manager import PaidVersionCommit
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_backends.base import ResumeExpiredError
 
 pytestmark = pytest.mark.unit
@@ -123,18 +124,21 @@ def _storyboard_checkpoint_json(
         sha256="a" * 64,
         size_bytes=1,
     )
-    visual = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-storyboard", kind_version=1, inputs={"unit": "E1S01"})
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": "E1S01",
+            "visual_prompt": {"action": "Run.", "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
     )
-    speech = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
-    )
-    duration = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build(
-            "artifact-speech/video-duration",
-            kind_version=1,
-            inputs={"request_duration_seconds": 8},
-        )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": 8},
     )
     return StoryboardSubmissionCheckpoint.create(
         task_id=task_id,
@@ -155,16 +159,18 @@ def _storyboard_checkpoint_json(
         service_tier="default",
         seed=None,
         visual_basis_digest="b" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=visual,
-        artifact_speech_basis=speech,
-        artifact_duration_basis=duration,
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=visual,
+            speech_basis=speech,
+            duration_basis=duration,
+            video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+            voice_style_speakers=(),
+            duration_tiers=(8,),
+            reference_image_limit=None,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=(),
-        artifact_duration_tiers=(8,),
-        artifact_reference_image_limit=None,
         narration=NarrationExecutionFacts(
             delivery="post_production",
             tts_status="not_applicable",
@@ -191,7 +197,7 @@ def _fake_video_context(
     与生产路径（``video=VideoLaneRequest()``）一致。
     """
     from lib.config.resolver import ProviderModel
-    from server.services.generation_context import GenerationContext, VideoLaneResult
+    from server.services.generation_context import AudioLaneResult, GenerationContext, VideoLaneResult
 
     return GenerationContext(
         generator=fake_generator,  # type: ignore[arg-type]
@@ -205,6 +211,14 @@ def _fake_video_context(
             max_duration=8,
             max_reference_images=None,
             endpoint=endpoint,
+        ),
+        audio_lane=AudioLaneResult(
+            provider_model=ProviderModel("dashscope", "tts-model"),
+            backend_name="dashscope",
+            backend_model="tts-model",
+            narration_voice="Cherry",
+            narration_speed=None,
+            voices=(),
         ),
     )
 
@@ -301,7 +315,8 @@ async def test_execute_resume_video_calls_backend_resume_directly(monkeypatch, f
     assert call["execution_visual_basis_digest"] == "b" * 64
     checkpoint = StoryboardSubmissionCheckpoint.from_json(video_task["execution_checkpoint_json"])
     assert checkpoint.artifact_visual_basis is not None
-    assert call["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
+    assert checkpoint.artifact_currency is not None
+    assert call["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
     assert call["execution_provider_media"][0]["source_locator"] == "storyboards/scene_E1S01.png"
     # 返回结果带 file_path / resource_type，供 worker mark_succeeded
     assert result["resource_type"] == "videos"
@@ -491,18 +506,22 @@ def _reference_checkpoint(
     staging = project_path / ".arcreel" / "tasks" / "T-ref" / "provider_media"
     staging.mkdir(parents=True, exist_ok=True)
     (staging / "crash-leftover").write_bytes(b"staged")
-    visual = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-visual/video-reference", kind_version=1, inputs={"unit": "E1U1"})
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-reference",
+        kind_version=1,
+        inputs={
+            "unit_id": "E1U1",
+            "visual_shots": [{"shot_index": 0, "lines": ["Run."]}],
+            "style": "cinematic",
+            "canvas": {"aspect_ratio": "16:9"},
+            "request_references": [],
+        },
     )
-    speech = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
-    )
-    duration = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build(
-            "artifact-speech/video-duration",
-            kind_version=1,
-            inputs={"request_duration_seconds": 12},
-        )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = ArtifactBasis.build(
+        "artifact-speech/video-duration",
+        kind_version=1,
+        inputs={"request_duration_seconds": 12},
     )
     return ReferenceSubmissionCheckpoint.create(
         task_id="T-ref",
@@ -523,16 +542,18 @@ def _reference_checkpoint(
         service_tier="pro",
         seed=123,
         visual_basis_digest="sha256-v1:" + "a" * 64,
-        artifact_episode=1,
-        artifact_visual_basis=visual,
-        artifact_speech_basis=speech,
-        artifact_duration_basis=duration,
-        artifact_video_basis=ArtifactBasisDescriptor.from_basis(
-            compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+        artifact_currency=VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=12,
+            visual_basis=visual,
+            speech_basis=speech,
+            duration_basis=duration,
+            video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+            voice_style_speakers=(),
+            duration_tiers=(12,),
+            reference_image_limit=3,
+            parent_version=0,
         ),
-        artifact_voice_style_speakers=(),
-        artifact_duration_tiers=(12,),
-        artifact_reference_image_limit=None,
         narration=(
             NarrationExecutionFacts(
                 delivery="use_tts",
@@ -632,7 +653,8 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
     assert call["execution_provider_media"] == []
     assert call["visual_basis_digest"] == checkpoint.visual_basis_digest
     assert checkpoint.artifact_visual_basis is not None
-    assert call["artifact_visual_basis"] == checkpoint.artifact_visual_basis.to_dict()
+    assert checkpoint.artifact_currency is not None
+    assert call["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
     output_guard.assert_awaited_once_with(
         project_name="demo",
         script_file="scripts/frozen.json",

--- a/tests/test_speech_artifact_provenance.py
+++ b/tests/test_speech_artifact_provenance.py
@@ -1,0 +1,346 @@
+"""Sound-owned Artifact Manifest provenance contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ArtifactStatus,
+    InMemoryArtifactManifestAdapter,
+    compose_video_artifact_basis,
+)
+from lib.narration_delivery import POST_PRODUCTION, USE_TTS, TtsSynthesisSettings, build_narration_audio_basis
+from lib.speech_artifact_provenance import (
+    CharacterVoiceEvidence,
+    SelectedMediaEvidence,
+    build_mechanical_subtitle_basis,
+    build_presentation_basis,
+    build_video_duration_basis,
+    build_video_speech_basis,
+)
+from lib.speech_composition import SpeechFieldLocation, SpeechMode, SpeechOwner, SpeechPreparation, SpeechUtterance
+
+pytestmark = pytest.mark.unit
+
+
+def _preparation(
+    mode: SpeechMode,
+    *utterances: tuple[str | None, str],
+    unit_id: str = "E1U01",
+) -> SpeechPreparation:
+    owner = SpeechOwner.CHARACTER if mode is SpeechMode.CHARACTER_SPEECH else SpeechOwner.NARRATOR
+    return SpeechPreparation(
+        unit_id=unit_id,
+        mode=mode,
+        utterances=tuple(
+            SpeechUtterance(
+                owner=owner,
+                speaker=speaker,
+                text=text,
+                location=SpeechFieldLocation(("utterances", index, "text")),
+            )
+            for index, (speaker, text) in enumerate(utterances)
+        ),
+    )
+
+
+def _character_speech(*utterances: tuple[str | None, str]) -> SpeechPreparation:
+    return _preparation(SpeechMode.CHARACTER_SPEECH, *(utterances or (("阿离", "快走。"),)))
+
+
+def _narration(*texts: str) -> SpeechPreparation:
+    return _preparation(SpeechMode.NARRATOR_VOICEOVER, *((None, text) for text in (texts or ("旁白正文",))))
+
+
+def _basis(kind: str, value: object) -> ArtifactBasis:
+    return ArtifactBasis.build(kind, kind_version=1, inputs={"value": value})
+
+
+def _media(kind: str, value: object, *, content: str, duration: float) -> SelectedMediaEvidence:
+    return SelectedMediaEvidence(
+        basis=ArtifactBasisDescriptor.from_basis(_basis(kind, value)),
+        content_digest=f"sha256-v1:{content * 64}",
+        actual_duration_seconds=duration,
+    )
+
+
+def test_character_video_speech_basis_tracks_ordered_text_speaker_and_used_voice_style() -> None:
+    preparation = _character_speech(("A\u0301nh", " 第一行\r\n第二行 "), ("阿离", "快走。"))
+    profiles = (
+        CharacterVoiceEvidence(speaker="Ánh", voice_style=" 低沉 "),
+        CharacterVoiceEvidence(speaker="阿离", voice_style="清亮"),
+    )
+    baseline = build_video_speech_basis(preparation, voices=profiles)
+
+    assert baseline == build_video_speech_basis(
+        _character_speech(("Ánh", "第一行\n第二行"), ("阿离", "快走。")),
+        voices=profiles,
+    )
+    assert baseline != build_video_speech_basis(
+        _character_speech(("Ánh", "第一行\n第二行"), ("阿离", "别走。")),
+        voices=profiles,
+    )
+    assert baseline != build_video_speech_basis(
+        _character_speech(("Ánh", "第一行\n第二行"), ("阿宁", "快走。")),
+        voices=profiles,
+    )
+    assert baseline != build_video_speech_basis(
+        preparation,
+        voices=(profiles[0], CharacterVoiceEvidence(speaker="阿离", voice_style="沙哑")),
+    )
+
+
+def test_character_video_speech_basis_ignores_unreferenced_character_voice() -> None:
+    preparation = _character_speech(("阿离", "快走。"))
+    baseline = build_video_speech_basis(
+        preparation,
+        voices=(
+            CharacterVoiceEvidence(speaker="阿离", voice_style="清亮"),
+            CharacterVoiceEvidence(speaker="路人", voice_style="低沉"),
+        ),
+    )
+
+    changed_unrelated = build_video_speech_basis(
+        preparation,
+        voices=(
+            CharacterVoiceEvidence(speaker="阿离", voice_style="清亮"),
+            CharacterVoiceEvidence(speaker="路人", voice_style="尖细"),
+        ),
+    )
+
+    assert changed_unrelated == baseline
+
+
+def test_narrator_text_does_not_enter_video_speech_or_same_tier_duration_basis() -> None:
+    visual = _basis("test/visual", "v1")
+    before = compose_video_artifact_basis(
+        visual=visual,
+        speech=build_video_speech_basis(_narration("原旁白")),
+        duration=build_video_duration_basis(8),
+    )
+    after_same_tier = compose_video_artifact_basis(
+        visual=visual,
+        speech=build_video_speech_basis(_narration("修改后的旁白")),
+        duration=build_video_duration_basis(8),
+    )
+    after_cross_tier = compose_video_artifact_basis(
+        visual=visual,
+        speech=build_video_speech_basis(_narration("修改后的旁白")),
+        duration=build_video_duration_basis(12),
+    )
+
+    assert after_same_tier == before
+    assert after_cross_tier != before
+
+
+def test_video_component_composition_accepts_frozen_descriptors() -> None:
+    visual = _basis("test/visual", "v1")
+    speech = build_video_speech_basis(_character_speech())
+    duration = build_video_duration_basis(8)
+
+    direct = compose_video_artifact_basis(visual=visual, speech=speech, duration=duration)
+    frozen = compose_video_artifact_basis(
+        visual=ArtifactBasisDescriptor.from_basis(visual),
+        speech=ArtifactBasisDescriptor.from_basis(speech),
+        duration=ArtifactBasisDescriptor.from_basis(duration),
+    )
+
+    assert frozen == direct
+
+
+def test_mechanical_subtitle_uses_selected_media_boundary_and_tts_basis() -> None:
+    video = _media("test/video", "v1", content="a", duration=8.0)
+    tts = _media("test/tts", "voice-1", content="b", duration=6.0)
+    narration = _narration("第一句", "第二句")
+
+    use_tts = build_mechanical_subtitle_basis(
+        narration,
+        variant=USE_TTS,
+        video=video,
+        narration_audio=tts,
+    )
+    post = build_mechanical_subtitle_basis(
+        narration,
+        variant=POST_PRODUCTION,
+        video=video,
+    )
+
+    assert use_tts != build_mechanical_subtitle_basis(
+        _narration("第一句改", "第二句"),
+        variant=USE_TTS,
+        video=video,
+        narration_audio=tts,
+    )
+    assert use_tts != build_mechanical_subtitle_basis(
+        narration,
+        variant=USE_TTS,
+        video=video,
+        narration_audio=_media("test/tts", "voice-2", content="c", duration=6.0),
+    )
+    assert post != use_tts
+
+
+def test_presentation_variants_are_independent_manifest_entries() -> None:
+    video = _media("test/video", "v1", content="a", duration=8.0)
+    tts = _media("test/tts", "voice-1", content="b", duration=6.0)
+    narration = _narration("旁白")
+    post_subtitle = build_mechanical_subtitle_basis(
+        narration,
+        variant=POST_PRODUCTION,
+        video=video,
+    )
+    tts_subtitle = build_mechanical_subtitle_basis(
+        narration,
+        variant=USE_TTS,
+        video=video,
+        narration_audio=tts,
+    )
+    post = build_presentation_basis(
+        variant=POST_PRODUCTION,
+        video=video,
+        subtitle=post_subtitle,
+    )
+    use_tts = build_presentation_basis(
+        variant=USE_TTS,
+        video=video,
+        subtitle=tts_subtitle,
+        narration_audio=tts,
+    )
+    adapter = InMemoryArtifactManifestAdapter(
+        artifacts={"presentations/E1U01-post.json", "presentations/E1U01-tts.json"}
+    )
+    manifest = ArtifactManifest(adapter)
+    post_key = ArtifactKey.episode_presentation(1, "E1U01", POST_PRODUCTION)
+    tts_key = ArtifactKey.episode_presentation(1, "E1U01", USE_TTS)
+    manifest.register(post_key, artifact_path="presentations/E1U01-post.json", basis=post)
+    manifest.register(tts_key, artifact_path="presentations/E1U01-tts.json", basis=use_tts)
+
+    changed_tts = _media("test/tts", "voice-2", content="c", duration=6.0)
+    changed_tts_subtitle = build_mechanical_subtitle_basis(
+        narration,
+        variant=USE_TTS,
+        video=video,
+        narration_audio=changed_tts,
+    )
+    changed_tts_presentation = build_presentation_basis(
+        variant=USE_TTS,
+        video=video,
+        subtitle=changed_tts_subtitle,
+        narration_audio=changed_tts,
+    )
+
+    assert (
+        manifest.compare(post_key, artifact_path="presentations/E1U01-post.json", basis=post).status
+        is ArtifactStatus.CURRENT
+    )
+    assert (
+        manifest.compare(
+            tts_key,
+            artifact_path="presentations/E1U01-tts.json",
+            basis=changed_tts_presentation,
+        ).status
+        is ArtifactStatus.STALE
+    )
+
+
+def test_stale_comparison_is_reversible_and_preserves_paid_media() -> None:
+    path = "videos/unit_E1U01.mp4"
+    adapter = InMemoryArtifactManifestAdapter(artifacts={path})
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_video(1, "E1U01")
+    visual = _basis("test/visual", "v1")
+    original = compose_video_artifact_basis(
+        visual=visual,
+        speech=build_video_speech_basis(_character_speech(("阿离", "快走。"))),
+        duration=build_video_duration_basis(8),
+    )
+    changed = compose_video_artifact_basis(
+        visual=visual,
+        speech=build_video_speech_basis(_character_speech(("阿离", "别走。"))),
+        duration=build_video_duration_basis(8),
+    )
+    manifest.register(key, artifact_path=path, basis=original)
+
+    assert manifest.compare(key, artifact_path=path, basis=changed).status is ArtifactStatus.STALE
+    assert manifest.compare(key, artifact_path=path, basis=original).status is ArtifactStatus.CURRENT
+    assert adapter.inspect_artifact(path).present
+
+
+def test_tts_change_stales_tts_subtitle_and_tts_presentation_but_not_video_or_post_variant() -> None:
+    narration = _narration("旁白")
+    settings = TtsSynthesisSettings("provider", "model", "voice", 1.0)
+    changed_settings = TtsSynthesisSettings("provider", "model", "other-voice", 1.0)
+    tts_basis = build_narration_audio_basis(narration, settings)
+    changed_tts_basis = build_narration_audio_basis(narration, changed_settings)
+    video_basis = compose_video_artifact_basis(
+        visual=_basis("test/visual", "v1"),
+        speech=build_video_speech_basis(narration),
+        duration=build_video_duration_basis(8),
+    )
+    video = SelectedMediaEvidence(
+        ArtifactBasisDescriptor.from_basis(video_basis),
+        f"sha256-v1:{'a' * 64}",
+        8.0,
+    )
+    tts = SelectedMediaEvidence(
+        ArtifactBasisDescriptor.from_basis(tts_basis),
+        f"sha256-v1:{'b' * 64}",
+        6.0,
+    )
+    changed_tts = SelectedMediaEvidence(
+        ArtifactBasisDescriptor.from_basis(changed_tts_basis),
+        f"sha256-v1:{'b' * 64}",
+        6.0,
+    )
+    post_subtitle = build_mechanical_subtitle_basis(narration, variant=POST_PRODUCTION, video=video)
+    tts_subtitle = build_mechanical_subtitle_basis(narration, variant=USE_TTS, video=video, narration_audio=tts)
+
+    assert video_basis == compose_video_artifact_basis(
+        visual=_basis("test/visual", "v1"),
+        speech=build_video_speech_basis(narration),
+        duration=build_video_duration_basis(8),
+    )
+    assert post_subtitle == build_mechanical_subtitle_basis(
+        narration,
+        variant=POST_PRODUCTION,
+        video=video,
+    )
+    assert tts_subtitle != build_mechanical_subtitle_basis(
+        narration,
+        variant=USE_TTS,
+        video=video,
+        narration_audio=changed_tts,
+    )
+    assert build_presentation_basis(
+        variant=POST_PRODUCTION,
+        video=video,
+        subtitle=post_subtitle,
+    ) == build_presentation_basis(
+        variant=POST_PRODUCTION,
+        video=video,
+        subtitle=post_subtitle,
+    )
+
+
+@pytest.mark.parametrize("invalid", [0, -1, True, 8.5, "8"])
+def test_video_duration_basis_requires_a_request_tier(invalid: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        build_video_duration_basis(invalid)  # type: ignore[arg-type]
+
+
+def test_use_tts_subtitle_and_presentation_require_narration_audio() -> None:
+    narration = _narration("旁白")
+    video = _media("test/video", "v1", content="a", duration=8.0)
+
+    with pytest.raises(ValueError, match="narration audio"):
+        build_mechanical_subtitle_basis(narration, variant=USE_TTS, video=video)
+    with pytest.raises(ValueError, match="narration audio"):
+        build_presentation_basis(
+            variant=USE_TTS,
+            video=video,
+            subtitle=_basis("test/subtitle", "v1"),
+        )

--- a/tests/test_speech_artifact_provenance_integration.py
+++ b/tests/test_speech_artifact_provenance_integration.py
@@ -1,0 +1,48 @@
+"""Filesystem-backed sound provenance contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.speech_artifact_provenance import CharacterVoiceEvidence, build_video_speech_basis
+from lib.speech_composition import SpeechFieldLocation, SpeechMode, SpeechOwner, SpeechPreparation, SpeechUtterance
+
+pytestmark = pytest.mark.integration
+
+
+def test_character_video_speech_basis_uses_reference_audio_content_not_path(tmp_path: Path) -> None:
+    first = tmp_path / "first.wav"
+    second = tmp_path / "renamed.wav"
+    first.write_bytes(b"same voice")
+    second.write_bytes(b"same voice")
+    preparation = SpeechPreparation(
+        unit_id="E1U01",
+        mode=SpeechMode.CHARACTER_SPEECH,
+        utterances=(
+            SpeechUtterance(
+                owner=SpeechOwner.CHARACTER,
+                speaker="阿离",
+                text="快走。",
+                location=SpeechFieldLocation(("utterances", 0, "text")),
+            ),
+        ),
+    )
+
+    baseline = build_video_speech_basis(
+        preparation,
+        voices=(CharacterVoiceEvidence(speaker="阿离", voice_style="清亮", reference_audio=first),),
+    )
+    renamed = build_video_speech_basis(
+        preparation,
+        voices=(CharacterVoiceEvidence(speaker="阿离", voice_style="清亮", reference_audio=second),),
+    )
+    second.write_bytes(b"different voice")
+    changed = build_video_speech_basis(
+        preparation,
+        voices=(CharacterVoiceEvidence(speaker="阿离", voice_style="清亮", reference_audio=second),),
+    )
+
+    assert renamed == baseline
+    assert changed != baseline

--- a/tests/test_tts_skeleton.py
+++ b/tests/test_tts_skeleton.py
@@ -311,6 +311,33 @@ class TestGenerateAudioAsync:
         assert [record["prompt"] for record in history["versions"]] == ["old text"]
         assert not any(path.name.startswith(".segment_E1S07") for path in formal.parent.iterdir())
 
+    async def test_paid_history_only_commit_does_not_require_a_formal_audio_file(self, tmp_path: Path):
+        gen = _build_generator(tmp_path)
+        gen.versions = VersionManager(gen.project_path)
+
+        def _commit(staged_path: Path, output_path: Path):
+            return gen.versions.commit_staged_paid_version(
+                resource_type="audio",
+                resource_id="E1S08",
+                prompt="late text",
+                staged_file=staged_path,
+                current_file=output_path,
+                select_current=False,
+            )
+
+        output_path, version = await gen.generate_audio_async(
+            text="late text",
+            resource_id="E1S08",
+            voice="Cherry",
+            commit_staged=_commit,
+        )
+
+        assert version == 1
+        assert not output_path.exists()
+        history = gen.versions.get_versions("audio", "E1S08")
+        assert history["current_version"] == 0
+        assert (gen.project_path / history["versions"][0]["file"]).read_bytes() == b"RIFFfakewav"
+
 
 # ── 用量聚合 audio_count ────────────────────────────────────────────────────────
 

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -227,6 +227,32 @@ class TestVersionManagerMore:
         assert history["versions"][-1]["is_current"] is False
         assert (project / history["versions"][-1]["file"]).read_bytes() == b"late-paid-video"
 
+    def test_paid_version_expected_zero_ignores_internal_legacy_current_bootstrap(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"legacy-current")
+        staged = current.with_name(".scene_E1S01.new.mp4")
+        staged.write_bytes(b"new-paid-video")
+
+        outcome = vm.commit_staged_paid_version(
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="new",
+            staged_file=staged,
+            current_file=current,
+            select_current=True,
+            expected_current_version=0,
+        )
+
+        assert outcome.selected is True
+        assert current.read_bytes() == b"new-paid-video"
+        history = vm.get_versions("videos", "E1S01")
+        assert history["current_version"] == outcome.version
+        assert [record["prompt"] for record in history["versions"]] == ["", "new"]
+        assert (project / history["versions"][0]["file"]).read_bytes() == b"legacy-current"
+
     def test_paid_version_selection_failure_keeps_history_and_old_current(self, tmp_path):
         project = tmp_path / "demo"
         vm = VersionManager(project)

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -92,6 +93,91 @@ class TestVersionManagerMore:
         assert current.read_bytes() == b"audio-v2"
         assert vm.get_current_version("audio", "E1S01") == v2
         assert observed[0]["artifact_audio_basis"]["kind"] == "narration-delivery/tts-audio"
+
+    @pytest.mark.parametrize(
+        ("transaction", "message"),
+        [
+            ("activation", "version activation failed and durable rollback was incomplete"),
+            ("rejection", "version rejection failed and durable rollback was incomplete"),
+            ("restore", "version restore failed and durable rollback was incomplete"),
+        ],
+    )
+    def test_failed_media_rollback_preserves_the_recovery_backup(
+        self,
+        tmp_path,
+        monkeypatch,
+        transaction,
+        message,
+    ):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "audio" / "segment_E1S01.wav"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"old-current")
+        old_version = vm.add_version("audio", "E1S01", "old", source_file=current)
+        operation_failure = RuntimeError("registration failed")
+        rollback_failure = OSError("media rollback failed")
+        original_replace = os.replace
+
+        def _fail_media_rollback(source, destination):
+            if Path(source).suffix == ".rollback" and Path(destination) == current:
+                raise rollback_failure
+            return original_replace(source, destination)
+
+        def _fail_registration(*_args):
+            raise operation_failure
+
+        if transaction == "activation":
+            staged = current.with_name(".segment_E1S01.new.wav")
+            staged.write_bytes(b"new-current")
+
+            def _run_transaction():
+                vm.commit_staged_version(
+                    "audio",
+                    "E1S01",
+                    "new",
+                    staged_file=staged,
+                    current_file=current,
+                    on_commit=_fail_registration,
+                )
+
+        elif transaction == "rejection":
+            current.write_bytes(b"new-current")
+            rejected_version = vm.add_version("audio", "E1S01", "new", source_file=current)
+
+            def _run_transaction():
+                vm.reject_current_version(
+                    "audio",
+                    "E1S01",
+                    rejected_version=rejected_version,
+                    current_file=current,
+                    on_reject=_fail_registration,
+                )
+
+        else:
+            current.write_bytes(b"new-current")
+            vm.add_version("audio", "E1S01", "new", source_file=current)
+
+            def _run_transaction():
+                vm.restore_version(
+                    "audio",
+                    "E1S01",
+                    old_version,
+                    current,
+                    on_restore=_fail_registration,
+                )
+
+        monkeypatch.setattr("lib.version_manager.os.replace", _fail_media_rollback)
+
+        with pytest.raises(RuntimeError, match=message) as caught:
+            _run_transaction()
+
+        backups = list(current.parent.glob(".*.rollback"))
+        assert len(backups) == 1
+        expected_backup = b"old-current" if transaction == "activation" else b"new-current"
+        assert backups[0].read_bytes() == expected_backup
+        assert caught.value.__cause__ is rollback_failure
+        assert rollback_failure.__cause__ is operation_failure
 
     def test_restore_errors_and_missing_current(self, tmp_path):
         project = tmp_path / "demo"

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -63,6 +63,34 @@ class TestVersionManagerMore:
         current.write_bytes(b"png-v3")
         assert vm.add_version("characters", "Alice", "p3", source_file=current) == 3
 
+    def test_restore_callback_runs_under_selection_and_failure_restores_old_current(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "audio" / "segment_E1S01.wav"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"audio-v1")
+        v1 = vm.add_version(
+            "audio",
+            "E1S01",
+            "v1",
+            source_file=current,
+            artifact_audio_basis={"kind": "narration-delivery/tts-audio", "digest": "sha256-v1:" + "1" * 64},
+        )
+        current.write_bytes(b"audio-v2")
+        v2 = vm.add_version("audio", "E1S01", "v2", source_file=current)
+        observed = []
+
+        def _fail(record):
+            observed.append(record)
+            raise RuntimeError("manifest restore failed")
+
+        with pytest.raises(RuntimeError, match="manifest restore failed"):
+            vm.restore_version("audio", "E1S01", v1, current, on_restore=_fail)
+
+        assert current.read_bytes() == b"audio-v2"
+        assert vm.get_current_version("audio", "E1S01") == v2
+        assert observed[0]["artifact_audio_basis"]["kind"] == "narration-delivery/tts-audio"
+
     def test_restore_errors_and_missing_current(self, tmp_path):
         project = tmp_path / "demo"
         vm = VersionManager(project)
@@ -168,3 +196,93 @@ class TestVersionManagerMore:
         history = vm.get_versions("videos", "E1S01")
         assert history["current_version"] == versions[0]
         assert len(history["versions"]) == 4
+
+    def test_commit_paid_version_can_append_history_without_exposing_it_as_current(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"selected-video")
+        selected_version = vm.add_version("videos", "E1S01", "selected", source_file=current)
+        staged = current.with_name(".scene_E1S01.late.mp4")
+        staged.write_bytes(b"late-paid-video")
+
+        outcome = vm.commit_staged_paid_version(
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="late",
+            staged_file=staged,
+            current_file=current,
+            select_current=False,
+            artifact_video_basis={"kind": "artifact-components/video"},
+        )
+
+        assert outcome.selected is False
+        assert outcome.version == selected_version + 1
+        assert current.read_bytes() == b"selected-video"
+        assert not staged.exists()
+        history = vm.get_versions("videos", "E1S01")
+        assert history["current_version"] == selected_version
+        assert len(history["versions"]) == 2
+        assert history["versions"][-1]["is_current"] is False
+        assert (project / history["versions"][-1]["file"]).read_bytes() == b"late-paid-video"
+
+    def test_paid_version_selection_failure_keeps_history_and_old_current(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"selected-video")
+        selected_version = vm.add_version("videos", "E1S01", "selected", source_file=current)
+        staged = current.with_name(".scene_E1S01.new.mp4")
+        staged.write_bytes(b"new-paid-video")
+
+        def _registration_failure() -> None:
+            raise RuntimeError("manifest registration failed")
+
+        with pytest.raises(RuntimeError, match="manifest registration failed"):
+            vm.commit_staged_paid_version(
+                resource_type="videos",
+                resource_id="E1S01",
+                prompt="new",
+                staged_file=staged,
+                current_file=current,
+                select_current=True,
+                on_select=_registration_failure,
+            )
+
+        assert current.read_bytes() == b"selected-video"
+        history = vm.get_versions("videos", "E1S01")
+        assert history["current_version"] == selected_version
+        assert len(history["versions"]) == 2
+        assert history["versions"][-1]["is_current"] is False
+        assert (project / history["versions"][-1]["file"]).read_bytes() == b"new-paid-video"
+
+    def test_paid_version_selection_decision_runs_after_history_is_durable_under_the_version_lock(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"selected-video")
+        selected_version = vm.add_version("videos", "E1S01", "selected", source_file=current)
+        staged = current.with_name(".scene_E1S01.late.mp4")
+        staged.write_bytes(b"late-paid-video")
+        observed: list[tuple[int, int, bytes]] = []
+
+        def _still_current() -> bool:
+            history = vm.get_versions("videos", "E1S01")
+            observed.append((history["current_version"], len(history["versions"]), current.read_bytes()))
+            return False
+
+        outcome = vm.commit_staged_paid_version(
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="late",
+            staged_file=staged,
+            current_file=current,
+            select_current=_still_current,
+        )
+
+        assert outcome.selected is False
+        assert observed == [(selected_version, 2, b"selected-video")]
+        assert current.read_bytes() == b"selected-video"

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from lib.api_errors import BadRequestError, NotFoundError
@@ -252,6 +254,78 @@ class TestVersionManagerMore:
         assert history["current_version"] == outcome.version
         assert [record["prompt"] for record in history["versions"]] == ["", "new"]
         assert (project / history["versions"][0]["file"]).read_bytes() == b"legacy-current"
+
+    def test_paid_version_history_rollback_preserves_operation_and_cleanup_failures(self, tmp_path, monkeypatch):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        staged = current.with_name(".scene_E1S01.new.mp4")
+        staged.parent.mkdir(parents=True)
+        staged.write_bytes(b"new-paid-video")
+        operation_failure = RuntimeError("versions persistence failed")
+        cleanup_failure = OSError("staged cleanup failed")
+        original_unlink = Path.unlink
+
+        def _fail_save(_data):
+            raise operation_failure
+
+        def _fail_staged_cleanup(path: Path, *, missing_ok: bool = False):
+            if path == staged:
+                raise cleanup_failure
+            return original_unlink(path, missing_ok=missing_ok)
+
+        monkeypatch.setattr(vm, "_save_versions", _fail_save)
+        monkeypatch.setattr(Path, "unlink", _fail_staged_cleanup)
+
+        with pytest.raises(RuntimeError, match="history commit failed and rollback was incomplete") as exc_info:
+            vm.commit_staged_paid_version(
+                resource_type="videos",
+                resource_id="E1S01",
+                prompt="new",
+                staged_file=staged,
+                current_file=current,
+                select_current=True,
+            )
+
+        assert exc_info.value.__cause__ is cleanup_failure
+        assert cleanup_failure.__cause__ is operation_failure
+
+    def test_paid_version_cleanup_attempts_backup_after_staged_cleanup_failure(self, tmp_path, monkeypatch, caplog):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"old-current")
+        vm.add_version("videos", "E1S01", "old", source_file=current)
+        staged = current.with_name(".scene_E1S01.new.mp4")
+        staged.write_bytes(b"new-paid-video")
+        cleanup_failure = OSError("staged cleanup failed")
+        original_unlink = Path.unlink
+        cleanup_attempts: list[Path] = []
+
+        def _fail_staged_cleanup(path: Path, *, missing_ok: bool = False):
+            cleanup_attempts.append(path)
+            if path == staged:
+                raise cleanup_failure
+            return original_unlink(path, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _fail_staged_cleanup)
+
+        outcome = vm.commit_staged_paid_version(
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="new",
+            staged_file=staged,
+            current_file=current,
+            select_current=True,
+        )
+
+        assert outcome.selected is True
+        assert current.read_bytes() == b"new-paid-video"
+        assert cleanup_attempts[0] == staged
+        assert len(cleanup_attempts) == 2
+        assert not list(current.parent.glob(".*.rollback"))
+        assert "failed to remove temporary version file" in caplog.text
 
     def test_paid_version_selection_failure_keeps_history_and_old_current(self, tmp_path):
         project = tmp_path / "demo"

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -286,3 +286,31 @@ class TestVersionManagerMore:
         assert outcome.selected is False
         assert observed == [(selected_version, 2, b"selected-video")]
         assert current.read_bytes() == b"selected-video"
+
+    def test_paid_version_selection_token_rejects_a_late_result_without_running_the_basis_callback(self, tmp_path):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"first")
+        submitted_parent = vm.add_version("videos", "E1S01", "first", source_file=current)
+        current.write_bytes(b"user-restored")
+        user_selection = vm.add_version("videos", "E1S01", "user", source_file=current)
+        staged = current.with_name(".scene_E1S01.late.mp4")
+        staged.write_bytes(b"late-paid")
+
+        outcome = vm.commit_staged_paid_version(
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="late",
+            staged_file=staged,
+            current_file=current,
+            select_current=lambda: pytest.fail("a changed selection token must short-circuit basis comparison"),
+            expected_current_version=submitted_parent,
+        )
+
+        assert outcome.selected is False
+        assert current.read_bytes() == b"user-restored"
+        history = vm.get_versions("videos", "E1S01")
+        assert history["current_version"] == user_selection
+        assert (project / history["versions"][-1]["file"]).read_bytes() == b"late-paid"

--- a/tests/test_version_manager_more.py
+++ b/tests/test_version_manager_more.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -443,6 +444,65 @@ class TestVersionManagerMore:
         assert len(history["versions"]) == 2
         assert history["versions"][-1]["is_current"] is False
         assert (project / history["versions"][-1]["file"]).read_bytes() == b"new-paid-video"
+
+    def test_paid_version_backup_copy_failure_keeps_the_selected_media_intact(self, tmp_path, monkeypatch):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"selected-video")
+        vm.add_version("videos", "E1S01", "selected", source_file=current)
+        staged = current.with_name(".scene_E1S01.new.mp4")
+        staged.write_bytes(b"new-paid-video")
+        real_copy2 = shutil.copy2
+
+        def _fail_partial_backup(source, destination, *args, **kwargs):
+            destination = Path(destination)
+            if destination.suffix == ".rollback":
+                destination.write_bytes(b"partial-backup")
+                raise OSError("backup copy failed")
+            return real_copy2(source, destination, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "copy2", _fail_partial_backup)
+
+        with pytest.raises(OSError, match="backup copy failed"):
+            vm.commit_staged_paid_version(
+                resource_type="videos",
+                resource_id="E1S01",
+                prompt="new",
+                staged_file=staged,
+                current_file=current,
+                select_current=True,
+            )
+
+        assert current.read_bytes() == b"selected-video"
+        assert not list(current.parent.glob(".*.rollback"))
+
+    def test_restore_backup_copy_failure_keeps_the_selected_media_intact(self, tmp_path, monkeypatch):
+        project = tmp_path / "demo"
+        vm = VersionManager(project)
+        current = project / "videos" / "scene_E1S01.mp4"
+        current.parent.mkdir(parents=True)
+        current.write_bytes(b"video-v1")
+        first = vm.add_version("videos", "E1S01", "v1", source_file=current)
+        current.write_bytes(b"video-v2")
+        vm.add_version("videos", "E1S01", "v2", source_file=current)
+        real_copy2 = shutil.copy2
+
+        def _fail_partial_backup(source, destination, *args, **kwargs):
+            destination = Path(destination)
+            if destination.suffix == ".rollback":
+                destination.write_bytes(b"partial-backup")
+                raise OSError("backup copy failed")
+            return real_copy2(source, destination, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "copy2", _fail_partial_backup)
+
+        with pytest.raises(OSError, match="backup copy failed"):
+            vm.restore_version("videos", "E1S01", first, current)
+
+        assert current.read_bytes() == b"video-v2"
+        assert not list(current.parent.glob(".*.rollback"))
 
     def test_paid_version_selection_decision_runs_after_history_is_durable_under_the_version_lock(self, tmp_path):
         project = tmp_path / "demo"

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -284,6 +285,57 @@ class TestVersionsRouter:
             assert restore_resp.status_code == 200
             assert restore_resp.json()["file_path"] == "products/保温杯.png"
             assert any(item[0] == "product" for item in fake_pm.updated)
+
+    @pytest.mark.parametrize("resource_type", ["videos", "reference_videos"])
+    def test_typed_video_restore_uses_selection_finalization_guard(self, tmp_path, monkeypatch, resource_type):
+        resource_id = "E1S01"
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        guard_active = False
+        guard_calls = []
+
+        class _PM:
+            @staticmethod
+            def get_project_path(_project_name):
+                return project_path
+
+        @asynccontextmanager
+        async def _guard(**identity):
+            nonlocal guard_active
+            guard_calls.append(identity)
+            guard_active = True
+            try:
+                yield
+            finally:
+                guard_active = False
+
+        target = versions.TypedMediaRestoreTarget(
+            episode=1,
+            script_file="episode_1.json",
+            basis=ArtifactBasisDescriptor.from_basis(build_video_duration_basis(4)),
+            created_at=None,
+        )
+
+        def _restore(**_kwargs):
+            assert guard_active
+            return {"restored_version": 1, "current_version": 1, "prompt": "p"}
+
+        monkeypatch.setattr(versions, "get_project_manager", _PM)
+        monkeypatch.setattr(versions, "get_version_manager", lambda _project_name: _FakeVM(project_path))
+        monkeypatch.setattr(versions, "get_typed_media_restore_target", lambda *_args, **_kwargs: target)
+        monkeypatch.setattr(versions, "restore_typed_media_version", _restore)
+        monkeypatch.setattr(versions, "generation_admission_lock", _guard)
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
+        register_error_handlers(app)
+        with TestClient(app) as client:
+            response = client.post(f"/api/v1/projects/demo/versions/{resource_type}/{resource_id}/restore/1")
+
+        assert response.status_code == 200
+        assert guard_calls == [{"project_name": "demo", "script_file": "episode_1.json", "resource_id": resource_id}]
+        assert not guard_active
 
     def test_audio_restore_is_enabled_for_typed_history(self, tmp_path, monkeypatch):
         pm, _project_path, manager = _typed_audio_project(tmp_path)

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -8,9 +8,15 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from lib.api_errors import BadRequestError
-from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    compose_video_artifact_basis,
+)
 from lib.script_editor import ScriptEditError
+from lib.speech_artifact_provenance import build_video_duration_basis
 from lib.version_manager import VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import versions
@@ -115,8 +121,43 @@ def _typed_video_versions(project_path: Path, resource_type: str, resource_id: s
     current_file, _relative = versions._resolve_resource_path(resource_type, resource_id, project_path)
     current_file.parent.mkdir(parents=True, exist_ok=True)
     current_file.write_bytes(b"typed-video")
-    basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"resource_id": resource_id})
+    visual = ArtifactBasis.build(
+        (
+            "artifact-visual/video-reference"
+            if resource_type == "reference_videos"
+            else "artifact-visual/video-storyboard"
+        ),
+        kind_version=1,
+        inputs=(
+            {
+                "unit_id": resource_id,
+                "visual_shots": [{"shot_index": 0, "lines": ["Run."]}],
+                "style": "cinematic",
+                "canvas": {"aspect_ratio": "9:16"},
+                "request_references": [],
+            }
+            if resource_type == "reference_videos"
+            else {
+                "resource_id": resource_id,
+                "visual_prompt": {"action": "Run.", "camera_motion": "Static"},
+                "canvas": {"aspect_ratio": "9:16"},
+                "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+            }
+        ),
+    )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "narrator_voiceover"})
+    duration = build_video_duration_basis(4)
+    currency = VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=4,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=(),
+        duration_tiers=(4,),
+        reference_image_limit=1 if resource_type == "reference_videos" else None,
+        parent_version=0,
     )
     manager = VersionManager(project_path)
     manager.add_version(
@@ -124,8 +165,10 @@ def _typed_video_versions(project_path: Path, resource_type: str, resource_id: s
         resource_id,
         "typed video",
         source_file=current_file,
-        artifact_episode=1,
-        artifact_video_basis=basis.to_dict(),
+        execution_checkpoint_schema_version=3,
+        execution_duration_seconds=4,
+        execution_request_digest="d" * 64,
+        artifact_video_currency=currency.to_dict(),
         execution_script_file="episode_1.json",
     )
     return manager
@@ -153,7 +196,17 @@ def _typed_audio_project(tmp_path: Path) -> tuple[object, Path, VersionManager]:
     current.parent.mkdir(parents=True, exist_ok=True)
     current.write_bytes(b"audio-v1")
     basis = ArtifactBasisDescriptor.from_basis(
-        ArtifactBasis.build("narration-delivery/tts-audio", kind_version=1, inputs={"text": "旁白"})
+        ArtifactBasis.build(
+            "narration-delivery/tts-audio",
+            kind_version=1,
+            inputs={
+                "text": "旁白",
+                "provider_id": "dashscope",
+                "model_id": "qwen3-tts-flash",
+                "voice": "Cherry",
+                "speed": None,
+            },
+        )
     )
     manager = VersionManager(project_path)
     manager.add_version(
@@ -165,6 +218,11 @@ def _typed_audio_project(tmp_path: Path) -> tuple[object, Path, VersionManager]:
         artifact_audio_basis=basis.to_dict(),
         execution_script_file="episode_1.json",
         tts_actual_duration_seconds=3.0,
+        tts_provider_id="dashscope",
+        tts_model_id="qwen3-tts-flash",
+        tts_voice="Cherry",
+        tts_speed=None,
+        tts_basis_digest=basis.digest,
     )
     return pm, project_path, manager
 

--- a/tests/test_versions_router.py
+++ b/tests/test_versions_router.py
@@ -1,13 +1,16 @@
 import os
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from lib.api_errors import BadRequestError
+from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
 from lib.script_editor import ScriptEditError
+from lib.version_manager import VersionManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import versions
@@ -108,6 +111,64 @@ class _StoryboardSyncPM:
             raise ScriptEditError("segments 必须是列表，当前为 NoneType")
 
 
+def _typed_video_versions(project_path: Path, resource_type: str, resource_id: str) -> VersionManager:
+    current_file, _relative = versions._resolve_resource_path(resource_type, resource_id, project_path)
+    current_file.parent.mkdir(parents=True, exist_ok=True)
+    current_file.write_bytes(b"typed-video")
+    basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"resource_id": resource_id})
+    )
+    manager = VersionManager(project_path)
+    manager.add_version(
+        resource_type,
+        resource_id,
+        "typed video",
+        source_file=current_file,
+        artifact_episode=1,
+        artifact_video_basis=basis.to_dict(),
+        execution_script_file="episode_1.json",
+    )
+    return manager
+
+
+def _typed_audio_project(tmp_path: Path) -> tuple[object, Path, VersionManager]:
+    from lib.project_manager import ProjectManager
+
+    pm = ProjectManager(tmp_path)
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Demo", "Anime", "narration")
+    pm.save_script(
+        "demo",
+        {
+            "episode": 1,
+            "title": "E1",
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "novel_text": "旁白", "generated_assets": {}}],
+        },
+        "episode_1.json",
+        validate=False,
+    )
+    project_path = pm.get_project_path("demo")
+    current = project_path / "audio" / "segment_E1S01.wav"
+    current.parent.mkdir(parents=True, exist_ok=True)
+    current.write_bytes(b"audio-v1")
+    basis = ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("narration-delivery/tts-audio", kind_version=1, inputs={"text": "旁白"})
+    )
+    manager = VersionManager(project_path)
+    manager.add_version(
+        "audio",
+        "E1S01",
+        "旁白",
+        source_file=current,
+        artifact_episode=1,
+        artifact_audio_basis=basis.to_dict(),
+        execution_script_file="episode_1.json",
+        tts_actual_duration_seconds=3.0,
+    )
+    return pm, project_path, manager
+
+
 def _client(monkeypatch):
     fake_pm = _FakePM()
     monkeypatch.setattr(versions, "get_project_manager", lambda: fake_pm)
@@ -165,6 +226,67 @@ class TestVersionsRouter:
             assert restore_resp.status_code == 200
             assert restore_resp.json()["file_path"] == "products/保温杯.png"
             assert any(item[0] == "product" for item in fake_pm.updated)
+
+    def test_audio_restore_is_enabled_for_typed_history(self, tmp_path, monkeypatch):
+        pm, _project_path, manager = _typed_audio_project(tmp_path)
+        monkeypatch.setattr(versions, "get_project_manager", lambda: pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: manager)
+        monkeypatch.setattr(versions, "active_tts_resource_ids", AsyncMock(return_value=frozenset()))
+        monkeypatch.setattr(versions, "active_narrated_video_resource_ids", AsyncMock(return_value=frozenset()))
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
+        register_error_handlers(app)
+        with TestClient(app) as client:
+            response = client.post("/api/v1/projects/demo/versions/audio/E1S01/restore/1")
+
+        assert response.status_code == 200
+        assert response.json()["file_path"] == "audio/segment_E1S01.wav"
+
+    def test_audio_restore_is_blocked_while_tts_is_active(self, tmp_path, monkeypatch):
+        pm, project_path, manager = _typed_audio_project(tmp_path)
+        before = (project_path / "audio" / "segment_E1S01.wav").read_bytes()
+        monkeypatch.setattr(versions, "get_project_manager", lambda: pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: manager)
+        monkeypatch.setattr(
+            versions,
+            "active_tts_resource_ids",
+            AsyncMock(return_value=frozenset({"E1S01"})),
+        )
+        monkeypatch.setattr(versions, "active_narrated_video_resource_ids", AsyncMock(return_value=frozenset()))
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
+        register_error_handlers(app)
+        with TestClient(app) as client:
+            response = client.post("/api/v1/projects/demo/versions/audio/E1S01/restore/1")
+
+        assert response.status_code == 409
+        assert (project_path / "audio" / "segment_E1S01.wav").read_bytes() == before
+
+    def test_audio_restore_is_blocked_while_video_consumes_current_tts(self, tmp_path, monkeypatch):
+        pm, project_path, manager = _typed_audio_project(tmp_path)
+        before = (project_path / "audio" / "segment_E1S01.wav").read_bytes()
+        monkeypatch.setattr(versions, "get_project_manager", lambda: pm)
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: manager)
+        monkeypatch.setattr(versions, "active_tts_resource_ids", AsyncMock(return_value=frozenset()))
+        monkeypatch.setattr(
+            versions,
+            "active_narrated_video_resource_ids",
+            AsyncMock(return_value=frozenset({"E1S01"})),
+        )
+
+        app = FastAPI()
+        app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
+        app.include_router(versions.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
+        register_error_handlers(app)
+        with TestClient(app) as client:
+            response = client.post("/api/v1/projects/demo/versions/audio/E1S01/restore/1")
+
+        assert response.status_code == 409
+        assert (project_path / "audio" / "segment_E1S01.wav").read_bytes() == before
 
     def test_restore_error_mapping(self, monkeypatch):
         client, _ = _client(monkeypatch)
@@ -371,9 +493,10 @@ class TestVersionsRouter:
         thumb = project_path / "reference_videos" / "thumbnails" / "E1U1.jpg"
         thumb.parent.mkdir(parents=True, exist_ok=True)
         thumb.write_bytes(b"jpg")
+        vm = _typed_video_versions(project_path, "reference_videos", "E1U1")
 
         monkeypatch.setattr(versions, "get_project_manager", lambda: real_pm)
-        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: vm)
 
         app = FastAPI()
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
@@ -425,9 +548,11 @@ class TestVersionsRouter:
             "episode_1.json",
             validate=False,
         )
+        project_path = real_pm.get_project_path("demo")
+        vm = _typed_video_versions(project_path, "reference_videos", "E1U1")
 
         monkeypatch.setattr(versions, "get_project_manager", lambda: real_pm)
-        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: vm)
 
         app = FastAPI()
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
@@ -476,9 +601,10 @@ class TestVersionsRouter:
         thumb = project_path / "thumbnails" / "scene_E1S01.jpg"
         thumb.parent.mkdir(parents=True, exist_ok=True)
         thumb.write_bytes(b"jpg")
+        vm = _typed_video_versions(project_path, "videos", "E1S01")
 
         monkeypatch.setattr(versions, "get_project_manager", lambda: real_pm)
-        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: _FakeVM())
+        monkeypatch.setattr(versions, "get_version_manager", lambda project_name: vm)
 
         app = FastAPI()
         app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")

--- a/tests/test_video_artifact_commit.py
+++ b/tests/test_video_artifact_commit.py
@@ -11,9 +11,12 @@ from lib.artifact_manifest import (
     ArtifactBasisDescriptor,
     ArtifactKey,
     ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
 )
+from lib.speech_artifact_provenance import build_video_duration_basis
 from lib.version_manager import VersionManager
 from lib.video_artifact_commit import commit_paid_video_artifact
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 pytestmark = pytest.mark.integration
 
@@ -21,6 +24,33 @@ pytestmark = pytest.mark.integration
 def _descriptor(label: str) -> ArtifactBasisDescriptor:
     return ArtifactBasisDescriptor.from_basis(
         ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"label": label})
+    )
+
+
+def _currency(label: str, *, parent_version: int) -> VideoArtifactCurrencyFacts:
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": label,
+            "visual_prompt": {"action": label, "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
+    )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = build_video_duration_basis(8)
+    return VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=8,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=(),
+        duration_tiers=(8,),
+        reference_image_limit=None,
+        parent_version=parent_version,
     )
 
 
@@ -36,10 +66,11 @@ def test_matching_typed_basis_selects_and_registers_inside_the_shared_guard(tmp_
     project = tmp_path / "project"
     project.mkdir()
     versions = VersionManager(project)
-    current, _old_version = _seed_current(project, versions)
+    current, old_version = _seed_current(project, versions)
     staged = current.with_name(".scene_E1S01.new.mp4")
     staged.write_bytes(b"new-current")
-    basis = _descriptor("new")
+    currency = _currency("new", parent_version=old_version)
+    basis = currency.video_descriptor
     events: list[str] = []
 
     @contextmanager
@@ -61,7 +92,7 @@ def test_matching_typed_basis_selects_and_registers_inside_the_shared_guard(tmp_
         staged_file=staged,
         current_file=current,
         duration_seconds=8,
-        version_metadata={"artifact_episode": 1, "artifact_video_basis": basis.to_dict()},
+        version_metadata={"artifact_video_currency": currency.to_dict()},
         resolve_current_basis=_current,
         selection_guard=_guard,
     )
@@ -79,8 +110,8 @@ def test_matching_typed_basis_selects_and_registers_inside_the_shared_guard(tmp_
     "metadata",
     [
         {},
-        {"artifact_episode": 1},
-        {"artifact_episode": 1, "artifact_video_basis": {"kind": "broken"}},
+        {"artifact_video_currency": {}},
+        {"artifact_video_currency": {"schema_version": 1}},
     ],
 )
 def test_incomplete_or_malformed_typed_facts_are_history_only(
@@ -122,7 +153,7 @@ def test_late_basis_mismatch_preserves_paid_history_without_taking_current(tmp_p
     current, old_version = _seed_current(project, versions)
     staged = current.with_name(".scene_E1S01.late.mp4")
     staged.write_bytes(b"late-paid")
-    frozen = _descriptor("submitted")
+    frozen = _currency("submitted", parent_version=old_version)
 
     outcome = commit_paid_video_artifact(
         project_path=project,
@@ -133,7 +164,7 @@ def test_late_basis_mismatch_preserves_paid_history_without_taking_current(tmp_p
         staged_file=staged,
         current_file=current,
         duration_seconds=8,
-        version_metadata={"artifact_episode": 1, "artifact_video_basis": frozen.to_dict()},
+        version_metadata={"artifact_video_currency": frozen.to_dict()},
         resolve_current_basis=lambda _metadata: _descriptor("edited"),
     )
 
@@ -164,7 +195,8 @@ def test_manifest_failure_restores_old_selection_but_keeps_paid_history(
     )
     staged = current.with_name(".scene_E1S01.new.mp4")
     staged.write_bytes(b"new-paid")
-    new_basis = _descriptor("new")
+    currency = _currency("new", parent_version=old_version)
+    new_basis = currency.video_descriptor
     original_put = ProjectArtifactManifestAdapter.put_entry
 
     def _write_then_fail(self, artifact_key, entry):
@@ -185,7 +217,7 @@ def test_manifest_failure_restores_old_selection_but_keeps_paid_history(
             staged_file=staged,
             current_file=current,
             duration_seconds=8,
-            version_metadata={"artifact_episode": 1, "artifact_video_basis": new_basis.to_dict()},
+            version_metadata={"artifact_video_currency": currency.to_dict()},
             resolve_current_basis=lambda _metadata: new_basis,
         )
 
@@ -206,7 +238,8 @@ def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -
     current, old_version = _seed_current(project, versions)
     staged = current.with_name(".scene_E1S01.paid.mp4")
     staged.write_bytes(b"paid-before-project-read-failed")
-    basis = _descriptor("submitted")
+    currency = _currency("submitted", parent_version=old_version)
+    basis = currency.video_descriptor
 
     @contextmanager
     def _failed_guard() -> Iterator[object]:
@@ -223,7 +256,7 @@ def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -
             staged_file=staged,
             current_file=current,
             duration_seconds=8,
-            version_metadata={"artifact_episode": 1, "artifact_video_basis": basis.to_dict()},
+            version_metadata={"artifact_video_currency": currency.to_dict()},
             resolve_current_basis=lambda _metadata: basis,
             selection_guard=_failed_guard,
         )
@@ -233,3 +266,34 @@ def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -
     assert history["current_version"] == old_version
     assert len(history["versions"]) == 2
     assert (project / history["versions"][-1]["file"]).read_bytes() == b"paid-before-project-read-failed"
+
+
+def test_same_basis_late_result_cannot_replace_a_newer_user_selection(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, submitted_parent = _seed_current(project, versions)
+    currency = _currency("same", parent_version=submitted_parent)
+    current.write_bytes(b"user-selection")
+    user_version = versions.add_version("videos", "E1S01", "user", source_file=current)
+    staged = current.with_name(".scene_E1S01.late.mp4")
+    staged.write_bytes(b"late-paid")
+
+    outcome = commit_paid_video_artifact(
+        project_path=project,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="late",
+        staged_file=staged,
+        current_file=current,
+        duration_seconds=8,
+        version_metadata={"artifact_video_currency": currency.to_dict()},
+        resolve_current_basis=lambda _metadata: currency.video_descriptor,
+    )
+
+    assert outcome.selected is False
+    assert current.read_bytes() == b"user-selection"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == user_version
+    assert (project / history["versions"][-1]["file"]).read_bytes() == b"late-paid"

--- a/tests/test_video_artifact_commit.py
+++ b/tests/test_video_artifact_commit.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasis,
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ProjectArtifactManifestAdapter,
+)
+from lib.version_manager import VersionManager
+from lib.video_artifact_commit import commit_paid_video_artifact
+
+pytestmark = pytest.mark.integration
+
+
+def _descriptor(label: str) -> ArtifactBasisDescriptor:
+    return ArtifactBasisDescriptor.from_basis(
+        ArtifactBasis.build("artifact-components/video", kind_version=1, inputs={"label": label})
+    )
+
+
+def _seed_current(project: Path, versions: VersionManager) -> tuple[Path, int]:
+    current = project / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+    version = versions.add_version("videos", "E1S01", "old", source_file=current)
+    return current, version
+
+
+def test_matching_typed_basis_selects_and_registers_inside_the_shared_guard(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, _old_version = _seed_current(project, versions)
+    staged = current.with_name(".scene_E1S01.new.mp4")
+    staged.write_bytes(b"new-current")
+    basis = _descriptor("new")
+    events: list[str] = []
+
+    @contextmanager
+    def _guard() -> Iterator[object]:
+        events.append("guard-enter")
+        yield object()
+        events.append("guard-exit")
+
+    def _current(_metadata: dict[str, object]) -> ArtifactBasisDescriptor:
+        events.append("compare")
+        return basis
+
+    outcome = commit_paid_video_artifact(
+        project_path=project,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="new",
+        staged_file=staged,
+        current_file=current,
+        duration_seconds=8,
+        version_metadata={"artifact_episode": 1, "artifact_video_basis": basis.to_dict()},
+        resolve_current_basis=_current,
+        selection_guard=_guard,
+    )
+
+    assert outcome.selected is True
+    assert current.read_bytes() == b"new-current"
+    assert events == ["guard-enter", "compare", "guard-exit"]
+    entry = ProjectArtifactManifestAdapter(project).get_entry(ArtifactKey.episode_video(1, "E1S01"))
+    assert entry is not None
+    assert entry.artifact_path == "videos/scene_E1S01.mp4"
+    assert entry.basis_digest == basis.digest
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"artifact_episode": 1},
+        {"artifact_episode": 1, "artifact_video_basis": {"kind": "broken"}},
+    ],
+)
+def test_incomplete_or_malformed_typed_facts_are_history_only(
+    tmp_path: Path,
+    metadata: dict[str, object],
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, old_version = _seed_current(project, versions)
+    staged = current.with_name(".scene_E1S01.late.mp4")
+    staged.write_bytes(b"late-paid")
+
+    outcome = commit_paid_video_artifact(
+        project_path=project,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="late",
+        staged_file=staged,
+        current_file=current,
+        duration_seconds=8,
+        version_metadata=metadata,
+        resolve_current_basis=lambda _metadata: pytest.fail("legacy output must not infer a basis"),
+    )
+
+    assert outcome.selected is False
+    assert current.read_bytes() == b"old-current"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == old_version
+    assert len(history["versions"]) == 2
+    assert ProjectArtifactManifestAdapter(project).get_entry(ArtifactKey.episode_video(1, "E1S01")) is None
+
+
+def test_late_basis_mismatch_preserves_paid_history_without_taking_current(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, old_version = _seed_current(project, versions)
+    staged = current.with_name(".scene_E1S01.late.mp4")
+    staged.write_bytes(b"late-paid")
+    frozen = _descriptor("submitted")
+
+    outcome = commit_paid_video_artifact(
+        project_path=project,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="late",
+        staged_file=staged,
+        current_file=current,
+        duration_seconds=8,
+        version_metadata={"artifact_episode": 1, "artifact_video_basis": frozen.to_dict()},
+        resolve_current_basis=lambda _metadata: _descriptor("edited"),
+    )
+
+    assert outcome.selected is False
+    assert current.read_bytes() == b"old-current"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == old_version
+    assert (project / history["versions"][-1]["file"]).read_bytes() == b"late-paid"
+
+
+def test_manifest_failure_restores_old_selection_but_keeps_paid_history(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, old_version = _seed_current(project, versions)
+    old_basis = _descriptor("old")
+    key = ArtifactKey.episode_video(1, "E1S01")
+    adapter = ProjectArtifactManifestAdapter(project)
+    from lib.artifact_manifest import ArtifactManifest
+
+    ArtifactManifest(adapter).register_descriptor(
+        key,
+        artifact_path="videos/scene_E1S01.mp4",
+        basis=old_basis,
+    )
+    staged = current.with_name(".scene_E1S01.new.mp4")
+    staged.write_bytes(b"new-paid")
+    new_basis = _descriptor("new")
+    original_put = ProjectArtifactManifestAdapter.put_entry
+
+    def _write_then_fail(self, artifact_key, entry):
+        changed = original_put(self, artifact_key, entry)
+        if artifact_key == key and entry.basis_digest == new_basis.digest:
+            raise RuntimeError("manifest injected failure")
+        return changed
+
+    monkeypatch.setattr(ProjectArtifactManifestAdapter, "put_entry", _write_then_fail)
+
+    with pytest.raises(RuntimeError, match="manifest injected failure"):
+        commit_paid_video_artifact(
+            project_path=project,
+            versions=versions,
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="new",
+            staged_file=staged,
+            current_file=current,
+            duration_seconds=8,
+            version_metadata={"artifact_episode": 1, "artifact_video_basis": new_basis.to_dict()},
+            resolve_current_basis=lambda _metadata: new_basis,
+        )
+
+    assert current.read_bytes() == b"old-current"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == old_version
+    assert len(history["versions"]) == 2
+    assert (project / history["versions"][-1]["file"]).read_bytes() == b"new-paid"
+    restored = ProjectArtifactManifestAdapter(project).get_entry(key)
+    assert restored is not None
+    assert restored.basis_digest == old_basis.digest
+
+
+def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    versions = VersionManager(project)
+    current, old_version = _seed_current(project, versions)
+    staged = current.with_name(".scene_E1S01.paid.mp4")
+    staged.write_bytes(b"paid-before-project-read-failed")
+    basis = _descriptor("submitted")
+
+    @contextmanager
+    def _failed_guard() -> Iterator[object]:
+        raise OSError("project snapshot unavailable")
+        yield object()
+
+    with pytest.raises(OSError, match="project snapshot unavailable"):
+        commit_paid_video_artifact(
+            project_path=project,
+            versions=versions,
+            resource_type="videos",
+            resource_id="E1S01",
+            prompt="paid",
+            staged_file=staged,
+            current_file=current,
+            duration_seconds=8,
+            version_metadata={"artifact_episode": 1, "artifact_video_basis": basis.to_dict()},
+            resolve_current_basis=lambda _metadata: basis,
+            selection_guard=_failed_guard,
+        )
+
+    assert current.read_bytes() == b"old-current"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == old_version
+    assert len(history["versions"]) == 2
+    assert (project / history["versions"][-1]["file"]).read_bytes() == b"paid-before-project-read-failed"

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lib.artifact_manifest import (
+    ArtifactBasis,
     ArtifactBasisDescriptor,
     ArtifactKey,
     ArtifactManifest,
@@ -23,15 +24,81 @@ from lib.speech_artifact_provenance import (
 )
 from lib.speech_composition import admit_script_unit
 from lib.version_manager import PaidVersionCommit, VersionManager
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
 from server.services import video_artifact_currency
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
     build_current_video_artifact_basis,
+    complete_video_artifact_commit,
     finalize_selected_video_result,
 )
 
 pytestmark = pytest.mark.integration
+
+
+def _currency(
+    label: str,
+    *,
+    request_duration: int = 8,
+    duration_tiers: tuple[int, ...] = (4, 8),
+    parent_version: int = 0,
+) -> VideoArtifactCurrencyFacts:
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": label,
+            "visual_prompt": {"action": label, "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
+    )
+    speech = ArtifactBasis.build("artifact-speech/video", kind_version=1, inputs={"mode": "silent"})
+    duration = build_video_duration_basis(request_duration)
+    return VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=request_duration,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=(),
+        duration_tiers=duration_tiers,
+        reference_image_limit=None,
+        parent_version=parent_version,
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_video_completion_returns_nonselected_paid_history_without_finalizing(tmp_path: Path) -> None:
+    project_path = tmp_path / "demo"
+    paid = project_path / "paid.mp4"
+    paid.parent.mkdir(parents=True)
+    paid.write_bytes(b"paid")
+    versions = VersionManager(project_path)
+    version = versions.add_version("videos", "E1S01", "p", source_file=paid)
+    committer = MagicMock()
+    committer.outcome = PaidVersionCommit(version=version, selected=False)
+    committer.selection_error = None
+    finalize = AsyncMock()
+    completed = MagicMock()
+
+    result = await complete_video_artifact_commit(
+        committer=committer,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        version=version,
+        video_uri="provider://paid",
+        finalize=finalize,
+        on_completed=completed,
+    )
+
+    assert result["selected_current"] is False
+    assert (project_path / str(result["file_path"])).read_bytes() == b"paid"
+    finalize.assert_not_awaited()
+    completed.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -42,6 +109,11 @@ async def test_formal_selection_preparation_turns_tts_validation_failure_into_hi
     failure = RuntimeError("generated video does not cover current TTS")
     validate = AsyncMock(side_effect=failure)
     monkeypatch.setattr(video_artifact_currency, "validate_generated_video_covers_current_tts", validate)
+    monkeypatch.setattr(
+        video_artifact_currency.CurrentTtsSettingsResolver,
+        "resolve_tts_synthesis_settings",
+        AsyncMock(return_value=TtsSynthesisSettings("p", "m", "v", None)),
+    )
     committer = VideoArtifactCommitter(
         project_manager=MagicMock(),
         project_name="demo",
@@ -84,15 +156,13 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     staged.write_bytes(b"short-paid-video")
     versions = VersionManager(project_path)
     old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
-    frozen = ArtifactBasisDescriptor.from_basis(
-        compose_video_artifact_basis(
-            visual=build_video_duration_basis(1),
-            speech=build_video_duration_basis(2),
-            duration=build_video_duration_basis(8),
-        )
-    )
+    currency = _currency("frozen", parent_version=old_version)
 
     class _PM:
+        @staticmethod
+        def load_project(_name):
+            return {}
+
         @contextmanager
         def locked_project_script_snapshot(self, *_args):
             yield {}, {}
@@ -102,6 +172,11 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
         video_artifact_currency,
         "validate_generated_video_covers_current_tts",
         AsyncMock(side_effect=failure),
+    )
+    monkeypatch.setattr(
+        video_artifact_currency.CurrentTtsSettingsResolver,
+        "resolve_tts_synthesis_settings",
+        AsyncMock(return_value=TtsSynthesisSettings("p", "m", "v", None)),
     )
     committer = VideoArtifactCommitter(
         project_manager=_PM(),  # type: ignore[arg-type]
@@ -113,8 +188,7 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
         prompt="p",
     )
     metadata = {
-        "artifact_episode": 1,
-        "artifact_video_basis": frozen.to_dict(),
+        "artifact_video_currency": currency.to_dict(),
         "execution_script_file": "episode_1.json",
         "execution_narration": {"delivery": "use_tts"},
     }
@@ -152,13 +226,8 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
             duration=build_video_duration_basis(4),
         )
     )
-    new_basis = ArtifactBasisDescriptor.from_basis(
-        compose_video_artifact_basis(
-            visual=build_video_duration_basis(1),
-            speech=build_video_duration_basis(2),
-            duration=build_video_duration_basis(8),
-        )
-    )
+    new_currency = _currency("new", parent_version=old_version)
+    new_basis = new_currency.video_descriptor
     adapter = ProjectArtifactManifestAdapter(project_path)
     ArtifactManifest(adapter).register_descriptor(
         ArtifactKey.episode_video(1, "E1S01"),
@@ -211,8 +280,7 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
         prompt="new",
     )
     metadata = {
-        "artifact_episode": 1,
-        "artifact_video_basis": new_basis.to_dict(),
+        "artifact_video_currency": new_currency.to_dict(),
         "execution_script_file": "episode_1.json",
         "execution_narration": {"delivery": "post_production"},
     }
@@ -303,11 +371,37 @@ def _storyboard_state(tmp_path: Path) -> tuple[Path, dict, dict, dict[str, objec
             }
         ],
     }
+    preparation = admit_script_unit("scenes", script["scenes"][0]).preparation
+    visual = build_storyboard_video_artifact_visual_basis(
+        resource_id="E1S01",
+        visual_prompt=script["scenes"][0]["video_prompt"],
+        storyboard_image=storyboard,
+        end_frame_image=None,
+        aspect_ratio="16:9",
+    )
+    speech = build_video_speech_basis(
+        preparation,
+        voices=project_character_voice_evidence(
+            preparation,
+            characters=project["characters"],
+            voice_style_speakers=("阿离",),
+        ),
+    )
+    duration = build_video_duration_basis(4)
+    currency = VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=4,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=("阿离",),
+        duration_tiers=(4, 8),
+        reference_image_limit=None,
+        parent_version=0,
+    )
     metadata: dict[str, object] = {
-        "artifact_episode": 1,
-        "artifact_voice_style_speakers": ["阿离"],
-        "artifact_duration_tiers": [4, 8],
-        "artifact_reference_image_limit": None,
+        "artifact_video_currency": currency.to_dict(),
         "execution_script_file": "episode_1.json",
         "execution_provider_media": [],
         "execution_narration": {
@@ -394,16 +488,21 @@ def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(t
             }
         ],
     }
-    metadata["artifact_voice_style_speakers"] = []
     metadata["execution_narration"] = {"delivery": "use_tts"}
+    metadata["artifact_video_currency"] = _currency(
+        "narration",
+        request_duration=8,
+        duration_tiers=(4, 8),
+    ).to_dict()
     versions = VersionManager(project_path)
     audio = project_path / "audio" / "segment_E1S01.wav"
     audio.parent.mkdir(parents=True)
     audio.write_bytes(b"audio")
     preparation = admit_script_unit("segments", script["segments"][0]).preparation
+    settings = TtsSynthesisSettings(provider_id="p", model_id="m", voice="v", speed=1.0)
     audio_basis = build_narration_audio_basis(
         preparation,
-        TtsSynthesisSettings(provider_id="p", model_id="m", voice="v", speed=1.0),
+        settings,
     )
     descriptor = ArtifactBasisDescriptor.from_basis(audio_basis)
     versions.add_version(
@@ -428,6 +527,7 @@ def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(t
         resource_id="E1S01",
         versions=versions,
         version_metadata=metadata,
+        current_tts_settings=settings,
     )
 
     versions.add_version(
@@ -446,6 +546,7 @@ def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(t
         resource_id="E1S01",
         versions=versions,
         version_metadata=metadata,
+        current_tts_settings=settings,
     )
     versions.add_version(
         "audio",
@@ -463,7 +564,33 @@ def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(t
         resource_id="E1S01",
         versions=versions,
         version_metadata=metadata,
+        current_tts_settings=settings,
+    )
+    stale_script = deepcopy(script)
+    stale_script["segments"][0]["novel_text"] = "旁白已修改，当前配音不再 fresh。"
+    stale_tts = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=stale_script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+        current_tts_settings=settings,
+    )
+    ProjectArtifactManifestAdapter(project_path).delete_entry(ArtifactKey.episode_audio(1, "E1S01"))
+    unavailable_tts = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+        current_tts_settings=settings,
     )
 
     assert long_basis == same_tier
     assert shorter_tier != long_basis
+    assert stale_tts == long_basis
+    assert unavailable_tts == long_basis

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lib.artifact_manifest import (
+    ArtifactBasisDescriptor,
+    ArtifactKey,
+    ArtifactManifest,
+    ProjectArtifactManifestAdapter,
+    compose_video_artifact_basis,
+)
+from lib.generation_queue import CompensableGenerationResult
+from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
+from lib.speech_artifact_provenance import (
+    build_video_duration_basis,
+    build_video_speech_basis,
+    project_character_voice_evidence,
+)
+from lib.speech_composition import admit_script_unit
+from lib.version_manager import PaidVersionCommit, VersionManager
+from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
+from server.services import video_artifact_currency
+from server.services.video_artifact_currency import (
+    VideoArtifactCommitter,
+    build_current_video_artifact_basis,
+    finalize_selected_video_result,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_formal_selection_preparation_turns_tts_validation_failure_into_history_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failure = RuntimeError("generated video does not cover current TTS")
+    validate = AsyncMock(side_effect=failure)
+    monkeypatch.setattr(video_artifact_currency, "validate_generated_video_covers_current_tts", validate)
+    committer = VideoArtifactCommitter(
+        project_manager=MagicMock(),
+        project_name="demo",
+        project_path=tmp_path,
+        versions=MagicMock(),
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="p",
+    )
+    staged = tmp_path / "staged.mp4"
+    staged.write_bytes(b"paid-video")
+    metadata = {
+        "execution_script_file": "episode_1.json",
+        "execution_narration": {"delivery": "use_tts"},
+    }
+
+    await committer.prepare_selection(staged, 8, metadata)
+
+    assert committer.selection_error is failure
+    validate.assert_awaited_once_with(
+        project_name="demo",
+        script_file="episode_1.json",
+        request_duration_seconds=8,
+        output_path=staged,
+        resource_type="videos",
+        resource_id="E1S01",
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_formal_selection_validation_archives_paid_video_without_current_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_path = tmp_path / "demo"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+    staged = current.with_name(".paid-staged.mp4")
+    staged.write_bytes(b"short-paid-video")
+    versions = VersionManager(project_path)
+    old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
+    frozen = ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(
+            visual=build_video_duration_basis(1),
+            speech=build_video_duration_basis(2),
+            duration=build_video_duration_basis(8),
+        )
+    )
+
+    class _PM:
+        @contextmanager
+        def locked_project_script_snapshot(self, *_args):
+            yield {}, {}
+
+    failure = RuntimeError("short output")
+    monkeypatch.setattr(
+        video_artifact_currency,
+        "validate_generated_video_covers_current_tts",
+        AsyncMock(side_effect=failure),
+    )
+    committer = VideoArtifactCommitter(
+        project_manager=_PM(),  # type: ignore[arg-type]
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="p",
+    )
+    metadata = {
+        "artifact_episode": 1,
+        "artifact_video_basis": frozen.to_dict(),
+        "execution_script_file": "episode_1.json",
+        "execution_narration": {"delivery": "use_tts"},
+    }
+
+    await committer.prepare_selection(staged, 8, metadata)
+    outcome = committer(staged, current, 8, metadata)
+
+    assert committer.selection_error is failure
+    assert outcome.selected is False
+    assert current.read_bytes() == b"old-current"
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == old_version
+    assert (project_path / history["versions"][-1]["file"]).read_bytes() == b"short-paid-video"
+
+
+def test_selected_video_cancellation_compensation_restores_media_manifest_and_only_video_asset_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_path = tmp_path / "demo"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+    thumbnail = project_path / "thumbnails" / "scene_E1S01.jpg"
+    thumbnail.parent.mkdir(parents=True)
+    thumbnail.write_bytes(b"old-thumbnail")
+    staged = current.with_name(".new-paid.mp4")
+    staged.write_bytes(b"new-paid")
+    versions = VersionManager(project_path)
+    old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
+    old_basis = ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(
+            visual=build_video_duration_basis(1),
+            speech=build_video_duration_basis(2),
+            duration=build_video_duration_basis(4),
+        )
+    )
+    new_basis = ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(
+            visual=build_video_duration_basis(1),
+            speech=build_video_duration_basis(2),
+            duration=build_video_duration_basis(8),
+        )
+    )
+    adapter = ProjectArtifactManifestAdapter(project_path)
+    ArtifactManifest(adapter).register_descriptor(
+        ArtifactKey.episode_video(1, "E1S01"),
+        artifact_path="videos/scene_E1S01.mp4",
+        basis=old_basis,
+    )
+    script = {
+        "episode": 1,
+        "content_mode": "narration",
+        "segments": [
+            {
+                "segment_id": "E1S01",
+                "novel_text": "n",
+                "generated_assets": {
+                    "video_clip": "videos/old.mp4",
+                    "video_uri": "provider://old",
+                    "video_thumbnail": "thumbnails/scene_E1S01.jpg",
+                    "status": "completed",
+                    "unrelated": "keep",
+                },
+            }
+        ],
+    }
+    project = {"episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}]}
+
+    class _PM:
+        @contextmanager
+        def locked_project_script_snapshot(self, *_args):
+            yield project, script
+
+        @contextmanager
+        def locked_episode_script(self, _name, resolve_script_file, **kwargs):
+            resolve_script_file(project)
+            yield script
+            if callback := kwargs.get("on_commit"):
+                callback(project_path / "scripts" / "episode_1.json")
+
+        @staticmethod
+        def update_scene_status(item):
+            item["generated_assets"]["status"] = "completed"
+
+    monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", lambda **_kwargs: new_basis)
+    committer = VideoArtifactCommitter(
+        project_manager=_PM(),  # type: ignore[arg-type]
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="new",
+    )
+    metadata = {
+        "artifact_episode": 1,
+        "artifact_video_basis": new_basis.to_dict(),
+        "execution_script_file": "episode_1.json",
+        "execution_narration": {"delivery": "post_production"},
+    }
+
+    outcome = committer(staged, current, 8, metadata)
+    assert outcome.selected is True
+    assets = script["segments"][0]["generated_assets"]
+    assets.update(
+        {
+            "video_clip": "videos/scene_E1S01.mp4",
+            "video_uri": "provider://new",
+            "video_thumbnail": "thumbnails/scene_E1S01.jpg",
+            "unrelated": "concurrent",
+        }
+    )
+    thumbnail.write_bytes(b"new-thumbnail")
+
+    assert committer.compensate_selection() is True
+
+    assert current.read_bytes() == b"old-current"
+    assert versions.get_current_version("videos", "E1S01") == old_version
+    assert adapter.get_entry(ArtifactKey.episode_video(1, "E1S01")).basis_digest == old_basis.digest
+    assert thumbnail.read_bytes() == b"old-thumbnail"
+    assert assets == {
+        "video_clip": "videos/old.mp4",
+        "video_uri": "provider://old",
+        "video_thumbnail": "thumbnails/scene_E1S01.jpg",
+        "status": "completed",
+        "unrelated": "concurrent",
+    }
+
+
+@pytest.mark.asyncio
+async def test_selected_video_finalize_failure_is_compensated_before_reraising() -> None:
+    failure = RuntimeError("finalize failed")
+    committer = MagicMock()
+    committer.outcome = PaidVersionCommit(version=2, selected=True)
+    committer.compensate_selection.return_value = True
+
+    async def _finalize() -> dict[str, object]:
+        raise failure
+
+    with pytest.raises(RuntimeError, match="finalize failed") as caught:
+        await finalize_selected_video_result(committer=committer, finalize=_finalize)
+
+    assert caught.value is failure
+    committer.compensate_selection.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_selected_video_finalize_result_compensates_once_when_terminal_cancellation_wins() -> None:
+    committer = MagicMock()
+    committer.outcome = PaidVersionCommit(version=2, selected=True)
+    committer.compensate_selection.return_value = True
+
+    async def _finalize() -> dict[str, object]:
+        return {"version": 2, "selected_current": True}
+
+    result = await finalize_selected_video_result(committer=committer, finalize=_finalize)
+
+    assert isinstance(result, CompensableGenerationResult)
+    assert result == {"version": 2, "selected_current": True}
+    result.compensate_cancelled()
+    result.compensate_cancelled()
+    committer.compensate_selection.assert_called_once_with()
+
+
+def _storyboard_state(tmp_path: Path) -> tuple[Path, dict, dict, dict[str, object]]:
+    project_path = tmp_path / "demo"
+    storyboard = project_path / "storyboards" / "scene_E1S01.png"
+    storyboard.parent.mkdir(parents=True)
+    storyboard.write_bytes(b"storyboard")
+    project = {
+        "content_mode": "drama",
+        "aspect_ratio": {"videos": "16:9"},
+        "characters": {"阿离": {"voice_style": "清亮"}},
+    }
+    script = {
+        "content_mode": "drama",
+        "episode": 1,
+        "scenes": [
+            {
+                "scene_id": "E1S01",
+                "duration_seconds": 4,
+                "utterances": [{"kind": "dialogue", "speaker": "阿离", "text": "快走。"}],
+                "video_prompt": {"action": "她冲出门", "camera_motion": "Track"},
+                "generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"},
+            }
+        ],
+    }
+    metadata: dict[str, object] = {
+        "artifact_episode": 1,
+        "artifact_voice_style_speakers": ["阿离"],
+        "artifact_duration_tiers": [4, 8],
+        "artifact_reference_image_limit": None,
+        "execution_script_file": "episode_1.json",
+        "execution_provider_media": [],
+        "execution_narration": {
+            "delivery": "post_production",
+            "tts_status": "not_applicable",
+            "artifact_path": "",
+            "basis_digest": None,
+            "actual_duration_seconds": None,
+        },
+    }
+    return project_path, project, script, metadata
+
+
+def test_storyboard_current_basis_tracks_speech_and_ignores_provider_metadata(tmp_path: Path) -> None:
+    project_path, project, script, metadata = _storyboard_state(tmp_path)
+    versions = VersionManager(project_path)
+    preparation = admit_script_unit("scenes", script["scenes"][0]).preparation
+    visual = build_storyboard_video_artifact_visual_basis(
+        resource_id="E1S01",
+        visual_prompt=script["scenes"][0]["video_prompt"],
+        storyboard_image=project_path / "storyboards" / "scene_E1S01.png",
+        end_frame_image=None,
+        aspect_ratio="16:9",
+    )
+    speech = build_video_speech_basis(
+        preparation,
+        voices=project_character_voice_evidence(
+            preparation,
+            characters=project["characters"],
+            voice_style_speakers=("阿离",),
+        ),
+    )
+    expected = ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(
+            visual=visual,
+            speech=speech,
+            duration=build_video_duration_basis(4),
+        )
+    )
+
+    assert (
+        build_current_video_artifact_basis(
+            project_path=project_path,
+            project=project,
+            script=script,
+            resource_type="videos",
+            resource_id="E1S01",
+            versions=versions,
+            version_metadata={**metadata, "execution_provider_id": "changed-provider"},
+        )
+        == expected
+    )
+
+    changed_project = deepcopy(project)
+    changed_project["characters"]["阿离"]["voice_style"] = "低沉"
+    assert (
+        build_current_video_artifact_basis(
+            project_path=project_path,
+            project=changed_project,
+            script=script,
+            resource_type="videos",
+            resource_id="E1S01",
+            versions=versions,
+            version_metadata=metadata,
+        )
+        != expected
+    )
+
+
+def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(tmp_path: Path) -> None:
+    project_path, project, script, metadata = _storyboard_state(tmp_path)
+    project["content_mode"] = "narration"
+    project["characters"] = {}
+    script = {
+        "content_mode": "narration",
+        "episode": 1,
+        "segments": [
+            {
+                "segment_id": "E1S01",
+                "duration_seconds": 4,
+                "novel_text": "风吹过旷野。",
+                "video_prompt": {"action": "荒野长风", "camera_motion": "Static"},
+                "generated_assets": {"storyboard_image": "storyboards/scene_E1S01.png"},
+            }
+        ],
+    }
+    metadata["artifact_voice_style_speakers"] = []
+    metadata["execution_narration"] = {"delivery": "use_tts"}
+    versions = VersionManager(project_path)
+    audio = project_path / "audio" / "segment_E1S01.wav"
+    audio.parent.mkdir(parents=True)
+    audio.write_bytes(b"audio")
+    preparation = admit_script_unit("segments", script["segments"][0]).preparation
+    audio_basis = build_narration_audio_basis(
+        preparation,
+        TtsSynthesisSettings(provider_id="p", model_id="m", voice="v", speed=1.0),
+    )
+    descriptor = ArtifactBasisDescriptor.from_basis(audio_basis)
+    versions.add_version(
+        "audio",
+        "E1S01",
+        "wind",
+        source_file=audio,
+        artifact_audio_basis=descriptor.to_dict(),
+        tts_actual_duration_seconds=7.0,
+    )
+    ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
+        ArtifactKey.episode_audio(1, "E1S01"),
+        artifact_path="audio/segment_E1S01.wav",
+        basis=descriptor,
+    )
+
+    long_basis = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+    )
+
+    versions.add_version(
+        "audio",
+        "E1S01",
+        "wind shorter",
+        source_file=audio,
+        artifact_audio_basis=descriptor.to_dict(),
+        tts_actual_duration_seconds=6.5,
+    )
+    same_tier = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+    )
+    versions.add_version(
+        "audio",
+        "E1S01",
+        "wind short",
+        source_file=audio,
+        artifact_audio_basis=descriptor.to_dict(),
+        tts_actual_duration_seconds=3.5,
+    )
+    shorter_tier = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+    )
+
+    assert long_basis == same_tier
+    assert shorter_tier != long_basis

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -25,9 +25,10 @@ from lib.speech_artifact_provenance import (
 )
 from lib.speech_composition import admit_script_unit
 from lib.version_manager import PaidVersionCommit, VersionManager
-from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+from lib.video_artifact_facts import VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD, VideoArtifactCurrencyFacts
 from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
 from server.services import video_artifact_currency
+from server.services.artifact_version_restore import is_typed_media_version_restorable
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
     build_current_video_artifact_basis,
@@ -315,6 +316,9 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     )
     metadata = {
         "artifact_video_currency": currency.to_dict(),
+        "execution_checkpoint_schema_version": 3,
+        "execution_duration_seconds": 8,
+        "execution_request_digest": "d" * 64,
         "execution_script_file": "episode_1.json",
         "execution_narration": NarrationExecutionFacts(
             delivery="use_tts",
@@ -333,7 +337,10 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     assert current.read_bytes() == b"old-current"
     history = versions.get_versions("videos", "E1S01")
     assert history["current_version"] == old_version
-    assert (project_path / history["versions"][-1]["file"]).read_bytes() == b"short-paid-video"
+    rejected = history["versions"][-1]
+    assert (project_path / rejected["file"]).read_bytes() == b"short-paid-video"
+    assert rejected[VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD] == "output_duration_unverified"
+    assert is_typed_media_version_restorable("videos", rejected) is False
 
 
 @pytest.mark.parametrize("script_rebound", [False, True])

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -650,7 +650,7 @@ def test_current_video_basis_rejects_an_episode_rebound_to_another_script(tmp_pa
     )
 
 
-def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(tmp_path: Path) -> None:
+def test_current_selected_tts_and_planned_tier_drive_video_currency(tmp_path: Path) -> None:
     project_path, project, script, metadata = _storyboard_state(tmp_path)
     project["content_mode"] = "narration"
     project["characters"] = {}
@@ -768,8 +768,21 @@ def test_current_selected_tts_changes_video_only_when_it_crosses_a_frozen_tier(t
         version_metadata=metadata,
         current_tts_settings=settings,
     )
+    expanded_script = deepcopy(script)
+    expanded_script["segments"][0]["duration_seconds"] = 12
+    unavailable_tts_with_longer_plan = build_current_video_artifact_basis(
+        project_path=project_path,
+        project=project,
+        script=expanded_script,
+        resource_type="videos",
+        resource_id="E1S01",
+        versions=versions,
+        version_metadata=metadata,
+        current_tts_settings=settings,
+    )
 
     assert long_basis == same_tier
     assert shorter_tier != long_basis
-    assert stale_tts == long_basis
-    assert unavailable_tts == long_basis
+    assert stale_tts != long_basis
+    assert unavailable_tts == shorter_tier
+    assert unavailable_tts_with_longer_plan is None

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -84,6 +84,7 @@ async def test_shared_video_completion_returns_nonselected_paid_history_without_
     committer = MagicMock()
     committer.outcome = PaidVersionCommit(version=version, selected=False)
     committer.selection_error = None
+    committer.release_admission_guard = AsyncMock()
     finalize = AsyncMock()
     completed = MagicMock()
 
@@ -102,6 +103,67 @@ async def test_shared_video_completion_returns_nonselected_paid_history_without_
     assert (project_path / str(result["file_path"])).read_bytes() == b"paid"
     finalize.assert_not_awaited()
     completed.assert_called_once_with()
+    committer.release_admission_guard.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_video_admission_guard_spans_selection_and_finalize(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_active = False
+    guard_calls: list[dict[str, str]] = []
+
+    @asynccontextmanager
+    async def _guard(**identity: str):
+        nonlocal guard_active
+        guard_calls.append(identity)
+        guard_active = True
+        try:
+            yield
+        finally:
+            guard_active = False
+
+    monkeypatch.setattr(video_artifact_currency, "generation_admission_lock", _guard)
+    committer = VideoArtifactCommitter(
+        project_manager=MagicMock(),
+        project_name="demo",
+        project_path=tmp_path,
+        versions=MagicMock(),
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="p",
+    )
+    staged = tmp_path / "staged.mp4"
+    staged.write_bytes(b"paid-video")
+    await committer.prepare_selection(
+        staged,
+        8,
+        {
+            "execution_script_file": "episode_1.json",
+            "execution_narration": {"delivery": "post_production"},
+        },
+    )
+    assert guard_active
+    committer.outcome = PaidVersionCommit(version=1, selected=True)
+
+    async def _finalize() -> dict[str, object]:
+        assert guard_active
+        return {"version": 1, "selected_current": True}
+
+    result = await complete_video_artifact_commit(
+        committer=committer,
+        versions=MagicMock(),
+        resource_type="videos",
+        resource_id="E1S01",
+        version=1,
+        video_uri="provider://video",
+        finalize=_finalize,
+    )
+
+    assert result["selected_current"] is True
+    assert guard_calls == [{"project_name": "demo", "script_file": "episode_1.json", "resource_id": "E1S01"}]
+    assert not guard_active
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -356,7 +356,7 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     assert is_typed_media_version_restorable("videos", rejected) is False
 
 
-@pytest.mark.parametrize("script_change", ["none", "rebound", "removed"])
+@pytest.mark.parametrize("script_change", ["none", "rebound", "removed", "legacy"])
 def test_selected_video_cancellation_compensation_restores_media_manifest_and_only_video_asset_fields(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -405,7 +405,9 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
             }
         ],
     }
-    project = {"episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}]}
+    project = (
+        {} if script_change == "legacy" else {"episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}]}
+    )
 
     class _PM:
         @contextmanager
@@ -464,7 +466,7 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
     assert manifest_entry is not None
     assert manifest_entry.basis_digest == old_basis.digest
     assert thumbnail.read_bytes() == b"old-thumbnail"
-    if script_change == "none":
+    if script_change in {"none", "legacy"}:
         assert assets == {
             "video_clip": "videos/old.mp4",
             "video_uri": "provider://old",

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -472,6 +472,98 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
         }
 
 
+def test_selected_video_compensation_preserves_the_original_and_rollback_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_path = tmp_path / "demo"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+    thumbnail = project_path / "thumbnails" / "scene_E1S01.jpg"
+    thumbnail.parent.mkdir(parents=True)
+    thumbnail.write_bytes(b"old-thumbnail")
+    staged = current.with_name(".new-paid.mp4")
+    staged.write_bytes(b"new-paid")
+    versions = VersionManager(project_path)
+    old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
+    old_basis = ArtifactBasisDescriptor.from_basis(
+        compose_video_artifact_basis(
+            visual=build_video_duration_basis(1),
+            speech=build_video_duration_basis(2),
+            duration=build_video_duration_basis(4),
+        )
+    )
+    new_currency = _currency("new", parent_version=old_version)
+    new_basis = new_currency.video_descriptor
+    ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register_descriptor(
+        ArtifactKey.episode_video(1, "E1S01"),
+        artifact_path="videos/scene_E1S01.mp4",
+        basis=old_basis,
+    )
+    script = {
+        "episode": 1,
+        "content_mode": "narration",
+        "segments": [
+            {
+                "segment_id": "E1S01",
+                "novel_text": "n",
+                "generated_assets": {"video_clip": "videos/old.mp4"},
+            }
+        ],
+    }
+    project = {"episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}]}
+
+    class _PM:
+        @contextmanager
+        def locked_project_script_snapshot(self, *_args):
+            yield project, script
+
+        @contextmanager
+        def locked_episode_script(self, _name, resolve_script_file, **kwargs):
+            resolve_script_file(project)
+            yield script
+            if callback := kwargs.get("on_commit"):
+                callback(project_path / "scripts" / "episode_1.json")
+
+        @staticmethod
+        def update_scene_status(item):
+            item["generated_assets"]["status"] = "completed"
+
+    monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", lambda **_kwargs: new_basis)
+    committer = VideoArtifactCommitter(
+        project_manager=_PM(),  # type: ignore[arg-type]
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="new",
+    )
+    metadata = {
+        "artifact_video_currency": new_currency.to_dict(),
+        "execution_script_file": "episode_1.json",
+        "execution_narration": {"delivery": "post_production"},
+    }
+    assert committer(staged, current, 8, metadata).selected is True
+    thumbnail.write_bytes(b"new-thumbnail")
+
+    original_failure = OSError("restore prior thumbnail failed")
+    rollback_failure = OSError("restore selected thumbnail failed")
+    failures = iter((original_failure, rollback_failure))
+
+    def _fail_thumbnail_write(*_args, **_kwargs):
+        raise next(failures)
+
+    monkeypatch.setattr(video_artifact_currency, "atomic_write_bytes", _fail_thumbnail_write)
+
+    with pytest.raises(RuntimeError, match="rollback was incomplete") as caught:
+        committer.compensate_selection()
+
+    assert caught.value.__cause__ is rollback_failure
+    assert rollback_failure.__cause__ is original_failure
+
+
 @pytest.mark.asyncio
 async def test_selected_video_finalize_failure_is_compensated_before_reraising() -> None:
     failure = RuntimeError("finalize failed")

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -356,11 +356,11 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     assert is_typed_media_version_restorable("videos", rejected) is False
 
 
-@pytest.mark.parametrize("script_rebound", [False, True])
+@pytest.mark.parametrize("script_change", ["none", "rebound", "removed"])
 def test_selected_video_cancellation_compensation_restores_media_manifest_and_only_video_asset_fields(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    script_rebound: bool,
+    script_change: str,
 ) -> None:
     project_path = tmp_path / "demo"
     current = project_path / "videos" / "scene_E1S01.mp4"
@@ -451,8 +451,10 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
         }
     )
     thumbnail.write_bytes(b"new-thumbnail")
-    if script_rebound:
+    if script_change == "rebound":
         project["episodes"][0]["script_file"] = "scripts/rebound_episode_1.json"
+    elif script_change == "removed":
+        script["segments"].clear()
 
     assert committer.compensate_selection() is True
 
@@ -462,7 +464,7 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
     assert manifest_entry is not None
     assert manifest_entry.basis_digest == old_basis.digest
     assert thumbnail.read_bytes() == b"old-thumbnail"
-    if not script_rebound:
+    if script_change == "none":
         assert assets == {
             "video_clip": "videos/old.mp4",
             "video_uri": "provider://old",
@@ -470,6 +472,8 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
             "status": "completed",
             "unrelated": "concurrent",
         }
+    elif script_change == "removed":
+        assert script["segments"] == []
 
 
 def test_selected_video_compensation_preserves_the_original_and_rollback_failures(

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -167,6 +167,65 @@ async def test_video_admission_guard_spans_selection_and_finalize(
 
 
 @pytest.mark.asyncio
+async def test_paid_video_guard_acquisition_defers_cancellation_until_the_guard_is_held(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acquire_started = asyncio.Event()
+    allow_acquire = asyncio.Event()
+    guard_active = False
+
+    @asynccontextmanager
+    async def _guard(**_identity: str):
+        nonlocal guard_active
+        acquire_started.set()
+        await allow_acquire.wait()
+        guard_active = True
+        try:
+            yield
+        finally:
+            guard_active = False
+
+    monkeypatch.setattr(video_artifact_currency, "generation_admission_lock", _guard)
+    committer = VideoArtifactCommitter(
+        project_manager=MagicMock(),
+        project_name="demo",
+        project_path=tmp_path,
+        versions=MagicMock(),
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="p",
+    )
+    staged = tmp_path / "staged.mp4"
+    staged.write_bytes(b"paid-video")
+    prepare = asyncio.create_task(
+        committer.prepare_selection(
+            staged,
+            8,
+            {
+                "execution_script_file": "episode_1.json",
+                "execution_narration": {"delivery": "post_production"},
+            },
+        )
+    )
+
+    await acquire_started.wait()
+    prepare.cancel()
+    await asyncio.sleep(0)
+    cancelled_before_guard = prepare.done()
+    allow_acquire.set()
+    try:
+        await prepare
+    except asyncio.CancelledError:
+        pass
+
+    assert not cancelled_before_guard
+    assert guard_active
+    await committer.release_admission_guard()
+    assert not guard_active
+
+
+@pytest.mark.asyncio
 async def test_formal_selection_preparation_turns_execution_tts_validation_failure_into_history_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -17,6 +17,7 @@ from lib.artifact_manifest import (
 )
 from lib.generation_queue import CompensableGenerationResult
 from lib.narration_delivery import TtsSynthesisSettings, build_narration_audio_basis
+from lib.reference_video.execution_checkpoint import NarrationExecutionFacts
 from lib.speech_artifact_provenance import (
     build_video_duration_basis,
     build_video_speech_basis,
@@ -102,18 +103,13 @@ async def test_shared_video_completion_returns_nonselected_paid_history_without_
 
 
 @pytest.mark.asyncio
-async def test_formal_selection_preparation_turns_tts_validation_failure_into_history_only(
+async def test_formal_selection_preparation_turns_execution_tts_validation_failure_into_history_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    failure = RuntimeError("generated video does not cover current TTS")
+    failure = RuntimeError("generated video does not cover execution TTS")
     validate = AsyncMock(side_effect=failure)
-    monkeypatch.setattr(video_artifact_currency, "validate_generated_video_covers_current_tts", validate)
-    monkeypatch.setattr(
-        video_artifact_currency.CurrentTtsSettingsResolver,
-        "resolve_tts_synthesis_settings",
-        AsyncMock(return_value=TtsSynthesisSettings("p", "m", "v", None)),
-    )
+    monkeypatch.setattr(video_artifact_currency, "validate_generated_video_covers_tts_duration", validate)
     committer = VideoArtifactCommitter(
         project_manager=MagicMock(),
         project_name="demo",
@@ -127,20 +123,150 @@ async def test_formal_selection_preparation_turns_tts_validation_failure_into_hi
     staged.write_bytes(b"paid-video")
     metadata = {
         "execution_script_file": "episode_1.json",
-        "execution_narration": {"delivery": "use_tts"},
+        "execution_narration": NarrationExecutionFacts(
+            delivery="use_tts",
+            tts_status="current",
+            artifact_path="audio/segment_E1S01.wav",
+            basis_digest="sha256-v1:" + "a" * 64,
+            actual_duration_seconds=6.2,
+        ).to_dict(),
     }
 
     await committer.prepare_selection(staged, 8, metadata)
 
     assert committer.selection_error is failure
     validate.assert_awaited_once_with(
-        project_name="demo",
-        script_file="episode_1.json",
+        resource_id="E1S01",
         request_duration_seconds=8,
         output_path=staged,
+        tts_actual_duration_seconds=6.2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_formal_selection_validates_frozen_tts_when_current_tts_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A paid result is judged against the TTS accepted at submission, not mutable current state."""
+
+    current_projection = AsyncMock(side_effect=RuntimeError("current TTS became stale"))
+    monkeypatch.setattr(
+        "server.services.narration_delivery_tasks._prepare_current_task_narration_delivery",
+        current_projection,
+    )
+    monkeypatch.setattr(
+        "server.services.narration_delivery_tasks.probe_existing_media_duration_seconds",
+        AsyncMock(return_value=8.0),
+    )
+    monkeypatch.setattr(
+        video_artifact_currency.CurrentTtsSettingsResolver,
+        "resolve_tts_synthesis_settings",
+        AsyncMock(side_effect=ValueError("current TTS is no longer configured")),
+    )
+    project_manager = MagicMock()
+    project_manager.load_project.return_value = {}
+    committer = VideoArtifactCommitter(
+        project_manager=project_manager,
+        project_name="demo",
+        project_path=tmp_path,
+        versions=MagicMock(),
         resource_type="videos",
         resource_id="E1S01",
+        prompt="p",
     )
+    staged = tmp_path / "staged.mp4"
+    staged.write_bytes(b"paid-video")
+    narration = NarrationExecutionFacts(
+        delivery="use_tts",
+        tts_status="current",
+        artifact_path="audio/segment_E1S01.wav",
+        basis_digest="sha256-v1:" + "a" * 64,
+        actual_duration_seconds=6.2,
+    )
+
+    await committer.prepare_selection(
+        staged,
+        8,
+        {
+            "artifact_video_currency": _currency("frozen").to_dict(),
+            "execution_script_file": "episode_1.json",
+            "execution_narration": narration.to_dict(),
+        },
+    )
+
+    assert committer.selection_error is None
+    current_projection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_formal_selection_reloads_current_tts_settings_for_currency_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_path = tmp_path / "demo"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"old-current")
+    staged = current.with_name(".paid-staged.mp4")
+    staged.write_bytes(b"paid-video")
+    versions = VersionManager(project_path)
+    old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
+    currency = _currency("frozen", parent_version=old_version)
+    current_settings = TtsSynthesisSettings("new-provider", "new-model", "new-voice", 1.2)
+
+    class _PM:
+        @staticmethod
+        def load_project(_name):
+            return {}
+
+        @contextmanager
+        def locked_project_script_snapshot(self, *_args):
+            yield {}, {}
+
+    monkeypatch.setattr(
+        video_artifact_currency,
+        "validate_generated_video_covers_tts_duration",
+        AsyncMock(),
+    )
+    resolve_settings = AsyncMock(return_value=current_settings)
+    monkeypatch.setattr(
+        video_artifact_currency.CurrentTtsSettingsResolver,
+        "resolve_tts_synthesis_settings",
+        resolve_settings,
+    )
+
+    def _current_basis(**kwargs):
+        assert kwargs["current_tts_settings"] == current_settings
+        return ArtifactBasisDescriptor.from_basis(build_video_duration_basis(12))
+
+    monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", _current_basis)
+    committer = VideoArtifactCommitter(
+        project_manager=_PM(),  # type: ignore[arg-type]
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="p",
+    )
+    metadata = {
+        "artifact_video_currency": currency.to_dict(),
+        "execution_script_file": "episode_1.json",
+        "execution_narration": NarrationExecutionFacts(
+            delivery="use_tts",
+            tts_status="current",
+            artifact_path="audio/segment_E1S01.wav",
+            basis_digest="sha256-v1:" + "a" * 64,
+            actual_duration_seconds=6.2,
+        ).to_dict(),
+    }
+
+    await committer.prepare_selection(staged, 8, metadata)
+    outcome = committer(staged, current, 8, metadata)
+
+    assert outcome.selected is False
+    resolve_settings.assert_awaited_once_with({})
 
 
 @pytest.mark.asyncio
@@ -170,7 +296,7 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     failure = RuntimeError("short output")
     monkeypatch.setattr(
         video_artifact_currency,
-        "validate_generated_video_covers_current_tts",
+        "validate_generated_video_covers_tts_duration",
         AsyncMock(side_effect=failure),
     )
     monkeypatch.setattr(
@@ -190,7 +316,13 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     metadata = {
         "artifact_video_currency": currency.to_dict(),
         "execution_script_file": "episode_1.json",
-        "execution_narration": {"delivery": "use_tts"},
+        "execution_narration": NarrationExecutionFacts(
+            delivery="use_tts",
+            tts_status="current",
+            artifact_path="audio/segment_E1S01.wav",
+            basis_digest="sha256-v1:" + "a" * 64,
+            actual_duration_seconds=6.2,
+        ).to_dict(),
     }
 
     await committer.prepare_selection(staged, 8, metadata)
@@ -204,9 +336,11 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
     assert (project_path / history["versions"][-1]["file"]).read_bytes() == b"short-paid-video"
 
 
+@pytest.mark.parametrize("script_rebound", [False, True])
 def test_selected_video_cancellation_compensation_restores_media_manifest_and_only_video_asset_fields(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    script_rebound: bool,
 ) -> None:
     project_path = tmp_path / "demo"
     current = project_path / "videos" / "scene_E1S01.mp4"
@@ -297,20 +431,25 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
         }
     )
     thumbnail.write_bytes(b"new-thumbnail")
+    if script_rebound:
+        project["episodes"][0]["script_file"] = "scripts/rebound_episode_1.json"
 
     assert committer.compensate_selection() is True
 
     assert current.read_bytes() == b"old-current"
     assert versions.get_current_version("videos", "E1S01") == old_version
-    assert adapter.get_entry(ArtifactKey.episode_video(1, "E1S01")).basis_digest == old_basis.digest
+    manifest_entry = adapter.get_entry(ArtifactKey.episode_video(1, "E1S01"))
+    assert manifest_entry is not None
+    assert manifest_entry.basis_digest == old_basis.digest
     assert thumbnail.read_bytes() == b"old-thumbnail"
-    assert assets == {
-        "video_clip": "videos/old.mp4",
-        "video_uri": "provider://old",
-        "video_thumbnail": "thumbnails/scene_E1S01.jpg",
-        "status": "completed",
-        "unrelated": "concurrent",
-    }
+    if not script_rebound:
+        assert assets == {
+            "video_clip": "videos/old.mp4",
+            "video_uri": "provider://old",
+            "video_thumbnail": "thumbnails/scene_E1S01.jpg",
+            "status": "completed",
+            "unrelated": "concurrent",
+        }
 
 
 @pytest.mark.asyncio
@@ -346,6 +485,21 @@ async def test_selected_video_finalize_result_compensates_once_when_terminal_can
     result.compensate_cancelled()
     result.compensate_cancelled()
     committer.compensate_selection.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_terminal_cancellation_does_not_silently_ignore_incomplete_video_compensation() -> None:
+    committer = MagicMock()
+    committer.outcome = PaidVersionCommit(version=2, selected=True)
+    committer.compensate_selection.return_value = False
+
+    async def _finalize() -> dict[str, object]:
+        return {"version": 2, "selected_current": True}
+
+    result = await finalize_selected_video_result(committer=committer, finalize=_finalize)
+
+    with pytest.raises(RuntimeError, match="remains selected"):
+        result.compensate_cancelled()
 
 
 def _storyboard_state(tmp_path: Path) -> tuple[Path, dict, dict, dict[str, object]]:
@@ -468,6 +622,24 @@ def test_storyboard_current_basis_tracks_speech_and_ignores_provider_metadata(tm
             version_metadata=metadata,
         )
         != expected
+    )
+
+
+def test_current_video_basis_rejects_an_episode_rebound_to_another_script(tmp_path: Path) -> None:
+    project_path, project, script, metadata = _storyboard_state(tmp_path)
+    project["episodes"] = [{"episode": 1, "script_file": "scripts/rebound_episode_1.json"}]
+
+    assert (
+        build_current_video_artifact_basis(
+            project_path=project_path,
+            project=project,
+            script=script,
+            resource_type="videos",
+            resource_id="E1S01",
+            versions=VersionManager(project_path),
+            version_metadata=metadata,
+        )
+        is None
     )
 
 

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -217,6 +217,7 @@ async def test_paid_video_guard_acquisition_defers_cancellation_until_the_guard_
     try:
         await prepare
     except asyncio.CancelledError:
+        # The guard state remains the assertion target after callers cancel preparation.
         pass
 
     assert not cancelled_before_guard
@@ -483,6 +484,25 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
     monkeypatch: pytest.MonkeyPatch,
     script_change: str,
 ) -> None:
+    compensation_guard_entries = 0
+
+    @contextmanager
+    def _compensation_guard(**identity: str):
+        nonlocal compensation_guard_entries
+        assert identity == {
+            "project_name": "demo",
+            "script_file": "episode_1.json",
+            "resource_id": "E1S01",
+        }
+        compensation_guard_entries += 1
+        yield
+
+    monkeypatch.setattr(
+        video_artifact_currency,
+        "generation_admission_lock_sync",
+        _compensation_guard,
+        raising=False,
+    )
     project_path = tmp_path / "demo"
     current = project_path / "videos" / "scene_E1S01.mp4"
     current.parent.mkdir(parents=True)
@@ -580,6 +600,7 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
         script["segments"].clear()
 
     assert committer.compensate_selection() is True
+    assert compensation_guard_entries == 1
 
     assert current.read_bytes() == b"old-current"
     assert versions.get_current_version("videos", "E1S01") == old_version

--- a/tests/test_video_artifact_currency.py
+++ b/tests/test_video_artifact_currency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -215,6 +216,7 @@ async def test_formal_selection_reloads_current_tts_settings_for_currency_check(
     old_version = versions.add_version("videos", "E1S01", "old", source_file=current)
     currency = _currency("frozen", parent_version=old_version)
     current_settings = TtsSynthesisSettings("new-provider", "new-model", "new-voice", 1.2)
+    selection_guard_active = False
 
     class _PM:
         @staticmethod
@@ -223,14 +225,24 @@ async def test_formal_selection_reloads_current_tts_settings_for_currency_check(
 
         @contextmanager
         def locked_project_script_snapshot(self, *_args):
-            yield {}, {}
+            nonlocal selection_guard_active
+            selection_guard_active = True
+            try:
+                yield {}, {}
+            finally:
+                selection_guard_active = False
 
     monkeypatch.setattr(
         video_artifact_currency,
         "validate_generated_video_covers_tts_duration",
         AsyncMock(),
     )
-    resolve_settings = AsyncMock(return_value=current_settings)
+
+    async def _resolve_settings(_project):
+        assert selection_guard_active
+        return current_settings
+
+    resolve_settings = AsyncMock(side_effect=_resolve_settings)
     monkeypatch.setattr(
         video_artifact_currency.CurrentTtsSettingsResolver,
         "resolve_tts_synthesis_settings",
@@ -264,7 +276,8 @@ async def test_formal_selection_reloads_current_tts_settings_for_currency_check(
     }
 
     await committer.prepare_selection(staged, 8, metadata)
-    outcome = committer(staged, current, 8, metadata)
+    resolve_settings.assert_not_awaited()
+    outcome = await asyncio.to_thread(committer, staged, current, 8, metadata)
 
     assert outcome.selected is False
     resolve_settings.assert_awaited_once_with({})

--- a/tests/test_video_artifact_facts.py
+++ b/tests/test_video_artifact_facts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import replace
 
 import pytest
 
@@ -90,6 +91,11 @@ def test_video_artifact_currency_rejects_incoherent_components_and_request_tier(
             reference_image_limit=None,
             parent_version=0,
         )
+
+
+def test_video_artifact_currency_rejects_non_integer_duration_tier_as_value_error() -> None:
+    with pytest.raises(ValueError, match="duration_tiers"):
+        replace(_facts(), duration_tiers=(4, "8"))
 
 
 def test_video_artifact_currency_accepts_unlimited_reference_projection_but_rejects_invalid_limits() -> None:

--- a/tests/test_video_artifact_facts.py
+++ b/tests/test_video_artifact_facts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from lib.artifact_manifest import ArtifactBasis, compose_video_artifact_basis
+from lib.speech_artifact_provenance import build_video_duration_basis
+from lib.video_artifact_facts import VideoArtifactCurrencyFacts
+
+pytestmark = pytest.mark.unit
+
+
+def _facts() -> VideoArtifactCurrencyFacts:
+    visual = ArtifactBasis.build(
+        "artifact-visual/video-storyboard",
+        kind_version=1,
+        inputs={
+            "resource_id": "E1S01",
+            "visual_prompt": {"action": "run", "camera_motion": "Static"},
+            "canvas": {"aspect_ratio": "9:16"},
+            "frames": [{"role": "storyboard", "sha256": "a" * 64}],
+        },
+    )
+    speech = ArtifactBasis.build(
+        "artifact-speech/video",
+        kind_version=1,
+        inputs={
+            "mode": "character_speech",
+            "utterances": [{"speaker": "阿离", "text": "走。"}],
+            "voices": [{"speaker": "阿离", "voice_style": "", "reference_audio_digest": None}],
+        },
+    )
+    duration = build_video_duration_basis(8)
+    return VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=8,
+        visual_basis=visual,
+        speech_basis=speech,
+        duration_basis=duration,
+        video_basis=compose_video_artifact_basis(visual=visual, speech=speech, duration=duration),
+        voice_style_speakers=("阿离",),
+        duration_tiers=(4, 8, 12),
+        reference_image_limit=None,
+        parent_version=3,
+    )
+
+
+def test_video_artifact_currency_round_trip_preserves_complete_verified_evidence() -> None:
+    facts = _facts()
+
+    restored = VideoArtifactCurrencyFacts.from_dict(facts.to_dict())
+
+    assert restored == facts
+    assert restored.video_descriptor.digest == facts.video_basis.digest
+    assert restored.currency_digest.startswith("sha256-v1:")
+
+
+def test_video_artifact_currency_rejects_component_input_and_route_knob_tampering() -> None:
+    raw = _facts().to_dict()
+    changed_visual = deepcopy(raw)
+    changed_visual["visual_basis"]["inputs"]["unit"] = "E1S02"  # type: ignore[index]
+    with pytest.raises(ValueError, match="self-verifying"):
+        VideoArtifactCurrencyFacts.from_dict(changed_visual)
+
+    changed_token = deepcopy(raw)
+    changed_token["parent_version"] = 4
+    with pytest.raises(ValueError, match="currency digest"):
+        VideoArtifactCurrencyFacts.from_dict(changed_token)
+
+
+def test_video_artifact_currency_rejects_incoherent_components_and_request_tier() -> None:
+    facts = _facts()
+    other_duration = build_video_duration_basis(12)
+
+    with pytest.raises(ValueError, match="paid request tier"):
+        VideoArtifactCurrencyFacts(
+            episode=facts.episode,
+            request_duration_seconds=8,
+            visual_basis=facts.visual_basis,
+            speech_basis=facts.speech_basis,
+            duration_basis=other_duration,
+            video_basis=compose_video_artifact_basis(
+                visual=facts.visual_basis,
+                speech=facts.speech_basis,
+                duration=other_duration,
+            ),
+            voice_style_speakers=facts.voice_style_speakers,
+            duration_tiers=(8, 12),
+            reference_image_limit=None,
+            parent_version=0,
+        )
+
+
+def test_video_artifact_currency_accepts_unlimited_reference_projection_but_rejects_invalid_limits() -> None:
+    facts = _facts()
+    reference = ArtifactBasis.build(
+        "artifact-visual/video-reference",
+        kind_version=1,
+        inputs={
+            "unit_id": "E1U1",
+            "visual_shots": [],
+            "style": "",
+            "canvas": {"aspect_ratio": "9:16"},
+            "request_references": [],
+        },
+    )
+    video = compose_video_artifact_basis(
+        visual=reference,
+        speech=facts.speech_basis,
+        duration=facts.duration_basis,
+    )
+
+    unlimited = VideoArtifactCurrencyFacts(
+        episode=1,
+        request_duration_seconds=8,
+        visual_basis=reference,
+        speech_basis=facts.speech_basis,
+        duration_basis=facts.duration_basis,
+        video_basis=video,
+        voice_style_speakers=facts.voice_style_speakers,
+        duration_tiers=facts.duration_tiers,
+        reference_image_limit=None,
+        parent_version=0,
+    )
+    assert VideoArtifactCurrencyFacts.from_dict(unlimited.to_dict()) == unlimited
+
+    with pytest.raises(ValueError, match="unlimited or non-negative"):
+        VideoArtifactCurrencyFacts(
+            episode=1,
+            request_duration_seconds=8,
+            visual_basis=reference,
+            speech_basis=facts.speech_basis,
+            duration_basis=facts.duration_basis,
+            video_basis=video,
+            voice_style_speakers=facts.voice_style_speakers,
+            duration_tiers=facts.duration_tiers,
+            reference_image_limit=-1,
+            parent_version=0,
+        )


### PR DESCRIPTION
## Summary

- 用类型化 Artifact Manifest 统一追踪旁白音频与视频的来源依据，并为字幕、成片提供共享的 provenance builder
- 付费视频按提交时冻结的旁白事实验收，同时按完成时的当前状态决定是否选中；普通、续跑与取消路径共享同一提交及补偿语义
- 保留失效或竞争失败的付费历史，并在没有当前旁白音频时仍可进入版本历史恢复

## Validation

- uv run python -m pytest — 9578 passed, 2 skipped
- uv run ruff check .
- uv run ruff format --check .
- uv run basedpyright — 0 errors
- uv run lint-imports
- pnpm check — 149 files / 1794 tests passed
- pnpm build

Closes #1747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持音频、视频和参考视频版本恢复，并同步更新项目内容。
  * 显示版本可恢复状态，无法验证来源的历史版本将限制恢复。
  * 增强视频、字幕和演示文稿的版本追踪与一致性校验。
  * 音频和视频生成支持历史归档及当前版本选择。
  * 新增生成任务排队控制，避免同一内容并发生成。

* **问题修复**
  * 未选择旁白音频时，仍可访问版本管理功能。
  * 活跃生成任务期间阻止冲突的音频恢复，并提供明确提示。
  * 提交、恢复或取消失败时，保留历史记录并恢复原有状态。
  * 参考音频更新与删除操作更加安全，避免并发导致数据不一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->