### PR TITLE
ci(website): 文档站变更自动校验翻译一致性与双语构建

### DIFF
--- a/.github/actions/domain-filter/action.yml
+++ b/.github/actions/domain-filter/action.yml
@@ -1,9 +1,9 @@
 name: domain-filter
 description: >-
-  按变更域裁剪 CI：输出 backend / frontend / docker 三个域是否被本次变更命中。
-  workflow 域（CI 配置本身）变更时保守全量触发；full 输入为 true 时跳过路径
-  过滤，所有域视为已变更（供 nightly 全量与 schedule 事件使用——paths-filter
-  不支持 schedule 事件的变更比对）。
+  按变更域裁剪 CI：输出 backend / frontend / docker / website 四个域是否被本次
+  变更命中。workflow 域（CI 配置本身）变更时保守全量触发；full 输入为 true 时
+  跳过路径过滤，所有域视为已变更（供 nightly 全量与 schedule 事件使用——
+  paths-filter 不支持 schedule 事件的变更比对）。
 
 inputs:
   full:
@@ -21,6 +21,9 @@ outputs:
   docker:
     description: 镜像装配域（Dockerfile/.dockerignore 及不属于代码域的 COPY 源）是否变更
     value: ${{ steps.gate.outputs.docker }}
+  website:
+    description: 文档站域（website/ 及上站 README/CONTRIBUTING）是否变更
+    value: ${{ steps.gate.outputs.website }}
 
 runs:
   using: composite
@@ -56,6 +59,13 @@ runs:
             - '.dockerignore'
             - 'public/**'
             - 'README.md'
+          # CONTRIBUTING.md/README.md/README.en.md 不上站，但在翻译 lockfile 的特例映射内
+          # （见 .claude/skills/translate-docs/），改动须当场冒出缺译/滞后报告
+          website:
+            - 'website/**'
+            - 'CONTRIBUTING.md'
+            - 'README.md'
+            - 'README.en.md'
 
     - id: gate
       shell: bash
@@ -66,13 +76,16 @@ runs:
         F_BACKEND: ${{ steps.filter.outputs.backend || 'false' }}
         F_FRONTEND: ${{ steps.filter.outputs.frontend || 'false' }}
         F_DOCKER: ${{ steps.filter.outputs.docker || 'false' }}
+        F_WEBSITE: ${{ steps.filter.outputs.website || 'false' }}
       run: |
         if [[ "$FULL" == "true" || "$F_WORKFLOW" == "true" ]]; then
           echo "backend=true" >> "$GITHUB_OUTPUT"
           echo "frontend=true" >> "$GITHUB_OUTPUT"
           echo "docker=true" >> "$GITHUB_OUTPUT"
+          echo "website=true" >> "$GITHUB_OUTPUT"
         else
           echo "backend=$F_BACKEND" >> "$GITHUB_OUTPUT"
           echo "frontend=$F_FRONTEND" >> "$GITHUB_OUTPUT"
           echo "docker=$F_DOCKER" >> "$GITHUB_OUTPUT"
+          echo "website=$F_WEBSITE" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/domain-filter/action.yml
+++ b/.github/actions/domain-filter/action.yml
@@ -22,7 +22,7 @@ outputs:
     description: 镜像装配域（Dockerfile/.dockerignore 及不属于代码域的 COPY 源）是否变更
     value: ${{ steps.gate.outputs.docker }}
   website:
-    description: 文档站域（website/ 及上站 README/CONTRIBUTING）是否变更
+    description: 文档站域（website/、CONTRIBUTING.md、两个 README 及翻译 skill）是否变更
     value: ${{ steps.gate.outputs.website }}
 
 runs:
@@ -59,13 +59,16 @@ runs:
             - '.dockerignore'
             - 'public/**'
             - 'README.md'
-          # CONTRIBUTING.md/README.md/README.en.md 不上站，但在翻译 lockfile 的特例映射内
-          # （见 .claude/skills/translate-docs/），改动须当场冒出缺译/滞后报告
+          # CONTRIBUTING.md 构建时复制上站；两个 README 不上站，但都在翻译 lockfile 的
+          # 特例映射内，改动须当场冒出缺译/滞后报告。translate-docs skill 目录同样列入：
+          # website-checks 的孤儿译文检测、滞后报告与该 skill 的单测都执行其中的
+          # translation-lock.mjs，脚本单独变更时这些检查必须照常跑。
           website:
             - 'website/**'
             - 'CONTRIBUTING.md'
             - 'README.md'
             - 'README.en.md'
+            - '.claude/skills/translate-docs/**'
 
     - id: gate
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,6 +233,10 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          # 版本取自 website/package.json 的 packageManager（含完整性哈希），不在此重复写死；
+          # 该输入必须显式指定——默认值是仓库根的 package.json，本仓库根目录没有这个文件
+          package_json_file: website/package.json
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,7 @@ jobs:
           fail_ci_if_error: false
 
   website-checks:
-    # 单一 job 覆盖文档站全部把关：CONTRIBUTING 复制前置（否则 gitignore 的中文副本
+    # 单一 job 串起文档站的四道闸：CONTRIBUTING 复制前置（否则 gitignore 的中文副本
     # 缺席，其已提交的英文译文会被误判为孤儿）→ 一致性脚本（孤儿译文 / 缺锚点 /
     # UI JSON key 齐全性，见 website/scripts/check-consistency.mjs）fail →
     # 双 locale build（onBrokenLinks/onBrokenAnchors/onBrokenMarkdownLinks 均 throw）
@@ -264,6 +264,8 @@ jobs:
         run: pnpm run build
 
       - name: Translation lag report
+        # 报告不阻断，也不该被前面的闸门吞掉：闸门红了的 PR 同样要看到缺译/滞后清单
+        if: always()
         run: |
           {
             echo "### 文档翻译滞后清单"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       backend: ${{ steps.domains.outputs.backend }}
       frontend: ${{ steps.domains.outputs.frontend }}
       docker: ${{ steps.domains.outputs.docker }}
+      website: ${{ steps.domains.outputs.website }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -216,6 +217,58 @@ jobs:
           flags: frontend
           fail_ci_if_error: false
 
+  website-checks:
+    # 单一 job 覆盖文档站全部把关：CONTRIBUTING 复制前置（否则 gitignore 的中文副本
+    # 缺席，其已提交的英文译文会被误判为孤儿）→ 一致性脚本（孤儿译文 / 缺锚点 /
+    # UI JSON key 齐全性，见 website/scripts/check-consistency.mjs）fail →
+    # 双 locale build（onBrokenLinks/onBrokenAnchors/onBrokenMarkdownLinks 均 throw）
+    # fail → 缺译/滞后清单写 step summary，不阻断。
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: website/.node-version
+          cache: "pnpm"
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - name: Translation lock unit tests
+        run: node --test .claude/skills/translate-docs/scripts/translation-lock.test.mjs
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync CONTRIBUTING copy
+        working-directory: website
+        run: pnpm run sync-contributing
+
+      - name: Consistency check (orphan translations / anchors / UI JSON keys)
+        working-directory: website
+        run: pnpm run check-consistency
+
+      - name: Build (zh-Hans + en)
+        working-directory: website
+        run: pnpm run build
+
+      - name: Translation lag report
+        run: |
+          {
+            echo "### 文档翻译滞后清单"
+            echo
+            echo '```'
+            node .claude/skills/translate-docs/scripts/translation-lock.mjs status
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   docker-verify:
     # PR 阶段的镜像装配验证：只构建 amd64、不登录、不推送。
     # 应用正确性由 backend/frontend 测试保证，这里只验证镜像能构建、容器能起、
@@ -343,6 +396,7 @@ jobs:
         postgres-compat,
         frontend-tests,
         docker-verify,
+        website-checks,
         release-integrity,
       ]
     runs-on: ubuntu-latest

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
     "sync-contributing": "node scripts/sync-contributing.mjs",
+    "check-consistency": "node scripts/check-consistency.mjs",
     "typecheck": "tsc",
     "write-translations": "docusaurus write-translations"
   },

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -34,7 +34,7 @@ function checkOrphanTranslations() {
 // 还是改回 Markdown 标题；已登记文件若不再含 JSX 标题也会 fail（登记项过期，须及时摘除）。
 const JSX_HEADING_EXEMPT_FILES = new Set(["docs/index.mdx"]);
 
-const FENCE = /^\s*(```|~~~)/;
+const FENCE = /^ {0,3}(```|~~~)/;
 const HEADING = /^ {0,3}(#{1,6})\s+(.*?)\s*$/;
 const ANCHOR_SUFFIX = /\{#([a-z0-9-]+)\}$/;
 const JSX_HEADING = /<h[1-6][\s/>]/i;

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// CI 一致性闸门：孤儿译文 / 上站文档标题缺显式锚点 / UI JSON key 齐全性。
+// 三项任一命中即非零退出；缺译/滞后清单不在本脚本范围（translation-lock.mjs status 已覆盖，
+// 由 workflow 单独一步写入 step summary，不阻断构建）。
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const websiteDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(websiteDir, "..");
+
+function toPosix(path) {
+  return path.split(sep).join("/");
+}
+
+// ---- 1. 孤儿译文：委托给翻译 skill 的唯一真相源（.claude/skills/translate-docs/），不重复实现。 ----
+
+function checkOrphanTranslations() {
+  const lockScript = resolve(repoRoot, ".claude/skills/translate-docs/scripts/translation-lock.mjs");
+  const output = execFileSync(process.execPath, [lockScript, "status", "--root", repoRoot, "--json"], {
+    encoding: "utf8",
+  });
+  const orphans = JSON.parse(output).filter((item) => item.state === "orphan");
+  return orphans.map((item) => `孤儿译文：${item.target}（源 ${item.source} 已不存在）`);
+}
+
+// ---- 2. 上站文档标题缺显式锚点 ----
+//
+// 全部标题须带 `{#id}`（两 locale 共用锚点作为链接目标）。index.mdx 的首页卡片标题是 JSX
+// `<h2>`，`{#id}` 语法在 JSX 里不生效，无法补锚点。这里显式登记豁免文件，而不是让扫描器
+// 对 JSX 标题沉默：新增 .mdx 若引入未登记的 JSX 标题会在此处 fail，逼审查者显式决定豁免
+// 还是改回 Markdown 标题；已登记文件若不再含 JSX 标题也会 fail（登记项过期，须及时摘除）。
+const JSX_HEADING_EXEMPT_FILES = new Set(["docs/index.mdx"]);
+
+const FENCE = /^\s*(```|~~~)/;
+const HEADING = /^(#{1,6})\s+(.*?)\s*$/;
+const ANCHOR_SUFFIX = /\{#([a-z0-9-]+)\}$/;
+const JSX_HEADING = /<h[1-6][\s/>]/i;
+
+function walkDocFiles(directory) {
+  const absoluteDirectory = resolve(websiteDir, directory);
+  if (!existsSync(absoluteDirectory)) return [];
+  return readdirSync(absoluteDirectory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(absoluteDirectory, entry.name);
+    if (entry.isDirectory()) return walkDocFiles(toPosix(relative(websiteDir, path)));
+    if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) return [];
+    return [toPosix(relative(websiteDir, path))];
+  });
+}
+
+function checkAnchors() {
+  const problems = [];
+  const jsxHeadingFiles = new Set();
+
+  for (const file of walkDocFiles("docs")) {
+    const content = readFileSync(resolve(websiteDir, file), "utf8");
+    const lines = content.split("\n");
+    const seenAnchors = new Set();
+    let fence = "";
+
+    for (const [index, line] of lines.entries()) {
+      const fenceMatch = FENCE.exec(line);
+      if (fenceMatch) {
+        if (!fence) fence = fenceMatch[1];
+        else if (line.trim().startsWith(fence)) fence = "";
+        continue;
+      }
+      if (fence) continue;
+
+      if (JSX_HEADING.test(line)) jsxHeadingFiles.add(file);
+
+      const heading = HEADING.exec(line);
+      if (!heading) continue;
+      const [, , text] = heading;
+      const anchorMatch = ANCHOR_SUFFIX.exec(text);
+      if (!anchorMatch) {
+        problems.push(`${file}:${index + 1} 标题缺少显式锚点 {#id}：${line.trim()}`);
+        continue;
+      }
+      const anchor = anchorMatch[1];
+      if (seenAnchors.has(anchor)) {
+        problems.push(`${file} 锚点 id「${anchor}」在同页内重复`);
+      }
+      seenAnchors.add(anchor);
+    }
+  }
+
+  for (const file of jsxHeadingFiles) {
+    if (!JSX_HEADING_EXEMPT_FILES.has(file)) {
+      problems.push(
+        `${file} 含 JSX 标题标签但未登记在 check-consistency.mjs 的 JSX_HEADING_EXEMPT_FILES 中——` +
+          "要么改回带 {#id} 的 Markdown 标题，要么显式登记豁免",
+      );
+    }
+  }
+  for (const file of JSX_HEADING_EXEMPT_FILES) {
+    if (!jsxHeadingFiles.has(file)) {
+      problems.push(`${file} 登记在 JSX_HEADING_EXEMPT_FILES 中但已不含 JSX 标题标签，登记项已过期，请摘除`);
+    }
+  }
+
+  return problems;
+}
+
+// ---- 3. UI JSON key 齐全性（比照 write-translations 输出比对） ----
+//
+// footer.json 的 `copyright` 键会把 write-translations 运行那一刻的年份写死进英文译文，
+// 而站点配置按当前年份动态求值版权文案——两者逐年错开。故意不提交该键，让其在渲染期
+// 回退到源语言的动态求值，不计入完整性校验。
+const UI_JSON_FILES = [
+  "i18n/en/code.json",
+  "i18n/en/docusaurus-theme-classic/navbar.json",
+  "i18n/en/docusaurus-theme-classic/footer.json",
+  "i18n/en/docusaurus-plugin-content-docs/current.json",
+];
+const KNOWN_OMITTED_KEYS = new Map([["i18n/en/docusaurus-theme-classic/footer.json", new Set(["copyright"])]]);
+
+function readKeys(relativePath) {
+  const path = resolve(websiteDir, relativePath);
+  if (!existsSync(path)) return new Set();
+  return new Set(Object.keys(JSON.parse(readFileSync(path, "utf8"))));
+}
+
+function checkUiJsonKeys() {
+  const before = new Map(UI_JSON_FILES.map((file) => [file, readKeys(file)]));
+
+  try {
+    execFileSync("pnpm", ["exec", "docusaurus", "write-translations", "--locale", "en"], {
+      cwd: websiteDir,
+      stdio: "pipe",
+    });
+  } finally {
+    // write-translations 就地改写委托文件；不管结果如何都把工作树恢复到改动前，
+    // 让后续的双 locale build 只看到仓库里已提交的状态。
+    execFileSync("git", ["checkout", "--", ...UI_JSON_FILES], { cwd: websiteDir });
+  }
+
+  const problems = [];
+  for (const file of UI_JSON_FILES) {
+    const beforeKeys = before.get(file);
+    const omitted = KNOWN_OMITTED_KEYS.get(file) ?? new Set();
+    const missing = [...readKeys(file)].filter((key) => !beforeKeys.has(key) && !omitted.has(key));
+    if (missing.length > 0) {
+      problems.push(`${file} 缺少 write-translations 生成的 key：${missing.join(", ")}`);
+    }
+  }
+  return problems;
+}
+
+const problems = [...checkOrphanTranslations(), ...checkAnchors(), ...checkUiJsonKeys()];
+
+if (problems.length > 0) {
+  console.error("一致性检查未通过：");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exitCode = 1;
+} else {
+  console.log("一致性检查通过：无孤儿译文、标题锚点齐全且唯一、UI JSON key 齐全。");
+}

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -35,7 +35,7 @@ function checkOrphanTranslations() {
 const JSX_HEADING_EXEMPT_FILES = new Set(["docs/index.mdx"]);
 
 const FENCE = /^\s*(```|~~~)/;
-const HEADING = /^(#{1,6})\s+(.*?)\s*$/;
+const HEADING = /^ {0,3}(#{1,6})\s+(.*?)\s*$/;
 const ANCHOR_SUFFIX = /\{#([a-z0-9-]+)\}$/;
 const JSX_HEADING = /<h[1-6][\s/>]/i;
 

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -4,7 +4,7 @@
 // 由 workflow 单独一步写入 step summary，不阻断构建）。
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -124,28 +124,39 @@ function readKeys(relativePath) {
 }
 
 function checkUiJsonKeys() {
+  const problems = [];
   const before = new Map(UI_JSON_FILES.map((file) => [file, readKeys(file)]));
+  // write-translations 会就地改写委托文件。恢复用内存快照按字节写回，而不是 git checkout：
+  // 后者会连同工作区里尚未提交的译文编辑一起抹掉（本地跑这个检查的正是刚编辑完 UI JSON 的人），
+  // 且原本不存在、被 write-translations 新建的文件也无法靠 checkout 清除。
+  const snapshots = new Map(
+    UI_JSON_FILES.map((file) => {
+      const path = resolve(websiteDir, file);
+      return [file, existsSync(path) ? readFileSync(path) : null];
+    }),
+  );
 
   try {
     execFileSync("pnpm", ["exec", "docusaurus", "write-translations", "--locale", "en"], {
       cwd: websiteDir,
       stdio: "pipe",
     });
+    for (const file of UI_JSON_FILES) {
+      const beforeKeys = before.get(file);
+      const omitted = KNOWN_OMITTED_KEYS.get(file) ?? new Set();
+      const missing = [...readKeys(file)].filter((key) => !beforeKeys.has(key) && !omitted.has(key));
+      if (missing.length > 0) {
+        problems.push(`${file} 缺少 write-translations 生成的 key：${missing.join(", ")}`);
+      }
+    }
   } finally {
-    // write-translations 就地改写委托文件；不管结果如何都把工作树恢复到改动前，
-    // 让后续的双 locale build 只看到仓库里已提交的状态。
-    execFileSync("git", ["checkout", "--", ...UI_JSON_FILES], { cwd: websiteDir });
-  }
-
-  const problems = [];
-  for (const file of UI_JSON_FILES) {
-    const beforeKeys = before.get(file);
-    const omitted = KNOWN_OMITTED_KEYS.get(file) ?? new Set();
-    const missing = [...readKeys(file)].filter((key) => !beforeKeys.has(key) && !omitted.has(key));
-    if (missing.length > 0) {
-      problems.push(`${file} 缺少 write-translations 生成的 key：${missing.join(", ")}`);
+    for (const [file, content] of snapshots) {
+      const path = resolve(websiteDir, file);
+      if (content === null) rmSync(path, { force: true });
+      else writeFileSync(path, content);
     }
   }
+
   return problems;
 }
 


### PR DESCRIPTION
Closes #1852

CI 现在会在 PR 触碰文档站内容时自动把关：坏的挡住（孤儿译文 / 上站文档标题缺显式锚点 / UI JSON key 缺失 / 双 locale 构建破坏），慢的放行（缺译与滞后清单只写 step summary）。

## 改了什么

- `domain-filter` 新增 `website` 域，`workflow` 域变更与 `full` 模式照常全量置 true
- 新增单一 `website-checks` job：CONTRIBUTING 复制前置 → 一致性脚本 → 双 locale `docusaurus build` → 滞后清单写 step summary
- `website-checks` 纳入 `ci-required` 聚合 needs
- 新增 `website/scripts/check-consistency.mjs`，孤儿译文判定委托给翻译 skill 的 `translation-lock.mjs`，不重复实现

## 本地审查发现与修复

三处在实现基础上修掉，均已实证：

1. **`pnpm/action-setup` 缺 `package_json_file` 会让 job 在 CI 第一步就挂。** 该 action 的默认值是仓库根 `package.json`，而本仓库根目录没有这个文件；不传 `version` 时它读不到 `packageManager` 就失败。本地因为全局装了 pnpm 而看不出来。已显式指向 `website/package.json`，与 Spec #1848 §1「CI pnpm/action-setup 读它」同源，仍不重复写死版本号。
2. **一致性脚本用 `git checkout --` 复原 UI JSON，会抹掉工作区里未提交的译文编辑。** 本地跑这个检查的正是刚编辑完 UI JSON 的人，实测编辑被静默丢弃。改为内存快照按字节写回，顺带去掉了脚本对 git 的依赖，并能清除 `write-translations` 新建的原本不存在的文件。
3. **滞后报告步骤加 `if: always()`**，闸门失败的 PR 同样看得到缺译/滞后清单。

## 对 Spec §4 的一处有意增补

§4 给 website 域列了四条 paths。本 PR 增加第五条 `.claude/skills/translate-docs/**`：孤儿检测、滞后报告与新接入的单测都执行该目录下的 `translation-lock.mjs`，这层依赖是本票自己引入的，§4 写路径清单时尚不存在。不纳入的话，单独修改该脚本会让 `website-checks` 被跳过，回归要等下一个碰 website 的 PR 才暴露。

## 验证

- `node --test .claude/skills/translate-docs/scripts/translation-lock.test.mjs` — 7 passed
- `pnpm run check-consistency` — 通过，工作区无残留改动；负向验证：临时加一个无锚点标题、删掉 `navbar.json` 一个 key，两种情况都如期非零退出
- `pnpm run build` — zh-Hans 与 en 双 locale 均构建成功，产出 `build/` 与 `build/en/`
- `actionlint .github/workflows/test.yml` — 0 error
- `ci-required` 聚合只检查 `failure` / `cancelled`，`website-checks` 未触发时为 `skipped`，不阻断


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增网站内容一致性检查，涵盖翻译状态、Markdown 标题锚点、重复锚点及界面文案。
  - 网站内容支持中英文构建验证，并检查贡献指南副本同步。
  - 新增翻译滞后报告，便于发现待完善内容。

- **质量改进**
  - 网站相关内容变更将自动触发专属检查流程。
  - 检查结果纳入必需的持续集成质量保障流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->