### PR TITLE
docs(site): 优化中英文站点文案与本地化标题

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -1,22 +1,22 @@
 ---
 id: index
 slug: /
-title: ArcReel 文档
-sidebar_label: 文档首页
+title: ArcReel 文档中心
+sidebar_label: 文档概览
 sidebar_position: 0
 hide_table_of_contents: true
 ---
 
 import Link from "@docusaurus/Link";
 
-ArcReel 是开源、自托管的 AI 视频生产工作台，把小说、剧本或商品素材转化为角色一致、过程可控、成本可追踪的短视频。
+ArcReel 是一个开源、自托管的 AI 视频创作平台，可将小说、剧本或商品素材转化为角色一致、流程可控、成本透明的短视频。
 
 <div className="row homeCards">
   <div className="col col--4">
     <Link className="card homeCard" to="/guide/getting-started">
-      <h2 className="homeCardTitle">快速上手</h2>
+      <h2 className="homeCardTitle">快速开始</h2>
       <p className="homeCardBody">
-        从安装到跑出第一条成片，跟着完整入门教程走一遍。
+        完成安装和基础配置，生成你的第一条视频。
       </p>
     </Link>
   </div>
@@ -24,7 +24,7 @@ ArcReel 是开源、自托管的 AI 视频生产工作台，把小说、剧本�
     <Link className="card homeCard" to="/ops/deployment">
       <h2 className="homeCardTitle">部署与运维</h2>
       <p className="homeCardBody">
-        自托管部署、数据库选型与日常运维的操作手册。
+        了解自托管部署、数据库配置、升级备份和故障排查。
       </p>
     </Link>
   </div>
@@ -32,7 +32,7 @@ ArcReel 是开源、自托管的 AI 视频生产工作台，把小说、剧本�
     <Link className="card homeCard" to="/dev/architecture">
       <h2 className="homeCardTitle">参与贡献</h2>
       <p className="homeCardBody">
-        了解三层架构与代码约定，再动手提交第一个改动。
+        熟悉项目架构与开发规范，参与 ArcReel 开发。
       </p>
     </Link>
   </div>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,8 +2,8 @@ import type * as Preset from "@docusaurus/preset-classic";
 import type { Config } from "@docusaurus/types";
 
 const config: Config = {
-  title: "ArcReel 文档",
-  tagline: "开源、自托管的 AI 视频生产工作台",
+  title: "ArcReel 文档中心",
+  tagline: "开源、自托管的 AI 视频创作平台",
   favicon: "img/favicon.ico",
 
   url: "https://docs.arc-reel.com",
@@ -78,7 +78,7 @@ const config: Config = {
         },
         {
           href: "https://github.com/ArcReel/ArcReel",
-          label: "GitHub",
+          label: "GitHub 仓库",
           position: "right",
         },
       ],
@@ -87,10 +87,10 @@ const config: Config = {
       style: "dark",
       links: [
         {
-          title: "ArcReel",
+          title: "资源",
           items: [
-            { label: "官网", href: "https://arc-reel.com" },
-            { label: "GitHub", href: "https://github.com/ArcReel/ArcReel" },
+            { label: "ArcReel 官网", href: "https://arc-reel.com" },
+            { label: "GitHub 仓库", href: "https://github.com/ArcReel/ArcReel" },
           ],
         },
       ],

--- a/website/i18n/en/code.json
+++ b/website/i18n/en/code.json
@@ -360,5 +360,13 @@
   "theme.tags.tagsPageTitle": {
     "message": "Tags",
     "description": "The title of the tag list page"
+  },
+  "site.title": {
+    "message": "ArcReel Documentation",
+    "description": "The documentation site title used in browser tabs and social cards"
+  },
+  "site.tagline": {
+    "message": "Open-source, self-hosted AI video creation platform",
+    "description": "The documentation site description used in social cards"
   }
 }

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/index.mdx
@@ -2,29 +2,29 @@
 id: index
 slug: /
 title: ArcReel Documentation
-sidebar_label: Documentation Home
+sidebar_label: Documentation Overview
 sidebar_position: 0
 hide_table_of_contents: true
 ---
 
 import Link from "@docusaurus/Link";
 
-ArcReel is an open-source, self-hosted AI video production workspace that turns novels, screenplays, or product assets into short videos with consistent characters, controllable workflows, and trackable costs.
+ArcReel is an open-source, self-hosted AI video creation platform that turns novels, scripts, or product assets into short videos while keeping characters consistent, workflows under control, and costs transparent.
 
 <div className="row homeCards">
   <div className="col col--4">
     <Link className="card homeCard" to="/guide/getting-started">
-      <h2 className="homeCardTitle">Getting Started</h2>
+      <h2 className="homeCardTitle">Get Started</h2>
       <p className="homeCardBody">
-        Follow the complete tutorial from installation to your first finished video.
+        Install ArcReel, complete the basic setup, and create your first video.
       </p>
     </Link>
   </div>
   <div className="col col--4">
     <Link className="card homeCard" to="/ops/deployment">
-      <h2 className="homeCardTitle">Deployment and Operations</h2>
+      <h2 className="homeCardTitle">Deploy and Operate</h2>
       <p className="homeCardBody">
-        A practical guide to self-hosted deployment, database selection, and day-to-day operations.
+        Set up self-hosted deployments, configure the database, plan upgrades and backups, and troubleshoot issues.
       </p>
     </Link>
   </div>
@@ -32,7 +32,7 @@ ArcReel is an open-source, self-hosted AI video production workspace that turns 
     <Link className="card homeCard" to="/dev/architecture">
       <h2 className="homeCardTitle">Contributing</h2>
       <p className="homeCardBody">
-        Learn the three-layer architecture and code conventions before submitting your first change.
+        Learn the architecture and development guidelines, then start contributing to ArcReel.
       </p>
     </Link>
   </div>

--- a/website/i18n/en/docusaurus-theme-classic/footer.json
+++ b/website/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,14 +1,14 @@
 {
-  "link.title.ArcReel": {
-    "message": "ArcReel",
-    "description": "The title of the footer links column with title=ArcReel in the footer"
+  "link.title.资源": {
+    "message": "Resources",
+    "description": "The title of the footer links column with title=资源 in the footer"
   },
-  "link.item.label.官网": {
-    "message": "Official Website",
-    "description": "The label of footer link with label=官网 linking to https://arc-reel.com"
+  "link.item.label.ArcReel 官网": {
+    "message": "ArcReel Website",
+    "description": "The label of footer link with label=ArcReel 官网 linking to https://arc-reel.com"
   },
-  "link.item.label.GitHub": {
-    "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/ArcReel/ArcReel"
+  "link.item.label.GitHub 仓库": {
+    "message": "GitHub Repository",
+    "description": "The label of footer link with label=GitHub 仓库 linking to https://github.com/ArcReel/ArcReel"
   }
 }

--- a/website/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/en/docusaurus-theme-classic/navbar.json
@@ -7,8 +7,8 @@
     "message": "ArcReel",
     "description": "The alt text of navbar logo"
   },
-  "item.label.GitHub": {
-    "message": "GitHub",
-    "description": "Navbar item with label GitHub"
+  "item.label.GitHub 仓库": {
+    "message": "GitHub Repository",
+    "description": "Navbar item with label GitHub 仓库"
   }
 }

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -7,7 +7,7 @@
   "website/docs/guide/jianying-export.md": "ca794fd28109a47ae20c1ce6265acf7fceb3561eea51e03796bf290aea5e662d",
   "website/docs/guide/providers.md": "a21c566431d63a7566962ae4292493ea3f1bab4ab08ba72499229b49fcaabb1e",
   "website/docs/guide/workflows.md": "d12d8ed9a343fd3669b64f74724fbb055a4f1acb57e40c34f333595963ad8913",
-  "website/docs/index.mdx": "7e400554fec23645159da7f462b313d21dbcf93c681a11ccc0de0e299f3b2b24",
+  "website/docs/index.mdx": "36bf1e64555bd31494be410015da65e342dcb6186ff974df3b7404a188ff547c",
   "website/docs/ops/deployment.md": "35bbfd0f148708d2e965d0bf0e8742194438c5f88c6a7fee29dd257b85b22e12",
   "website/docs/ops/migrate-to-postgres.md": "c949c2284ef469d0f0f6a1242c67217d13dce5ff99a9a708a4c7e7acafba65a3"
 }

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
+    "@docusaurus/theme-common": "^3.10.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@docusaurus/preset-classic':
         specifier: ^3.10.2
         version: 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(typescript@5.9.3)
+      '@docusaurus/theme-common':
+        specifier: ^3.10.2
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@easyops-cn/docusaurus-search-local':
         specifier: ^0.55.3
         version: 0.55.3(@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)

--- a/website/src/i18n/siteMetadata.ts
+++ b/website/src/i18n/siteMetadata.ts
@@ -1,0 +1,17 @@
+import { translate } from "@docusaurus/Translate";
+
+export function getSiteTitle(): string {
+  return translate({
+    id: "site.title",
+    message: "ArcReel 文档中心",
+    description: "The documentation site title used in browser tabs and social cards",
+  });
+}
+
+export function getSiteTagline(): string {
+  return translate({
+    id: "site.tagline",
+    message: "开源、自托管的 AI 视频创作平台",
+    description: "The documentation site description used in social cards",
+  });
+}

--- a/website/src/theme/SiteMetadata/index.tsx
+++ b/website/src/theme/SiteMetadata/index.tsx
@@ -1,0 +1,25 @@
+import React, { type ReactNode } from "react";
+import Head from "@docusaurus/Head";
+import OriginalSiteMetadata from "@theme-original/SiteMetadata";
+import { getSiteTagline, getSiteTitle } from "../../i18n/siteMetadata";
+
+export default function SiteMetadata(): ReactNode {
+  const title = getSiteTitle();
+  const tagline = getSiteTagline();
+
+  return (
+    <>
+      <OriginalSiteMetadata children={null} />
+      <Head
+        children={
+          <>
+            <title>{title}</title>
+            <meta property="og:title" content={title} />
+            <meta name="description" content={tagline} />
+            <meta property="og:description" content={tagline} />
+          </>
+        }
+      />
+    </>
+  );
+}

--- a/website/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/website/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -1,0 +1,13 @@
+import React, { type ComponentProps, type ReactNode } from "react";
+import { TitleFormatterProvider } from "@docusaurus/theme-common/internal";
+import type { Props } from "@theme/ThemeProvider/TitleFormatter";
+import { getSiteTitle } from "../../../i18n/siteMetadata";
+
+type Formatter = ComponentProps<typeof TitleFormatterProvider>["formatter"];
+
+const formatter: Formatter = (params) =>
+  params.defaultFormatter({ ...params, siteTitle: getSiteTitle() });
+
+export default function ThemeProviderTitleFormatter({ children }: Props): ReactNode {
+  return <TitleFormatterProvider formatter={formatter} children={children} />;
+}


### PR DESCRIPTION
## 变更摘要

- 统一润色中英文档首页、导航和页脚文案，改为更自然的 SaaS 说明文风。
- 通过 Docusaurus 标题格式化与站点元数据扩展按 locale 呈现 title/tagline，英文页的浏览器标题和社交卡片不再带中文站点后缀。
- 同步英文 UI 翻译、主页译文与 translation lockfile，并声明 swizzle 所需的 Docusaurus 直接依赖。

## 验证

- website: pnpm typecheck
- website: pnpm build（zh-Hans 与 en 产物均生成）
- website: pnpm check-consistency
- translation-lock status: Translations are up to date.
- 产物抽查：英文首页及内页 title、og:title、og:description 无中文；中英文导航、页脚和首页卡片文案按 locale 正确呈现。

Closes #1867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新文档首页标题、平台简介及导航卡片文案，导航链接保持不变。
  * 优化导航栏与页脚标签，明确展示官网和 GitHub 仓库入口。
* **本地化**
  * 补充英文站点标题与标语翻译，完善中英文界面文案。
* **体验优化**
  * 页面标题、描述及社交分享信息现可根据语言自动显示对应内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->