### PR TITLE
docs(ops): 补全数据库迁移与备份指引

### DIFF
--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -95,7 +95,22 @@ POSTGRES_PASSWORD=请设置数据库密码
 # LOG_LEVEL=INFO
 ```
 
-`POSTGRES_PASSWORD` 建议只使用字母和数字，避免 URL 特殊字符影响 `DATABASE_URL` 解析。
+推荐生成只含十六进制字符的密码：
+
+```bash
+openssl rand -hex 16
+```
+
+默认 Compose 会把 `POSTGRES_PASSWORD` 的原始值交给 PostgreSQL，同时把它拼入 `DATABASE_URL` 的密码段。如果密码含有 `@`、`:`、`/`、`?`、`#`、`%` 等 URL 保留字符，连接 URI 中的密码必须做百分号编码。不要把编码后的值直接填入 `POSTGRES_PASSWORD`：PostgreSQL 需要原始密码，只有 URI 需要编码。
+
+当必须使用特殊字符时，在 `.env` 中分开保存原始值与编码值：
+
+```dotenv
+POSTGRES_PASSWORD='p@ss/word'
+POSTGRES_PASSWORD_URLENCODED=p%40ss%2Fword
+```
+
+然后把 `deploy/production/docker-compose.yml` 中 `DATABASE_URL` 的密码部分改为 `${POSTGRES_PASSWORD_URLENCODED}`；PostgreSQL 容器的 `POSTGRES_PASSWORD` 仍保持不变。可用 `urllib.parse.quote(raw_password, safe="")` 生成编码值。如果不想维护这项 Compose 改动，就使用上述十六进制密码。
 
 启动：
 
@@ -122,6 +137,8 @@ curl http://localhost:1241/health
 | `deploy/production/vertex_keys/` | Vertex AI 凭据 |
 | `deploy/production/claude_data/` | Agent 运行时数据 |
 | `deploy/production/.env` | 认证和数据库配置 |
+
+`pgdata/` 只保存 PostgreSQL 集群数据，`projects/` 保存项目元数据和媒体资产，两者都必须持久化且配套备份。生产部署通过 `DATABASE_URL` 使用 PostgreSQL，不会使用 `deploy/production/projects/.arcreel.db`；不要把 SQLite 文件复制进 `pgdata/`，也不要把两个目录当成可相互替代的数据库备份。
 
 ### 2.3 数据库迁移 {#database-migrations}
 
@@ -269,6 +286,8 @@ tar -czf "backups/arcreel-$(date +%Y%m%d-%H%M%S).tar.gz" \
   .env projects vertex_keys claude_data
 ```
 
+服务停止后再归档整个 `projects/`，可以让 `.arcreel.db` 与项目资产保持在同一时点。不要在 ArcReel 写入时只复制 `.arcreel.db`：WAL 模式下，已提交交易可能仍在 `.arcreel.db-wal` 中，丢失或错配 WAL 文件会造成数据丢失甚至损坏。如果无法停服，应使用 SQLite Online Backup API（例如 `sqlite3` 的 `.backup`）或 `VACUUM INTO` 生成一致快照，而不是直接 `cp` 主数据库文件。
+
 恢复服务：
 
 ```bash
@@ -294,8 +313,8 @@ docker compose stop arcreel
 
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
 
-docker compose exec -T postgres \
-  pg_dump -U arcreel -d arcreel \
+docker compose exec -T postgres sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" exec pg_dump -h 127.0.0.1 -U arcreel -d arcreel' \
   > "backups/arcreel-db-${backup_stamp}.sql"
 
 tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
@@ -305,6 +324,8 @@ docker compose start arcreel
 ```
 
 数据库备份和文件备份使用同一时间标签，必须配套保存和恢复。
+
+`pg_dump` 会使用 libpq 的 `PGPASSWORD`。上述命令只在 PostgreSQL 容器内的该次 `pg_dump` 进程中设置它，因此 `docker compose exec -T` 可以非交互执行，也不会把密码展开到宿主机命令行。长期的宿主机备份自动化应改用权限为 `0600` 的 PostgreSQL password file，不要把密码写进脚本或备份文件名。
 
 如果 `tar` 报 `Permission denied`，说明挂载目录中存在由容器内 root 用户创建、宿主机当前用户不可读的文件。可用 `sudo` 重新执行对应的 `tar` 命令，并在完成后限制备份文件的读取权限。
 

--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -271,22 +271,33 @@ image: ghcr.io/arcreel/arcreel:vX.Y.Z
 
 ### 6.1 SQLite 部署备份 {#backup-sqlite}
 
-先停止写入，最简单的方式是短暂停止服务：
+先确认宿主机上的实际数据根目录，再停止写入。默认 Compose 使用 `deploy/projects/`；如果通过 `ARCREEL_DATA_DIR` 和自定义挂载改变了容器内路径，请把 `data_dir` 改为该挂载对应的宿主机绝对路径：
 
 ```bash
 cd deploy
+
+data_dir="$(cd projects && pwd)"
+# 自定义数据目录示例：data_dir="/srv/arcreel/projects"
+
 docker compose stop arcreel
 ```
 
 备份：
 
 ```bash
+backup_stamp="$(date +%Y%m%d-%H%M%S)"
+umask 077
 mkdir -p backups
-tar -czf "backups/arcreel-$(date +%Y%m%d-%H%M%S).tar.gz" \
-  .env projects vertex_keys claude_data
+chmod 700 backups
+
+tar -czf "backups/arcreel-config-${backup_stamp}.tar.gz" \
+  .env vertex_keys claude_data
+
+tar -czf "backups/arcreel-projects-${backup_stamp}.tar.gz" \
+  -C "${data_dir}" .
 ```
 
-服务停止后再归档整个 `projects/`，可以让 `.arcreel.db` 与项目资产保持在同一时点。不要在 ArcReel 写入时只复制 `.arcreel.db`：WAL 模式下，已提交交易可能仍在 `.arcreel.db-wal` 中，丢失或错配 WAL 文件会造成数据丢失甚至损坏。如果无法停服，应使用 SQLite Online Backup API（例如 `sqlite3` 的 `.backup`）或 `VACUUM INTO` 生成一致快照，而不是直接 `cp` 主数据库文件。
+服务停止后再归档整个 `data_dir`，可以让 `.arcreel.db` 与项目资产保持在同一时点。配置归档与数据归档必须使用相同时间标签并配套保存；`umask 077` 与备份目录模式 `0700` 会限制其中凭据和项目资产的读取权限。不要在 ArcReel 写入时只复制 `.arcreel.db`：WAL 模式下，已提交交易可能仍在 `.arcreel.db-wal` 中，丢失或错配 WAL 文件会造成数据丢失甚至损坏。如果无法停服，应使用 SQLite Online Backup API（例如 `sqlite3` 的 `.backup`）或 `VACUUM INTO` 生成一致快照，而不是直接 `cp` 主数据库文件。
 
 恢复服务：
 
@@ -298,7 +309,7 @@ docker compose start arcreel
 
 1. 停止 ArcReel；
 2. 备份当前目录，避免覆盖后无法回退；
-3. 将归档中的 `.env`、`projects/`、`vertex_keys/` 和 `claude_data/` 恢复到原位置；
+3. 将配置归档中的 `.env`、`vertex_keys/` 和 `claude_data/` 恢复到原位置，并将配套数据归档完整解压到空的 `data_dir`；
 4. 启动并检查 `/health`；
 5. 打开几个项目验证图片、视频和版本历史。
 
@@ -308,7 +319,9 @@ docker compose start arcreel
 
 ```bash
 cd "$(git rev-parse --show-toplevel)/deploy/production"
+umask 077
 mkdir -p backups
+chmod 700 backups
 docker compose stop arcreel
 
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
@@ -323,7 +336,7 @@ tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
 docker compose start arcreel
 ```
 
-数据库备份和文件备份使用同一时间标签，必须配套保存和恢复。
+数据库备份和文件备份使用同一时间标签，必须配套保存和恢复。`umask 077` 与备份目录模式 `0700` 会让宿主机重定向生成的 SQL 文件和文件归档仅对当前用户可读写。
 
 `pg_dump` 会使用 libpq 的 `PGPASSWORD`。上述命令只在 PostgreSQL 容器内的该次 `pg_dump` 进程中设置它，因此 `docker compose exec -T` 可以非交互执行，也不会把密码展开到宿主机命令行。长期的宿主机备份自动化应改用权限为 `0600` 的 PostgreSQL password file，不要把密码写进脚本或备份文件名。
 

--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -331,12 +331,12 @@ docker compose exec -T postgres sh -c \
   > "backups/arcreel-db-${backup_stamp}.sql"
 
 tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
-  .env projects vertex_keys claude_data
+  .env docker-compose.yml projects vertex_keys claude_data
 
 docker compose start arcreel
 ```
 
-数据库备份和文件备份使用同一时间标签，必须配套保存和恢复。`umask 077` 与备份目录模式 `0700` 会让宿主机重定向生成的 SQL 文件和文件归档仅对当前用户可读写。
+数据库备份和文件备份使用同一时间标签，必须配套保存和恢复。文件备份包含当前 `docker-compose.yml`，因此特殊字符密码所需的 `DATABASE_URL` 定制也会随 `.env` 一起恢复。`umask 077` 与备份目录模式 `0700` 会让宿主机重定向生成的 SQL 文件和文件归档仅对当前用户可读写。
 
 `pg_dump` 会使用 libpq 的 `PGPASSWORD`。上述命令只在 PostgreSQL 容器内的该次 `pg_dump` 进程中设置它，因此 `docker compose exec -T` 可以非交互执行，也不会把密码展开到宿主机命令行。长期的宿主机备份自动化应改用权限为 `0600` 的 PostgreSQL password file，不要把密码写进脚本或备份文件名。
 
@@ -349,9 +349,12 @@ docker compose start arcreel
 ```bash
 cd "$(git rev-parse --show-toplevel)/deploy/production"
 docker compose stop arcreel
+
+backup_stamp=YYYYMMDD-HHMMSS
+tar -xzf "backups/arcreel-files-${backup_stamp}.tar.gz"
 ```
 
-以下流程会删除目标 `arcreel` 数据库中的现有数据。先确认数据库备份和配套文件备份完整，并在隔离环境演练恢复流程。
+文件归档会恢复 `.env`、`docker-compose.yml`、`projects/` 和运行时目录。以下流程还会删除目标 `arcreel` 数据库中的现有数据；先确认同一 `backup_stamp` 的数据库与文件备份完整，并在隔离环境演练恢复流程。
 
 重建空数据库后再导入，避免与已有表结构或数据冲突：
 
@@ -362,11 +365,11 @@ docker compose exec -T postgres \
 docker compose exec -T postgres \
   createdb -U arcreel --maintenance-db=postgres -O arcreel arcreel
 
-cat backups/arcreel-db-YYYYMMDD-HHMMSS.sql | \
+cat "backups/arcreel-db-${backup_stamp}.sql" | \
   docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U arcreel -d arcreel
 ```
 
-然后恢复对应的 `projects/` 等文件目录，重新启动：
+数据库导入成功后，重新启动：
 
 ```bash
 docker compose start arcreel

--- a/website/docs/ops/migrate-to-postgres.md
+++ b/website/docs/ops/migrate-to-postgres.md
@@ -48,6 +48,8 @@ docker compose -f deploy/docker-compose.yml down
 ### 2. 生成一致备份 {#backup-sqlite}
 
 ```bash
+set -euo pipefail
+
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
 umask 077
 mkdir -p deploy/backups
@@ -56,8 +58,13 @@ chmod 700 deploy/backups
 sqlite3 "${source_projects}/.arcreel.db" \
   ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
 
-sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
-  "PRAGMA quick_check;"
+check_result="$(sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
+  "PRAGMA quick_check;")"
+
+if [ "${check_result}" != "ok" ]; then
+  echo "错误：SQLite 备份 quick_check 未通过" >&2
+  exit 1
+fi
 
 tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
   -C "${source_projects}" .
@@ -65,7 +72,7 @@ tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
 cp deploy/.env "deploy/backups/arcreel-source-${backup_stamp}.env"
 ```
 
-`PRAGMA quick_check;` 必须输出 `ok`。`sqlite3 .backup` 通过 SQLite 备份 API 生成包含已提交 WAL 内容的一致快照；不要在服务运行时只用 `cp` 复制 `.arcreel.db`。SQLite 的 `.arcreel.db-wal` 可能保存已提交但尚未 checkpoint 的交易，与主文件分离可能丢数据或损坏备份。配套的 tar 归档保存 `source_projects` 的完整内容，旁边的 `.env` 副本保存默认部署配置；回滚时两者必须使用相同时间标签。`umask 077` 与目录模式 `0700` 会限制其中凭据和项目资产的读取权限。
+守卫只接受 `PRAGMA quick_check;` 精确返回 `ok`；任一备份、校验、归档或配置复制命令失败都会立即停止迁移。`sqlite3 .backup` 通过 SQLite 备份 API 生成包含已提交 WAL 内容的一致快照；不要在服务运行时只用 `cp` 复制 `.arcreel.db`。SQLite 的 `.arcreel.db-wal` 可能保存已提交但尚未 checkpoint 的交易，与主文件分离可能丢数据或损坏备份。配套的 tar 归档保存 `source_projects` 的完整内容，旁边的 `.env` 副本保存默认部署配置；回滚时两者必须使用相同时间标签。`umask 077` 与目录模式 `0700` 会限制其中凭据和项目资产的读取权限。
 
 ### 3. 准备 PostgreSQL 部署 {#configure-env}
 
@@ -115,10 +122,14 @@ done
 将项目和媒体资产复制到生产目录，但不把 SQLite 数据库复制进去：
 
 ```bash
+set -euo pipefail
+
 mkdir -p deploy/production/projects
 tar -C "${source_projects}" --exclude='.arcreel.db*' -cf - . | \
   tar -C deploy/production/projects -xf -
 ```
+
+严格模式会在目录创建或管道任一端失败时立即停止，禁止继续使用不完整的资产副本。
 
 ### 4. 启动 PostgreSQL {#start-postgresql}
 
@@ -209,7 +220,22 @@ curl -f http://localhost:1241/health
    docker compose -f deploy/production/docker-compose.yml down
    ```
 
-2. 确认 `${source_projects}/.arcreel.db` 和 `deploy/.env` 仍在。如果源目录被修改或损坏，先保留当前目录，再把第 2 步的 `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` 完整解压到空的 `${source_projects}`，并将同一时间标签的 `.env` 副本恢复为 `deploy/.env`；不要只覆盖主 SQLite 文件而留下不匹配的 `-wal` 或 `-shm` 文件。
+2. 确认 `${source_projects}/.arcreel.db` 和 `deploy/.env` 仍在。如果源目录被修改或损坏，先选定第 2 步中同一时间标签的两个备份文件，再执行：
+
+   ```bash
+   set -euo pipefail
+
+   archive="deploy/backups/arcreel-source-YYYYMMDD-HHMMSS.tar.gz"
+   env_backup="deploy/backups/arcreel-source-YYYYMMDD-HHMMSS.env"
+   preserved="${source_projects}.before-rollback-$(date +%Y%m%d-%H%M%S)"
+
+   mv -- "${source_projects}" "${preserved}"
+   mkdir -p "${source_projects}"
+   tar -xzf "${archive}" -C "${source_projects}"
+   cp "${env_backup}" deploy/.env
+   ```
+
+   这会先完整移走旧源目录，再创建空目录并解压，避免保留归档中不存在的旧文件。只有解压成功后才恢复 `.env`；不要只覆盖主 SQLite 文件而留下不匹配的 `-wal` 或 `-shm` 文件。保留 `${preserved}` 直到回滚验证完成。
 
 3. 重新启动 SQLite 默认部署：
 

--- a/website/docs/ops/migrate-to-postgres.md
+++ b/website/docs/ops/migrate-to-postgres.md
@@ -16,7 +16,7 @@ sidebar_position: 2
 | `deploy/projects/` 中的其他文件 | 项目元数据和媒体资产 | 复制到 `deploy/production/projects/` |
 | `deploy/production/pgdata/` | PostgreSQL 集群数据 | 由 PostgreSQL 初始化，不放项目文件或 SQLite 文件 |
 
-如果通过 `ARCREEL_DATA_DIR` 自定义了数据根目录，请把本文中的 `deploy/projects/` 替换为实际源目录。
+以下命令统一用 shell 变量 `source_projects` 指向宿主机上的源数据根目录。默认部署会把它设为 `deploy/projects/` 的绝对路径；如果通过 `ARCREEL_DATA_DIR` 和自定义挂载更改了容器内数据目录，请在第 1 步把 `source_projects` 改为对应的宿主机绝对路径。容器内路径与宿主机路径可能不同，因此本文不会直接从 `.env` 推导该值。迁移期间在同一个 shell 中保留此变量。
 
 ## 前置条件 {#prerequisites}
 
@@ -31,6 +31,15 @@ sidebar_position: 2
 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
+
+source_projects="$(cd deploy/projects && pwd)"
+# 自定义数据目录示例：source_projects="/srv/arcreel/projects"
+
+if [ ! -f "${source_projects}/.arcreel.db" ]; then
+  echo "错误：${source_projects}/.arcreel.db 不存在" >&2
+  exit 1
+fi
+
 docker compose -f deploy/docker-compose.yml down
 ```
 
@@ -40,30 +49,38 @@ docker compose -f deploy/docker-compose.yml down
 
 ```bash
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
+umask 077
 mkdir -p deploy/backups
+chmod 700 deploy/backups
 
-sqlite3 deploy/projects/.arcreel.db \
+sqlite3 "${source_projects}/.arcreel.db" \
   ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
 
 sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
   "PRAGMA quick_check;"
 
 tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
-  -C deploy .env projects
+  -C "${source_projects}" .
+
+cp deploy/.env "deploy/backups/arcreel-source-${backup_stamp}.env"
 ```
 
-`PRAGMA quick_check;` 必须输出 `ok`。`sqlite3 .backup` 通过 SQLite 备份 API 生成包含已提交 WAL 内容的一致快照；不要在服务运行时只用 `cp` 复制 `.arcreel.db`。SQLite 的 `.arcreel.db-wal` 可能保存已提交但尚未 checkpoint 的交易，与主文件分离可能丢数据或损坏备份。配套的 tar 归档用于恢复原 `.env`、数据库边车文件和项目资产。
+`PRAGMA quick_check;` 必须输出 `ok`。`sqlite3 .backup` 通过 SQLite 备份 API 生成包含已提交 WAL 内容的一致快照；不要在服务运行时只用 `cp` 复制 `.arcreel.db`。SQLite 的 `.arcreel.db-wal` 可能保存已提交但尚未 checkpoint 的交易，与主文件分离可能丢数据或损坏备份。配套的 tar 归档保存 `source_projects` 的完整内容，旁边的 `.env` 副本保存默认部署配置；回滚时两者必须使用相同时间标签。`umask 077` 与目录模式 `0700` 会限制其中凭据和项目资产的读取权限。
 
 ### 3. 准备 PostgreSQL 部署 {#configure-env}
 
 创建生产配置：
 
 ```bash
-test ! -e deploy/production/.env
+if [ -e deploy/production/.env ]; then
+  echo "错误：deploy/production/.env 已存在；请保留并人工核对，禁止覆盖" >&2
+  exit 1
+fi
+
 cp deploy/production/.env.example deploy/production/.env
 ```
 
-如果第一条命令失败，说明生产配置已存在；先核对并保留其中的有效设置，不要直接覆盖。
+如果生产配置已存在，上述守卫会显示错误并停止当前 shell；先核对并保留其中的有效设置，不要直接覆盖。
 
 编辑 `deploy/production/.env`，设置认证参数与 PostgreSQL 密码：
 
@@ -76,18 +93,30 @@ POSTGRES_PASSWORD=请设置只含字母和数字的数据库密码
 
 `DATABASE_URL` 已在生产 Compose 中自动拼接。本迁移命令也会把密码放入 pgloader 的 PostgreSQL URI，因此建议用 `openssl rand -hex 16` 生成 URL-safe 密码。如果必须使用特殊字符，需按[部署指南的说明](./deployment.md#postgresql-start)分开保存原始密码与百分号编码后的 URI 密码，不能把编码值直接当作 `POSTGRES_PASSWORD`。下面的 pgloader 命令在存在 `POSTGRES_PASSWORD_URLENCODED` 时优先使用它。
 
-确认以下命令没有输出；如果目标目录已有内容，先停止迁移，不要覆盖：
+运行目录守卫。目标目录不存在或为空时不会输出；发现任一文件（包括隐藏文件）时会显示错误并停止当前 shell：
 
 ```bash
-find deploy/production/projects -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null
-test ! -e deploy/production/pgdata/PG_VERSION
+for target_dir in deploy/production/projects deploy/production/pgdata; do
+  if [ -e "${target_dir}" ] && [ ! -d "${target_dir}" ]; then
+    echo "错误：${target_dir} 已存在且不是目录；停止迁移" >&2
+    exit 1
+  fi
+
+  if [ -d "${target_dir}" ]; then
+    first_entry="$(find "${target_dir}" -mindepth 1 -maxdepth 1 -print -quit)" || exit 1
+    if [ -n "${first_entry}" ]; then
+      echo "错误：${target_dir} 非空；停止迁移且禁止覆盖" >&2
+      exit 1
+    fi
+  fi
+done
 ```
 
 将项目和媒体资产复制到生产目录，但不把 SQLite 数据库复制进去：
 
 ```bash
 mkdir -p deploy/production/projects
-tar -C deploy/projects --exclude='.arcreel.db*' -cf - . | \
+tar -C "${source_projects}" --exclude='.arcreel.db*' -cf - . | \
   tar -C deploy/production/projects -xf -
 ```
 
@@ -110,8 +139,6 @@ docker compose -f deploy/production/docker-compose.yml ps
 在 ArcReel 容器内使用 pgloader 将原 SQLite 数据库直接迁移到 PostgreSQL：
 
 ```bash
-source_projects="$(cd deploy/projects && pwd)"
-
 docker compose -f deploy/production/docker-compose.yml run --rm \
   -v "${source_projects}:/migration-source:ro" \
   arcreel bash -c '
@@ -148,7 +175,7 @@ docker compose -f deploy/production/docker-compose.yml \
 对比 SQLite 中的记录数：
 
 ```bash
-sqlite3 deploy/projects/.arcreel.db "
+sqlite3 "${source_projects}/.arcreel.db" "
   SELECT 'tasks', COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -173,7 +200,7 @@ curl -f http://localhost:1241/health
 
 ## 回滚到 SQLite {#rollback-to-sqlite}
 
-以上迁移流程不会改写原 `deploy/projects/` 和 `deploy/.env`，因此正常回滚应重新启动默认 Compose，而不是修改生产 `.env`：
+以上迁移流程不会改写 `source_projects` 指向的源数据目录和 `deploy/.env`，因此正常回滚应重新启动原 SQLite 部署，而不是修改生产 `.env`。如果在新的 shell 中回滚，先按第 1 步重新设置 `source_projects`：
 
 1. 停止 PostgreSQL 生产部署：
 
@@ -182,7 +209,7 @@ curl -f http://localhost:1241/health
    docker compose -f deploy/production/docker-compose.yml down
    ```
 
-2. 确认 `deploy/projects/.arcreel.db` 和 `deploy/.env` 仍在。如果原目录被修改或损坏，先保留当前副本，再从第 2 步的 `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` 恢复 `.env` 与整个 `projects/`；不要只覆盖主 SQLite 文件而留下不匹配的 `-wal` 或 `-shm` 文件。
+2. 确认 `${source_projects}/.arcreel.db` 和 `deploy/.env` 仍在。如果源目录被修改或损坏，先保留当前目录，再把第 2 步的 `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` 完整解压到空的 `${source_projects}`，并将同一时间标签的 `.env` 副本恢复为 `deploy/.env`；不要只覆盖主 SQLite 文件而留下不匹配的 `-wal` 或 `-shm` 文件。
 
 3. 重新启动 SQLite 默认部署：
 
@@ -196,4 +223,4 @@ curl -f http://localhost:1241/health
 
 5. 在回滚验证完成前，保留 `deploy/production/pgdata/`、`deploy/production/projects/` 和迁移备份以便排查，不要删除。`POSTGRES_PASSWORD` 位于独立的 `deploy/production/.env`，无需从 `deploy/.env` 移除。
 
-如果原来不是默认 Compose，还需将启动环境中的 `DATABASE_URL` 恢复为 SQLite URL 或取消设置，并确认 `ARCREEL_DATA_DIR` 指回原数据目录后再启动。
+如果原来使用自定义 Compose 或数据挂载，还需将启动环境中的 `DATABASE_URL` 恢复为 SQLite URL 或取消设置，确认 `ARCREEL_DATA_DIR` 仍指向容器内原数据目录，并确认该挂载对应宿主机上的 `${source_projects}` 后再启动。

--- a/website/docs/ops/migrate-to-postgres.md
+++ b/website/docs/ops/migrate-to-postgres.md
@@ -6,73 +6,135 @@ sidebar_position: 2
 
 # 从 SQLite 迁移到 PostgreSQL {#migrate-to-postgres}
 
-本文档适用于已使用默认 SQLite 部署 ArcReel、希望切换到 PostgreSQL 的场景。
+本文档适用于已使用默认 Docker + SQLite 部署 ArcReel、希望切换到 `deploy/production/` PostgreSQL 部署的场景。以下命令都从 ArcReel 仓库根目录执行。
+
+迁移前先区分三类数据：
+
+| 路径 | 用途 | 迁移处理 |
+|---|---|---|
+| `deploy/projects/.arcreel.db` | 默认部署的 SQLite 数据库 | 由 pgloader 导入 PostgreSQL |
+| `deploy/projects/` 中的其他文件 | 项目元数据和媒体资产 | 复制到 `deploy/production/projects/` |
+| `deploy/production/pgdata/` | PostgreSQL 集群数据 | 由 PostgreSQL 初始化，不放项目文件或 SQLite 文件 |
+
+如果通过 `ARCREEL_DATA_DIR` 自定义了数据根目录，请把本文中的 `deploy/projects/` 替换为实际源目录。
 
 ## 前置条件 {#prerequisites}
 
 - 已安装 Docker 和 Docker Compose
-- ArcReel 当前使用 SQLite 运行（数据库文件位于 `projects/.arcreel.db`）
+- 已安装 `sqlite3` 命令行工具（先运行 `sqlite3 --version` 确认）
+- ArcReel 当前使用默认 SQLite 部署，数据库位于 `deploy/projects/.arcreel.db`
+- `deploy/production/pgdata/` 与 `deploy/production/projects/` 尚未存放需要保留的生产数据
 
 ## 迁移步骤 {#migration-steps}
 
 ### 1. 停止 ArcReel 服务 {#stop-services}
 
 ```bash
-# 如果通过 Docker 运行
-docker compose down
-
-# 如果通过命令行直接运行，停止 uvicorn 进程
+cd "$(git rev-parse --show-toplevel)"
+docker compose -f deploy/docker-compose.yml down
 ```
 
-### 2. 备份 SQLite 数据库 {#backup-sqlite}
+从此到迁移验证完成前，不要重新启动默认部署，以免 SQLite 数据库与项目资产继续发生写入。
+
+### 2. 生成一致备份 {#backup-sqlite}
 
 ```bash
-cp projects/.arcreel.db projects/.arcreel.db.bak
+backup_stamp="$(date +%Y%m%d-%H%M%S)"
+mkdir -p deploy/backups
+
+sqlite3 deploy/projects/.arcreel.db \
+  ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
+
+sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
+  "PRAGMA quick_check;"
+
+tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
+  -C deploy .env projects
 ```
 
-### 3. 配置环境变量 {#configure-env}
+`PRAGMA quick_check;` 必须输出 `ok`。`sqlite3 .backup` 通过 SQLite 备份 API 生成包含已提交 WAL 内容的一致快照；不要在服务运行时只用 `cp` 复制 `.arcreel.db`。SQLite 的 `.arcreel.db-wal` 可能保存已提交但尚未 checkpoint 的交易，与主文件分离可能丢数据或损坏备份。配套的 tar 归档用于恢复原 `.env`、数据库边车文件和项目资产。
 
-在 `.env` 中新增以下变量（用于 docker-compose 中 PostgreSQL 容器的初始化）：
+### 3. 准备 PostgreSQL 部署 {#configure-env}
+
+创建生产配置：
+
+```bash
+test ! -e deploy/production/.env
+cp deploy/production/.env.example deploy/production/.env
+```
+
+如果第一条命令失败，说明生产配置已存在；先核对并保留其中的有效设置，不要直接覆盖。
+
+编辑 `deploy/production/.env`，设置认证参数与 PostgreSQL 密码：
 
 ```env
-POSTGRES_PASSWORD=你的数据库密码
+AUTH_USERNAME=admin
+AUTH_PASSWORD=请设置强密码
+AUTH_TOKEN_SECRET=请设置长期固定的随机密钥
+POSTGRES_PASSWORD=请设置只含字母和数字的数据库密码
 ```
 
-> `DATABASE_URL` 无需手动设置，已在 `docker-compose.yml` 中通过 `POSTGRES_PASSWORD` 自动拼接。
+`DATABASE_URL` 已在生产 Compose 中自动拼接。本迁移命令也会把密码放入 pgloader 的 PostgreSQL URI，因此建议用 `openssl rand -hex 16` 生成 URL-safe 密码。如果必须使用特殊字符，需按[部署指南的说明](./deployment.md#postgresql-start)分开保存原始密码与百分号编码后的 URI 密码，不能把编码值直接当作 `POSTGRES_PASSWORD`。下面的 pgloader 命令在存在 `POSTGRES_PASSWORD_URLENCODED` 时优先使用它。
+
+确认以下命令没有输出；如果目标目录已有内容，先停止迁移，不要覆盖：
+
+```bash
+find deploy/production/projects -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null
+test ! -e deploy/production/pgdata/PG_VERSION
+```
+
+将项目和媒体资产复制到生产目录，但不把 SQLite 数据库复制进去：
+
+```bash
+mkdir -p deploy/production/projects
+tar -C deploy/projects --exclude='.arcreel.db*' -cf - . | \
+  tar -C deploy/production/projects -xf -
+```
 
 ### 4. 启动 PostgreSQL {#start-postgresql}
 
 先只启动数据库服务：
 
 ```bash
-docker compose up -d postgres
+docker compose -f deploy/production/docker-compose.yml up -d postgres
 ```
 
 等待健康检查通过：
 
 ```bash
-docker compose ps  # 确认 postgres 状态为 healthy
+docker compose -f deploy/production/docker-compose.yml ps
 ```
 
 ### 5. 迁移数据 {#migrate-data}
 
-在 ArcReel 容器内使用 pgloader 将 SQLite 数据直接迁移到 PostgreSQL：
+在 ArcReel 容器内使用 pgloader 将原 SQLite 数据库直接迁移到 PostgreSQL：
 
 ```bash
-docker compose run --rm arcreel bash -c "
-  apt-get update && apt-get install -y --no-install-recommends pgloader &&
-  pgloader sqlite:///app/projects/.arcreel.db \
-           postgresql://arcreel:\${POSTGRES_PASSWORD}@postgres:5432/arcreel
-"
+source_projects="$(cd deploy/projects && pwd)"
+
+docker compose -f deploy/production/docker-compose.yml run --rm \
+  -v "${source_projects}:/migration-source:ro" \
+  arcreel bash -c '
+    apt-get update &&
+    apt-get install -y --no-install-recommends pgloader &&
+    pgloader sqlite:///migration-source/.arcreel.db \
+             "postgresql://arcreel:${POSTGRES_PASSWORD_URLENCODED:-$POSTGRES_PASSWORD}@postgres:5432/arcreel"
+  '
 ```
 
-> pgloader 会自动处理 SQLite 与 PostgreSQL 之间的类型和语法差异（布尔值、时间格式等），
-> 并跳过已存在的表结构，只导入数据。
+:::danger
+
+**不要对已有数据的目标重复执行。** pgloader 的 SQLite 默认选项包含 `include drop`：它会用 `CASCADE` 删除目标中与源数据库同名的表，再重建结构和导入数据。这不是“跳过现有表”。只对本流程刚初始化的空 `arcreel` 数据库执行一次。如果迁移失败，先确认目标没有需要保留的数据，重建空目标后再重试；不要在 ArcReel 已经向 PostgreSQL 写入数据后重跑。
+
+:::
+
+pgloader 会自动处理 SQLite 与 PostgreSQL 之间的常见类型和语法差异，并重置导入表的序列。
 
 ### 6. 验证数据 {#verify-data}
 
 ```bash
-docker compose exec postgres psql -U arcreel -d arcreel -c "
+docker compose -f deploy/production/docker-compose.yml \
+  exec postgres psql -U arcreel -d arcreel -c "
   SELECT 'tasks' AS tbl, COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -86,7 +148,7 @@ docker compose exec postgres psql -U arcreel -d arcreel -c "
 对比 SQLite 中的记录数：
 
 ```bash
-sqlite3 projects/.arcreel.db "
+sqlite3 deploy/projects/.arcreel.db "
   SELECT 'tasks', COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -100,7 +162,9 @@ sqlite3 projects/.arcreel.db "
 ### 7. 启动完整服务 {#start-all-services}
 
 ```bash
-docker compose up -d
+docker compose -f deploy/production/docker-compose.yml up -d
+docker compose -f deploy/production/docker-compose.yml ps
+curl -f http://localhost:1241/health
 ```
 
 访问 `http://<你的IP>:1241` 验证服务正常。
@@ -109,8 +173,27 @@ docker compose up -d
 
 ## 回滚到 SQLite {#rollback-to-sqlite}
 
-如果需要回退：
+以上迁移流程不会改写原 `deploy/projects/` 和 `deploy/.env`，因此正常回滚应重新启动默认 Compose，而不是修改生产 `.env`：
 
-1. 停止服务：`docker compose down`
-2. 恢复备份：`cp projects/.arcreel.db.bak projects/.arcreel.db`
-3. 移除 `.env` 中的 `POSTGRES_PASSWORD`，不使用 `docker-compose.yml` 中的 PostgreSQL 配置启动
+1. 停止 PostgreSQL 生产部署：
+
+   ```bash
+   cd "$(git rev-parse --show-toplevel)"
+   docker compose -f deploy/production/docker-compose.yml down
+   ```
+
+2. 确认 `deploy/projects/.arcreel.db` 和 `deploy/.env` 仍在。如果原目录被修改或损坏，先保留当前副本，再从第 2 步的 `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` 恢复 `.env` 与整个 `projects/`；不要只覆盖主 SQLite 文件而留下不匹配的 `-wal` 或 `-shm` 文件。
+
+3. 重新启动 SQLite 默认部署：
+
+   ```bash
+   docker compose -f deploy/docker-compose.yml up -d
+   docker compose -f deploy/docker-compose.yml ps
+   curl -f http://localhost:1241/health
+   ```
+
+4. 登录后抽查项目、图片、视频和任务记录，并用第 6 步的 SQLite 查询复核记录数。
+
+5. 在回滚验证完成前，保留 `deploy/production/pgdata/`、`deploy/production/projects/` 和迁移备份以便排查，不要删除。`POSTGRES_PASSWORD` 位于独立的 `deploy/production/.env`，无需从 `deploy/.env` 移除。
+
+如果原来不是默认 Compose，还需将启动环境中的 `DATABASE_URL` 恢复为 SQLite URL 或取消设置，并确认 `ARCREEL_DATA_DIR` 指回原数据目录后再启动。

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -331,12 +331,12 @@ docker compose exec -T postgres sh -c \
   > "backups/arcreel-db-${backup_stamp}.sql"
 
 tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
-  .env projects vertex_keys claude_data
+  .env docker-compose.yml projects vertex_keys claude_data
 
 docker compose start arcreel
 ```
 
-The database and file backups use the same timestamp and must be stored and restored together. `umask 077` and backup directory mode `0700` ensure that the host-created SQL file and file archive are readable and writable only by the current user.
+The database and file backups use the same timestamp and must be stored and restored together. The file backup includes the active `docker-compose.yml`, so any `DATABASE_URL` customization required by a special-character password is restored together with `.env`. `umask 077` and backup directory mode `0700` ensure that the host-created SQL file and file archive are readable and writable only by the current user.
 
 `pg_dump` reads `PGPASSWORD` through libpq. The command above sets it only for that `pg_dump` process inside the PostgreSQL container, allowing `docker compose exec -T` to run non-interactively without expanding the password into the host command line. For long-running host-side backup automation, use a PostgreSQL password file with `0600` permissions instead. Never put the password in a script or backup filename.
 
@@ -349,9 +349,12 @@ Before restoring, stop ArcReel but leave PostgreSQL running:
 ```bash
 cd "$(git rev-parse --show-toplevel)/deploy/production"
 docker compose stop arcreel
+
+backup_stamp=YYYYMMDD-HHMMSS
+tar -xzf "backups/arcreel-files-${backup_stamp}.tar.gz"
 ```
 
-The following procedure deletes the existing data in the target `arcreel` database. First verify that both the database backup and its paired file backup are complete, and rehearse the restoration procedure in an isolated environment.
+The file archive restores `.env`, `docker-compose.yml`, `projects/`, and the runtime directories. The following procedure also deletes the existing data in the target `arcreel` database. First verify that the database and file backups with the same `backup_stamp` are complete, and rehearse the restoration procedure in an isolated environment.
 
 Recreate an empty database before importing to avoid conflicts with existing schemas or data:
 
@@ -362,11 +365,11 @@ docker compose exec -T postgres \
 docker compose exec -T postgres \
   createdb -U arcreel --maintenance-db=postgres -O arcreel arcreel
 
-cat backups/arcreel-db-YYYYMMDD-HHMMSS.sql | \
+cat "backups/arcreel-db-${backup_stamp}.sql" | \
   docker compose exec -T postgres psql -v ON_ERROR_STOP=1 -U arcreel -d arcreel
 ```
 
-Then restore the matching `projects/` and other file directories and restart the application:
+After the database import succeeds, restart the application:
 
 ```bash
 docker compose start arcreel

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -95,7 +95,22 @@ POSTGRES_PASSWORD=set a database password
 # LOG_LEVEL=INFO
 ```
 
-Use only letters and numbers in `POSTGRES_PASSWORD` where possible, to prevent special URL characters from affecting `DATABASE_URL` parsing.
+Generate a password containing only hexadecimal characters where possible:
+
+```bash
+openssl rand -hex 16
+```
+
+The default Compose configuration passes the raw `POSTGRES_PASSWORD` to PostgreSQL and also interpolates it into the password segment of `DATABASE_URL`. If the password contains URL-reserved characters such as `@`, `:`, `/`, `?`, `#`, or `%`, the password in the connection URI must be percent-encoded. Do not put the encoded value directly in `POSTGRES_PASSWORD`: PostgreSQL needs the raw password, while only the URI needs the encoded form.
+
+When special characters are required, keep the raw and encoded values separate in `.env`:
+
+```dotenv
+POSTGRES_PASSWORD='p@ss/word'
+POSTGRES_PASSWORD_URLENCODED=p%40ss%2Fword
+```
+
+Then change only the password segment of `DATABASE_URL` in `deploy/production/docker-compose.yml` to `${POSTGRES_PASSWORD_URLENCODED}`; leave the PostgreSQL container's `POSTGRES_PASSWORD` unchanged. You can generate the encoded value with `urllib.parse.quote(raw_password, safe="")`. If you do not want to maintain this Compose customization, use the hexadecimal password described above.
 
 Start the service:
 
@@ -122,6 +137,8 @@ curl http://localhost:1241/health
 | `deploy/production/vertex_keys/` | Vertex AI credentials |
 | `deploy/production/claude_data/` | Agent runtime data |
 | `deploy/production/.env` | Authentication and database configuration |
+
+`pgdata/` stores only the PostgreSQL cluster, while `projects/` stores project metadata and media assets. Both directories must be persisted and backed up together. The production deployment uses PostgreSQL through `DATABASE_URL` and does not use `deploy/production/projects/.arcreel.db`. Do not copy SQLite files into `pgdata/`, and do not treat these two directories as interchangeable database backups.
 
 ### 2.3 Database Migrations {#database-migrations}
 
@@ -269,6 +286,8 @@ tar -czf "backups/arcreel-$(date +%Y%m%d-%H%M%S).tar.gz" \
   .env projects vertex_keys claude_data
 ```
 
+Archiving the entire `projects/` directory after the service has stopped keeps `.arcreel.db` and project assets at the same point in time. Do not copy only `.arcreel.db` while ArcReel is writing to it. In WAL mode, committed transactions may still reside in `.arcreel.db-wal`; losing or mismatching the WAL can cause data loss or corruption. If downtime is not possible, use the SQLite Online Backup API, such as the `sqlite3` `.backup` command, or `VACUUM INTO` to create a consistent snapshot instead of copying the main database file directly with `cp`.
+
 Restart the service:
 
 ```bash
@@ -294,8 +313,8 @@ docker compose stop arcreel
 
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
 
-docker compose exec -T postgres \
-  pg_dump -U arcreel -d arcreel \
+docker compose exec -T postgres sh -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" exec pg_dump -h 127.0.0.1 -U arcreel -d arcreel' \
   > "backups/arcreel-db-${backup_stamp}.sql"
 
 tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
@@ -305,6 +324,8 @@ docker compose start arcreel
 ```
 
 The database backup and file backup use the same timestamp and must be stored and restored together.
+
+`pg_dump` reads `PGPASSWORD` through libpq. The command above sets it only for that `pg_dump` process inside the PostgreSQL container, allowing `docker compose exec -T` to run non-interactively without expanding the password into the host command line. For long-running host-side backup automation, use a PostgreSQL password file with `0600` permissions instead. Never put the password in a script or backup filename.
 
 If `tar` reports `Permission denied`, the mounted directory contains files created by the container's root user that the current host user cannot read. Rerun the corresponding `tar` command with `sudo`, then restrict read access to the backup file when finished.
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -271,22 +271,33 @@ Explicitly changing the version when upgrading reduces the risk of unintentional
 
 ### 6.1 Back Up a SQLite Deployment {#backup-sqlite}
 
-First stop writes. The simplest method is to stop the service briefly:
+First identify the actual data root on the host, then stop writes. Default Compose uses `deploy/projects/`. If you changed the container path with `ARCREEL_DATA_DIR` and a custom mount, set `data_dir` to the corresponding absolute host path:
 
 ```bash
 cd deploy
+
+data_dir="$(cd projects && pwd)"
+# Custom data directory example: data_dir="/srv/arcreel/projects"
+
 docker compose stop arcreel
 ```
 
 Create the backup:
 
 ```bash
+backup_stamp="$(date +%Y%m%d-%H%M%S)"
+umask 077
 mkdir -p backups
-tar -czf "backups/arcreel-$(date +%Y%m%d-%H%M%S).tar.gz" \
-  .env projects vertex_keys claude_data
+chmod 700 backups
+
+tar -czf "backups/arcreel-config-${backup_stamp}.tar.gz" \
+  .env vertex_keys claude_data
+
+tar -czf "backups/arcreel-projects-${backup_stamp}.tar.gz" \
+  -C "${data_dir}" .
 ```
 
-Archiving the entire `projects/` directory after the service has stopped keeps `.arcreel.db` and project assets at the same point in time. Do not copy only `.arcreel.db` while ArcReel is writing to it. In WAL mode, committed transactions may still reside in `.arcreel.db-wal`; losing or mismatching the WAL can cause data loss or corruption. If downtime is not possible, use the SQLite Online Backup API, such as the `sqlite3` `.backup` command, or `VACUUM INTO` to create a consistent snapshot instead of copying the main database file directly with `cp`.
+Archiving the entire `data_dir` after the service has stopped keeps `.arcreel.db` and project assets at the same point in time. The configuration and data archives must use the same timestamp and be stored together. `umask 077` and backup directory mode `0700` restrict access to the credentials and project assets they contain. Do not copy only `.arcreel.db` while ArcReel is writing to it. In WAL mode, committed transactions may still reside in `.arcreel.db-wal`; losing or mismatching the WAL can cause data loss or corruption. If downtime is not possible, use the SQLite Online Backup API, such as the `sqlite3` `.backup` command, or `VACUUM INTO` to create a consistent snapshot instead of copying the main database file directly with `cp`.
 
 Restart the service:
 
@@ -298,7 +309,7 @@ To restore:
 
 1. Stop ArcReel;
 2. Back up the current directory so you can roll back if files are overwritten;
-3. Restore `.env`, `projects/`, `vertex_keys/`, and `claude_data/` from the archive to their original locations;
+3. Restore `.env`, `vertex_keys/`, and `claude_data/` from the configuration archive, then extract the paired data archive completely into an empty `data_dir`;
 4. Start the service and check `/health`;
 5. Open several projects and verify their images, videos, and version history.
 
@@ -308,7 +319,9 @@ Stop the ArcReel application first, but leave PostgreSQL running, so no new writ
 
 ```bash
 cd "$(git rev-parse --show-toplevel)/deploy/production"
+umask 077
 mkdir -p backups
+chmod 700 backups
 docker compose stop arcreel
 
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
@@ -323,7 +336,7 @@ tar -czf "backups/arcreel-files-${backup_stamp}.tar.gz" \
 docker compose start arcreel
 ```
 
-The database backup and file backup use the same timestamp and must be stored and restored together.
+The database and file backups use the same timestamp and must be stored and restored together. `umask 077` and backup directory mode `0700` ensure that the host-created SQL file and file archive are readable and writable only by the current user.
 
 `pg_dump` reads `PGPASSWORD` through libpq. The command above sets it only for that `pg_dump` process inside the PostgreSQL container, allowing `docker compose exec -T` to run non-interactively without expanding the password into the host command line. For long-running host-side backup automation, use a PostgreSQL password file with `0600` permissions instead. Never put the password in a script or backup filename.
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
@@ -6,73 +6,135 @@ sidebar_position: 2
 
 # Migrate from SQLite to PostgreSQL {#migrate-to-postgres}
 
-This guide is for ArcReel deployments currently using the default SQLite configuration that need to switch to PostgreSQL.
+This guide is for ArcReel deployments currently using the default Docker + SQLite configuration that need to switch to the PostgreSQL deployment under `deploy/production/`. Run every command below from the root of the ArcReel repository.
+
+Before migrating, distinguish the three types of data involved:
+
+| Path | Purpose | Migration Action |
+|---|---|---|
+| `deploy/projects/.arcreel.db` | SQLite database used by the default deployment | Import into PostgreSQL with pgloader |
+| Other files under `deploy/projects/` | Project metadata and media assets | Copy to `deploy/production/projects/` |
+| `deploy/production/pgdata/` | PostgreSQL cluster data | Initialize with PostgreSQL; never place project or SQLite files here |
+
+If you customized the data root with `ARCREEL_DATA_DIR`, replace `deploy/projects/` throughout this guide with the actual source directory.
 
 ## Prerequisites {#prerequisites}
 
 - Docker and Docker Compose are installed
-- ArcReel is currently running with SQLite (the database file is located at `projects/.arcreel.db`)
+- The `sqlite3` command-line tool is installed; run `sqlite3 --version` to confirm
+- ArcReel currently uses the default SQLite deployment, with the database at `deploy/projects/.arcreel.db`
+- `deploy/production/pgdata/` and `deploy/production/projects/` do not contain production data that must be preserved
 
 ## Migration Steps {#migration-steps}
 
 ### 1. Stop the ArcReel services {#stop-services}
 
 ```bash
-# If running via Docker
-docker compose down
-
-# If running directly from the command line, stop the uvicorn process
+cd "$(git rev-parse --show-toplevel)"
+docker compose -f deploy/docker-compose.yml down
 ```
 
-### 2. Back up the SQLite database {#backup-sqlite}
+Do not restart the default deployment until migration verification is complete. Otherwise, the SQLite database and project assets may continue to receive writes.
+
+### 2. Create a Consistent Backup {#backup-sqlite}
 
 ```bash
-cp projects/.arcreel.db projects/.arcreel.db.bak
+backup_stamp="$(date +%Y%m%d-%H%M%S)"
+mkdir -p deploy/backups
+
+sqlite3 deploy/projects/.arcreel.db \
+  ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
+
+sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
+  "PRAGMA quick_check;"
+
+tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
+  -C deploy .env projects
 ```
 
-### 3. Configure environment variables {#configure-env}
+`PRAGMA quick_check;` must print `ok`. `sqlite3 .backup` uses the SQLite backup API to create a consistent snapshot that includes committed WAL content. Do not copy only `.arcreel.db` with `cp` while the service is running. `.arcreel.db-wal` may contain committed transactions that have not yet been checkpointed, so separating it from the main file can lose data or corrupt the backup. The paired tar archive restores the original `.env`, database sidecar files, and project assets.
 
-Add the following variable to `.env` (used to initialize the PostgreSQL container in docker-compose):
+### 3. Prepare the PostgreSQL Deployment {#configure-env}
+
+Create the production configuration:
+
+```bash
+test ! -e deploy/production/.env
+cp deploy/production/.env.example deploy/production/.env
+```
+
+If the first command fails, a production configuration already exists. Review and preserve its valid settings instead of overwriting it.
+
+Edit `deploy/production/.env` and set the authentication values and PostgreSQL password:
 
 ```env
-POSTGRES_PASSWORD=your database password
+AUTH_USERNAME=admin
+AUTH_PASSWORD=set a strong password
+AUTH_TOKEN_SECRET=set a long-lived random secret
+POSTGRES_PASSWORD=set a database password containing only letters and numbers
 ```
 
-> You do not need to set `DATABASE_URL` manually. It is assembled automatically in `docker-compose.yml` from `POSTGRES_PASSWORD`.
+Production Compose assembles `DATABASE_URL` automatically. The migration command also embeds the password in pgloader's PostgreSQL URI, so use `openssl rand -hex 16` to generate a URL-safe password. If special characters are required, follow the [deployment guide](./deployment.md#postgresql-start) to store the raw password separately from the percent-encoded URI password. Never use the encoded value itself as `POSTGRES_PASSWORD`. The pgloader command below prefers `POSTGRES_PASSWORD_URLENCODED` when it is present.
+
+Confirm that the following commands produce no output. If either target directory already contains data, stop the migration instead of overwriting it:
+
+```bash
+find deploy/production/projects -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null
+test ! -e deploy/production/pgdata/PG_VERSION
+```
+
+Copy project and media assets to the production directory without copying the SQLite database:
+
+```bash
+mkdir -p deploy/production/projects
+tar -C deploy/projects --exclude='.arcreel.db*' -cf - . | \
+  tar -C deploy/production/projects -xf -
+```
 
 ### 4. Start PostgreSQL {#start-postgresql}
 
 Start only the database service first:
 
 ```bash
-docker compose up -d postgres
+docker compose -f deploy/production/docker-compose.yml up -d postgres
 ```
 
 Wait for the health check to pass:
 
 ```bash
-docker compose ps  # Confirm that postgres is healthy
+docker compose -f deploy/production/docker-compose.yml ps
 ```
 
 ### 5. Migrate the data {#migrate-data}
 
-Use pgloader inside the ArcReel container to migrate the SQLite data directly to PostgreSQL:
+Use pgloader inside the ArcReel container to migrate the original SQLite database directly to PostgreSQL:
 
 ```bash
-docker compose run --rm arcreel bash -c "
-  apt-get update && apt-get install -y --no-install-recommends pgloader &&
-  pgloader sqlite:///app/projects/.arcreel.db \
-           postgresql://arcreel:\${POSTGRES_PASSWORD}@postgres:5432/arcreel
-"
+source_projects="$(cd deploy/projects && pwd)"
+
+docker compose -f deploy/production/docker-compose.yml run --rm \
+  -v "${source_projects}:/migration-source:ro" \
+  arcreel bash -c '
+    apt-get update &&
+    apt-get install -y --no-install-recommends pgloader &&
+    pgloader sqlite:///migration-source/.arcreel.db \
+             "postgresql://arcreel:${POSTGRES_PASSWORD_URLENCODED:-$POSTGRES_PASSWORD}@postgres:5432/arcreel"
+  '
 ```
 
-> pgloader automatically handles type and syntax differences between SQLite and PostgreSQL (Booleans, time formats, and so on),
-> and skips existing table structures, importing only the data.
+:::danger
+
+**Do not run this command repeatedly against a target that contains data.** pgloader's default SQLite options include `include drop`: it uses `CASCADE` to drop target tables whose names match the source database, then recreates the schema and imports the data. It does not skip existing tables. Run it once, only against the empty `arcreel` database initialized by this procedure. If migration fails, first verify that the target contains no data you need to preserve, recreate an empty target, and then retry. Never rerun pgloader after ArcReel has started writing to PostgreSQL.
+
+:::
+
+pgloader handles common type and syntax differences between SQLite and PostgreSQL and resets the sequences for imported tables.
 
 ### 6. Verify the data {#verify-data}
 
 ```bash
-docker compose exec postgres psql -U arcreel -d arcreel -c "
+docker compose -f deploy/production/docker-compose.yml \
+  exec postgres psql -U arcreel -d arcreel -c "
   SELECT 'tasks' AS tbl, COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -86,7 +148,7 @@ docker compose exec postgres psql -U arcreel -d arcreel -c "
 Compare the record counts in SQLite:
 
 ```bash
-sqlite3 projects/.arcreel.db "
+sqlite3 deploy/projects/.arcreel.db "
   SELECT 'tasks', COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -100,7 +162,9 @@ sqlite3 projects/.arcreel.db "
 ### 7. Start all services {#start-all-services}
 
 ```bash
-docker compose up -d
+docker compose -f deploy/production/docker-compose.yml up -d
+docker compose -f deploy/production/docker-compose.yml ps
+curl -f http://localhost:1241/health
 ```
 
 Visit `http://<your-ip>:1241` and verify that the service is working.
@@ -109,8 +173,27 @@ Visit `http://<your-ip>:1241` and verify that the service is working.
 
 ## Roll Back to SQLite {#rollback-to-sqlite}
 
-If you need to roll back:
+The migration procedure above does not modify the original `deploy/projects/` or `deploy/.env`. A normal rollback therefore restarts the default Compose deployment instead of changing the production `.env`:
 
-1. Stop the services: `docker compose down`
-2. Restore the backup: `cp projects/.arcreel.db.bak projects/.arcreel.db`
-3. From `.env`, remove `POSTGRES_PASSWORD`, then start without the PostgreSQL configuration in `docker-compose.yml`
+1. Stop the PostgreSQL production deployment:
+
+   ```bash
+   cd "$(git rev-parse --show-toplevel)"
+   docker compose -f deploy/production/docker-compose.yml down
+   ```
+
+2. Confirm that `deploy/projects/.arcreel.db` and `deploy/.env` still exist. If the original directory was changed or damaged, preserve its current contents first, then restore `.env` and the entire `projects/` directory from `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` created in step 2. Do not overwrite only the main SQLite file while leaving mismatched `-wal` or `-shm` files behind.
+
+3. Restart the default SQLite deployment:
+
+   ```bash
+   docker compose -f deploy/docker-compose.yml up -d
+   docker compose -f deploy/docker-compose.yml ps
+   curl -f http://localhost:1241/health
+   ```
+
+4. Sign in and inspect several projects, images, videos, and task records. Run the SQLite query from step 6 again to verify record counts.
+
+5. Keep `deploy/production/pgdata/`, `deploy/production/projects/`, and the migration backups until rollback verification is complete. Do not delete them. `POSTGRES_PASSWORD` is stored in the separate `deploy/production/.env` and does not need to be removed from `deploy/.env`.
+
+If the original deployment did not use the default Compose configuration, also restore or unset `DATABASE_URL` so it selects SQLite, confirm that `ARCREEL_DATA_DIR` points to the original data directory, and only then restart ArcReel.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
@@ -16,7 +16,7 @@ Before migrating, distinguish the three types of data involved:
 | Other files under `deploy/projects/` | Project metadata and media assets | Copy to `deploy/production/projects/` |
 | `deploy/production/pgdata/` | PostgreSQL cluster data | Initialize with PostgreSQL; never place project or SQLite files here |
 
-If you customized the data root with `ARCREEL_DATA_DIR`, replace `deploy/projects/` throughout this guide with the actual source directory.
+The commands below consistently use the shell variable `source_projects` for the source data root on the host. The default deployment sets it to the absolute path of `deploy/projects/`. If you changed the container data directory with `ARCREEL_DATA_DIR` and a custom mount, set `source_projects` in step 1 to the corresponding absolute host path. The container and host paths may differ, so this guide does not derive that value directly from `.env`. Keep this variable in the same shell throughout the migration.
 
 ## Prerequisites {#prerequisites}
 
@@ -31,6 +31,15 @@ If you customized the data root with `ARCREEL_DATA_DIR`, replace `deploy/project
 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
+
+source_projects="$(cd deploy/projects && pwd)"
+# Custom data directory example: source_projects="/srv/arcreel/projects"
+
+if [ ! -f "${source_projects}/.arcreel.db" ]; then
+  echo "Error: ${source_projects}/.arcreel.db does not exist" >&2
+  exit 1
+fi
+
 docker compose -f deploy/docker-compose.yml down
 ```
 
@@ -40,30 +49,38 @@ Do not restart the default deployment until migration verification is complete. 
 
 ```bash
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
+umask 077
 mkdir -p deploy/backups
+chmod 700 deploy/backups
 
-sqlite3 deploy/projects/.arcreel.db \
+sqlite3 "${source_projects}/.arcreel.db" \
   ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
 
 sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
   "PRAGMA quick_check;"
 
 tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
-  -C deploy .env projects
+  -C "${source_projects}" .
+
+cp deploy/.env "deploy/backups/arcreel-source-${backup_stamp}.env"
 ```
 
-`PRAGMA quick_check;` must print `ok`. `sqlite3 .backup` uses the SQLite backup API to create a consistent snapshot that includes committed WAL content. Do not copy only `.arcreel.db` with `cp` while the service is running. `.arcreel.db-wal` may contain committed transactions that have not yet been checkpointed, so separating it from the main file can lose data or corrupt the backup. The paired tar archive restores the original `.env`, database sidecar files, and project assets.
+`PRAGMA quick_check;` must print `ok`. `sqlite3 .backup` uses the SQLite backup API to create a consistent snapshot that includes committed WAL content. Do not copy only `.arcreel.db` with `cp` while the service is running. `.arcreel.db-wal` may contain committed transactions that have not yet been checkpointed, so separating it from the main file can lose data or corrupt the backup. The paired tar archive stores the complete contents of `source_projects`, while the adjacent `.env` copy stores the default deployment configuration. Restore only artifacts with the same timestamp. `umask 077` and directory mode `0700` restrict access to the credentials and project assets they contain.
 
 ### 3. Prepare the PostgreSQL Deployment {#configure-env}
 
 Create the production configuration:
 
 ```bash
-test ! -e deploy/production/.env
+if [ -e deploy/production/.env ]; then
+  echo "Error: deploy/production/.env already exists; preserve and review it instead of overwriting it" >&2
+  exit 1
+fi
+
 cp deploy/production/.env.example deploy/production/.env
 ```
 
-If the first command fails, a production configuration already exists. Review and preserve its valid settings instead of overwriting it.
+If a production configuration already exists, the guard above prints an error and stops the current shell. Review and preserve its valid settings instead of overwriting it.
 
 Edit `deploy/production/.env` and set the authentication values and PostgreSQL password:
 
@@ -76,18 +93,30 @@ POSTGRES_PASSWORD=set a database password containing only letters and numbers
 
 Production Compose assembles `DATABASE_URL` automatically. The migration command also embeds the password in pgloader's PostgreSQL URI, so use `openssl rand -hex 16` to generate a URL-safe password. If special characters are required, follow the [deployment guide](./deployment.md#postgresql-start) to store the raw password separately from the percent-encoded URI password. Never use the encoded value itself as `POSTGRES_PASSWORD`. The pgloader command below prefers `POSTGRES_PASSWORD_URLENCODED` when it is present.
 
-Confirm that the following commands produce no output. If either target directory already contains data, stop the migration instead of overwriting it:
+Run the directory guard. It produces no output when the target directories are absent or empty. If it finds any entry, including a hidden file, it prints an error and stops the current shell:
 
 ```bash
-find deploy/production/projects -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null
-test ! -e deploy/production/pgdata/PG_VERSION
+for target_dir in deploy/production/projects deploy/production/pgdata; do
+  if [ -e "${target_dir}" ] && [ ! -d "${target_dir}" ]; then
+    echo "Error: ${target_dir} exists and is not a directory; stopping migration" >&2
+    exit 1
+  fi
+
+  if [ -d "${target_dir}" ]; then
+    first_entry="$(find "${target_dir}" -mindepth 1 -maxdepth 1 -print -quit)" || exit 1
+    if [ -n "${first_entry}" ]; then
+      echo "Error: ${target_dir} is not empty; stopping migration without overwriting it" >&2
+      exit 1
+    fi
+  fi
+done
 ```
 
 Copy project and media assets to the production directory without copying the SQLite database:
 
 ```bash
 mkdir -p deploy/production/projects
-tar -C deploy/projects --exclude='.arcreel.db*' -cf - . | \
+tar -C "${source_projects}" --exclude='.arcreel.db*' -cf - . | \
   tar -C deploy/production/projects -xf -
 ```
 
@@ -110,8 +139,6 @@ docker compose -f deploy/production/docker-compose.yml ps
 Use pgloader inside the ArcReel container to migrate the original SQLite database directly to PostgreSQL:
 
 ```bash
-source_projects="$(cd deploy/projects && pwd)"
-
 docker compose -f deploy/production/docker-compose.yml run --rm \
   -v "${source_projects}:/migration-source:ro" \
   arcreel bash -c '
@@ -148,7 +175,7 @@ docker compose -f deploy/production/docker-compose.yml \
 Compare the record counts in SQLite:
 
 ```bash
-sqlite3 deploy/projects/.arcreel.db "
+sqlite3 "${source_projects}/.arcreel.db" "
   SELECT 'tasks', COUNT(*) FROM tasks
   UNION ALL
   SELECT 'api_calls', COUNT(*) FROM api_calls
@@ -173,7 +200,7 @@ Visit `http://<your-ip>:1241` and verify that the service is working.
 
 ## Roll Back to SQLite {#rollback-to-sqlite}
 
-The migration procedure above does not modify the original `deploy/projects/` or `deploy/.env`. A normal rollback therefore restarts the default Compose deployment instead of changing the production `.env`:
+The migration procedure above does not modify the source data directory referenced by `source_projects` or `deploy/.env`. A normal rollback therefore restarts the original SQLite deployment instead of changing the production `.env`. If you roll back from a new shell, first set `source_projects` again as described in step 1:
 
 1. Stop the PostgreSQL production deployment:
 
@@ -182,7 +209,7 @@ The migration procedure above does not modify the original `deploy/projects/` or
    docker compose -f deploy/production/docker-compose.yml down
    ```
 
-2. Confirm that `deploy/projects/.arcreel.db` and `deploy/.env` still exist. If the original directory was changed or damaged, preserve its current contents first, then restore `.env` and the entire `projects/` directory from `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` created in step 2. Do not overwrite only the main SQLite file while leaving mismatched `-wal` or `-shm` files behind.
+2. Confirm that `${source_projects}/.arcreel.db` and `deploy/.env` still exist. If the source directory was changed or damaged, preserve the current directory first, extract the complete `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` from step 2 into an empty `${source_projects}`, and restore the `.env` copy with the same timestamp as `deploy/.env`. Do not overwrite only the main SQLite file while leaving mismatched `-wal` or `-shm` files behind.
 
 3. Restart the default SQLite deployment:
 
@@ -196,4 +223,4 @@ The migration procedure above does not modify the original `deploy/projects/` or
 
 5. Keep `deploy/production/pgdata/`, `deploy/production/projects/`, and the migration backups until rollback verification is complete. Do not delete them. `POSTGRES_PASSWORD` is stored in the separate `deploy/production/.env` and does not need to be removed from `deploy/.env`.
 
-If the original deployment did not use the default Compose configuration, also restore or unset `DATABASE_URL` so it selects SQLite, confirm that `ARCREEL_DATA_DIR` points to the original data directory, and only then restart ArcReel.
+If the original deployment used custom Compose configuration or a custom data mount, also restore or unset `DATABASE_URL` so it selects SQLite, confirm that `ARCREEL_DATA_DIR` still points to the original directory inside the container, and verify that the mount maps it to `${source_projects}` on the host before restarting ArcReel.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/migrate-to-postgres.md
@@ -48,6 +48,8 @@ Do not restart the default deployment until migration verification is complete. 
 ### 2. Create a Consistent Backup {#backup-sqlite}
 
 ```bash
+set -euo pipefail
+
 backup_stamp="$(date +%Y%m%d-%H%M%S)"
 umask 077
 mkdir -p deploy/backups
@@ -56,8 +58,13 @@ chmod 700 deploy/backups
 sqlite3 "${source_projects}/.arcreel.db" \
   ".backup 'deploy/backups/arcreel-sqlite-${backup_stamp}.db'"
 
-sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
-  "PRAGMA quick_check;"
+check_result="$(sqlite3 "deploy/backups/arcreel-sqlite-${backup_stamp}.db" \
+  "PRAGMA quick_check;")"
+
+if [ "${check_result}" != "ok" ]; then
+  echo "Error: SQLite backup quick_check failed" >&2
+  exit 1
+fi
 
 tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
   -C "${source_projects}" .
@@ -65,7 +72,7 @@ tar -czf "deploy/backups/arcreel-source-${backup_stamp}.tar.gz" \
 cp deploy/.env "deploy/backups/arcreel-source-${backup_stamp}.env"
 ```
 
-`PRAGMA quick_check;` must print `ok`. `sqlite3 .backup` uses the SQLite backup API to create a consistent snapshot that includes committed WAL content. Do not copy only `.arcreel.db` with `cp` while the service is running. `.arcreel.db-wal` may contain committed transactions that have not yet been checkpointed, so separating it from the main file can lose data or corrupt the backup. The paired tar archive stores the complete contents of `source_projects`, while the adjacent `.env` copy stores the default deployment configuration. Restore only artifacts with the same timestamp. `umask 077` and directory mode `0700` restrict access to the credentials and project assets they contain.
+The guard accepts only an exact `ok` response from `PRAGMA quick_check;`. Any backup, check, archive, or configuration-copy failure stops the migration immediately. `sqlite3 .backup` uses the SQLite backup API to create a consistent snapshot that includes committed WAL content. Do not copy only `.arcreel.db` with `cp` while the service is running. `.arcreel.db-wal` may contain committed transactions that have not yet been checkpointed, so separating it from the main file can lose data or corrupt the backup. The paired tar archive stores the complete contents of `source_projects`, while the adjacent `.env` copy stores the default deployment configuration. Restore only artifacts with the same timestamp. `umask 077` and directory mode `0700` restrict access to the credentials and project assets they contain.
 
 ### 3. Prepare the PostgreSQL Deployment {#configure-env}
 
@@ -115,10 +122,14 @@ done
 Copy project and media assets to the production directory without copying the SQLite database:
 
 ```bash
+set -euo pipefail
+
 mkdir -p deploy/production/projects
 tar -C "${source_projects}" --exclude='.arcreel.db*' -cf - . | \
   tar -C deploy/production/projects -xf -
 ```
+
+Strict mode stops immediately if directory creation or either side of the pipeline fails, preventing the migration from using an incomplete asset copy.
 
 ### 4. Start PostgreSQL {#start-postgresql}
 
@@ -209,7 +220,22 @@ The migration procedure above does not modify the source data directory referenc
    docker compose -f deploy/production/docker-compose.yml down
    ```
 
-2. Confirm that `${source_projects}/.arcreel.db` and `deploy/.env` still exist. If the source directory was changed or damaged, preserve the current directory first, extract the complete `arcreel-source-YYYYMMDD-HHMMSS.tar.gz` from step 2 into an empty `${source_projects}`, and restore the `.env` copy with the same timestamp as `deploy/.env`. Do not overwrite only the main SQLite file while leaving mismatched `-wal` or `-shm` files behind.
+2. Confirm that `${source_projects}/.arcreel.db` and `deploy/.env` still exist. If the source directory was changed or damaged, first select the two backup files from step 2 that have the same timestamp, then run:
+
+   ```bash
+   set -euo pipefail
+
+   archive="deploy/backups/arcreel-source-YYYYMMDD-HHMMSS.tar.gz"
+   env_backup="deploy/backups/arcreel-source-YYYYMMDD-HHMMSS.env"
+   preserved="${source_projects}.before-rollback-$(date +%Y%m%d-%H%M%S)"
+
+   mv -- "${source_projects}" "${preserved}"
+   mkdir -p "${source_projects}"
+   tar -xzf "${archive}" -C "${source_projects}"
+   cp "${env_backup}" deploy/.env
+   ```
+
+   This moves the old source directory out of the way before creating an empty directory and extracting the archive, so files absent from the archive cannot remain. It restores `.env` only after extraction succeeds. Do not overwrite only the main SQLite file while leaving mismatched `-wal` or `-shm` files behind. Keep `${preserved}` until rollback verification is complete.
 
 3. Restart the default SQLite deployment:
 

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -8,6 +8,6 @@
   "website/docs/guide/providers.md": "a21c566431d63a7566962ae4292493ea3f1bab4ab08ba72499229b49fcaabb1e",
   "website/docs/guide/workflows.md": "d12d8ed9a343fd3669b64f74724fbb055a4f1acb57e40c34f333595963ad8913",
   "website/docs/index.mdx": "36bf1e64555bd31494be410015da65e342dcb6186ff974df3b7404a188ff547c",
-  "website/docs/ops/deployment.md": "3c23d990d684c1c2abcdeb74d2039a75bd24c1c6962e4525db250576206f893b",
-  "website/docs/ops/migrate-to-postgres.md": "cdf3c310eae1b5a3b8acdfa4b0aaad95070bcb8107376c16aada08e7dd8722bd"
+  "website/docs/ops/deployment.md": "e57d20eb083e335850c694d201bdef562e02d699258068fca1a8ce5d465db420",
+  "website/docs/ops/migrate-to-postgres.md": "fb98af7fdcf87388828326b2349a33793aaa1799ede1316e99513eca056308a5"
 }

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -8,6 +8,6 @@
   "website/docs/guide/providers.md": "a21c566431d63a7566962ae4292493ea3f1bab4ab08ba72499229b49fcaabb1e",
   "website/docs/guide/workflows.md": "d12d8ed9a343fd3669b64f74724fbb055a4f1acb57e40c34f333595963ad8913",
   "website/docs/index.mdx": "36bf1e64555bd31494be410015da65e342dcb6186ff974df3b7404a188ff547c",
-  "website/docs/ops/deployment.md": "25349d8f750d55fe45e5726ce4a5d4d49a60475cafaab8b73c75e816d14bd1b5",
-  "website/docs/ops/migrate-to-postgres.md": "7c841f10abe499c22c2cd0665a51100afaaae2a216021b78f0dff963e1e00002"
+  "website/docs/ops/deployment.md": "3c23d990d684c1c2abcdeb74d2039a75bd24c1c6962e4525db250576206f893b",
+  "website/docs/ops/migrate-to-postgres.md": "cdf3c310eae1b5a3b8acdfa4b0aaad95070bcb8107376c16aada08e7dd8722bd"
 }

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -8,6 +8,6 @@
   "website/docs/guide/providers.md": "a21c566431d63a7566962ae4292493ea3f1bab4ab08ba72499229b49fcaabb1e",
   "website/docs/guide/workflows.md": "d12d8ed9a343fd3669b64f74724fbb055a4f1acb57e40c34f333595963ad8913",
   "website/docs/index.mdx": "36bf1e64555bd31494be410015da65e342dcb6186ff974df3b7404a188ff547c",
-  "website/docs/ops/deployment.md": "35bbfd0f148708d2e965d0bf0e8742194438c5f88c6a7fee29dd257b85b22e12",
-  "website/docs/ops/migrate-to-postgres.md": "c949c2284ef469d0f0f6a1242c67217d13dce5ff99a9a708a4c7e7acafba65a3"
+  "website/docs/ops/deployment.md": "25349d8f750d55fe45e5726ce4a5d4d49a60475cafaab8b73c75e816d14bd1b5",
+  "website/docs/ops/migrate-to-postgres.md": "7c841f10abe499c22c2cd0665a51100afaaae2a216021b78f0dff963e1e00002"
 }


### PR DESCRIPTION
Closes #1869

## 变更摘要

1. 为 pg_dump 备份补充容器内 PGPASSWORD 的非交互传递方式，并说明长期自动化应使用 0600 权限的 password file。
2. 说明 POSTGRES_PASSWORD 原始值与连接 URI 百分号编码值的区别，提供 URL-safe 密码生成建议及特殊字符配置方式。
3. 用 sqlite3 .backup 生成一致快照，补充 WAL、checkpoint、边车文件与项目资产配套备份的风险说明。
4. 明确警示 pgloader 默认 include drop 会 CASCADE 删除同名目标表，仅允许对空目标执行一次，失败后须重建空目标再重试。
5. 将 sqlite3 CLI 及版本确认加入迁移前置依赖。
6. 补全回滚流程：停止生产部署、确认或整体恢复 SQLite 源数据、重启默认部署、复核数据并保留 PostgreSQL 现场。
7. 明确 deploy/projects、deploy/production/projects 与 deploy/production/pgdata 的职责，并补充资产复制边界。

中英文两篇运维文档已同步更新，translation.lock.json 已重新记录。

## 验证

- translation-lock status：Translations are up to date
- Bash 代码块：bash -n 通过
- pnpm typecheck：通过
- pnpm check-consistency：通过
- pnpm build：zh-Hans 与 en 均构建成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新 PostgreSQL 部署指南，补充密码生成、URL 编码、持久化、备份、恢复及安全配置说明。
  * 强化 SQLite 一致性备份与恢复指南，支持自定义数据目录，并说明 WAL 风险及在线备份方法。
  * 重写 SQLite 迁移至 PostgreSQL 的完整流程，涵盖前置检查、资源归档、数据验证、健康检查和回滚。
  * 补充迁移风险、备份权限及密码保护要求，并同步更新英文文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->