### PR TITLE
docs(readme): 精简项目首页并集中引导文档站

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,6 +82,8 @@ docker compose up -d
 
 Open <http://localhost:1241>. The default username is `admin`. If `AUTH_PASSWORD` is empty, ArcReel generates a password on first startup and writes it back to `deploy/.env`.
 
+> Default Compose publishes port `1241` on all host interfaces. Do not expose ArcReel directly to the public Internet; before enabling remote access, configure authentication and use HTTPS, a VPN, or a secure tunnel. See [Reverse Proxy and HTTPS](https://docs.arc-reel.com/en/ops/deployment#reverse-proxy-and-https).
+
 After signing in, open **Settings**, configure the ArcReel AI assistant and the required text, image, and video generation capabilities, then create a project.
 
 For the complete first-run workflow, see [Getting Started](https://docs.arc-reel.com/en/guide/getting-started). For production deployment, upgrades, backups, and reverse proxies, see [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment).

--- a/README.en.md
+++ b/README.en.md
@@ -44,44 +44,14 @@
   <img src="docs/assets/hero-screenshot.png" alt="ArcReel Workspace" width="900">
 </p>
 
-> ArcReel is not a thin prompt wrapper. It organizes content analysis, screenplay structuring, character and scene assets, storyboards, media generation tasks, cost tracking, version history, and export into an inspectable and resumable production pipeline.
+## What ArcReel is
 
-## What ArcReel solves
+ArcReel is an open-source, self-hosted workspace for AI drama and novel adaptation, narrated short videos, ads, and product shorts. It organizes content analysis, asset management, storyboards, media generation, cost tracking, and export into an inspectable and resumable production pipeline.
 
-- **Content to final cut**: bring a novel, a finished screenplay, or product assets into one workspace and progressively produce characters, scenes, props, storyboards, video clips, and a final video.
-- **Visual continuity**: establish reference assets for characters, scenes, and key props first, then reuse them in downstream shots to reduce cross-shot drift.
-- **Human control**: review results and confirm them at key stages, regenerate individual assets, and roll back to earlier versions.
-- **Provider freedom**: manage multiple text, image, video, and TTS providers behind a unified interface, including compatible APIs.
-- **Cost visibility**: estimate costs before generation and track calls and actual costs by project, episode, and shot afterward.
-- **Editable delivery**: render a final video or export a CapCut draft to continue adjusting subtitles, voice-over, pacing, and transitions.
-
-## Best-fit workflows
-
-<table>
-<tr>
-<td width="33%" valign="top">
-
-### 🎭 AI drama and novel adaptation
-
-Extract characters, scenes, and plot structure from long-form fiction or finished screenplays, then produce episodic animation with consistent characters.
-
-</td>
-<td width="33%" valign="top">
-
-### 🎙️ Narrated short videos
-
-Split content by narration rhythm, generate storyboards and voice-over tracks, and export a vertical video or editable CapCut draft.
-
-</td>
-<td width="33%" valign="top">
-
-### 🛍️ Ads and product shorts
-
-Upload multiple product images, build product reference assets, and generate product-selling shot scripts and product-anchored visuals for a target duration.
-
-</td>
-</tr>
-</table>
+- **One production workflow**: turn novels, finished screenplays, or product assets into characters, scenes, props, storyboards, video clips, and final videos step by step.
+- **Visual continuity with human control**: reuse reference assets across shots, review key stages, regenerate individual assets, and roll back to earlier versions.
+- **Manageable models and costs**: configure text, image, video, and TTS capabilities in one place, then review estimated costs and actual usage.
+- **Editable delivery**: render final videos directly or export CapCut drafts to refine subtitles, voice-over, pacing, and transitions.
 
 ## From source to final video
 
@@ -100,17 +70,7 @@ Every stage can be orchestrated by the AI assistant, or reviewed, adjusted, and 
 
 ## Quick Start
 
-### Prerequisites
-
-- Docker and Docker Compose
-- Start with at least 2 GB of available memory
-- A complete workflow requires:
-  - model credentials for the ArcReel AI assistant
-  - working text, image, and video generation capabilities, provided by one multimodal provider or a combination of providers
-  - optional TTS capability when narration is needed
-- The default setup uses remote model APIs and normally does not require a local GPU; local model deployments have their own requirements
-
-### Default deployment: SQLite
+Install Docker and Docker Compose, then run:
 
 ```bash
 git clone https://github.com/ArcReel/ArcReel.git
@@ -120,135 +80,26 @@ cp .env.example .env
 docker compose up -d
 ```
 
-Verify the service:
+Open <http://localhost:1241>. The default username is `admin`. If `AUTH_PASSWORD` is empty, ArcReel generates a password on first startup and writes it back to `deploy/.env`.
 
-```bash
-docker compose ps
-curl http://localhost:1241/health
-```
+After signing in, open **Settings**, configure the ArcReel AI assistant and the required text, image, and video generation capabilities, then create a project.
 
-Open <http://localhost:1241>.
-
-The default username is `admin`. Set `AUTH_PASSWORD` in `deploy/.env`; when left empty, a password is generated on first startup and written back to `.env`.
-
-After signing in, open **Settings**:
-
-1. Follow the onboarding tour and explore the read-only demo project.
-2. Configure the model credentials used by the ArcReel AI assistant.
-3. Configure the text, image, and video capabilities required by the full workflow.
-4. Create a project and start with a small amount of content to validate the workflow.
-
-> The default deployment is suitable for personal evaluation and light use. For production, concurrent, or long-running environments, use the [PostgreSQL production deployment](https://docs.arc-reel.com/en/ops/deployment#postgresql-deployment). PostgreSQL does not add user isolation; ArcReel does not currently support sharing one instance between mutually untrusted users.
-
-### Production deployment: PostgreSQL
-
-```bash
-cd "$(git rev-parse --show-toplevel)/deploy/production"
-
-cp .env.example .env
-# Edit .env and set POSTGRES_PASSWORD, AUTH_PASSWORD, and AUTH_TOKEN_SECRET
-docker compose up -d
-```
-
-See [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment) for deployment, upgrades, backups, and reverse proxies. See the [Security Policy](SECURITY.md) for support boundaries and vulnerability reporting.
-
-## Core capabilities
-
-### 🤖 Agent-driven, resumable workflow
-
-ArcReel uses an orchestration Skill and focused Subagents built on the Claude Agent SDK. The main Agent detects the current project stage, delegates character extraction, episode planning, screenplay normalization, and asset generation to the appropriate Subagents, and receives only their condensed results.
-
-### 🎨 Reusable character, scene, and prop assets
-
-Character design sheets, style reference images, and scene and prop assets serve as cross-shot references, reducing drift in character appearance, scene atmosphere, and key objects across shots.
-
-### 🎬 Three video-making workflows
-
-- **Storyboard to Video**: use a single storyboard image to drive video generation, suitable for shot-by-shot review and adjustment.
-- **Grid Storyboard to Video**: generate multiple shots together on one grid storyboard, split it into individual storyboard images, and then generate video; suitable when cross-shot consistency matters more.
-- **Reference to Video**: reference character, scene, and prop assets directly, skipping the standard storyboard step.
-
-### ⚡ Asynchronous tasks and concurrency controls
-
-Image, video, and audio jobs use independent concurrency channels, with RPM limits, task status tracking, failure recovery, and continuation after an interruption.
-
-### 🕰️ Version history and project archives
-
-Regeneration preserves earlier versions. Entire projects can be exported and imported for backup, migration, and handoff.
-
-### 💰 Estimates and actual usage
-
-Track calls by provider and media type, keep currencies separate, and compare estimated and actual costs at the project, episode, and shot levels.
-
-### 🎙️ Voice-over and editable export
-
-Generate narration with TTS, audition it segment by segment, and generate it in bulk. CapCut draft exports preserve video clips, voice-over tracks, and subtitle tracks for further editing.
-
-### 🔌 External Agent integration
-
-ArcReel can issue `arc-` API keys and expose a synchronous Agent chat endpoint for platforms such as OpenClaw.
-
-## Provider support
-
-ArcReel hides provider differences behind `TextBackend`, `ImageBackend`, and `VideoBackend` protocols. Models, parameters, availability, and pricing change over time, so the **ArcReel Settings page and provider documentation are the source of truth**.
-
-| Provider | Text | Image | Video | TTS |
-|---|:---:|:---:|:---:|:---:|
-| Gemini | ✅ | ✅ | ✅ | — |
-| Volcengine Ark | ✅ | ✅ | ✅ | — |
-| Grok | ✅ | ✅ | ✅ | — |
-| OpenAI | ✅ | ✅ | ✅ | — |
-| Vidu | — | ✅ | ✅ | — |
-| DashScope | ✅ | ✅ | ✅ | ✅ |
-| MiniMax | ✅ | ✅ | ✅ | — |
-| Kling | — | ✅ | ✅ | — |
-| Agnes | ✅ | ✅ | ✅ | — |
-| Custom providers | Interface-dependent | Interface-dependent | Interface-dependent | Interface-dependent |
-
-Global defaults, project-level overrides, and multiple API keys per provider are supported. See [Provider Configuration](https://docs.arc-reel.com/en/guide/providers).
-
-## Architecture
-
-```mermaid
-flowchart TB
-    UI["React 19 Web UI"] --> API["FastAPI API / SSE"]
-    API --> AGENT["Agent Runtime<br/>Skill + Subagent"]
-    API --> CORE["Core Services"]
-    AGENT --> CORE
-    CORE --> PROVIDERS["Text / Image / Video / TTS Backends"]
-    CORE --> QUEUE["Generation Queue<br/>RPM + Independent Channels"]
-    CORE --> PROJECTS["Project Manager<br/>File Assets + Version History"]
-    CORE --> DB["SQLAlchemy 2.0<br/>SQLite / PostgreSQL"]
-```
-
-The stack includes React 19, TypeScript, FastAPI, Python 3.12+, the Claude Agent SDK, SQLAlchemy 2.0, FFmpeg, Docker, and Docker Compose. See [Architecture](https://docs.arc-reel.com/en/dev/architecture) for boundaries and extension points.
-
-## Important limitations
-
-- Media generation depends on third-party services; speed, availability, policy, and pricing are provider-controlled.
-- Long-form content still requires human review of episode divisions, character assets, and key plot points. ArcReel aims to empower creators, not eliminate review entirely.
-- Video providers differ in reference-image count, duration, start/end-frame support, audio support, and regional availability.
-- Native Windows can run parts of the basic workflow, but POSIX-dependent Agent sandbox features degrade; prefer Linux, macOS, WSL2, or Docker.
-- Production deployments should use PostgreSQL, HTTPS, strong credentials, and regular backups. Do not expose an unprotected port `1241` to the public Internet.
-
-See [FAQ](https://docs.arc-reel.com/en/guide/faq) for more.
+For the complete first-run workflow, see [Getting Started](https://docs.arc-reel.com/en/guide/getting-started). For production deployment, upgrades, backups, and reverse proxies, see [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment).
 
 ## Documentation
 
-| Document | Purpose |
+| Page | Purpose |
 |---|---|
-| [Documentation Index](https://docs.arc-reel.com/en/) | Documentation entry points organized for users, operators, and developers |
+| [Documentation Home](https://docs.arc-reel.com/en/) | Entry points for users, operators, and developers |
 | [Getting Started](https://docs.arc-reel.com/en/guide/getting-started) | From first deployment to the first generated video |
 | [Workflows and Modes](https://docs.arc-reel.com/en/guide/workflows) | Novel, screenplay, and ad modes, plus the three video-making workflows |
 | [Provider Configuration](https://docs.arc-reel.com/en/guide/providers) | Selection and configuration of Agent, text, image, video, and TTS providers |
-| [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment) | SQLite, PostgreSQL, upgrades, backups, and reverse proxies |
-| [Security Policy](SECURITY.md) | Supported versions, deployment boundaries, private reporting, and coordinated disclosure |
-| [Security Threat Model](docs/security/threat-model.md) | Security assets, trust boundaries, attack surfaces, and reassessment triggers |
 | [CapCut Draft Export](https://docs.arc-reel.com/en/guide/jianying-export) | Continue editing ArcReel output in CapCut |
-| [Architecture](https://docs.arc-reel.com/en/dev/architecture) | Agent Runtime, task queue, provider abstraction, and data layer |
 | [FAQ](https://docs.arc-reel.com/en/guide/faq) | Deployment, cost, model, data, and licensing questions |
-| [Contributing](CONTRIBUTING.md) | Local development, tests, conventions, and pull requests |
-| [Changelog](CHANGELOG.md) | Release history |
+| [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment) | SQLite, PostgreSQL, upgrades, backups, and reverse proxies |
+| [Migrate from SQLite to PostgreSQL](https://docs.arc-reel.com/en/ops/migrate-to-postgres) | Data migration, verification, and rollback |
+| [Architecture](https://docs.arc-reel.com/en/dev/architecture) | Agent Runtime, task queue, provider abstraction, and data layer |
+| [Contributing](https://docs.arc-reel.com/en/dev/contributing) | Local development, tests, conventions, and pull requests |
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ docker compose up -d
 
 访问 <http://localhost:1241>。默认用户名为 `admin`；`AUTH_PASSWORD` 留空时，首次启动会自动生成密码并回写到 `deploy/.env`。
 
+> 默认 Compose 会将 `1241` 端口发布到宿主机所有网络接口。请勿将服务直接暴露到公网；远程访问前请配置认证，并使用 HTTPS、VPN 或安全隧道，详见 [反向代理与 HTTPS](https://docs.arc-reel.com/ops/deployment#reverse-proxy-and-https)。
+
 登录后进入 **设置** 页面，配置 ArcReel AI 助手以及文本、图像、视频等生成能力，再创建项目开始制作。
 
 完整的首次使用流程见 [完整入门教程](https://docs.arc-reel.com/guide/getting-started)；生产部署、升级、备份和反向代理见 [部署与运维](https://docs.arc-reel.com/ops/deployment)。

--- a/README.md
+++ b/README.md
@@ -44,44 +44,14 @@
   <img src="docs/assets/hero-screenshot.png" alt="ArcReel 工作台" width="900">
 </p>
 
-> ArcReel 不是一个简单的“提示词套壳”。它把内容分析、剧本结构化、角色与场景资产、分镜生成、视频任务、费用统计、版本回滚和成片导出组织成一条可审核、可中断恢复的生产流水线。
+## ArcReel 是什么
 
-## ArcReel 能解决什么
+ArcReel 是面向 AI 漫剧与小说改编、说书与旁白短视频、广告与带货短片的开源自托管工作台。它把内容分析、资产管理、分镜、媒体生成、费用追踪和导出组织成一条可审核、可中断恢复的生产流水线。
 
-- **从内容到成片**：小说、成品剧本或商品素材进入同一个工作台，逐步产出角色、场景、道具、分镜、视频片段和最终成片。
-- **保持视觉连续性**：先沉淀角色、场景和关键道具参考资产，再让后续镜头持续引用，降低跨镜头漂移。
-- **保留人的控制权**：关键阶段展示结果并等待确认，单个素材可以重做，历史版本可以回滚。
-- **自由选择模型供应商**：统一管理多个文本、图像、视频和 TTS 供应商，也可以接入兼容 API。
-- **控制生产成本**：生成前估算费用，生成后追踪调用量和实际成本，支持项目、剧集和镜头级查看。
-- **保留后期空间**：既能合成最终视频，也能导出剪映草稿继续调整字幕、配音、节奏和转场。
-
-## 适合的创作场景
-
-<table>
-<tr>
-<td width="33%" valign="top">
-
-### 🎭 AI 漫剧与小说改编
-
-从长篇小说或成品剧本提取角色、场景和剧情结构，分集制作角色一致的剧集动画。
-
-</td>
-<td width="33%" valign="top">
-
-### 🎙️ 说书与旁白短视频
-
-按朗读节奏拆分内容，生成分镜、旁白音轨和竖屏视频，并导出可继续编辑的剪映草稿。
-
-</td>
-<td width="33%" valign="top">
-
-### 🛍️ 广告与带货短片
-
-上传商品多图，建立产品参考资产，按目标时长生成带货镜头脚本和产品锚定画面。
-
-</td>
-</tr>
-</table>
+- **统一生产链路**：小说、成品剧本或商品素材都能逐步转化为角色、场景、道具、分镜、视频片段和最终成片。
+- **视觉一致、人工可控**：跨镜头复用参考资产，关键阶段可审核，单个素材可重做，历史版本可回滚。
+- **模型与成本可管理**：统一配置文本、图像、视频和 TTS 能力，并在生成前后查看费用与实际用量。
+- **交付可继续编辑**：既可直接合成视频，也可导出剪映草稿继续调整字幕、配音、节奏和转场。
 
 ## 从输入到成片
 
@@ -100,17 +70,7 @@ flowchart LR
 
 ## 快速开始
 
-### 准备工作
-
-- Docker 和 Docker Compose
-- 建议从 2 GB 可用内存起步
-- 完整创作流程需要：
-  - 一组用于 ArcReel AI 助手的模型凭据
-  - 可用的文本、图像和视频生成能力（可以由一家全模态供应商提供，也可以组合多家供应商）
-  - 按需配置的 TTS 能力
-- 默认使用远程模型 API，通常不要求本机 GPU；接入本地模型时，资源要求由对应服务决定
-
-### 默认部署：SQLite
+准备好 Docker 和 Docker Compose，然后运行：
 
 ```bash
 git clone https://github.com/ArcReel/ArcReel.git
@@ -120,135 +80,26 @@ cp .env.example .env
 docker compose up -d
 ```
 
-检查服务状态：
+访问 <http://localhost:1241>。默认用户名为 `admin`；`AUTH_PASSWORD` 留空时，首次启动会自动生成密码并回写到 `deploy/.env`。
 
-```bash
-docker compose ps
-curl http://localhost:1241/health
-```
+登录后进入 **设置** 页面，配置 ArcReel AI 助手以及文本、图像、视频等生成能力，再创建项目开始制作。
 
-然后访问 <http://localhost:1241>。
-
-默认用户名为 `admin`。密码通过 `deploy/.env` 中的 `AUTH_PASSWORD` 设置；留空时，首次启动会自动生成并回写到 `.env`。
-
-登录后进入 **设置** 页面：
-
-1. 按首次使用引导浏览工作台和只读演示项目。
-2. 配置 ArcReel AI 助手所使用的模型凭据。
-3. 配置完整创作流程所需的文本、图像和视频生成能力。
-4. 创建项目并从少量内容开始验证工作流。
-
-> 默认部署适合个人体验和轻量使用。正式、并发或长期运行环境建议采用 [PostgreSQL 生产部署](https://docs.arc-reel.com/ops/deployment#postgresql-deployment)。PostgreSQL 不提供用户隔离；ArcReel 目前不支持互不信任的用户共享同一实例。
-
-### 生产部署：PostgreSQL
-
-```bash
-cd "$(git rev-parse --show-toplevel)/deploy/production"
-
-cp .env.example .env
-# 编辑 .env，并设置 POSTGRES_PASSWORD、AUTH_PASSWORD、AUTH_TOKEN_SECRET
-docker compose up -d
-```
-
-部署、升级、备份和反向代理见 [部署与运维](https://docs.arc-reel.com/ops/deployment)；支持边界和漏洞报告方式见 [安全政策](SECURITY.md)。
-
-## 核心能力
-
-### 🤖 Agent 驱动的可恢复工作流
-
-基于 Claude Agent SDK 的编排 Skill 与聚焦 Subagent：主 Agent 识别项目所处阶段，把角色提取、分集规划、剧本规范化和资产生成分发给对应 Subagent，并只接收精炼结果。
-
-### 🎨 角色、场景与道具资产
-
-角色设计图、风格参考图以及场景和道具资产作为跨镜头参考源，减少人物外观、场景氛围和关键物品在不同镜头中的漂移。
-
-### 🎬 三种视频制作方式
-
-- **分镜图生视频**：以单张分镜图驱动视频生成，适合逐镜审核和调整。
-- **分镜板生视频**：先在一张分镜板（宫格）中统一生成多个镜头，再切分为单镜头分镜图生成视频，适合多镜头一致性要求较高的场景。
-- **参考生视频**：直接引用角色、场景和道具资产，跳过普通分镜步骤。
-
-### ⚡ 异步任务与并发控制
-
-图像、视频和音频任务拥有独立并发通道；支持 RPM 限速、任务状态跟踪、失败恢复和中断后的继续执行。
-
-### 🕰️ 版本历史与项目归档
-
-重新生成会保留历史版本；项目可整体导入和导出，便于备份、迁移以及不同环境之间交接。
-
-### 💰 费用预估与实际用量
-
-按供应商和媒体类型统计调用量，区分币种，并提供项目、剧集和镜头级的预估与实际费用对比。
-
-### 🎙️ 旁白与后期导出
-
-支持旁白 TTS、逐段试听和批量生成；剪映草稿导出可保留视频片段、旁白音轨和字幕轨，方便继续后期处理。
-
-### 🔌 外部 Agent 集成
-
-ArcReel 可以签发 `arc-` 前缀 API Key，并通过同步 Agent 对话端点供 OpenClaw 等外部 Agent 平台调用。
-
-## 供应商支持
-
-ArcReel 使用统一的 `TextBackend`、`ImageBackend` 和 `VideoBackend` 协议屏蔽供应商差异。具体可用模型、参数和计费信息会随供应商更新，**以 ArcReel 设置页和供应商官方文档为准**。
-
-| 供应商 | 文本 | 图像 | 视频 | TTS |
-|---|:---:|:---:|:---:|:---:|
-| Gemini | ✅ | ✅ | ✅ | — |
-| 火山方舟 | ✅ | ✅ | ✅ | — |
-| Grok | ✅ | ✅ | ✅ | — |
-| OpenAI | ✅ | ✅ | ✅ | — |
-| Vidu | — | ✅ | ✅ | — |
-| 阿里百炼 | ✅ | ✅ | ✅ | ✅ |
-| MiniMax | ✅ | ✅ | ✅ | — |
-| 可灵 Kling | — | ✅ | ✅ | — |
-| Agnes | ✅ | ✅ | ✅ | — |
-| 自定义供应商 | 取决于接口 | 取决于接口 | 取决于接口 | 取决于接口 |
-
-支持全局默认和项目级覆盖，也支持为同一供应商管理多个 API Key。详细说明见 [供应商与模型配置](https://docs.arc-reel.com/guide/providers)。
-
-## 技术架构
-
-```mermaid
-flowchart TB
-    UI["React 19 Web UI"] --> API["FastAPI API / SSE"]
-    API --> AGENT["Agent Runtime<br/>Skill + Subagent"]
-    API --> CORE["Core Services"]
-    AGENT --> CORE
-    CORE --> PROVIDERS["Text / Image / Video / TTS Backends"]
-    CORE --> QUEUE["Generation Queue<br/>RPM + 独立并发通道"]
-    CORE --> PROJECTS["Project Manager<br/>文件资产 + 版本历史"]
-    CORE --> DB["SQLAlchemy 2.0<br/>SQLite / PostgreSQL"]
-```
-
-技术栈包括 React 19、TypeScript、FastAPI、Python 3.12+、Claude Agent SDK、SQLAlchemy 2.0、FFmpeg、Docker 和 Docker Compose。架构边界与扩展方式见 [架构说明](https://docs.arc-reel.com/dev/architecture)。
-
-## 使用前需要了解的边界
-
-- 媒体生成依赖第三方模型服务，生成速度、可用性、内容策略和成本受供应商影响。
-- 长篇内容仍需要人工审核分集、角色资产和关键剧情节点，ArcReel 的目标是增强创作者，而不是完全取消审核。
-- 不同视频模型对参考图数量、视频时长、首尾帧、音频和地区可用性的支持不同。
-- Windows 原生环境可以运行部分基础流程，但 Agent 沙箱等 POSIX 能力会降级；优先使用 Linux、macOS、WSL2 或 Docker。
-- 生产环境应使用 PostgreSQL、HTTPS、强密码和定期备份，不建议直接把未加保护的 `1241` 端口暴露到公网。
-
-更多问题见 [常见问题](https://docs.arc-reel.com/guide/faq)。
+完整的首次使用流程见 [完整入门教程](https://docs.arc-reel.com/guide/getting-started)；生产部署、升级、备份和反向代理见 [部署与运维](https://docs.arc-reel.com/ops/deployment)。
 
 ## 文档
 
-| 文档 | 内容 |
+| 页面 | 内容 |
 |---|---|
-| [文档导航](https://docs.arc-reel.com/) | 按使用者、运维者和开发者整理的文档入口 |
+| [文档首页](https://docs.arc-reel.com/) | 按使用者、运维者和开发者进入文档 |
 | [完整入门教程](https://docs.arc-reel.com/guide/getting-started) | 从首次部署到生成第一条视频 |
 | [创作流程与模式](https://docs.arc-reel.com/guide/workflows) | 小说、剧本、广告模式以及三种视频制作方式 |
 | [供应商与模型配置](https://docs.arc-reel.com/guide/providers) | Agent、文本、图像、视频、TTS 供应商的选择和配置 |
-| [部署与运维](https://docs.arc-reel.com/ops/deployment) | SQLite、PostgreSQL、升级、备份、反向代理 |
-| [安全政策](SECURITY.md) | 支持版本、部署边界、私密漏洞报告和协调披露 |
-| [安全威胁模型](docs/security/threat-model.md) | 安全资产、信任边界、攻击面和重评触发条件 |
 | [剪映草稿导出](https://docs.arc-reel.com/guide/jianying-export) | 将 ArcReel 生成结果交给剪映继续编辑 |
-| [架构说明](https://docs.arc-reel.com/dev/architecture) | Agent Runtime、任务队列、供应商抽象和数据层 |
 | [常见问题](https://docs.arc-reel.com/guide/faq) | 部署、费用、模型、数据和许可证问题 |
-| [贡献指南](CONTRIBUTING.md) | 本地开发、测试、代码规范和 PR 流程 |
-| [更新记录](CHANGELOG.md) | 每个版本的功能和修复 |
+| [部署与运维](https://docs.arc-reel.com/ops/deployment) | SQLite、PostgreSQL、升级、备份和反向代理 |
+| [从 SQLite 迁移到 PostgreSQL](https://docs.arc-reel.com/ops/migrate-to-postgres) | 数据迁移、验证与回滚流程 |
+| [架构说明](https://docs.arc-reel.com/dev/architecture) | Agent Runtime、任务队列、供应商抽象和数据层 |
+| [贡献指南](https://docs.arc-reel.com/dev/contributing) | 本地开发、测试、代码规范和 PR 流程 |
 
 ## 交流群
 

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -1,6 +1,6 @@
 {
   "CONTRIBUTING.md": "685412c2f75ecd9b5b7909d263d88a1e74c05c42b16b283aea8a9c1209c061a6",
-  "README.md": "af95d79ef6c4a51cb3b5d8627c83945eed6000dafaff57fc0c0e251774d27807",
+  "README.md": "64b7a52d972791e35743a7266b724f6432ea0a1e78163c6efcbe083bef6863a8",
   "website/docs/dev/architecture.md": "5765f8027c8977486c3d99e7b61251ff46248e67b6cbde3130e21cbf0b174613",
   "website/docs/guide/faq.md": "4d3c8e6c55539267c4474c3fdaf551eca5503723c3dabdc1137260261f3964f2",
   "website/docs/guide/getting-started.md": "ef6c982cceae06c62197ab47ef7ff4643b86bc2f3ad0c0555f14cfe12b65f1a6",

--- a/website/i18n/translation.lock.json
+++ b/website/i18n/translation.lock.json
@@ -1,6 +1,6 @@
 {
   "CONTRIBUTING.md": "685412c2f75ecd9b5b7909d263d88a1e74c05c42b16b283aea8a9c1209c061a6",
-  "README.md": "64b7a52d972791e35743a7266b724f6432ea0a1e78163c6efcbe083bef6863a8",
+  "README.md": "104091296eab3792cea0f0562ac67e95ca51dbff3586c5251f63ad5bde743ba0",
   "website/docs/dev/architecture.md": "5765f8027c8977486c3d99e7b61251ff46248e67b6cbde3130e21cbf0b174613",
   "website/docs/guide/faq.md": "4d3c8e6c55539267c4474c3fdaf551eca5503723c3dabdc1137260261f3964f2",
   "website/docs/guide/getting-started.md": "ef6c982cceae06c62197ab47ef7ff4643b86bc2f3ad0c0555f14cfe12b65f1a6",


### PR DESCRIPTION
Closes #1854

## 变更摘要

- 将产品定位、适用场景与核心能力合并为精简定位，保留从输入到成片流程。
- 快速开始只保留最短 Docker + SQLite 路径，深入部署与首次使用流程统一引导到文档站。
- 删除 README 内供应商矩阵、技术架构和使用边界正文，相关信息改由站点对应页面承载。
- 将文档一节改为站点首页与三区九页的完整入口表，移除 docs/*.md 和 pages.dev 链接。
- README.en.md 按中文源同构瘦身，并通过 translation lockfile 机制同步。

中英文 README 均从 287 行精简到 138 行。

## 验证

- translation-lock status：Translations are up to date
- 中英文 7 个章节及 docs.arc-reel.com URL 映射一致
- 站点入口均映射到 website/docs 对应页面，无 docs/*.md 或 pages.dev 链接
- pnpm typecheck：通过
- pnpm check-consistency：通过
- pnpm build：zh-Hans 与 en 均构建成功
- README 中全部唯一 docs.arc-reel.com URL 可达

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 重组中英文 README，突出 ArcReel 自托管 AI 视频生产工作台定位及四项核心能力。
  * 精简 Docker 启动、首次访问和初始配置流程。
  * 新增集中式文档导航，补充部署运维及数据库迁移等文档链接。
  * 同步更新网站翻译内容版本记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->