### PR TITLE
fix(docs): 检出未登记的文档译文

### DIFF
--- a/.claude/skills/translate-docs/SKILL.md
+++ b/.claude/skills/translate-docs/SKILL.md
@@ -24,9 +24,7 @@ Treat every reported item as one batch:
 
 - `missing`: create the reported target from the complete source.
 - `stale`: retranslate the complete source into the reported target.
-- `orphan`: if an existing source still maps to the reported target but only its lock entry is missing, retranslate the
-  complete source and let `record` restore the entry. Otherwise delete the reported target; `record` removes any obsolete
-  lock entry.
+- `orphan`: delete the reported target if it exists; the later `record` command removes the obsolete lock entry.
 
 Finish discovery only after every item has an explicit action. Never hand-edit `website/i18n/translation.lock.json`.
 

--- a/.claude/skills/translate-docs/SKILL.md
+++ b/.claude/skills/translate-docs/SKILL.md
@@ -87,4 +87,5 @@ pnpm typecheck
 pnpm build
 ```
 
-`record` refuses to update the lockfile while a target is missing. Completion requires `status` to print `Translations are up to date.`, typecheck to pass, and the build to emit both `build/` and `build/en/` without broken links or anchors.
+`record` refuses to update the lockfile while a target is missing, and while any Markdown file under
+`website/i18n/*/docusaurus-plugin-content-docs/current/` has no source mapping to it. Completion requires `status` to print `Translations are up to date.`, typecheck to pass, and the build to emit both `build/` and `build/en/` without broken links or anchors.

--- a/.claude/skills/translate-docs/SKILL.md
+++ b/.claude/skills/translate-docs/SKILL.md
@@ -24,7 +24,9 @@ Treat every reported item as one batch:
 
 - `missing`: create the reported target from the complete source.
 - `stale`: retranslate the complete source into the reported target.
-- `orphan`: delete the reported target if it exists; the later `record` command removes the obsolete lock entry.
+- `orphan`: if an existing source still maps to the reported target but only its lock entry is missing, retranslate the
+  complete source and let `record` restore the entry. Otherwise delete the reported target; `record` removes any obsolete
+  lock entry.
 
 Finish discovery only after every item has an explicit action. Never hand-edit `website/i18n/translation.lock.json`.
 

--- a/.claude/skills/translate-docs/scripts/translation-lock.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.mjs
@@ -72,8 +72,13 @@ function sourceForTranslationTarget(target) {
   return `website/docs/${relativeTarget}`;
 }
 
-function unregisteredTranslationOrphans(root, lock) {
-  const registeredTargets = new Set(Object.keys(lock).map(targetForSource).filter((target) => target !== null));
+// A target is registered when a current source maps to it (its lock entry may still be missing or
+// stale) or when a lock entry maps to it (the forward scan already reports it as an orphan).
+function unregisteredTranslationOrphans(root, lock, currentTargets) {
+  const registeredTargets = new Set([
+    ...currentTargets,
+    ...Object.keys(lock).map(targetForSource).filter((target) => target !== null),
+  ]);
   return documentTranslationTargets(root)
     .filter((target) => !registeredTargets.has(target))
     .map((target) => ({ source: sourceForTranslationTarget(target), target, state: "orphan" }));
@@ -94,17 +99,16 @@ function translationStatus(root) {
   const lock = readLock(root);
   const mappings = sourceTargets(root);
   const currentSources = new Set(mappings.map(([source]) => source));
-  const translatedDocumentTargets = new Set(documentTranslationTargets(root));
+  const currentTargets = new Set(mappings.map(([, target]) => target));
   const dirty = mappings.flatMap(([source, target]) => {
     if (!existsSync(resolve(root, target))) return [{ source, target, state: "missing" }];
-    if (!Object.hasOwn(lock, source) && translatedDocumentTargets.has(target)) return [];
     if (lock[source] !== digest(resolve(root, fingerprintSource(source)))) return [{ source, target, state: "stale" }];
     return [];
   });
   const orphans = Object.keys(lock)
     .filter((source) => !currentSources.has(source))
     .map((source) => ({ source, target: targetForSource(source), state: "orphan" }));
-  return [...dirty, ...orphans, ...unregisteredTranslationOrphans(root, lock)].sort(
+  return [...dirty, ...orphans, ...unregisteredTranslationOrphans(root, lock, currentTargets)].sort(
     (left, right) => left.source.localeCompare(right.source) || left.target.localeCompare(right.target),
   );
 }

--- a/.claude/skills/translate-docs/scripts/translation-lock.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.mjs
@@ -5,6 +5,8 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFile
 import { dirname, relative, resolve, sep } from "node:path";
 
 const DOCS_TRANSLATION_ROOT = "website/i18n/en/docusaurus-plugin-content-docs/current";
+const DOCS_TRANSLATION_SUBDIRECTORY = "docusaurus-plugin-content-docs/current";
+const I18N_ROOT = "website/i18n";
 const LOCK_PATH = "website/i18n/translation.lock.json";
 
 function toPosix(path) {
@@ -53,6 +55,30 @@ function sourceTargets(root) {
     .sort(([left], [right]) => left.localeCompare(right));
 }
 
+function documentTranslationTargets(root) {
+  const absoluteI18nRoot = resolve(root, I18N_ROOT);
+  if (!existsSync(absoluteI18nRoot)) return [];
+
+  return readdirSync(absoluteI18nRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => walkMarkdown(root, `${I18N_ROOT}/${entry.name}/${DOCS_TRANSLATION_SUBDIRECTORY}`))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function sourceForTranslationTarget(target) {
+  const marker = `/${DOCS_TRANSLATION_SUBDIRECTORY}/`;
+  const relativeTarget = target.slice(target.indexOf(marker) + marker.length);
+  if (relativeTarget === "dev/contributing.md") return "CONTRIBUTING.md";
+  return `website/docs/${relativeTarget}`;
+}
+
+function unregisteredTranslationOrphans(root, lock) {
+  const registeredTargets = new Set(Object.keys(lock).map(targetForSource).filter((target) => target !== null));
+  return documentTranslationTargets(root)
+    .filter((target) => !registeredTargets.has(target))
+    .map((target) => ({ source: sourceForTranslationTarget(target), target, state: "orphan" }));
+}
+
 function digest(path) {
   const normalized = readFileSync(path, "utf8").replace(/\r\n?/g, "\n");
   return createHash("sha256").update(normalized, "utf8").digest("hex");
@@ -68,15 +94,19 @@ function translationStatus(root) {
   const lock = readLock(root);
   const mappings = sourceTargets(root);
   const currentSources = new Set(mappings.map(([source]) => source));
+  const translatedDocumentTargets = new Set(documentTranslationTargets(root));
   const dirty = mappings.flatMap(([source, target]) => {
     if (!existsSync(resolve(root, target))) return [{ source, target, state: "missing" }];
+    if (!Object.hasOwn(lock, source) && translatedDocumentTargets.has(target)) return [];
     if (lock[source] !== digest(resolve(root, fingerprintSource(source)))) return [{ source, target, state: "stale" }];
     return [];
   });
   const orphans = Object.keys(lock)
     .filter((source) => !currentSources.has(source))
     .map((source) => ({ source, target: targetForSource(source), state: "orphan" }));
-  return [...dirty, ...orphans].sort((left, right) => left.source.localeCompare(right.source));
+  return [...dirty, ...orphans, ...unregisteredTranslationOrphans(root, lock)].sort(
+    (left, right) => left.source.localeCompare(right.source) || left.target.localeCompare(right.target),
+  );
 }
 
 function recordTranslations(root) {
@@ -86,12 +116,16 @@ function recordTranslations(root) {
     throw new Error(`Refusing to record missing translations:\n${missing.map(([source]) => source).join("\n")}`);
   }
   const currentSources = new Set(mappings.map(([source]) => source));
-  const orphanTargets = Object.keys(readLock(root))
-    .filter((source) => !currentSources.has(source))
-    .map(targetForSource)
-    .filter((target) => target !== null && existsSync(resolve(root, target)));
+  const currentTargets = new Set(mappings.map(([, target]) => target));
+  const orphanTargets = [
+    ...Object.keys(readLock(root))
+      .filter((source) => !currentSources.has(source))
+      .map(targetForSource)
+      .filter((target) => target !== null && existsSync(resolve(root, target))),
+    ...documentTranslationTargets(root).filter((target) => !currentTargets.has(target)),
+  ];
   if (orphanTargets.length > 0) {
-    throw new Error(`Refusing to record orphan translations:\n${orphanTargets.join("\n")}`);
+    throw new Error(`Refusing to record orphan translations:\n${[...new Set(orphanTargets)].sort().join("\n")}`);
   }
 
   const lock = Object.fromEntries(

--- a/.claude/skills/translate-docs/scripts/translation-lock.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.mjs
@@ -4,9 +4,9 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve, sep } from "node:path";
 
-const DOCS_TRANSLATION_ROOT = "website/i18n/en/docusaurus-plugin-content-docs/current";
-const DOCS_TRANSLATION_SUBDIRECTORY = "docusaurus-plugin-content-docs/current";
 const I18N_ROOT = "website/i18n";
+const DOCS_TRANSLATION_SUBDIRECTORY = "docusaurus-plugin-content-docs/current";
+const DOCS_TRANSLATION_ROOT = `${I18N_ROOT}/en/${DOCS_TRANSLATION_SUBDIRECTORY}`;
 const LOCK_PATH = "website/i18n/translation.lock.json";
 
 function toPosix(path) {

--- a/.claude/skills/translate-docs/scripts/translation-lock.test.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.test.mjs
@@ -70,11 +70,19 @@ test("status reports translations whose sources were deleted", () => {
   const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
   write(root, "README.md", "# ArcReel\n");
   write(root, "README.en.md", "# ArcReel\n");
+  write(root, "website/docs/guide/start.md", "# 入门\n");
+  write(root, "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md", "# Getting started\n");
   record(root);
   renameSync(join(root, "README.md"), join(root, "README.deleted"));
+  renameSync(join(root, "website/docs/guide/start.md"), join(root, "website/docs/guide/start.deleted"));
 
   assert.deepEqual(status(root), [
     { source: "README.md", target: "README.en.md", state: "orphan" },
+    {
+      source: "website/docs/guide/start.md",
+      target: "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md",
+      state: "orphan",
+    },
   ]);
 });
 
@@ -98,7 +106,7 @@ test("status reports unregistered document translations but ignores locale asset
   ]);
 });
 
-test("status reports a translation as orphan when its lock entry was removed", () => {
+test("status reports a translation as stale when its lock entry was removed", () => {
   const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
   write(root, "website/docs/guide/start.md", "# 入门\n");
   write(root, "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md", "# Getting started\n");
@@ -109,7 +117,7 @@ test("status reports a translation as orphan when its lock entry was removed", (
     {
       source: "website/docs/guide/start.md",
       target: "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md",
-      state: "orphan",
+      state: "stale",
     },
   ]);
 });

--- a/.claude/skills/translate-docs/scripts/translation-lock.test.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.test.mjs
@@ -78,6 +78,42 @@ test("status reports translations whose sources were deleted", () => {
   ]);
 });
 
+test("status reports unregistered document translations but ignores locale assets", () => {
+  const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
+  write(
+    root,
+    "website/i18n/vi/docusaurus-plugin-content-docs/current/guide/unregistered.md",
+    "# Unregistered\n",
+  );
+  write(root, "website/i18n/en/docusaurus-plugin-content-docs/current.json", '{"title":"Docs"}\n');
+  write(root, "website/i18n/en/docusaurus-theme-classic/navbar.json", '{"title":"Docs"}\n');
+  write(root, "website/i18n/en/code.json", '{"theme.ErrorPageContent.title":"Error"}\n');
+
+  assert.deepEqual(status(root), [
+    {
+      source: "website/docs/guide/unregistered.md",
+      target: "website/i18n/vi/docusaurus-plugin-content-docs/current/guide/unregistered.md",
+      state: "orphan",
+    },
+  ]);
+});
+
+test("status reports a translation as orphan when its lock entry was removed", () => {
+  const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
+  write(root, "website/docs/guide/start.md", "# 入门\n");
+  write(root, "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md", "# Getting started\n");
+  record(root);
+  write(root, "website/i18n/translation.lock.json", "{}\n");
+
+  assert.deepEqual(status(root), [
+    {
+      source: "website/docs/guide/start.md",
+      target: "website/i18n/en/docusaurus-plugin-content-docs/current/guide/start.md",
+      state: "orphan",
+    },
+  ]);
+});
+
 test("status reports a translated source whose recorded content changed", () => {
   const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
   write(root, "README.md", "# ArcReel\n");
@@ -133,4 +169,19 @@ test("record refuses to hide an orphan translation that still exists", () => {
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Refusing to record orphan translations:\nREADME\.en\.md/);
+});
+
+test("record refuses to hide an unregistered document translation", () => {
+  const root = mkdtempSync(join(tmpdir(), "arcreel-translation-lock-"));
+  write(root, "website/i18n/en/docusaurus-plugin-content-docs/current/guide/unregistered.md", "# Unregistered\n");
+
+  const result = spawnSync(process.execPath, [scriptPath, "record", "--root", root], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Refusing to record orphan translations:\nwebsite\/i18n\/en\/docusaurus-plugin-content-docs\/current\/guide\/unregistered\.md/,
+  );
 });

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -23,7 +23,9 @@ function checkOrphanTranslations() {
     encoding: "utf8",
   });
   const orphans = JSON.parse(output).filter((item) => item.state === "orphan");
-  return orphans.map((item) => `孤儿译文：${item.target}（源 ${item.source} 已不存在）`);
+  // 孤儿有两种来源：lockfile 里源已删的登记项，以及反向扫描发现的未登记译文文件。
+  // 后者的 source 是按目标路径反推的、未必存在的源，所以措辞不断言「已不存在」。
+  return orphans.map((item) => `孤儿译文：${item.target}（源 ${item.source} 未登记或已不存在）`);
 }
 
 // ---- 2. 上站文档标题缺显式锚点 ----


### PR DESCRIPTION
Closes #1876

## 改动

translation-lock 的孤儿判定原先只从 lockfile 的 key 反推，手工放进译文目录、或 lock 记录被误删后残留的译文都检不出来。现在增加反向扫描：遍历 `website/i18n/*/docusaurus-plugin-content-docs/current/` 下的 Markdown/MDX，凡没有现存源、也没有 lock 登记映射到它的文件，`status` 报 `orphan`、`record` 拒绝写入。Docusaurus 自身的 `code.json`、theme 与 `current.json` 等非文档译文资产不在扫描范围。

源文档仍在、只是 lock 条目丢失的情形保持原有的 `stale` 语义（重译后 `record` 恢复登记），不会被误导向「删除译文」。CI 一致性闸门的孤儿提示相应改为不断言源「已不存在」。

## 验证

- `node --test .claude/skills/translate-docs/scripts/translation-lock.test.mjs`：10 项全过，新增未登记译文报孤儿、locale 资产不误报、record 拒绝、源删除不重复上报等用例
- 真实仓库手工放置未登记译文：`status` 报 orphan、`record` 拒绝；移除后 `status` 回到 `Translations are up to date.`
- `pnpm check-consistency`、`pnpm typecheck`（website）通过
- `uv run python -m pytest tests/test_agent_profile_lint.py` 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 加强翻译记录与状态检查，及时识别未登记、缺失或过期的翻译文档。
  * 优化翻译状态输出，结果按源文档和目标路径排序，便于核查。
* **测试**
  * 新增多种翻译一致性场景验证，避免遗漏翻译或错误更新记录。
* **质量改进**
  * 完成条件现会检查类型、构建结果以及断链和锚点错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->