### PR TITLE
fix(docs): 文档站锚点检查覆盖各语言译文

### DIFF
--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -72,10 +72,11 @@ function checkAnchors() {
 
   for (const root of docRoots()) {
     const jsxHeadingDocs = new Set();
-    const files = walkDocFiles(root);
+    const docPaths = new Set();
 
-    for (const file of files) {
+    for (const file of walkDocFiles(root)) {
       const docPath = toPosix(relative(root, file));
+      docPaths.add(docPath);
       const seenAnchors = new Set();
 
       for (const { index, line, hashes, text, hasJsxHeading } of scanMarkdownLines(
@@ -106,7 +107,7 @@ function checkAnchors() {
       }
     }
     for (const docPath of JSX_HEADING_EXEMPT_DOCS) {
-      if (!files.includes(`${root}/${docPath}`)) continue;
+      if (!docPaths.has(docPath)) continue;
       exemptDocsFound.add(docPath);
       if (!jsxHeadingDocs.has(docPath)) {
         problems.push(

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -8,6 +8,8 @@ import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "no
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { scanMarkdownLines } from "./markdown-scan.mjs";
+
 const websiteDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(websiteDir, "..");
 
@@ -28,16 +30,30 @@ function checkOrphanTranslations() {
 
 // ---- 2. 上站文档标题缺显式锚点 ----
 //
-// 全部标题须带 `{#id}`（两 locale 共用锚点作为链接目标）。index.mdx 的首页卡片标题是 JSX
-// `<h2>`，`{#id}` 语法在 JSX 里不生效，无法补锚点。这里显式登记豁免文件，而不是让扫描器
-// 对 JSX 标题沉默：新增 .mdx 若引入未登记的 JSX 标题会在此处 fail，逼审查者显式决定豁免
-// 还是改回 Markdown 标题；已登记文件若不再含 JSX 标题也会 fail（登记项过期，须及时摘除）。
-const JSX_HEADING_EXEMPT_FILES = new Set(["docs/index.mdx"]);
+// 全部标题须带 `{#id}`（各 locale 共用锚点作为链接目标）。译文与源同结构、受同一套规则约束：
+// 只扫源的话，译文漏写 `{#id}` 只有在恰好有链接指向该锚点时才会被 build 期 onBrokenAnchors 拦下。
+//
+// index.mdx 的首页卡片标题是 JSX `<h2>`，`{#id}` 语法在 JSX 里不生效，无法补锚点。这里显式登记
+// 豁免文件，而不是让扫描器对 JSX 标题沉默：新增 .mdx 若引入未登记的 JSX 标题会在此处 fail，逼
+// 审查者显式决定豁免还是改回 Markdown 标题；已登记文件若不再含 JSX 标题也会 fail（登记项过期，
+// 须及时摘除）。登记路径相对文档根，源与各 locale 译文里的同名副本一并豁免。
+const JSX_HEADING_EXEMPT_DOCS = new Set(["index.mdx"]);
 
-const FENCE = /^ {0,3}(```|~~~)/;
-const HEADING = /^ {0,3}(#{1,6})\s+(.*?)\s*$/;
 const ANCHOR_SUFFIX = /\{#([a-z0-9-]+)\}$/;
-const JSX_HEADING = /<h[1-6][\s/>]/i;
+
+const TRANSLATION_DOCS_SUFFIX = "docusaurus-plugin-content-docs/current";
+
+// 文档根：中文源目录，加 i18n 下每个 locale 的译文目录。新增 locale 自动纳入，无需登记。
+function docRoots() {
+  const i18nDir = resolve(websiteDir, "i18n");
+  if (!existsSync(i18nDir)) return ["docs"];
+  const localeRoots = readdirSync(i18nDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `i18n/${entry.name}/${TRANSLATION_DOCS_SUFFIX}`)
+    .filter((root) => existsSync(resolve(websiteDir, root)))
+    .sort();
+  return ["docs", ...localeRoots];
+}
 
 function walkDocFiles(directory) {
   const absoluteDirectory = resolve(websiteDir, directory);
@@ -52,52 +68,57 @@ function walkDocFiles(directory) {
 
 function checkAnchors() {
   const problems = [];
-  const jsxHeadingFiles = new Set();
+  const exemptDocsFound = new Set();
 
-  for (const file of walkDocFiles("docs")) {
-    const content = readFileSync(resolve(websiteDir, file), "utf8");
-    const lines = content.split("\n");
-    const seenAnchors = new Set();
-    let fence = "";
+  for (const root of docRoots()) {
+    const jsxHeadingDocs = new Set();
+    const files = walkDocFiles(root);
 
-    for (const [index, line] of lines.entries()) {
-      const fenceMatch = FENCE.exec(line);
-      if (fenceMatch) {
-        if (!fence) fence = fenceMatch[1];
-        else if (line.trim().startsWith(fence)) fence = "";
-        continue;
+    for (const file of files) {
+      const docPath = toPosix(relative(root, file));
+      const seenAnchors = new Set();
+
+      for (const { index, line, hashes, text, hasJsxHeading } of scanMarkdownLines(
+        readFileSync(resolve(websiteDir, file), "utf8"),
+      )) {
+        if (hasJsxHeading) jsxHeadingDocs.add(docPath);
+        if (hashes === null) continue;
+
+        const anchorMatch = ANCHOR_SUFFIX.exec(text);
+        if (!anchorMatch) {
+          problems.push(`${file}:${index + 1} 标题缺少显式锚点 {#id}：${line.trim()}`);
+          continue;
+        }
+        const anchor = anchorMatch[1];
+        if (seenAnchors.has(anchor)) {
+          problems.push(`${file} 锚点 id「${anchor}」在同页内重复`);
+        }
+        seenAnchors.add(anchor);
       }
-      if (fence) continue;
+    }
 
-      if (JSX_HEADING.test(line)) jsxHeadingFiles.add(file);
-
-      const heading = HEADING.exec(line);
-      if (!heading) continue;
-      const [, , text] = heading;
-      const anchorMatch = ANCHOR_SUFFIX.exec(text);
-      if (!anchorMatch) {
-        problems.push(`${file}:${index + 1} 标题缺少显式锚点 {#id}：${line.trim()}`);
-        continue;
+    for (const docPath of jsxHeadingDocs) {
+      if (!JSX_HEADING_EXEMPT_DOCS.has(docPath)) {
+        problems.push(
+          `${root}/${docPath} 含 JSX 标题标签但 ${docPath} 未登记在 check-consistency.mjs 的 ` +
+            "JSX_HEADING_EXEMPT_DOCS 中——要么改回带 {#id} 的 Markdown 标题，要么显式登记豁免",
+        );
       }
-      const anchor = anchorMatch[1];
-      if (seenAnchors.has(anchor)) {
-        problems.push(`${file} 锚点 id「${anchor}」在同页内重复`);
+    }
+    for (const docPath of JSX_HEADING_EXEMPT_DOCS) {
+      if (!files.includes(`${root}/${docPath}`)) continue;
+      exemptDocsFound.add(docPath);
+      if (!jsxHeadingDocs.has(docPath)) {
+        problems.push(
+          `${root}/${docPath} 已不含 JSX 标题标签，若各 locale 副本均已如此，请从 JSX_HEADING_EXEMPT_DOCS 摘除 ${docPath}`,
+        );
       }
-      seenAnchors.add(anchor);
     }
   }
 
-  for (const file of jsxHeadingFiles) {
-    if (!JSX_HEADING_EXEMPT_FILES.has(file)) {
-      problems.push(
-        `${file} 含 JSX 标题标签但未登记在 check-consistency.mjs 的 JSX_HEADING_EXEMPT_FILES 中——` +
-          "要么改回带 {#id} 的 Markdown 标题，要么显式登记豁免",
-      );
-    }
-  }
-  for (const file of JSX_HEADING_EXEMPT_FILES) {
-    if (!jsxHeadingFiles.has(file)) {
-      problems.push(`${file} 登记在 JSX_HEADING_EXEMPT_FILES 中但已不含 JSX 标题标签，登记项已过期，请摘除`);
+  for (const docPath of JSX_HEADING_EXEMPT_DOCS) {
+    if (!exemptDocsFound.has(docPath)) {
+      problems.push(`${docPath} 登记在 JSX_HEADING_EXEMPT_DOCS 中但源与各 locale 译文均无此文件，登记项已过期，请摘除`);
     }
   }
 

--- a/website/scripts/markdown-scan.mjs
+++ b/website/scripts/markdown-scan.mjs
@@ -3,7 +3,10 @@
 // 「哪一行算标题」给出同一答案，否则一处认得的标题在另一处漏检。
 
 // CommonMark 允许标题与围栏有 0–3 个前导空格；4 个及以上是缩进代码块，其中的 ``` 不开围栏。
-const FENCE = /^ {0,3}(```|~~~)/;
+// 开栏捕获完整的重复字符（长度 ≥3），闭栏要求同字符、长度 ≥ 开栏长度、且行内除前导空格与
+// 结尾空白外无其他字符——否则四个反引号开出的围栏会被内容里演示用的三个反引号提前闭合。
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+const CLOSING_FENCE = /^ {0,3}(`+|~+)\s*$/;
 const HEADING = /^ {0,3}(#{1,6})\s+(.*?)\s*$/;
 const JSX_HEADING = /<h[1-6][\s/>]/i;
 
@@ -18,13 +21,16 @@ export function* scanMarkdownLines(content) {
   let fence = "";
 
   for (const [index, line] of content.split("\n").entries()) {
-    const fenceMatch = FENCE.exec(line);
-    if (fenceMatch) {
-      if (!fence) fence = fenceMatch[1];
-      else if (line.trim().startsWith(fence)) fence = "";
+    if (fence) {
+      const closingMatch = CLOSING_FENCE.exec(line);
+      if (closingMatch && closingMatch[1][0] === fence[0] && closingMatch[1].length >= fence.length) fence = "";
       continue;
     }
-    if (fence) continue;
+    const fenceMatch = FENCE.exec(line);
+    if (fenceMatch) {
+      fence = fenceMatch[1];
+      continue;
+    }
 
     const heading = HEADING.exec(line);
     yield {

--- a/website/scripts/markdown-scan.mjs
+++ b/website/scripts/markdown-scan.mjs
@@ -1,0 +1,38 @@
+// 文档脚本共用的 Markdown 逐行扫描：识别围栏代码块并跳过其内容，对正文行给出标题解析结果。
+// 围栏与标题的识别规则只在这里定义一次——check-consistency 与 sync-contributing 必须对
+// 「哪一行算标题」给出同一答案，否则一处认得的标题在另一处漏检。
+
+// CommonMark 允许标题与围栏有 0–3 个前导空格；4 个及以上是缩进代码块，其中的 ``` 不开围栏。
+const FENCE = /^ {0,3}(```|~~~)/;
+const HEADING = /^ {0,3}(#{1,6})\s+(.*?)\s*$/;
+const JSX_HEADING = /<h[1-6][\s/>]/i;
+
+/**
+ * 逐行扫描 Markdown 正文，产出围栏代码块之外每一行的扫描结果。
+ *
+ * @param {string} content
+ * @returns {Generator<{ index: number, line: string, hashes: string | null, text: string | null, hasJsxHeading: boolean }>}
+ *   `index` 是 0 基行号；非标题行的 `hashes` / `text` 为 null。
+ */
+export function* scanMarkdownLines(content) {
+  let fence = "";
+
+  for (const [index, line] of content.split("\n").entries()) {
+    const fenceMatch = FENCE.exec(line);
+    if (fenceMatch) {
+      if (!fence) fence = fenceMatch[1];
+      else if (line.trim().startsWith(fence)) fence = "";
+      continue;
+    }
+    if (fence) continue;
+
+    const heading = HEADING.exec(line);
+    yield {
+      index,
+      line,
+      hashes: heading ? heading[1] : null,
+      text: heading ? heading[2] : null,
+      hasJsxHeading: JSX_HEADING.test(line),
+    };
+  }
+}

--- a/website/scripts/sync-contributing.mjs
+++ b/website/scripts/sync-contributing.mjs
@@ -6,6 +6,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { scanMarkdownLines } from "./markdown-scan.mjs";
+
 const websiteDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const source = resolve(websiteDir, "..", "CONTRIBUTING.md");
 const target = resolve(websiteDir, "docs", "dev", "contributing.md");
@@ -36,29 +38,14 @@ const ANCHORS = new Map([
   ["### commit 示例", "commit-examples"],
 ]);
 
-const FENCE = /^\s*(```|~~~)/;
-const HEADING = /^(#{1,6})\s+(.*?)\s*$/;
-
 function injectAnchors(markdown) {
   const seen = new Set();
   const usedAnchors = new Set();
-  let fence = "";
-  const lines = markdown.split("\n").map((line) => {
-    const fenceMatch = FENCE.exec(line);
-    if (fenceMatch) {
-      if (!fence) {
-        fence = fenceMatch[1];
-      } else if (line.trim().startsWith(fence)) {
-        fence = "";
-      }
-      return line;
-    }
-    if (fence) return line;
+  const lines = markdown.split("\n");
 
-    const heading = HEADING.exec(line);
-    if (!heading) return line;
+  for (const { index, hashes, text } of scanMarkdownLines(markdown)) {
+    if (hashes === null) continue;
 
-    const [, hashes, text] = heading;
     const key = `${hashes} ${text}`;
     const anchor = ANCHORS.get(key);
     if (!anchor) {
@@ -72,8 +59,8 @@ function injectAnchors(markdown) {
     }
     usedAnchors.add(anchor);
     seen.add(key);
-    return `${hashes} ${text} {#${anchor}}`;
-  });
+    lines[index] = `${lines[index].replace(/\s*$/, "")} {#${anchor}}`;
+  }
 
   const stale = [...ANCHORS.keys()].filter((key) => !seen.has(key));
   if (stale.length > 0) {


### PR DESCRIPTION
Closes #1875

## 变更

文档站的标题锚点检查此前只扫中文源目录 `website/docs`，各 locale 译文漏写 `{#id}` 只有在恰好有链接指向该锚点时才会被 build 期 `onBrokenAnchors` 拦下。现在检查覆盖 `website/i18n/*/docusaurus-plugin-content-docs/current` 下的全部译文目录，新增语种自动纳入。

同时把围栏/标题识别的正则与逐行扫描循环提取到共用模块 `website/scripts/markdown-scan.mjs`，`check-consistency.mjs` 与 `sync-contributing.mjs` 共同消费。两脚本原先各持一份且已分叉（sync 的围栏正则是 `/^\s*(```|~~~)/`，check 的是修过缩进围栏缺陷的 `/^ {0,3}(```|~~~)/`），现按 CommonMark 语义收敛到一处定义：围栏与标题均允许 0–3 个前导空格，4 个及以上属缩进代码块。

## 两处与 issue 字面描述的偏离

- **豁免登记按文档根相对路径**：issue 写「`JSX_HEADING_EXEMPT_FILES` 豁免登记同步扩展到对应 locale 副本路径」，字面读法是每个 locale 副本各登记一条。实现改为登记文档根相对路径（`index.mdx`，常量随之更名为 `JSX_HEADING_EXEMPT_DOCS`），一条登记同时覆盖源与全部 locale 副本，新增语种无需补登记。覆盖面是字面方案的超集。
- **sync-contributing 的标题行改为追加而非重建**：收敛后的 HEADING 正则允许前导缩进，用 `${hashes} ${text}` 重建整行会顺手吃掉缩进，因此改为「原行去尾空白后追加 `{#id}`」，保持原行前缀不变。

## 验证

- 重构等价性：改造前后各跑一次 `sync-contributing.mjs`，产出的 `website/docs/dev/contributing.md` 字节一致——正则收敛没有改变现有 CONTRIBUTING.md 的处理结果，translation-lock 也不会因此把它标 stale。
- 验收标准逐字复现：删掉 en 译文中一个无任何链接指向的 `{#id}` 后 `check-consistency` 报错退出 1，恢复后通过。
- 豁免机制四向：未登记的 JSX 标题报未登记；登记文件在某 locale 已不含 JSX 标题报该副本登记过期；单个 locale 缺该文件不误报；源与译文均无该文件报登记项过期。
- 质量门（对齐 CI 的 website-checks）：translation-lock 单测 7 passed、`sync-contributing`、`check-consistency`、`pnpm run build` 双 locale 全绿。

## 已知薄弱点

- 共用模块本身无单测（website 侧无测试框架），缩进围栏/缩进标题这类边界目前只靠现有文档内容间接覆盖。
- 检查只覆盖 docusaurus-plugin-content-docs 的 `current` 版本目录；将来启用文档版本化（`version-*`）需一并纳入。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 扩展文档一致性检查，覆盖主文档及现有多语言文档。
  * 增强标题锚点、重复锚点和 JSX 标题豁免项校验，减少文档导航问题。
  * 改进 Markdown 扫描逻辑，正确忽略围栏代码块中的内容。
  * 优化贡献指南中的锚点同步，确保标题链接与登记信息保持一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->