### PR TITLE
fix(i18n): 统一 onboarding 文案中剪映英文名的拼写为 Jianying

### DIFF
--- a/frontend/src/i18n/en/onboarding.ts
+++ b/frontend/src/i18n/en/onboarding.ts
@@ -22,7 +22,7 @@ export default {
   'workbench_timeline_title': 'Shot canvas',
   'workbench_timeline_body': 'Each episode\'s shots are laid out on a timeline, with their image prompt, storyboard frame, and video. Generate the storyboard frame first to confirm the composition, then generate the video; any single shot can be regenerated at any time.',
   'workbench_export_title': 'Export',
-  'workbench_export_body': 'When production is done, export a JianYing draft from the top bar to continue editing, or download the whole project as an archive. The demo project has no finished footage, so the export button is unavailable.',
+  'workbench_export_body': 'When production is done, export a Jianying draft from the top bar to continue editing, or download the whole project as an archive. The demo project has no finished footage, so the export button is unavailable.',
   'finish_title': 'Start your first project',
   'finish_body': 'Create a project and import a novel or script to start production. This tour is available any time under Settings → About.',
 

--- a/frontend/src/i18n/vi/onboarding.ts
+++ b/frontend/src/i18n/vi/onboarding.ts
@@ -23,7 +23,7 @@ export default {
   'workbench_timeline_title': 'Bảng phân cảnh',
   'workbench_timeline_body': 'Các cảnh quay của mỗi tập xếp theo dòng thời gian, gồm prompt hình ảnh, ảnh phân cảnh và video. Có thể tạo ảnh phân cảnh trước để chốt bố cục rồi mới tạo video; từng cảnh quay đều có thể tạo lại bất cứ lúc nào.',
   'workbench_export_title': 'Xuất',
-  'workbench_export_body': 'Sản xuất xong, xuất bản nháp JianYing từ thanh trên cùng để tiếp tục dựng, hoặc tải cả dự án về. Dự án minh hoạ chưa có thành phẩm nên nút xuất không khả dụng.',
+  'workbench_export_body': 'Sản xuất xong, xuất bản nháp Jianying từ thanh trên cùng để tiếp tục dựng, hoặc tải cả dự án về. Dự án minh hoạ chưa có thành phẩm nên nút xuất không khả dụng.',
   'finish_title': 'Bắt đầu dự án đầu tiên của bạn',
   'finish_body': 'Tạo dự án và nhập tiểu thuyết hoặc kịch bản là có thể bắt đầu sản xuất. Có thể xem lại phần hướng dẫn này bất cứ lúc nào trong Cài đặt → Giới thiệu.',
 


### PR DESCRIPTION
## Summary
- 将 onboarding 命名空间下 en/vi 两处用户可见文案中的 `JianYing` 拼写统一为 `Jianying`，与全仓既有拼写（`frontend/src/i18n/en/dashboard.ts` 等 11 处、README.en、文档站英文版）保持一致
- `pyJianYingDraft`（第三方库名）与 `docs/superpowers/` 下历史文档均未触碰，按验收标准排除

Closes #1886

## Test plan
- [x] `git grep -n 'JianYing' -- frontend/src/i18n/` 无命中
- [x] `cd frontend && pnpm lint && pnpm check` 通过（151 个测试文件全绿）
- [x] `/code-review origin/main`：Standards 轴、Spec 轴均无 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更正导出说明中的品牌名称拼写，将“JianYing”统一为“Jianying”。
  * 更新英文和越南语版本的相关文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->