### PR TITLE
fix(video): 视频已生成成功却被判为超时失败

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,7 +83,7 @@ ArcReel 中始终与 server 主进程**捆绑在同一个 uvicorn 进程内**的
 DB 中状态为 `running` 但 worker 内存里没有对应 asyncio.Task 的任务。唯一现实成因是**服务重启**（部署 / 崩溃恢复）；处理原则是不重新触发生成，只有具备完整恢复身份的提交-轮询型任务才可继续轮询。
 
 **provider job status（供应商任务状态）**：
-提交-轮询型 video backend 从供应商回包读到的**远端 job** 状态，与上面 task 状态机同名不同物——它由供应商写、只决定轮询何时终止，不是 DB 里的任务状态。各家状态串写法不一，且经 OpenAI 兼容代理网关转发时会透传底层厂商的串，故一律过 `lib/video_backends/base.py::normalize_provider_status` 归一到五档：`queued` / `running` / `succeeded` / `failed` / `expired`。`expired` 独立于 `failed`：它决定续跑走 `[resume_expired]`（不再自愈）而非普通失败。未登记的状态串按 `running` 处理继续轮询——保守方向，否则会对未就绪任务触发下载。
+提交-轮询型 video backend 从供应商回包读到的**远端 job** 状态，与上面 task 状态机同名不同物——它由供应商写、只决定轮询何时终止，不是 DB 里的任务状态。OpenAI 兼容协议的三个端点（`openai-video` / `newapi-video` / `v2-video-generations`）状态串不由单一厂商固定，经代理网关转发时还会透传底层厂商的写法，故过 `lib/video_backends/base.py::normalize_provider_status` 归一到五档：`queued` / `running` / `succeeded` / `failed` / `expired`；各家自有 API 的 backend 状态串由该家文档定死，仍按字面量判定。`expired` 独立于 `failed`：它决定续跑走 `[resume_expired]`（不再自愈）而非普通失败；协议本身没有过期语义的端点（`v2-video-generations`）在五档之上自行折叠。未登记的状态串按 `running` 处理继续轮询——保守方向，否则会对未就绪任务触发下载。
 _Avoid_: 与 task 状态机的 succeeded/failed 混为一谈；给未知状态串加「猜测即终态」的启发式；在 backend 里各写一份同义词判定。
 
 **execution checkpoint（执行检查点）**：

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,10 @@ ArcReel 中始终与 server 主进程**捆绑在同一个 uvicorn 进程内**的
 **孤儿任务（orphan task）**：
 DB 中状态为 `running` 但 worker 内存里没有对应 asyncio.Task 的任务。唯一现实成因是**服务重启**（部署 / 崩溃恢复）；处理原则是不重新触发生成，只有具备完整恢复身份的提交-轮询型任务才可继续轮询。
 
+**provider job status（供应商任务状态）**：
+提交-轮询型 video backend 从供应商回包读到的**远端 job** 状态，与上面 task 状态机同名不同物——它由供应商写、只决定轮询何时终止，不是 DB 里的任务状态。各家状态串写法不一，且经 OpenAI 兼容代理网关转发时会透传底层厂商的串，故一律过 `lib/video_backends/base.py::normalize_provider_status` 归一到五档：`queued` / `running` / `succeeded` / `failed` / `expired`。`expired` 独立于 `failed`：它决定续跑走 `[resume_expired]`（不再自愈）而非普通失败。未登记的状态串按 `running` 处理继续轮询——保守方向，否则会对未就绪任务触发下载。
+_Avoid_: 与 task 状态机的 succeeded/failed 混为一谈；给未知状态串加「猜测即终态」的启发式；在 backend 里各写一份同义词判定。
+
 **execution checkpoint（执行检查点）**：
 视频任务（分镜路线与参考路线）首次向 provider 提交前冻结的单次付费请求身份与实际输入事实。它只证明「这次提交如何发生」，不是入队快照、provider job、任务状态、Artifact Manifest 写入或产物 current 标记；命中同档复用时不创建 checkpoint。
 _Avoid_: request snapshot、resume payload、current marker。

--- a/docs/api-docs/endpoints/newapi-video.md
+++ b/docs/api-docs/endpoints/newapi-video.md
@@ -3,3 +3,4 @@
 - 协议：[视频生成 API](https://doc.newapi.pro/api/generate-video/)、[可灵与即梦格式](https://doc.newapi.pro/api/kling-jimeng/)
 - 计费：[模型计费说明](https://doc.newapi.pro/guide/pricing/)；实际价格由部署方配置
 - 代码：`lib/custom_provider/endpoints.py::ENDPOINT_REGISTRY["newapi-video"]`、`lib/video_backends/newapi.py::NewAPIVideoBackend`
+- 任务状态与回包形状：状态串随底层厂商透传，过共享归一 `lib/video_backends/base.py::normalize_provider_status`；状态、视频地址与 metadata 按 `NewAPIVideoBackend` 内的路径表并集探测，兼容扁平与 `data` 包装两种回包

--- a/docs/api-docs/endpoints/openai-video.md
+++ b/docs/api-docs/endpoints/openai-video.md
@@ -3,3 +3,4 @@
 - 协议：[OpenAI video generation](https://developers.openai.com/api/docs/guides/video-generation)
 - 计费：[API pricing](https://developers.openai.com/api/docs/pricing)
 - 代码：`lib/custom_provider/endpoints.py::ENDPOINT_REGISTRY["openai-video"]`、`lib/video_backends/openai.py::OpenAIVideoBackend`
+- 任务状态：官方 Sora 只发协议文档列出的状态串，代理网关转发非 Sora 型号时会透传底层厂商的写法，故过共享归一 `lib/video_backends/base.py::normalize_provider_status`

--- a/docs/api-docs/endpoints/v2-video-generations.md
+++ b/docs/api-docs/endpoints/v2-video-generations.md
@@ -4,3 +4,4 @@
 - 边界：ArcReel 只实现多家中转站共享的 `/v2/video/generations` 公共子集，具体模型字段仍以所接中转站官方文档为准。
 - 计费：[AIMLAPI pricing](https://aimlapi.com/ai-ml-api-pricing)；共享协议没有跨中转站统一价格
 - 代码：`lib/custom_provider/endpoints.py::ENDPOINT_REGISTRY["v2-video-generations"]`、`lib/video_backends/v2_video_generations.py::V2VideoGenerationsBackend`
+- 任务状态：共享协议下各中转站状态串写法不一，过共享归一 `lib/video_backends/base.py::normalize_provider_status`；本协议无过期语义，`v2_video_generations.py::normalize_status` 在其上折叠为四值

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -337,6 +337,110 @@ async def submit_post(
     return resp
 
 
+class ProviderJobStatus(StrEnum):
+    """供应商异步任务状态的 canonical 分档。
+
+    ``EXPIRED`` 独立于 ``FAILED``：OpenAI / NewAPI 两条链路据其按 generate / resume 上下文
+    分流抛 ``RuntimeError`` / ``ResumeExpiredError``，后者驱动 worker 的 ``[resume_expired]``
+    前缀与「不再尝试重启自愈」判定。折进 failed 会静默吃掉这条分流。没有过期语义的端点
+    （如流派 C ``/v2/video/generations``）在本分档之上自行折叠。
+    """
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+
+TERMINAL_PROVIDER_STATUSES: frozenset[ProviderJobStatus] = frozenset(
+    {ProviderJobStatus.SUCCEEDED, ProviderJobStatus.FAILED, ProviderJobStatus.EXPIRED}
+)
+
+# 跨厂商状态同义词表（lowercase + strip 后查表）。OpenAI 兼容代理网关转发非原生型号时会把
+# 底层厂商的状态串原样透传，各后端若只认自家文档里的字面量，已就绪的任务会被当成"仍在跑"
+# 一路轮询到 max_wait —— 用户侧报超时失败，供应商侧成品已生成且已计费。
+_PROVIDER_STATUS_SYNONYMS: dict[str, ProviderJobStatus] = {
+    "completed": ProviderJobStatus.SUCCEEDED,
+    "succeeded": ProviderJobStatus.SUCCEEDED,
+    "succeed": ProviderJobStatus.SUCCEEDED,
+    "success": ProviderJobStatus.SUCCEEDED,
+    "failed": ProviderJobStatus.FAILED,
+    "fail": ProviderJobStatus.FAILED,
+    "error": ProviderJobStatus.FAILED,
+    "canceled": ProviderJobStatus.FAILED,
+    "cancelled": ProviderJobStatus.FAILED,
+    "expired": ProviderJobStatus.EXPIRED,
+    "generating": ProviderJobStatus.RUNNING,
+    "in_progress": ProviderJobStatus.RUNNING,
+    "running": ProviderJobStatus.RUNNING,
+    "processing": ProviderJobStatus.RUNNING,
+    "queued": ProviderJobStatus.QUEUED,
+    "queueing": ProviderJobStatus.QUEUED,
+    "preparing": ProviderJobStatus.QUEUED,
+    "submitted": ProviderJobStatus.QUEUED,
+    "pending": ProviderJobStatus.QUEUED,
+    "created": ProviderJobStatus.QUEUED,
+}
+
+
+def normalize_provider_status(raw: object) -> ProviderJobStatus:
+    """任意供应商状态值 → canonical 分档（大小写与首尾空白无关）。
+
+    未登记的状态串一律当 ``RUNNING`` 继续轮询：把未知串判成终态，会让返回非标进行中状态
+    （如 ``NOT_START``）的网关触发"下载未就绪任务"。非字符串（缺字段 / None）同理。
+    """
+    if not isinstance(raw, str):
+        return ProviderJobStatus.RUNNING
+    return _PROVIDER_STATUS_SYNONYMS.get(raw.strip().lower(), ProviderJobStatus.RUNNING)
+
+
+def _dig(payload: object, path: tuple[str | int, ...]) -> object | None:
+    """按 path 逐层走 dict key / list 下标（int 段表 list 下标），任一层缺失返回 None。"""
+    cur: object = payload
+    for seg in path:
+        if isinstance(seg, int):
+            if not isinstance(cur, list) or seg >= len(cur):
+                return None
+            cur = cur[seg]
+        else:
+            if not isinstance(cur, dict) or seg not in cur:
+                return None
+            cur = cur[seg]
+    return cur
+
+
+def first_str_by_paths(payload: object, paths: tuple[tuple[str | int, ...], ...]) -> str | None:
+    """按优先级逐个试取第一个非空字符串值（int 容忍并 str 化）。
+
+    各家回包结构不一致时，用一张按优先级排序的路径表容错取值，而不是为每种形状写一条分支。
+    """
+    for path in paths:
+        val = _dig(payload, path)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+        if isinstance(val, int) and not isinstance(val, bool):
+            return str(val)
+    return None
+
+
+# 错误描述的常见落点：扁平 error 与包装体内的 data.error。
+_ERROR_PATHS: tuple[tuple[str | int, ...], ...] = (("error",), ("data", "error"))
+
+
+def extract_provider_error_message(state: object) -> str:
+    """从回包里尽力取供应商错误描述（dict 取 message/name，或直接是字符串）；取不到返回 unknown。"""
+    for path in _ERROR_PATHS:
+        err = _dig(state, path)
+        if isinstance(err, dict):
+            msg = err.get("message") or err.get("name")
+            if isinstance(msg, str) and msg.strip():
+                return msg.strip()
+        elif isinstance(err, str) and err.strip():
+            return err.strip()
+    return "unknown"
+
+
 async def poll_with_retry[T](
     *,
     poll_fn: Callable[[], Awaitable[T]],

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -446,9 +446,10 @@ def extract_provider_error_message(state: object) -> str:
     for path in _ERROR_PATHS:
         err = _dig(state, path)
         if isinstance(err, dict):
-            msg = err.get("message") or err.get("name")
-            if isinstance(msg, str) and msg.strip():
-                return msg.strip()
+            # 两个字段各自判定：message 为空白或非字符串时仍要落到 name，别把回退一并跳过。
+            for value in (err.get("message"), err.get("name")):
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
         elif isinstance(err, str) and err.strip():
             return err.strip()
     return "unknown"

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -424,6 +424,19 @@ def first_str_by_paths(payload: object, paths: tuple[tuple[str | int, ...], ...]
     return None
 
 
+def first_mapping_by_paths(payload: object, paths: tuple[tuple[str | int, ...], ...]) -> dict | None:
+    """按优先级逐个试取第一个 dict 值；取不到返回 None。
+
+    同 ``first_str_by_paths``，用于回包里成组的子结构（如 metadata）——形状随部署变化时
+    与状态、视频地址走同一张优先级表，不各写一套形状分支。
+    """
+    for path in paths:
+        val = _dig(payload, path)
+        if isinstance(val, dict):
+            return val
+    return None
+
+
 # 错误描述的常见落点：扁平 error 与包装体内的 data.error。
 _ERROR_PATHS: tuple[tuple[str | int, ...], ...] = (("error",), ("data", "error"))
 

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -31,6 +31,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     download_video,
     extract_provider_error_message,
+    first_mapping_by_paths,
     first_str_by_paths,
     normalize_provider_status,
     poll_with_retry,
@@ -63,6 +64,9 @@ _VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
     ("data", "result_url"),
     ("result_url",),
 )
+# metadata 与状态、视频地址同源：包装体形状下它一并落在 ``data`` 里。实际时长是计费依据，
+# 取不到会退回请求时长记账。
+_METADATA_PATHS: tuple[tuple[str | int, ...], ...] = (("metadata",), ("data", "metadata"))
 
 
 def _task_status(state: object) -> ProviderJobStatus:
@@ -214,7 +218,7 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
         # 流式下载，不携带 Authorization 头（视频 URL 常为 CDN/OSS，避免 API Key 泄露）
         await self._download_with_retry(video_url, request.output_path)
 
-        meta = final.get("metadata") or {}
+        meta = first_mapping_by_paths(final, _METADATA_PATHS) or {}
         raw_duration = meta.get("duration")
         duration_seconds = int(float(raw_duration)) if raw_duration is not None else request.duration_seconds
         return VideoGenerationResult(

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -60,9 +60,9 @@ _VIDEO_ROUND_TO = 8
 _STATUS_PATHS: tuple[tuple[str | int, ...], ...] = (("status",), ("data", "status"))
 _VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
     ("url",),
+    ("result_url",),
     ("data", "url"),
     ("data", "result_url"),
-    ("result_url",),
 )
 # metadata 与状态、视频地址同源：包装体形状下它一并落在 ``data`` 里。实际时长是计费依据，
 # 取不到会退回请求时长记账。

--- a/lib/video_backends/newapi.py
+++ b/lib/video_backends/newapi.py
@@ -22,12 +22,17 @@ from lib.retry import (
     with_retry_async,
 )
 from lib.video_backends.base import (
+    TERMINAL_PROVIDER_STATUSES,
     ProviderJobIdPersistenceMixin,
+    ProviderJobStatus,
     ResumeExpiredError,
     VideoCapabilities,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
+    extract_provider_error_message,
+    first_str_by_paths,
+    normalize_provider_status,
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
@@ -47,6 +52,22 @@ _LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
 
 # 视频标准尺寸对齐 8 的倍数（1920x1080 / 1080x1920 等；1080 非 16 的倍数），主流视频模型通用。
 _VIDEO_ROUND_TO = 8
+
+# 状态与视频地址的多路径优先级表：该端点的回包形状跨部署不统一，既有扁平 ``{status, url}``，
+# 也有 ``{"code": ..., "data": {...}}`` 包装体（视频地址字段名另有 ``result_url`` 一说）。
+# 故按优先级并集探测而非二选一：扁平路径恒排表首，包装路径仅在其缺失时兜底。
+_STATUS_PATHS: tuple[tuple[str | int, ...], ...] = (("status",), ("data", "status"))
+_VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
+    ("url",),
+    ("data", "url"),
+    ("data", "result_url"),
+    ("result_url",),
+)
+
+
+def _task_status(state: object) -> ProviderJobStatus:
+    """回包 → canonical 状态。端点跨厂商分发，状态串随底层厂商透传，必须过共享归一。"""
+    return normalize_provider_status(first_str_by_paths(state, _STATUS_PATHS))
 
 
 def _resolve_size(resolution: str | None, aspect_ratio: str) -> tuple[int, int]:
@@ -153,7 +174,7 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
         *,
         is_resume: bool,
     ) -> VideoGenerationResult:
-        # _is_done 纯谓词：completed / failed / expired 均视为终态；caller 按 is_resume
+        # is_done 纯谓词：成功 / 失败 / 过期三档均视为终态；caller 按 is_resume
         # flag 决定 expired 抛 RuntimeError（generate）还是 ResumeExpiredError（resume）。
         # resume 路径下 404 由 _gated_poll 直接抛 ResumeExpiredError：should_retry_poll 把
         # 轮询 404 当作"短暂未就绪"重试，对已过期的 resume 任务会一直重到 max_wait 超时、
@@ -169,7 +190,7 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
 
         final = await poll_with_retry(
             poll_fn=_gated_poll,
-            is_done=lambda state: state.get("status") in ("completed", "failed", "expired"),
+            is_done=lambda state: _task_status(state) in TERMINAL_PROVIDER_STATUSES,
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
@@ -177,7 +198,7 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
             label="NewAPI",
         )
 
-        if final.get("status") == "expired":
+        if _task_status(final) is ProviderJobStatus.EXPIRED:
             if is_resume:
                 raise ResumeExpiredError(
                     job_id=task_id,
@@ -186,9 +207,9 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
                 )
             raise RuntimeError(f"NewAPI task expired during generate: {task_id}")
 
-        video_url = final.get("url")
+        video_url = first_str_by_paths(final, _VIDEO_URL_PATHS)
         if not video_url:
-            raise RuntimeError(f"NewAPI 任务完成但缺少 url 字段: {final}")
+            raise RuntimeError(f"NewAPI 任务完成但未能从已知路径提取视频 URL: {final}")
 
         # 流式下载，不携带 Authorization 头（视频 URL 常为 CDN/OSS，避免 API Key 泄露）
         await self._download_with_retry(video_url, request.output_path)
@@ -252,7 +273,6 @@ class NewAPIVideoBackend(ProviderJobIdPersistenceMixin):
 
 
 def _extract_failure(state: dict) -> str | None:
-    if state.get("status") != "failed":
+    if _task_status(state) is not ProviderJobStatus.FAILED:
         return None
-    err = (state.get("error") or {}).get("message") or "unknown"
-    return f"NewAPI 视频生成失败: {err}"
+    return f"NewAPI 视频生成失败: {extract_provider_error_message(state)}"

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -55,6 +55,30 @@ def _video_status(video: object) -> ProviderJobStatus:
     return normalize_provider_status(getattr(video, "status", None))
 
 
+def _video_error_message(video: object) -> str:
+    """SDK Video 对象 → 供应商失败原因文本；取不到返回 unknown。
+
+    这句话原样落进 ``task.error_message``，是用户在任务面板读到的全部原因，故显式取字段而不是
+    插值整个对象：``Video.error`` 是带 ``code`` / ``message`` 的模型，直接插值会把类名与字段名
+    一并写给用户；``None``（网关只给 status 不给 error 的常见形态）会写出一句没有原因的失败。
+    代理网关透传的裸 dict / 裸字符串同样认。
+    """
+    err = getattr(video, "error", None)
+    if err is None:
+        return "unknown"
+    if isinstance(err, str):
+        return err.strip() or "unknown"
+    if isinstance(err, dict):
+        candidates = (err.get("message"), err.get("code"))
+    else:
+        candidates = (getattr(err, "message", None), getattr(err, "code", None))
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    # 认不出的形态：宁可带上 repr 也不丢原因——空信息的失败最难排查
+    return str(err).strip() or "unknown"
+
+
 def _resolve_size(model: str, resolution: str | None, aspect_ratio: str) -> str:
     """比例优先：在 model+分辨率档对应的 sora 合法档中选比例最接近 aspect_ratio 的；并列取像素更高者。
 
@@ -233,7 +257,7 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
             poll_fn=lambda: self._client.videos.retrieve(video_id),
             is_done=lambda v: _video_status(v) in TERMINAL_PROVIDER_STATUSES,
             is_failed=lambda v: (
-                f"Sora 视频生成失败: {getattr(v, 'error', None)}"
+                f"Sora 视频生成失败: {_video_error_message(v)}"
                 if _video_status(v) is ProviderJobStatus.FAILED
                 else None
             ),

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -13,11 +13,14 @@ from lib.providers import PROVIDER_OPENAI
 from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
+    TERMINAL_PROVIDER_STATUSES,
     ProviderJobIdPersistenceMixin,
+    ProviderJobStatus,
     ResumeExpiredError,
     VideoCapabilities,
     VideoGenerationRequest,
     VideoGenerationResult,
+    normalize_provider_status,
     poll_with_retry,
 )
 
@@ -40,6 +43,16 @@ _SORA_SIZES_1080P: tuple[str, ...] = ("1080x1920", "1920x1080")
 # 向后兼容的并集导出（外部/测试引用「全部合法档」）。
 _SORA_LEGAL_SIZES: tuple[str, ...] = _SORA_SIZES_720P + _SORA_SIZES_1080P
 _SORA_1080P_MIN_SHORT = 1080
+
+
+def _video_status(video: object) -> ProviderJobStatus:
+    """SDK Video 对象 → canonical 状态。
+
+    本端点同时服务内置 Sora 与自定义供应商的 openai-video 协议：官方 Sora 只发
+    ``queued`` / ``in_progress`` / ``completed`` / ``failed``，而 OpenAI 兼容代理网关转发
+    非 Sora 型号时会透传底层厂商的状态串（如 ``succeeded``），故一律过共享归一。
+    """
+    return normalize_provider_status(getattr(video, "status", None))
 
 
 def _resolve_size(model: str, resolution: str | None, aspect_ratio: str) -> str:
@@ -149,7 +162,7 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
 
         # generate 路径下 expired 是「provider 异常 / 输入参数过期」类失败，
         # 抛 RuntimeError 让 worker mark_failed（不带 [resume_expired] 前缀）。
-        if final.status == "expired":
+        if _video_status(final) is ProviderJobStatus.EXPIRED:
             raise RuntimeError(f"OpenAI Sora job expired during generate: {final.id}")
 
         return await self._download_and_build_result(final, request, kwargs)
@@ -165,7 +178,7 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
 
         # resume 路径下 expired = provider 端已忘 / 输入资产过期，归类
         # [resume_expired] 让 worker 错误前缀化、不再尝试重启自愈
-        if final.status == "expired":
+        if _video_status(final) is ProviderJobStatus.EXPIRED:
             raise ResumeExpiredError(
                 job_id=job_id,
                 provider=PROVIDER_OPENAI,
@@ -203,23 +216,27 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
         return await self._client.videos.create(**kwargs)
 
     async def _poll_until_complete(self, video_id: str, duration_seconds: int):
-        """轮询任务直到 status=='completed'。
+        """轮询任务直到状态归一到终态。
 
         不复用 SDK 的 client.videos.poll：它仅识别 in_progress/queued/completed/failed，
         对接返回非标状态（如 NOT_START）的 OpenAI 兼容网关时会提前退出，导致下载未就绪任务。
         """
         max_wait = max(_MIN_POLL_TIMEOUT_SECONDS, float(duration_seconds) * _POLL_TIMEOUT_PER_SECOND)
 
-        # _is_done 是纯谓词：completed / failed / expired 三种状态都视为「已终态」让 poll 返回。
+        # is_done 是纯谓词：成功 / 失败 / 过期三档都视为「已终态」让 poll 返回。
         # caller (generate / resume_video) 拿到 result 后再分流：
-        #   - completed → 下载
-        #   - failed   → is_failed 已抛 RuntimeError
-        #   - expired  → 在 caller 处按 generate vs resume 上下文抛 RuntimeError / ResumeExpiredError
+        #   - succeeded → 下载
+        #   - failed    → is_failed 已抛 RuntimeError
+        #   - expired   → 在 caller 处按 generate vs resume 上下文抛 RuntimeError / ResumeExpiredError
         # 关键不变量：is_failed 不识别 expired，避免覆盖 caller 分流。
         return await poll_with_retry(
             poll_fn=lambda: self._client.videos.retrieve(video_id),
-            is_done=lambda v: v.status in ("completed", "failed", "expired"),
-            is_failed=lambda v: f"Sora 视频生成失败: {getattr(v, 'error', None)}" if v.status == "failed" else None,
+            is_done=lambda v: _video_status(v) in TERMINAL_PROVIDER_STATUSES,
+            is_failed=lambda v: (
+                f"Sora 视频生成失败: {getattr(v, 'error', None)}"
+                if _video_status(v) is ProviderJobStatus.FAILED
+                else None
+            ),
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=max_wait,
             retryable_errors=OPENAI_RETRYABLE_ERRORS,

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -61,7 +61,7 @@ def _video_error_message(video: object) -> str:
     这句话原样落进 ``task.error_message``，是用户在任务面板读到的全部原因，故显式取字段而不是
     插值整个对象：``Video.error`` 是带 ``code`` / ``message`` 的模型，直接插值会把类名与字段名
     一并写给用户；``None``（网关只给 status 不给 error 的常见形态）会写出一句没有原因的失败。
-    代理网关透传的裸 dict / 裸字符串同样认。
+    代理网关透传的裸 dict / 裸字符串同样认，认不出的形态一律 unknown。
     """
     err = getattr(video, "error", None)
     if err is None:
@@ -75,8 +75,11 @@ def _video_error_message(video: object) -> str:
     for value in candidates:
         if isinstance(value, str) and value.strip():
             return value.strip()
-    # 认不出的形态：宁可带上 repr 也不丢原因——空信息的失败最难排查
-    return str(err).strip() or "unknown"
+        # 数字错误码（网关常见的裸 HTTP 码）也是原因，别因为不是字符串就丢掉
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+    # 认不出的形态说不出原因就说 unknown：把对象自身的 repr 写进任务面板等于没说
+    return "unknown"
 
 
 def _resolve_size(model: str, resolution: str | None, aspect_ratio: str) -> str:

--- a/lib/video_backends/v2_video_generations.py
+++ b/lib/video_backends/v2_video_generations.py
@@ -10,8 +10,8 @@ CometAPI 等事实标准）：``POST /v2/video/generations`` 提交拿 generatio
 - 请求体取各家公共子集（model / prompt / duration / image_url / last_image_url /
   image_urls / seed / resolution）；尾帧键随模型差异（Veo ``last_image_url`` /
   Kling ``tail_image_url``），generic 取最常见的 ``last_image_url``。
-- 状态串归一化：覆盖 aimlapi 官方枚举（queued/generating/completed/error）并并入
-  跨厂商同义词，未知串当 running 继续轮询。
+- 状态串归一化：走 base 的跨厂商共享归一（覆盖 aimlapi 官方枚举 queued/generating/
+  completed/error），本端点无过期语义故把 expired 折进 failed，未知串当 running 继续轮询。
 - 视频 URL / task_id / status 各用一张多路径优先级表逐个试取，容忍各家回包结构差异。
 """
 
@@ -32,11 +32,15 @@ from lib.retry import (
 )
 from lib.video_backends.base import (
     ProviderJobIdPersistenceMixin,
+    ProviderJobStatus,
     ResumeExpiredError,
     VideoCapabilities,
     VideoGenerationRequest,
     VideoGenerationResult,
     download_video,
+    extract_provider_error_message,
+    first_str_by_paths,
+    normalize_provider_status,
     poll_with_retry,
     should_retry_poll,
     should_retry_submit,
@@ -62,32 +66,7 @@ _LARGE_IMAGE_WARN_BYTES = 4 * 1024 * 1024
 # 日志摘要里 prompt 截断长度（避免长 prompt 撑爆日志）
 _PROMPT_LOG_MAX = 200
 
-# 状态串 → canonical（lowercase 后查表）。覆盖 aimlapi 官方枚举 queued/generating/
-# completed/error，并并入跨厂商同义词（流派 C 路由到多家时底层状态串可能透传）。
-_STATUS_SYNONYMS: dict[str, str] = {
-    "completed": "succeeded",
-    "succeeded": "succeeded",
-    "succeed": "succeeded",
-    "success": "succeeded",
-    "failed": "failed",
-    "fail": "failed",
-    "error": "failed",
-    "expired": "failed",
-    "canceled": "failed",
-    "cancelled": "failed",
-    "generating": "running",
-    "in_progress": "running",
-    "running": "running",
-    "processing": "running",
-    "queued": "queued",
-    "queueing": "queued",
-    "preparing": "queued",
-    "submitted": "queued",
-    "pending": "queued",
-    "created": "queued",
-}
-
-# 多路径优先级表，配 _dig 逐层走 dict key / list 下标（int 段表 list 下标）。
+# 多路径优先级表，配 dig 逐层走 dict key / list 下标（int 段表 list 下标）。
 # 取自参数对齐表「视频 URL 路径 / task_id 路径」的流派 C 并集。
 _VIDEO_URL_PATHS: tuple[tuple[str | int, ...], ...] = (
     ("video", "url"),
@@ -114,37 +93,14 @@ _STATUS_PATHS: tuple[tuple[str | int, ...], ...] = (
 )
 
 
-def _dig(payload: object, path: tuple[str | int, ...]) -> object | None:
-    """按 path 逐层走 dict key / list 下标，任一层缺失返回 None。"""
-    cur: object = payload
-    for seg in path:
-        if isinstance(seg, int):
-            if not isinstance(cur, list) or seg >= len(cur):
-                return None
-            cur = cur[seg]
-        else:
-            if not isinstance(cur, dict) or seg not in cur:
-                return None
-            cur = cur[seg]
-    return cur
+def normalize_status(raw: object) -> ProviderJobStatus:
+    """raw 状态值 → canonical：queued | running | succeeded | failed。未知串当 running。
 
-
-def _first_str_by_paths(payload: object, paths: tuple[tuple[str | int, ...], ...]) -> str | None:
-    """按优先级逐个试取第一个非空字符串值（int 容忍并 str 化）。"""
-    for path in paths:
-        val = _dig(payload, path)
-        if isinstance(val, str) and val.strip():
-            return val.strip()
-        if isinstance(val, int) and not isinstance(val, bool):
-            return str(val)
-    return None
-
-
-def normalize_status(raw: object) -> str:
-    """raw 状态值 → canonical：queued | running | succeeded | failed。未知串当 running。"""
-    if not isinstance(raw, str):
-        return "running"
-    return _STATUS_SYNONYMS.get(raw.strip().lower(), "running")
+    本端点无独立的过期语义（任务过期即失败、无续跑分流），故在共享的五档归一之上把
+    ``EXPIRED`` 折进 ``FAILED``。
+    """
+    status = normalize_provider_status(raw)
+    return ProviderJobStatus.FAILED if status is ProviderJobStatus.EXPIRED else status
 
 
 def _warn_if_large(path: Path) -> None:
@@ -244,16 +200,9 @@ def _normalize_root(base_url: str) -> str:
 
 
 def _extract_failure(state: dict) -> str | None:
-    if normalize_status(_first_str_by_paths(state, _STATUS_PATHS)) != "failed":
+    if normalize_status(first_str_by_paths(state, _STATUS_PATHS)) is not ProviderJobStatus.FAILED:
         return None
-    err = _dig(state, ("error",))
-    if isinstance(err, dict):
-        msg = err.get("message") or err.get("name") or "unknown"
-    elif isinstance(err, str) and err.strip():
-        msg = err
-    else:
-        msg = "unknown"
-    return f"V2 视频生成失败: {msg}"
+    return f"V2 视频生成失败: {extract_provider_error_message(state)}"
 
 
 class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
@@ -319,7 +268,7 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
             provider=PROVIDER_V2_VIDEO,
         )
         payload = resp.json()
-        generation_id = _first_str_by_paths(payload, _TASK_ID_PATHS)
+        generation_id = first_str_by_paths(payload, _TASK_ID_PATHS)
         if not generation_id:
             raise RuntimeError(f"V2 创建任务返回体未能从已知路径提取 task_id: {payload}")
         return generation_id
@@ -355,7 +304,7 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
 
         final = await poll_with_retry(
             poll_fn=_gated_poll,
-            is_done=lambda s: normalize_status(_first_str_by_paths(s, _STATUS_PATHS)) == "succeeded",
+            is_done=lambda s: normalize_status(first_str_by_paths(s, _STATUS_PATHS)) is ProviderJobStatus.SUCCEEDED,
             is_failed=_extract_failure,
             poll_interval=_POLL_INTERVAL_SECONDS,
             max_wait=self._max_wait(request.duration_seconds),
@@ -363,7 +312,7 @@ class V2VideoGenerationsBackend(ProviderJobIdPersistenceMixin):
             label="V2",
         )
 
-        video_url = _first_str_by_paths(final, _VIDEO_URL_PATHS)
+        video_url = first_str_by_paths(final, _VIDEO_URL_PATHS)
         if not video_url:
             raise RuntimeError(f"V2 任务完成但未能从已知路径提取视频 URL: {final}")
         await self._download_with_retry(video_url, request.output_path)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,10 +7,13 @@ Single-file fakes stay in their respective test modules.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, patch
 
 from instructor.core import InstructorRetryException
 
@@ -423,3 +426,19 @@ def instructor_api_call_exhausted(cause: Exception) -> InstructorRetryException:
     )
     exc.__cause__ = cause
     return exc
+
+
+@contextmanager
+def bounded_poll_clock(step: float = 30.0):
+    """把 ``poll_with_retry`` 的时钟换成假表：sleep 不真等，每读一次表推进 step 秒。
+
+    终态判定失灵时（把已就绪的任务当成"仍在跑"），真实时钟下 sleep 被 mock 掉的轮询会以近乎
+    为零的真实耗时空转到天荒地老——测试表现为挂起而不是失败。假表让这类回归在几十次轮询内
+    撞上 ``max_wait`` 抛 ``TimeoutError``，红得快且可读。
+    """
+    clock = itertools.count(0.0, step)
+    with (
+        patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+        patch("lib.video_backends.base.time.monotonic", side_effect=lambda: next(clock)),
+    ):
+        yield

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -825,6 +825,34 @@ class TestWrappedResponseShape:
 
         assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"
 
+    async def test_flat_result_url_wins_over_wrapped(self, tmp_path: Path):
+        """混合形状下扁平字段整体优先于包装体，不因字段名不同而让位。"""
+        mock_client = _mock_http_client(
+            poll_body={
+                "task_id": "t-proxy",
+                "status": "completed",
+                "result_url": "https://cdn/flat.mp4",
+                "data": {"url": "https://cdn/wrapped.mp4"},
+            }
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory())
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"
+
     async def test_wrapped_metadata_feeds_duration_and_seed(self, tmp_path: Path):
         """包装体里的 metadata 与状态、视频地址同源，同样要取到——实际时长是计费依据。"""
         mock_client = _mock_http_client(

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -824,3 +824,34 @@ class TestWrappedResponseShape:
             )
 
         assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"
+
+    async def test_wrapped_metadata_feeds_duration_and_seed(self, tmp_path: Path):
+        """包装体里的 metadata 与状态、视频地址同源，同样要取到——实际时长是计费依据。"""
+        mock_client = _mock_http_client(
+            poll_body={
+                "code": "success",
+                "data": {
+                    "task_id": "t-proxy",
+                    "status": "SUCCESS",
+                    "result_url": "https://cdn/wrapped.mp4",
+                    "metadata": {"duration": 8, "seed": 4242},
+                },
+            }
+        )
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", AsyncMock(side_effect=_fake_download_factory())),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert result.duration_seconds == 8
+        assert result.seed == 4242

--- a/tests/test_newapi_video_backend.py
+++ b/tests/test_newapi_video_backend.py
@@ -11,6 +11,7 @@ import pytest
 
 from lib.providers import PROVIDER_NEWAPI
 from lib.video_backends.base import VideoGenerationRequest
+from tests.fakes import bounded_poll_clock
 
 pytestmark = pytest.mark.unit
 
@@ -680,3 +681,146 @@ class TestNewAPIVideoBackend:
                 )
             assert "expired" in str(ei.value).lower()
             assert not isinstance(ei.value, ResumeExpiredError), "generate 路径不应抛 ResumeExpiredError"
+
+
+def _mock_http_client(*, create_body: dict | None = None, poll_body: dict) -> AsyncMock:
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_make_response(200, create_body or {"task_id": "t-proxy"}))
+    client.get = AsyncMock(return_value=_make_response(200, poll_body))
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+class TestProxyStatusSynonyms:
+    """NewAPI 端点跨厂商分发，状态串随底层厂商透传，终态判定不能只认单一字面量。"""
+
+    @pytest.mark.parametrize("proxy_status", ["succeeded", "success", "SUCCEEDED", "  succeeded  "])
+    async def test_success_synonyms_finish_polling_and_download(self, tmp_path: Path, proxy_status: str):
+        mock_client = _mock_http_client(
+            poll_body={"task_id": "t-proxy", "status": proxy_status, "url": "https://cdn/v.mp4"}
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"ok"))
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert mock_client.get.call_count == 1
+        fake_download.assert_awaited_once()
+        assert result.video_path == tmp_path / "out.mp4"
+
+    @pytest.mark.parametrize("proxy_status", ["error", "fail", "FAILED", "canceled"])
+    async def test_failure_synonyms_raise_immediately(self, tmp_path: Path, proxy_status: str):
+        mock_client = _mock_http_client(
+            poll_body={"task_id": "t-proxy", "status": proxy_status, "error": {"message": "upstream down"}}
+        )
+        fake_download = AsyncMock()
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await backend.generate(
+                    VideoGenerationRequest(
+                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                    )
+                )
+
+        assert mock_client.get.call_count == 1
+        fake_download.assert_not_awaited()
+
+    async def test_uppercase_expired_still_splits_generate_and_resume(self, tmp_path: Path):
+        from lib.video_backends.base import ResumeExpiredError
+
+        mock_client = _mock_http_client(poll_body={"task_id": "t-proxy", "status": "EXPIRED"})
+
+        with bounded_poll_clock(), patch("httpx.AsyncClient", return_value=mock_client):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            request = VideoGenerationRequest(
+                prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+            )
+
+            with pytest.raises(RuntimeError) as ei:
+                await backend.generate(request)
+            assert not isinstance(ei.value, ResumeExpiredError)
+
+            with pytest.raises(ResumeExpiredError) as resume_ei:
+                await backend.resume_video("t-proxy", request)
+            assert resume_ei.value.job_id == "t-proxy"
+
+
+class TestWrappedResponseShape:
+    """回包为 ``{"code": ..., "data": {...}}`` 包装体时同样能取到状态与视频地址；
+    扁平形状保持最高优先级、行为不变。"""
+
+    async def test_wrapped_status_and_result_url(self, tmp_path: Path):
+        mock_client = _mock_http_client(
+            poll_body={
+                "code": "success",
+                "data": {"task_id": "t-proxy", "status": "SUCCESS", "result_url": "https://cdn/wrapped.mp4"},
+            }
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory(b"wrapped"))
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            result = await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert fake_download.await_args.args[0] == "https://cdn/wrapped.mp4"
+        assert result.duration_seconds == 5
+        assert (tmp_path / "out.mp4").read_bytes() == b"wrapped"
+
+    async def test_flat_url_wins_over_wrapped(self, tmp_path: Path):
+        mock_client = _mock_http_client(
+            poll_body={
+                "task_id": "t-proxy",
+                "status": "completed",
+                "url": "https://cdn/flat.mp4",
+                "data": {"result_url": "https://cdn/wrapped.mp4"},
+            }
+        )
+        fake_download = AsyncMock(side_effect=_fake_download_factory())
+
+        with (
+            bounded_poll_clock(),
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("lib.video_backends.newapi.download_video", fake_download),
+        ):
+            from lib.video_backends.newapi import NewAPIVideoBackend
+
+            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
+            await backend.generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+                )
+            )
+
+        assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -672,9 +673,14 @@ class TestFailureMessage:
             # 代理网关透传的裸 dict / 裸字符串
             ({"code": 500, "message": "upstream down"}, "upstream down"),
             ({"code": "billing_hard_limit_reached"}, "billing_hard_limit_reached"),
+            # 数字错误码同样是原因，别因为不是字符串就丢掉
+            ({"code": 500}, "500"),
             ("boom", "boom"),
             # 只给 status 不给 error 的网关：说不出原因，也不能写出一句 "None"
             (None, "unknown"),
+            # 认不出的形态：宁可说不知道，也不把对象自身的 repr 写给用户
+            ({"detail": "internal"}, "unknown"),
+            (SimpleNamespace(), "unknown"),
         ],
     )
     async def test_provider_reason_reaches_error_message(self, tmp_path: Path, error, expected: str):

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai import InternalServerError
+from openai.types.video_create_error import VideoCreateError
 
 from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.base import VideoGenerationRequest
@@ -658,3 +659,41 @@ class TestProxyStatusSynonyms:
             with pytest.raises(ResumeExpiredError) as resume_ei:
                 await backend.resume_video("vid_new", request)
             assert resume_ei.value.job_id == "vid_new"
+
+
+class TestFailureMessage:
+    """失败原因要以可读文本落进 task.error_message —— 用户在任务面板读的就是这一句。"""
+
+    @pytest.mark.parametrize(
+        "error,expected",
+        [
+            # SDK 原生形态：带 code / message 的模型，只取 message
+            (VideoCreateError(code="moderation_blocked", message="content policy"), "content policy"),
+            # 代理网关透传的裸 dict / 裸字符串
+            ({"code": 500, "message": "upstream down"}, "upstream down"),
+            ({"code": "billing_hard_limit_reached"}, "billing_hard_limit_reached"),
+            ("boom", "boom"),
+            # 只给 status 不给 error 的网关：说不出原因，也不能写出一句 "None"
+            (None, "unknown"),
+        ],
+    )
+    async def test_provider_reason_reaches_error_message(self, tmp_path: Path, error, expected: str):
+        failed = _make_mock_video(status="failed")
+        failed.error = error
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=failed)
+        mock_client.videos.download_content = AsyncMock()
+
+        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            with pytest.raises(RuntimeError) as ei:
+                await backend.generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "out.mp4", duration_seconds=8)
+                )
+
+        # 逐字断言：错误文本原样落 task.error_message，内部类型的 repr 不该出现在里面
+        assert str(ei.value) == f"Sora 视频生成失败: {expected}"

--- a/tests/test_openai_video_backend.py
+++ b/tests/test_openai_video_backend.py
@@ -10,6 +10,7 @@ from openai import InternalServerError
 
 from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.base import VideoGenerationRequest
+from tests.fakes import bounded_poll_clock
 
 pytestmark = pytest.mark.unit
 
@@ -582,3 +583,78 @@ class TestOpenAIVideoBackend:
                 await backend.generate(request)
             assert "expired" in str(ei.value).lower()
             assert not isinstance(ei.value, ResumeExpiredError), "generate 路径不应抛 ResumeExpiredError"
+
+
+class TestProxyStatusSynonyms:
+    """OpenAI 兼容代理网关（NewAPI 系）转发非 Sora 型号时会透传底层厂商状态串。
+
+    终态判定若只认 Sora 文档里的字面量，已就绪的任务会一直轮询到 max_wait 超时——
+    用户侧看到失败，供应商侧有成品且已计费。
+    """
+
+    @pytest.mark.parametrize("proxy_status", ["succeeded", "success", "SUCCEEDED", "  succeeded  "])
+    async def test_success_synonyms_finish_polling_and_download(self, tmp_path: Path, proxy_status: str):
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status=proxy_status))
+        mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
+
+        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            output_path = tmp_path / "out.mp4"
+            result = await backend.generate(
+                VideoGenerationRequest(prompt="p", output_path=output_path, duration_seconds=8)
+            )
+
+        assert mock_client.videos.retrieve.call_count == 1
+        mock_client.videos.download_content.assert_awaited_once()
+        assert result.video_path == output_path
+        assert output_path.read_bytes() == b"v"
+
+    @pytest.mark.parametrize("proxy_status", ["error", "fail", "FAILED", "canceled"])
+    async def test_failure_synonyms_raise_immediately(self, tmp_path: Path, proxy_status: str):
+        err = MagicMock()
+        err.message = "upstream rejected"
+        failed = _make_mock_video(status=proxy_status)
+        failed.error = err
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
+        mock_client.videos.retrieve = AsyncMock(return_value=failed)
+        mock_client.videos.download_content = AsyncMock()
+
+        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            with pytest.raises(RuntimeError, match="Sora 视频生成失败"):
+                await backend.generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "out.mp4", duration_seconds=8)
+                )
+
+        assert mock_client.videos.retrieve.call_count == 1
+        mock_client.videos.download_content.assert_not_awaited()
+
+    async def test_uppercase_expired_still_splits_generate_and_resume(self, tmp_path: Path):
+        """大写 EXPIRED 同样命中过期档：generate 抛 RuntimeError、resume 抛 ResumeExpiredError。"""
+        from lib.video_backends.base import ResumeExpiredError
+
+        mock_client = AsyncMock()
+        mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued", video_id="vid_new"))
+        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="EXPIRED", video_id="vid_new"))
+
+        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            request = VideoGenerationRequest(prompt="p", output_path=tmp_path / "out.mp4", duration_seconds=8)
+
+            with pytest.raises(RuntimeError) as ei:
+                await backend.generate(request)
+            assert not isinstance(ei.value, ResumeExpiredError)
+
+            with pytest.raises(ResumeExpiredError) as resume_ei:
+                await backend.resume_video("vid_new", request)
+            assert resume_ei.value.job_id == "vid_new"

--- a/tests/test_v2_video_generations_backend.py
+++ b/tests/test_v2_video_generations_backend.py
@@ -15,14 +15,13 @@ from lib.video_backends.base import (
     AmbiguousSubmitError,
     ResumeExpiredError,
     VideoGenerationRequest,
+    first_str_by_paths,
 )
 from lib.video_backends.v2_video_generations import (
     _TASK_ID_PATHS,
     _VIDEO_URL_PATHS,
     PROVIDER_V2_VIDEO,
-    _dig,
     _extract_failure,
-    _first_str_by_paths,
     _log_fields,
     _normalize_root,
     build_request_body,
@@ -113,21 +112,6 @@ class TestNormalizeStatus:
         assert normalize_status(raw) == expected
 
 
-class TestDig:
-    def test_walks_dict_and_list_index(self):
-        payload = {"data": {"task_result": {"videos": [{"url": "u0"}, {"url": "u1"}]}}}
-        assert _dig(payload, ("data", "task_result", "videos", 0, "url")) == "u0"
-
-    def test_missing_key_returns_none(self):
-        assert _dig({"a": 1}, ("a", "b")) is None
-
-    def test_list_index_out_of_range_returns_none(self):
-        assert _dig({"v": []}, ("v", 0)) is None
-
-    def test_type_mismatch_returns_none(self):
-        assert _dig({"v": "str"}, ("v", 0)) is None  # 期望 list 实为 str
-
-
 class TestVideoUrlExtraction:
     @pytest.mark.parametrize(
         "payload,expected",
@@ -141,18 +125,18 @@ class TestVideoUrlExtraction:
         ],
     )
     def test_extracts_first_match(self, payload, expected):
-        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == expected
+        assert first_str_by_paths(payload, _VIDEO_URL_PATHS) == expected
 
     def test_priority_video_url_wins_over_bare_url(self):
         payload = {"video": {"url": "https://primary/v.mp4"}, "url": "https://fallback/v.mp4"}
-        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://primary/v.mp4"
+        assert first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://primary/v.mp4"
 
     def test_all_miss_returns_none(self):
-        assert _first_str_by_paths({"foo": "bar"}, _VIDEO_URL_PATHS) is None
+        assert first_str_by_paths({"foo": "bar"}, _VIDEO_URL_PATHS) is None
 
     def test_empty_string_skipped(self):
         payload = {"video": {"url": "   "}, "url": "https://fallback/v.mp4"}
-        assert _first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://fallback/v.mp4"
+        assert first_str_by_paths(payload, _VIDEO_URL_PATHS) == "https://fallback/v.mp4"
 
 
 class TestTaskIdExtraction:
@@ -169,14 +153,14 @@ class TestTaskIdExtraction:
         ],
     )
     def test_extracts(self, payload, expected):
-        assert _first_str_by_paths(payload, _TASK_ID_PATHS) == expected
+        assert first_str_by_paths(payload, _TASK_ID_PATHS) == expected
 
     def test_priority_id_wins(self):
-        assert _first_str_by_paths({"id": "primary", "task_id": "secondary"}, _TASK_ID_PATHS) == "primary"
+        assert first_str_by_paths({"id": "primary", "task_id": "secondary"}, _TASK_ID_PATHS) == "primary"
 
     def test_priority_generation_id_wins(self):
         # generation_id 是端点文档约定字段，优先级压过 id（表首）
-        assert _first_str_by_paths({"generation_id": "gen", "id": "fallback"}, _TASK_ID_PATHS) == "gen"
+        assert first_str_by_paths({"generation_id": "gen", "id": "fallback"}, _TASK_ID_PATHS) == "gen"
 
 
 class TestBuildRequestBody:

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -16,6 +16,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
     _dig,
     extract_provider_error_message,
+    first_mapping_by_paths,
     first_str_by_paths,
     is_retryable_http_status,
     normalize_provider_status,
@@ -308,6 +309,17 @@ class TestDigAndFirstStrByPaths:
         assert first_str_by_paths({"data": {"result_url": "b"}}, paths) == "b"
         assert first_str_by_paths({"url": "   ", "data": {"result_url": "b"}}, paths) == "b"
         assert first_str_by_paths({"foo": "bar"}, paths) is None
+
+    def test_first_mapping_by_paths_priority(self):
+        paths = (("metadata",), ("data", "metadata"))
+        assert first_mapping_by_paths({"metadata": {"seed": 1}, "data": {"metadata": {"seed": 2}}}, paths) == {
+            "seed": 1
+        }
+        assert first_mapping_by_paths({"data": {"metadata": {"seed": 2}}}, paths) == {"seed": 2}
+        assert first_mapping_by_paths({"metadata": "not-a-mapping", "data": {"metadata": {"seed": 2}}}, paths) == {
+            "seed": 2
+        }
+        assert first_mapping_by_paths({"foo": "bar"}, paths) is None
 
 
 class TestExtractProviderErrorMessage:

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -329,6 +329,15 @@ class TestExtractProviderErrorMessage:
     def test_dict_error_name_fallback(self):
         assert extract_provider_error_message({"error": {"name": "moderation"}}) == "moderation"
 
+    def test_blank_message_falls_back_to_name(self):
+        assert extract_provider_error_message({"error": {"message": "   ", "name": "moderation"}}) == "moderation"
+
+    def test_non_string_message_falls_back_to_name(self):
+        assert (
+            extract_provider_error_message({"error": {"message": {"detail": "x"}, "name": "moderation"}})
+            == "moderation"
+        )
+
     def test_string_error(self):
         assert extract_provider_error_message({"error": " boom "}) == "boom"
 

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -7,12 +7,18 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from lib.video_backends.base import (
+    TERMINAL_PROVIDER_STATUSES,
     AmbiguousSubmitError,
     ProviderJobIdPersistenceMixin,
+    ProviderJobStatus,
     ResumeExpiredError,
     VideoGenerationRequest,
     VideoGenerationResult,
+    _dig,
+    extract_provider_error_message,
+    first_str_by_paths,
     is_retryable_http_status,
+    normalize_provider_status,
     persist_api_call_id,
     persist_provider_job_id,
     poll_with_retry,
@@ -240,6 +246,85 @@ class TestPollWithRetry:
 
         assert result == "done"
         assert poll_fn.await_count == 2
+
+
+class TestNormalizeProviderStatus:
+    """跨厂商状态串归一：OpenAI 兼容代理会把底层厂商的状态串原样透传。"""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("completed", ProviderJobStatus.SUCCEEDED),
+            ("succeeded", ProviderJobStatus.SUCCEEDED),
+            ("succeed", ProviderJobStatus.SUCCEEDED),
+            ("success", ProviderJobStatus.SUCCEEDED),
+            ("SUCCEEDED", ProviderJobStatus.SUCCEEDED),
+            ("  succeeded  ", ProviderJobStatus.SUCCEEDED),
+            ("failed", ProviderJobStatus.FAILED),
+            ("fail", ProviderJobStatus.FAILED),
+            ("error", ProviderJobStatus.FAILED),
+            ("FAILED", ProviderJobStatus.FAILED),
+            ("canceled", ProviderJobStatus.FAILED),
+            ("cancelled", ProviderJobStatus.FAILED),
+            ("in_progress", ProviderJobStatus.RUNNING),
+            ("Processing", ProviderJobStatus.RUNNING),
+            ("generating", ProviderJobStatus.RUNNING),
+            ("PENDING", ProviderJobStatus.QUEUED),
+            ("submitted", ProviderJobStatus.QUEUED),
+            # 未知 / 非字符串 → 当 running 继续轮询（保守：不对未就绪任务触发下载）
+            ("NOT_START", ProviderJobStatus.RUNNING),
+            ("weird-status", ProviderJobStatus.RUNNING),
+            (None, ProviderJobStatus.RUNNING),
+            (99, ProviderJobStatus.RUNNING),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_provider_status(raw) is expected
+
+    @pytest.mark.parametrize("raw", ["expired", "EXPIRED", " Expired "])
+    def test_expired_is_its_own_bucket(self, raw):
+        """expired 不得折进 failed：caller 据其按 generate / resume 分流抛不同异常。"""
+        assert normalize_provider_status(raw) is ProviderJobStatus.EXPIRED
+
+    def test_terminal_set(self):
+        assert TERMINAL_PROVIDER_STATUSES == frozenset(
+            {ProviderJobStatus.SUCCEEDED, ProviderJobStatus.FAILED, ProviderJobStatus.EXPIRED}
+        )
+        assert ProviderJobStatus.RUNNING not in TERMINAL_PROVIDER_STATUSES
+        assert ProviderJobStatus.QUEUED not in TERMINAL_PROVIDER_STATUSES
+
+
+class TestDigAndFirstStrByPaths:
+    def test_walks_dict_and_list_index(self):
+        payload = {"data": {"videos": [{"url": "u0"}, {"url": "u1"}]}}
+        assert _dig(payload, ("data", "videos", 1, "url")) == "u1"
+
+    def test_missing_segment_returns_none(self):
+        assert _dig({"a": 1}, ("a", "b")) is None
+
+    def test_first_str_by_paths_priority(self):
+        paths = (("url",), ("data", "result_url"))
+        assert first_str_by_paths({"url": "a", "data": {"result_url": "b"}}, paths) == "a"
+        assert first_str_by_paths({"data": {"result_url": "b"}}, paths) == "b"
+        assert first_str_by_paths({"url": "   ", "data": {"result_url": "b"}}, paths) == "b"
+        assert first_str_by_paths({"foo": "bar"}, paths) is None
+
+
+class TestExtractProviderErrorMessage:
+    def test_dict_error_message(self):
+        assert extract_provider_error_message({"error": {"code": 500, "message": "upstream down"}}) == "upstream down"
+
+    def test_dict_error_name_fallback(self):
+        assert extract_provider_error_message({"error": {"name": "moderation"}}) == "moderation"
+
+    def test_string_error(self):
+        assert extract_provider_error_message({"error": " boom "}) == "boom"
+
+    def test_wrapped_error(self):
+        assert extract_provider_error_message({"data": {"error": {"message": "nested"}}}) == "nested"
+
+    def test_missing_error_is_unknown(self):
+        assert extract_provider_error_message({"status": "failed"}) == "unknown"
 
 
 class TestIsRetryableHttpStatus:


### PR DESCRIPTION
## 范围

`lib/video_backends/` 三条 OpenAI 兼容链路（`openai` / `newapi` / `v2_video_generations`）的**轮询终态判定**与失败原因提取，外加共享归一层 `base.py`、对应测试与文档索引。

明确不动：超时倍率与 max_wait 机制（#642）、长任务异步语义（#1708）、各家自有 API 的 backend（ark / gemini / agnes / kling / minimax / dashscope / vidu）、能力声明与计费口径、NewAPI 既有扁平回包的解析行为。

## 问题

经 OpenAI 兼容代理网关（自定义供应商）生成视频时，供应商侧已出片、应用侧却在 10 分钟后报「任务超时」失败：网关转发非原生型号时透传底层厂商的状态串（如 `succeeded`），而各后端的终态判定只认自家文档里的字面量，已就绪的任务继续轮询直到 max_wait —— 用户看到失败，供应商侧有成品且已计费。失败侧对称存在且更隐蔽：一次确定的失败也要拖满整个超时才以超时形式报出，错误原因还丢了。

## 变更

- 跨厂商状态同义词归一下沉到 `lib/video_backends/base.py::normalize_provider_status`（大小写与首尾空白无关），三条链路共用一份；未登记的状态串仍按「进行中」继续轮询，不对未就绪任务触发下载
- 过期保持独立于失败一档，续跑的 `[resume_expired]` 分流与 generate / resume 的分歧行为逐字不变（大写形态同样命中）；协议本身无过期语义的 `v2-video-generations` 在五档之上自行折叠，对外仍是四值
- NewAPI 的状态、视频地址与 metadata 改为多路径并集探测，兼容 `data` 包装体形状的回包；两条扁平路径排在表首、原有行为不变。包装体形状下不再丢失实际时长与 seed（结算据此记账）
- Sora 失败原因改为取供应商给出的文本（含数字错误码），不再把内部错误对象整体写进任务错误信息；认不出的形态写 `unknown`
- `CONTEXT.md` 补 provider job status 术语条（限定到上述三个端点，各家自有 API 的 backend 仍按字面量判定）；`docs/api-docs/endpoints/` 三份索引补上共享归一入口与回包形状导航

## 验收清单

- [x] 本地已跑相关测试：`uv run python -m pytest`（9674 passed / 2 skipped）、`uv run ruff check . && uv run ruff format --check .`、`uv run basedpyright`（0 error）、`uv run lint-imports`（契约 KEPT，无新增 ignore）
- [x] 手动验证了改动所声称的行为：以网关透传状态串（`succeeded` / 大写 `EXPIRED`）、包装体回包、失败原因各形态构造回归用例逐字断言；Sora 失败原因含真实 SDK 错误模型用例，SDK 换字段名即红
- [x] 新增面向用户文案已加 zh/en 翻译（如适用）：不适用——本 PR 未新增面向用户文案，backend 抛出的 service 层异常按 `CLAUDE.md` i18n 规约豁免，失败原因的本地化边界在 `lib/task_failure.py`
- [x] 无新增 ESLint disable；若有，已在本 PR 底部以表格列出 `rule | file:line | 理由`：无前端改动
- [x] CODEOWNERS 要求的 review 已请求

## 已知 defer

- 已按旧超时落 `failed` 的历史任务，手动重试仍走重新生成而非复用既有 provider job（续跑只在服务重启的孤儿任务上触发），这批任务重试会二次计费。复用既有 job 的重试涉及「哪类失败可复用」「复用窗口多长」「与 execution checkpoint 的身份如何对齐」三项决策，不在本 PR 范围内。按本次判断暂不立项：受影响面只有本修复上线前已落超时失败的存量任务，重试与否由用户逐条决定，碰到再议。

Closes #1888


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 统一视频任务状态处理，支持排队、运行中、成功、失败和过期状态。
  * 兼容多种供应商响应格式，可从嵌套或扁平结构中解析视频地址、任务信息及元数据。
  * 改进失败信息提取，错误提示更加具体。
* **文档**
  * 补充各视频接口的任务状态和响应格式说明。
* **问题修复**
  * 改善任务轮询、恢复及过期任务处理，提升不同供应商状态兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->