### PR TITLE
feat(workflow): 提供完整可执行的制作计划

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1494,6 +1494,7 @@ export default {
   'tool_name_complete_asset_inventory': 'Complete asset inventory',
   'tool_name_complete_step1_rebuild': 'Complete step 1 rebuild',
   'tool_name_get_workflow_status': 'Get workflow status',
+  'tool_name_get_workflow_plan': 'Get complete workflow plan',
   'tool_name_get_episode_script_revision': 'Get script revision',
   'tool_name_generate_assets': 'Generate assets',
   'tool_name_generate_storyboards': 'Generate storyboards',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1616,6 +1616,7 @@ export default {
   'tool_name_complete_asset_inventory': 'Hoàn tất kiểm kê tài sản',
   'tool_name_complete_step1_rebuild': 'Hoàn tất tái tạo bước 1',
   'tool_name_get_workflow_status': 'Xem trạng thái quy trình',
+  'tool_name_get_workflow_plan': 'Xem kế hoạch quy trình đầy đủ',
   'tool_name_get_episode_script_revision': 'Lấy phiên bản kịch bản',
   'tool_name_generate_assets': 'Tạo tài sản',
   'tool_name_generate_storyboards': 'Tạo storyboard',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1493,6 +1493,7 @@ export default {
   'tool_name_complete_asset_inventory': '完成资产清单分析',
   'tool_name_complete_step1_rebuild': '完成第一阶段重建',
   'tool_name_get_workflow_status': '查询工作流状态',
+  'tool_name_get_workflow_plan': '查询完整工作流计划',
   'tool_name_get_episode_script_revision': '读取剧本版本',
   'tool_name_generate_assets': '生成资产',
   'tool_name_generate_storyboards': '生成分镜图',

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -999,14 +999,44 @@ class ProjectArtifactManifestAdapter:
         )
 
     def get_entry(self, key: ArtifactKey) -> ArtifactManifestEntry | None:
-        with self._locked() as root_fd:
-            entries, _ = self._load_unlocked(root_fd)
-            return entries.get(key.encode())
+        return self._load_readonly().get(key.encode())
 
     def snapshot_entries(self) -> Mapping[ArtifactKey, ArtifactManifestEntry]:
-        with self._locked() as root_fd:
-            entries, _ = self._load_unlocked(root_fd)
-            return {ArtifactKey.decode(encoded): entry for encoded, entry in entries.items()}
+        entries = self._load_readonly()
+        return {ArtifactKey.decode(encoded): entry for encoded, entry in entries.items()}
+
+    def _load_readonly(self) -> dict[str, ArtifactManifestEntry]:
+        """Read one consistent snapshot without creating runtime state.
+
+        Once a writer has created the durable lock file, readers serialize with
+        that lock exactly as before.  A project that has never needed a manifest
+        write has no lock file; in that state two identical guarded reads provide
+        a stable snapshot without turning a status query into a filesystem write.
+        A legitimate writer creates the lock before replacing the manifest, so a
+        lock appearing during either read sends the reader back through the
+        serialized path.
+        """
+
+        lock_path = self._project_dir / LOCK_FILENAME
+        if self._runtime_file_identity(lock_path, "manifest lock") is not None:
+            with self._locked() as root_fd:
+                entries, _ = self._load_unlocked(root_fd)
+                return entries
+
+        with self._guard_portable_project_root():
+            entries, original_bytes = self._load_unlocked(None)
+            if self._runtime_file_identity(lock_path, "manifest lock") is not None:
+                with self._locked() as root_fd:
+                    locked_entries, _ = self._load_unlocked(root_fd)
+                    return locked_entries
+            repeated_entries, repeated_bytes = self._load_unlocked(None)
+            if self._runtime_file_identity(lock_path, "manifest lock") is not None:
+                with self._locked() as root_fd:
+                    locked_entries, _ = self._load_unlocked(root_fd)
+                    return locked_entries
+        if original_bytes != repeated_bytes or entries != repeated_entries:
+            raise ArtifactManifestError("artifact manifest changed during an unlocked read")
+        return entries
 
     def put_entry(self, key: ArtifactKey, entry: ArtifactManifestEntry) -> bool:
         with self._locked() as root_fd:

--- a/lib/workflow_plan.py
+++ b/lib/workflow_plan.py
@@ -274,11 +274,14 @@ def build_workflow_plan(
 
     delivery_step = by_id["narration_delivery"]
     delivery_index = next(index for index, item in enumerate(rules) if item.id == "narration_delivery")
-    if not structure_problems:
-        if narration_delivery is not None and current_index >= delivery_index:
-            delivery_step.state = WorkflowStepState.COMPLETED
-        elif narration_delivery is None and current_index >= delivery_index:
-            delivery_step.state = WorkflowStepState.READY
+    if not structure_problems and current_index >= delivery_index:
+        # 音轨产物 blocked 只对本次选择 TTS 的请求成立：后期配音路径不消费 TTS 产物，
+        # 交付选择尚未作出时两条路径都还开放，两种情况都不该被音轨阻断吞掉。
+        tts_blocked = narration_delivery == USE_TTS and delivery_step.state is WorkflowStepState.BLOCKED
+        if not tts_blocked:
+            delivery_step.state = (
+                WorkflowStepState.COMPLETED if narration_delivery is not None else WorkflowStepState.READY
+            )
 
     for observation in task_observations:
         step_id = _TASK_STEP.get(observation.task_type)

--- a/lib/workflow_plan.py
+++ b/lib/workflow_plan.py
@@ -1,0 +1,351 @@
+"""Side-effect-free projection of authoritative workflow facts into an executable plan."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from lib.generation_result import GenerationAction, GenerationBatchResult, GenerationProblem, ProviderCheckpoint
+from lib.narration_delivery import POST_PRODUCTION, USE_TTS, NarrationDelivery
+from lib.workflow_rules import WorkflowStepRule, workflow_rule
+from lib.workflow_state import WorkflowBlocker, WorkflowNextAction, WorkflowStatus
+
+PositiveStrictInt = Annotated[int, Field(strict=True, gt=0)]
+
+
+class WorkflowStepState(StrEnum):
+    """Progress of the orchestration step, independent from artifact and task state."""
+
+    COMPLETED = "completed"
+    READY = "ready"
+    ACTIVE = "active"
+    BLOCKED = "blocked"
+    PENDING = "pending"
+    SKIPPED = "skipped"
+
+
+class WorkflowPlanRequest(BaseModel):
+    """Transient choices used to plan one request without changing project workflow state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    episode: int | None = Field(default=None, ge=1, strict=True)
+    narration_delivery: NarrationDelivery | None = None
+    confirmed_request_durations: dict[str, PositiveStrictInt] = Field(default_factory=dict)
+
+    @field_validator("confirmed_request_durations")
+    @classmethod
+    def _valid_confirmed_durations(cls, value: dict[str, int]) -> dict[str, int]:
+        for unit_id in value:
+            if not unit_id.strip():
+                raise ValueError("confirmed_request_durations keys must be non-empty unit ids")
+        return value
+
+
+class WorkflowNarrationDelivery(BaseModel):
+    """The non-persistent delivery choice attached to this plan only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    selected: NarrationDelivery | None
+    options: tuple[Literal["post_production"], Literal["use_tts"]] = (POST_PRODUCTION, USE_TTS)
+    persisted: Literal[False] = False
+
+
+class WorkflowTaskObservation(BaseModel):
+    """One task axis, kept separate from provider submission and artifact currency."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    unit_id: str
+    task_id: str
+    task_type: str
+    status: str
+    provider_checkpoint: ProviderCheckpoint | None = None
+    problem: GenerationProblem | None = None
+
+
+class WorkflowStepContracts(BaseModel):
+    """Existing deep-module contracts an action must cross when it executes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    script_edit: Literal["script_batch_edit/v1"] | None = None
+    batch_admission: Literal["video_batch_admission/v1"] | None = None
+    generation_result: Literal["generation_result/v1"] | None = None
+
+
+class WorkflowPlanStep(BaseModel):
+    """One ordered step without collapsing its artifact, task, and execution axes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    state: WorkflowStepState
+    required: bool
+    action: WorkflowNextAction | None = None
+    requested_ids: list[str] = Field(default_factory=list)
+    artifacts: dict[str, Any] = Field(default_factory=dict)
+    problems: list[GenerationProblem] = Field(default_factory=list)
+    tasks: list[WorkflowTaskObservation] = Field(default_factory=list)
+    admission: dict[str, Any] | None = None
+    generation_result: GenerationBatchResult | None = None
+    contracts: WorkflowStepContracts = Field(default_factory=WorkflowStepContracts)
+
+
+class WorkflowPlan(BaseModel):
+    """Versioned plan shared unchanged by REST and MCP adapters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    status: WorkflowStatus
+    narration_delivery: WorkflowNarrationDelivery
+    steps: list[WorkflowPlanStep]
+    blockers: list[WorkflowBlocker]
+    problems: list[GenerationProblem]
+    next_action: WorkflowNextAction
+
+
+_ARTIFACT_BY_STEP: dict[str, str] = {
+    "asset_inventory": "asset_inventory",
+    "asset_sheets": "asset_sheets",
+    "step1_content": "step1",
+    "step1_review": "step1",
+    "final_script": "script",
+    "storyboard": "storyboards",
+    "narration_delivery": "audio",
+    "video": "videos",
+}
+
+_TASK_STEP: dict[str, str] = {
+    "storyboard": "storyboard",
+    "grid": "storyboard",
+    "tts": "narration_delivery",
+    "video": "video",
+    "reference_video": "video",
+}
+
+
+def _baseline_step_state(
+    rule: WorkflowStepRule,
+    *,
+    index: int,
+    current_index: int,
+    status: WorkflowStatus,
+) -> WorkflowStepState:
+    if not rule.applicable:
+        return WorkflowStepState.SKIPPED
+    if index < current_index:
+        return WorkflowStepState.COMPLETED
+    if index > current_index:
+        return WorkflowStepState.PENDING
+    if status.blockers or status.next_action.type == "none":
+        return WorkflowStepState.BLOCKED
+    return WorkflowStepState.READY
+
+
+def _current_rule_index(status: WorkflowStatus, rules: tuple[WorkflowStepRule, ...]) -> int:
+    if status.next_action.type == "repair_video_units":
+        return next(index for index, rule in enumerate(rules) if rule.id == "script_structure")
+    for index, rule in enumerate(rules):
+        if rule.applicable and rule.checkpoint == status.state:
+            return index
+    raise ValueError(f"workflow state {status.state!r} is absent from its mode rule")
+
+
+def _admission_problems(admission: dict[str, Any] | None) -> list[GenerationProblem]:
+    if not admission:
+        return []
+    problems: list[GenerationProblem] = []
+    for unit in admission.get("units", []):
+        if not isinstance(unit, dict):
+            continue
+        raw_problems = unit.get("problems", [])
+        if not isinstance(raw_problems, list):
+            continue
+        for raw in raw_problems:
+            problems.append(GenerationProblem.model_validate(raw))
+    return problems
+
+
+def _problem_unit_ids(problems: list[GenerationProblem]) -> list[str]:
+    ids: list[str] = []
+    for problem in problems:
+        unit_id = problem.params.get("unit_id")
+        if not isinstance(unit_id, str):
+            admission = problem.params.get("speech_admission")
+            unit_id = admission.get("unit_id") if isinstance(admission, dict) else None
+        if isinstance(unit_id, str) and unit_id and unit_id not in ids:
+            ids.append(unit_id)
+    return ids
+
+
+def _structure_action(
+    problems: list[GenerationProblem],
+    *,
+    script_revision: str | None,
+) -> WorkflowNextAction:
+    return WorkflowNextAction(
+        type="patch_episode_script",
+        args={
+            "expected_revision": script_revision,
+            "problems": [problem.model_dump(mode="json") for problem in problems],
+        },
+        requested_ids=_problem_unit_ids(problems),
+        reason=problems[0].detail,
+    )
+
+
+def _admission_action(
+    admission: dict[str, Any],
+    problems: list[GenerationProblem],
+    requested_ids: list[str],
+) -> WorkflowNextAction:
+    requires_confirmation = admission.get("decision") == "confirmation_required"
+    return WorkflowNextAction(
+        type=problems[0].action.value if problems else GenerationAction.CONFIRM_REQUEST_DURATION.value,
+        args={"admission": admission},
+        requested_ids=requested_ids,
+        requires_confirmation=requires_confirmation,
+        reason=problems[0].detail if problems else "video batch requires confirmation",
+    )
+
+
+def build_workflow_plan(
+    status: WorkflowStatus,
+    *,
+    narration_delivery: NarrationDelivery | None = None,
+    structure_problems: list[GenerationProblem] | None = None,
+    script_revision: str | None = None,
+    task_observations: list[WorkflowTaskObservation] | None = None,
+    admission: dict[str, Any] | None = None,
+    generation_result: GenerationBatchResult | None = None,
+) -> WorkflowPlan:
+    """Project one immutable status snapshot and transient request observations."""
+
+    rule = workflow_rule(status.project.content_mode, status.project.generation_mode)
+    rules = rule.steps
+    current_index = _current_rule_index(status, rules)
+    structure_problems = list(structure_problems or [])
+    task_observations = list(task_observations or [])
+    admission_problems = _admission_problems(admission)
+    steps: list[WorkflowPlanStep] = []
+
+    for index, step_rule in enumerate(rules):
+        artifact_key = _ARTIFACT_BY_STEP.get(step_rule.id)
+        step = WorkflowPlanStep(
+            id=step_rule.id,
+            state=_baseline_step_state(step_rule, index=index, current_index=current_index, status=status),
+            required=step_rule.applicable,
+            action=status.next_action if step_rule.checkpoint == status.state else None,
+            requested_ids=(list(status.next_action.requested_ids) if step_rule.checkpoint == status.state else []),
+            artifacts=dict(status.artifacts.get(artifact_key, {})) if artifact_key is not None else {},
+            contracts=(
+                WorkflowStepContracts(script_edit="script_batch_edit/v1")
+                if step_rule.id == "script_structure"
+                else WorkflowStepContracts(
+                    batch_admission="video_batch_admission/v1",
+                    generation_result="generation_result/v1",
+                )
+                if step_rule.id == "video"
+                else WorkflowStepContracts()
+            ),
+        )
+        if step_rule.id == "narration_delivery":
+            step.required = status.state == "VIDEO" and status.next_action.type == "generate_videos"
+        if step.artifacts.get("state") == "blocked" and step.state is not WorkflowStepState.SKIPPED:
+            step.state = WorkflowStepState.BLOCKED
+        steps.append(step)
+
+    by_id = {step.id: step for step in steps}
+    structure_step = by_id["script_structure"]
+    if structure_problems:
+        structure_step.state = WorkflowStepState.BLOCKED
+        structure_step.problems = structure_problems
+        structure_step.requested_ids = _problem_unit_ids(structure_problems)
+        structure_step.action = _structure_action(structure_problems, script_revision=script_revision)
+        for media_step in ("storyboard", "narration_delivery", "video"):
+            if by_id[media_step].state is not WorkflowStepState.SKIPPED:
+                by_id[media_step].state = WorkflowStepState.PENDING
+                by_id[media_step].action = None
+
+    delivery_step = by_id["narration_delivery"]
+    delivery_index = next(index for index, item in enumerate(rules) if item.id == "narration_delivery")
+    if not structure_problems:
+        if narration_delivery is not None and current_index >= delivery_index:
+            delivery_step.state = WorkflowStepState.COMPLETED
+        elif narration_delivery is None and current_index >= delivery_index:
+            delivery_step.state = WorkflowStepState.READY
+
+    for observation in task_observations:
+        step_id = _TASK_STEP.get(observation.task_type)
+        if step_id is None:
+            continue
+        step = by_id[step_id]
+        step.tasks.append(observation)
+        if observation.status in {"queued", "running", "cancelling"}:
+            step.state = WorkflowStepState.ACTIVE
+
+    video_step = by_id["video"]
+    video_step.admission = admission
+    video_step.generation_result = generation_result
+    video_step.problems = admission_problems
+    if admission is not None and admission.get("decision") != "admitted" and not video_step.tasks:
+        video_step.state = WorkflowStepState.BLOCKED
+
+    active_tasks = [task for task in task_observations if task.status in {"queued", "running", "cancelling"}]
+    if status.blockers:
+        next_action = status.next_action
+    elif structure_problems:
+        next_action = _structure_action(structure_problems, script_revision=script_revision)
+    elif active_tasks:
+        next_action = WorkflowNextAction(
+            type=GenerationAction.WAIT_FOR_TASK.value,
+            args={"task_ids": [task.task_id for task in active_tasks]},
+            requested_ids=[task.unit_id for task in active_tasks],
+            reason="workflow has active generation tasks",
+        )
+        for step in steps:
+            if step.state is WorkflowStepState.ACTIVE:
+                step.action = next_action
+        if video_step.state is not WorkflowStepState.ACTIVE:
+            video_step.action = None
+    elif status.state == "VIDEO" and status.next_action.type == "generate_videos" and narration_delivery is None:
+        next_action = WorkflowNextAction(
+            type="choose_narration_delivery",
+            args={"options": [POST_PRODUCTION, USE_TTS]},
+            requested_ids=list(status.next_action.requested_ids),
+            reason="choose narration delivery for this video request",
+        )
+        delivery_step.action = next_action
+        video_step.state = WorkflowStepState.PENDING
+        video_step.action = None
+    elif admission is not None and admission.get("decision") != "admitted":
+        next_action = _admission_action(admission, admission_problems, list(status.next_action.requested_ids))
+        video_step.action = next_action
+    else:
+        next_action = status.next_action
+
+    return WorkflowPlan(
+        status=status,
+        narration_delivery=WorkflowNarrationDelivery(selected=narration_delivery),
+        steps=steps,
+        blockers=list(status.blockers),
+        problems=[*structure_problems, *admission_problems],
+        next_action=next_action,
+    )
+
+
+__all__ = [
+    "WorkflowNarrationDelivery",
+    "WorkflowPlan",
+    "WorkflowPlanRequest",
+    "WorkflowPlanStep",
+    "WorkflowStepContracts",
+    "WorkflowStepState",
+    "WorkflowTaskObservation",
+    "build_workflow_plan",
+]

--- a/lib/workflow_rules.py
+++ b/lib/workflow_rules.py
@@ -1,0 +1,126 @@
+"""Data-driven workflow step rules for every content and generation mode pair."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lib.script_skeleton import resolve_declared_kind
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowStepRule:
+    """One ordered workflow step and the status checkpoint that owns it."""
+
+    id: str
+    checkpoint: str | None
+    applicable: bool
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRule:
+    """The complete workflow shape for one immutable project mode pair."""
+
+    content_mode: str
+    generation_mode: str
+    skeleton_kind: str
+    preprocessor: str | None
+    steps: tuple[WorkflowStepRule, ...]
+
+
+_STEP_CHECKPOINTS: tuple[tuple[str, str | None], ...] = (
+    ("project_input", "PROJECT_INPUT"),
+    ("selling_points", "SELLING_POINTS"),
+    ("asset_inventory", "ASSET_INVENTORY"),
+    ("episode_plan", "EPISODE_PLAN"),
+    ("step1_content", "STEP1_CONTENT"),
+    ("step1_review", "STEP1_REVIEW"),
+    ("final_script", "FINAL_SCRIPT"),
+    ("asset_sheets", "ASSET_SHEETS"),
+    ("script_structure", None),
+    ("storyboard", "STORYBOARD"),
+    ("narration_delivery", None),
+    ("video", "VIDEO"),
+    ("export", "EXPORT_READY"),
+)
+
+_EPISODIC_STEPS = frozenset(
+    {
+        "project_input",
+        "asset_inventory",
+        "episode_plan",
+        "step1_content",
+        "step1_review",
+        "final_script",
+        "asset_sheets",
+        "script_structure",
+        "narration_delivery",
+        "video",
+        "export",
+    }
+)
+
+_CONTENT_STEPS: dict[str, frozenset[str]] = {
+    "narration": _EPISODIC_STEPS,
+    "drama": _EPISODIC_STEPS,
+    "ad": frozenset(
+        {
+            "project_input",
+            "selling_points",
+            "final_script",
+            "asset_sheets",
+            "script_structure",
+            "narration_delivery",
+            "video",
+            "export",
+        }
+    ),
+}
+
+_PREPROCESSORS: dict[tuple[str, str], str | None] = {
+    ("narration", "storyboard"): "split-narration-segments",
+    ("narration", "reference_video"): "split-reference-video-units",
+    ("drama", "storyboard"): "normalize-drama-script",
+    ("drama", "reference_video"): "split-reference-video-units",
+    ("ad", "storyboard"): None,
+    ("ad", "reference_video"): None,
+}
+
+
+def _build_rule(content_mode: str, generation_mode: str) -> WorkflowRule:
+    applicable = set(_CONTENT_STEPS[content_mode])
+    if generation_mode == "storyboard":
+        applicable.add("storyboard")
+    return WorkflowRule(
+        content_mode=content_mode,
+        generation_mode=generation_mode,
+        skeleton_kind=resolve_declared_kind(content_mode, generation_mode),
+        preprocessor=_PREPROCESSORS[(content_mode, generation_mode)],
+        steps=tuple(
+            WorkflowStepRule(id=step_id, checkpoint=checkpoint, applicable=step_id in applicable)
+            for step_id, checkpoint in _STEP_CHECKPOINTS
+        ),
+    )
+
+
+WORKFLOW_RULES: dict[tuple[str, str], WorkflowRule] = {
+    (content_mode, generation_mode): _build_rule(content_mode, generation_mode)
+    for content_mode in ("narration", "drama", "ad")
+    for generation_mode in ("storyboard", "reference_video")
+}
+
+
+def workflow_rule(content_mode: str, generation_mode: str) -> WorkflowRule:
+    """Return the exhaustive rule for a validated project mode pair."""
+
+    try:
+        return WORKFLOW_RULES[(content_mode, generation_mode)]
+    except KeyError as exc:
+        raise ValueError(f"unsupported workflow mode pair: {content_mode!r}, {generation_mode!r}") from exc
+
+
+__all__ = [
+    "WORKFLOW_RULES",
+    "WorkflowRule",
+    "WorkflowStepRule",
+    "workflow_rule",
+]

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -35,6 +35,7 @@ from lib.script_models import get_generated_assets
 from lib.script_skeleton import SKELETONS, STORYBOARD_ITEM_ID_PATTERN, ensure_route_skeleton
 from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
 from lib.version_manager import VersionManager
+from lib.workflow_rules import workflow_rule
 
 WorkflowStateName = Literal[
     "PROJECT_INPUT",
@@ -854,13 +855,7 @@ class WorkflowStateService:
                 state = "EPISODE_PLAN"
                 next_action = self._planning_action(project, "target episode is unavailable")
             else:
-                preprocessor = (
-                    "split-reference-video-units"
-                    if generation_mode == "reference_video"
-                    else "split-narration-segments"
-                    if mode == "narration"
-                    else "normalize-drama-script"
-                )
+                preprocessor = workflow_rule(str(mode), str(generation_mode)).preprocessor
                 if mode != "ad" and selected is not None and selected[1].get("ledger_status") == "stale":
                     step1_path = script_review.step1_path(project_path, project, target.episode)
                     live_revision = script_review.content_fingerprint(step1_path) if step1_path is not None else None

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -52,6 +52,15 @@ WorkflowStateName = Literal[
 ]
 
 
+class WorkflowRequestError(ValueError):
+    """调用方给出的查询参数本身不合法。
+
+    与之相对的是持久化数据损坏（剧本骨架、content_mode / generation_mode 组合等）：
+    那类问题同样以 ``ValueError`` 家族抛出，但责任在服务端数据而非本次请求，消费方
+    据此区分「回 400 / invalid_request」与「按服务端故障上报」，不把排障方向指向调用方。
+    """
+
+
 class WorkflowProject(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -749,9 +758,9 @@ class WorkflowStateService:
     ) -> WorkflowStatus:
         mode = project.get("content_mode")
         if episode is not None and (isinstance(episode, bool) or episode < 1):
-            raise ValueError("episode must be a positive integer")
+            raise WorkflowRequestError("episode must be a positive integer")
         if mode == "ad" and episode not in {None, 1}:
-            raise ValueError("ad workflow only has episode 1")
+            raise WorkflowRequestError("ad workflow only has episode 1")
         generation_mode = project.get("generation_mode")
         grid = project.get("grid_storyboard") is True and generation_mode == "storyboard"
         blockers = list(shared.blockers)
@@ -1154,6 +1163,7 @@ __all__ = [
     "WorkflowBlocker",
     "WorkflowNextAction",
     "WorkflowProject",
+    "WorkflowRequestError",
     "WorkflowStateService",
     "WorkflowStatus",
     "WorkflowTarget",

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -56,6 +56,7 @@ from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
     validate_and_promote_reference_draft_tool,
 )
+from server.agent_runtime.sdk_tools.workflow_plan import get_workflow_plan_tool
 from server.agent_runtime.sdk_tools.workflow_status import complete_step1_rebuild_tool, get_workflow_status_tool
 
 __all__ = ["build_arcreel_mcp_server", "ToolContext", "ARCREEL_MCP_TOOL_IDS"]
@@ -71,6 +72,7 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
     "complete_asset_inventory",
     "complete_step1_rebuild",
     "get_workflow_status",
+    "get_workflow_plan",
     "list_pending_assets",
     "generate_assets",
     "generate_storyboards",
@@ -112,6 +114,7 @@ def build_arcreel_mcp_server(*, project_name: str, projects_root: Path) -> Any:
             complete_asset_inventory_tool(ctx),
             complete_step1_rebuild_tool(ctx),
             get_workflow_status_tool(ctx),
+            get_workflow_plan_tool(ctx),
             list_pending_assets_tool(ctx),
             generate_assets_tool(ctx),
             generate_storyboards_tool(ctx),

--- a/server/agent_runtime/sdk_tools/enqueue_videos.py
+++ b/server/agent_runtime/sdk_tools/enqueue_videos.py
@@ -17,7 +17,6 @@ from lib.artifact_activation import (
     active_artifact_currency_resolver,
     artifact_is_usable,
     resolve_artifact_episode,
-    resolve_usable_storyboard_video_inputs,
 )
 from lib.artifact_manifest import ArtifactKey, ArtifactManifestError, ArtifactStatus
 from lib.batch_admission import (
@@ -26,7 +25,6 @@ from lib.batch_admission import (
     UnitAdmissionTicket,
     refused_ticket,
 )
-from lib.config.resolver import video_bucket_for_generation_mode
 from lib.generation_queue_client import (
     BatchEnqueueAborted,
     BatchTaskResult,
@@ -48,13 +46,6 @@ from lib.generation_result import (
     select_generation_targets,
 )
 from lib.project_manager import ProjectManager, is_reference_video_project
-from lib.prompt_utils import (
-    build_drama_video_prompt,
-    build_drama_video_prompt_from_legacy_dialogue,
-    is_structured_video_prompt,
-    strip_voice_profiles,
-    video_prompt_to_yaml,
-)
 from lib.reference_video.request_projection import (
     POST_PRODUCTION,
     USE_TTS,
@@ -64,10 +55,9 @@ from lib.script_models import get_generated_assets, resolve_content_mode
 from lib.script_skeleton import ensure_route_skeleton, resolve_script_kind
 from lib.speech_composition import (
     SpeechAdmissionError,
-    require_script_unit_admitted,
     video_unit_replan_problems,
 )
-from lib.storyboard_sequence import StoryboardImageUnavailable, get_storyboard_items
+from lib.storyboard_sequence import get_storyboard_items
 from lib.version_manager import VersionManager
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
@@ -77,16 +67,18 @@ from server.agent_runtime.sdk_tools._context import (
 )
 from server.services.video_batch_admission import (
     admit_reference_video_batch,
-    admit_storyboard_video_batch,
+    admit_storyboard_video_request,
     artifact_state_tickets,
+    build_storyboard_video_specs,
     diagnostic_unit_id,
     reference_unit_task_spec,
     request_options_for_unit,
+    resolve_voice_context,
     screen_script_entries,
+    speech_admission_ticket,
     storyboard_item_id,
     video_target_states,
 )
-from server.services.video_caps import assert_audio_switch_supported, resolve_project_is_silent
 
 _CONFIRMED_REQUEST_DURATION_SCHEMA_PROPERTY = {
     "type": "integer",
@@ -166,23 +158,6 @@ def _currency_reusable_ids(
         for unit_id, state in states.items()
         if unit_id not in done and artifact_is_reusable(state, manifest_active=manifest_active)
     ]
-
-
-def _speech_admission_ticket(unit_id: str, exc: SpeechAdmissionError) -> UnitAdmissionTicket:
-    """Refuse a target on its speech admission, carrying that verdict through.
-
-    The admission's own problem code and action are kept unchanged, so a caller
-    never has to read the rendered text to decide what to do next.
-    """
-
-    problem = exc.admission.problems[0]
-    return refused_ticket(
-        unit_id or exc.admission.unit_id,
-        code=problem.code.value,
-        detail=f"发声准入未通过：{json.dumps(exc.admission.to_dict(), ensure_ascii=False)}",
-        action=(GenerationAction.REPLAN_UNIT if problem.action.value == "replan_unit" else GenerationAction.FIX_INPUT),
-        params={"speech_admission": exc.admission.to_dict()},
-    )
 
 
 def _sole_speech_admission(result: GenerationBatchResult) -> dict[str, Any]:
@@ -379,54 +354,29 @@ async def _admit_storyboard_specs(
     selection: GenerationSelectionMode,
     extra_tickets: list[UnitAdmissionTicket],
 ) -> BatchAdmission:
-    """Admit the storyboard-route specs as one request, then stamp the delivery choice.
+    """Admit the storyboard-route specs, then stamp the delivery choice onto them.
 
-    The visual prompt each spec already carries is what the admission compares
-    against the paid artifact, so the triples are built before the delivery payload
-    is applied — the payload is a request fact, not part of the visual basis.
-
-    音频开关冲突属于请求自身已知的配置缺口，在这里与投影侧的缺口折进同一批逐目标结论：
-    留到提交前才检查，用户会先被问一遍跨档确认、同意之后才收到一句通用报错。
+    The admission itself is the shared one the read-only plan also consults, so a
+    preview and the submission it predicts cannot reach different verdicts. Only the
+    payload stamping is enqueue-side: it is a request fact, not part of the basis the
+    admission compares.
     """
 
-    items_by_id = {str(storyboard_item_id(item, id_field) or ""): item for item in items}
-    targets: list[tuple[str, dict[str, Any], object]] = []
-    for spec in specs:
-        item = items_by_id.get(spec.resource_id)
-        if item is None:
-            raise ValueError(f"找不到待生成条目: {spec.resource_id}")
-        targets.append((spec.resource_id, item, (spec.payload or {}).get("prompt")))
-    audio_conflict = await _audio_switch_conflict(ctx) if specs else None
-    admission = await admit_storyboard_video_batch(
+    admission = await admit_storyboard_video_request(
         project_name=ctx.project_name,
         project=project,
         project_path=ctx.project_path,
         script=script,
         script_file=script_filename,
-        items=targets,
+        items=items,
+        id_field=id_field,
+        specs=specs,
         request_options=request_options,
         confirmed_request_durations=confirmed_request_durations,
         operation=operation,
         selection=selection,
         extra_tickets=extra_tickets,
     )
-    if audio_conflict is not None:
-        # 音频开关冲突与投影侧的缺口写进同一批票：短路返回只会报出这一条，用户改完配置
-        # 重试才撞见下一个已知缺口，正是这道门要免掉的逐条试探。
-        conflict = GenerationProblem(
-            code="video_audio_switch_not_supported",
-            detail=audio_conflict,
-            action=GenerationAction.CONFIGURE_PROVIDER,
-            params={},
-        )
-        target_ids = {spec.resource_id for spec in specs}
-        admission = replace(
-            admission,
-            tickets=tuple(
-                replace(ticket, problems=(*ticket.problems, conflict)) if ticket.unit_id in target_ids else ticket
-                for ticket in admission.tickets
-            ),
-        )
     if admission.admitted:
         _apply_delivery_payload(specs, request_options, confirmed_request_durations)
     return admission
@@ -442,72 +392,6 @@ def _enqueue_aborted_error(name: str, exc: BatchEnqueueAborted, log: list[str] |
     if log:
         text = "\n".join([text, *log])
     return {"content": [{"type": "text", "text": text}], "is_error": True}
-
-
-def _get_video_prompt(
-    item: dict[str, Any], *, content_mode: str, voice_characters: dict[str, Any] | None = None
-) -> str:
-    prompt = item.get("video_prompt")
-    if not prompt:
-        item_id = item.get("segment_id") or item.get("scene_id")
-        raise ValueError(f"片段/场景缺少 video_prompt 字段: {item_id}")
-    if is_structured_video_prompt(prompt):
-        # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 系的机械派生：剧本 JSON
-        # 里残留的 voice_profiles 一律先剥离，不因门控不触发（narration/ad、或 drama 无
-        # utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
-        prompt = strip_voice_profiles(prompt)
-        if content_mode == "drama":
-            # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
-            # dialogue 出口（drama video_prompt 已不带 dialogue）。utterances 迁移前的存量剧本
-            # （load_script 按原始 JSON 读盘不过 pydantic，不会被 DramaScene._migrate_legacy
-            # 自动补齐）台词仍留在 video_prompt.dialogue，改走 legacy 出口。
-            if "utterances" in item:
-                prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
-            else:
-                prompt = build_drama_video_prompt_from_legacy_dialogue(prompt, characters=voice_characters)
-        return video_prompt_to_yaml(prompt)
-    if isinstance(prompt, dict):
-        item_id = item.get("segment_id") or item.get("scene_id")
-        raise ValueError(f"片段/场景 video_prompt 为对象但格式不符合结构化规范: {item_id}")
-    if not isinstance(prompt, str):
-        item_id = item.get("segment_id") or item.get("scene_id")
-        raise TypeError(f"片段/场景 video_prompt 类型无效（期望 str 或 dict）: {item_id}")
-    return prompt
-
-
-async def _audio_switch_conflict(ctx: ToolContext) -> str | None:
-    """分镜路线入队前的音频闸门（``assert_audio_switch_supported``，与 WebUI 提交入口同一判据）。
-
-    成片恒有声的模型收不到关闭音频的请求，放行只会让无声判据把音色约束整批裁掉。闸门与内容模式
-    无关，narration/ad 同样受检。
-
-    调用点固定在「确有任务要入队」之后：整集已完成、或条目全被 :func:`_build_video_specs`
-    过滤时本就不会产生任何请求，此时拒绝等于把一次正常的空转变成报错。
-    参考路线由公共 request projection 给出同一音频能力判定。
-
-    返回冲突说明文本；无冲突返回 ``None``。调用方把它折成逐目标的准入结论，与其它缺口
-    一起在建任务之前一次报全。
-    """
-    project = ctx.pm.load_project(ctx.project_name)
-    try:
-        await assert_audio_switch_supported(project, video_bucket_for_generation_mode(project.get("generation_mode")))
-    except ValueError as exc:
-        return str(exc)
-    return None
-
-
-async def _resolve_voice_context(ctx: ToolContext, content_mode: str) -> dict[str, Any] | None:
-    """供 Voice_Profiles 注入的角色资产（``None`` 表示不注入）。
-
-    非 drama 不注入；drama 按无声判据排除（C 类模型不产音、或本集关闭了音频，两条路径同口径）。
-    台词不受影响、照常下发。
-    """
-    if content_mode != "drama":
-        return None
-    project = ctx.pm.load_project(ctx.project_name)
-    if await resolve_project_is_silent(project):
-        return None
-    return project.get("characters") or {}
 
 
 def _resolve_reference_route(ctx: ToolContext, script: dict[str, Any]) -> str | None:
@@ -698,129 +582,6 @@ def _screen_storyboard_items(
     return clean, tickets
 
 
-def _build_video_specs(
-    *,
-    items: list[dict[str, Any]],
-    id_field: str,
-    content_mode: str,
-    skeleton_kind: str,
-    script_filename: str,
-    project_dir: Path,
-    skip_ids: list[str] | None,
-    project: dict[str, Any] | None = None,
-    episode: int = 1,
-    resolver: ArtifactCurrencyResolver | None = None,
-    voice_characters: dict[str, Any] | None = None,
-) -> tuple[list[TaskSpec], dict[str, int], list[UnitAdmissionTicket]]:
-    """Build the storyboard-route specs, refusing each unit that cannot be requested.
-
-    A unit whose speech, inputs or prompt are unusable is refused with its own code
-    and next action instead of being dropped into a log line, so one bad unit never
-    silently shrinks the batch — and, because the refusal is a ticket rather than a
-    recorded block, it can hold the whole batch back before any task exists.
-
-    ``skeleton_kind`` 取路线闸门给出的剧本实际骨架种类，而不是按内容模式反推：族内的历史
-    形态（narration 数据落 ``scenes`` 键）按反推值去适配，合法的旧剧本会被整批判成解析失败。
-
-    发声准入在这里执行，与参考路线由 ``reference_unit_task_spec`` 承担的位置对应：
-    构造 TaskSpec 的这一步是「这个 unit 能不能被请求」的唯一口径，四个 storyboard 入口
-    （整集 / 全部 / 点名 / 单条）都经由它，混合发声与 needs_replan 因此在任何入口都会
-    在建任务之前扣住整批。
-    """
-
-    item_type = "片段" if content_mode == "narration" else "场景"
-    skip_set = set(skip_ids or [])
-
-    specs: list[TaskSpec] = []
-    order_map: dict[str, int] = {}
-    refused: list[UnitAdmissionTicket] = []
-    project = project or {}
-    if resolver is None:
-        resolver = active_artifact_currency_resolver(project_dir, project)
-    for idx, item in enumerate(items):
-        item_id = str(storyboard_item_id(item, id_field))
-        if item_id in skip_set:
-            continue
-
-        try:
-            require_script_unit_admitted(skeleton_kind, item)
-        except SpeechAdmissionError as exc:
-            # 逐 ID 契约与既有 speech_admission 载荷并存：前者说「这个 ID 没做成、
-            # 下一步做什么」，后者带着准入自己的完整定位信息。
-            refused.append(_speech_admission_ticket(str(item_id), exc))
-            continue
-
-        try:
-            resolve_usable_storyboard_video_inputs(
-                project_path=project_dir,
-                project=project,
-                episode=episode,
-                resource_id=str(item_id),
-                item=item,
-                resolver=resolver,
-                allow_legacy_same_name=False,
-            )
-        except (OSError, ValueError) as exc:
-            # 分镜图本身不可用是最常见的一种，给出下一步该跑什么，而不是只报路径。
-            advice = "，请先运行 generate_storyboards" if isinstance(exc, StoryboardImageUnavailable) else ""
-            refused.append(
-                refused_ticket(
-                    str(item_id),
-                    code=GenerationProblemCode.UNIT_INPUT_UNUSABLE,
-                    detail=f"{item_type} {item_id} 的视频输入不可用: {exc}{advice}",
-                    action=GenerationAction.GENERATE_DEPENDENCY,
-                )
-            )
-            continue
-
-        try:
-            prompt = _get_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
-        except Exception as exc:  # noqa: BLE001
-            refused.append(
-                refused_ticket(
-                    str(item_id),
-                    code=GenerationProblemCode.UNIT_REQUEST_INVALID,
-                    detail=f"{item_type} {item_id} 的 video_prompt 无效: {exc}",
-                    action=GenerationAction.FIX_INPUT,
-                )
-            )
-            continue
-
-        # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
-        # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
-        # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
-        extra_payload: dict[str, Any] = {}
-        duration = item.get("duration_seconds")
-        if duration is not None:
-            extra_payload["duration_seconds"] = duration
-
-        # 构造 TaskSpec 本身也是可入队性判定（空提示词等，``TaskSpecValidationError``
-        # 是 ValueError 子类）：不接住就会让一个坏条目把整批打成一句通用报错，
-        # 其余条目的结论无从得知。
-        try:
-            spec = TaskSpec.from_request(
-                task_type="video",
-                media_type="video",
-                resource_id=item_id,
-                prompt=prompt,
-                script_file=script_filename,
-                extra_payload=extra_payload or None,
-            )
-        except ValueError as exc:
-            refused.append(
-                refused_ticket(
-                    str(item_id),
-                    code=GenerationProblemCode.UNIT_REQUEST_INVALID,
-                    detail=f"{item_type} {item_id} 无法构造入队请求: {exc}",
-                    action=GenerationAction.FIX_INPUT,
-                )
-            )
-            continue
-        specs.append(spec)
-        order_map[item_id] = idx
-    return specs, order_map, refused
-
-
 def _build_reference_specs(
     *,
     units: list[Any],
@@ -844,7 +605,7 @@ def _build_reference_specs(
         try:
             spec = reference_unit_task_spec(unit, script_filename)
         except SpeechAdmissionError as exc:
-            refused.append(_speech_admission_ticket(unit_id, exc))
+            refused.append(speech_admission_ticket(unit_id, exc))
             continue
         except ValueError as exc:
             refused.append(
@@ -1405,8 +1166,8 @@ def generate_video_episode_tool(ctx: ToolContext):
             refused = artifact_state_tickets(blocked_states)
             refused.extend(screen_refused)
 
-            voice_characters = await _resolve_voice_context(ctx, content_mode)
-            specs, order_map, spec_refused = _build_video_specs(
+            voice_characters = await resolve_voice_context(project, content_mode)
+            specs, order_map, spec_refused = build_storyboard_video_specs(
                 items=items,
                 id_field=id_field,
                 content_mode=content_mode,
@@ -1557,8 +1318,8 @@ def generate_video_scene_tool(ctx: ToolContext):
             # 发声准入与输入可用性都由 _build_video_specs 判定，点名单条与整批走同一条缝：
             # 两处各判一次，口径就会随其中一处的改动分叉。
             content_mode = resolve_content_mode(script, project)
-            voice_characters = await _resolve_voice_context(ctx, content_mode)
-            specs, _order_map, refused = _build_video_specs(
+            voice_characters = await resolve_voice_context(project, content_mode)
+            specs, _order_map, refused = build_storyboard_video_specs(
                 items=[item],
                 id_field=id_field,
                 content_mode=content_mode,
@@ -1693,8 +1454,8 @@ def generate_video_all_tool(ctx: ToolContext):
             # 这里若只认 ``id_field`` 会把它筛没——进了 requested 却永远不入队。
             target_id_set = set(selection.target_ids)
             pending = [item for item in items if str(storyboard_item_id(item, id_field) or "") in target_id_set]
-            voice_characters = await _resolve_voice_context(ctx, content_mode)
-            specs, _order_map, refused = _build_video_specs(
+            voice_characters = await resolve_voice_context(project, content_mode)
+            specs, _order_map, refused = build_storyboard_video_specs(
                 items=pending,
                 id_field=id_field,
                 content_mode=content_mode,
@@ -1894,8 +1655,8 @@ def generate_video_selected_tool(ctx: ToolContext):
             for done_id in already_done:
                 builder.skip(_state_for(states, str(done_id)))
 
-            voice_characters = await _resolve_voice_context(ctx, content_mode)
-            specs, order_map, spec_refused = _build_video_specs(
+            voice_characters = await resolve_voice_context(project, content_mode)
+            specs, order_map, spec_refused = build_storyboard_video_specs(
                 items=selected,
                 id_field=id_field,
                 content_mode=content_mode,

--- a/server/agent_runtime/sdk_tools/workflow_plan.py
+++ b/server/agent_runtime/sdk_tools/workflow_plan.py
@@ -8,6 +8,7 @@ from typing import Any
 from claude_agent_sdk import tool
 
 from lib.workflow_plan import WorkflowPlanRequest
+from lib.workflow_state import WorkflowRequestError
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 from server.services import workflow_planner
 
@@ -47,9 +48,7 @@ def get_workflow_plan_tool(ctx: ToolContext):
         try:
             plan = await workflow_planner.get_workflow_planner(ctx.pm).get_plan(ctx.project_name, request)
             return {"content": [{"type": "text", "text": plan.model_dump_json()}]}
-        except json.JSONDecodeError as exc:
-            return tool_error("get_workflow_plan", exc)
-        except ValueError as exc:
+        except WorkflowRequestError as exc:
             return _error("invalid_request", str(exc))
         except Exception as exc:  # noqa: BLE001
             return tool_error("get_workflow_plan", exc)

--- a/server/agent_runtime/sdk_tools/workflow_plan.py
+++ b/server/agent_runtime/sdk_tools/workflow_plan.py
@@ -1,0 +1,60 @@
+"""SDK MCP adapter for the authoritative workflow planner."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from claude_agent_sdk import tool
+
+from lib.workflow_plan import WorkflowPlanRequest
+from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
+from server.services import workflow_planner
+
+
+def _error(code: str, detail: str) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": json.dumps({"error": code, "detail": detail}, ensure_ascii=False)}],
+        "is_error": True,
+    }
+
+
+def get_workflow_plan_tool(ctx: ToolContext):
+    @tool(
+        "get_workflow_plan",
+        "读取只读的完整工作流计划。返回有序步骤、阻断原因、活动任务、视频准入与唯一下一动作。",
+        {
+            "type": "object",
+            "properties": {
+                "episode": {"type": "integer", "minimum": 1},
+                "narration_delivery": {
+                    "type": "string",
+                    "enum": ["post_production", "use_tts"],
+                    "description": "本次视频请求的旁白交付选择；不写入项目 workflow。",
+                },
+                "confirmed_request_durations": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer", "minimum": 1},
+                },
+            },
+        },
+    )
+    async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        try:
+            request = WorkflowPlanRequest.model_validate(args)
+        except ValueError as exc:
+            return _error("invalid_request", str(exc))
+        try:
+            plan = await workflow_planner.get_workflow_planner(ctx.pm).get_plan(ctx.project_name, request)
+            return {"content": [{"type": "text", "text": plan.model_dump_json()}]}
+        except json.JSONDecodeError as exc:
+            return tool_error("get_workflow_plan", exc)
+        except ValueError as exc:
+            return _error("invalid_request", str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return tool_error("get_workflow_plan", exc)
+
+    return _handler
+
+
+__all__ = ["get_workflow_plan_tool"]

--- a/server/agent_runtime/sdk_tools/workflow_status.py
+++ b/server/agent_runtime/sdk_tools/workflow_status.py
@@ -9,7 +9,7 @@ from typing import Any
 from claude_agent_sdk import tool
 
 from lib.script_review import Step1RebuildCompletionError, complete_stale_step1_rebuild
-from lib.workflow_state import WorkflowStateService
+from lib.workflow_state import WorkflowRequestError, WorkflowStateService
 from server.agent_runtime.sdk_tools._context import ToolContext, tool_error
 
 
@@ -45,9 +45,7 @@ def get_workflow_status_tool(ctx: ToolContext):
         try:
             status = await asyncio.to_thread(WorkflowStateService(ctx.pm).get_status, ctx.project_name, raw_episode)
             return {"content": [{"type": "text", "text": status.model_dump_json()}]}
-        except json.JSONDecodeError as exc:
-            return tool_error("get_workflow_status", exc)
-        except ValueError as exc:
+        except WorkflowRequestError as exc:
             return _error("invalid_episode", str(exc))
         except Exception as exc:  # noqa: BLE001
             return tool_error("get_workflow_status", exc)

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -45,7 +45,7 @@ from lib.speech_rate import MAX_SPEECH_RATE_UPS, MIN_SPEECH_RATE_UPS, SPEECH_RAT
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
 from lib.workflow_plan import WorkflowPlan, WorkflowPlanRequest
-from lib.workflow_state import WorkflowStateService, WorkflowStatus
+from lib.workflow_state import WorkflowRequestError, WorkflowStateService, WorkflowStatus
 from server.auth import CurrentUser, create_download_token, verify_download_token
 from server.routers._reorder import full_permutation_error
 from server.routers._script_edits import (
@@ -695,9 +695,7 @@ async def get_workflow_status(
         return await asyncio.to_thread(WorkflowStateService(get_project_manager()).get_status, name, episode)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
-    except json.JSONDecodeError:
-        raise
-    except ValueError as exc:
+    except WorkflowRequestError as exc:
         raise BadRequestError("request_invalid") from exc
 
 
@@ -709,9 +707,7 @@ async def get_workflow_plan(name: str, request: WorkflowPlanRequest):
         return await workflow_plan_service.get_workflow_planner(get_project_manager()).get_plan(name, request)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
-    except json.JSONDecodeError:
-        raise
-    except ValueError as exc:
+    except WorkflowRequestError as exc:
         raise BadRequestError("request_invalid") from exc
 
 

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -44,6 +44,7 @@ from lib.script_batch_edit import ScriptBatchEditCommand, ScriptBatchEditor, scr
 from lib.speech_rate import MAX_SPEECH_RATE_UPS, MIN_SPEECH_RATE_UPS, SPEECH_RATE_FIELD, is_valid_speech_rate
 from lib.status_calculator import StatusCalculator
 from lib.style_templates import is_known_template, resolve_template_prompt
+from lib.workflow_plan import WorkflowPlan, WorkflowPlanRequest
 from lib.workflow_state import WorkflowStateService, WorkflowStatus
 from server.auth import CurrentUser, create_download_token, verify_download_token
 from server.routers._reorder import full_permutation_error
@@ -53,6 +54,7 @@ from server.routers._script_edits import (
     script_batch_status,
 )
 from server.routers._validators import validate_backend_value
+from server.services import workflow_planner as workflow_plan_service
 from server.services.project_archive import (
     ProjectArchiveService,
     ProjectArchiveValidationError,
@@ -691,6 +693,20 @@ async def get_workflow_status(
 
     try:
         return await asyncio.to_thread(WorkflowStateService(get_project_manager()).get_status, name, episode)
+    except FileNotFoundError as exc:
+        raise NotFoundError("project_not_found", name=name) from exc
+    except json.JSONDecodeError:
+        raise
+    except ValueError as exc:
+        raise BadRequestError("request_invalid") from exc
+
+
+@router.post("/projects/{name}/workflow-plan", response_model=WorkflowPlan)
+async def get_workflow_plan(name: str, request: WorkflowPlanRequest):
+    """Return the side-effect-free plan for one transient workflow request."""
+
+    try:
+        return await workflow_plan_service.get_workflow_planner(get_project_manager()).get_plan(name, request)
     except FileNotFoundError as exc:
         raise NotFoundError("project_not_found", name=name) from exc
     except json.JSONDecodeError:

--- a/server/services/video_batch_admission.py
+++ b/server/services/video_batch_admission.py
@@ -57,7 +57,7 @@ from lib.reference_video.request_projection import (
     project_reference_unit_request,
 )
 from lib.script_models import get_generated_assets
-from lib.speech_composition import SpeechAdmissionError, require_script_unit_admitted
+from lib.speech_composition import SpeechAdmission, SpeechAdmissionError, require_script_unit_admitted
 from lib.version_manager import VersionManager
 from server.services.cost_estimation import quote_video_request
 from server.services.narration_delivery_tasks import (
@@ -346,17 +346,26 @@ def _generation_problem(problem: ProjectionProblem | NarrationDeliveryProblem, *
     )
 
 
-def _speech_problem(exc: SpeechAdmissionError) -> GenerationProblem:
-    problem = exc.admission.problems[0]
-    return GenerationProblem(
-        code=problem.code.value,
-        detail=problem.reason.value,
-        action=_SPEECH_ACTIONS.get(problem.action.value, GenerationAction.FIX_INPUT),
-        params={"speech_admission": exc.admission.to_dict()},
+def speech_admission_problems(admission: SpeechAdmission) -> tuple[GenerationProblem, ...]:
+    """Lift every speech blocker into the shared generation problem contract."""
+
+    payload = admission.to_dict()
+    return tuple(
+        GenerationProblem(
+            code=problem.code.value,
+            detail=problem.reason.value,
+            action=_SPEECH_ACTIONS.get(problem.action.value, GenerationAction.FIX_INPUT),
+            params={"unit_id": admission.unit_id, "speech_admission": payload},
+        )
+        for problem in admission.problems
     )
 
 
-def _active_task_problem(task: Mapping[str, Any]) -> GenerationProblem:
+def _speech_problem(exc: SpeechAdmissionError) -> GenerationProblem:
+    return speech_admission_problems(exc.admission)[0]
+
+
+def active_task_problem(task: Mapping[str, Any]) -> GenerationProblem:
     return GenerationProblem(
         code=GenerationProblemCode.ACTIVE_TASK_CONFLICT,
         detail=f"该 unit 已有在途任务（状态：{task.get('status')}），等待其结束后再提交本次批量请求",
@@ -491,7 +500,7 @@ async def admit_reference_video_batch(
         seen_ids.add(unit_id)
         problems: list[GenerationProblem] = []
         if unit_id in conflicts:
-            problems.append(_active_task_problem(conflicts[unit_id]))
+            problems.append(active_task_problem(conflicts[unit_id]))
         if spec_check is not None:
             try:
                 spec_check(unit)
@@ -655,7 +664,7 @@ async def admit_storyboard_video_batch(
     for resource_id, item, visual_prompt in items:
         if resource_id in conflicts:
             tickets.append(
-                UnitAdmissionTicket(unit_id=resource_id, problems=(_active_task_problem(conflicts[resource_id]),))
+                UnitAdmissionTicket(unit_id=resource_id, problems=(active_task_problem(conflicts[resource_id]),))
             )
             continue
         if request_options.narration_delivery != USE_TTS:
@@ -730,11 +739,13 @@ async def _storyboard_ticket(
 
 
 __all__ = [
+    "active_task_problem",
     "admit_reference_video_batch",
     "admit_storyboard_video_batch",
     "reference_unit_task_spec",
     "artifact_state_tickets",
     "request_options_for_unit",
     "resolve_reference_batch_targets",
+    "speech_admission_problems",
     "video_target_states",
 ]

--- a/server/services/video_batch_admission.py
+++ b/server/services/video_batch_admission.py
@@ -13,12 +13,18 @@ different conclusions about the same project.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
-from lib.artifact_activation import ArtifactCurrencyResolver, active_artifact_currency_resolver, artifact_is_usable
+from lib.artifact_activation import (
+    ArtifactCurrencyResolver,
+    active_artifact_currency_resolver,
+    artifact_is_usable,
+    resolve_usable_storyboard_video_inputs,
+)
 from lib.artifact_manifest import ArtifactKey
 from lib.batch_admission import (
     BatchAdmission,
@@ -49,6 +55,13 @@ from lib.narration_delivery import (
     video_request_requires_exact_quote,
     video_request_reuses_current_visual,
 )
+from lib.prompt_utils import (
+    build_drama_video_prompt,
+    build_drama_video_prompt_from_legacy_dialogue,
+    is_structured_video_prompt,
+    strip_voice_profiles,
+    video_prompt_to_yaml,
+)
 from lib.reference_video import assemble_shots_text
 from lib.reference_video.request_projection import (
     ProjectionProblem,
@@ -58,6 +71,7 @@ from lib.reference_video.request_projection import (
 )
 from lib.script_models import get_generated_assets
 from lib.speech_composition import SpeechAdmission, SpeechAdmissionError, require_script_unit_admitted
+from lib.storyboard_sequence import StoryboardImageUnavailable
 from lib.version_manager import VersionManager
 from server.services.cost_estimation import quote_video_request
 from server.services.narration_delivery_tasks import (
@@ -65,6 +79,7 @@ from server.services.narration_delivery_tasks import (
     prepare_current_reference_video_request_options,
     prepare_current_storyboard_narrated_video_duration,
 )
+from server.services.video_caps import assert_audio_switch_supported, resolve_project_is_silent
 
 
 def video_target_states(
@@ -738,8 +753,286 @@ async def _storyboard_ticket(
     )
 
 
+def speech_admission_ticket(unit_id: str, exc: SpeechAdmissionError) -> UnitAdmissionTicket:
+    """Refuse a target on its speech admission, carrying that verdict through.
+
+    The admission's own problem code and action are kept unchanged, so a caller
+    never has to read the rendered text to decide what to do next.
+    """
+
+    problem = exc.admission.problems[0]
+    return refused_ticket(
+        unit_id or exc.admission.unit_id,
+        code=problem.code.value,
+        detail=f"发声准入未通过：{json.dumps(exc.admission.to_dict(), ensure_ascii=False)}",
+        action=(GenerationAction.REPLAN_UNIT if problem.action.value == "replan_unit" else GenerationAction.FIX_INPUT),
+        params={"speech_admission": exc.admission.to_dict()},
+    )
+
+
+def storyboard_video_prompt(
+    item: dict[str, Any], *, content_mode: str, voice_characters: dict[str, Any] | None = None
+) -> str:
+    prompt = item.get("video_prompt")
+    if not prompt:
+        item_id = item.get("segment_id") or item.get("scene_id")
+        raise ValueError(f"片段/场景缺少 video_prompt 字段: {item_id}")
+    if is_structured_video_prompt(prompt):
+        # Voice_Profiles 声明段唯一来源是下方 build_drama_video_prompt 系的机械派生：剧本 JSON
+        # 里残留的 voice_profiles 一律先剥离，不因门控不触发（narration/ad、或 drama 无
+        # utterances 的条目）而绕过 C 类（真无声）门控直达 YAML。
+        prompt = strip_voice_profiles(prompt)
+        if content_mode == "drama":
+            # drama 口型台词单一真相源在场景级有序 utterances：取 dialogue-kind 注入 video YAML 的
+            # dialogue 出口（drama video_prompt 已不带 dialogue）。utterances 迁移前的存量剧本
+            # （load_script 按原始 JSON 读盘不过 pydantic，不会被 DramaScene._migrate_legacy
+            # 自动补齐）台词仍留在 video_prompt.dialogue，改走 legacy 出口。
+            if "utterances" in item:
+                prompt = build_drama_video_prompt(prompt, item.get("utterances"), characters=voice_characters)
+            else:
+                prompt = build_drama_video_prompt_from_legacy_dialogue(prompt, characters=voice_characters)
+        return video_prompt_to_yaml(prompt)
+    if isinstance(prompt, dict):
+        item_id = item.get("segment_id") or item.get("scene_id")
+        raise ValueError(f"片段/场景 video_prompt 为对象但格式不符合结构化规范: {item_id}")
+    if not isinstance(prompt, str):
+        item_id = item.get("segment_id") or item.get("scene_id")
+        raise TypeError(f"片段/场景 video_prompt 类型无效（期望 str 或 dict）: {item_id}")
+    return prompt
+
+
+async def resolve_voice_context(project: dict[str, Any], content_mode: str) -> dict[str, Any] | None:
+    """供 Voice_Profiles 注入的角色资产（``None`` 表示不注入）。
+
+    非 drama 不注入；drama 按无声判据排除（C 类模型不产音、或本集关闭了音频，两条路径同口径）。
+    台词不受影响、照常下发。
+    """
+    if content_mode != "drama":
+        return None
+    if await resolve_project_is_silent(project):
+        return None
+    return project.get("characters") or {}
+
+
+async def audio_switch_conflict(project: dict[str, Any]) -> str | None:
+    """分镜路线的音频闸门（``assert_audio_switch_supported``，与 WebUI 提交入口同一判据）。
+
+    成片恒有声的模型收不到关闭音频的请求，放行只会让无声判据把音色约束整批裁掉。闸门与内容模式
+    无关，narration/ad 同样受检。
+
+    调用点固定在「确有目标要请求」之后：整集已完成、或条目全被 :func:`build_storyboard_video_specs`
+    过滤时本就不会产生任何请求，此时拒绝等于把一次正常的空转变成报错。
+    参考路线由公共 request projection 给出同一音频能力判定。
+
+    返回冲突说明文本；无冲突返回 ``None``。调用方把它折成逐目标的准入结论，与其它缺口
+    一起在建任务之前一次报全。
+    """
+    try:
+        await assert_audio_switch_supported(project, video_bucket_for_generation_mode(project.get("generation_mode")))
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def build_storyboard_video_specs(
+    *,
+    items: list[dict[str, Any]],
+    id_field: str,
+    content_mode: str,
+    skeleton_kind: str,
+    script_filename: str,
+    project_dir: Path,
+    skip_ids: list[str] | None,
+    project: dict[str, Any] | None = None,
+    episode: int = 1,
+    resolver: ArtifactCurrencyResolver | None = None,
+    voice_characters: dict[str, Any] | None = None,
+) -> tuple[list[TaskSpec], dict[str, int], list[UnitAdmissionTicket]]:
+    """Build the storyboard-route specs, refusing each unit that cannot be requested.
+
+    A unit whose speech, inputs or prompt are unusable is refused with its own code
+    and next action instead of being dropped into a log line, so one bad unit never
+    silently shrinks the batch — and, because the refusal is a ticket rather than a
+    recorded block, it can hold the whole batch back before any task exists.
+
+    ``skeleton_kind`` 取路线闸门给出的剧本实际骨架种类，而不是按内容模式反推：族内的历史
+    形态（narration 数据落 ``scenes`` 键）按反推值去适配，合法的旧剧本会被整批判成解析失败。
+
+    发声准入在这里执行，与参考路线由 ``reference_unit_task_spec`` 承担的位置对应：
+    构造 TaskSpec 的这一步是「这个 unit 能不能被请求」的唯一口径，四个 storyboard 入口
+    （整集 / 全部 / 点名 / 单条）与只读的工作流计划都经由它，混合发声与 needs_replan 因此
+    在任何入口都会在建任务之前扣住整批，计划预告的准入结论也与真正提交时一致。
+    """
+
+    item_type = "片段" if content_mode == "narration" else "场景"
+    skip_set = set(skip_ids or [])
+
+    specs: list[TaskSpec] = []
+    order_map: dict[str, int] = {}
+    refused: list[UnitAdmissionTicket] = []
+    project = project or {}
+    if resolver is None:
+        resolver = active_artifact_currency_resolver(project_dir, project)
+    for idx, item in enumerate(items):
+        item_id = str(storyboard_item_id(item, id_field))
+        if item_id in skip_set:
+            continue
+
+        try:
+            require_script_unit_admitted(skeleton_kind, item)
+        except SpeechAdmissionError as exc:
+            # 逐 ID 契约与既有 speech_admission 载荷并存：前者说「这个 ID 没做成、
+            # 下一步做什么」，后者带着准入自己的完整定位信息。
+            refused.append(speech_admission_ticket(str(item_id), exc))
+            continue
+
+        try:
+            resolve_usable_storyboard_video_inputs(
+                project_path=project_dir,
+                project=project,
+                episode=episode,
+                resource_id=str(item_id),
+                item=item,
+                resolver=resolver,
+                allow_legacy_same_name=False,
+            )
+        except (OSError, ValueError) as exc:
+            # 分镜图本身不可用是最常见的一种，给出下一步该跑什么，而不是只报路径。
+            advice = "，请先运行 generate_storyboards" if isinstance(exc, StoryboardImageUnavailable) else ""
+            refused.append(
+                refused_ticket(
+                    str(item_id),
+                    code=GenerationProblemCode.UNIT_INPUT_UNUSABLE,
+                    detail=f"{item_type} {item_id} 的视频输入不可用: {exc}{advice}",
+                    action=GenerationAction.GENERATE_DEPENDENCY,
+                )
+            )
+            continue
+
+        try:
+            prompt = storyboard_video_prompt(item, content_mode=content_mode, voice_characters=voice_characters)
+        except Exception as exc:  # noqa: BLE001
+            refused.append(
+                refused_ticket(
+                    str(item_id),
+                    code=GenerationProblemCode.UNIT_REQUEST_INVALID,
+                    detail=f"{item_type} {item_id} 的 video_prompt 无效: {exc}",
+                    action=GenerationAction.FIX_INPUT,
+                )
+            )
+            continue
+
+        # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）；
+        # 原样透传调用方显式指定的值，不在入队侧做 int() 截断式归一化（否则会把
+        # 本应被执行层拒绝的非法值静默修正）。缺省由执行层按 caps 收口默认。
+        extra_payload: dict[str, Any] = {}
+        duration = item.get("duration_seconds")
+        if duration is not None:
+            extra_payload["duration_seconds"] = duration
+
+        # 构造 TaskSpec 本身也是可入队性判定（空提示词等，``TaskSpecValidationError``
+        # 是 ValueError 子类）：不接住就会让一个坏条目把整批打成一句通用报错，
+        # 其余条目的结论无从得知。
+        try:
+            spec = TaskSpec.from_request(
+                task_type="video",
+                media_type="video",
+                resource_id=item_id,
+                prompt=prompt,
+                script_file=script_filename,
+                extra_payload=extra_payload or None,
+            )
+        except ValueError as exc:
+            refused.append(
+                refused_ticket(
+                    str(item_id),
+                    code=GenerationProblemCode.UNIT_REQUEST_INVALID,
+                    detail=f"{item_type} {item_id} 无法构造入队请求: {exc}",
+                    action=GenerationAction.FIX_INPUT,
+                )
+            )
+            continue
+        specs.append(spec)
+        order_map[item_id] = idx
+    return specs, order_map, refused
+
+
+async def admit_storyboard_video_request(
+    *,
+    project_name: str,
+    project: dict[str, Any],
+    project_path: Path,
+    script: dict[str, Any],
+    script_file: str,
+    items: Sequence[dict[str, Any]],
+    id_field: str,
+    specs: Sequence[TaskSpec],
+    request_options: ReferenceRequestOptions,
+    confirmed_request_durations: Mapping[str, int],
+    operation: str,
+    selection: GenerationSelectionMode,
+    extra_tickets: Sequence[UnitAdmissionTicket],
+) -> BatchAdmission:
+    """Admit one storyboard-route request from the specs it would actually enqueue.
+
+    The visual prompt each spec already carries is what the admission compares
+    against the paid artifact, so the triples are built from the specs rather than
+    from the raw script items — a preview that skipped them would judge reuse on a
+    different basis than the submission it predicts.
+
+    音频开关冲突属于请求自身已知的配置缺口，在这里与投影侧的缺口折进同一批逐目标结论：
+    留到提交前才检查，用户会先被问一遍跨档确认、同意之后才收到一句通用报错。
+    """
+
+    items_by_id = {str(storyboard_item_id(item, id_field) or ""): item for item in items}
+    targets: list[tuple[str, dict[str, Any], object]] = []
+    for spec in specs:
+        item = items_by_id.get(spec.resource_id)
+        if item is None:
+            raise ValueError(f"找不到待生成条目: {spec.resource_id}")
+        targets.append((spec.resource_id, item, (spec.payload or {}).get("prompt")))
+    conflict_detail = await audio_switch_conflict(project) if specs else None
+    admission = await admit_storyboard_video_batch(
+        project_name=project_name,
+        project=project,
+        project_path=project_path,
+        script=script,
+        script_file=script_file,
+        items=targets,
+        request_options=request_options,
+        confirmed_request_durations=confirmed_request_durations,
+        operation=operation,
+        selection=selection,
+        extra_tickets=extra_tickets,
+    )
+    if conflict_detail is None:
+        return admission
+    # 音频开关冲突与投影侧的缺口写进同一批票：短路返回只会报出这一条，用户改完配置
+    # 重试才撞见下一个已知缺口，正是这道门要免掉的逐条试探。
+    conflict = GenerationProblem(
+        code="video_audio_switch_not_supported",
+        detail=conflict_detail,
+        action=GenerationAction.CONFIGURE_PROVIDER,
+        params={},
+    )
+    target_ids = {spec.resource_id for spec in specs}
+    return replace(
+        admission,
+        tickets=tuple(
+            replace(ticket, problems=(*ticket.problems, conflict)) if ticket.unit_id in target_ids else ticket
+            for ticket in admission.tickets
+        ),
+    )
+
+
 __all__ = [
     "active_task_problem",
+    "admit_storyboard_video_request",
+    "audio_switch_conflict",
+    "build_storyboard_video_specs",
+    "resolve_voice_context",
+    "speech_admission_ticket",
+    "storyboard_video_prompt",
     "admit_reference_video_batch",
     "admit_storyboard_video_batch",
     "reference_unit_task_spec",

--- a/server/services/workflow_planner.py
+++ b/server/services/workflow_planner.py
@@ -25,10 +25,12 @@ from lib.workflow_state import WorkflowStateService, WorkflowStatus
 from server.services.video_batch_admission import (
     active_task_problem,
     admit_reference_video_batch,
-    admit_storyboard_video_batch,
+    admit_storyboard_video_request,
     artifact_state_tickets,
+    build_storyboard_video_specs,
     reference_unit_task_spec,
     resolve_reference_batch_targets,
+    resolve_voice_context,
     screen_script_entries,
     speech_admission_problems,
 )
@@ -205,24 +207,44 @@ class WorkflowPlanner:
             )
             return admission.to_payload()
 
+        # 计划要预告的是「这一批真提交时会得到什么结论」，所以走的是提交侧同一条缝：
+        # spec 由 build_storyboard_video_specs 构造（发声准入、输入可用性、prompt 组装
+        # 与逐 ID 拒绝票都在其中），准入由 admit_storyboard_video_request 给出（音频闸门
+        # 与投影缺口折在同一批票里）。自行挑目标并把视觉提示词留空，会让计划按另一套
+        # 视觉基准判断已付费产物能否复用，与真正提交时的结论分叉。
         requested = set(status.next_action.requested_ids)
         id_field = SKELETONS[facts.kind].id_field
-        targets = [
-            (str(item[id_field]), item, None)
-            for item in facts.items
-            if isinstance(item.get(id_field), str) and str(item[id_field]) in requested
+        items = [
+            item for item in facts.items if isinstance(item.get(id_field), str) and str(item[id_field]) in requested
         ]
-        admission = await admit_storyboard_video_batch(
+        voice_characters = await resolve_voice_context(facts.project, status.project.content_mode)
+        specs, _order_map, refused = await asyncio.to_thread(
+            build_storyboard_video_specs,
+            items=items,
+            id_field=id_field,
+            content_mode=status.project.content_mode,
+            skeleton_kind=facts.kind,
+            script_filename=facts.script_file,
+            project_dir=facts.project_path,
+            skip_ids=None,
+            project=facts.project,
+            episode=status.target.episode if status.target is not None else 1,
+            voice_characters=voice_characters,
+        )
+        admission = await admit_storyboard_video_request(
             project_name=project_name,
             project=facts.project,
             project_path=facts.project_path,
             script=facts.script,
             script_file=facts.script_file,
-            items=targets,
+            items=items,
+            id_field=id_field,
+            specs=specs,
             request_options=options,
             operation=status.next_action.type,
             selection=GenerationSelectionMode.MISSING_ONLY,
             confirmed_request_durations=request.confirmed_request_durations,
+            extra_tickets=refused,
         )
         return admission.to_payload()
 

--- a/server/services/workflow_planner.py
+++ b/server/services/workflow_planner.py
@@ -1,0 +1,234 @@
+"""Async current-state adapter for the side-effect-free workflow planner."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.generation_queue_client import get_active_tasks_for_resources
+from lib.generation_result import GenerationProblem, GenerationSelectionMode, provider_checkpoint_from_task
+from lib.narration_delivery import USE_TTS
+from lib.project_manager import ProjectManager, get_project_manager
+from lib.reference_video.request_projection import ReferenceRequestOptions
+from lib.script_batch_edit import script_revision
+from lib.script_skeleton import SKELETONS, ensure_route_skeleton
+from lib.speech_composition import admit_script_unit
+from lib.workflow_plan import (
+    WorkflowPlan,
+    WorkflowPlanRequest,
+    WorkflowTaskObservation,
+    build_workflow_plan,
+)
+from lib.workflow_state import WorkflowStateService, WorkflowStatus
+from server.services.video_batch_admission import (
+    active_task_problem,
+    admit_reference_video_batch,
+    admit_storyboard_video_batch,
+    artifact_state_tickets,
+    reference_unit_task_spec,
+    resolve_reference_batch_targets,
+    screen_script_entries,
+    speech_admission_problems,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ScriptFacts:
+    project: dict[str, Any]
+    project_path: Path
+    script: dict[str, Any]
+    script_file: str
+    kind: str
+    items: tuple[dict[str, Any], ...]
+    revision: str
+
+
+class WorkflowPlanner:
+    """Compose durable workflow status with transient request and queue facts."""
+
+    def __init__(self, project_manager: ProjectManager):
+        self._pm = project_manager
+
+    async def get_plan(
+        self,
+        project_name: str,
+        request: WorkflowPlanRequest,
+    ) -> WorkflowPlan:
+        status = await asyncio.to_thread(
+            WorkflowStateService(self._pm).get_status,
+            project_name,
+            request.episode,
+        )
+        facts = await self._script_facts(project_name, status)
+        structure_problems = self._structure_problems(facts)
+        tasks = await self._active_tasks(project_name, status, facts, request)
+        admission = None
+        if (
+            facts is not None
+            and not structure_problems
+            and request.narration_delivery is not None
+            and status.state == "VIDEO"
+            and status.next_action.type == "generate_videos"
+        ):
+            admission = await self._video_admission(project_name, status, facts, request)
+        return build_workflow_plan(
+            status,
+            narration_delivery=request.narration_delivery,
+            structure_problems=structure_problems,
+            script_revision=facts.revision if facts is not None else None,
+            task_observations=tasks,
+            admission=admission,
+        )
+
+    async def _script_facts(self, project_name: str, status: WorkflowStatus) -> _ScriptFacts | None:
+        target = status.target
+        script_state = status.artifacts.get("script", {}).get("state")
+        if target is None or script_state not in {"current", "stale"}:
+            return None
+
+        def _read() -> _ScriptFacts:
+            project = self._pm.load_project_readonly(project_name)
+            script = self._pm.load_script_readonly(project_name, target.script)
+            kind = ensure_route_skeleton(
+                script,
+                status.project.content_mode,
+                status.project.generation_mode,
+            )
+            raw_items = script.get(kind)
+            if not isinstance(raw_items, list) or not all(isinstance(item, dict) for item in raw_items):
+                raise ValueError(f"{kind} must be an array of objects")
+            return _ScriptFacts(
+                project=project,
+                project_path=self._pm.get_project_path(project_name),
+                script=script,
+                script_file=target.script_filename,
+                kind=kind,
+                items=tuple(raw_items),
+                revision=script_revision(script),
+            )
+
+        return await asyncio.to_thread(_read)
+
+    @staticmethod
+    def _structure_problems(facts: _ScriptFacts | None) -> list[GenerationProblem]:
+        if facts is None:
+            return []
+        problems = []
+        for item in facts.items:
+            admission = admit_script_unit(facts.kind, item)
+            problems.extend(speech_admission_problems(admission))
+        return problems
+
+    @staticmethod
+    async def _active_tasks(
+        project_name: str,
+        status: WorkflowStatus,
+        facts: _ScriptFacts | None,
+        request: WorkflowPlanRequest,
+    ) -> list[WorkflowTaskObservation]:
+        if facts is None:
+            return []
+        id_field = SKELETONS[facts.kind].id_field
+        unit_ids = [
+            str(item[id_field]) for item in facts.items if isinstance(item.get(id_field), str) and str(item[id_field])
+        ]
+        if not unit_ids:
+            return []
+        task_types = ["reference_video" if status.project.generation_mode == "reference_video" else "video"]
+        if status.project.generation_mode == "storyboard" and not status.project.grid_storyboard:
+            task_types.append("storyboard")
+        if request.narration_delivery == USE_TTS:
+            task_types.append("tts")
+
+        rows: list[dict[str, Any]] = []
+        for task_type in task_types:
+            rows.extend(
+                await get_active_tasks_for_resources(
+                    project_name=project_name,
+                    task_type=task_type,
+                    resource_ids=unit_ids,
+                    script_file=facts.script_file,
+                )
+            )
+        seen: set[str] = set()
+        observations: list[WorkflowTaskObservation] = []
+        for task in rows:
+            task_id = str(task.get("task_id") or "")
+            if not task_id or task_id in seen:
+                continue
+            seen.add(task_id)
+            observations.append(
+                WorkflowTaskObservation(
+                    unit_id=str(task.get("resource_id") or ""),
+                    task_id=task_id,
+                    task_type=str(task.get("task_type") or ""),
+                    status=str(task.get("status") or ""),
+                    provider_checkpoint=provider_checkpoint_from_task(task),
+                    problem=active_task_problem(task),
+                )
+            )
+        return observations
+
+    @staticmethod
+    async def _video_admission(
+        project_name: str,
+        status: WorkflowStatus,
+        facts: _ScriptFacts,
+        request: WorkflowPlanRequest,
+    ) -> dict[str, Any]:
+        options = ReferenceRequestOptions(narration_delivery=request.narration_delivery or "post_production")
+        if status.project.generation_mode == "reference_video":
+            screened, malformed = screen_script_entries(facts.script.get("video_units"), requested_ids=None)
+            targets, selection, _states = resolve_reference_batch_targets(
+                units=screened,
+                requested_ids=None,
+                project=facts.project,
+                project_path=facts.project_path,
+                episode=status.target.episode if status.target is not None else 1,
+            )
+            extra = [*malformed, *artifact_state_tickets(selection.unavailable)]
+            admission = await admit_reference_video_batch(
+                project_name=project_name,
+                project=facts.project,
+                project_path=facts.project_path,
+                script=facts.script,
+                script_file=facts.script_file,
+                units=targets,
+                request_options=options,
+                operation=status.next_action.type,
+                selection=selection.mode,
+                confirmed_request_durations=request.confirmed_request_durations,
+                spec_check=lambda unit: reference_unit_task_spec(unit, facts.script_file),
+                extra_tickets=extra,
+            )
+            return admission.to_payload()
+
+        requested = set(status.next_action.requested_ids)
+        id_field = SKELETONS[facts.kind].id_field
+        targets = [
+            (str(item[id_field]), item, None)
+            for item in facts.items
+            if isinstance(item.get(id_field), str) and str(item[id_field]) in requested
+        ]
+        admission = await admit_storyboard_video_batch(
+            project_name=project_name,
+            project=facts.project,
+            project_path=facts.project_path,
+            script=facts.script,
+            script_file=facts.script_file,
+            items=targets,
+            request_options=options,
+            operation=status.next_action.type,
+            selection=GenerationSelectionMode.MISSING_ONLY,
+            confirmed_request_durations=request.confirmed_request_durations,
+        )
+        return admission.to_payload()
+
+
+def get_workflow_planner(project_manager: ProjectManager | None = None) -> WorkflowPlanner:
+    return WorkflowPlanner(project_manager or get_project_manager())
+
+
+__all__ = ["WorkflowPlanner", "get_workflow_planner"]

--- a/tests/integration/test_workflow_planner.py
+++ b/tests/integration/test_workflow_planner.py
@@ -6,12 +6,13 @@ from typing import Any
 import pytest
 
 from lib.batch_admission import BatchAdmission, UnitAdmissionTicket
+from lib.generation_queue_client import TaskSpec
 from lib.generation_result import GenerationSelectionMode
 from lib.narration_delivery import POST_PRODUCTION
 from lib.project_manager import ProjectManager
 from lib.workflow_plan import WorkflowPlanRequest, WorkflowStepState
 from lib.workflow_state import WorkflowNextAction, WorkflowProject, WorkflowStatus, WorkflowTarget
-from server.services import workflow_planner
+from server.services import video_batch_admission, workflow_planner
 
 pytestmark = pytest.mark.integration
 
@@ -113,7 +114,7 @@ async def test_planner_uses_shared_admission_and_never_reads_the_real_task_singl
         )
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
-    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
     request = WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
     first = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)  # type: ignore[arg-type]
@@ -157,7 +158,7 @@ async def test_active_task_and_provider_checkpoint_are_reported_as_separate_axes
         )
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
-    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
     plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
@@ -203,7 +204,7 @@ async def test_recovery_checkpoint_without_provider_job_remains_visible(
         )
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
-    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
     plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
@@ -273,3 +274,116 @@ async def test_status_read_is_idempotent_and_does_not_touch_project_files(
 
     assert first == second
     assert before == middle == after
+
+
+async def test_planner_refuses_a_unit_whose_video_input_is_unusable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """计划走的是提交侧同一条 spec 构造缝：分镜图不可用的条目在计划里就被逐 ID 拒绝。"""
+
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+
+    async def _no_active_tasks(**_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _no_active_tasks)
+    monkeypatch.setattr(video_batch_admission, "get_active_tasks_for_resources", _no_active_tasks)
+
+    before = sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*"))
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+        "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    )
+
+    # 走提交侧那条缝要读 Manifest 与分镜图，读到的一切仍不得在项目目录留下痕迹。
+    assert sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*")) == before
+
+    video = next(step for step in plan.steps if step.id == "video")
+    assert video.admission is not None
+    assert video.admission["decision"] != "admitted"
+    codes = {problem["code"] for ticket in video.admission["units"] for problem in ticket["problems"]}
+    assert "generation_unit_input_unusable" in codes
+
+
+async def test_planner_hands_the_submitted_visual_prompt_to_the_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """准入按真正会提交的视觉提示词判断已付费产物能否复用，计划不得把它留空。"""
+
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+
+    async def _no_active_tasks(**_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    spec = TaskSpec.from_request(
+        task_type="video",
+        media_type="video",
+        resource_id="E1S01",
+        prompt="镜头提示",
+        script_file="episode_1.json",
+    )
+
+    def _specs(**_kwargs: Any):
+        return [spec], {"E1S01": 0}, []
+
+    captured: dict[str, Any] = {}
+
+    async def _admit(**kwargs: Any) -> BatchAdmission:
+        captured.update(kwargs)
+        return BatchAdmission(
+            operation=kwargs["operation"],
+            selection=kwargs["selection"],
+            narration_delivery=kwargs["request_options"].narration_delivery,
+            tickets=(UnitAdmissionTicket("E1S01"),),
+        )
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _no_active_tasks)
+    monkeypatch.setattr(workflow_planner, "build_storyboard_video_specs", _specs)
+    monkeypatch.setattr(video_batch_admission, "admit_storyboard_video_batch", _admit)
+
+    await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+        "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    )
+
+    assert [prompt for _id, _item, prompt in captured["items"]] == ["镜头提示"]
+
+
+async def test_planner_reports_the_audio_switch_conflict_before_any_task_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """音频闸门与入队入口同一道：计划预告的准入结论包含它，用户不必提交后才撞见。"""
+
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+
+    async def _no_active_tasks(**_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    async def _reject(_project: dict[str, Any], _capability: Any) -> None:
+        raise ValueError("成片恒有声")
+
+    spec = TaskSpec.from_request(
+        task_type="video",
+        media_type="video",
+        resource_id="E1S01",
+        prompt="镜头提示",
+        script_file="episode_1.json",
+    )
+
+    def _specs(**_kwargs: Any):
+        return [spec], {"E1S01": 0}, []
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _no_active_tasks)
+    monkeypatch.setattr(workflow_planner, "build_storyboard_video_specs", _specs)
+    monkeypatch.setattr(video_batch_admission, "get_active_tasks_for_resources", _no_active_tasks)
+    monkeypatch.setattr(video_batch_admission, "assert_audio_switch_supported", _reject)
+
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+        "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    )
+
+    video = next(step for step in plan.steps if step.id == "video")
+    assert video.admission is not None
+    codes = {problem["code"] for ticket in video.admission["units"] for problem in ticket["problems"]}
+    assert "video_audio_switch_not_supported" in codes

--- a/tests/integration/test_workflow_planner.py
+++ b/tests/integration/test_workflow_planner.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lib.batch_admission import BatchAdmission, UnitAdmissionTicket
+from lib.generation_result import GenerationSelectionMode
+from lib.narration_delivery import POST_PRODUCTION
+from lib.project_manager import ProjectManager
+from lib.workflow_plan import WorkflowPlanRequest, WorkflowStepState
+from lib.workflow_state import WorkflowNextAction, WorkflowProject, WorkflowStatus, WorkflowTarget
+from server.services import workflow_planner
+
+pytestmark = pytest.mark.integration
+
+
+def _status(*, state: str = "VIDEO", action: str = "generate_videos") -> WorkflowStatus:
+    return WorkflowStatus.model_validate(
+        {
+            "project_revision": "sha256-v1:project",
+            "source_revision": "sha256-v1:source",
+            "project": WorkflowProject(
+                content_mode="narration",
+                generation_mode="storyboard",
+                grid_storyboard=False,
+            ),
+            "target": WorkflowTarget(
+                episode=1,
+                script="scripts/episode_1.json",
+                script_filename="episode_1.json",
+                source="source/episode_1.txt",
+            ),
+            "state": state,
+            "blockers": [],
+            "gates": {"step1_review": {"state": "confirmed", "revision": "step1"}},
+            "artifacts": {
+                "asset_inventory": {"state": "current"},
+                "asset_sheets": {},
+                "step1": {"state": "current"},
+                "script": {"state": "current", "path": "scripts/episode_1.json"},
+                "storyboards": {"current_ids": ["E1S01"], "stale_ids": [], "missing_ids": []},
+                "videos": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
+                "audio": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
+            },
+            "next_action": WorkflowNextAction(
+                type=action,
+                requested_ids=["E1S01"],
+                reason="next",
+            ),
+        }
+    )
+
+
+class _ProjectManager:
+    def __init__(self, project_path: Path, script: dict[str, Any]):
+        self.project_path = project_path
+        self.script = script
+
+    def load_project_readonly(self, project_name: str) -> dict[str, Any]:
+        assert project_name == "demo"
+        return {"content_mode": "narration", "generation_mode": "storyboard"}
+
+    def load_script_readonly(self, project_name: str, script_file: str) -> dict[str, Any]:
+        assert project_name == "demo"
+        assert script_file == "scripts/episode_1.json"
+        return self.script
+
+    def get_project_path(self, project_name: str) -> Path:
+        assert project_name == "demo"
+        return self.project_path
+
+
+def _script(*, mixed: bool = False) -> dict[str, Any]:
+    return {
+        "episode": 1,
+        "content_mode": "narration",
+        "segments": [
+            {
+                "segment_id": "E1S01",
+                "novel_text": "旁白文本",
+                "video_prompt": (
+                    {"action": "人物交谈", "dialogue": [{"speaker": "角色A", "line": "台词"}]} if mixed else "镜头提示"
+                ),
+                "duration_seconds": 5,
+                "generated_assets": {},
+            }
+        ],
+    }
+
+
+async def test_planner_uses_shared_admission_and_never_reads_the_real_task_singleton(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+    task_calls: list[str] = []
+
+    async def _active_tasks(**kwargs: Any) -> list[dict[str, Any]]:
+        task_calls.append(kwargs["task_type"])
+        return []
+
+    admission_calls: list[dict[str, Any]] = []
+
+    async def _admit(**kwargs: Any) -> BatchAdmission:
+        admission_calls.append(kwargs)
+        return BatchAdmission(
+            operation=kwargs["operation"],
+            selection=kwargs["selection"],
+            narration_delivery=kwargs["request_options"].narration_delivery,
+            tickets=(UnitAdmissionTicket("E1S01"),),
+        )
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+
+    request = WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    first = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)  # type: ignore[arg-type]
+    second = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)  # type: ignore[arg-type]
+
+    assert first == second
+    assert task_calls == ["video", "storyboard", "video", "storyboard"]
+    assert len(admission_calls) == 2
+    assert admission_calls[0]["selection"] is GenerationSelectionMode.MISSING_ONLY
+    assert first.next_action.type == "generate_videos"
+    assert next(step for step in first.steps if step.id == "video").admission["decision"] == "admitted"
+
+
+async def test_active_task_and_provider_checkpoint_are_reported_as_separate_axes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+
+    async def _active_tasks(**kwargs: Any) -> list[dict[str, Any]]:
+        if kwargs["task_type"] != "video":
+            return []
+        return [
+            {
+                "task_id": "task-1",
+                "resource_id": "E1S01",
+                "task_type": "video",
+                "status": "running",
+                "provider_id": "provider-a",
+                "provider_job_id": "job-1",
+                "execution_checkpoint_json": "{}",
+            }
+        ]
+
+    async def _admit(**kwargs: Any) -> BatchAdmission:
+        return BatchAdmission(
+            operation=kwargs["operation"],
+            selection=kwargs["selection"],
+            narration_delivery=kwargs["request_options"].narration_delivery,
+            tickets=(UnitAdmissionTicket("E1S01"),),
+        )
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+        "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    )
+
+    video = next(step for step in plan.steps if step.id == "video")
+    assert video.state is WorkflowStepState.ACTIVE
+    assert video.artifacts["missing_ids"] == ["E1S01"]
+    assert video.tasks[0].status == "running"
+    assert video.tasks[0].provider_checkpoint is not None
+    assert video.tasks[0].provider_checkpoint.submitted is True
+    assert video.tasks[0].provider_checkpoint.provider_job_id == "job-1"
+    assert plan.next_action.type == "wait_for_task"
+
+
+async def test_recovery_checkpoint_without_provider_job_remains_visible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _ProjectManager(tmp_path, _script())
+    monkeypatch.setattr(workflow_planner.WorkflowStateService, "get_status", lambda *_args: _status())
+
+    async def _active_tasks(**kwargs: Any) -> list[dict[str, Any]]:
+        if kwargs["task_type"] != "video":
+            return []
+        return [
+            {
+                "task_id": "task-recovery",
+                "resource_id": "E1S01",
+                "task_type": "video",
+                "status": "running",
+                "provider_id": "provider-a",
+                "provider_job_id": None,
+                "execution_checkpoint_json": '{"schema_version": 1}',
+            }
+        ]
+
+    async def _admit(**kwargs: Any) -> BatchAdmission:
+        return BatchAdmission(
+            operation=kwargs["operation"],
+            selection=kwargs["selection"],
+            narration_delivery=kwargs["request_options"].narration_delivery,
+            tickets=(UnitAdmissionTicket("E1S01"),),
+        )
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
+    monkeypatch.setattr(workflow_planner, "admit_storyboard_video_batch", _admit)
+
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+        "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
+    )
+
+    checkpoint = next(step for step in plan.steps if step.id == "video").tasks[0].provider_checkpoint
+    assert checkpoint is not None
+    assert checkpoint.submitted is False
+    assert checkpoint.provider_id == "provider-a"
+    assert checkpoint.provider_job_id is None
+
+
+async def test_mixed_speech_blocks_before_storyboard_and_uses_atomic_script_edit_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _ProjectManager(tmp_path, _script(mixed=True))
+    monkeypatch.setattr(
+        workflow_planner.WorkflowStateService,
+        "get_status",
+        lambda *_args: _status(state="STORYBOARD", action="generate_storyboards"),
+    )
+
+    async def _active_tasks(**_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
+
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())  # type: ignore[arg-type]
+
+    structure = next(step for step in plan.steps if step.id == "script_structure")
+    storyboard = next(step for step in plan.steps if step.id == "storyboard")
+    assert structure.state is WorkflowStepState.BLOCKED
+    assert structure.problems[0].code == "mixed_speech"
+    assert structure.contracts.script_edit == "script_batch_edit/v1"
+    assert storyboard.state is WorkflowStepState.PENDING
+    assert plan.next_action.type == "patch_episode_script"
+    assert plan.next_action.args["expected_revision"].startswith("sha256-v1:")
+
+
+async def test_status_read_is_idempotent_and_does_not_touch_project_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    projects_root = tmp_path / "projects"
+    pm = ProjectManager(projects_root)
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Ad", "", "ad", target_duration=30)
+
+    async def _fail_db_read(**_kwargs: Any) -> list[dict[str, Any]]:
+        raise AssertionError("an early workflow state must not consult the real task DB singleton")
+
+    monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _fail_db_read)
+
+    def _snapshot() -> dict[str, tuple[bytes, int]]:
+        project_path = pm.get_project_path("demo")
+        return {
+            path.relative_to(project_path).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+            for path in project_path.rglob("*")
+            if path.is_file()
+        }
+
+    before = _snapshot()
+    planner = workflow_planner.WorkflowPlanner(pm)
+    first = await planner.get_plan("demo", WorkflowPlanRequest())
+    middle = _snapshot()
+    second = await planner.get_plan("demo", WorkflowPlanRequest())
+    after = _snapshot()
+
+    assert first == second
+    assert before == middle == after

--- a/tests/server/agent_runtime/test_enqueue_videos_audio_switch.py
+++ b/tests/server/agent_runtime/test_enqueue_videos_audio_switch.py
@@ -102,8 +102,8 @@ class TestStoryboardRouteGate:
             seen.append(capability)
             raise ValueError("成片恒有声")
 
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _reject)
-        conflict = await mod._audio_switch_conflict(_ctx(tmp_path, {"generation_mode": "storyboard"}))
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _reject)
+        conflict = await admission_mod.audio_switch_conflict({"generation_mode": "storyboard"})
         assert conflict == "成片恒有声"
         assert seen == ["i2v"]
 
@@ -111,9 +111,9 @@ class TestStoryboardRouteGate:
         async def _not_silent(_project):
             return False
 
-        monkeypatch.setattr(mod, "resolve_project_is_silent", _not_silent)
+        monkeypatch.setattr(admission_mod, "resolve_project_is_silent", _not_silent)
         project = {"generation_mode": "storyboard", "characters": {"张三": {"description": "主角"}}}
-        assert await mod._resolve_voice_context(_ctx(tmp_path, project), "drama") == project["characters"]
+        assert await admission_mod.resolve_voice_context(project, "drama") == project["characters"]
 
 
 @pytest.mark.unit
@@ -244,7 +244,7 @@ class TestStoryboardGateSkipsEmptyBatches:
             rejected.append(capability)
             raise ValueError("成片恒有声")
 
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _reject)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _reject)
         tool_obj = mod.generate_video_episode_tool(ctx)
         out = await tool_obj.handler({"script": "episode_1.json", **args})
         return {"out": out, "rejected": rejected}
@@ -302,7 +302,7 @@ class TestStoryboardGateEntersAdmission:
             raise ValueError("成片恒有声，无法关闭音频")
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _reject)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _reject)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
         tool_obj = mod.generate_video_episode_tool(self._ctx(tmp_path))
@@ -323,7 +323,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         ctx.pm.script_payload["segments"][0]["video_prompt"] = "   "  # type: ignore[attr-defined]
@@ -346,7 +346,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -387,8 +387,8 @@ class TestStoryboardGateEntersAdmission:
             )
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _reject)
-        monkeypatch.setattr(mod, "admit_storyboard_video_batch", _admit)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _reject)
+        monkeypatch.setattr(admission_mod, "admit_storyboard_video_batch", _admit)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
         tool_obj = mod.generate_video_episode_tool(self._ctx(tmp_path))
@@ -408,7 +408,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         ctx.pm.script_payload["segments"][0]["segment_id"] = ["E1S01"]  # type: ignore[attr-defined]
@@ -431,7 +431,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         ctx.pm.script_payload["segments"].insert(0, 42)  # type: ignore[attr-defined]
@@ -454,7 +454,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -476,7 +476,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -501,7 +501,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -521,7 +521,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -549,7 +549,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -573,7 +573,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
@@ -598,7 +598,7 @@ class TestStoryboardGateEntersAdmission:
             return None
 
         enqueue = AsyncMock(return_value=([], []))
-        monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow)
+        monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
         segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -2817,7 +2817,7 @@ async def test_generate_video_episode_rejects_unbound_active_script_before_enque
     )
 
     def fake_build_specs(**_kwargs):
-        return [spec], {"E1S01": 0}
+        return [spec], {"E1S01": 0}, []
 
     async def fake_submit(**_kwargs):
         nonlocal submitted
@@ -4373,7 +4373,7 @@ async def test_generate_video_all_preserves_the_selected_manual_upload(
     )
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _MissingEverythingResolver())
     monkeypatch.setattr(mod, "artifact_is_usable", lambda *_args: False)
-    monkeypatch.setattr(mod, "build_storyboard_video_specs", lambda **_kwargs: ([spec], {"E1S01": 0}))
+    monkeypatch.setattr(mod, "build_storyboard_video_specs", lambda **_kwargs: ([spec], {"E1S01": 0}, []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(generate_video_all_tool(fake_ctx), {"script": "episode_1.json"})

--- a/tests/server/agent_runtime/test_sdk_tools.py
+++ b/tests/server/agent_runtime/test_sdk_tools.py
@@ -223,7 +223,7 @@ def _stub_audio_switch_guard(monkeypatch):
 
     行为覆盖在 tests/server/agent_runtime/test_enqueue_videos_audio_switch.py。
     """
-    from server.agent_runtime.sdk_tools import enqueue_videos as _mod
+    from server.services import video_batch_admission as _mod
 
     async def _noop(_project, _capability):
         return None
@@ -2824,7 +2824,7 @@ async def test_generate_video_episode_rejects_unbound_active_script_before_enque
         submitted = True
         return []
 
-    monkeypatch.setattr(mod, "_build_video_specs", fake_build_specs)
+    monkeypatch.setattr(mod, "build_storyboard_video_specs", fake_build_specs)
     monkeypatch.setattr(mod, "_submit_with_checkpoint", fake_submit)
 
     out = await _call(mod.generate_video_episode_tool(fake_ctx), {"script": "episode_1.json"})
@@ -2841,6 +2841,7 @@ async def test_generate_video_episode_resolves_episode_from_canonical_filename(
 ) -> None:
     """A schema-8 script may rely on its canonical filename for the episode identity."""
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
+    from server.services import video_batch_admission as admission_mod
 
     fake_ctx.pm.script_payload.pop("episode")  # type: ignore[attr-defined]
     fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
@@ -2852,7 +2853,7 @@ async def test_generate_video_episode_resolves_episode_from_canonical_filename(
         }
     )
     captured: dict[str, int] = {}
-    build_video_specs = mod._build_video_specs
+    build_video_specs = admission_mod.build_storyboard_video_specs
 
     def _capture_episode(**kwargs):
         captured["episode"] = kwargs["episode"]
@@ -2873,7 +2874,7 @@ async def test_generate_video_episode_resolves_episode_from_canonical_filename(
                 )
         return [], []
 
-    monkeypatch.setattr(mod, "_build_video_specs", _capture_episode)
+    monkeypatch.setattr(mod, "build_storyboard_video_specs", _capture_episode)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: None)
 
@@ -4372,7 +4373,7 @@ async def test_generate_video_all_preserves_the_selected_manual_upload(
     )
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _MissingEverythingResolver())
     monkeypatch.setattr(mod, "artifact_is_usable", lambda *_args: False)
-    monkeypatch.setattr(mod, "_build_video_specs", lambda **_kwargs: ([spec], {"E1S01": 0}))
+    monkeypatch.setattr(mod, "build_storyboard_video_specs", lambda **_kwargs: ([spec], {"E1S01": 0}))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(generate_video_all_tool(fake_ctx), {"script": "episode_1.json"})
@@ -4470,7 +4471,7 @@ def test_asset_requested_ids_resolve_nfd_registered_key() -> None:
 @pytest.mark.unit
 def test_build_video_specs_does_not_validate_duration_at_enqueue(tmp_path) -> None:
     """duration 是能力维度，入队侧不再校验——任意 duration 都透传给执行层（见 ADR-0001）。"""
-    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+    from server.services.video_batch_admission import build_storyboard_video_specs as _build_video_specs
 
     (tmp_path / "storyboards").mkdir()
     (tmp_path / "storyboards" / "scene_S01.png").write_bytes(b"png")
@@ -4523,7 +4524,7 @@ def test_build_video_specs_skips_invalid_storyboard_image_without_aborting_batch
 ) -> None:
     """批量入队场景下，单个条目 storyboard_image 非法（脏数据/越界/绝对路径）只记为该 ID 的
     blocked，不应让 `project_dir / storyboard_image` 抛未处理异常中断整批。"""
-    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+    from server.services.video_batch_admission import build_storyboard_video_specs as _build_video_specs
 
     (tmp_path / "storyboards").mkdir()
     (tmp_path / "storyboards" / "scene_S02.png").write_bytes(b"png")
@@ -4558,7 +4559,7 @@ def test_build_video_specs_skips_invalid_storyboard_image_without_aborting_batch
 def test_build_video_specs_skips_non_dict_generated_assets_without_aborting_batch(tmp_path: Path) -> None:
     """generated_assets 容器本身被外部编辑损坏为非 dict（如 list）时按「没有分镜图」跳过，
     不应让 `.get("storyboard_image")` 在非 dict 上抛未处理 AttributeError 中断整批。"""
-    from server.agent_runtime.sdk_tools.enqueue_videos import _build_video_specs
+    from server.services.video_batch_admission import build_storyboard_video_specs as _build_video_specs
 
     (tmp_path / "storyboards").mkdir()
     (tmp_path / "storyboards" / "scene_S02.png").write_bytes(b"png")
@@ -4606,7 +4607,7 @@ def test_get_video_prompt_drama_sources_dialogue_from_utterances() -> None:
     voiceover-kind 不进；narration / ad（无 utterances 字段）原样渲染既有 video_prompt.dialogue。"""
     import yaml
 
-    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+    from server.services.video_batch_admission import storyboard_video_prompt as _get_video_prompt
 
     drama_item = {
         "scene_id": "E1S01",
@@ -4638,7 +4639,7 @@ def test_get_video_prompt_injects_voice_profiles_when_characters_given() -> None
     voice_characters 缺省（既有调用点行为）不注入。"""
     import yaml
 
-    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+    from server.services.video_batch_admission import storyboard_video_prompt as _get_video_prompt
 
     drama_item = {
         "scene_id": "E1S01",
@@ -4665,7 +4666,7 @@ def test_get_video_prompt_injects_voice_profiles_from_legacy_dialogue() -> None:
     video_prompt.dialogue）：改走 legacy 出口派生 Voice_Profiles，不因缺 utterances 静默丢失。"""
     import yaml
 
-    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+    from server.services.video_batch_admission import storyboard_video_prompt as _get_video_prompt
 
     legacy_drama_item = {
         "scene_id": "E1S01",
@@ -4690,7 +4691,7 @@ def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() 
     （真无声）门控直达 YAML。"""
     import yaml
 
-    from server.agent_runtime.sdk_tools.enqueue_videos import _get_video_prompt
+    from server.services.video_batch_admission import storyboard_video_prompt as _get_video_prompt
 
     narration_item = {
         "segment_id": "E1S01",
@@ -4708,9 +4709,9 @@ def test_get_video_prompt_strips_caller_supplied_voice_profiles_for_non_drama() 
 @pytest.mark.unit
 async def test_resolve_voice_context_skips_non_drama(fake_ctx: ToolContext) -> None:
     """narration/ad：不解析 voice_consistency，直接跳过（无 drama dialogue speaker 概念）。"""
-    from server.agent_runtime.sdk_tools.enqueue_videos import _resolve_voice_context
+    from server.services.video_batch_admission import resolve_voice_context as _resolve_voice_context
 
-    assert await _resolve_voice_context(fake_ctx, "narration") is None
+    assert await _resolve_voice_context(fake_ctx.pm.project_payload, "narration") is None
 
 
 @pytest.mark.unit
@@ -4718,20 +4719,20 @@ async def test_resolve_voice_context_drama_reads_project_characters_and_gate(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """drama：读项目角色资产，无声（C 类真无声、或本集关闭音频）时退回不注入。"""
-    from server.agent_runtime.sdk_tools import enqueue_videos as mod
+    from server.services import video_batch_admission as admission_mod
 
     async def fake_not_silent(_project, _episode=None):
         return False
 
-    monkeypatch.setattr(mod, "resolve_project_is_silent", fake_not_silent)
-    characters = await mod._resolve_voice_context(fake_ctx, "drama")
+    monkeypatch.setattr(admission_mod, "resolve_project_is_silent", fake_not_silent)
+    characters = await admission_mod.resolve_voice_context(fake_ctx.pm.project_payload, "drama")
     assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
 
     async def fake_silent(_project, _episode=None):
         return True
 
-    monkeypatch.setattr(mod, "resolve_project_is_silent", fake_silent)
-    assert await mod._resolve_voice_context(fake_ctx, "drama") is None
+    monkeypatch.setattr(admission_mod, "resolve_project_is_silent", fake_silent)
+    assert await admission_mod.resolve_voice_context(fake_ctx.pm.project_payload, "drama") is None
 
 
 @pytest.mark.unit
@@ -6076,7 +6077,6 @@ def _ad_reference_unit(**overrides: Any) -> dict[str, Any]:
 
 @pytest.fixture
 def ad_reference_ctx(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> ToolContext:
-    from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
     pm = fake_ctx.pm
     pm.project_payload.update(  # type: ignore[attr-defined]
@@ -6102,7 +6102,7 @@ def ad_reference_ctx(fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch) -> 
         return None
 
     monkeypatch.setattr("server.services.video_batch_admission.get_active_tasks_for_resources", _fake_no_active_tasks)
-    monkeypatch.setattr(mod, "assert_audio_switch_supported", _allow_audio_switch)
+    monkeypatch.setattr("server.services.video_batch_admission.assert_audio_switch_supported", _allow_audio_switch)
     return fake_ctx
 
 

--- a/tests/test_artifact_manifest_storage.py
+++ b/tests/test_artifact_manifest_storage.py
@@ -232,6 +232,16 @@ def test_project_adapter_serializes_concurrent_manifest_updates(tmp_path: Path) 
     assert len(stored["entries"]) == len(episodes)
 
 
+def test_project_adapter_read_does_not_create_a_lock_file(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    adapter = ProjectArtifactManifestAdapter(project)
+
+    assert adapter.get_entry(ArtifactKey.episode_script(1)) is None
+    assert adapter.snapshot_entries() == {}
+    assert not (project / LOCK_FILENAME).exists()
+
+
 @pytest.mark.skipif(os.name != "posix", reason="exclusive lock-file creation protects concurrent openat calls")
 def test_project_adapter_creates_lock_file_exclusively(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     project = tmp_path / "project"

--- a/tests/test_workflow_plan.py
+++ b/tests/test_workflow_plan.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.artifact_manifest import ArtifactStatus
+from lib.batch_admission import BatchAdmission, UnitAdmissionTicket
+from lib.generation_result import (
+    GenerationAction,
+    GenerationBatchResult,
+    GenerationItemResult,
+    GenerationItemState,
+    GenerationProblem,
+    GenerationSelectionMode,
+    GenerationTaskState,
+    ProviderCheckpoint,
+)
+from lib.narration_delivery import POST_PRODUCTION, USE_TTS, NarrationDelivery
+from lib.workflow_plan import (
+    WorkflowStepState,
+    WorkflowTaskObservation,
+    build_workflow_plan,
+)
+from lib.workflow_rules import WORKFLOW_RULES, workflow_rule
+from lib.workflow_state import (
+    WorkflowBlocker,
+    WorkflowNextAction,
+    WorkflowProject,
+    WorkflowStatus,
+    WorkflowTarget,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _status(
+    content_mode: str = "narration",
+    generation_mode: str = "storyboard",
+    *,
+    state: str = "VIDEO",
+    action: str = "generate_videos",
+    requested_ids: list[str] | None = None,
+) -> WorkflowStatus:
+    return WorkflowStatus.model_validate(
+        {
+            "schema_version": 1,
+            "project_revision": "sha256-v1:project",
+            "source_revision": None if content_mode == "ad" else "sha256-v1:source",
+            "project": WorkflowProject(
+                content_mode=content_mode,
+                generation_mode=generation_mode,
+                grid_storyboard=False,
+            ),
+            "target": WorkflowTarget(
+                episode=1,
+                script="scripts/episode_1.json",
+                script_filename="episode_1.json",
+                source="source/episode_1.txt",
+            ),
+            "state": state,
+            "blockers": [],
+            "gates": {"step1_review": {"state": "confirmed", "revision": "sha256-v1:step1"}},
+            "artifacts": {
+                "asset_inventory": {"state": "current" if content_mode != "ad" else "not_applicable"},
+                "asset_sheets": {},
+                "step1": {"state": "current" if content_mode != "ad" else "not_applicable"},
+                "script": {"state": "current", "path": "scripts/episode_1.json"},
+                "storyboards": {"current_ids": ["E1S01"], "stale_ids": [], "missing_ids": []},
+                "videos": {
+                    "current_ids": [],
+                    "stale_ids": [],
+                    "missing_ids": requested_ids or ["E1S01"],
+                },
+                "audio": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
+            },
+            "next_action": WorkflowNextAction(
+                type=action,
+                requested_ids=requested_ids or ["E1S01"],
+                reason="video clips are missing",
+            ),
+        }
+    )
+
+
+def _step(plan, step_id: str):
+    return next(step for step in plan.steps if step.id == step_id)
+
+
+def test_rules_exhaust_the_six_content_and_generation_mode_combinations() -> None:
+    assert set(WORKFLOW_RULES) == {
+        ("narration", "storyboard"),
+        ("narration", "reference_video"),
+        ("drama", "storyboard"),
+        ("drama", "reference_video"),
+        ("ad", "storyboard"),
+        ("ad", "reference_video"),
+    }
+
+    for content_mode, generation_mode in WORKFLOW_RULES:
+        rule = workflow_rule(content_mode, generation_mode)
+        step_ids = [step.id for step in rule.steps]
+        assert step_ids.index("script_structure") < step_ids.index("storyboard")
+        assert step_ids.index("storyboard") < step_ids.index("narration_delivery")
+        assert step_ids.index("narration_delivery") < step_ids.index("video")
+        storyboard = next(step for step in rule.steps if step.id == "storyboard")
+        assert storyboard.applicable is (generation_mode == "storyboard")
+        assert next(step for step in rule.steps if step.id == "narration_delivery").applicable is True
+
+
+@pytest.mark.parametrize("content_mode,generation_mode", sorted(WORKFLOW_RULES))
+@pytest.mark.parametrize("narration_delivery", [POST_PRODUCTION, USE_TTS])
+def test_every_route_keeps_each_transient_narration_delivery_choice(
+    content_mode: str,
+    generation_mode: str,
+    narration_delivery: NarrationDelivery,
+) -> None:
+    status = _status(content_mode=content_mode, generation_mode=generation_mode)
+    admission = BatchAdmission(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        narration_delivery=narration_delivery,
+        tickets=(UnitAdmissionTicket("E1S01"),),
+    )
+
+    plan = build_workflow_plan(
+        status,
+        narration_delivery=narration_delivery,
+        admission=admission.to_payload(),
+    )
+
+    assert plan.narration_delivery.selected == narration_delivery
+    assert plan.narration_delivery.persisted is False
+    assert _step(plan, "storyboard").required is (generation_mode == "storyboard")
+    assert _step(plan, "narration_delivery").state is WorkflowStepState.COMPLETED
+    assert _step(plan, "video").state is WorkflowStepState.READY
+
+
+def test_reference_route_skips_only_storyboard_media_not_delivery_choice() -> None:
+    plan = build_workflow_plan(_status(generation_mode="reference_video"))
+
+    assert _step(plan, "storyboard").state is WorkflowStepState.SKIPPED
+    assert _step(plan, "narration_delivery").state is WorkflowStepState.READY
+    assert plan.next_action.type == "choose_narration_delivery"
+
+
+def test_post_production_keeps_video_executable_when_tts_is_missing() -> None:
+    status = _status()
+    admission = BatchAdmission(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        narration_delivery=POST_PRODUCTION,
+        tickets=(UnitAdmissionTicket("E1S01"),),
+    )
+
+    plan = build_workflow_plan(
+        status,
+        narration_delivery=POST_PRODUCTION,
+        admission=admission.to_payload(),
+    )
+
+    assert plan.narration_delivery.selected == POST_PRODUCTION
+    assert _step(plan, "narration_delivery").state is WorkflowStepState.COMPLETED
+    assert _step(plan, "video").state is WorkflowStepState.READY
+    assert _step(plan, "video").artifacts["missing_ids"] == ["E1S01"]
+    assert plan.next_action == status.next_action
+
+
+def test_use_tts_preserves_structured_admission_blockers() -> None:
+    problem = GenerationProblem(
+        code="tts_missing",
+        detail="current TTS is missing",
+        action=GenerationAction.GENERATE_TTS,
+    )
+    admission = BatchAdmission(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        narration_delivery=USE_TTS,
+        tickets=(UnitAdmissionTicket("E1S01", problems=(problem,)),),
+    )
+
+    plan = build_workflow_plan(
+        _status(),
+        narration_delivery=USE_TTS,
+        admission=admission.to_payload(),
+    )
+
+    video = _step(plan, "video")
+    assert video.state is WorkflowStepState.BLOCKED
+    assert video.problems == [problem]
+    assert video.admission["decision"] == "blocked"
+    assert plan.next_action.type == GenerationAction.GENERATE_TTS.value
+
+
+def test_multiple_admission_repairs_preserve_the_first_structured_action() -> None:
+    generate_tts = GenerationProblem(
+        code="tts_missing",
+        detail="current TTS is missing",
+        action=GenerationAction.GENERATE_TTS,
+    )
+    configure_provider = GenerationProblem(
+        code="video_capability_missing_i2v",
+        detail="the selected model cannot generate this video",
+        action=GenerationAction.CONFIGURE_PROVIDER,
+    )
+    admission = BatchAdmission(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        narration_delivery=USE_TTS,
+        tickets=(
+            UnitAdmissionTicket("E1S01", problems=(generate_tts,)),
+            UnitAdmissionTicket("E1S02", problems=(configure_provider,)),
+        ),
+    )
+
+    plan = build_workflow_plan(
+        _status(requested_ids=["E1S01", "E1S02"]),
+        narration_delivery=USE_TTS,
+        admission=admission.to_payload(),
+    )
+
+    assert plan.problems == [generate_tts, configure_provider]
+    assert plan.next_action.type == GenerationAction.GENERATE_TTS.value
+
+
+def test_structure_problems_block_before_every_media_step_and_point_to_atomic_edit() -> None:
+    problem = GenerationProblem(
+        code="mixed_speech",
+        detail="character and narrator speech are mixed",
+        action=GenerationAction.REPLAN_UNIT,
+        params={"unit_id": "E1S01"},
+    )
+
+    plan = build_workflow_plan(
+        _status(state="STORYBOARD", action="generate_storyboards"),
+        structure_problems=[problem],
+        script_revision="sha256-v1:script",
+    )
+
+    assert _step(plan, "script_structure").state is WorkflowStepState.BLOCKED
+    assert _step(plan, "storyboard").state is WorkflowStepState.PENDING
+    assert _step(plan, "video").state is WorkflowStepState.PENDING
+    assert plan.next_action.type == "patch_episode_script"
+    assert plan.next_action.args["expected_revision"] == "sha256-v1:script"
+    assert plan.next_action.requested_ids == ["E1S01"]
+
+
+def test_needs_replan_uses_the_same_atomic_structure_edit_step() -> None:
+    problem = GenerationProblem(
+        code="needs_replan",
+        detail="unit requires replanning",
+        action=GenerationAction.REPLAN_UNIT,
+        params={"unit_id": "E1U01"},
+    )
+
+    plan = build_workflow_plan(
+        _status(generation_mode="reference_video"),
+        structure_problems=[problem],
+        script_revision="sha256-v1:script",
+    )
+
+    assert _step(plan, "storyboard").state is WorkflowStepState.SKIPPED
+    assert _step(plan, "script_structure").problems[0].code == "needs_replan"
+    assert plan.next_action.type == "patch_episode_script"
+    assert plan.next_action.requested_ids == ["E1U01"]
+
+
+def test_unrepairable_structural_blocker_stays_a_status_blocker_before_media() -> None:
+    status = _status(state="PROJECT_INPUT", action="none")
+    blocker = WorkflowBlocker(
+        code="invalid_script_structure",
+        path="scripts/episode_1.json",
+        reason="script container is not repairable through media actions",
+    )
+    status.blockers = [blocker]
+    status.next_action = WorkflowNextAction(type="none", reason="workflow is blocked")
+
+    plan = build_workflow_plan(status)
+
+    assert plan.blockers == [blocker]
+    assert _step(plan, "project_input").state is WorkflowStepState.BLOCKED
+    assert _step(plan, "storyboard").state is WorkflowStepState.PENDING
+    assert _step(plan, "video").state is WorkflowStepState.PENDING
+    assert plan.next_action.type == "none"
+
+
+def test_artifact_task_and_checkpoint_axes_remain_distinct() -> None:
+    status = _status()
+    status.artifacts["videos"] = {
+        "current_ids": [],
+        "stale_ids": ["E1S01"],
+        "missing_ids": ["E1S02"],
+        "state": "blocked",
+    }
+    task = WorkflowTaskObservation(
+        unit_id="E1S02",
+        task_id="task-1",
+        task_type="video",
+        status="running",
+        provider_checkpoint=ProviderCheckpoint(
+            submitted=True,
+            provider_id="provider-a",
+            provider_job_id="job-1",
+        ),
+    )
+
+    plan = build_workflow_plan(
+        status,
+        narration_delivery=POST_PRODUCTION,
+        task_observations=[task],
+    )
+
+    video = _step(plan, "video")
+    assert video.artifacts == status.artifacts["videos"]
+    assert video.tasks == [task]
+    assert video.state is WorkflowStepState.ACTIVE
+    assert video.tasks[0].provider_checkpoint is not None
+    assert video.tasks[0].provider_checkpoint.submitted is True
+    assert "is_ready" not in video.model_dump()
+    assert plan.next_action.type == GenerationAction.WAIT_FOR_TASK.value
+
+
+def test_partial_execution_result_does_not_reinterpret_admission_or_artifact_status() -> None:
+    admission = BatchAdmission(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        narration_delivery=POST_PRODUCTION,
+        tickets=(UnitAdmissionTicket("E1S01"), UnitAdmissionTicket("E1S02")),
+    )
+    failed_problem = GenerationProblem(
+        code="provider_failed",
+        detail="provider rejected one unit",
+        action=GenerationAction.RETRY,
+    )
+    result = GenerationBatchResult(
+        operation="generate_videos",
+        selection=GenerationSelectionMode.MISSING_ONLY,
+        requested=["E1S01", "E1S02"],
+        succeeded=["E1S01"],
+        failed=["E1S02"],
+        blocked=[],
+        items=[
+            GenerationItemResult(
+                unit_id="E1S01",
+                state=GenerationItemState.SUCCEEDED,
+                task_state=GenerationTaskState.SUCCEEDED,
+                artifact_status=ArtifactStatus.STALE,
+            ),
+            GenerationItemResult(
+                unit_id="E1S02",
+                state=GenerationItemState.FAILED,
+                task_state=GenerationTaskState.FAILED,
+                artifact_status=ArtifactStatus.MISSING,
+                problem=failed_problem,
+            ),
+        ],
+    )
+
+    plan = build_workflow_plan(
+        _status(requested_ids=["E1S01", "E1S02"]),
+        narration_delivery=POST_PRODUCTION,
+        admission=admission.to_payload(),
+        generation_result=result,
+    )
+
+    video = _step(plan, "video")
+    assert video.admission["decision"] == "admitted"
+    assert video.generation_result == result
+    assert video.generation_result.succeeded == ["E1S01"]
+    assert video.generation_result.failed == ["E1S02"]
+    assert video.generation_result.items[0].artifact_status is ArtifactStatus.STALE
+    assert video.generation_result.items[1].artifact_status is ArtifactStatus.MISSING
+
+
+def test_stale_video_remains_exportable_without_an_implicit_regeneration_step() -> None:
+    status = _status(state="EXPORT_READY", action="export")
+    status.artifacts["videos"] = {
+        "current_ids": [],
+        "stale_ids": ["E1S01"],
+        "missing_ids": [],
+    }
+    status.next_action = WorkflowNextAction(type="export", reason="usable media is ready")
+
+    plan = build_workflow_plan(status)
+
+    video = _step(plan, "video")
+    assert video.state is WorkflowStepState.COMPLETED
+    assert video.artifacts["stale_ids"] == ["E1S01"]
+    assert video.action is None
+    assert plan.next_action.type == "export"

--- a/tests/test_workflow_plan.py
+++ b/tests/test_workflow_plan.py
@@ -164,6 +164,28 @@ def test_post_production_keeps_video_executable_when_tts_is_missing() -> None:
     assert plan.next_action == status.next_action
 
 
+def _status_with_blocked_audio() -> WorkflowStatus:
+    status = _status()
+    artifacts = dict(status.artifacts)
+    artifacts["audio"] = {"state": "blocked", "current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]}
+    return status.model_copy(update={"artifacts": artifacts})
+
+
+def test_blocked_audio_artifact_survives_the_delivery_step_projection() -> None:
+    plan = build_workflow_plan(_status_with_blocked_audio(), narration_delivery=USE_TTS)
+
+    assert _step(plan, "narration_delivery").state is WorkflowStepState.BLOCKED
+    assert _step(plan, "narration_delivery").artifacts["state"] == "blocked"
+
+
+@pytest.mark.parametrize("delivery", [POST_PRODUCTION, None])
+def test_blocked_audio_artifact_does_not_block_the_post_production_path(delivery: NarrationDelivery | None) -> None:
+    plan = build_workflow_plan(_status_with_blocked_audio(), narration_delivery=delivery)
+
+    expected = WorkflowStepState.COMPLETED if delivery is not None else WorkflowStepState.READY
+    assert _step(plan, "narration_delivery").state is expected
+
+
 def test_use_tts_preserves_structured_admission_blockers() -> None:
     problem = GenerationProblem(
         code="tts_missing",

--- a/tests/test_workflow_plan_adapters.py
+++ b/tests/test_workflow_plan_adapters.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from lib.narration_delivery import POST_PRODUCTION
+from lib.project_manager import ProjectManager
+from lib.workflow_plan import WorkflowPlanRequest, build_workflow_plan
+from lib.workflow_state import WorkflowNextAction, WorkflowProject, WorkflowStatus, WorkflowTarget
+from server.agent_runtime.sdk_tools._context import ToolContext
+from server.agent_runtime.sdk_tools.workflow_plan import get_workflow_plan_tool
+from server.auth import CurrentUserInfo, get_current_user
+from server.routers import projects
+from server.services import workflow_planner
+
+pytestmark = pytest.mark.integration
+
+
+def _project(tmp_path: Path) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects")
+    pm.create_project("demo")
+    pm.create_project_metadata("demo", "Ad", "", "ad", target_duration=30)
+    return pm
+
+
+def _status() -> WorkflowStatus:
+    return WorkflowStatus.model_validate(
+        {
+            "project_revision": "sha256-v1:project",
+            "source_revision": None,
+            "project": WorkflowProject(content_mode="ad", generation_mode="storyboard", grid_storyboard=False),
+            "target": WorkflowTarget(
+                episode=1,
+                script="scripts/episode_1.json",
+                script_filename="episode_1.json",
+                source="source/episode_1.txt",
+            ),
+            "state": "VIDEO",
+            "blockers": [],
+            "gates": {"step1_review": {"state": "not_applicable", "revision": None}},
+            "artifacts": {
+                "asset_inventory": {"state": "not_applicable"},
+                "asset_sheets": {},
+                "step1": {"state": "not_applicable"},
+                "script": {"state": "current"},
+                "storyboards": {"current_ids": ["E1S01"], "stale_ids": [], "missing_ids": []},
+                "videos": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
+                "audio": {"state": "not_applicable", "current_ids": [], "stale_ids": [], "missing_ids": []},
+            },
+            "next_action": WorkflowNextAction(
+                type="generate_videos",
+                requested_ids=["E1S01"],
+                reason="video missing",
+            ),
+        }
+    )
+
+
+class _Planner:
+    def __init__(self):
+        self.calls: list[tuple[str, WorkflowPlanRequest]] = []
+
+    async def get_plan(self, project_name: str, request: WorkflowPlanRequest):
+        self.calls.append((project_name, request))
+        return build_workflow_plan(_status(), narration_delivery=request.narration_delivery)
+
+
+async def test_rest_and_mcp_serialize_the_same_workflow_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pm = _project(tmp_path)
+    planner = _Planner()
+    monkeypatch.setattr(workflow_planner, "get_workflow_planner", lambda _pm=None: planner)
+    monkeypatch.setattr(projects, "get_project_manager", lambda: pm)
+    payload = {
+        "episode": 1,
+        "narration_delivery": POST_PRODUCTION,
+        "confirmed_request_durations": {"E1S01": 5},
+    }
+
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    mcp_result = await get_workflow_plan_tool(ctx).handler(payload)
+    mcp_body = json.loads(mcp_result["content"][0]["text"])
+
+    app = FastAPI()
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
+    app.include_router(projects.router, prefix="/api/v1", dependencies=[Depends(get_current_user)])
+    with TestClient(app) as client:
+        response = client.post("/api/v1/projects/demo/workflow-plan", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == mcp_body
+    assert planner.calls == [
+        ("demo", WorkflowPlanRequest.model_validate(payload)),
+        ("demo", WorkflowPlanRequest.model_validate(payload)),
+    ]
+
+
+async def test_workflow_plan_mcp_rejects_invalid_transient_choice_before_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    calls: list[object] = []
+
+    def _planner(*args: object, **kwargs: object) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(workflow_planner, "get_workflow_planner", _planner)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+
+    result = await get_workflow_plan_tool(ctx).handler({"narration_delivery": "persist_this_choice"})
+
+    assert result["is_error"] is True
+    assert json.loads(result["content"][0]["text"])["error"] == "invalid_request"
+    assert calls == []

--- a/tests/test_workflow_plan_adapters.py
+++ b/tests/test_workflow_plan_adapters.py
@@ -10,10 +10,17 @@ from fastapi.testclient import TestClient
 from lib.narration_delivery import POST_PRODUCTION
 from lib.project_manager import ProjectManager
 from lib.workflow_plan import WorkflowPlanRequest, build_workflow_plan
-from lib.workflow_state import WorkflowNextAction, WorkflowProject, WorkflowStatus, WorkflowTarget
+from lib.workflow_state import (
+    WorkflowNextAction,
+    WorkflowProject,
+    WorkflowRequestError,
+    WorkflowStatus,
+    WorkflowTarget,
+)
 from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.workflow_plan import get_workflow_plan_tool
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import projects
 from server.services import workflow_planner
 
@@ -115,3 +122,58 @@ async def test_workflow_plan_mcp_rejects_invalid_transient_choice_before_service
     assert result["is_error"] is True
     assert json.loads(result["content"][0]["text"])["error"] == "invalid_request"
     assert calls == []
+
+
+class _FailingPlanner:
+    def __init__(self, error: Exception):
+        self._error = error
+
+    async def get_plan(self, project_name: str, request: WorkflowPlanRequest):
+        raise self._error
+
+
+def _adapter_app(pm: ProjectManager, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    monkeypatch.setattr(projects, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    register_error_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
+    app.include_router(projects.router, prefix="/api/v1", dependencies=[Depends(get_current_user)])
+    return app
+
+
+async def test_workflow_plan_adapters_blame_the_request_only_for_request_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    planner = _FailingPlanner(WorkflowRequestError("ad workflow only has episode 1"))
+    monkeypatch.setattr(workflow_planner, "get_workflow_planner", lambda _pm=None: planner)
+
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    mcp_result = await get_workflow_plan_tool(ctx).handler({"episode": 2})
+
+    assert mcp_result["is_error"] is True
+    assert json.loads(mcp_result["content"][0]["text"])["error"] == "invalid_request"
+
+    with TestClient(_adapter_app(pm, monkeypatch), raise_server_exceptions=False) as client:
+        response = client.post("/api/v1/projects/demo/workflow-plan", json={"episode": 2})
+
+    assert response.status_code == 400
+
+
+async def test_workflow_plan_adapters_report_corrupt_script_as_server_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pm = _project(tmp_path)
+    planner = _FailingPlanner(ValueError("segments must be an array of objects"))
+    monkeypatch.setattr(workflow_planner, "get_workflow_planner", lambda _pm=None: planner)
+
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+    mcp_result = await get_workflow_plan_tool(ctx).handler({"episode": 1})
+
+    assert mcp_result["is_error"] is True
+    assert mcp_result["content"][0]["text"].startswith("get_workflow_plan 失败:")
+
+    with TestClient(_adapter_app(pm, monkeypatch), raise_server_exceptions=False) as client:
+        response = client.post("/api/v1/projects/demo/workflow-plan", json={"episode": 1})
+
+    assert response.status_code == 500

--- a/tests/test_workflow_status_adapters.py
+++ b/tests/test_workflow_status_adapters.py
@@ -8,10 +8,11 @@ from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from lib.project_manager import ProjectManager
-from lib.workflow_state import WorkflowStateService
+from lib.workflow_state import WorkflowRequestError, WorkflowStateService
 from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.workflow_status import complete_step1_rebuild_tool, get_workflow_status_tool
 from server.auth import CurrentUserInfo, get_current_user
+from server.error_handlers import register_error_handlers
 from server.routers import projects
 
 
@@ -141,3 +142,45 @@ async def test_workflow_status_adapters_treat_corrupt_project_as_server_failure(
         response = client.get("/api/v1/projects/demo/workflow-status")
 
     assert response.status_code == 500
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("error", "expected_status", "expects_request_blame"),
+    [
+        (WorkflowRequestError("ad workflow only has episode 1"), 400, True),
+        (ValueError("scenes must be an array of objects"), 500, False),
+    ],
+)
+async def test_workflow_status_adapters_blame_the_request_only_for_request_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_status: int,
+    expects_request_blame: bool,
+) -> None:
+    pm = _project(tmp_path)
+    ctx = ToolContext(project_name="demo", projects_root=tmp_path / "projects", pm=pm)
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise error
+
+    monkeypatch.setattr(WorkflowStateService, "get_status", _raise)
+
+    result = await get_workflow_status_tool(ctx).handler({"episode": 2})
+
+    assert result["is_error"] is True
+    if expects_request_blame:
+        assert json.loads(result["content"][0]["text"])["error"] == "invalid_episode"
+    else:
+        assert result["content"][0]["text"].startswith("get_workflow_status 失败:")
+
+    monkeypatch.setattr(projects, "get_project_manager", lambda: pm)
+    app = FastAPI()
+    register_error_handlers(app)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
+    app.include_router(projects.router, prefix="/api/v1", dependencies=[Depends(get_current_user)])
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/projects/demo/workflow-status", params={"episode": 2})
+
+    assert response.status_code == expected_status


### PR DESCRIPTION
把三种内容模式、两条生成路线、结构编辑、旁白交付选择、批量准入、任务与产物状态汇成一份可解释的制作计划，供 Web 与智能体共用同一份下一步判断。

## 变更

- `lib/workflow_rules.py`：六个模式组合的步骤表与预处理器由数据驱动，`lib/workflow_state.py` 的预处理器分支改读同一张表，路线判断不再散落
- `lib/workflow_plan.py`：把工作流状态与本次请求事实投影成有序步骤、阻断原因与唯一下一动作；产物、任务、准入、执行结果各占独立轴，不压成单个布尔
- `server/services/workflow_planner.py`：异步适配层，只编排既有深模块（工作流状态、批量准入、结构问题、任务队列查询），不重新实现领域规则
- REST `POST /api/v1/projects/{name}/workflow-plan` 与 MCP `get_workflow_plan` 共用同一份模型序列化；旁白交付选择与逐 ID 时长确认只属于该次请求，不写入项目
- `lib/artifact_manifest.py`：只读快照不再创建锁文件，让状态查询真正零写；已有锁文件时仍走原有串行读路径

## 验证

- `uv run python -m pytest`：10122 passed, 2 skipped
- `uv run ruff check/format`、`uv run lint-imports`、`uv run basedpyright`：0 error
- `pnpm lint && pnpm check`：1822 passed

Closes #1676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增工作流计划功能，集中展示步骤状态、阻塞问题、活动任务及视频准入结果。
  - 提供项目接口和 MCP 工具，支持统一获取执行计划。
  - 支持英文、越南文和中文显示“获取完整工作流计划”。

- **改进**
  - 工作流规则可根据内容与生成模式自动匹配。
  - 优化音频、语音及视频任务的准入检查。
  - 改进请求错误处理与状态读取，减少不必要的锁文件并增强并发修改检测。

- **测试**
  - 新增接口一致性、工作流状态、任务阻塞及清单读取测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->