### PR TITLE
fix(lint): 档案检查不再把「旧格式已废弃」的说明句判为违规

### DIFF
--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Static integrity checks for the materialized Agent Runtime Profile."""
+"""Static integrity checks for the materialized Agent Runtime Profile.
+
+``--target-profile`` 额外启用目标档案专属的废弃用法检查。其中禁用字符串
+(`_TARGET_DEPRECATED_STRINGS`) 的判定边界如下：
+
+- 判定粒度是**子句**——按换行、中英文逗号/分号/句号/问号/叹号与括号切分；只看命中
+  字符串所在的那个子句，不看整段上下文。
+- 子句含废弃语境标记（否定词、「残留」「旧项目」「废弃」「legacy」等）时视为反向说明，
+  即告诫读者不要再用旧格式，不判违规。该判断优先于路由标记。
+- 否则要求子句含路由/指令标记（读取/使用/运行/参数/路径、read/use/run、命令行形态等）
+  才判违规；两者都没有的纯提及不判违规。
+
+因此「旧稿 X 不算有效输入」不报，而「读取 X 作为输入」仍报。
+"""
 
 from __future__ import annotations
 
@@ -33,6 +46,18 @@ _TARGET_DEPRECATED_STRINGS = (
     "--scene-ids",
     "--music-volume",
     "step1_normalized_script.md",
+)
+_CLAUSE_SPLIT_RE = re.compile(r"[\n，,。；;！!？?（）()]|——")
+_DEPRECATION_CONTEXT_RE = re.compile(
+    r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|不当|不是|无需|禁止|勿|别用"
+    r"|残留|遗留|废弃|已移除|已删除|旧项目|旧稿|旧格式|历史"
+    r"|deprecated|legacy|obsolete|removed|no longer|instead of",
+    re.IGNORECASE,
+)
+_ROUTING_MARKER_RE = re.compile(
+    r"读取|读|写入|写|使用|用|运行|执行|调用|传入|传|加上|附加|指定|填|生成|保存|输出|输入|参数|选项|路径"
+    r"|\bread\b|\bwrite\b|\buse\b|\bruns?\b|\bpass\b|\bexec\b|\bpython\b|\.py\b|\$\s|^\s*[>`]",
+    re.IGNORECASE,
 )
 _DIRECT_STEP1_EDIT_RE = re.compile(
     r"(?:Edit|Write).{0,100}(?:step1_normalized_script|narration.{0,30}step1|drama.{0,30}step1)",
@@ -161,6 +186,18 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
                 seen[eval_id] = path
 
 
+def _routes_to_deprecated_string(text: str, needle: str) -> bool:
+    """判断文本是否真的把 ``needle`` 当作可用路由/指令，而非反向说明它已废弃。"""
+    for clause in _CLAUSE_SPLIT_RE.split(text):
+        if needle not in clause:
+            continue
+        if _DEPRECATION_CONTEXT_RE.search(clause):
+            continue
+        if _ROUTING_MARKER_RE.search(clause):
+            return True
+    return False
+
+
 def _validate_target_deprecations(profile_dir: Path, errors: list[str]) -> None:
     for path in sorted(profile_dir.rglob("*.md")):
         try:
@@ -169,7 +206,7 @@ def _validate_target_deprecations(profile_dir: Path, errors: list[str]) -> None:
             errors.append(f"{path.relative_to(profile_dir)}: cannot read: {exc}")
             continue
         for needle in _TARGET_DEPRECATED_STRINGS:
-            if needle in text:
+            if _routes_to_deprecated_string(text, needle):
                 errors.append(f"{path.relative_to(profile_dir)}: deprecated profile string {needle!r}")
         if _PYTHON_RESUME_RE.search(text):
             errors.append(f"{path.relative_to(profile_dir)}: deprecated Python --resume invocation")

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -4,14 +4,15 @@
 ``--target-profile`` 额外启用目标档案专属的废弃用法检查。其中禁用字符串
 (`_TARGET_DEPRECATED_STRINGS`) 的判定边界如下：
 
-- 判定粒度是**子句**——按换行、中英文逗号/分号/句号/问号/叹号与括号切分；只看命中
-  字符串所在的那个子句，不看整段上下文。
-- 子句含废弃语境标记（否定词、「残留」「旧项目」「废弃」「legacy」等）时视为反向说明，
-  即告诫读者不要再用旧格式，不判违规。该判断优先于路由标记。
-- 否则要求子句含路由/指令标记（读取/使用/运行/参数/路径、read/use/run、命令行形态等）
-  才判违规；两者都没有的纯提及不判违规。
+- 判定粒度是**子句**——散文按句读切分（见 ``_CLAUSE_SPLIT_RE``），围栏代码块内以整行
+  为一个子句；只看命中字符串所在的那个子句，不看整段上下文。
+- 子句命中废弃语境标记（``_DEPRECATION_CONTEXT_RE``）时视为反向说明，即告诫读者不要
+  再用旧格式，不判违规。该判断优先于下面的路由判定。
+- 否则，子句满足下列任一条即判违规：位于围栏代码块内（代码块是可执行指令而非散文告诫）、
+  禁用串本身是命令行 flag（``--`` 开头，其出现即指令形态）、或子句含路由/指令标记
+  （``_ROUTING_MARKER_RE``）。三者皆无的纯提及不判违规。
 
-因此「旧稿 X 不算有效输入」不报，而「读取 X 作为输入」仍报。
+因此「旧稿 X 不算有效输入」不报，而「读取 X 作为输入」与代码块里的 ``cmd --flag`` 仍报。
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import json
 import posixpath
 import re
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
 from typing import NoReturn
 from urllib.parse import unquote
@@ -47,16 +49,17 @@ _TARGET_DEPRECATED_STRINGS = (
     "--music-volume",
     "step1_normalized_script.md",
 )
-_CLAUSE_SPLIT_RE = re.compile(r"[\n，,。；;！!？?（）()]|——")
+_CODE_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+_CLAUSE_SPLIT_RE = re.compile(r"[，,。；;！!？?]|——")
 _DEPRECATION_CONTEXT_RE = re.compile(
-    r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|不当|不是|无需|禁止|勿|别用"
-    r"|残留|遗留|废弃|已移除|已删除|旧项目|旧稿|旧格式|历史"
+    r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|无需|禁止|勿|别用"
+    r"|残留|遗留|废弃|已移除|已删除|旧项目|旧稿|旧格式"
     r"|deprecated|legacy|obsolete|removed|no longer|instead of",
     re.IGNORECASE,
 )
 _ROUTING_MARKER_RE = re.compile(
-    r"读取|读|写入|写|使用|用|运行|执行|调用|传入|传|加上|附加|指定|填|生成|保存|输出|输入|参数|选项|路径"
-    r"|\bread\b|\bwrite\b|\buse\b|\bruns?\b|\bpass\b|\bexec\b|\bpython\b|\.py\b|\$\s|^\s*[>`]",
+    r"读取|写入|使用|运行|执行|调用|传入|加上|附加|指定|生成|保存|输出|输入|参数|选项|路径"
+    r"|\bread\b|\bwrite\b|\buse\b|\bruns?\b|\bpass\b|\bexec\b|\bpython\b|\.py\b|\$\s",
     re.IGNORECASE,
 )
 _DIRECT_STEP1_EDIT_RE = re.compile(
@@ -186,14 +189,32 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
                 seen[eval_id] = path
 
 
+def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
+    """按行遍历 Markdown，产出 ``(子句, 是否位于围栏代码块内)``。
+
+    围栏内以整行为一个子句——代码里的逗号分号是语法而非句读，不能当切分点。
+    """
+    in_fence = False
+    for line in text.splitlines():
+        if _CODE_FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            yield line, True
+        else:
+            for clause in _CLAUSE_SPLIT_RE.split(line):
+                yield clause, False
+
+
 def _routes_to_deprecated_string(text: str, needle: str) -> bool:
     """判断文本是否真的把 ``needle`` 当作可用路由/指令，而非反向说明它已废弃。"""
-    for clause in _CLAUSE_SPLIT_RE.split(text):
+    needle_is_cli_flag = needle.startswith("--")
+    for clause, in_code_fence in _iter_clauses(text):
         if needle not in clause:
             continue
         if _DEPRECATION_CONTEXT_RE.search(clause):
             continue
-        if _ROUTING_MARKER_RE.search(clause):
+        if in_code_fence or needle_is_cli_flag or _ROUTING_MARKER_RE.search(clause):
             return True
     return False
 

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -49,7 +49,7 @@ _TARGET_DEPRECATED_STRINGS = (
     "--music-volume",
     "step1_normalized_script.md",
 )
-_CODE_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+_CODE_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
 _CLAUSE_SPLIT_RE = re.compile(r"[，,。；;！!？?]|——")
 _DEPRECATION_CONTEXT_RE = re.compile(
     r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|无需|禁止|勿|别用"
@@ -192,18 +192,51 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
 def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
     """按行遍历 Markdown，产出 ``(子句, 是否位于围栏代码块内)``。
 
-    围栏内以整行为一个子句——代码里的逗号分号是语法而非句读，不能当切分点。
+    三条判定形状：围栏内以整行为一个子句（代码里的逗号分号是语法而非句读，不能当切分点）；
+    开合围栏须同字符、闭合长度不短于开启长度、且闭合行不带信息字符串才配对，避免更短的嵌套
+    反引号序列被误判为收围栏；围栏外先把连续的非空行合并为一个逻辑段落再切分子句——Markdown
+    软换行只是排版折行，不是句读边界，逐物理行切分会把同一子句拆散到两行而漏判。
     """
-    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    prose_lines: list[str] = []
+
+    def _flush_prose() -> list[str]:
+        nonlocal prose_lines
+        if not prose_lines:
+            return []
+        paragraph = " ".join(prose_lines)
+        prose_lines = []
+        return _CLAUSE_SPLIT_RE.split(paragraph)
+
     for line in text.splitlines():
-        if _CODE_FENCE_RE.match(line):
-            in_fence = not in_fence
+        if fence_char:
+            match = _CODE_FENCE_RE.match(line)
+            if (
+                match
+                and match.group(1)[0] == fence_char
+                and len(match.group(1)) >= fence_len
+                and not match.group(2).strip()
+            ):
+                fence_char = ""
+                fence_len = 0
+            else:
+                yield line, True
             continue
-        if in_fence:
-            yield line, True
-        else:
-            for clause in _CLAUSE_SPLIT_RE.split(line):
+        match = _CODE_FENCE_RE.match(line)
+        if match:
+            for clause in _flush_prose():
                 yield clause, False
+            fence_char = match.group(1)[0]
+            fence_len = len(match.group(1))
+            continue
+        if line.strip():
+            prose_lines.append(line)
+        else:
+            for clause in _flush_prose():
+                yield clause, False
+    for clause in _flush_prose():
+        yield clause, False
 
 
 def _routes_to_deprecated_string(text: str, needle: str) -> bool:

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -50,6 +50,7 @@ _TARGET_DEPRECATED_STRINGS = (
     "step1_normalized_script.md",
 )
 _CODE_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
+_BLOCK_START_RE = re.compile(r"^\s{0,3}([-*+]\s|\d+[.)]\s|#{1,6}\s|>)")
 _CLAUSE_SPLIT_RE = re.compile(r"[，,。；;！!？?]|——")
 _DEPRECATION_CONTEXT_RE = re.compile(
     r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|无需|禁止|勿|别用"
@@ -195,7 +196,9 @@ def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
     三条判定形状：围栏内以整行为一个子句（代码里的逗号分号是语法而非句读，不能当切分点）；
     开合围栏须同字符、闭合长度不短于开启长度、且闭合行不带信息字符串才配对，避免更短的嵌套
     反引号序列被误判为收围栏；围栏外先把连续的非空行合并为一个逻辑段落再切分子句——Markdown
-    软换行只是排版折行，不是句读边界，逐物理行切分会把同一子句拆散到两行而漏判。
+    软换行只是排版折行，不是句读边界，逐物理行切分会把同一子句拆散到两行而漏判。合并在遇到
+    新的列表项/标题/引用起始行（``_BLOCK_START_RE``）时截断，紧邻无空行分隔的两个列表项各
+    自独立成句——否则前一项若命中废弃语境，会连带吞掉后一项里本应报告的真实路由指令。
     """
     fence_char = ""
     fence_len = 0
@@ -231,6 +234,9 @@ def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
             fence_len = len(match.group(1))
             continue
         if line.strip():
+            if _BLOCK_START_RE.match(line):
+                for clause in _flush_prose():
+                    yield clause, False
             prose_lines.append(line)
         else:
             for clause in _flush_prose():

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -51,6 +51,7 @@ _TARGET_DEPRECATED_STRINGS = (
 )
 _CODE_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
 _BLOCK_START_RE = re.compile(r"^\s{0,3}([-*+]\s|\d+[.)]\s|#{1,6}\s|>)")
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
 _CLAUSE_SPLIT_RE = re.compile(r"[，,。；;！!？?]|——")
 _DEPRECATION_CONTEXT_RE = re.compile(
     r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|无需|禁止|勿|别用"
@@ -198,7 +199,8 @@ def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
     反引号序列被误判为收围栏；围栏外先把连续的非空行合并为一个逻辑段落再切分子句——Markdown
     软换行只是排版折行，不是句读边界，逐物理行切分会把同一子句拆散到两行而漏判。合并在遇到
     新的列表项/标题/引用起始行（``_BLOCK_START_RE``）时截断，紧邻无空行分隔的两个列表项各
-    自独立成句——否则前一项若命中废弃语境，会连带吞掉后一项里本应报告的真实路由指令。
+    自独立成句——否则前一项若命中废弃语境，会连带吞掉后一项里本应报告的真实路由指令；标题
+    行（``_HEADING_RE``）额外在自身之后立即截断——ATX 标题恒为单行块，不与下方段落同句。
     """
     fence_char = ""
     fence_len = 0
@@ -238,6 +240,9 @@ def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
                 for clause in _flush_prose():
                     yield clause, False
             prose_lines.append(line)
+            if _HEADING_RE.match(line):
+                for clause in _flush_prose():
+                    yield clause, False
         else:
             for clause in _flush_prose():
                 yield clause, False

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -260,6 +260,21 @@ def test_target_deprecation_rules_flag_adjacent_list_items_without_blank_line(tm
     assert ".claude/agents/adjacent-items.md: deprecated profile string 'step1_normalized_script.md'" in errors
 
 
+def test_target_deprecation_rules_flag_routing_paragraph_after_deprecated_heading(tmp_path: Path) -> None:
+    """标题（ATX 单行块）不与其后段落同句：标题命中废弃语境不应吞掉紧邻下方的真实路由段落。"""
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "heading.md").write_text(
+        "---\nname: heading\ndescription: Heading boundary agent\n---\n"
+        "### 已废弃的旧格式\n"
+        "读取 step1_normalized_script.md 作为输入。\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/heading.md: deprecated profile string 'step1_normalized_script.md'" in errors
+
+
 def test_target_deprecation_rules_flag_nested_fence_content(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / ".claude" / "agents" / "nested-fence.md").write_text(

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -184,6 +184,29 @@ def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Pat
     )
 
 
+def test_target_deprecation_rules_flag_routing_and_spare_reverse_notes(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "router.md").write_text(
+        "---\nname: router\ndescription: Routing agent\n---\n"
+        "- 读取 `drafts/episode_1/step1_normalized_script.md` 作为剧本生成输入。\n"
+        "- 重生成指定场景时运行 generate-storyboard --scene-ids E1S01。\n",
+        encoding="utf-8",
+    )
+    (profile / ".claude" / "agents" / "note.md").write_text(
+        "---\nname: note\ndescription: Reverse note agent\n---\n"
+        "- 旧项目残留的 `step1_normalized_script.md`（结构化前自由文本稿）不算有效 step1，"
+        "须重跑 normalize 产出 `.json`。\n"
+        "- 旧脚本的 --scene-ids 参数已废弃，不要再传。\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/router.md: deprecated profile string 'step1_normalized_script.md'" in errors
+    assert ".claude/agents/router.md: deprecated profile string '--scene-ids'" in errors
+    assert not any(error.startswith(".claude/agents/note.md") for error in errors)
+
+
 def test_reports_invalid_utf8_across_profile_inputs(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / "CLAUDE.narration.md").write_bytes(b"\xff")
@@ -209,3 +232,11 @@ def test_frontmatter_accepts_utf8_bom(tmp_path: Path) -> None:
 def test_shipped_profile_passes_current_lint() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     assert lint_profile(repo_root / "agent_runtime_profile") == []
+
+
+def test_shipped_profile_has_no_deprecated_string_routing() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    errors = lint_profile(repo_root / "agent_runtime_profile", enforce_target_rules=True)
+
+    assert not any("deprecated profile string" in error for error in errors)

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -245,6 +245,21 @@ def test_target_deprecation_rules_flag_soft_wrapped_routing_clause(tmp_path: Pat
     assert ".claude/agents/wrapped.md: deprecated profile string 'step1_normalized_script.md'" in errors
 
 
+def test_target_deprecation_rules_flag_adjacent_list_items_without_blank_line(tmp_path: Path) -> None:
+    """紧邻、无空行分隔的反向说明列表项与真实路由列表项须各自独立成句，不因段落合并互相吞并。"""
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "adjacent-items.md").write_text(
+        "---\nname: adjacent-items\ndescription: Adjacent list item agent\n---\n"
+        "- 不要使用旧格式 step1_normalized_script.md\n"
+        "- 读取 step1_normalized_script.md 作为输入\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/adjacent-items.md: deprecated profile string 'step1_normalized_script.md'" in errors
+
+
 def test_target_deprecation_rules_flag_nested_fence_content(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / ".claude" / "agents" / "nested-fence.md").write_text(

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -231,6 +231,52 @@ def test_target_deprecation_rules_flag_code_fences_and_parenthesised_paths(tmp_p
         assert f".claude/agents/{source}: deprecated profile string '--scene-ids'" in errors
 
 
+def test_target_deprecation_rules_flag_soft_wrapped_routing_clause(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "wrapped.md").write_text(
+        "---\nname: wrapped\ndescription: Soft-wrapped routing agent\n---\n"
+        "- 请读取\n"
+        "  step1_normalized_script.md 后再继续下一步。\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/wrapped.md: deprecated profile string 'step1_normalized_script.md'" in errors
+
+
+def test_target_deprecation_rules_flag_nested_fence_content(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "nested-fence.md").write_text(
+        "---\nname: nested-fence\ndescription: Nested fence agent\n---\n"
+        "````markdown\n"
+        "```bash\n"
+        "cat drafts/episode_1/step1_normalized_script.md\n"
+        "```\n"
+        "````\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/nested-fence.md: deprecated profile string 'step1_normalized_script.md'" in errors
+
+
+def test_target_deprecation_rules_flag_routing_clause_alongside_reverse_note(tmp_path: Path) -> None:
+    """反向说明子句与真实路由子句同文共存同一 needle 时，仍须按各自子句独立判定并报违规。"""
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "mixed.md").write_text(
+        "---\nname: mixed\ndescription: Mixed clause agent\n---\n"
+        "- 旧项目残留的 step1_normalized_script.md 不算有效 step1。\n"
+        "- 读取 step1_normalized_script.md 作为剧本生成输入。\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    assert ".claude/agents/mixed.md: deprecated profile string 'step1_normalized_script.md'" in errors
+
+
 def test_reports_invalid_utf8_across_profile_inputs(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / "CLAUDE.narration.md").write_bytes(b"\xff")

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -207,6 +207,30 @@ def test_target_deprecation_rules_flag_routing_and_spare_reverse_notes(tmp_path:
     assert not any(error.startswith(".claude/agents/note.md") for error in errors)
 
 
+def test_target_deprecation_rules_flag_code_fences_and_parenthesised_paths(tmp_path: Path) -> None:
+    profile = _valid_profile(tmp_path)
+    (profile / ".claude" / "agents" / "fenced.md").write_text(
+        "---\nname: fenced\ndescription: Fenced command agent\n---\n"
+        "```bash\n"
+        "generate-storyboard --scene-ids E1S01\n"
+        "cat drafts/episode_1/step1_normalized_script.md\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    (profile / ".claude" / "agents" / "inline.md").write_text(
+        "---\nname: inline\ndescription: Inline reference agent\n---\n"
+        "- 读取剧本草稿（`step1_normalized_script.md`）后继续。\n"
+        "- 请使用 generate-storyboard 重生成；--scene-ids E1S01\n",
+        encoding="utf-8",
+    )
+
+    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+
+    for source in ("fenced.md", "inline.md"):
+        assert f".claude/agents/{source}: deprecated profile string 'step1_normalized_script.md'" in errors
+        assert f".claude/agents/{source}: deprecated profile string '--scene-ids'" in errors
+
+
 def test_reports_invalid_utf8_across_profile_inputs(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / "CLAUDE.narration.md").write_bytes(b"\xff")


### PR DESCRIPTION
Closes #1897

## 变更

`scripts/lint_agent_runtime_profile.py --target-profile` 的禁用字符串检查从裸子串匹配改为带上下文的子句级判定：

- **散文告诫不再误报** —— 子句命中废弃语境标记（「不算」「残留」「旧项目」「legacy」等）即视为「告诉读者别再用旧格式」的反向说明，跳过。该判断优先于路由判定。
- **真实引用仍然报** —— 子句位于围栏代码块内、禁用串本身是 `--` 开头的命令行 flag、或子句含路由/指令标记（读取/运行/参数/路径、read/use/run 等）三者任一即判违规。
- 围栏代码块内以整行为一个子句（代码里的逗号分号是语法不是句读）；散文按句读切分，不再把括号当边界，避免把动词和它指向的路径切开。
- 判定边界写进脚本模块 docstring。

## 验证

- `--target-profile` 对当前 `agent_runtime_profile/`：改前 4 条错误（3 条误报 + 1 条真阳性），改后仅剩 `.claude/agents/normalize-drama-script.md: deprecated direct Edit/Write of formal step1` 这条真阳性（issue Notes 已声明另行裁决，不在本次范围）。软档 `lint_agent_runtime_profile.py` 仍 exit 0。
- 新增夹具测试三组：路由式引用（应报）、反向说明（不应报）、围栏代码块裸命令与括号内路径（应报）；另加一条对随仓库发布的 `agent_runtime_profile/` 的回归断言。
- `ruff check` / `ruff format --check` / `lint-imports` / `basedpyright`（0 errors）/ `pytest -m 'not e2e'`（10183 passed, 2 skipped）全绿。

## 已知边界

以否定词包裹的**肯定**指令（如「不要漏传 `--scene-ids`」）会被当作反向说明放过。收敛需句法级判定，成本与该规则的价值不匹配，记为 follow-up。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进目标档案中的废弃用法检查，减少对反向说明和普通文本的误报。
  * 支持识别代码块、命令行参数、路由说明及括号路径中的废弃字符串。
  * 增加已发布档案校验，确保其中不包含受禁用的旧用法。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->