### PR TITLE
perf(workflow): 制作状态查询不再重复读源文，工作台面板不被别的项目刷屏

### DIFF
--- a/frontend/src/components/workflow/WorkflowPanel.test.tsx
+++ b/frontend/src/components/workflow/WorkflowPanel.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { API } from "@/api";
+import { useTasksStore } from "@/stores/tasks-store";
 import { useWorkflowStore } from "@/stores/workflow-store";
 import { WorkflowPanel } from "./WorkflowPanel";
-import { makePlan, makeStep } from "@/test/factories";
+import { makePlan, makeStep, makeTask } from "@/test/factories";
 import type { WorkflowPlan } from "@/types/workflow";
 
 function mockPlan(plan: WorkflowPlan) {
@@ -461,5 +462,64 @@ describe("WorkflowPanel 布局与展开", () => {
     expect(summary.className).toContain("flex-wrap");
     // 摘要文本在窄屏下截断而不是把整行撑宽
     expect(summary.querySelector(".truncate")).not.toBeNull();
+  });
+});
+
+
+describe("WorkflowPanel 刷新纪律", () => {
+  beforeEach(() => {
+    useTasksStore.getState().setTasks([]);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    useTasksStore.getState().setTasks([]);
+  });
+
+  /** 推过防抖窗口，把待发布的指纹变化结算掉。 */
+  async function settleDebounce() {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+  }
+
+  it("别的项目的任务状态跳变不惊动本项目的计划", async () => {
+    const spy = mockPlan(makePlan());
+    render(<WorkflowPanel projectName="proj" episode={1} />);
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useTasksStore
+        .getState()
+        .setTasks([makeTask({ task_id: "other-1", project_name: "another", status: "queued" })]);
+    });
+    act(() => {
+      useTasksStore
+        .getState()
+        .setTasks([makeTask({ task_id: "other-1", project_name: "another", status: "succeeded" })]);
+    });
+    await settleDebounce();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("本项目任务连续跳状态时合并为一次求解", async () => {
+    const spy = mockPlan(makePlan());
+    render(<WorkflowPanel projectName="proj" episode={1} />);
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+    for (const status of ["queued", "running", "succeeded"] as const) {
+      act(() => {
+        useTasksStore
+          .getState()
+          .setTasks([makeTask({ task_id: "t1", project_name: "proj", status })]);
+      });
+    }
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    await settleDebounce();
+
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/components/workflow/WorkflowPanel.test.tsx
+++ b/frontend/src/components/workflow/WorkflowPanel.test.tsx
@@ -477,11 +477,16 @@ describe("WorkflowPanel 刷新纪律", () => {
     useTasksStore.getState().setTasks([]);
   });
 
+  /** 推进指定毫秒数的定时器。 */
+  async function advanceDebounce(ms: number) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  }
+
   /** 推过防抖窗口，把待发布的指纹变化结算掉。 */
   async function settleDebounce() {
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(400);
-    });
+    await advanceDebounce(400);
   }
 
   it("别的项目的任务状态跳变不惊动本项目的计划", async () => {
@@ -518,7 +523,9 @@ describe("WorkflowPanel 刷新纪律", () => {
     }
     expect(spy).toHaveBeenCalledTimes(1);
 
-    await settleDebounce();
+    await advanceDebounce(249);
+    expect(spy).toHaveBeenCalledTimes(1);
+    await advanceDebounce(1);
 
     await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
   });

--- a/frontend/src/components/workflow/WorkflowPanel.tsx
+++ b/frontend/src/components/workflow/WorkflowPanel.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from "lucide-react";
 import { useProjectsStore } from "@/stores/projects-store";
 import { useTasksStore } from "@/stores/tasks-store";
 import { useWorkflowStore } from "@/stores/workflow-store";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import type { NarrationDelivery } from "@/types/workflow";
 import { ProblemList } from "./ProblemList";
 import { WorkflowStepRow } from "./WorkflowStepRow";
@@ -12,6 +13,15 @@ import { blockerViews, nextStepForAction, problemViews } from "./problem-views";
 
 /** TTS 没配好时后端给出的问题码；它挡住的只是 use_tts 这一条路径。 */
 const TTS_NOT_CONFIGURED = "tts_not_configured";
+
+/**
+ * 任务指纹变化到发起重新求解之间的合并窗口（毫秒）。
+ *
+ * 一批任务入队/开跑/落地时状态是逐条跳的，每跳一次就求解一次计划，等于为同一批生成
+ * 打出十几个 `POST /workflow-plan`。窗口内的连续跳变合并成一次；窗口取值只需盖住同一
+ * 轮轮询写回引起的连锁跳变，不该长到让面板明显滞后于任务列表。
+ */
+const PLAN_REFRESH_DEBOUNCE_MS = 250;
 
 interface Props {
   projectName: string;
@@ -50,10 +60,17 @@ export function WorkflowPanel({ projectName, episode, onViewUnit, onRegenerate }
 
   // 项目快照修订号与任务指纹是两条既有的变更信号：前者随 project.json / 剧本写入递增
   // （SSE 项目事件驱动），后者随任务轮询变化。计划同时依赖这两类事实，故两者都进依赖。
+  //
+  // 任务指纹只取当前项目的任务：任务列表在「不按项目过滤」的作用域下是全局的，别的项目
+  // 跑生成同样会让指纹变，本项目的计划却不会因此改变——不过滤就等于替别人的进度重求解。
   const snapshotRevision = useProjectsStore((s) => s.projectSnapshotRevisions[projectName] ?? 0);
   const taskFingerprint = useTasksStore((s) =>
-    s.tasks.map((task) => `${task.task_id}:${task.status}`).join("|"),
+    s.tasks
+      .filter((task) => task.project_name === projectName)
+      .map((task) => `${task.task_id}:${task.status}`)
+      .join("|"),
   );
+  const settledTaskFingerprint = useDebouncedValue(taskFingerprint, PLAN_REFRESH_DEBOUNCE_MS);
 
   useEffect(() => {
     if (!projectName) return;
@@ -62,7 +79,7 @@ export function WorkflowPanel({ projectName, episode, onViewUnit, onRegenerate }
     projectName,
     episode,
     snapshotRevision,
-    taskFingerprint,
+    settledTaskFingerprint,
     narrationDelivery,
     confirmedDurations,
     refreshPlan,

--- a/frontend/src/components/workflow/action-language.test.ts
+++ b/frontend/src/components/workflow/action-language.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import enWorkflow from "@/i18n/en/workflow";
+import viWorkflow from "@/i18n/vi/workflow";
+import zhWorkflow from "@/i18n/zh/workflow";
+import { WORKFLOW_ACTION_TYPES } from "@/types/workflow";
+
+const CATALOGS = { en: enWorkflow, vi: viWorkflow, zh: zhWorkflow } as const;
+
+describe("下一步动作的文案覆盖", () => {
+  it.each(Object.keys(CATALOGS))("%s 为每个受控动作备了文案", (locale) => {
+    const catalog: Record<string, string> = CATALOGS[locale as keyof typeof CATALOGS];
+    const missing = WORKFLOW_ACTION_TYPES.filter((action) => !catalog[`action_${action}`]);
+    expect(missing).toEqual([]);
+  });
+
+  it("登记过的动作一个都不落到「未知动作」兜底文案上", () => {
+    // action_unknown 是运行时防线：后端先于前端上线新动作时，它保证这一步不被整个吞掉。
+    // 但闭集里已登记的动作不得靠它充数。
+    expect(zhWorkflow.action_unknown).toBeTruthy();
+    const fallingBack = WORKFLOW_ACTION_TYPES.filter((action) => !(`action_${action}` in zhWorkflow));
+    expect(fallingBack).toEqual([]);
+  });
+});

--- a/frontend/src/components/workflow/problem-views.ts
+++ b/frontend/src/components/workflow/problem-views.ts
@@ -3,6 +3,7 @@ import type {
   AdmissionProblem,
   BatchAdmissionUnit,
   GenerationProblem,
+  WorkflowActionType,
   WorkflowBlocker,
 } from "@/types/workflow";
 
@@ -39,10 +40,11 @@ function localizedSummary(t: Translate, code: string, fallback: string): string 
 
 /**
  * 复述后端给的下一步动作。动作译文是裸的祈使短语，「下一步：」这层框架在这里统一加，
- * 各调用点不各写一遍。动作类型是开放集合，未登记的取值落到 `action_unknown` 兜底陈述——
- * 说不出是哪个动作，也好过把后端明确给出的这一步整个吞掉。
+ * 各调用点不各写一遍。动作类型是 {@link WorkflowActionType} 那个闭集，每个取值都配了
+ * 文案（覆盖检查见 `action-language.test.ts`）；`action_unknown` 只作运行时防线，接住
+ * 后端先于前端上线的新动作——说不出是哪个动作，也好过把这一步整个吞掉。
  */
-export function nextStepForAction(t: Translate, action: string): string {
+export function nextStepForAction(t: Translate, action: WorkflowActionType): string {
   return t("next_step", {
     step: t(`action_${action}`, { defaultValue: t("action_unknown") }),
   });

--- a/frontend/src/i18n/en/workflow.ts
+++ b/frontend/src/i18n/en/workflow.ts
@@ -153,6 +153,7 @@ export default {
   'action_patch_episode_script': 'correct the script fields listed below',
   'action_choose_narration_delivery': 'choose how narration is delivered for this batch',
   'action_export': 'export the finished episode',
+  'action_retry_project_migration': 'fix the reported project files, then retry the data upgrade',
 
   // ---- Problem summaries ----
   'problem_generation_unit_not_found': 'This unit is no longer in the script.',

--- a/frontend/src/i18n/vi/workflow.ts
+++ b/frontend/src/i18n/vi/workflow.ts
@@ -155,6 +155,7 @@ export default {
   'action_patch_episode_script': 'sửa các trường kịch bản được liệt kê bên dưới',
   'action_choose_narration_delivery': 'chọn cách đưa lời dẫn cho lô này',
   'action_export': 'xuất tập đã hoàn thành',
+  'action_retry_project_migration': 'sửa các tệp dự án được báo cáo rồi thử lại việc nâng cấp dữ liệu',
 
   // ---- Tóm tắt vấn đề ----
   'problem_generation_unit_not_found': 'Đơn vị này không còn trong kịch bản.',

--- a/frontend/src/i18n/zh/workflow.ts
+++ b/frontend/src/i18n/zh/workflow.ts
@@ -155,6 +155,7 @@ export default {
   'action_patch_episode_script': '修正下面列出的剧本字段',
   'action_choose_narration_delivery': '选择本批的旁白交付方式',
   'action_export': '导出成片',
+  'action_retry_project_migration': '修复报告的项目文件后重试数据升级',
 
   // ---- 问题摘要 ----
   'problem_generation_unit_not_found': '剧本里已经没有这个单元了。',

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -35,10 +35,43 @@ export type GenerationTaskState =
   | "interrupted";
 
 /**
- * 后端给出的下一步动作标识。取值是开放集合（编排层会派生动态类型），
- * 界面按已知值分派、其余走兜底陈述，不做穷举断言。
+ * 后端给出的下一步动作标识的闭集，与 `lib/workflow_state.py` 的 `WorkflowActionType`
+ * 一一对应，后端契约测试守住两侧同步。列成运行时数组而不只是类型，是为了让译文覆盖
+ * 检查能逐个遍历：新增动作没配文案时测试直接红，而不是静默落到兜底陈述。
  */
-export type WorkflowActionType = string;
+export const WORKFLOW_ACTION_TYPES = [
+  "none",
+  "collect_project_input",
+  "draft_selling_points",
+  "analyze_assets",
+  "plan_episodes",
+  "reset_episode_planning",
+  "prepare_step1",
+  "confirm_step1",
+  "generate_script",
+  "generate_asset_sheets",
+  "generate_storyboards",
+  "generate_grid",
+  "repair_video_units",
+  "generate_videos",
+  "export",
+  "retry_project_migration",
+  "patch_episode_script",
+  "choose_narration_delivery",
+  "retry",
+  "resume",
+  "fix_input",
+  "generate_dependency",
+  "generate_tts",
+  "regenerate_tts",
+  "wait_for_task",
+  "replan_unit",
+  "confirm_request_duration",
+  "configure_provider",
+  "repair_artifact_state",
+] as const;
+
+export type WorkflowActionType = (typeof WORKFLOW_ACTION_TYPES)[number];
 
 export interface WorkflowNextAction {
   type: WorkflowActionType;

--- a/lib/source_revision.py
+++ b/lib/source_revision.py
@@ -43,6 +43,22 @@ class SourceRevisionBlocker(BaseModel):
     reason: str
 
 
+class SourceFileRead(BaseModel):
+    """One source file as it was read while computing the revision.
+
+    ``name`` is the on-disk directory entry, kept un-normalized so consumers can
+    rebuild the very same relative path other source readers use; ``rel_path`` is
+    the NFC-normalized project-relative path that ``SourceRevisionResult.files``
+    reports. ``text`` is the decoded content, not yet line-ending normalized.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    rel_path: str
+    text: str
+
+
 class SourceRevisionResult(BaseModel):
     """Revision calculation result; blockers and a revision are mutually exclusive."""
 
@@ -50,6 +66,9 @@ class SourceRevisionResult(BaseModel):
     revision: str | None
     files: list[str] = Field(default_factory=list)
     blockers: list[SourceRevisionBlocker] = Field(default_factory=list)
+    # 本次计算读到的原文，供同一请求内的其他消费方复用，免得为同一批源文再读一遍磁盘。
+    # 只在进程内传递，故排除出任何序列化输出。
+    documents: list[SourceFileRead] = Field(default_factory=list, exclude=True, repr=False)
 
 
 def _blocked(
@@ -152,9 +171,11 @@ def _read_sources(
     project_dir: Path,
     scope: SourceScope,
     paths: list[tuple[str, Path]],
-) -> tuple[list[tuple[str, str]], SourceRevisionResult | None]:
+) -> tuple[list[tuple[SourceFileRead, str]], SourceRevisionResult | None]:
+    """Read each source file exactly once, returning its text alongside its digest."""
+
     project_real = project_dir.resolve()
-    fingerprints: list[tuple[str, str]] = []
+    reads: list[tuple[SourceFileRead, str]] = []
     canonical_paths: set[str] = set()
     for rel, path in paths:
         if rel in canonical_paths:
@@ -182,11 +203,11 @@ def _read_sources(
         except OSError as exc:
             return [], _blocked(scope, "source_unreadable", rel, f"source file cannot be read: {exc}")
         try:
-            content.decode("utf-8")
+            text = content.decode("utf-8")
         except UnicodeDecodeError:
             return [], _blocked(scope, "source_unreadable", rel, "source file is not valid UTF-8")
-        fingerprints.append((rel, hashlib.sha256(content).hexdigest()))
-    return fingerprints, None
+        reads.append((SourceFileRead(name=path.name, rel_path=rel, text=text), hashlib.sha256(content).hexdigest()))
+    return reads, None
 
 
 def compute_source_revision(
@@ -212,13 +233,13 @@ def compute_source_revision(
     if error is not None:
         return error
 
-    fingerprints, error = _read_sources(project_dir, parsed_scope, paths)
+    reads, error = _read_sources(project_dir, parsed_scope, paths)
     if error is not None:
         return error
 
-    canonical_fingerprints = sorted(fingerprints, key=lambda item: item[0])
+    canonical_fingerprints = sorted(reads, key=lambda item: item[0].rel_path)
     payload = {
-        "files": [{"path": rel, "sha256": digest} for rel, digest in canonical_fingerprints],
+        "files": [{"path": read.rel_path, "sha256": digest} for read, digest in canonical_fingerprints],
         "source_kind": project.get("source_kind", "novel"),
         "source_language": project.get("source_language"),
     }
@@ -231,10 +252,12 @@ def compute_source_revision(
         scope=canonical_scope,
         revision=revision,
         files=[rel for rel, _path in paths],
+        documents=[read for read, _digest in reads],
     )
 
 
 __all__ = [
+    "SourceFileRead",
     "SourceRevisionBlocker",
     "SourceRevisionResult",
     "SourceScope",

--- a/lib/workflow_plan.py
+++ b/lib/workflow_plan.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from lib.generation_result import GenerationAction, GenerationBatchResult, GenerationProblem, ProviderCheckpoint
 from lib.narration_delivery import POST_PRODUCTION, USE_TTS, NarrationDelivery
 from lib.workflow_rules import WorkflowStepRule, workflow_rule
-from lib.workflow_state import WorkflowBlocker, WorkflowNextAction, WorkflowStatus
+from lib.workflow_state import WorkflowActionType, WorkflowBlocker, WorkflowNextAction, WorkflowStatus
 
 PositiveStrictInt = Annotated[int, Field(strict=True, gt=0)]
 
@@ -142,13 +142,13 @@ def _baseline_step_state(
         return WorkflowStepState.COMPLETED
     if index > current_index:
         return WorkflowStepState.PENDING
-    if status.blockers or status.next_action.type == "none":
+    if status.blockers or status.next_action.type is WorkflowActionType.NONE:
         return WorkflowStepState.BLOCKED
     return WorkflowStepState.READY
 
 
 def _current_rule_index(status: WorkflowStatus, rules: tuple[WorkflowStepRule, ...]) -> int:
-    if status.next_action.type == "repair_video_units":
+    if status.next_action.type is WorkflowActionType.REPAIR_VIDEO_UNITS:
         return next(index for index, rule in enumerate(rules) if rule.id == "script_structure")
     for index, rule in enumerate(rules):
         if rule.applicable and rule.checkpoint == status.state:
@@ -189,7 +189,7 @@ def _structure_action(
     script_revision: str | None,
 ) -> WorkflowNextAction:
     return WorkflowNextAction(
-        type="patch_episode_script",
+        type=WorkflowActionType.PATCH_EPISODE_SCRIPT,
         args={
             "expected_revision": script_revision,
             "problems": [problem.model_dump(mode="json") for problem in problems],
@@ -205,8 +205,9 @@ def _admission_action(
     requested_ids: list[str],
 ) -> WorkflowNextAction:
     requires_confirmation = admission.get("decision") == "confirmation_required"
+    action = problems[0].action if problems else GenerationAction.CONFIRM_REQUEST_DURATION
     return WorkflowNextAction(
-        type=problems[0].action.value if problems else GenerationAction.CONFIRM_REQUEST_DURATION.value,
+        type=WorkflowActionType(action.value),
         args={"admission": admission},
         requested_ids=requested_ids,
         requires_confirmation=requires_confirmation,
@@ -255,7 +256,7 @@ def build_workflow_plan(
             ),
         )
         if step_rule.id == "narration_delivery":
-            step.required = status.state == "VIDEO" and status.next_action.type == "generate_videos"
+            step.required = status.state == "VIDEO" and status.next_action.type is WorkflowActionType.GENERATE_VIDEOS
         if step.artifacts.get("state") == "blocked" and step.state is not WorkflowStepState.SKIPPED:
             step.state = WorkflowStepState.BLOCKED
         steps.append(step)
@@ -306,7 +307,7 @@ def build_workflow_plan(
         next_action = _structure_action(structure_problems, script_revision=script_revision)
     elif active_tasks:
         next_action = WorkflowNextAction(
-            type=GenerationAction.WAIT_FOR_TASK.value,
+            type=WorkflowActionType.WAIT_FOR_TASK,
             args={"task_ids": [task.task_id for task in active_tasks]},
             requested_ids=[task.unit_id for task in active_tasks],
             reason="workflow has active generation tasks",
@@ -316,9 +317,13 @@ def build_workflow_plan(
                 step.action = next_action
         if video_step.state is not WorkflowStepState.ACTIVE:
             video_step.action = None
-    elif status.state == "VIDEO" and status.next_action.type == "generate_videos" and narration_delivery is None:
+    elif (
+        status.state == "VIDEO"
+        and status.next_action.type is WorkflowActionType.GENERATE_VIDEOS
+        and narration_delivery is None
+    ):
         next_action = WorkflowNextAction(
-            type="choose_narration_delivery",
+            type=WorkflowActionType.CHOOSE_NARRATION_DELIVERY,
             args={"options": [POST_PRODUCTION, USE_TTS]},
             requested_ids=list(status.next_action.requested_ids),
             reason="choose narration delivery for this video request",

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -7,6 +7,7 @@ import json
 import unicodedata
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from functools import partial
 from pathlib import Path
 from typing import Any, Literal
@@ -22,7 +23,6 @@ from lib.episode_ledger import (
     SOURCE_FINGERPRINTS_KEY,
     SourceDoc,
     compute_source_fingerprints,
-    discover_sources,
     episodes_without_source_range,
     mismatched_source_fingerprints,
     normalize_source_text,
@@ -33,7 +33,6 @@ from lib.project_manager import ProjectManager
 from lib.project_migration_failure import (
     MIGRATION_FAILURE_CODE,
     MIGRATION_FAILURE_FILENAME,
-    RETRY_MIGRATION_ACTION,
     MigrationFailureRecord,
     load_migration_failure,
 )
@@ -93,10 +92,57 @@ class WorkflowBlocker(BaseModel):
     reason: str
 
 
+class WorkflowActionType(StrEnum):
+    """``WorkflowNextAction.type`` 的闭集。
+
+    三个来源合成同一份取值：本模块按编排阶段给出的动作、``lib.workflow_plan`` 投影时
+    额外注入的动作，以及批量准入被拒时原样交回的 ``lib.generation_result.GenerationAction``。
+    消费方（前端联合类型、profile 受控动作表、动作译文）一律从本枚举派生，新增成员即
+    自动进入各处覆盖检查，不必再手抄一份清单。
+    """
+
+    # 本模块按编排阶段给出的动作
+    NONE = "none"
+    COLLECT_PROJECT_INPUT = "collect_project_input"
+    DRAFT_SELLING_POINTS = "draft_selling_points"
+    ANALYZE_ASSETS = "analyze_assets"
+    PLAN_EPISODES = "plan_episodes"
+    RESET_EPISODE_PLANNING = "reset_episode_planning"
+    PREPARE_STEP1 = "prepare_step1"
+    CONFIRM_STEP1 = "confirm_step1"
+    GENERATE_SCRIPT = "generate_script"
+    GENERATE_ASSET_SHEETS = "generate_asset_sheets"
+    GENERATE_STORYBOARDS = "generate_storyboards"
+    GENERATE_GRID = "generate_grid"
+    REPAIR_VIDEO_UNITS = "repair_video_units"
+    GENERATE_VIDEOS = "generate_videos"
+    EXPORT = "export"
+
+    # 数据升级失败的项目在任何阶段都只报这一个动作
+    RETRY_PROJECT_MIGRATION = "retry_project_migration"
+
+    # ``build_workflow_plan`` 投影时注入的动作
+    PATCH_EPISODE_SCRIPT = "patch_episode_script"
+    CHOOSE_NARRATION_DELIVERY = "choose_narration_delivery"
+
+    # ``GenerationAction`` 闭集；批量准入与任务失败把它原样交回成 next_action
+    RETRY = "retry"
+    RESUME = "resume"
+    FIX_INPUT = "fix_input"
+    GENERATE_DEPENDENCY = "generate_dependency"
+    GENERATE_TTS = "generate_tts"
+    REGENERATE_TTS = "regenerate_tts"
+    WAIT_FOR_TASK = "wait_for_task"
+    REPLAN_UNIT = "replan_unit"
+    CONFIRM_REQUEST_DURATION = "confirm_request_duration"
+    CONFIGURE_PROVIDER = "configure_provider"
+    REPAIR_ARTIFACT_STATE = "repair_artifact_state"
+
+
 class WorkflowNextAction(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    type: str
+    type: WorkflowActionType
     args: dict[str, Any] = Field(default_factory=dict)
     requested_ids: list[str] = Field(default_factory=list)
     requires_confirmation: bool = False
@@ -138,7 +184,7 @@ def _project_revision(project: Mapping[str, Any]) -> str:
 
 
 def _action(
-    action_type: str,
+    action_type: WorkflowActionType,
     reason: str,
     *,
     args: dict[str, Any] | None = None,
@@ -151,6 +197,21 @@ def _action(
         requested_ids=ids or [],
         requires_confirmation=requires_confirmation,
         reason=reason,
+    )
+
+
+def planning_docs(source: SourceRevisionResult | None) -> tuple[SourceDoc, ...]:
+    """把修订号计算那一次读取的原文转成账本坐标系里的源文档。
+
+    源文在一次状态查询里只读一遍：``compute_source_revision`` 已经把每份源文读进内存，
+    分集排布所需的归一化全文由那一次读取派生，不再回磁盘重读。
+    """
+
+    if source is None or source.blockers:
+        return ()
+    return tuple(
+        SourceDoc(rel_path=f"source/{document.name}", text=normalize_source_text(document.text))
+        for document in source.documents
     )
 
 
@@ -438,26 +499,29 @@ class WorkflowStateService:
     def _planning_action(project: dict[str, Any], reason: str) -> WorkflowNextAction:
         if episodes_without_source_range(project):
             return _action(
-                "reset_episode_planning",
+                WorkflowActionType.RESET_EPISODE_PLANNING,
                 "episode ledger lacks source range records",
                 args={"from_episode": 1},
             )
-        return _action("plan_episodes", reason)
+        return _action(WorkflowActionType.PLAN_EPISODES, reason)
 
     @staticmethod
     def _planning_complete(
-        project_path: Path,
         project: dict[str, Any],
         source: SourceRevisionResult | None,
-        planning_sources: tuple[SourceDoc, ...] | None = None,
+        planning_sources: tuple[SourceDoc, ...],
     ) -> bool:
+        """判定源文是否已全部排布完。
+
+        源文只来自 ``planning_sources``——本次请求已经读过一遍的那份，不再回磁盘取。
+        """
+
         if source is None or not source.files:
             return False
         recorded_fingerprints = project.get(SOURCE_FINGERPRINTS_KEY)
         if not isinstance(recorded_fingerprints, Mapping) or not recorded_fingerprints:
             return False
-        current_sources = tuple(discover_sources(project_path)) if planning_sources is None else planning_sources
-        current_fingerprints = compute_source_fingerprints(list(current_sources))
+        current_fingerprints = compute_source_fingerprints(list(planning_sources))
         if dict(recorded_fingerprints) != current_fingerprints:
             return False
         cursor = project.get("planning_cursor")
@@ -468,28 +532,8 @@ class WorkflowStateService:
         canonical_rel = unicodedata.normalize("NFC", rel) if isinstance(rel, str) else None
         if canonical_rel != source.files[-1] or not isinstance(offset, int) or isinstance(offset, bool):
             return False
-        if planning_sources is not None:
-            matching_docs = [
-                doc for doc in current_sources if unicodedata.normalize("NFC", doc.rel_path) == canonical_rel
-            ]
-            return len(matching_docs) == 1 and offset >= len(matching_docs[0].text)
-        try:
-            source_dir = project_path / "source"
-            if source_dir.is_symlink():
-                return False
-            matching_paths = [
-                path
-                for path in source_dir.iterdir()
-                if unicodedata.normalize("NFC", f"source/{path.name}") == canonical_rel
-            ]
-            if len(matching_paths) != 1 or matching_paths[0].is_symlink():
-                return False
-            path = matching_paths[0]
-            path.resolve(strict=True).relative_to(project_path.resolve())
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError, ValueError):
-            return False
-        return offset >= len(normalize_source_text(text))
+        matching_docs = [doc for doc in planning_sources if unicodedata.normalize("NFC", doc.rel_path) == canonical_rel]
+        return len(matching_docs) == 1 and offset >= len(matching_docs[0].text)
 
     def _load_script_artifacts(
         self,
@@ -741,10 +785,8 @@ class WorkflowStateService:
                 )
             )
         source, inventory = self._source_inventory(project_path, project, str(mode), blockers)
-        planning_sources = (
-            tuple(discover_sources(project_path)) if mode != "ad" and source is not None and not source.blockers else ()
-        )
-        planning_complete = self._planning_complete(project_path, project, source, planning_sources)
+        planning_sources = planning_docs(source) if mode != "ad" else ()
+        planning_complete = self._planning_complete(project, source, planning_sources)
         sheets = self._asset_sheets(project_path, project, blockers, currency)
         episodes = self._episodes(project, blockers)
         return _SharedWorkflowFacts(
@@ -825,17 +867,17 @@ class WorkflowStateService:
         next_action: WorkflowNextAction
         if blockers:
             state = "PROJECT_INPUT"
-            next_action = _action("none", "workflow is blocked")
+            next_action = _action(WorkflowActionType.NONE, "workflow is blocked")
         elif mode != "ad" and (source is None or not source.files):
             state = "PROJECT_INPUT"
-            next_action = _action("collect_project_input", "source text is required")
+            next_action = _action(WorkflowActionType.COLLECT_PROJECT_INPUT, "source text is required")
         elif mode != "ad" and not any(doc.text.strip() for doc in shared.planning_sources):
             state = "PROJECT_INPUT"
-            next_action = _action("collect_project_input", "non-blank source text is required")
+            next_action = _action(WorkflowActionType.COLLECT_PROJECT_INPUT, "non-blank source text is required")
         elif mode != "ad" and inventory.get("state") != "current":
             state = "ASSET_INVENTORY"
             next_action = _action(
-                "analyze_assets",
+                WorkflowActionType.ANALYZE_ASSETS,
                 "asset inventory is missing or out of date",
                 args={
                     "scope": {"kind": "all", "files": []},
@@ -845,14 +887,14 @@ class WorkflowStateService:
         elif mode != "ad" and _planning_fingerprints_diverged(project, shared.planning_sources):
             state = "EPISODE_PLAN"
             next_action = _action(
-                "reset_episode_planning",
+                WorkflowActionType.RESET_EPISODE_PLANNING,
                 "source files changed after episode planning",
                 args={"from_episode": 1},
             )
         elif mode != "ad" and _new_source_precedes_cursor(project, shared.planning_sources):
             state = "EPISODE_PLAN"
             next_action = _action(
-                "reset_episode_planning",
+                WorkflowActionType.RESET_EPISODE_PLANNING,
                 "new source text precedes the current planning cursor",
                 args={"from_episode": 1},
             )
@@ -866,7 +908,7 @@ class WorkflowStateService:
                         reason="requested episode is absent and all source text is already planned",
                     )
                 )
-                next_action = _action("none", "requested episode is unavailable")
+                next_action = _action(WorkflowActionType.NONE, "requested episode is unavailable")
             else:
                 next_action = self._planning_action(project, "episode ledger has no target episode")
         else:
@@ -886,7 +928,7 @@ class WorkflowStateService:
                         artifacts["step1"] = {"state": "stale"}
                         state = "EPISODE_PLAN"
                         next_action = _action(
-                            "reset_episode_planning",
+                            WorkflowActionType.RESET_EPISODE_PLANNING,
                             "legacy stale episode has no rebuild baseline",
                             args={"from_episode": target.episode},
                         )
@@ -897,7 +939,7 @@ class WorkflowStateService:
                         artifacts["step1"] = {"state": "stale"}
                         state = "STEP1_CONTENT"
                         next_action = _action(
-                            "prepare_step1",
+                            WorkflowActionType.PREPARE_STEP1,
                             "target episode was replanned and its downstream artifacts are stale",
                             args={
                                 "episode": target.episode,
@@ -920,7 +962,7 @@ class WorkflowStateService:
                     if pending_points:
                         state = "SELLING_POINTS"
                         next_action = _action(
-                            "draft_selling_points", "products need selling points", ids=pending_points
+                            WorkflowActionType.DRAFT_SELLING_POINTS, "products need selling points", ids=pending_points
                         )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                 else:
@@ -951,16 +993,18 @@ class WorkflowStateService:
                             )
                         )
                         state = "STEP1_REVIEW"
-                        next_action = _action("none", "quarantined step1 must be repaired before confirmation")
+                        next_action = _action(
+                            WorkflowActionType.NONE, "quarantined step1 must be repaired before confirmation"
+                        )
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                     if artifacts["step1"]["state"] == "blocked":
                         state = "STEP1_CONTENT"
-                        next_action = _action("none", "formal step1 currency is blocked")
+                        next_action = _action(WorkflowActionType.NONE, "formal step1 currency is blocked")
                         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
                     if artifacts["step1"]["state"] == "missing":
                         state = "STEP1_CONTENT"
                         next_action = _action(
-                            "prepare_step1",
+                            WorkflowActionType.PREPARE_STEP1,
                             "target episode has no formal step1",
                             args={"episode": target.episode, "preprocessor": preprocessor},
                         )
@@ -979,7 +1023,7 @@ class WorkflowStateService:
                     if review != "confirmed":
                         state = "STEP1_REVIEW"
                         next_action = _action(
-                            "confirm_step1",
+                            WorkflowActionType.CONFIRM_STEP1,
                             "formal step1 awaits content review",
                             args={"episode": target.episode},
                             requires_confirmation=True,
@@ -1006,13 +1050,13 @@ class WorkflowStateService:
                         artifacts["script"]["state"] = "stale"
                 if blockers:
                     state = "FINAL_SCRIPT"
-                    next_action = _action("none", "script is blocked")
+                    next_action = _action(WorkflowActionType.NONE, "script is blocked")
                 elif script_artifact["state"] == "missing" or (
                     currency is None and script_artifact["state"] == "stale"
                 ):
                     state = "FINAL_SCRIPT"
                     next_action = _action(
-                        "generate_script",
+                        WorkflowActionType.GENERATE_SCRIPT,
                         "target episode has no current final script",
                         args={"episode": target.episode},
                     )
@@ -1026,7 +1070,9 @@ class WorkflowStateService:
                     if missing_sheets:
                         state = "ASSET_SHEETS"
                         next_action = _action(
-                            "generate_asset_sheets", "asset definitions need sheets", ids=missing_sheets
+                            WorkflowActionType.GENERATE_ASSET_SHEETS,
+                            "asset definitions need sheets",
+                            ids=missing_sheets,
                         )
                     else:
                         artifacts["storyboards"] = (
@@ -1077,12 +1123,12 @@ class WorkflowStateService:
                         )
                         if blockers:
                             state = "VIDEO"
-                            next_action = _action("none", "video metadata is blocked")
+                            next_action = _action(WorkflowActionType.NONE, "video metadata is blocked")
                         elif generation_mode == "storyboard" and artifacts["storyboards"]["missing_ids"]:
                             missing = artifacts["storyboards"]["missing_ids"]
                             state = "STORYBOARD"
                             next_action = _action(
-                                "generate_grid" if grid else "generate_storyboards",
+                                WorkflowActionType.GENERATE_GRID if grid else WorkflowActionType.GENERATE_STORYBOARDS,
                                 "storyboard images are missing",
                                 args={"episode": target.episode},
                                 ids=missing,
@@ -1094,7 +1140,7 @@ class WorkflowStateService:
                         ]:
                             state = "VIDEO"
                             next_action = _action(
-                                "repair_video_units",
+                                WorkflowActionType.REPAIR_VIDEO_UNITS,
                                 "video units need replanning before generation",
                                 args={"episode": target.episode},
                                 ids=replan_ids,
@@ -1103,7 +1149,7 @@ class WorkflowStateService:
                             missing = artifacts["videos"]["missing_ids"]
                             state = "VIDEO"
                             next_action = _action(
-                                "generate_videos",
+                                WorkflowActionType.GENERATE_VIDEOS,
                                 "video clips are missing",
                                 args={"episode": target.episode},
                                 ids=missing,
@@ -1131,13 +1177,13 @@ class WorkflowStateService:
                                 next_action = self._planning_action(project, "source text remains unplanned")
                             else:
                                 state = "EXPORT_READY"
-                                next_action = _action("export", "all required artifacts are usable")
+                                next_action = _action(WorkflowActionType.EXPORT, "all required artifacts are usable")
                         elif mode != "ad" and not shared.planning_complete:
                             state = "EPISODE_PLAN"
                             next_action = self._planning_action(project, "source text remains unplanned")
                         else:
                             state = "EXPORT_READY"
-                            next_action = _action("export", "all required artifacts are usable")
+                            next_action = _action(WorkflowActionType.EXPORT, "all required artifacts are usable")
 
         return self._response(project, source, target, state, blockers, gates, artifacts, next_action)
 
@@ -1208,13 +1254,14 @@ def migration_next_action(failure: MigrationFailureRecord) -> WorkflowNextAction
     """Repair the reported inputs, then rerun the chain — the only way forward."""
 
     return _action(
-        RETRY_MIGRATION_ACTION,
+        WorkflowActionType.RETRY_PROJECT_MIGRATION,
         failure.reason,
         args={"details": [detail.model_dump(mode="json") for detail in failure.details]},
     )
 
 
 __all__ = [
+    "WorkflowActionType",
     "WorkflowBlocker",
     "WorkflowNextAction",
     "WorkflowProject",
@@ -1224,4 +1271,5 @@ __all__ = [
     "WorkflowTarget",
     "migration_blocker",
     "migration_next_action",
+    "planning_docs",
 ]

--- a/tests/integration/test_workflow_planner.py
+++ b/tests/integration/test_workflow_planner.py
@@ -11,7 +11,13 @@ from lib.generation_result import GenerationSelectionMode
 from lib.narration_delivery import POST_PRODUCTION
 from lib.project_manager import ProjectManager
 from lib.workflow_plan import WorkflowPlanRequest, WorkflowStepState
-from lib.workflow_state import WorkflowNextAction, WorkflowProject, WorkflowStatus, WorkflowTarget
+from lib.workflow_state import (
+    WorkflowActionType,
+    WorkflowNextAction,
+    WorkflowProject,
+    WorkflowStatus,
+    WorkflowTarget,
+)
 from server.services import video_batch_admission, workflow_planner
 
 pytestmark = pytest.mark.integration
@@ -46,7 +52,7 @@ def _status(*, state: str = "VIDEO", action: str = "generate_videos") -> Workflo
                 "audio": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
             },
             "next_action": WorkflowNextAction(
-                type=action,
+                type=WorkflowActionType(action),
                 requested_ids=["E1S01"],
                 reason="next",
             ),

--- a/tests/integration/test_workflow_state.py
+++ b/tests/integration/test_workflow_state.py
@@ -15,7 +15,7 @@ from lib.project_manager import ProjectManager
 from lib.project_migrations.v7_to_v8_artifact_manifest import migrate_v7_to_v8
 from lib.source_revision import SourceScope, compute_source_revision
 from lib.version_manager import MANUAL_UPLOAD_VERSION_SOURCE, VersionManager
-from lib.workflow_state import WorkflowStateService
+from lib.workflow_state import WorkflowStateService, planning_docs
 
 
 def _make_project(
@@ -468,6 +468,49 @@ def test_unplanned_source_with_legacy_episode_without_source_range_requires_full
     assert status.next_action.args == {"from_episode": 1}
 
 
+def _count_source_reads(monkeypatch: pytest.MonkeyPatch, project_path: Path) -> dict[str, int]:
+    """记录 ``source/`` 直下每份源文被读取的次数，字节与文本两条读法都算。"""
+
+    counts: dict[str, int] = {}
+    source_dir = (project_path / "source").resolve()
+    original_read_bytes = Path.read_bytes
+    original_read_text = Path.read_text
+
+    def _record(path: Path) -> None:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return
+        if resolved.parent == source_dir:
+            counts[resolved.name] = counts.get(resolved.name, 0) + 1
+
+    def _counted_read_bytes(self: Path) -> bytes:
+        _record(self)
+        return original_read_bytes(self)
+
+    def _counted_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        _record(self)
+        return original_read_text(self, *args, **kwargs)  # pyright: ignore[reportArgumentType, reportCallIssue]
+
+    monkeypatch.setattr(Path, "read_bytes", _counted_read_bytes)
+    monkeypatch.setattr(Path, "read_text", _counted_read_text)
+    return counts
+
+
+@pytest.mark.integration
+def test_status_reads_each_source_file_exactly_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """修订号计算与分集排布共用同一次读取；源文越多，重复读的代价越大。"""
+
+    pm, project_path = _make_project(tmp_path, "narration")
+    (project_path / "source" / "novel.txt").write_text("第一份原文", encoding="utf-8")
+    (project_path / "source" / "extra.md").write_text("第二份原文", encoding="utf-8")
+
+    source_reads = _count_source_reads(monkeypatch, project_path)
+    WorkflowStateService(pm).get_status("demo")
+
+    assert source_reads == {"novel.txt": 1, "extra.md": 1}
+
+
 @pytest.mark.integration
 def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -512,10 +555,8 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
     load_calls = 0
     source_inventory_calls = 0
     asset_sheet_calls = 0
-    source_discovery_calls = 0
     original_source_inventory = WorkflowStateService._source_inventory
     original_asset_sheets = WorkflowStateService._asset_sheets
-    original_discover_sources = discover_sources
 
     def _counted_load_project(project_name: str) -> dict:
         nonlocal load_calls
@@ -532,21 +573,16 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
         asset_sheet_calls += 1
         return original_asset_sheets(*args, **kwargs)
 
-    def _counted_discover_sources(*args, **kwargs):
-        nonlocal source_discovery_calls
-        source_discovery_calls += 1
-        return original_discover_sources(*args, **kwargs)
-
     monkeypatch.setattr(pm, "load_project_readonly", _counted_load_project)
     monkeypatch.setattr(WorkflowStateService, "_source_inventory", _counted_source_inventory)
     monkeypatch.setattr(WorkflowStateService, "_asset_sheets", _counted_asset_sheets)
-    monkeypatch.setattr("lib.workflow_state.discover_sources", _counted_discover_sources)
+    source_reads = _count_source_reads(monkeypatch, project_path)
     status = WorkflowStateService(pm).get_status("demo")
 
     assert load_calls == 1
     assert source_inventory_calls == 1
     assert asset_sheet_calls == 1
-    assert source_discovery_calls == 1
+    assert source_reads == {"novel.txt": 1}
     assert status.target is not None
     assert status.target.episode == 2
     assert status.state == "STEP1_CONTENT"
@@ -1638,7 +1674,7 @@ def test_planning_completion_resolves_nfc_cursor_to_nfd_filesystem_path(tmp_path
     project["planning_cursor"] = {"source_file": source.files[-1], "offset": 4}
     project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(discover_sources(project_path))
 
-    assert WorkflowStateService._planning_complete(project_path, project, source) is True
+    assert WorkflowStateService._planning_complete(project, source, planning_docs(source)) is True
 
 
 @pytest.mark.integration
@@ -1651,7 +1687,7 @@ def test_planning_without_source_fingerprint_baseline_is_incomplete(tmp_path: Pa
     assert source.revision is not None
     project["planning_cursor"] = {"source_file": source.files[-1], "offset": 4}
 
-    assert WorkflowStateService._planning_complete(project_path, project, source) is False
+    assert WorkflowStateService._planning_complete(project, source, planning_docs(source)) is False
 
 
 @pytest.mark.integration
@@ -1691,7 +1727,7 @@ def test_planning_completion_preserves_planner_order_for_canonical_paths(tmp_pat
     project["planning_cursor"] = {"source_file": docs[-1].rel_path, "offset": len(docs[-1].text)}
     project[SOURCE_FINGERPRINTS_KEY] = compute_source_fingerprints(docs)
 
-    assert WorkflowStateService._planning_complete(project_path, project, source) is True
+    assert WorkflowStateService._planning_complete(project, source, planning_docs(source)) is True
 
 
 @pytest.mark.integration

--- a/tests/prompt_rules/test_video_workflow_prompt.py
+++ b/tests/prompt_rules/test_video_workflow_prompt.py
@@ -32,7 +32,7 @@ from lib.narration_delivery import POST_PRODUCTION, USE_TTS, NarrationTtsStatus
 from lib.profile_manifest import VALID_CONTENT_MODES, resolve_profile_files_for_mode
 from lib.workflow_plan import _structure_action
 from lib.workflow_rules import WORKFLOW_RULES
-from lib.workflow_state import WorkflowTarget
+from lib.workflow_state import WorkflowActionType, WorkflowTarget
 from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 
 pytestmark = pytest.mark.unit
@@ -47,34 +47,10 @@ GENERATION_RESULTS_REFERENCE = REFERENCES / "generation-results.md"
 WORKFLOW_VARIANTS = ("SKILL.narration.md", "SKILL.drama.md", "SKILL.ad.md")
 EPISODIC_VARIANTS = ("SKILL.narration.md", "SKILL.drama.md")
 
-# ``workflow_state`` 自己产出的动作类型是散落的字符串字面量，没有枚举可导入，只能手写。
-_WORKFLOW_STATE_ACTIONS = (
-    "collect_project_input",
-    "draft_selling_points",
-    "analyze_assets",
-    "plan_episodes",
-    "reset_episode_planning",
-    "prepare_step1",
-    "confirm_step1",
-    "generate_script",
-    "generate_asset_sheets",
-    "generate_storyboards",
-    "generate_grid",
-    "generate_videos",
-    "repair_video_units",
-    "export",
-    "none",
-)
-
-# ``build_workflow_plan`` 额外注入的动作类型。
-_PLAN_INJECTED_ACTIONS = ("patch_episode_script", "choose_narration_delivery")
-
-# 批量准入被拒时 ``_admission_action`` 把 ``problems[0].action`` 直接当成 ``next_action.type``
-# 交回，所以整个 ``GenerationAction`` 闭集都可能出现在计划里。从枚举导出而不是手抄，新增
-# 动作时这份契约测试会直接红。
-CONTROLLED_ACTIONS = tuple(
-    dict.fromkeys((*_WORKFLOW_STATE_ACTIONS, *_PLAN_INJECTED_ACTIONS, *(action.value for action in GenerationAction)))
-)
+# ``next_action.type`` 的闭集就是 ``WorkflowActionType``：编排动作、计划注入的动作与
+# ``GenerationAction``（批量准入被拒时原样交回）都在其中。从枚举导出而不是手抄，新增成员
+# 时这份契约测试会直接红。
+CONTROLLED_ACTIONS = tuple(action.value for action in WorkflowActionType)
 
 
 def _skill(filename: str) -> str:

--- a/tests/test_workflow_action_types.py
+++ b/tests/test_workflow_action_types.py
@@ -1,0 +1,48 @@
+"""`next_action.type` 闭集的跨语言契约。
+
+枚举是唯一真相源；前端联合类型与 profile 受控动作表都从它派生，这里守住派生结果没有漂移。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lib.generation_result import GenerationAction
+from lib.project_migration_failure import RETRY_MIGRATION_ACTION
+from lib.workflow_state import WorkflowActionType
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[1]
+FRONTEND_TYPES = REPO / "frontend" / "src" / "types" / "workflow.ts"
+
+_ARRAY_RE = re.compile(r"export const WORKFLOW_ACTION_TYPES = \[(.*?)\] as const;", re.DOTALL)
+
+
+def _frontend_action_types() -> list[str]:
+    match = _ARRAY_RE.search(FRONTEND_TYPES.read_text(encoding="utf-8"))
+    assert match is not None, "frontend/src/types/workflow.ts 未导出 WORKFLOW_ACTION_TYPES"
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def test_generation_actions_are_all_dispatchable_next_actions() -> None:
+    """批量准入被拒时 problems[0].action 会原样成为 next_action.type，闭集必须容得下它。"""
+
+    missing = {action.value for action in GenerationAction} - {action.value for action in WorkflowActionType}
+
+    assert not missing, f"WorkflowActionType 缺少 GenerationAction 取值：{sorted(missing)}"
+
+
+def test_migration_retry_action_is_in_the_closed_set() -> None:
+    """升级失败的项目只报这一个动作；它与闭集脱钩就等于状态查询整体不可用。"""
+
+    assert RETRY_MIGRATION_ACTION == WorkflowActionType.RETRY_PROJECT_MIGRATION.value
+
+
+def test_frontend_union_matches_the_backend_enum() -> None:
+    """前端按这份闭集分派动作；漏一个就是界面把后端明确给出的一步讲成未知动作。"""
+
+    assert _frontend_action_types() == [action.value for action in WorkflowActionType]

--- a/tests/test_workflow_plan.py
+++ b/tests/test_workflow_plan.py
@@ -22,6 +22,7 @@ from lib.workflow_plan import (
 )
 from lib.workflow_rules import WORKFLOW_RULES, workflow_rule
 from lib.workflow_state import (
+    WorkflowActionType,
     WorkflowBlocker,
     WorkflowNextAction,
     WorkflowProject,
@@ -73,7 +74,7 @@ def _status(
                 "audio": {"current_ids": [], "stale_ids": [], "missing_ids": ["E1S01"]},
             },
             "next_action": WorkflowNextAction(
-                type=action,
+                type=WorkflowActionType(action),
                 requested_ids=requested_ids or ["E1S01"],
                 reason="video clips are missing",
             ),
@@ -293,7 +294,7 @@ def test_unrepairable_structural_blocker_stays_a_status_blocker_before_media() -
         reason="script container is not repairable through media actions",
     )
     status.blockers = [blocker]
-    status.next_action = WorkflowNextAction(type="none", reason="workflow is blocked")
+    status.next_action = WorkflowNextAction(type=WorkflowActionType.NONE, reason="workflow is blocked")
 
     plan = build_workflow_plan(status)
 
@@ -399,7 +400,7 @@ def test_stale_video_remains_exportable_without_an_implicit_regeneration_step() 
         "stale_ids": ["E1S01"],
         "missing_ids": [],
     }
-    status.next_action = WorkflowNextAction(type="export", reason="usable media is ready")
+    status.next_action = WorkflowNextAction(type=WorkflowActionType.EXPORT, reason="usable media is ready")
 
     plan = build_workflow_plan(status)
 

--- a/tests/test_workflow_plan_adapters.py
+++ b/tests/test_workflow_plan_adapters.py
@@ -11,6 +11,7 @@ from lib.narration_delivery import POST_PRODUCTION
 from lib.project_manager import ProjectManager
 from lib.workflow_plan import WorkflowPlanRequest, build_workflow_plan
 from lib.workflow_state import (
+    WorkflowActionType,
     WorkflowNextAction,
     WorkflowProject,
     WorkflowRequestError,
@@ -59,7 +60,7 @@ def _status() -> WorkflowStatus:
                 "audio": {"state": "not_applicable", "current_ids": [], "stale_ids": [], "missing_ids": []},
             },
             "next_action": WorkflowNextAction(
-                type="generate_videos",
+                type=WorkflowActionType.GENERATE_VIDEOS,
                 requested_ids=["E1S01"],
                 reason="video missing",
             ),


### PR DESCRIPTION
Closes #1914

## 变更

- **制作状态查询不再重复读源文**：`compute_source_revision` 计算修订号时本就把每份源文读进内存，现在把读取结果随 `SourceRevisionResult.documents` 一并回传（`exclude=True`，不进任何序列化），分集排布所需的 `SourceDoc` 由它派生，不再回磁盘重读。`SourceFileRead` 同时带磁盘原始文件名与 NFC 归一化路径，避免 macOS 上 NFD 文件名的项目指纹对不上。
- **工作台面板不再被别的项目刷屏**：任务指纹按当前项目过滤后再拼接，并加 250ms 防抖窗口——一批任务逐条跳状态时合并成一次 `POST /workflow-plan`。防抖只包住任务指纹这条噪声轴，项目名、剧集与用户选择仍即时生效。
- **下一步动作改为闭集枚举**：`WorkflowNextAction.type` 收敛为 `WorkflowActionType`（StrEnum），前端联合类型、profile 受控动作表与三语文案都从它派生，新增动作不再静默落到「未知动作」兜底文案。

## 与 #1923 的整合

本 PR rebase 到 `4ae96b22c` 时把 #1923 引入的 `retry_project_migration` 并入了闭集：枚举新增成员、前端 `WORKFLOW_ACTION_TYPES` 同位置追加、补三语 `action_retry_project_migration` 文案，并新增一条断言守住 `RETRY_MIGRATION_ACTION` 常量与枚举值不漂移。此前该动作以字符串常量直接传入，在 `type` 收敛为枚举后必须登记进闭集，否则升级失败的项目查状态会直接 ValidationError。

## 验证

在 `4ae96b22c`（origin/main）上 rebase 后重跑全部质量门，均通过：

| 质量门 | 结果 |
|---|---|
| `uv run python -m pytest` | 10249 passed, 2 skipped |
| `uv run ruff check .` / `ruff format --check .` | 通过，869 files already formatted |
| `uv run basedpyright` | 0 errors, 1284 warnings |
| `uv run lint-imports` | 1 kept, 0 broken |
| `uv run python -m pytest tests/prompt_rules` | 通过 |
| `cd frontend && pnpm lint` | 通过 |
| `cd frontend && pnpm check` | 155 files / 1866 tests passed |

三条验收标准各有对应断言：

- `tests/integration/test_workflow_state.py::test_status_reads_each_source_file_exactly_once` 同时打桩 `Path.read_bytes` 与 `Path.read_text`，断言每份源文读取次数恰为 1。
- `frontend/src/components/workflow/WorkflowPanel.test.tsx` 分别断言「别的项目的任务跳变不触发求解」与「本项目连续三次跳状态合并为一次求解」。
- `tests/test_workflow_action_types.py` 守住后端枚举与前端 `WORKFLOW_ACTION_TYPES` 同步，`frontend/src/components/workflow/action-language.test.ts` 逐个遍历闭集校验 zh/en/vi 文案覆盖。

## 备注

后端返回闭集之外的 `next_action.type` 时 `WorkflowStatus` 会 ValidationError 而非降级——这是刻意的 fail loud。`action_unknown` 兜底文案保留，供后端先于前端上线新动作的场景使用。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 工作流新增“修复项目文件后重试数据升级”操作提示，支持英文、越南文和中文。
  - 工作流规划可复用已读取的源文件内容，减少重复读取。

- **问题修复**
  - 连续任务状态变化将在短暂延迟后合并刷新，避免频繁重新计算。
  - 其他项目的任务状态变化不再触发当前项目的计划刷新。

- **稳定性改进**
  - 统一工作流动作定义，提升前后端动作识别和执行的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->