### PR TITLE
refactor(agent): 档案守卫只校验能对照代码的结构，说书档案清掉不适用的成片合成入口

### DIFF
--- a/agent_runtime_profile/.claude/references/workflow-plan.md
+++ b/agent_runtime_profile/.claude/references/workflow-plan.md
@@ -127,9 +127,8 @@ mcp__arcreel__get_workflow_plan({
 | `post_production` | 后期配音：视频照常生成，旁白留到剪映等后期工具里补 |
 | `use_tts` | 使用当前 TTS：把已生成的旁白音频作为本次请求的依据 |
 
-`generation_mode == "reference_video"` **只跳过分镜图**这一步（计划里 `storyboard` 步骤
-`required=false`），**不跳过 audio**：`narration_delivery` 步骤在两条路线上都适用。参考路线没有
-按段批量 TTS 的入口，但每个叙述旁白 unit 的交付选择照样要做。
+参考路线同样要做交付选择：两条路线跳过哪些步骤见
+[generation-modes.md](generation-modes.md)。
 
 计划给出 `next_action.type == "choose_narration_delivery"` 时：
 
@@ -179,19 +178,11 @@ mcp__arcreel__get_workflow_plan({
 
 ## 四条状态轴分开报告
 
-`workflow`（步骤进度）、`task`（队列任务）、`provider_checkpoint`（供应商是否已提交）、
-`artifact`（产物 `current_ids` / `stale_ids` / `missing_ids` 与集合级 `state`）互相独立，
-**分开陈述，不要互相翻译**：
-
-- 「任务成功」不等于「当前产物有效」。任务成功而产物 `stale`，说明依据变了、产物还在。
-- 「产物缺失」不等于「任务失败」。可能根本没入队（`blocked`，不计费）。
-- `provider_checkpoint.submitted == true` 表示供应商侧已提交、很可能已计费；任务状态
-  `interrupted` 表示没有供应商裁决，盲目重试可能重复计费——按 `problem.action` 决定，
-  `resume` 与 `retry` 不可互换。
-- 产物历史另成一轴：`current` 是当前选中的产物，`stale` 是依据已变但仍在的旧产物，
-  历史版本是此前付费产出的其它版本。
-
-用户问「做完了没有」时，回答要落在这四轴上，而不是压成一句「成功了」。
+计划里这四轴的字段分别是 `steps[].state`（步骤进度）、`steps[].tasks[].status`（队列任务）、
+`steps[].tasks[].provider_checkpoint`（供应商是否已提交）与 `steps[].artifacts`
+（`current_ids` / `stale_ids` / `missing_ids` 与集合级 `state`）。四轴互相独立、分开陈述、
+不要互相翻译——读法与逐轴含义见
+[generation-results.md](generation-results.md)。
 
 ## stale 与历史
 

--- a/agent_runtime_profile/CLAUDE.narration.md
+++ b/agent_runtime_profile/CLAUDE.narration.md
@@ -32,7 +32,7 @@
 - **业务入队 / 文本生成 / 能力查询**：统一走 `mcp__arcreel__*` 系列 SDK in-process MCP tool（角色/场景/道具/分镜/视频/宫格/图片编辑/集脚本/规范化剧本/说书片段拆分/参考视频单元拆分/分集规划与重置/视频能力查询）。它们跑在 server 主进程，不受 sandbox 网络白名单约束，agent 直接以 tool 形式调用。
 - **图片编辑 vs 重新生成**：审核检查点用户只想改设计图/分镜图的局部（换色、去杂物、调光线等）时用 `edit_images`——保底图微调、不改 `description`/`image_prompt`；用户想推翻构图整体重来、或本来就要改 description/image_prompt 时仍用对应的 `generate_*` 工具重新生成。用户脱离生成流程直接说「把某某改一下」时也可直接调 `edit_images`，不依赖处于哪个工作流步骤。
 - **编辑项目 JSON**：修改剧本（`scripts/*.json`）或角色/场景/道具（`project.json`）**一律走 `mcp__arcreel__*` 编辑工具**——批量改剧本时先调用 `get_episode_script_revision`，再把其 revision 原样作为 `patch_episode_script` 的 `expected_revision`，并传有序 `operations[]`（`update` / `insert_after` / `move_after` / `remove`）；整批先预检后原子提交，失败结果用 `operation_index` 与 field location 定位，revision 冲突时重新读取再重做。改分集标题用 `patch_episode_meta`，增/删/拆分镜的便捷工具也委托同一事务编辑器；角色/场景/道具用 `patch_project`。**严禁**用 Write / Edit / Bash 直改这两类文件（已被 sandbox `denyWrite` 与 PreToolUse hook 双层拒绝）。**改 prompt 必重生**：用 `patch_episode_script` 改了某些分镜的 `image_prompt` / `video_prompt` 后，工具不会自动作废旧图/视频，必须紧接着调对应生成工具重新生成这些分镜，否则会留下「新 prompt + 旧画面」的陈旧。
-- **Bash 用途**：仅供通用排查与文件浏览（`ls / cat / jq / python / curl` 等），以及 `compose-video` skill 内还保留的 Python 脚本。
+- **Bash 用途**：仅供通用排查与文件浏览（`ls / cat / jq / python / curl` 等）。
 - **敏感文件保护**：`.env` / `vertex_keys/` / `.system_config.json*` / `.arcreel.db*` / `.claude/settings.json` 由 sandbox profile（`filesystem.denyRead`）内核级拒绝读取，并由 PreToolUse 文件访问 hook 双重防御；代码文件（.py/.js/.ts/.tsx/.sh/.yaml/.yml/.toml）受运行时 hook 阻止写入。
 
 ### 路径规范
@@ -109,7 +109,7 @@ agent session 的当前工作目录（cwd）已绑定到当前项目根，**所�
 
 ### 职责边界
 
-- **禁止编写代码**：不得创建或修改任何代码文件（.py/.js/.sh 等），数据处理走 `mcp__arcreel__*` 工具或 `manage-project` / `compose-video` 的现有脚本
+- **禁止编写代码**：不得创建或修改任何代码文件（.py/.js/.sh 等），数据处理走 `mcp__arcreel__*` 工具或 `manage-project` 的现有脚本
 - **代码 bug 上报**：如果明确判断 MCP 工具或 skill 脚本出现的是代码 bug（而非参数或环境问题），向用户报告错误并建议反馈给开发者
 
 ## 可用 Skills
@@ -124,7 +124,6 @@ agent session 的当前工作目录（cwd）已绑定到当前项目根，**所�
 | generate-grid | `/generate-grid` | 生成宫格分镜图（`grid_storyboard=true` 时：按 segment_break 分组的链式宫格） |
 | generate-video | `/generate-video` | 生成视频 |
 | generate-narration-audio | `/generate-narration-audio` | 生成旁白配音（按段 TTS，只依赖剧本 novel_text） |
-| compose-video | `/compose-video` | 单集片段串接 + 可选 BGM（仅 drama，ffmpeg） |
 
 ## 快速开始
 

--- a/scripts/lint_agent_runtime_profile.py
+++ b/scripts/lint_agent_runtime_profile.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python3
 """Static integrity checks for the materialized Agent Runtime Profile.
 
-``--target-profile`` 额外启用目标档案专属的废弃用法检查。其中禁用字符串
-(`_TARGET_DEPRECATED_STRINGS`) 的判定边界如下：
-
-- 判定粒度是**子句**——散文按句读切分（见 ``_CLAUSE_SPLIT_RE``），围栏代码块内以整行
-  为一个子句；只看命中字符串所在的那个子句，不看整段上下文。
-- 子句命中废弃语境标记（``_DEPRECATION_CONTEXT_RE``）时视为反向说明，即告诫读者不要
-  再用旧格式，不判违规。该判断优先于下面的路由判定。
-- 否则，子句满足下列任一条即判违规：位于围栏代码块内（代码块是可执行指令而非散文告诫）、
-  禁用串本身是命令行 flag（``--`` 开头，其出现即指令形态）、或子句含路由/指令标记
-  （``_ROUTING_MARKER_RE``）。三者皆无的纯提及不判违规。
-
-因此「旧稿 X 不算有效输入」不报，而「读取 X 作为输入」与代码块里的 ``cmd --flag`` 仍报。
-
-「Edit/Write 直改正式 step1」（``_DIRECT_STEP1_EDIT_RE``）同样按子句判定并让废弃语境标记豁免，
-否则写禁本身的告诫语句会把自己判成违规。
+校验范围限于能对照代码真相源的结构：frontmatter 与变体身份、按内容模式物化后的
+Markdown 指针可达性、`mcp__arcreel__*` 工具名是否已注册、eval id 是否唯一。
+档案散文本身不做措辞校验——越界行为（如直改正式 step1）由 ``AgentAccessPolicy``
+在工具边界上拒绝，不靠对散文做黑名单。
 """
 
 from __future__ import annotations
@@ -25,7 +14,6 @@ import json
 import posixpath
 import re
 from collections import defaultdict
-from collections.abc import Iterator
 from pathlib import Path
 from typing import NoReturn
 from urllib.parse import unquote
@@ -47,32 +35,6 @@ _MARKDOWN_REFERENCE_LINK_RE = re.compile(
     r"(?:\s+(?:\"[^\"\n]*\"|'[^'\n]*'|\([^()\n]*\)))?\s*$",
     re.MULTILINE,
 )
-_TARGET_DEPRECATED_STRINGS = (
-    "--scene-ids",
-    "--music-volume",
-    "step1_normalized_script.md",
-)
-_CODE_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})(.*)$")
-_BLOCK_START_RE = re.compile(r"^\s{0,3}([-*+]\s|\d+[.)]\s|#{1,6}\s|>)")
-_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
-_CLAUSE_SPLIT_RE = re.compile(r"[，,。；;！!？?]|——")
-_DEPRECATION_CONTEXT_RE = re.compile(
-    r"不算|不再|不要|不需|不得|不能|不应|不作为|不视为|无需|禁止|勿|别用"
-    r"|残留|遗留|废弃|已移除|已删除|旧项目|旧稿|旧格式"
-    r"|deprecated|legacy|obsolete|removed|no longer|instead of",
-    re.IGNORECASE,
-)
-_ROUTING_MARKER_RE = re.compile(
-    r"读取|写入|使用|运行|执行|调用|传入|加上|附加|指定|生成|保存|输出|输入|参数|选项|路径"
-    r"|\bread\b|\bwrite\b|\buse\b|\bruns?\b|\bpass\b|\bexec\b|\bpython\b|\.py\b|\$\s",
-    re.IGNORECASE,
-)
-_DIRECT_STEP1_EDIT_RE = re.compile(
-    r"(?:Edit|Write).{0,100}(?:step1_normalized_script|step1_reference_units"
-    r"|narration.{0,30}step1|drama.{0,30}step1|reference.video.{0,30}step1)",
-    re.IGNORECASE | re.DOTALL,
-)
-_PYTHON_RESUME_RE = re.compile(r"python[^\n`]*\s--resume(?:\s|$)")
 
 
 def _reject_json_constant(value: str) -> NoReturn:
@@ -195,108 +157,7 @@ def _validate_evals(profile_dir: Path, errors: list[str]) -> None:
                 seen[eval_id] = path
 
 
-def _iter_clauses(text: str) -> Iterator[tuple[str, bool]]:
-    """按行遍历 Markdown，产出 ``(子句, 是否位于围栏代码块内)``。
-
-    三条判定形状：围栏内以整行为一个子句（代码里的逗号分号是语法而非句读，不能当切分点）；
-    开合围栏须同字符、闭合长度不短于开启长度、且闭合行不带信息字符串才配对，避免更短的嵌套
-    反引号序列被误判为收围栏；围栏外先把连续的非空行合并为一个逻辑段落再切分子句——Markdown
-    软换行只是排版折行，不是句读边界，逐物理行切分会把同一子句拆散到两行而漏判。合并在遇到
-    新的列表项/标题/引用起始行（``_BLOCK_START_RE``）时截断，紧邻无空行分隔的两个列表项各
-    自独立成句——否则前一项若命中废弃语境，会连带吞掉后一项里本应报告的真实路由指令；标题
-    行（``_HEADING_RE``）额外在自身之后立即截断——ATX 标题恒为单行块，不与下方段落同句。
-    """
-    fence_char = ""
-    fence_len = 0
-    prose_lines: list[str] = []
-
-    def _flush_prose() -> list[str]:
-        nonlocal prose_lines
-        if not prose_lines:
-            return []
-        paragraph = " ".join(prose_lines)
-        prose_lines = []
-        return _CLAUSE_SPLIT_RE.split(paragraph)
-
-    for line in text.splitlines():
-        if fence_char:
-            match = _CODE_FENCE_RE.match(line)
-            if (
-                match
-                and match.group(1)[0] == fence_char
-                and len(match.group(1)) >= fence_len
-                and not match.group(2).strip()
-            ):
-                fence_char = ""
-                fence_len = 0
-            else:
-                yield line, True
-            continue
-        match = _CODE_FENCE_RE.match(line)
-        if match:
-            for clause in _flush_prose():
-                yield clause, False
-            fence_char = match.group(1)[0]
-            fence_len = len(match.group(1))
-            continue
-        if line.strip():
-            if _BLOCK_START_RE.match(line):
-                for clause in _flush_prose():
-                    yield clause, False
-            prose_lines.append(line)
-            if _HEADING_RE.match(line):
-                for clause in _flush_prose():
-                    yield clause, False
-        else:
-            for clause in _flush_prose():
-                yield clause, False
-    for clause in _flush_prose():
-        yield clause, False
-
-
-def _routes_to_deprecated_string(text: str, needle: str) -> bool:
-    """判断文本是否真的把 ``needle`` 当作可用路由/指令，而非反向说明它已废弃。"""
-    needle_is_cli_flag = needle.startswith("--")
-    for clause, in_code_fence in _iter_clauses(text):
-        if needle not in clause:
-            continue
-        if _DEPRECATION_CONTEXT_RE.search(clause):
-            continue
-        if in_code_fence or needle_is_cli_flag or _ROUTING_MARKER_RE.search(clause):
-            return True
-    return False
-
-
-def _edits_formal_step1_directly(text: str) -> bool:
-    """判断文本是否指示用 Edit/Write 直改正式 step1，而非反向告诫不要这么做。"""
-    return any(
-        _DIRECT_STEP1_EDIT_RE.search(clause) and not _DEPRECATION_CONTEXT_RE.search(clause)
-        for clause, _ in _iter_clauses(text)
-    )
-
-
-def _validate_target_deprecations(profile_dir: Path, errors: list[str]) -> None:
-    for path in sorted(profile_dir.rglob("*.md")):
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError) as exc:
-            errors.append(f"{path.relative_to(profile_dir)}: cannot read: {exc}")
-            continue
-        for needle in _TARGET_DEPRECATED_STRINGS:
-            if _routes_to_deprecated_string(text, needle):
-                errors.append(f"{path.relative_to(profile_dir)}: deprecated profile string {needle!r}")
-        if _PYTHON_RESUME_RE.search(text):
-            errors.append(f"{path.relative_to(profile_dir)}: deprecated Python --resume invocation")
-        if _edits_formal_step1_directly(text):
-            errors.append(f"{path.relative_to(profile_dir)}: deprecated direct Edit/Write of formal step1")
-
-
-def lint_profile(
-    profile_dir: Path,
-    *,
-    registered_tools: set[str] | None = None,
-    enforce_target_rules: bool = False,
-) -> list[str]:
+def lint_profile(profile_dir: Path, *, registered_tools: set[str] | None = None) -> list[str]:
     """Return deterministic profile lint errors; an empty list means success."""
     errors: list[str] = []
     if not profile_dir.is_dir():
@@ -306,21 +167,14 @@ def lint_profile(
     for mode in sorted(VALID_CONTENT_MODES):
         _validate_projection(profile_dir, mode, tool_ids, errors)
     _validate_evals(profile_dir, errors)
-    if enforce_target_rules:
-        _validate_target_deprecations(profile_dir, errors)
     return sorted(set(errors))
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--profile-dir", type=Path, default=Path("agent_runtime_profile"))
-    parser.add_argument(
-        "--target-profile",
-        action="store_true",
-        help="also enforce strings forbidden in the common target profile",
-    )
     args = parser.parse_args()
-    errors = lint_profile(args.profile_dir, enforce_target_rules=args.target_profile)
+    errors = lint_profile(args.profile_dir)
     if errors:
         for error in errors:
             print(f"ERROR: {error}")

--- a/tests/prompt_rules/test_episode_pacing.py
+++ b/tests/prompt_rules/test_episode_pacing.py
@@ -1,3 +1,5 @@
+"""``render_pacing_section`` 只按 content_mode 交回对应常量，断言对照常量本身，不抄文案措辞。"""
+
 import pytest
 
 from lib.prompt_rules.episode_pacing import (
@@ -9,34 +11,14 @@ from lib.prompt_rules.episode_pacing import (
 pytestmark = pytest.mark.unit
 
 
-def test_drama_rules_keywords() -> None:
-    text = render_pacing_section("drama")
-    assert text == DRAMA_PACING_RULES
-    assert "4 秒" in text
-    assert "钩子" in text
-    assert "15 秒" in text
-    assert "Close-up" in text
+def test_drama_mode_renders_the_drama_constant() -> None:
+    assert render_pacing_section("drama") == DRAMA_PACING_RULES
 
 
-def test_narration_rules_keywords() -> None:
-    text = render_pacing_section("narration")
-    assert text == NARRATION_PACING_RULES
-    assert "4 秒" in text
-    assert "钩子" in text
-    assert "卡点留悬" in text
+def test_narration_mode_renders_the_narration_constant() -> None:
+    assert render_pacing_section("narration") == NARRATION_PACING_RULES
 
 
 def test_unknown_mode_raises() -> None:
     with pytest.raises(ValueError, match="unknown content_mode"):
         render_pacing_section("unknown")
-
-
-def test_softened_phrasing() -> None:
-    """文案应使用柔性建议词（"宜 / 例 / 建议"）而非硬性"必须"。"""
-    drama = render_pacing_section("drama")
-    # 不应再用"铁则"措辞
-    assert "铁则" not in drama
-    assert "杜绝" not in drama
-    assert "禁止" not in drama
-    # 至少应包含"建议 / 宜"等柔性词或"例"
-    assert any(w in drama for w in ["建议", "宜", "例"])

--- a/tests/prompt_rules/test_video_workflow_prompt.py
+++ b/tests/prompt_rules/test_video_workflow_prompt.py
@@ -69,6 +69,7 @@ CONTROLLED_ACTIONS = tuple(
 )
 
 TTS_PROBLEM_CODES = tuple(code for code in _TASK_FAILURE_ACTIONS if code.startswith("tts_"))
+assert TTS_PROBLEM_CODES, "_TASK_FAILURE_ACTIONS 里已没有 tts_ 前缀问题码，请更新本测试的派生条件"
 
 
 def _skill(filename: str) -> str:

--- a/tests/prompt_rules/test_video_workflow_prompt.py
+++ b/tests/prompt_rules/test_video_workflow_prompt.py
@@ -1,36 +1,26 @@
-"""Behaviour acceptance for the video-workflow Agent Profile.
+"""Contract coverage for the video-workflow Agent Profile.
 
-The profile is a prompt, so what it promises the agent is checked as statements that must
-be present in (or absent from) the materialized Markdown. Contract surfaces — action
-types, problem codes, admission decisions, delivery options, tool ids — are asserted
-through symbols imported from the authoritative module, so widening one of those enums
-without teaching the profile about it breaks the test. The remaining assertions quote the
-profile's own prose and only guard that the instruction has not been dropped.
+档案是 prompt，但这里只断言**能对照代码真相源的覆盖**：受控动作与问题码枚举、产物状态枚举、
+准入结论、旁白交付常量、已注册的 `mcp__arcreel__*` 工具名，以及按内容模式物化出的文件映射。
+措辞不在断言范围内——服务端扩一个枚举而档案没跟上会红，改一句措辞不会。越界行为由服务端契约
+与 ``AgentAccessPolicy`` 在工具边界上拒绝，不靠在测试里抄一遍 prompt 原文。
 """
 
 from __future__ import annotations
 
-import json
-import re
 from pathlib import Path
 
 import pytest
 
-from lib.artifact_manifest import ArtifactStatus
 from lib.batch_admission import DURATION_CONFIRMATION_CODE, BatchAdmissionDecision
 from lib.generation_result import (
     _TASK_FAILURE_ACTIONS,
     GenerationAction,
-    GenerationCandidate,
     GenerationItemState,
-    GenerationProblem,
     GenerationProblemCode,
-    GenerationTargetState,
-    artifact_is_reusable,
 )
-from lib.narration_delivery import POST_PRODUCTION, USE_TTS, NarrationTtsStatus
+from lib.narration_delivery import POST_PRODUCTION, USE_TTS
 from lib.profile_manifest import VALID_CONTENT_MODES, resolve_profile_files_for_mode
-from lib.workflow_plan import _structure_action
 from lib.workflow_rules import WORKFLOW_RULES
 from lib.workflow_state import WorkflowTarget
 from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
@@ -43,6 +33,8 @@ SKILL_DIR = PROFILE / ".claude" / "skills" / "video-workflow"
 REFERENCES = PROFILE / ".claude" / "references"
 WORKFLOW_PLAN_REFERENCE = REFERENCES / "workflow-plan.md"
 GENERATION_RESULTS_REFERENCE = REFERENCES / "generation-results.md"
+VIDEO_SKILL = PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md"
+NARRATION_AUDIO_SKILL = PROFILE / ".claude" / "skills" / "generate-narration-audio" / "SKILL.md"
 
 WORKFLOW_VARIANTS = ("SKILL.narration.md", "SKILL.drama.md", "SKILL.ad.md")
 EPISODIC_VARIANTS = ("SKILL.narration.md", "SKILL.drama.md")
@@ -76,6 +68,8 @@ CONTROLLED_ACTIONS = tuple(
     dict.fromkeys((*_WORKFLOW_STATE_ACTIONS, *_PLAN_INJECTED_ACTIONS, *(action.value for action in GenerationAction)))
 )
 
+TTS_PROBLEM_CODES = tuple(code for code in _TASK_FAILURE_ACTIONS if code.startswith("tts_"))
+
 
 def _skill(filename: str) -> str:
     return (SKILL_DIR / filename).read_text(encoding="utf-8")
@@ -89,18 +83,17 @@ def _reference(path: Path) -> str:
 
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_route_through_the_authoritative_plan(filename: str) -> None:
+def test_variants_route_through_the_registered_plan_tool(filename: str) -> None:
     content = _skill(filename)
 
+    assert "get_workflow_plan" in ARCREEL_MCP_TOOL_IDS
     assert "mcp__arcreel__get_workflow_plan" in content
     assert "mcp__arcreel__get_workflow_status" not in content
-    assert "workflow-plan.md" in content
-    assert "next_action" in content
 
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_do_not_hardcode_a_route_or_content_mode_step_table(filename: str) -> None:
-    """六组合的步骤适用性只能由计划表达，profile 侧不得再推一遍。"""
+def test_variants_do_not_name_the_preprocessor_subagents_themselves(filename: str) -> None:
+    """预处理 subagent 由计划的 ``next_action.args.preprocessor`` 指名，档案侧不得再推一遍。"""
 
     content = _skill(filename)
 
@@ -109,27 +102,6 @@ def test_variants_do_not_hardcode_a_route_or_content_mode_step_table(filename: s
             assert rule.preprocessor not in content, (
                 f"{filename} 硬编码了预处理 subagent {rule.preprocessor}；应改读 next_action.args.preprocessor"
             )
-    # 禁的是「按模式挑步骤」，不是提到模式：AC2 要求变体写明参考路线只跳过分镜图，那句同样带
-    # `generation_mode == "reference_video"`。因此只在同一行还出现路由标记时判违约，并放宽引号与空格。
-    comparison = re.compile(
-        r"(?:generation_mode|content_mode)\s*==\s*[\"']?(?:reference_video|storyboard|drama|narration|ad)\b"
-    )
-    routing = ("→", "dispatch", "步骤", "mcp__arcreel__generate")
-    for line in content.splitlines():
-        if comparison.search(line):
-            assert not any(marker in line for marker in routing), (
-                f"{filename} 按内容模式/生成路线自己挑步骤：{line.strip()}"
-            )
-
-
-def test_plan_reference_shows_duration_confirmation_keyed_by_a_real_unit_id() -> None:
-    """键是 unit ID；写成字面量 `unit_id` 会被原样发出去，确认对不上任何 unit。"""
-
-    content = _reference(WORKFLOW_PLAN_REFERENCE)
-
-    assert '"confirmed_request_durations": {"unit_id"' not in content
-    assert "confirmed_request_durations" in content
-    assert "键是 unit ID" in content
 
 
 def test_plan_reference_covers_every_controlled_action() -> None:
@@ -148,187 +120,112 @@ def test_plan_reference_names_only_registered_mcp_tools() -> None:
         assert f"mcp__arcreel__{tool_id}" in content
 
 
+def test_plan_reference_documents_every_target_field() -> None:
+    content = _reference(WORKFLOW_PLAN_REFERENCE)
+
+    for field in WorkflowTarget.model_fields:
+        assert f"`{field}`" in content
+
+
 # ------------------------------------------------------------------- 旁白交付
 
 
-def test_plan_reference_states_both_narration_delivery_options() -> None:
+@pytest.mark.parametrize("path", (WORKFLOW_PLAN_REFERENCE, VIDEO_SKILL))
+def test_delivery_options_are_both_named_where_the_choice_is_made(path: Path) -> None:
+    content = _reference(path)
+
+    assert POST_PRODUCTION in content
+    assert USE_TTS in content
+
+
+def test_plan_reference_covers_every_tts_problem_code_and_its_action() -> None:
     content = _reference(WORKFLOW_PLAN_REFERENCE)
 
-    assert f"`{POST_PRODUCTION}`" in content
-    assert f"`{USE_TTS}`" in content
-    assert "choose_narration_delivery" in content
-    assert "从不持久化" in content
+    for code in TTS_PROBLEM_CODES:
+        assert f"`{code}`" in content, f"旁白问题码表缺 {code}"
+        assert f"`{_TASK_FAILURE_ACTIONS[code].value}`" in content
 
 
-def test_prompts_state_that_the_video_tools_require_a_declared_delivery() -> None:
-    """工具侧已把交付方式收紧为必填，prompt 不能还在描述「省略即后期配音」。"""
+def test_narration_audio_skill_covers_the_tts_actions() -> None:
+    content = NARRATION_AUDIO_SKILL.read_text(encoding="utf-8")
 
-    plan_reference = _reference(WORKFLOW_PLAN_REFERENCE)
-    video_skill = (PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md").read_text(encoding="utf-8")
-
-    for content in (plan_reference, video_skill):
-        assert "必填" in content
-        assert "不入队任何任务" in content
-        assert "省略即按 `post_production` 处理" not in content
-
-
-def test_reference_route_skips_only_storyboard_images() -> None:
-    for path in (WORKFLOW_PLAN_REFERENCE, REFERENCES / "generation-modes.md"):
-        content = _reference(path)
-        assert "只跳过" in content and "不跳过 audio" in content
-
-
-def test_missing_tts_defaults_to_post_production_without_pushing_provider_setup() -> None:
-    plan_reference = _reference(WORKFLOW_PLAN_REFERENCE)
-
-    assert NarrationTtsStatus.NOT_CONFIGURED.value in plan_reference
-    assert "tts_not_configured" in plan_reference
-    assert "不要建议用户为了继续做视频去配置 TTS 供应商" in plan_reference
-
-    audio_skill = (PROFILE / ".claude" / "skills" / "generate-narration-audio" / "SKILL.md").read_text(encoding="utf-8")
-    assert "不要建议用户为了" in audio_skill
-
-    video_skill = (PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md").read_text(encoding="utf-8")
-    assert "试听" in video_skill
-    assert "tts_missing" in video_skill
-    assert "tts_stale" in video_skill
+    for action in (GenerationAction.GENERATE_TTS, GenerationAction.REGENERATE_TTS, GenerationAction.WAIT_FOR_TASK):
+        assert action.value in content
+    for code in ("tts_stale", "tts_duration_unavailable"):
+        assert _TASK_FAILURE_ACTIONS[code] is GenerationAction.REGENERATE_TTS
+        assert code in content
 
 
 # ------------------------------------------------------------------- 批量准入
 
 
-def test_plan_reference_states_all_or_nothing_admission() -> None:
+def test_plan_reference_covers_every_admission_decision() -> None:
     content = _reference(WORKFLOW_PLAN_REFERENCE)
 
     for decision in BatchAdmissionDecision:
         assert decision.value in content
-    assert "全有或全无" in content
     assert GenerationProblemCode.BATCH_ADMISSION_WITHHELD.value in content
-    assert "blocked_unit_ids" in content
-    assert "不拆批" in content or "不要把整批拆成小批" in content
 
 
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_refuse_to_resubmit_the_passing_half_of_a_refused_batch(filename: str) -> None:
-    content = _skill(filename)
-
-    assert "admission" in content
-    assert BatchAdmissionDecision.ADMITTED.value in content
-    assert "一个任务都不入队" in content
-    assert "不拆批先跑通过的那一半" in content
+def test_variants_name_the_admitted_decision(filename: str) -> None:
+    assert BatchAdmissionDecision.ADMITTED.value in _skill(filename)
 
 
-@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
-def test_episodic_variants_route_repair_wait_and_named_redo(filename: str) -> None:
-    """计划可以交回这三类动作，变体里必须各有落点，否则 agent 收到就没路可走。"""
-
-    content = _skill(filename)
-
-    assert "repair_video_units" in content
-    assert "patch_episode_script" in content
-    assert GenerationAction.WAIT_FOR_TASK.value in content
-    # 点名即强制重做的请求选择语义：非空 requested_ids 必须走 selected 工具。
-    assert "mcp__arcreel__generate_video_selected" in content
-    assert "mcp__arcreel__generate_video_episode" in content
+def test_video_skill_names_the_duration_confirmation_code() -> None:
+    assert DURATION_CONFIRMATION_CODE in VIDEO_SKILL.read_text(encoding="utf-8")
 
 
-def test_video_skill_confirms_duration_tiers_without_splitting_the_batch() -> None:
-    content = (PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md").read_text(encoding="utf-8")
-
-    assert DURATION_CONFIRMATION_CODE in content
-    assert "confirmed_request_durations" in content
-    assert "仍作为一批重发" in content
-
-    # 入队工具没有 confirm_duration 参数，写进 skill 会让 agent 发出必被拒的请求。
-    # DURATION_CONFIRMATION_CODE 本身含该子串，先摘掉再查裸参数名。
-    assert "confirm_duration" not in content.replace(DURATION_CONFIRMATION_CODE, "")
+# ----------------------------------------------------------------- 产物状态轴
 
 
-# ------------------------------------------------------- 四条状态轴 / 逐 ID 分账
-
-
-def test_generation_results_reference_keeps_four_axes_apart() -> None:
+def test_generation_results_reference_covers_every_item_state() -> None:
     content = _reference(GENERATION_RESULTS_REFERENCE)
 
-    assert "四条状态轴分开读" in content
-    assert "provider_checkpoint" in content
-    assert "任务成功 ≠ 产物匹配当前依据" in content
     for state in GenerationItemState:
         assert state.value in content
 
 
-def test_plan_reference_keeps_four_axes_apart() -> None:
-    content = _reference(WORKFLOW_PLAN_REFERENCE)
-
-    assert "provider_checkpoint" in content
-    assert "「任务成功」不等于「当前产物有效」" in content
-    assert "interrupted" in content
-
-
 @pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_report_per_id_outcomes_on_four_axes(filename: str) -> None:
+def test_variants_name_the_per_id_outcome_states(filename: str) -> None:
     content = _skill(filename)
 
-    assert "provider checkpoint" in content
-    assert "四轴" in content
     for state in (GenerationItemState.SUCCEEDED, GenerationItemState.FAILED, GenerationItemState.BLOCKED):
         assert state.value in content
 
 
-# ---------------------------------------------------------------- stale 与付费历史
+# ---------------------------------------------------- 各变体落点的工具名覆盖
 
 
-def test_plan_reference_protects_stale_artifacts_and_paid_history() -> None:
-    content = _reference(WORKFLOW_PLAN_REFERENCE)
+@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
+def test_episodic_variants_name_the_registered_recovery_tools(filename: str) -> None:
+    content = _skill(filename)
 
-    assert "stale 产物照常可预览、可导出、可参与成片" in content
-    assert "不得自动删除、覆盖或重生任何已付费产物" in content
-    assert "重复计费" in content
-
-
-def test_generation_results_reference_protects_paid_history() -> None:
-    content = _reference(GENERATION_RESULTS_REFERENCE)
-
-    assert "历史版本" in content
-    assert "不得自动删除、覆盖或重生" in content
-
-
-# ------------------------------------------------------- 恢复任务与重试不可互换
+    for tool_id in (
+        "generate_video_selected",
+        "generate_video_episode",
+        "reset_episode_planning",
+        "complete_step1_rebuild",
+        "get_episode_script_revision",
+        "patch_episode_script",
+    ):
+        assert tool_id in ARCREEL_MCP_TOOL_IDS
+        assert f"mcp__arcreel__{tool_id}" in content
 
 
-def test_plan_reference_separates_resume_from_retry() -> None:
-    content = _reference(WORKFLOW_PLAN_REFERENCE)
+def test_ad_variant_names_the_registered_video_tools() -> None:
+    content = _skill("SKILL.ad.md")
 
-    assert "wait_for_task" in content
-    assert "`resume` 与 `retry` 不可互换" in content
-
-
-def test_video_skill_separates_resume_from_retry() -> None:
-    content = (PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md").read_text(encoding="utf-8")
-
-    assert "`resume` 与 `retry` 不可互换" in content
-    assert "interrupted" in content
+    for tool_id in ("generate_video_selected", "generate_video_episode"):
+        assert tool_id in ARCREEL_MCP_TOOL_IDS
+        assert f"mcp__arcreel__{tool_id}" in content
 
 
-# ------------------------------------------ compose / export 的声音与字幕归服务端
+def test_asset_analysis_subagent_names_its_registered_tool() -> None:
+    content = (PROFILE / ".claude" / "agents" / "analyze-assets.md").read_text(encoding="utf-8")
 
-
-def test_compose_skill_defers_sound_and_subtitles_to_presentation() -> None:
-    content = (PROFILE / ".claude" / "skills" / "compose-video" / "SKILL.md").read_text(encoding="utf-8")
-
-    assert "presentation" in content
-    assert "不静音" in content
-    assert "不自行估算字幕时间轴" in content
-    assert "不替用户判断 TTS 是否必需" in content
-
-
-@pytest.mark.parametrize("mode", sorted(VALID_CONTENT_MODES))
-def test_top_level_profile_defers_export_semantics_to_presentation(mode: str) -> None:
-    content = (PROFILE / f"CLAUDE.{mode}.md").read_text(encoding="utf-8")
-
-    assert "presentation" in content
-    assert "不静音 provider 原音" in content
-    assert "不替用户判断 TTS 是否必需" in content
+    assert "complete_asset_inventory" in ARCREEL_MCP_TOOL_IDS
+    assert "mcp__arcreel__complete_asset_inventory" in content
 
 
 # ------------------------------------ Profile 物化：每个模式都拿到工作流 skill
@@ -342,239 +239,3 @@ def test_every_content_mode_materializes_the_video_workflow_skill(mode: str) -> 
     assert mapping[".claude/references/workflow-plan.md"] == ".claude/references/workflow-plan.md"
     assert mapping["CLAUDE.md"] == f"CLAUDE.{mode}.md"
     assert not any(logical.startswith(".claude/skills/manga-workflow/") for logical in mapping)
-
-
-# --------------------------------------------- 既有约束：权威参数原样透传、恢复动作
-
-
-@pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_asset_and_storyboard_routes_forward_authoritative_arguments(filename: str) -> None:
-    content = _skill(filename)
-
-    assert '"names": [该类型 requested_ids]' in content
-    assert '"segment_ids": requested_ids' in content
-    assert '"scene_ids": requested_ids' in content
-    assert "target.episode" in content
-    assert '"script": target.script_filename' in content
-    assert "next_action.args" in content
-    if filename != "SKILL.ad.md":
-        assert "names = artifacts.asset_sheets[type].missing_ids ∩ requested_ids" in content
-        assert "若 names 为空 → 跳过，不 dispatch；不得回退到整类 missing_ids" in content
-
-
-def test_plan_reference_documents_every_target_field_and_the_two_script_forms() -> None:
-    """两个剧本字段一个是可读路径、一个是工具入参裸名，漏掉任一都会让 agent 选错。"""
-
-    content = WORKFLOW_PLAN_REFERENCE.read_text(encoding="utf-8")
-
-    for field in WorkflowTarget.model_fields:
-        assert f"`{field}`" in content
-    assert "`script` 是相对项目根的剧本路径" in content
-    assert "所有 `mcp__arcreel__*` 工具的 `script` 参数用它" in content
-
-
-@pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_read_the_script_by_path_and_call_tools_by_bare_filename(filename: str) -> None:
-    content = _skill(filename)
-
-    assert "target.script_filename" in content
-    assert not re.search(r'"script":\s*target\.script(?!_filename)', content)
-    assert re.search(r"(Read|读取)\s*`?target\.script`?(?!_filename)", content)
-
-
-@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
-def test_episodic_variants_take_the_preprocessor_from_the_plan(filename: str) -> None:
-    """ad 无 step1，不参与本断言。"""
-
-    assert "next_action.args.preprocessor" in _skill(filename)
-
-
-@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
-def test_reset_route_executes_recovery_and_refreshes_the_plan(filename: str) -> None:
-    content = _skill(filename)
-
-    assert "mcp__arcreel__reset_episode_planning" in content
-    assert "confirm_consumed: true" in content
-    assert "重置成功后刷新计划" in content
-
-
-@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
-def test_stale_step1_records_explicit_rebuild_completion(filename: str) -> None:
-    content = _skill(filename)
-
-    assert "mcp__arcreel__complete_step1_rebuild" in content
-    assert "expected_stale_step1_revision" in content
-    assert "确定性重建可能产出完全相同的 JSON" in content
-
-
-def test_ad_workflow_regenerates_named_reference_units_with_selected_tool() -> None:
-    content = _skill("SKILL.ad.md")
-
-    assert (
-        'mcp__arcreel__generate_video_selected({"script": target.script_filename, "scene_ids": requested_ids, '
-        '"narration_delivery": chosen_narration_delivery})' in content
-    )
-    assert "`requested_ids` 为空时才调 `mcp__arcreel__generate_video_episode" in content
-    assert "`narration_delivery` 必填" in content
-
-
-def test_asset_analysis_records_completion_fact() -> None:
-    content = (PROFILE / ".claude" / "agents" / "analyze-assets.md").read_text(encoding="utf-8")
-
-    assert "mcp__arcreel__complete_asset_inventory" in content
-    assert "expected_source_revision" in content
-    assert "严格按主 agent 传入的 `scope`" in content
-    assert "排除文件名以 `.` / `_` 开头" in content
-    assert "`episode_[0-9]+.txt`" in content
-    assert "`.text`" not in content
-    assert "不要调用 `patch_project`" in content
-
-
-# ------------------------------------------- TTS 与档位确认按 action 路由、选择不丢
-
-
-def test_narration_audio_skill_routes_by_problem_action_not_by_code() -> None:
-    """`tts_duration_unavailable` 服务端登记为重新合成；按 code 自己推会把它漏成不处理。"""
-
-    content = (PROFILE / ".claude" / "skills" / "generate-narration-audio" / "SKILL.md").read_text(encoding="utf-8")
-
-    assert "problems[].action" in content
-    assert "action 是权威" in content
-    for code, action in (
-        ("tts_stale", GenerationAction.REGENERATE_TTS),
-        ("tts_duration_unavailable", GenerationAction.REGENERATE_TTS),
-    ):
-        assert _TASK_FAILURE_ACTIONS[code] is action
-        assert code in content
-    assert GenerationAction.GENERATE_TTS.value in content
-    assert GenerationAction.WAIT_FOR_TASK.value in content
-
-
-@pytest.mark.parametrize("filename", WORKFLOW_VARIANTS)
-def test_variants_carry_the_delivery_choice_into_the_confirmed_resend(filename: str) -> None:
-    """`narration_delivery` 不持久化，重发漏带即失败，不退回 post_production。"""
-
-    content = _skill(filename)
-
-    assert "confirmed_request_durations" in content
-    assert "`narration_delivery`" in content
-    assert "problems[].action" in content
-    assert "必填" in content
-    assert "不要自己填" in content or "不要自己填一个值" in content
-
-
-def test_video_skill_resend_example_keeps_the_delivery_choice() -> None:
-    content = (PROFILE / ".claude" / "skills" / "generate-video" / "SKILL.md").read_text(encoding="utf-8")
-
-    blocks = [block for block in content.split("```")[1::2] if "confirmed_request_durations" in block]
-    assert blocks, "确认重发的示例代码块不见了"
-    for block in blocks:
-        assert "narration_delivery" in block
-        assert "mcp__arcreel__generate_video" in block
-    assert POST_PRODUCTION in content
-
-
-# ------------------------------------------------- 用户意图不越过计划、隔离草稿优先
-
-
-@pytest.mark.parametrize("filename", EPISODIC_VARIANTS)
-def test_user_named_action_is_checked_against_the_plan(filename: str) -> None:
-    content = _skill(filename)
-
-    assert "直接跳到该动作" not in content
-    assert "与 `next_action.type` 一致才执行" in content
-
-
-def test_narration_variant_routes_plan_driven_tts_as_a_controlled_action() -> None:
-    """批量准入被拒时计划会把 TTS 动作交回成 next_action，不能一律当成用户显式触发。"""
-
-    content = _skill("SKILL.narration.md")
-
-    assert GenerationAction.GENERATE_TTS.value in content
-    assert GenerationAction.REGENERATE_TTS.value in content
-    assert "计划驱动" in content
-    assert "用户显式触发" in content
-
-
-def test_split_reference_subagent_prefers_the_quarantined_draft() -> None:
-    """违约时正式 JSON 不写、只落 invalid.json——首次生成分支不收紧就会重跑工具重复计费。"""
-
-    content = (PROFILE / ".claude" / "agents" / "split-reference-video-units.md").read_text(encoding="utf-8")
-
-    trigger = content.split("### 情况 A", 1)[1].split("### 情况", 1)[0]
-    assert "step1_reference_units.invalid.json" in trigger
-    assert "都不存在" in trigger
-    assert "先走情况 C" in trigger
-
-
-# ----------------------------------------- openspec 与 eval 用例跟随计划权威一起迁移
-
-
-def test_orchestration_spec_and_evals_describe_plan_driven_routing() -> None:
-    spec = (REPO / "openspec" / "specs" / "workflow-orchestration" / "spec.md").read_text(encoding="utf-8")
-
-    assert "get_workflow_plan" in spec
-    assert "next_action" in spec
-    assert "基于 project.json 和文件系统判断当前所处阶段" not in spec
-    assert "状态检测" not in spec
-
-    evals = json.loads((PROFILE / "skill-optimization-workspace" / "evals" / "evals.json").read_text(encoding="utf-8"))
-    names = {
-        assertion["name"]
-        for case in evals["evals"]
-        if "video-workflow" in case["target_skills"]
-        for assertion in case["assertions"]
-    }
-    assert {"reads_project_json", "uses_glob_check", "identifies_correct_stage"}.isdisjoint(names)
-    assert {"queries_workflow_plan", "does_not_infer_stage", "executes_next_action"}.issubset(names)
-
-
-def test_repair_section_takes_the_revision_from_whichever_action_supplies_it() -> None:
-    """`expected_revision` 只随 `patch_episode_script` 注入；两个动作共用一节，来源必须分开写。"""
-
-    problem = GenerationProblem(
-        code=GenerationProblemCode.UNIT_REQUEST_INVALID,
-        detail="unit 规划不合法",
-        action=GenerationAction.FIX_INPUT,
-    )
-    injected = _structure_action([problem], script_revision="r1")
-    assert injected.type == "patch_episode_script"
-    assert "expected_revision" in injected.args
-
-    for filename in EPISODIC_VARIANTS:
-        section = _skill(filename).split("## `repair_video_units`", 1)[1].split("\n---", 1)[0]
-        assert "revision 按动作取" in section
-        assert "不必再查" in section
-        assert "mcp__arcreel__get_episode_script_revision" in section
-
-
-def test_export_guidance_forbids_muting_rather_than_merely_recommending_against_it() -> None:
-    texts = [_skill(name) for name in WORKFLOW_VARIANTS]
-    texts += [(PROFILE / f"CLAUDE.{mode}.md").read_text(encoding="utf-8") for mode in VALID_CONTENT_MODES]
-
-    for text in texts:
-        if "静音" in text:
-            assert "不要建议静音" not in text
-            assert "不静音 provider 原音" in text or "不要静音 provider 原音" in text
-
-
-def test_regenerating_narration_audio_names_the_segments(tmp_path: Path) -> None:
-    """缺省是「只补缺失」，而 stale 算可复用被跳过——不带 ID 的重合成什么都不做。"""
-
-    assert artifact_is_reusable(
-        GenerationTargetState(
-            candidate=GenerationCandidate(unit_id="E1S01", artifact_key=None, artifact_path="a.mp3"),
-            status=ArtifactStatus.STALE,
-            blocker=None,
-        ),
-        manifest_active=True,
-        project_dir=tmp_path,
-    )
-
-    for content in (
-        _skill("SKILL.narration.md"),
-        (PROFILE / ".claude" / "skills" / "generate-narration-audio" / "SKILL.md").read_text(encoding="utf-8"),
-    ):
-        assert f"`{GenerationAction.REGENERATE_TTS.value}`" in content
-        assert "segment_ids" in content
-        assert "只补缺失" in content

--- a/tests/test_agent_profile_lint.py
+++ b/tests/test_agent_profile_lint.py
@@ -172,151 +172,15 @@ def test_ignores_external_markdown_uri_schemes(tmp_path: Path) -> None:
     assert lint_profile(profile, registered_tools={"patch_project"}) == []
 
 
-def test_target_deprecation_rules_are_explicit_for_variant_profile(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    skill = profile / ".claude" / "skills" / "demo" / "SKILL.md"
-    skill.write_text(skill.read_text(encoding="utf-8") + "Run --scene-ids.\n", encoding="utf-8")
-
-    assert not any("deprecated" in error for error in lint_profile(profile, registered_tools={"patch_project"}))
-    assert any(
-        "deprecated" in error
-        for error in lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-    )
-
-
-def test_target_deprecation_rules_flag_routing_and_spare_reverse_notes(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "router.md").write_text(
-        "---\nname: router\ndescription: Routing agent\n---\n"
-        "- 读取 `drafts/episode_1/step1_normalized_script.md` 作为剧本生成输入。\n"
-        "- 重生成指定场景时运行 generate-storyboard --scene-ids E1S01。\n",
-        encoding="utf-8",
-    )
-    (profile / ".claude" / "agents" / "note.md").write_text(
-        "---\nname: note\ndescription: Reverse note agent\n---\n"
-        "- 旧项目残留的 `step1_normalized_script.md`（结构化前自由文本稿）不算有效 step1，"
-        "须重跑 normalize 产出 `.json`。\n"
-        "- 旧脚本的 --scene-ids 参数已废弃，不要再传。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/router.md: deprecated profile string 'step1_normalized_script.md'" in errors
-    assert ".claude/agents/router.md: deprecated profile string '--scene-ids'" in errors
-    assert not any(error.startswith(".claude/agents/note.md") for error in errors)
-
-
-def test_target_deprecation_rules_flag_code_fences_and_parenthesised_paths(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "fenced.md").write_text(
-        "---\nname: fenced\ndescription: Fenced command agent\n---\n"
-        "```bash\n"
-        "generate-storyboard --scene-ids E1S01\n"
-        "cat drafts/episode_1/step1_normalized_script.md\n"
-        "```\n",
-        encoding="utf-8",
-    )
-    (profile / ".claude" / "agents" / "inline.md").write_text(
-        "---\nname: inline\ndescription: Inline reference agent\n---\n"
-        "- 读取剧本草稿（`step1_normalized_script.md`）后继续。\n"
-        "- 请使用 generate-storyboard 重生成；--scene-ids E1S01\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    for source in ("fenced.md", "inline.md"):
-        assert f".claude/agents/{source}: deprecated profile string 'step1_normalized_script.md'" in errors
-        assert f".claude/agents/{source}: deprecated profile string '--scene-ids'" in errors
-
-
-def test_target_deprecation_rules_flag_soft_wrapped_routing_clause(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "wrapped.md").write_text(
-        "---\nname: wrapped\ndescription: Soft-wrapped routing agent\n---\n"
-        "- 请读取\n"
-        "  step1_normalized_script.md 后再继续下一步。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/wrapped.md: deprecated profile string 'step1_normalized_script.md'" in errors
-
-
-def test_target_deprecation_rules_flag_adjacent_list_items_without_blank_line(tmp_path: Path) -> None:
-    """紧邻、无空行分隔的反向说明列表项与真实路由列表项须各自独立成句，不因段落合并互相吞并。"""
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "adjacent-items.md").write_text(
-        "---\nname: adjacent-items\ndescription: Adjacent list item agent\n---\n"
-        "- 不要使用旧格式 step1_normalized_script.md\n"
-        "- 读取 step1_normalized_script.md 作为输入\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/adjacent-items.md: deprecated profile string 'step1_normalized_script.md'" in errors
-
-
-def test_target_deprecation_rules_flag_routing_paragraph_after_deprecated_heading(tmp_path: Path) -> None:
-    """标题（ATX 单行块）不与其后段落同句：标题命中废弃语境不应吞掉紧邻下方的真实路由段落。"""
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "heading.md").write_text(
-        "---\nname: heading\ndescription: Heading boundary agent\n---\n"
-        "### 已废弃的旧格式\n"
-        "读取 step1_normalized_script.md 作为输入。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/heading.md: deprecated profile string 'step1_normalized_script.md'" in errors
-
-
-def test_target_deprecation_rules_flag_nested_fence_content(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "nested-fence.md").write_text(
-        "---\nname: nested-fence\ndescription: Nested fence agent\n---\n"
-        "````markdown\n"
-        "```bash\n"
-        "cat drafts/episode_1/step1_normalized_script.md\n"
-        "```\n"
-        "````\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/nested-fence.md: deprecated profile string 'step1_normalized_script.md'" in errors
-
-
-def test_target_deprecation_rules_flag_routing_clause_alongside_reverse_note(tmp_path: Path) -> None:
-    """反向说明子句与真实路由子句同文共存同一 needle 时，仍须按各自子句独立判定并报违规。"""
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "mixed.md").write_text(
-        "---\nname: mixed\ndescription: Mixed clause agent\n---\n"
-        "- 旧项目残留的 step1_normalized_script.md 不算有效 step1。\n"
-        "- 读取 step1_normalized_script.md 作为剧本生成输入。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/mixed.md: deprecated profile string 'step1_normalized_script.md'" in errors
-
-
 def test_reports_invalid_utf8_across_profile_inputs(tmp_path: Path) -> None:
     profile = _valid_profile(tmp_path)
     (profile / "CLAUDE.narration.md").write_bytes(b"\xff")
     (profile / "evals" / "cases.json").write_bytes(b"\xff")
 
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
+    errors = lint_profile(profile, registered_tools={"patch_project"})
 
     assert any("cannot read projected file" in error for error in errors)
     assert any("invalid eval JSON" in error for error in errors)
-    assert any(error.startswith("CLAUDE.narration.md: cannot read:") for error in errors)
 
 
 def test_frontmatter_accepts_utf8_bom(tmp_path: Path) -> None:
@@ -329,52 +193,6 @@ def test_frontmatter_accepts_utf8_bom(tmp_path: Path) -> None:
     assert metadata.description == "Demo skill"
 
 
-def test_direct_step1_edit_rule_spares_write_deny_notices(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "deny-note.md").write_text(
-        "---\nname: deny-note\ndescription: Deny notice agent\n---\n"
-        "正式 `step1_normalized_script.json` 不可用 Write/Edit 直改。\n\n"
-        "结构有问题时走「取回草稿 → 改草稿 → 晋升」：不要用 Edit 直改正式文件（会被拒）。\n\n"
-        "```text\n"
-        'mcp__arcreel__open_step1_for_edit({"episode": 1})\n'
-        "```\n\n"
-        "内容被取回到 `drafts/episode_1/step1_normalized_script.invalid.json`。\n",
-        encoding="utf-8",
-    )
-    (profile / ".claude" / "agents" / "direct-edit.md").write_text(
-        "---\nname: direct-edit\ndescription: Direct edit agent\n---\n"
-        "用 Edit 工具修改 `drafts/episode_1/step1_normalized_script.json` 后继续。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert not any(error.startswith(".claude/agents/deny-note.md") for error in errors)
-    assert ".claude/agents/direct-edit.md: deprecated direct Edit/Write of formal step1" in errors
-
-
-def test_direct_step1_edit_rule_catches_reference_video_formal_step1(tmp_path: Path) -> None:
-    profile = _valid_profile(tmp_path)
-    (profile / ".claude" / "agents" / "direct-edit-reference.md").write_text(
-        "---\nname: direct-edit-reference\ndescription: Direct edit agent\n---\n"
-        "用 Edit 工具修改 `drafts/episode_1/step1_reference_units.json` 后继续。\n",
-        encoding="utf-8",
-    )
-
-    errors = lint_profile(profile, registered_tools={"patch_project"}, enforce_target_rules=True)
-
-    assert ".claude/agents/direct-edit-reference.md: deprecated direct Edit/Write of formal step1" in errors
-
-
 def test_shipped_profile_passes_current_lint() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     assert lint_profile(repo_root / "agent_runtime_profile") == []
-
-
-def test_shipped_profile_has_no_deprecated_string_routing() -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-
-    errors = lint_profile(repo_root / "agent_runtime_profile", enforce_target_rules=True)
-
-    assert not any("deprecated profile string" in error for error in errors)
-    assert not any("deprecated direct Edit/Write" in error for error in errors)


### PR DESCRIPTION
Closes #1917

## 变更

档案守卫从「拿措辞当门禁」收敛为「只校验能对照代码真相源的结构」：

- **profile lint** — 删除 `--target-profile` 整层：废弃字符串黑名单、否定语境 / 路由标记正则、直改正式 step1 与 `python --resume` 的检测，以及配套的散文子句切分器。留下的是 frontmatter 与变体身份、按内容模式物化后的 Markdown 指针可达性、`mcp__arcreel__*` 工具名注册核对、eval id 唯一性。越界行为本就由 `AgentAccessPolicy` 在工具边界上双层拒绝（hook + sandbox `denyWrite`），不需要再对散文做黑名单。CI `backend-static` 的 `uv run python scripts/lint_agent_runtime_profile.py` 仍是硬门禁，且从未传过该 flag。
- **prompt_rules** — 断言的期望值一律要求在运行时由导入的代码符号算出（枚举 `.value`、`model_fields`、`WORKFLOW_RULES`、`_TASK_FAILURE_ACTIONS`、`DURATION_CONFIRMATION_CODE` / `POST_PRODUCTION` / `USE_TTS`），或是经 `ARCREEL_MCP_TOOL_IDS` 核对过的工具名；对具体措辞的断言全部删除。两处顺带收严：旁白问题码改为遍历 `_TASK_FAILURE_ACTIONS` 中全部 `tts_` 码并连带断言各自 action；工具名断言统一先核注册表再核档案。
- **说书档案** — `CLAUDE.narration.md` 删掉 `compose-video`：skill 表那一行，以及把它列为「可用的现有脚本」的另两处（Bash 用途、职责边界）。该脚本读剧本顶层 `scenes[]`，对说书的 `segments[]` 结构直接拒绝执行，留着只会让说书项目的智能体白跑一轮。
- **references 散文去重** — `workflow-plan.md` 的「四条状态轴」与「只跳过分镜图」两整段改为指向 `generation-results.md` / `generation-modes.md`，并就地给出四轴在计划里对应的字段路径（`steps[].state` / `steps[].tasks[].status` / `steps[].tasks[].provider_checkpoint` / `steps[].artifacts`）。

## 验证

在 worktree 内全量跑通：

| 门禁 | 结果 |
|---|---|
| `pytest -m "not e2e" --cov=lib --cov=server --cov-fail-under=80` | 通过，覆盖率 91% |
| `ruff check .` / `ruff format --check .` | 通过 |
| `basedpyright` | 0 errors |
| `lint-imports` | 1 kept, 0 broken |
| `scripts/lint_agent_runtime_profile.py` | 通过 |

审查中额外核实的点：

- 全仓无 `--target-profile` / `enforce_target_rules` 残留引用；`.github/workflows/test.yml` 是该脚本唯一调用点。
- 随措辞断言一并删掉的两处代码断言（`_structure_action` 注入 `patch_episode_script` + `expected_revision`、`artifact_is_reusable` 视 `STALE` 为可复用）在 `tests/test_workflow_plan.py` 与 `tests/test_generation_result.py` 中已有等价或更强的覆盖，非真实缺口。
- 受控动作表用 AST 提取 `lib/workflow_state.py` 全部动作字面量比对，与测试中的清单完全一致，无遗漏。
- 两段散文的迁入目标确认承载了原文全部要点（含「产物历史另成一轴」）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 更新工作流、旁白交付与节奏规则说明，统一引用最新生成模式和结果定义。
  - 明确 Bash、脚本工具及可用技能的使用边界，移除过时操作指引。

- **改进**
  - 简化配置文件静态检查范围，聚焦元数据、Markdown 引用、工具注册和评估标识唯一性。
  - 增强对无效编码配置及评估文件的错误提示和检测能力。

- **测试**
  - 更新工作流契约、旁白模式及视频生成结果验证，提升规则变更后的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->