### PR TITLE
refactor(lib): 脚本条目访问收口为骨架模块唯一入口

### DIFF
--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -6,9 +6,10 @@
 统一入口的 `_write_script_unlocked`（「不更坏」+ Pydantic 模型）兜底，本模块只负责数组手术、
 id 分配与资产作废。MCP 工具与测试都复用它。
 
-三种内容/生成模式（narration/drama/reference_video）的分镜数组与 id 字段判别集中在
-`resolve_items`，与 `script_structure_validator._select_model`、写盘统一入口的 metadata 重算共用
-同一判别，避免三处漂移。
+三种内容/生成模式（narration/drama/reference_video）的分镜数组与 id 字段判别委托给
+`script_skeleton.resolve_kind_items`（骨架模块的唯一条目访问入口），`resolve_items` 在其上
+叠加编辑核心特有的 fail-loud 校验策略；与 `script_structure_validator._select_model`、写盘
+统一入口的 metadata 重算共用同一取证解析，避免多处漂移。
 """
 
 from __future__ import annotations
@@ -17,7 +18,7 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from lib.script_skeleton import SKELETONS, resolve_script_kind
+from lib.script_skeleton import resolve_kind_items
 
 logger = logging.getLogger(__name__)
 
@@ -40,26 +41,25 @@ class ScriptEditError(ValueError):
 def resolve_items(script: dict[str, Any]) -> tuple[list[dict[str, Any]], str, str]:
     """按内容/生成模式选出当前剧本的分镜数组、其 id 字段名与种类。
 
-    返回 ``(items, id_field, kind)``：``kind`` ∈ {"segments", "scenes", "shots", "video_units"}，
-    由 `script_skeleton.resolve_script_kind`（取证解析）判别，id 字段查 `SKELETONS`。**键缺失**
-    视为空数组；**键存在但类型非 list（含值为 null）**时 fail-loud 抛 `ScriptEditError`（不静默降级
-    为 []，避免把数据损坏掩盖成「未找到 id」——`"segments": null` 这类损坏会暴露而非被当成空草稿）。
+    返回 ``(items, id_field, kind)``：``kind`` ∈ {"segments", "scenes", "shots", "video_units"}。
+    键与 id 字段的查法委托给 `script_skeleton.resolve_kind_items`（骨架模块的唯一条目访问入口，
+    取证解析同源）；本函数在其原样返回值上加编辑核心特有的校验策略：**键缺失**视为空数组；
+    **键存在但类型非 list（含值为 null）**时 fail-loud 抛 `ScriptEditError`（不静默降级为 []，
+    避免把数据损坏掩盖成「未找到 id」——`"segments": null` 这类损坏会暴露而非被当成空草稿）。
     返回的 list 在键存在时即 script 内的实际引用（就地编辑生效）。
     """
-    kind = resolve_script_kind(script)
-    id_field = SKELETONS[kind].id_field
+    raw_items, id_field, kind = resolve_kind_items(script)
     if kind not in script:
         return [], id_field, kind
-    items = script[kind]
-    if not isinstance(items, list):
-        type_name = type(items).__name__
+    if not isinstance(raw_items, list):
+        type_name = type(raw_items).__name__
         raise ScriptEditError(
             f"{kind} 必须是列表，当前为 {type_name}",
             key="script_edit_items_not_list",
             kind=kind,
             type_name=type_name,
         )
-    return items, id_field, kind
+    return raw_items, id_field, kind
 
 
 def _find_index(items: list[dict[str, Any]], id_field: str, item_id: str) -> int:

--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -7,9 +7,9 @@
 id 分配与资产作废。MCP 工具与测试都复用它。
 
 三种内容/生成模式（narration/drama/reference_video）的分镜数组与 id 字段判别委托给
-`script_skeleton.resolve_kind_items`（骨架模块的唯一条目访问入口），`resolve_items` 在其上
-叠加编辑核心特有的 fail-loud 校验策略；与 `script_structure_validator._select_model`、写盘
-统一入口的 metadata 重算共用同一取证解析，避免多处漂移。
+`script_skeleton.resolve_kind_items`（骨架条目访问的唯一入口），`resolve_items` 在其上叠加
+编辑核心特有的 fail-loud 校验策略；与 `script_structure_validator._select_model`、写盘统一
+入口的 metadata 重算共用同一取证解析，避免多处漂移。
 """
 
 from __future__ import annotations
@@ -38,17 +38,18 @@ class ScriptEditError(ValueError):
         self.params = params
 
 
-def resolve_items(script: dict[str, Any]) -> tuple[list[dict[str, Any]], str, str]:
+def resolve_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[list[dict[str, Any]], str, str]:
     """按内容/生成模式选出当前剧本的分镜数组、其 id 字段名与种类。
 
     返回 ``(items, id_field, kind)``：``kind`` ∈ {"segments", "scenes", "shots", "video_units"}。
-    键与 id 字段的查法委托给 `script_skeleton.resolve_kind_items`（骨架模块的唯一条目访问入口，
-    取证解析同源）；本函数在其原样返回值上加编辑核心特有的校验策略：**键缺失**视为空数组；
+    键与 id 字段的查法委托给 `script_skeleton.resolve_kind_items`（骨架条目访问的唯一入口，
+    取证解析同源）；``kind`` 由调用方显式给定（如任务开工时已定死的生成路线）时跳过取证解析，
+    直接按该种类取值。本函数在原样返回值上加编辑核心特有的校验策略：**键缺失**视为空数组；
     **键存在但类型非 list（含值为 null）**时 fail-loud 抛 `ScriptEditError`（不静默降级为 []，
     避免把数据损坏掩盖成「未找到 id」——`"segments": null` 这类损坏会暴露而非被当成空草稿）。
     返回的 list 在键存在时即 script 内的实际引用（就地编辑生效）。
     """
-    raw_items, id_field, kind = resolve_kind_items(script)
+    raw_items, id_field, kind = resolve_kind_items(script, kind=kind)
     if kind not in script:
         return [], id_field, kind
     if not isinstance(raw_items, list):

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -1574,8 +1574,8 @@ class ScriptGenerator:
         # 名跨集冲突（如 storyboards/scene_E1S01.png 被 E2 重新覆盖）。
         ep = int(episode)
         # segment/scene/shot/unit ID 前缀统一经规范解析定骨架 + resolve_kind_items 查条目数组
-        # 与 id 字段改写（参考路线三种 content_mode 均映射到 video_units；不再手写 reference
-        # 分支）。self.content_mode 为项目级校验值，解析不会 fail-loud。
+        # 与 id 字段改写（参考路线三种 content_mode 均映射到 video_units，无需按路线分支）。
+        # self.content_mode 为项目级校验值，解析不会 fail-loud。
         kind = resolve_declared_kind(self.content_mode, gen_mode)
         raw_rewrite_items, id_field, _kind = resolve_kind_items(script_data, kind=kind)
         # 校验失败降级保存的原始 dict 里该数组可能为非列表脏值（LLM 误写标量），

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -100,7 +100,7 @@ from lib.script_review import (
     gate_blocks_step2,
     migrate_step1_draft_in_place,
 )
-from lib.script_skeleton import SKELETONS, resolve_declared_kind
+from lib.script_skeleton import resolve_declared_kind, resolve_kind_items
 from lib.speech_composition import admit_script_unit, require_script_unit_admitted, video_unit_replan_problems
 from lib.speech_rate import project_speech_rate_override
 from lib.text_backends.base import DEFAULT_MAX_OUTPUT_TOKENS, TextGenerationRequest, TextTaskType
@@ -1573,14 +1573,13 @@ class ScriptGenerator:
         # 兜底改写 segment/scene/unit ID 中的 E\d+ 前缀，避免 LLM 写错集号导致文件
         # 名跨集冲突（如 storyboards/scene_E1S01.png 被 E2 重新覆盖）。
         ep = int(episode)
-        # segment/scene/shot/unit ID 前缀统一经规范解析定骨架 + SKELETONS 查 id 字段改写
-        # （参考路线三种 content_mode 均映射到 video_units；不再手写 reference 分支）。self.content_mode
-        # 为项目级校验值，解析不会 fail-loud。
+        # segment/scene/shot/unit ID 前缀统一经规范解析定骨架 + resolve_kind_items 查条目数组
+        # 与 id 字段改写（参考路线三种 content_mode 均映射到 video_units；不再手写 reference
+        # 分支）。self.content_mode 为项目级校验值，解析不会 fail-loud。
         kind = resolve_declared_kind(self.content_mode, gen_mode)
-        id_field = SKELETONS[kind].id_field
+        raw_rewrite_items, id_field, _kind = resolve_kind_items(script_data, kind=kind)
         # 校验失败降级保存的原始 dict 里该数组可能为非列表脏值（LLM 误写标量），
         # `... or []` 只挡 falsy、挡不住真值标量，isinstance 守卫避免 `for` 迭代崩溃。
-        raw_rewrite_items = script_data.get(kind)
         rewritten_output_ids: list[str] = []
         for s in raw_rewrite_items if isinstance(raw_rewrite_items, list) else []:
             if isinstance(s, dict) and id_field in s:
@@ -1713,14 +1712,14 @@ class ScriptGenerator:
         try:
             short_ids: list[str] = []
 
-            # 骨架经规范解析统一判别、id 字段查 SKELETONS（同 _add_metadata id 改写处置）。
-            # video_units 的过短样本落在 unit 内嵌 shots.text，与 narration/drama/ad 平铺条目的
-            # image_prompt/video_prompt 探针数据形状不同——结构分支按 kind 显式区分、非骨架分派。
+            # 骨架经规范解析统一判别、条目数组与 id 字段查 resolve_kind_items（同 _add_metadata
+            # id 改写处置）。video_units 的过短样本落在 unit 内嵌 shots.text，与 narration/drama/ad
+            # 平铺条目的 image_prompt/video_prompt 探针数据形状不同——结构分支按 kind 显式区分、
+            # 非骨架分派。
             kind = resolve_declared_kind(self.content_mode, self.generation_mode)
-            id_key = SKELETONS[kind].id_field
+            raw_items, id_key, _kind = resolve_kind_items(script_data, kind=kind)
             # 降级保存的原始 dict 里数组可能为非列表脏值；`... or []` 挡不住真值标量，
             # isinstance 守卫避免 `for` 迭代崩溃（外层 try/except 会吞异常但会误跳过整段探针）。
-            raw_items = script_data.get(kind)
             items = raw_items if isinstance(raw_items, list) else []
             if kind == "video_units":
                 for u in items:

--- a/lib/script_skeleton.py
+++ b/lib/script_skeleton.py
@@ -169,18 +169,17 @@ def resolve_script_kind(script: dict[str, Any]) -> str:
 
 
 def resolve_kind_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[Any, str, str]:
-    """按骨架种类取条目的唯一入口：返回 ``(items, id_field, kind)``。
+    """按骨架种类取条目数组与其 id 字段的唯一入口：返回 ``(items, id_field, kind)``。
 
     ``kind`` 缺省时经 ``resolve_script_kind``（取证解析）由剧本数据形状判别；调用方已持有
     项目声明或路线闸门算出的种类（``resolve_declared_kind`` / ``ensure_route_skeleton`` 的
     返回值）可显式传入，跳过重复判别。
 
     返回的条目值是 ``script.get(kind)`` 原样——**不做类型校验、不把非 list 兜底为空数组**：
-    键缺失时为 ``None``，键存在但非 list（含 ``null``）时原样返回该非法值。校验策略（是否
-    fail-loud、是否降级为空数组并记录、是否要求非空且逐项为 dict）由各调用方决定——既有调用方
-    对此分歧不小（``script_editor.resolve_items`` 抛异常、快照差分降级为空并 warning、工作流
-    状态机要求非空 list），收口校验会引入行为变化，本函数只统一「查哪个键、哪个 id 字段」这
-    一份结构事实，不越界统一校验。
+    键缺失时为 ``None``，键存在但非 list（含 ``null``）时原样返回该非法值。本函数只统一
+    「查哪个键、哪个 id 字段」这一份结构事实；脏值该 fail-loud 还是降级、空数组算不算合法，
+    是各消费路径自己的策略，归调用方，不在此收口。条目内的角色引用字段（``chars_field``）
+    不属于条目访问，仍直查 ``SKELETONS``。
     """
     resolved_kind = kind if kind is not None else resolve_script_kind(script)
     return script.get(resolved_kind), SKELETONS[resolved_kind].id_field, resolved_kind

--- a/lib/script_skeleton.py
+++ b/lib/script_skeleton.py
@@ -168,6 +168,24 @@ def resolve_script_kind(script: dict[str, Any]) -> str:
     return "segments"
 
 
+def resolve_kind_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[Any, str, str]:
+    """按骨架种类取条目的唯一入口：返回 ``(items, id_field, kind)``。
+
+    ``kind`` 缺省时经 ``resolve_script_kind``（取证解析）由剧本数据形状判别；调用方已持有
+    项目声明或路线闸门算出的种类（``resolve_declared_kind`` / ``ensure_route_skeleton`` 的
+    返回值）可显式传入，跳过重复判别。
+
+    返回的条目值是 ``script.get(kind)`` 原样——**不做类型校验、不把非 list 兜底为空数组**：
+    键缺失时为 ``None``，键存在但非 list（含 ``null``）时原样返回该非法值。校验策略（是否
+    fail-loud、是否降级为空数组并记录、是否要求非空且逐项为 dict）由各调用方决定——既有调用方
+    对此分歧不小（``script_editor.resolve_items`` 抛异常、快照差分降级为空并 warning、工作流
+    状态机要求非空 list），收口校验会引入行为变化，本函数只统一「查哪个键、哪个 id 字段」这
+    一份结构事实，不越界统一校验。
+    """
+    resolved_kind = kind if kind is not None else resolve_script_kind(script)
+    return script.get(resolved_kind), SKELETONS[resolved_kind].id_field, resolved_kind
+
+
 # 路线要求的骨架族：参考生视频路线要 ``video_units``，其余路线要分镜族骨架
 # （``segments`` / ``scenes`` / ``shots``）。族内差异（如 narration 数据落 ``scenes`` 键的历史
 # 形态）不构成失配，只有跨族才是——跨族意味着生成侧要读的数组根本不在剧本里。

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -62,12 +62,11 @@ def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str
     异常上冒，避免脏数据被静默吞成 ``TypeError: 'NoneType' is not iterable``。
     """
     items, id_field, kind = resolve_items(script)
-    if kind == "video_units":
-        unit = SKELETONS["video_units"]
-        return ([], unit.id_field, unit.chars_field, "scenes", "props")
-
-    # 角色引用字段名改查 SKELETONS 单一真相源（video_units→None 强制显式决策）。
+    # 角色引用字段名改查 SKELETONS 单一真相源（video_units→None 强制显式决策）。id_field 已由
+    # resolve_items 按同一 kind 查出，video_units 分支不再重复查表取值。
     char_field = SKELETONS[kind].chars_field
+    if kind == "video_units":
+        return ([], id_field, char_field, "scenes", "props")
     return (items, id_field, char_field, "scenes", "props")
 
 

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -62,8 +62,8 @@ def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str
     异常上冒，避免脏数据被静默吞成 ``TypeError: 'NoneType' is not iterable``。
     """
     items, id_field, kind = resolve_items(script)
-    # 角色引用字段名改查 SKELETONS 单一真相源（video_units→None 强制显式决策）。id_field 已由
-    # resolve_items 按同一 kind 查出，video_units 分支不再重复查表取值。
+    # 角色引用字段名查 SKELETONS 单一真相源（video_units→None 强制显式决策）；id_field 由
+    # resolve_items 按同一 kind 一并给出，各分支共用。
     char_field = SKELETONS[kind].chars_field
     if kind == "video_units":
         return ([], id_field, char_field, "scenes", "props")

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -36,7 +36,7 @@ from lib.project_migration_failure import (
     load_migration_verdict,
 )
 from lib.script_models import get_generated_assets, script_duration_total
-from lib.script_skeleton import SKELETONS, STORYBOARD_ITEM_ID_PATTERN, ensure_route_skeleton
+from lib.script_skeleton import SKELETONS, STORYBOARD_ITEM_ID_PATTERN, ensure_route_skeleton, resolve_kind_items
 from lib.source_revision import SourceRevisionResult, SourceScope, compute_source_revision
 from lib.version_manager import VersionManager
 from lib.workflow_rules import workflow_rule
@@ -688,7 +688,7 @@ class WorkflowStateService:
         except ValueError as exc:
             blockers.append(WorkflowBlocker(code="invalid_project_mode", path="content_mode", reason=str(exc)))
             return {"state": "blocked", "path": path}, [], None, script
-        raw_items = script.get(kind)
+        raw_items, id_field, _kind = resolve_kind_items(script, kind=kind)
         if not isinstance(raw_items, list) or not raw_items or not all(isinstance(item, dict) for item in raw_items):
             blockers.append(
                 WorkflowBlocker(
@@ -698,7 +698,6 @@ class WorkflowStateService:
                 )
             )
             return {"state": "blocked", "path": path}, [], kind, script
-        id_field = SKELETONS[kind].id_field
         seen_ids: set[str] = set()
         for index, item in enumerate(raw_items):
             resource_id = item.get(id_field)

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -1723,7 +1723,8 @@ def _resolve_tts_task_items(
 
     if not reference_video_route:
         return resolve_items(script)
-    return resolve_items({"video_units": script.get("video_units", [])})
+    # 参考路线的骨架种类由任务开工时定死的路线给出，直接指定；取证解析只服务于路线未知的调用方。
+    return resolve_items(script, kind="video_units")
 
 
 async def execute_tts_task(

--- a/server/services/project_archive.py
+++ b/server/services/project_archive.py
@@ -41,7 +41,7 @@ from lib.project_migrations.v1_to_v2_normalize_providers import migrate_project_
 from lib.project_schema import project_schema_is_current
 from lib.reference_video.duration_migration import migrate_unit_durations
 from lib.resource_paths import resource_extension, resource_relative_path
-from lib.script_skeleton import SKELETONS, resolve_declared_kind
+from lib.script_skeleton import SKELETONS, resolve_declared_kind, resolve_kind_items
 from lib.source_loader.migration import migrate_project_source_encoding
 from lib.validation_messages import MessageRef, ValidationMessage, ValidationResult
 
@@ -1035,12 +1035,11 @@ class ProjectArchiveService:
 
         # storyboard 骨架（segments/scenes/shots，含 ad 的 shots）逐条补全字段与资产回填。
         items_key = kind
-        id_field = SKELETONS[kind].id_field
+        raw_items, id_field, _kind = resolve_kind_items(script_payload, kind=kind)
         chars_field = SKELETONS[kind].chars_field
         # storyboard 骨架必有 chars_field；video_units 已在上分支返回。
         assert chars_field is not None
 
-        raw_items = script_payload.get(items_key)
         if not isinstance(raw_items, list):
             return script_changed, project_changed
 

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -32,7 +32,7 @@ from lib.script_skeleton import (
     SKELETON_ENTITY_TYPES,
     SKELETON_ITEM_NOUNS,
     SKELETONS,
-    resolve_script_kind,
+    resolve_kind_items,
 )
 from server.sse_channel import IDLE, DropSubscriber, SseChannel
 
@@ -748,10 +748,11 @@ class ProjectEventService:
         # narration/drama，二值兜底会把 ad 的 shots 与 reference 的 video_units 全部漏读——差分恒空、
         # 分镜级事件从不发出，正是本次修复的 bug 根因）。键即条目数组键。
         content_mode = str(script.get("content_mode") or "narration")
-        kind = resolve_script_kind(script)
-        skeleton = SKELETONS[kind]
-        raw_items = script.get(kind, [])
-        if not isinstance(raw_items, list):
+        raw_items, id_field, kind = resolve_kind_items(script)
+        chars_field = SKELETONS[kind].chars_field
+        if kind not in script:
+            raw_items = []
+        elif not isinstance(raw_items, list):
             logger.warning(
                 "剧本条目字段非列表，按空快照处理 kind=%s type=%s",
                 kind,
@@ -763,11 +764,11 @@ class ProjectEventService:
         for item in raw_items:
             if not isinstance(item, dict):
                 continue
-            item_id = str(item.get(skeleton.id_field) or "")
+            item_id = str(item.get(id_field) or "")
             if not item_id:
                 continue
             assets = get_generated_assets(item)
-            characters, scenes, props, products = self._item_entities(item, skeleton.chars_field)
+            characters, scenes, props, products = self._item_entities(item, chars_field)
             items[item_id] = {
                 "duration_seconds": item.get("duration_seconds"),
                 "needs_replan": bool(item.get("needs_replan")),
@@ -778,7 +779,7 @@ class ProjectEventService:
                 "props": props,
                 "products": products,
                 "shots": self._item_member_shots(item.get("shots")),
-                "references": self._item_references(item.get("references")) if skeleton.chars_field is None else [],
+                "references": self._item_references(item.get("references")) if chars_field is None else [],
                 "image_prompt": item.get("image_prompt"),
                 "video_prompt": item.get("video_prompt"),
                 "generated_assets": {

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -745,8 +745,8 @@ class ProjectEventService:
 
     def _normalize_script_snapshot(self, script: dict[str, Any]) -> dict[str, Any]:
         # 取证解析：由剧本数据形状判别骨架种类（narration/drama 走 reference 时 content_mode 仍是
-        # narration/drama，二值兜底会把 ad 的 shots 与 reference 的 video_units 全部漏读——差分恒空、
-        # 分镜级事件从不发出，正是本次修复的 bug 根因）。键即条目数组键。
+        # narration/drama，按 content_mode 二值兜底会把 ad 的 shots 与 reference 的 video_units
+        # 全部漏读，差分恒空、分镜级事件从不发出）。键即条目数组键。
         content_mode = str(script.get("content_mode") or "narration")
         raw_items, id_field, kind = resolve_kind_items(script)
         chars_field = SKELETONS[kind].chars_field

--- a/server/services/workflow_planner.py
+++ b/server/services/workflow_planner.py
@@ -23,7 +23,7 @@ from lib.project_migration_failure import (
 )
 from lib.reference_video.request_projection import ReferenceRequestOptions
 from lib.script_batch_edit import script_revision
-from lib.script_skeleton import SKELETONS, ensure_route_skeleton
+from lib.script_skeleton import ensure_route_skeleton, resolve_kind_items
 from lib.speech_composition import admit_script_unit
 from lib.workflow_plan import (
     WorkflowPlan,
@@ -53,6 +53,7 @@ class _ScriptFacts:
     script: dict[str, Any]
     script_file: str
     kind: str
+    id_field: str
     items: tuple[dict[str, Any], ...]
     revision: str
 
@@ -135,7 +136,7 @@ class WorkflowPlanner:
                 status.project.content_mode,
                 status.project.generation_mode,
             )
-            raw_items = script.get(kind)
+            raw_items, id_field, _kind = resolve_kind_items(script, kind=kind)
             if not isinstance(raw_items, list) or not all(isinstance(item, dict) for item in raw_items):
                 raise ValueError(f"{kind} must be an array of objects")
             return _ScriptFacts(
@@ -144,6 +145,7 @@ class WorkflowPlanner:
                 script=script,
                 script_file=target.script_filename,
                 kind=kind,
+                id_field=id_field,
                 items=tuple(raw_items),
                 revision=script_revision(script),
             )
@@ -169,7 +171,7 @@ class WorkflowPlanner:
     ) -> list[WorkflowTaskObservation]:
         if facts is None:
             return []
-        id_field = SKELETONS[facts.kind].id_field
+        id_field = facts.id_field
         unit_ids = [
             str(item[id_field]) for item in facts.items if isinstance(item.get(id_field), str) and str(item[id_field])
         ]
@@ -250,7 +252,7 @@ class WorkflowPlanner:
         # 与投影缺口折在同一批票里）。自行挑目标并把视觉提示词留空，会让计划按另一套
         # 视觉基准判断已付费产物能否复用，与真正提交时的结论分叉。
         requested = set(status.next_action.requested_ids)
-        id_field = SKELETONS[facts.kind].id_field
+        id_field = facts.id_field
         items = [
             item for item in facts.items if isinstance(item.get(id_field), str) and str(item[id_field]) in requested
         ]

--- a/tests/test_script_skeleton.py
+++ b/tests/test_script_skeleton.py
@@ -19,6 +19,7 @@ from lib.script_skeleton import (
     SkeletonRouteMismatchError,
     ensure_route_skeleton,
     resolve_declared_kind,
+    resolve_kind_items,
     resolve_script_kind,
 )
 
@@ -229,3 +230,51 @@ class TestRouteSkeletonGate:
     def test_unknown_content_mode_still_fails_loud(self):
         with pytest.raises(ValueError):
             ensure_route_skeleton({"segments": []}, None, "storyboard")
+
+
+@pytest.mark.unit
+class TestKindItemsAccessor:
+    """条目访问唯一入口：种类判别的两条来路 × 条目值原样返回。"""
+
+    def test_forensic_kind_when_not_given(self):
+        # kind 缺省 → 走取证解析，与 resolve_script_kind 同一判别。
+        script = {"content_mode": "drama", "scenes": [{"scene_id": "E1S01"}]}
+        items, id_field, kind = resolve_kind_items(script)
+        assert kind == "scenes"
+        assert id_field == SKELETONS["scenes"].id_field
+        assert items == [{"scene_id": "E1S01"}]
+
+    def test_explicit_kind_skips_forensics(self):
+        # 显式 kind 覆盖数据形状：取证解析会判 segments，指定 video_units 则按后者取值。
+        script = {"content_mode": "narration", "segments": [], "video_units": [{"unit_id": "E1U01"}]}
+        items, id_field, kind = resolve_kind_items(script, kind="video_units")
+        assert (kind, id_field) == ("video_units", SKELETONS["video_units"].id_field)
+        assert items == [{"unit_id": "E1U01"}]
+
+    def test_id_field_per_kind(self):
+        # 四骨架各自的条目身份不被通用化。
+        for kind, expected in (
+            ("segments", "segment_id"),
+            ("scenes", "scene_id"),
+            ("shots", "shot_id"),
+            ("video_units", "unit_id"),
+        ):
+            assert resolve_kind_items({}, kind=kind)[1] == expected
+
+    def test_items_returned_by_reference(self):
+        # 返回的是 script 内实际引用，就地编辑对调用方生效。
+        items_in_script: list[dict[str, object]] = []
+        script = {"content_mode": "narration", "segments": items_in_script}
+        items, _id_field, _kind = resolve_kind_items(script)
+        assert items is items_in_script
+
+    def test_missing_key_yields_none_not_empty_list(self):
+        # 不把缺失兜底成空数组——「键缺失」与「键在场但空」由调用方各自定策略。
+        items, id_field, kind = resolve_kind_items({"content_mode": "narration"})
+        assert (items, kind) == (None, "segments")
+        assert id_field == "segment_id"
+
+    def test_non_list_value_returned_as_is(self):
+        # 脏值原样上交，不在此 fail-loud、也不静默降级。
+        assert resolve_kind_items({"content_mode": "narration", "segments": None})[0] is None
+        assert resolve_kind_items({"content_mode": "drama", "scenes": "E1S01"})[0] == "E1S01"


### PR DESCRIPTION
Closes #1941

## 背景

「按骨架种类取脚本条目数组 + 该骨架的条目 ID 字段」此前散落在工作流状态、脚本生成、工作流规划、项目归档、分镜序列等处各自手写：先 `resolve_*_kind()` 定种类，再 `SKELETONS[kind].id_field` 查 ID 字段，再 `script.get(kind)` 自取数组。三处组合各写一遍，形状一致但没有共同入口。

## 改动

- `lib/script_skeleton.py` 新增 `resolve_kind_items(script, *, kind=None)`，返回 `(items, id_field, kind)`，作为骨架条目访问的唯一入口。`kind` 缺省时走取证解析（`resolve_script_kind`）；调用方已由项目声明或路线闸门定死种类时可显式传入，跳过重复判别。
- 条目值按 `script.get(kind)` 原样返回，**不做类型校验、不把非 list 兜底成空数组**。既有调用方对脏值的处置策略本就不同（编辑核心 fail-loud 抛 `ScriptEditError`、快照差分降级为空并 warning、工作流状态机要求非空且逐项为 dict），把校验一并收口会引入行为变化，故入口只统一「查哪个键、哪个 ID 字段」这一份结构事实。
- 各手写组合改走新入口：`lib/script_editor.resolve_items`（保留对外签名与 fail-loud 承诺，内部委托后再校验，数十处消费方与测试 mock 无需改动）、`lib/script_generator`（ID 前缀改写 + 质量探针）、`lib/workflow_state`、`lib/storyboard_sequence`、`server/services/project_archive`、`server/services/project_events`、`server/services/workflow_planner`。
- `resolve_items` 增加可选 `kind` 透传，`server/services/generation_tasks._resolve_tts_task_items` 的参考路线分支不再合成 `{"video_units": ...}` 临时 dict 反推骨架，改为显式指定种类。
- `workflow_planner._ScriptFacts` 随 `kind` 一并携带 `id_field`，在唯一构造点算一次，两处下游消费点不再各自查表。

各骨架的 `segment_id` / `scene_id` / `shot_id` / `unit_id` 身份不变，未引入通用条目类型或通用 ID 字段。条目内的角色引用字段（`chars_field`）不属于条目访问，仍直查 `SKELETONS`。

纯 prefactor，无行为变化，为后续分镜数/视频单元数与视频单元正文的重构铺路。

## 验证

- `uv run ruff check . && uv run ruff format .` — 通过
- `uv run basedpyright` — 0 errors
- `uv run lint-imports` — 1 kept, 0 broken
- `uv run python -m pytest` — 10190 passed, 2 skipped
- 新增 `tests/test_script_skeleton.py::TestKindItemsAccessor` 6 项，覆盖两条种类来路、四骨架 ID 字段、返回引用即 script 内实际数组、键缺失返回 `None` 而非 `[]`、非 list 脏值原样上交
- 未改前端，未跑前端检查

行为等价性逐点核对：`resolve_items` 的三分支（键缺失→空数组、键存在但非 list→`ScriptEditError`、正常→script 内实际引用）逐条保持；`project_events._normalize_script_snapshot` 由 `script.get(kind, [])` 改为「键缺失→`[]`，否则非 list 才 warning」，warning 触发条件与改前完全一致（`"segments": null` 仍触发）；`generation_tasks` 原先的合成 dict 仅含 `video_units` 键，取证解析恒判 `video_units`，与显式指定等价。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 统一支持不同剧本骨架类型的条目与标识字段解析。
  - 改善视频分镜、语音生成、工作流规划及项目归档流程的兼容性。
  - 支持显式指定剧本类型，减少特殊剧本结构下的解析歧义。

- **问题修复**
  - 优化缺失字段和非法条目数据的处理，避免相关流程异常。
  - 改善剧本快照、实体提取及条目校验在非标准数据下的稳定性。

- **测试**
  - 补充多种剧本类型、缺失字段及异常数据场景的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->