### PR TITLE
refactor(tasks): 任务记录的供应商协议标识与请求域名分列存放

### DIFF
--- a/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
+++ b/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
@@ -1,7 +1,8 @@
 """split task provider_endpoint (protocol id) from submitted_base_url (request domain)
 
-`tasks.provider_endpoint` 收窄为只承载自定义供应商的协议标识；内置供应商此前落在该列的
-请求域名迁入 `tasks.submitted_base_url`。存量行按真实语义回填：值是 http(s) 形态的即域名。
+`tasks.provider_endpoint` 只承载自定义供应商的协议标识，请求域名一律落
+`tasks.submitted_base_url`。存量行按真实语义回填：`provider_endpoint` 中 http(s) 形态的值是
+域名，搬去 `submitted_base_url`。
 
 Revision ID: b3f9c07ae214
 Revises: f6a41746c0de

--- a/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
+++ b/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
@@ -1,0 +1,57 @@
+"""split task provider_endpoint (protocol id) from submitted_base_url (request domain)
+
+`tasks.provider_endpoint` 收窄为只承载自定义供应商的协议标识；内置供应商此前落在该列的
+请求域名迁入 `tasks.submitted_base_url`。存量行按真实语义回填：值是 http(s) 形态的即域名。
+
+Revision ID: b3f9c07ae214
+Revises: f6a41746c0de
+Create Date: 2026-08-18 04:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3f9c07ae214"
+down_revision: str | Sequence[str] | None = "f6a41746c0de"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 域名判据：该列只可能出现协议标识或请求域名，只有 http(s) 前缀的是后者。
+# lower(...) LIKE 在 SQLite 与 PostgreSQL 上语义一致，无需方言分支。
+_HAS_DOMAIN = (
+    "provider_endpoint IS NOT NULL "
+    "AND (lower(provider_endpoint) LIKE 'http://%' OR lower(provider_endpoint) LIKE 'https://%')"
+)
+
+# 先搬后清，且只填空列：域名两处都有值的行以专列为准，不覆盖。
+_MOVE_DOMAIN = (
+    f"UPDATE tasks SET submitted_base_url = provider_endpoint WHERE submitted_base_url IS NULL AND {_HAS_DOMAIN}"
+)
+_CLEAR_DOMAIN = f"UPDATE tasks SET provider_endpoint = NULL WHERE {_HAS_DOMAIN}"
+_COUNT_DOMAIN = f"SELECT COUNT(*) FROM tasks WHERE {_HAS_DOMAIN}"
+
+# 回填后内置供应商的行只剩域名一列有值，据此反向还原；自定义供应商的行两列俱在，不动。
+_RESTORE_DOMAIN = (
+    "UPDATE tasks SET provider_endpoint = submitted_base_url, submitted_base_url = NULL "
+    "WHERE provider_endpoint IS NULL AND submitted_base_url IS NOT NULL"
+)
+
+
+def upgrade() -> None:
+    """Backfill data: move request domains out of provider_endpoint into submitted_base_url."""
+    bind = op.get_bind()
+    bind.execute(sa.text(_MOVE_DOMAIN))
+    bind.execute(sa.text(_CLEAR_DOMAIN))
+    remaining = bind.execute(sa.text(_COUNT_DOMAIN)).scalar()
+    if remaining:
+        raise RuntimeError(f"{remaining} 行的 tasks.provider_endpoint 仍存放请求域名，回填未完成")
+
+
+def downgrade() -> None:
+    """Move builtin-provider domains back into provider_endpoint."""
+    bind = op.get_bind()
+    bind.execute(sa.text(_RESTORE_DOMAIN))

--- a/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
+++ b/alembic/versions/b3f9c07ae214_split_task_endpoint_and_base_url.py
@@ -20,7 +20,10 @@ down_revision: str | Sequence[str] | None = "f6a41746c0de"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-# 域名判据：该列只可能出现协议标识或请求域名，只有 http(s) 前缀的是后者。
+# 域名判据：该列只可能出现协议标识或请求域名，只有 http(s) 前缀的是后者。协议标识取自一份
+# 闭合的 endpoint 注册表（全是 slug，无 scheme）；域名一侧也不会缺 scheme——落库发生在创建
+# 供应商任务的 HTTP 调用成功之后，而无 scheme 的 base_url 在发请求时就被 httpx 拒绝，根本走
+# 不到持久化。故 http(s) 前缀是完备判据。
 # lower(...) LIKE 在 SQLite 与 PostgreSQL 上语义一致，无需方言分支。
 _HAS_DOMAIN = (
     "provider_endpoint IS NOT NULL "
@@ -32,7 +35,11 @@ _MOVE_DOMAIN = (
     f"UPDATE tasks SET submitted_base_url = provider_endpoint WHERE submitted_base_url IS NULL AND {_HAS_DOMAIN}"
 )
 _CLEAR_DOMAIN = f"UPDATE tasks SET provider_endpoint = NULL WHERE {_HAS_DOMAIN}"
-_COUNT_DOMAIN = f"SELECT COUNT(*) FROM tasks WHERE {_HAS_DOMAIN}"
+
+# 校验判据刻意不与回填判据同源：拿同一个谓词自查必然得 0，问不出任何东西。改问「还有没有行
+# 带 scheme 分隔符」，既复核 http(s) 已清空，也能撞见 lower()/LIKE 行为不符预期或存量里躺着
+# 其他 scheme 的情形——协议标识里不会出现 `://`，命中即回填没做干净。
+_COUNT_SCHEME_LIKE = "SELECT COUNT(*) FROM tasks WHERE provider_endpoint LIKE '%://%'"
 
 # 回填后内置供应商的行只剩域名一列有值，据此反向还原；自定义供应商的行两列俱在，不动。
 _RESTORE_DOMAIN = (
@@ -46,7 +53,7 @@ def upgrade() -> None:
     bind = op.get_bind()
     bind.execute(sa.text(_MOVE_DOMAIN))
     bind.execute(sa.text(_CLEAR_DOMAIN))
-    remaining = bind.execute(sa.text(_COUNT_DOMAIN)).scalar()
+    remaining = bind.execute(sa.text(_COUNT_SCHEME_LIKE)).scalar()
     if remaining:
         raise RuntimeError(f"{remaining} 行的 tasks.provider_endpoint 仍存放请求域名，回填未完成")
 

--- a/lib/db/models/task.py
+++ b/lib/db/models/task.py
@@ -33,13 +33,11 @@ class Task(UserOwnedMixin, Base):
     cancelled_by: Mapped[str | None] = mapped_column(String)
     provider_id: Mapped[str | None] = mapped_column(String)
     provider_job_id: Mapped[str | None] = mapped_column(String)
-    # 提交该 job 时实际使用的执行端点，与 provider_job_id 同一次写入落地：自定义供应商记模型行
-    # 的 endpoint 标识（续跑据此判定协议是否已被换掉），提交域名随用户配置变化的内置供应商记实际
-    # 请求域名（续跑据此回放原域名轮询）。常态下两类取值各由对应续跑分支消费；内置供应商提交
-    # 后在途改成自定义供应商时，比对闸会拿落库的域名与当下 endpoint 标识比较并拒绝接续。
+    # 提交该供应商任务时所用的协议标识（协议维度），只有自定义供应商有这个维度，内置供应商恒 NULL。
+    # 与 provider_job_id 同一次写入落地，供续跑判定协议是否已被换掉。不存请求域名。
     provider_endpoint: Mapped[str | None] = mapped_column(String)
-    # 自定义供应商提交该 job 时实际请求的域名（连接维度），与 provider_job_id 同一次写入落地，
-    # 供续跑回放原域名轮询——该类供应商的 provider_endpoint 已被协议标识占用，域名另存于此。
+    # 提交该供应商任务时实际请求的域名（连接维度），两类供应商通用，与 provider_job_id 同一次
+    # 写入落地。域名随用户配置变化，续跑据此回放原域名轮询，避免按新域名轮旧任务查无。
     submitted_base_url: Mapped[str | None] = mapped_column(String)
     # 参考视频首次提交前冻结的严格执行事实。独立列避免与可变 enqueue payload 混合，且让
     # checkpoint/job 组合在重启时可无歧义分流；只由 worker 内部消费，不属于 tasks API 契约。

--- a/lib/db/models/task.py
+++ b/lib/db/models/task.py
@@ -34,7 +34,8 @@ class Task(UserOwnedMixin, Base):
     provider_id: Mapped[str | None] = mapped_column(String)
     provider_job_id: Mapped[str | None] = mapped_column(String)
     # 提交该供应商任务时所用的协议标识（协议维度），只有自定义供应商有这个维度，内置供应商恒 NULL。
-    # 与 provider_job_id 同一次写入落地，供续跑判定协议是否已被换掉。不存请求域名。
+    # 与 provider_job_id 同一次写入落地，记录这笔供应商任务按哪套协议提交，供排障时归因。不存请求
+    # 域名。续跑的协议比对不读这一列——那道闸的权威是 execution_checkpoint_json 里的 endpoint_guard。
     provider_endpoint: Mapped[str | None] = mapped_column(String)
     # 提交该供应商任务时实际请求的域名（连接维度），两类供应商通用，与 provider_job_id 同一次
     # 写入落地。域名随用户配置变化，续跑据此回放原域名轮询，避免按新域名轮旧任务查无。

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -732,8 +732,9 @@ class TaskRepository(BaseRepository):
 
         端点信息按维度分列：``endpoint`` 是协议标识（只有自定义供应商有），落 ``provider_endpoint``；
         ``base_url`` 是本次实际请求的域名（两类供应商通用），落 ``submitted_base_url``。两者都与
-        job_id 同一次 UPDATE 落地：必须同时可见，否则续跑会拿到 job_id 却判不出协议是否已被换掉、
-        也无从回放原域名。None 时不写对应列——保留既有值比清空更安全（清空等于放弃比对 / 放弃回放）。
+        job_id 同一次 UPDATE 落地：域名必须与 job_id 同时可见，否则续跑拿到 job_id 却无从回放原
+        域名；协议标识同批落地，这笔供应商任务的协议归属才可查。None 时不写对应列——保留既有值比
+        清空更安全（清空等于丢掉协议归属 / 放弃回放）。
 
         失败抛异常，由 worker finally 兜底 mark_failed（ADR 0007 fail-fast：未持久化的
         submit 视为整笔失败，避免「幽灵任务」继续在 provider 端跑而 DB 已忘）。

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -730,12 +730,10 @@ class TaskRepository(BaseRepository):
     ) -> None:
         """单独事务持久化 provider_job_id；不带 WHERE 状态守卫（worker 内调用，确定是 running）。
 
-        ``endpoint`` 是提交本 job 时实际使用的执行端点，按供应商类型有两种取值：自定义供应商
-        传模型行的 endpoint 标识，提交域名随用户配置变化的内置供应商传实际请求域名。
-        ``base_url`` 只由自定义供应商传——它的 ``endpoint`` 位已被协议标识占用，实际请求域名
-        另落 ``submitted_base_url`` 列。两者都与 job_id 同一次 UPDATE 落地：必须同时可见，否则
-        续跑会拿到 job_id 却判不出协议是否已被换掉、也无从回放原域名。None 时不写对应列——保留
-        既有值比清空更安全（清空等于放弃比对 / 放弃回放）。
+        端点信息按维度分列：``endpoint`` 是协议标识（只有自定义供应商有），落 ``provider_endpoint``；
+        ``base_url`` 是本次实际请求的域名（两类供应商通用），落 ``submitted_base_url``。两者都与
+        job_id 同一次 UPDATE 落地：必须同时可见，否则续跑会拿到 job_id 却判不出协议是否已被换掉、
+        也无从回放原域名。None 时不写对应列——保留既有值比清空更安全（清空等于放弃比对 / 放弃回放）。
 
         失败抛异常，由 worker finally 兜底 mark_failed（ADR 0007 fail-fast：未持久化的
         submit 视为整笔失败，避免「幽灵任务」继续在 provider 端跑而 DB 已忘）。

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -57,12 +57,10 @@ async def persist_provider_job_id(
 ) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    Caller 显式传 task_id；``endpoint`` 记提交该 job 实际使用的执行端点，与 job_id 同一次写入
-    落地供续跑消费，按供应商类型有两种取值：自定义供应商记 endpoint 标识（协议维度，续跑据
-    此判定协议是否已被换掉），内置供应商记实际请求域名（连接维度，续跑据此回放原域名轮询）。
-    ``base_url`` 是自定义供应商那半边的请求域名，其 ``endpoint`` 位已被协议标识占用，域名另落
-    一列，同样供续跑回放。DB 瞬态错误最多重试 3 次，业务异常立即抛。重试用尽抛异常，由 worker
-    finally 兜底 mark_failed（fail-fast）。
+    Caller 显式传 task_id；``endpoint`` 是协议标识（协议维度，只有自定义供应商有，续跑据此判定
+    协议是否已被换掉），``base_url`` 是本次实际请求的域名（连接维度，两类供应商通用，续跑据此
+    回放原域名轮询）。两者与 job_id 同一次写入落地供续跑消费。DB 瞬态错误最多重试 3 次，业务
+    异常立即抛。重试用尽抛异常，由 worker finally 兜底 mark_failed（fail-fast）。
     """
     try:
         await _persist_with_retry(task_id, job_id, endpoint, base_url)
@@ -101,21 +99,20 @@ class ProviderJobIdPersistenceMixin:
     ) -> None:
         """submit 成功后立即调：worker 路径写回 job_id，非 worker 路径（task_id=None）跳过。
 
-        同时写回该 job 执行所用的端点，两个维度各占一列：``request.execution_endpoint`` 由自定义
-        供应商的包装层在转发前注入，是续跑比对协议的依据；``endpoint`` 由提交域名随用户配置变化的
-        backend（只有 dashscope 协议这一条线）传入实际请求域名，供续跑回放。自定义供应商两者兼有——
-        协议标识占 endpoint 位、域名走 base_url 位，互不覆盖；内置供应商只有域名，仍落 endpoint 位。
-        持久化失败抛出（DB 瞬态错误已在 ``persist_provider_job_id`` 内重试 3 次），由 worker finally
-        兜底 mark_failed —— 保持现有 fail-fast 语义（ADR 0007）。
+        同时按维度分列写回本次提交所用的端点信息：协议标识取 ``request.execution_endpoint``（由
+        自定义供应商的包装层在转发前注入，内置供应商无此维度、恒 None），实际请求域名取参数
+        ``endpoint``（由提交域名随用户配置变化的 backend 传入，只有 dashscope 协议这一条线）。
+        两类供应商共用同一套写法，域名一律落 ``submitted_base_url``。持久化失败抛出（DB 瞬态错误
+        已在 ``persist_provider_job_id`` 内重试 3 次），由 worker finally 兜底 mark_failed ——
+        保持现有 fail-fast 语义（ADR 0007）。
         """
         if request.task_id is not None:
-            execution_endpoint = request.execution_endpoint
             await persist_provider_job_id(
                 request.task_id,
                 job_id,
                 provider=provider,
-                endpoint=execution_endpoint or endpoint,
-                base_url=endpoint if execution_endpoint else None,
+                endpoint=request.execution_endpoint,
+                base_url=endpoint,
             )
         if request.on_provider_resubmit_unsafe is not None:
             request.on_provider_resubmit_unsafe()
@@ -681,11 +678,11 @@ class VideoGenerationRequest:
     # call whose failure cannot prove that the provider rejected the request before accepting a paid job.
     on_provider_resubmit_unsafe: Callable[[], None] | None = None
 
-    # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的 endpoint，
-    # 与 job_id 一并持久化供续跑比对。内置供应商无 endpoint 维度，保持 None。
+    # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的协议标识，
+    # 与 job_id 一并持久化到 `tasks.provider_endpoint` 供续跑比对。内置供应商无此维度，保持 None。
     execution_endpoint: str | None = None
 
-    # 续跑路径专用：提交本 job 时实际使用的请求域名，由 resume_executor 从持久化列回放。
+    # 续跑路径专用：提交本 job 时实际使用的请求域名，由 resume_executor 从 `tasks.submitted_base_url` 回放。
     # backend 轮询时优先用它而非当下配置解析出的域名——域名是连接维度而非协议维度，
     # 用户在途改配置后按新域名轮旧 job 会查无（404）而被误判成过期。提交路径恒 None。
     submitted_base_url: str | None = None

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -57,10 +57,10 @@ async def persist_provider_job_id(
 ) -> None:
     """Submit 之后立即调：把 job_id 持久化到 DB 让重启可接续。
 
-    Caller 显式传 task_id；``endpoint`` 是协议标识（协议维度，只有自定义供应商有，续跑据此判定
-    协议是否已被换掉），``base_url`` 是本次实际请求的域名（连接维度，两类供应商通用，续跑据此
-    回放原域名轮询）。两者与 job_id 同一次写入落地供续跑消费。DB 瞬态错误最多重试 3 次，业务
-    异常立即抛。重试用尽抛异常，由 worker finally 兜底 mark_failed（fail-fast）。
+    Caller 显式传 task_id；``endpoint`` 是协议标识（协议维度，只有自定义供应商有，记录本笔供应商
+    任务按哪套协议提交），``base_url`` 是本次实际请求的域名（连接维度，两类供应商通用，续跑据此
+    回放原域名轮询）。两者与 job_id 同一次写入落地。DB 瞬态错误最多重试 3 次，业务异常立即抛。
+    重试用尽抛异常，由 worker finally 兜底 mark_failed（fail-fast）。
     """
     try:
         await _persist_with_retry(task_id, job_id, endpoint, base_url)
@@ -678,8 +678,9 @@ class VideoGenerationRequest:
     # call whose failure cannot prove that the provider rejected the request before accepting a paid job.
     on_provider_resubmit_unsafe: Callable[[], None] | None = None
 
-    # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的协议标识，
-    # 与 job_id 一并持久化到 `tasks.provider_endpoint` 供续跑比对。内置供应商无此维度，保持 None。
+    # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的协议标识，与 job_id
+    # 一并持久化到 `tasks.provider_endpoint`，记录本笔供应商任务的协议归属。内置供应商无此维度，
+    # 保持 None。续跑比对协议读的是 checkpoint 的 endpoint_guard，不读该列。
     execution_endpoint: str | None = None
 
     # 续跑路径专用：提交本 job 时实际使用的请求域名，由 resume_executor 从 `tasks.submitted_base_url` 回放。

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -78,6 +78,9 @@ def _submitted_base_url(task: dict[str, Any]) -> str | None:
     调用点在 ``_ensure_checkpoint_endpoint_unchanged`` 之后：协议标识与内置/自定义的归属已经与
     提交时逐字相等，落库的域名必定属于当下这套凭据，可直接回放。列为空（未落此值的存量任务、
     提交域名不随配置变化的供应商）时回退 None，backend 按当下配置的域名轮询。
+
+    http(s) 形态判别是对落库值的兜底断言：写入侧只往该列放请求域名，读到别的形态说明这行来路
+    不明（人工改库、迁移前两列都有值的畸形行），宁可回退到当下配置的域名，也不拿它拼轮询 URL。
     """
     submitted = task.get("submitted_base_url")
     if isinstance(submitted, str) and submitted.lower().startswith(("http://", "https://")):

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -71,31 +71,17 @@ def _validate_resolved_checkpoint_identity(checkpoint: VideoSubmissionCheckpoint
         )
 
 
-def _is_request_domain(value: Any) -> bool:
-    """落库值是否为请求域名形态——两列都可能躺着 endpoint 标识，只有 http(s) 前缀的才是域名。"""
-    return isinstance(value, str) and value.lower().startswith(("http://", "https://"))
+def _submitted_base_url(task: dict[str, Any]) -> str | None:
+    """提交本供应商任务时的请求域名，供 backend 回放轮询；未记录时 None。
 
-
-def _submitted_base_url(task: dict[str, Any], current_endpoint: str | None) -> str | None:
-    """提交本 job 时的请求域名，供 backend 回放轮询；无从判定时 None。
-
-    域名按供应商类型分落两列，读取时按当下的供应商类型选列——``current_endpoint`` 非空即当下
-    是自定义供应商，取专列 ``submitted_base_url``（该类供应商的 ``provider_endpoint`` 位被协议
-    标识占用，归比对闸消费）；为空即当下是内置供应商，无协议维度，域名就在 ``provider_endpoint``。
-    空值统一取 falsy，否则空串会让两条分支都不生效。
-
-    按当下类型选列而非先读专列，是为了拦住跨类切换：任务由自定义供应商提交、模型行在途被改成
-    内置供应商时，专列里躺着的是另一个供应商的域名，拿它配内置凭据轮询只会把 404（可归因为任务
-    过期）换成更难归因的认证或连接错误；反向切换同理，域名形态确认拦住把 endpoint 标识当域名用。
-    选中的列没有域名（未落此值的存量任务、非 dashscope 协议的自定义供应商、跨类切换）时回退
-    None，backend 按当下配置的域名轮询。
+    域名不分供应商类型，一律落 ``submitted_base_url``（``provider_endpoint`` 只承载协议标识）。
+    调用点在 ``_ensure_checkpoint_endpoint_unchanged`` 之后：协议标识与内置/自定义的归属已经与
+    提交时逐字相等，落库的域名必定属于当下这套凭据，可直接回放。列为空（未落此值的存量任务、
+    提交域名不随配置变化的供应商）时回退 None，backend 按当下配置的域名轮询。
     """
-    if current_endpoint:
-        submitted = task.get("submitted_base_url")
-        return str(submitted) if _is_request_domain(submitted) else None
-    endpoint_column = task.get("provider_endpoint")
-    if _is_request_domain(endpoint_column):
-        return str(endpoint_column)
+    submitted = task.get("submitted_base_url")
+    if isinstance(submitted, str) and submitted.lower().startswith(("http://", "https://")):
+        return submitted
     return None
 
 
@@ -184,7 +170,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
                 resolution=resolution,
                 task_id=task_id,
                 api_call_id=api_call_id,
-                submitted_base_url=_submitted_base_url(task, ctx.video.endpoint),
+                submitted_base_url=_submitted_base_url(task),
                 seed=seed,
                 service_tier=service_tier,
                 before_formal_commit=artifact_committer.prepare_selection,

--- a/tests/test_alembic_task_endpoint_base_url_split.py
+++ b/tests/test_alembic_task_endpoint_base_url_split.py
@@ -132,7 +132,7 @@ def test_upgrade_fails_loud_when_a_scheme_survives_the_backfill(alembic_cfg):
         _insert_task(conn, "T-odd-scheme", "ftp://legacy.example.com/api/v1", None)
     engine.dispose()
 
-    with pytest.raises(Exception, match="仍存放请求域名"):
+    with pytest.raises(RuntimeError, match="仍存放请求域名"):
         command.upgrade(cfg, REVISION)
 
 

--- a/tests/test_alembic_task_endpoint_base_url_split.py
+++ b/tests/test_alembic_task_endpoint_base_url_split.py
@@ -122,6 +122,20 @@ def test_downgrade_restores_builtin_domains(alembic_cfg):
     assert rows["T-custom"] == ("dashscope-async-video", "https://custom-a.example.com/api/v1")
 
 
+def test_upgrade_fails_loud_when_a_scheme_survives_the_backfill(alembic_cfg):
+    """校验判据独立于回填判据：回填够不着的 scheme 形态会让升级显式失败，而不是静默留下。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, DOWN_REVISION)
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        _insert_task(conn, "T-odd-scheme", "ftp://legacy.example.com/api/v1", None)
+    engine.dispose()
+
+    with pytest.raises(Exception, match="仍存放请求域名"):
+        command.upgrade(cfg, REVISION)
+
+
 def test_migration_keeps_dedupe_index(alembic_cfg):
     """纯数据迁移不重建表，表达式型 partial 唯一索引双向都在。"""
     cfg, db_path = alembic_cfg

--- a/tests/test_alembic_task_endpoint_base_url_split.py
+++ b/tests/test_alembic_task_endpoint_base_url_split.py
@@ -1,0 +1,132 @@
+"""Alembic b3f9c07ae214（tasks 协议标识与请求域名分列）双向迁移测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+REVISION = "b3f9c07ae214"
+DOWN_REVISION = "f6a41746c0de"
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    # alembic env.py 的 fileConfig 默认 disable_existing_loggers=True，会禁掉测试进程已注册的
+    # logger，污染后续 caplog 测试。
+    import logging.config
+
+    real_file_config = logging.config.fileConfig
+    monkeypatch.setattr(
+        logging.config,
+        "fileConfig",
+        lambda *args, **kwargs: real_file_config(*args, **{**kwargs, "disable_existing_loggers": False}),
+    )
+    cfg = Config(str(PROJECT_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(PROJECT_ROOT / "alembic"))
+    return cfg, db_path
+
+
+def _insert_task(conn, task_id: str, endpoint: str | None, base_url: str | None) -> None:
+    conn.execute(
+        sa.text(
+            "INSERT INTO tasks (task_id, project_name, task_type, media_type, resource_id, status, source, "
+            "provider_endpoint, submitted_base_url, queued_at, updated_at) "
+            "VALUES (:tid, 'demo', 'video', 'video', :tid, 'running', 'webui', :ep, :url, "
+            "'2026-08-18 00:00:00', '2026-08-18 00:00:00')"
+        ),
+        {"tid": task_id, "ep": endpoint, "url": base_url},
+    )
+
+
+def _rows(db_path: Path) -> dict[str, tuple[str | None, str | None]]:
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        rows = conn.execute(sa.text("SELECT task_id, provider_endpoint, submitted_base_url FROM tasks")).fetchall()
+    engine.dispose()
+    return {r[0]: (r[1], r[2]) for r in rows}
+
+
+def _tasks_indexes(db_path: Path) -> set[str]:
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        rows = conn.execute(sa.text("PRAGMA index_list('tasks')")).fetchall()
+    engine.dispose()
+    return {r[1] for r in rows}
+
+
+def test_upgrade_moves_domains_into_submitted_base_url(alembic_cfg):
+    """升级后无任何行在协议标识列存放域名；自定义供应商的两列各归其位、不被改写。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, DOWN_REVISION)
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        _insert_task(conn, "T-builtin", "https://maas-a.example.com/ws-1/api/v1", None)
+        _insert_task(conn, "T-builtin-upper", "HTTPS://maas-b.example.com/ws-1/api/v1", None)
+        _insert_task(conn, "T-custom", "dashscope-async-video", "https://custom-a.example.com/api/v1")
+        _insert_task(conn, "T-custom-nodomain", "openai-video", None)
+        _insert_task(conn, "T-empty", None, None)
+    engine.dispose()
+
+    command.upgrade(cfg, REVISION)
+
+    rows = _rows(db_path)
+    assert rows["T-builtin"] == (None, "https://maas-a.example.com/ws-1/api/v1")
+    assert rows["T-builtin-upper"] == (None, "HTTPS://maas-b.example.com/ws-1/api/v1")
+    assert rows["T-custom"] == ("dashscope-async-video", "https://custom-a.example.com/api/v1")
+    assert rows["T-custom-nodomain"] == ("openai-video", None)
+    assert rows["T-empty"] == (None, None)
+
+
+def test_upgrade_keeps_existing_domain_when_both_columns_hold_one(alembic_cfg):
+    """两列都有域名的畸形行以专列为准：只清协议标识位，不覆盖已有域名。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, DOWN_REVISION)
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        _insert_task(conn, "T-both", "https://stale.example.com/api/v1", "https://kept.example.com/api/v1")
+    engine.dispose()
+
+    command.upgrade(cfg, REVISION)
+
+    assert _rows(db_path)["T-both"] == (None, "https://kept.example.com/api/v1")
+
+
+def test_downgrade_restores_builtin_domains(alembic_cfg):
+    """降级把只有域名的行搬回协议标识列；自定义供应商的行两列俱在，原样不动。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, DOWN_REVISION)
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        _insert_task(conn, "T-builtin", "https://maas-a.example.com/ws-1/api/v1", None)
+        _insert_task(conn, "T-custom", "dashscope-async-video", "https://custom-a.example.com/api/v1")
+    engine.dispose()
+
+    command.upgrade(cfg, REVISION)
+    command.downgrade(cfg, DOWN_REVISION)
+
+    rows = _rows(db_path)
+    assert rows["T-builtin"] == ("https://maas-a.example.com/ws-1/api/v1", None)
+    assert rows["T-custom"] == ("dashscope-async-video", "https://custom-a.example.com/api/v1")
+
+
+def test_migration_keeps_dedupe_index(alembic_cfg):
+    """纯数据迁移不重建表，表达式型 partial 唯一索引双向都在。"""
+    cfg, db_path = alembic_cfg
+    command.upgrade(cfg, REVISION)
+    assert "idx_tasks_dedupe_active" in _tasks_indexes(db_path)
+
+    command.downgrade(cfg, DOWN_REVISION)
+    assert "idx_tasks_dedupe_active" in _tasks_indexes(db_path)

--- a/tests/test_dashscope_video_backend.py
+++ b/tests/test_dashscope_video_backend.py
@@ -1193,7 +1193,8 @@ class TestWan3:
                 )
             )
 
-        assert persist.call_args.kwargs["endpoint"] == "https://maas-a.example.com/ws-1/api/v1"
+        assert persist.call_args.kwargs["base_url"] == "https://maas-a.example.com/ws-1/api/v1"
+        assert persist.call_args.kwargs["endpoint"] is None
 
     @pytest.mark.unit
     async def test_resume_polls_submitted_base_url_after_config_change(self, tmp_path: Path):

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -663,7 +663,7 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
         "script_file": "scripts/frozen.json",
         "provider_id": "stale-provider",
         "provider_job_id": "job-1",
-        "provider_endpoint": "stale-endpoint-column",
+        "provider_endpoint": "stale-protocol-id",
         "submitted_base_url": "https://submitted.example/v1",
         "execution_checkpoint_json": _reference_checkpoint(
             fake_pm.project_path,
@@ -917,13 +917,18 @@ async def test_resume_proceeds_for_builtin_provider_without_endpoint(monkeypatch
 
 @pytest.mark.asyncio
 async def test_resume_replays_submitted_base_url_for_builtin(monkeypatch, fake_pm, video_task):
-    """内置供应商：持久化的提交域名透传给 backend，改配置后续跑仍轮原主机。"""
+    """内置供应商重启续跑：持久化的提交域名透传给 backend，改配置后仍轮原主机。"""
     from server.services.resume_executor import execute_resume_video_task
 
     fake_gen = _FakeGenerator()
     _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
 
-    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "https://maas-a.example.com/ws-1/api/v1"}
+    task = {
+        **video_task,
+        "provider_id": "dashscope",
+        "provider_endpoint": None,
+        "submitted_base_url": "https://maas-a.example.com/ws-1/api/v1",
+    }
     await execute_resume_video_task(task, job_id="dashscope-job-1")
 
     assert fake_gen.resume_calls[0]["submitted_base_url"] == "https://maas-a.example.com/ws-1/api/v1"
@@ -937,30 +942,15 @@ async def test_resume_replays_submitted_base_url_with_uppercase_scheme(monkeypat
     fake_gen = _FakeGenerator()
     _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
 
-    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "HTTPS://maas-a.example.com/ws-1/api/v1"}
+    task = {**video_task, "provider_id": "dashscope", "submitted_base_url": "HTTPS://maas-a.example.com/ws-1/api/v1"}
     await execute_resume_video_task(task, job_id="dashscope-job-1")
 
     assert fake_gen.resume_calls[0]["submitted_base_url"] == "HTTPS://maas-a.example.com/ws-1/api/v1"
 
 
 @pytest.mark.asyncio
-async def test_resume_does_not_replay_endpoint_id_for_custom(monkeypatch, fake_pm, video_task):
-    """自定义供应商：列里是 endpoint 标识、归比对闸消费，不当域名回放。"""
-    from server.services.resume_executor import execute_resume_video_task
-
-    fake_gen = _FakeGenerator()
-    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="openai-video", provider_id="custom-7")
-
-    task = _with_storyboard_identity(video_task, provider_id="custom-7", endpoint_guard="openai-video")
-    task["provider_endpoint"] = "openai-video"
-    await execute_resume_video_task(task, job_id="custom-job-1")
-
-    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
-
-
-@pytest.mark.asyncio
 async def test_resume_replays_submitted_base_url_for_custom(monkeypatch, fake_pm, video_task):
-    """自定义供应商：域名落在专列，在途改 base_url 后续跑仍按提交时的域名轮询。"""
+    """自定义供应商重启续跑：协议标识与域名各在其列，在途改 base_url 后仍按提交时的域名轮询。"""
     from server.services.resume_executor import execute_resume_video_task
 
     fake_gen = _FakeGenerator()
@@ -987,17 +977,36 @@ async def test_resume_replays_submitted_base_url_for_custom(monkeypatch, fake_pm
 
 
 @pytest.mark.asyncio
+async def test_resume_does_not_read_domain_from_endpoint_column(monkeypatch, fake_pm, video_task):
+    """协议标识列不参与域名回放：未记域名的任务回退到按当下配置的域名轮询。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="openai-video", provider_id="custom-7")
+
+    task = _with_storyboard_identity(video_task, provider_id="custom-7", endpoint_guard="openai-video")
+    task["provider_endpoint"] = "openai-video"
+    task["submitted_base_url"] = None
+    await execute_resume_video_task(task, job_id="custom-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
+
+
+@pytest.mark.asyncio
 async def test_resume_fails_when_custom_endpoint_changed_even_with_base_url(monkeypatch, fake_pm, video_task):
     """协议标识不一致仍显式失败——域名回放不为换协议的续跑开口子。"""
     from lib.video_backends.base import ResumeEndpointChangedError
     from server.services.resume_executor import execute_resume_video_task
 
     fake_gen = _FakeGenerator()
-    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="minimax-video")
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="minimax-video", provider_id="custom-7")
 
     task = {
-        **video_task,
-        "provider_id": "custom-7",
+        **_with_storyboard_identity(
+            video_task,
+            provider_id="custom-7",
+            endpoint_guard="dashscope-async-video",
+        ),
         "provider_endpoint": "dashscope-async-video",
         "submitted_base_url": "https://custom-a.example.com/api/v1",
     }
@@ -1008,50 +1017,38 @@ async def test_resume_fails_when_custom_endpoint_changed_even_with_base_url(monk
 
 
 @pytest.mark.asyncio
-async def test_resume_ignores_endpoint_id_left_by_provider_switch(monkeypatch, fake_pm, video_task):
-    """任务由自定义供应商提交、模型行在途被改成内置供应商：列里的标识不当域名用。
+async def test_resume_does_not_replay_domain_across_provider_kind_switch(monkeypatch, fake_pm, video_task):
+    """任务由自定义供应商提交、模型行在途被改成内置供应商：比对闸先拦下，域名无从回放。
 
-    拿 endpoint 标识拼 URL 只会把可归因的 404 换成更难归因的连接错误。
+    落库域名属于提交时那套凭据，拿它配另一类供应商的凭据轮询只会把可归因的 404 换成认证或
+    连接错误；比对闸对内置/自定义跨类切换逐字判不等，回放分支根本到不了。
     """
+    from lib.video_backends.base import ResumeEndpointChangedError
     from server.services.resume_executor import execute_resume_video_task
 
     fake_gen = _FakeGenerator()
-    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
-
-    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "openai-video"}
-    await execute_resume_video_task(task, job_id="dashscope-job-1")
-
-    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
-
-
-@pytest.mark.asyncio
-async def test_resume_ignores_custom_domain_left_by_provider_switch(monkeypatch, fake_pm, video_task):
-    """同一跨类切换下专列里的自定义域名同样不回放：当下是内置供应商，只认 ``provider_endpoint``。
-
-    拿另一个供应商的域名配内置凭据轮询，只会把可归因的 404 换成认证或连接错误。
-    """
-    from server.services.resume_executor import execute_resume_video_task
-
-    fake_gen = _FakeGenerator()
-    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None, provider_id="custom-7")
 
     task = {
-        **video_task,
-        "provider_id": "dashscope",
+        **_with_storyboard_identity(
+            video_task,
+            provider_id="custom-7",
+            endpoint_guard="dashscope-async-video",
+        ),
         "provider_endpoint": "dashscope-async-video",
         "submitted_base_url": "https://custom-a.example.com/api/v1",
     }
-    await execute_resume_video_task(task, job_id="dashscope-job-1")
+    with pytest.raises(ResumeEndpointChangedError):
+        await execute_resume_video_task(task, job_id="dashscope-job-1")
 
-    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
+    assert fake_gen.resume_calls == []
 
 
 @pytest.mark.asyncio
 async def test_resume_fails_when_builtin_task_switched_to_custom_provider(monkeypatch, fake_pm, video_task):
-    """任务由内置供应商提交（列里是域名）、模型行在途被改成自定义供应商：比对闸拦下。
+    """任务由内置供应商提交（无协议标识）、模型行在途被改成自定义供应商：比对闸拦下。
 
-    域名与 endpoint 标识必然不等，闸门据此判定协议已被换掉。内置任务的该列有值后这条路径
-    才可达，语义上也确实换了协议——宁可显式失败，也不拿新协议 backend 轮旧 job。
+    宁可显式失败，也不拿新协议 backend 轮旧的供应商任务。
     """
     from lib.video_backends.base import ResumeEndpointChangedError
     from server.services.resume_executor import execute_resume_video_task
@@ -1059,7 +1056,12 @@ async def test_resume_fails_when_builtin_task_switched_to_custom_provider(monkey
     fake_gen = _FakeGenerator()
     _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint="dashscope-async-video")
 
-    task = {**video_task, "provider_id": "dashscope", "provider_endpoint": "https://maas-a.example.com/ws-1/api/v1"}
+    task = {
+        **video_task,
+        "provider_id": "dashscope",
+        "provider_endpoint": None,
+        "submitted_base_url": "https://maas-a.example.com/ws-1/api/v1",
+    }
     with pytest.raises(ResumeEndpointChangedError):
         await execute_resume_video_task(task, job_id="dashscope-job-1")
 

--- a/tests/test_resume_executor.py
+++ b/tests/test_resume_executor.py
@@ -993,6 +993,20 @@ async def test_resume_does_not_read_domain_from_endpoint_column(monkeypatch, fak
 
 
 @pytest.mark.asyncio
+async def test_resume_ignores_non_domain_value_in_base_url_column(monkeypatch, fake_pm, video_task):
+    """专列里躺着非域名形态的值（人工改库等来路不明的行）：不回放，退回按当下配置轮询。"""
+    from server.services.resume_executor import execute_resume_video_task
+
+    fake_gen = _FakeGenerator()
+    _patch_resume_executor_deps(monkeypatch, fake_pm, fake_gen, endpoint=None)
+
+    task = {**video_task, "provider_id": "dashscope", "submitted_base_url": "dashscope-async-video"}
+    await execute_resume_video_task(task, job_id="dashscope-job-1")
+
+    assert fake_gen.resume_calls[0]["submitted_base_url"] is None
+
+
+@pytest.mark.asyncio
 async def test_resume_fails_when_custom_endpoint_changed_even_with_base_url(monkeypatch, fake_pm, video_task):
     """协议标识不一致仍显式失败——域名回放不为换协议的续跑开口子。"""
     from lib.video_backends.base import ResumeEndpointChangedError

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -697,8 +697,8 @@ class TestProviderJobIdPersistenceMixin:
             "local-task-1", "job-1", provider="ark", endpoint="openai-video", base_url=None
         )
 
-    async def test_worker_path_persists_backend_endpoint_when_builtin(self):
-        """内置供应商由 backend 传入实际请求域名 → 落库供续跑回放。"""
+    async def test_worker_path_persists_backend_domain_when_builtin(self):
+        """内置供应商由 backend 传入实际请求域名 → 落域名列供续跑回放，协议标识位保持空。"""
         with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
             await self._backend()._persist_provider_job_id(
                 self._request(task_id="local-task-1"),
@@ -707,11 +707,11 @@ class TestProviderJobIdPersistenceMixin:
                 endpoint="https://maas.example.com/api/v1",
             )
         persist.assert_awaited_once_with(
-            "local-task-1", "job-1", provider="dashscope", endpoint="https://maas.example.com/api/v1", base_url=None
+            "local-task-1", "job-1", provider="dashscope", endpoint=None, base_url="https://maas.example.com/api/v1"
         )
 
     async def test_execution_endpoint_and_backend_domain_land_in_separate_columns(self):
-        """自定义供应商：endpoint 位落协议标识供比对，域名另落 base_url 位供回放，互不覆盖。"""
+        """自定义供应商：协议标识走 endpoint 位供比对，域名走 base_url 位供回放，互不覆盖。"""
         request = self._request(task_id="local-task-1")
         request.execution_endpoint = "dashscope-async-video"
         with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:


### PR DESCRIPTION
Closes #1943

## 收益

任务记录里「用哪套协议提交」与「往哪个域名发的请求」此前挤在同一列：内置供应商把请求域名写进 `provider_endpoint`，自定义供应商把协议标识写进去、域名另存 `submitted_base_url`。读取侧只好按当下供应商类型猜该读哪一列。本 PR 把两个维度分列固定：`provider_endpoint` 只承载协议标识，请求域名一律落 `submitted_base_url`，两类供应商共用同一套写入与读取。

对用户可感知的行为不变：重启后接续未完成的供应商任务，仍按提交时的域名轮询——用户中途改过 base_url 也不会把仍在跑的任务误判成过期。

## 改动

- 一条纯数据 Alembic revision（`b3f9c07ae214`）把存量行里 `provider_endpoint` 的请求域名搬进 `submitted_base_url`，先搬后清、只填空列（两列都有域名的畸形行以专列为准）。无 DDL，故无需 `batch_alter_table`；`lower(...) LIKE` 在 SQLite 与 PostgreSQL 上语义一致，无方言分支。
- 回填后的自检用一条独立判据（`LIKE '%://%'`）而非回填谓词本身，回填够不着的形态会让升级显式失败而不是静默留下。
- 写入路径（`lib/video_backends/base.py`）两类供应商统一：协议标识取 `request.execution_endpoint`，域名取 backend 传入的参数，各落各列，不再互相顶替。
- 续跑读取（`server/services/resume_executor.py`）只读 `submitted_base_url`，去掉按供应商类型选列的双读。跨内置/自定义切换仍由既有的 checkpoint 比对闸拦截，该闸位于域名回放之前。
- 模型与文档字符串按新语义重写，并修正一处旧表述：`provider_endpoint` 不是续跑比对协议的依据（那道闸读 checkpoint 的 `endpoint_guard`），它记录的是这笔供应商任务的协议归属。

## 验证

- `uv run python -m pytest`：10189 passed, 2 skipped
- `uv run ruff check . && uv run ruff format .`：通过，无改写
- `uv run basedpyright`：0 errors
- `uv run lint-imports`：1 kept, 0 broken
- `uv run alembic heads`：单 head `b3f9c07ae214`
- 迁移双向测试覆盖：域名搬迁（含大写 scheme）、自定义供应商两列不被改写、两列都有域名时不覆盖专列、降级还原、表达式型 partial 唯一索引双向保持、自检 fail loud
- 续跑行为测试覆盖内置与自定义两类供应商的重启接续，以及跨类切换被比对闸拦下

未改前端，未跑前端检查。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 明确区分服务协议标识与实际请求地址，提升任务提交及恢复时的地址记录准确性。
  * 任务续跑可更可靠地恢复原始请求地址，并在协议不匹配或地址无效时及时停止。

* **数据迁移**
  * 现有任务数据将自动整理至新的地址字段，支持升级与回退，并保留已有去重约束。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->