### PR TITLE
refactor(studio): 每集内容规模按生成路线显示分镜数或视频单元数

### DIFF
--- a/agent_runtime_profile/.claude/skills/video-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/video-workflow/SKILL.drama.md
@@ -322,4 +322,4 @@ revision 重试。改完后按上面的请求选择语义点名重做这些 ID�
 
 - 角色 / 场景 / 道具完整定义**只存 project.json**，剧本中仅引用名称
 - 统计字段（item_count、status、progress）**读时计算**，不存储
-- 剧集元数据在剧本保存时**写时同步**
+- 剧集元数据（episode/title/script_file）在剧本保存时**写时同步**

--- a/agent_runtime_profile/.claude/skills/video-workflow/SKILL.drama.md
+++ b/agent_runtime_profile/.claude/skills/video-workflow/SKILL.drama.md
@@ -321,5 +321,5 @@ revision 重试。改完后按上面的请求选择语义点名重做这些 ID�
 ## 数据分层
 
 - 角色 / 场景 / 道具完整定义**只存 project.json**，剧本中仅引用名称
-- 统计字段（scenes_count、status、progress）**读时计算**，不存储
+- 统计字段（item_count、status、progress）**读时计算**，不存储
 - 剧集元数据在剧本保存时**写时同步**

--- a/agent_runtime_profile/.claude/skills/video-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/video-workflow/SKILL.narration.md
@@ -367,5 +367,5 @@ revision 重试。改完后按上面的请求选择语义点名重做这些 ID�
 ## 数据分层
 
 - 角色 / 场景 / 道具完整定义**只存 project.json**，剧本中仅引用名称
-- 统计字段（scenes_count、status、progress）**读时计算**，不存储
+- 统计字段（item_count、status、progress）**读时计算**，不存储
 - 剧集元数据在剧本保存时**写时同步**

--- a/agent_runtime_profile/.claude/skills/video-workflow/SKILL.narration.md
+++ b/agent_runtime_profile/.claude/skills/video-workflow/SKILL.narration.md
@@ -368,4 +368,4 @@ revision 重试。改完后按上面的请求选择语义点名重做这些 ID�
 
 - 角色 / 场景 / 道具完整定义**只存 project.json**，剧本中仅引用名称
 - 统计字段（item_count、status、progress）**读时计算**，不存储
-- 剧集元数据在剧本保存时**写时同步**
+- 剧集元数据（episode/title/script_file）在剧本保存时**写时同步**

--- a/agent_runtime_profile/CLAUDE.ad.md
+++ b/agent_runtime_profile/CLAUDE.ad.md
@@ -161,5 +161,5 @@ projects/{项目名}/      # ← session cwd 已在此，下面均为 cwd 内的
 ### 数据分层原则
 
 - 产品/角色/场景/道具的完整定义**只存储在 project.json**，剧本中仅引用名称
-- `scenes_count`、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
+- `item_count`（分镜数 / 视频单元数）、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
 - 剧集元数据（episode/title/script_file）在剧本保存时**写时同步**

--- a/agent_runtime_profile/CLAUDE.drama.md
+++ b/agent_runtime_profile/CLAUDE.drama.md
@@ -193,5 +193,5 @@ projects/{项目名}/      # ← session cwd 已在此，下面均为 cwd 内的
 ### 数据分层原则
 
 - 角色/场景/道具的完整定义**只存储在 project.json**，剧本中仅引用名称
-- `scenes_count`、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
+- `item_count`（分镜数 / 视频单元数）、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
 - 剧集元数据（episode/title/script_file）在剧本保存时**写时同步**

--- a/agent_runtime_profile/CLAUDE.narration.md
+++ b/agent_runtime_profile/CLAUDE.narration.md
@@ -194,5 +194,5 @@ projects/{项目名}/      # ← session cwd 已在此，下面均为 cwd 内的
 ### 数据分层原则
 
 - 角色/场景/道具的完整定义**只存储在 project.json**，剧本中仅引用名称
-- `scenes_count`、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
+- `item_count`（分镜数 / 视频单元数）、`status`、产物计数等统计字段由项目摘要**读时计算**，不存储
 - 剧集元数据（episode/title/script_file）在剧本保存时**写时同步**

--- a/frontend/src/components/canvas/OverviewCanvas.test.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.test.tsx
@@ -53,6 +53,41 @@ describe("OverviewCanvas", () => {
     expect(screen.getByText("Demo")).toBeInTheDocument();
   });
 
+  it("reports the storyboard count per episode on the storyboard route", () => {
+    // 分镜路线上三种创作类型同一口径：广告/短片也报分镜数，不再另说一套。
+    render(
+      <OverviewCanvas
+        projectName="demo"
+        projectData={makeProjectData({
+          content_mode: "ad",
+          brief: "一支 30 秒广告",
+          generation_mode: "storyboard",
+          episodes: [
+            { episode: 1, title: "EP1", script_file: "scripts/episode_1.json", item_count: 3 },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/3 分镜 ·/)).toBeInTheDocument();
+  });
+
+  it("reports the video unit count per episode on the reference route", () => {
+    render(
+      <OverviewCanvas
+        projectName="demo"
+        projectData={makeProjectData({
+          generation_mode: "reference_video",
+          episodes: [
+            { episode: 1, title: "EP1", script_file: "scripts/episode_1.json", item_count: 3 },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/3 视频单元 ·/)).toBeInTheDocument();
+  });
+
   it("shows welcome canvas when there is no overview and no episodes", () => {
     render(
       <OverviewCanvas

--- a/frontend/src/components/canvas/OverviewCanvas.tsx
+++ b/frontend/src/components/canvas/OverviewCanvas.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useCostStore } from "@/stores/cost-store";
 import { costEntries, formatCost, totalBreakdown } from "@/utils/cost-format";
 import { errMsg } from "@/utils/async";
+import { itemCountKey, normalizeRoute } from "@/utils/generation-mode";
 
 import { WelcomeCanvas } from "./WelcomeCanvas";
 import { AdInitCanvas } from "./AdInitCanvas";
@@ -52,6 +53,8 @@ export function OverviewCanvas({
   tRef.current = t;
   // 广告/短片项目恒单集：界面隐藏「集」语义，区块按单视频呈现
   const isAd = projectData?.content_mode === "ad";
+  // 内容规模的口径按生成路线定，与创作类型无关：分镜路线报分镜数、参考路线报视频单元数。
+  const route = normalizeRoute(projectData?.generation_mode);
   const projectTotals = useCostStore((s) => s.costData?.project_totals);
   const getEpisodeCost = useCostStore((s) => s.getEpisodeCost);
   const costLoading = useCostStore((s) => s.loading);
@@ -782,8 +785,8 @@ export function OverviewCanvas({
                           {ep.title || (isAd ? projectData.title : "")}
                         </span>
                         <span style={{ color: "var(--color-text-4)" }}>
-                          {t(isAd ? "shots_and_status" : "segments_and_status", {
-                            count: ep.scenes_count ?? "?",
+                          {t(itemCountKey(route, { withStatus: true }), {
+                            count: ep.item_count ?? "?",
                             status: t(`episode_status_label_${ep.status ?? "draft"}`),
                           })}
                         </span>

--- a/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
+++ b/frontend/src/components/canvas/grid/GridImageToVideoCanvas.tsx
@@ -191,7 +191,7 @@ export function GridImageToVideoCanvas({
       episode,
       title: episodeTitle ?? episodeScript?.title ?? "",
       script_file: scriptFile ?? "",
-      scenes_count: segments.length,
+      item_count: segments.length,
       duration_seconds: totalDuration,
       status: hasScript ? "in_production" : "draft",
     } as const);

--- a/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
+++ b/frontend/src/components/canvas/timeline/TimelineCanvas.tsx
@@ -198,7 +198,7 @@ export function TimelineCanvas(props: TimelineCanvasProps) {
       episode,
       title: episodeTitle ?? episodeScript?.title ?? "",
       script_file: scriptFile ?? "",
-      scenes_count: segments.length,
+      item_count: segments.length,
       duration_seconds: totalDuration,
       status: hasScript ? "in_production" : "draft",
     } as const);

--- a/frontend/src/components/layout/AssetSidebar.tsx
+++ b/frontend/src/components/layout/AssetSidebar.tsx
@@ -20,6 +20,7 @@ import { useAppStore } from "@/stores/app-store";
 import { API } from "@/api";
 import { useDemoWorkbench } from "@/onboarding/use-demo-workbench";
 import { isDemoProject } from "@/onboarding/demo-project";
+import { normalizeRoute } from "@/utils/generation-mode";
 import { EpisodeCard } from "./EpisodeCard";
 
 interface AssetSidebarProps {
@@ -312,6 +313,7 @@ export function AssetSidebar({ className }: AssetSidebarProps) {
                   onClick={() => setLocation(`/episodes/${ep.episode}`)}
                   showEpisodeBadge={!isAd}
                   fallbackTitle={isAd ? currentProjectData?.title : undefined}
+                  route={normalizeRoute(currentProjectData?.generation_mode)}
                 />
               ))
             )}

--- a/frontend/src/components/layout/EpisodeCard.test.tsx
+++ b/frontend/src/components/layout/EpisodeCard.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { EpisodeCard } from "./EpisodeCard";
 import type { EpisodeMeta } from "@/types/project";
+import type { GenerationRoute } from "@/utils/generation-mode";
 
 /**
  * 剧集卡上的两个数字都来自项目摘要，口径是产物清单：可用 = current ∪ stale，
@@ -15,7 +16,7 @@ function makeEpisode(overrides: Partial<EpisodeMeta> = {}): EpisodeMeta {
     script_file: "scripts/episode_1.json",
     script_status: "generated",
     status: "in_production",
-    scenes_count: 4,
+    item_count: 4,
     duration_seconds: 96,
     storyboards: { total: 4, available: 4, stale: 0 },
     videos: { total: 4, available: 3, stale: 0 },
@@ -23,14 +24,16 @@ function makeEpisode(overrides: Partial<EpisodeMeta> = {}): EpisodeMeta {
   };
 }
 
-function renderCard(ep: EpisodeMeta) {
-  return render(<EpisodeCard ep={ep} active={false} onClick={() => {}} />);
+function renderCard(ep: EpisodeMeta, route: GenerationRoute = "storyboard") {
+  return render(
+    <EpisodeCard ep={ep} active={false} onClick={() => {}} route={route} />,
+  );
 }
 
 describe("EpisodeCard", () => {
   it("reports available videos against the total, not the script item count", () => {
-    // scenes_count 与 videos.total 刻意取不同值：读错字段的实现会显示 4/4 或裸 4。
-    renderCard(makeEpisode({ scenes_count: 9 }));
+    // item_count 与 videos.total 刻意取不同值：读错字段的实现会显示 4/4 或裸 4。
+    renderCard(makeEpisode({ item_count: 9 }));
 
     expect(screen.getByText(/3\/4/)).toBeInTheDocument();
   });
@@ -55,15 +58,30 @@ describe("EpisodeCard", () => {
   });
 
   it("falls back to the script item count for an episode with no videos planned yet", () => {
-    renderCard(
-      makeEpisode({
-        status: "scripted",
-        storyboards: { total: 0, available: 0, stale: 0 },
-        videos: { total: 0, available: 0, stale: 0 },
-      }),
-    );
+    renderCard(unplannedEpisode());
 
     expect(screen.getByText(/^4/)).toBeInTheDocument();
     expect(screen.queryByText(/0\/0/)).not.toBeInTheDocument();
   });
+
+  it("names the fallback count 分镜数 on the storyboard route", () => {
+    renderCard(unplannedEpisode(), "storyboard");
+
+    expect(screen.getByTitle("4 分镜")).toBeInTheDocument();
+  });
+
+  it("names the fallback count 视频单元数 on the reference route", () => {
+    renderCard(unplannedEpisode(), "reference_video");
+
+    expect(screen.getByTitle("4 视频单元")).toBeInTheDocument();
+  });
 });
+
+/** 一集只有脚本、还没排视频产物：卡片只能显示条目数本身。 */
+function unplannedEpisode(): EpisodeMeta {
+  return makeEpisode({
+    status: "scripted",
+    storyboards: { total: 0, available: 0, stale: 0 },
+    videos: { total: 0, available: 0, stale: 0 },
+  });
+}

--- a/frontend/src/components/layout/EpisodeCard.test.tsx
+++ b/frontend/src/components/layout/EpisodeCard.test.tsx
@@ -60,20 +60,21 @@ describe("EpisodeCard", () => {
   it("falls back to the script item count for an episode with no videos planned yet", () => {
     renderCard(unplannedEpisode());
 
-    expect(screen.getByText(/^4/)).toBeInTheDocument();
+    expect(screen.getByText(/^4 /)).toBeInTheDocument();
     expect(screen.queryByText(/0\/0/)).not.toBeInTheDocument();
   });
 
   it("names the fallback count 分镜数 on the storyboard route", () => {
     renderCard(unplannedEpisode(), "storyboard");
 
-    expect(screen.getByTitle("4 分镜")).toBeInTheDocument();
+    // 名词进正文而不是 title：触屏没有悬停，读屏也不必依赖 tooltip
+    expect(screen.getByText(/^4 分镜/)).toBeInTheDocument();
   });
 
   it("names the fallback count 视频单元数 on the reference route", () => {
     renderCard(unplannedEpisode(), "reference_video");
 
-    expect(screen.getByTitle("4 视频单元")).toBeInTheDocument();
+    expect(screen.getByText(/^4 视频单元/)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/layout/EpisodeCard.tsx
+++ b/frontend/src/components/layout/EpisodeCard.tsx
@@ -154,10 +154,10 @@ export function EpisodeCard({
                 title={
                   videoTotal > 0
                     ? t("episode_available_videos_hint", { count: availableVideos, total: videoTotal })
-                    : itemCountLabel
+                    : undefined
                 }
               >
-                {videoTotal > 0 ? `${availableVideos}/${videoTotal}` : totalShots}
+                {videoTotal > 0 ? `${availableVideos}/${videoTotal}` : itemCountLabel}
                 {durLabel ? ` · ${durLabel}` : ""}
               </span>
             </>

--- a/frontend/src/components/layout/EpisodeCard.tsx
+++ b/frontend/src/components/layout/EpisodeCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Clapperboard } from "lucide-react";
 import type { EpisodeMeta } from "@/types";
+import { itemCountKey, type GenerationRoute } from "@/utils/generation-mode";
 import { useCostStore } from "@/stores/cost-store";
 import { totalBreakdown } from "@/utils/cost-format";
 
@@ -12,6 +13,8 @@ interface EpisodeCardProps {
   showEpisodeBadge?: boolean;
   /** ep.title 为空时的兜底显示文本（ad 项目用项目标题）。 */
   fallbackTitle?: string;
+  /** 项目生成路线：决定条目数报「分镜数」还是「视频单元数」。必填，漏接线时类型报错而不是静默显示错名词。 */
+  route: GenerationRoute;
 }
 
 const STATUS_COLOR: Record<string, string> = {
@@ -40,6 +43,7 @@ export function EpisodeCard({
   onClick,
   showEpisodeBadge = true,
   fallbackTitle,
+  route,
 }: EpisodeCardProps) {
   const { t } = useTranslation(["dashboard"]);
   const status = ep.status ?? "draft";
@@ -48,9 +52,11 @@ export function EpisodeCard({
   const isActive = status === "in_production";
 
   // 进度按视频产物的可用数算——可用 = current ∪ stale，与工作台同一份计数。
-  // 视频总数为 0（尚未成脚本）时退回剧本条目数，只用于显示"这集有几个镜头"。
+  // 视频总数为 0（尚未成脚本）时退回剧本条目数，只用于显示"这集有几件内容"。
   const videoTotal = ep.videos?.total ?? 0;
-  const totalShots = videoTotal || (ep.scenes_count ?? 0);
+  const itemCount = ep.item_count ?? 0;
+  const totalShots = videoTotal || itemCount;
+  const itemCountLabel = t(itemCountKey(route), { count: itemCount });
   const availableVideos = ep.videos?.available ?? 0;
   const progress =
     videoTotal > 0 ? Math.round((availableVideos / videoTotal) * 100) : 0;
@@ -148,7 +154,7 @@ export function EpisodeCard({
                 title={
                   videoTotal > 0
                     ? t("episode_available_videos_hint", { count: availableVideos, total: videoTotal })
-                    : undefined
+                    : itemCountLabel
                 }
               >
                 {videoTotal > 0 ? `${availableVideos}/${videoTotal}` : totalShots}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -31,7 +31,6 @@ export default {
   'content_mode_ad_desc': 'Single video — shots are planned against a target duration, each carrying voiceover copy. Best for product ads and creative shorts.',
   'target_duration_label': 'Target Duration',
   'ad_video_section_title': 'Video',
-  'shots_and_status': '{{count}} shots · {{status}}',
   'content_mode_narration_desc': 'Narration-driven — a single voiceover guides the visuals across the episode. Best for storytelling, documentary, or explainer shorts.',
   'content_mode_drama_desc': 'Content-driven — character dialogue and plot propel the visuals. Best for drama episodes and fiction adaptations.',
   'source_kind': 'Source type',
@@ -713,7 +712,10 @@ export default {
   'cost_estimate_failed': 'Cost estimation failed: {{message}}',
   'episodes_title': 'Episodes',
   'no_episodes_ai_hint': 'No episodes yet. Use the AI assistant to generate scripts.',
-  'segments_and_status': '{{count}} segments · {{status}}',
+  'storyboard_count_and_status': '{{count}} shots · {{status}}',
+  'video_unit_count_and_status': '{{count}} video units · {{status}}',
+  'storyboard_count': '{{count}} shots',
+  'video_unit_count': '{{count}} video units',
 
   // ProjectSettingsPage
   'project_settings': 'Project Settings',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -32,7 +32,6 @@ export default {
   'content_mode_ad_desc': 'Một video duy nhất — các cảnh quay được lên kế hoạch theo tổng thời lượng mục tiêu, mỗi cảnh kèm lời thoại quảng cáo. Phù hợp cho video bán hàng và video sáng tạo ngắn.',
   'target_duration_label': 'Tổng thời lượng mục tiêu',
   'ad_video_section_title': 'Video',
-  'shots_and_status': '{{count}} cảnh quay · {{status}}',
   'content_mode_narration_desc': 'Dẫn dắt bởi thuyết minh — một giọng đọc duy nhất dẫn dắt hình ảnh xuyên suốt tập. Phù hợp cho kể chuyện, phim tài liệu hoặc video giải thích ngắn.',
   'content_mode_drama_desc': 'Dẫn dắt bởi nội dung — đối thoại nhân vật và cốt truyện thúc đẩy hình ảnh. Phù hợp cho phim truyện và chuyển thể tiểu thuyết.',
   'source_kind': 'Loại tệp nguồn',
@@ -693,7 +692,10 @@ export default {
   'cost_estimate_failed': 'Ước tính chi phí thất bại: {{message}}',
   'episodes_title': 'Tập',
   'no_episodes_ai_hint': 'Chưa có tập nào. Dùng trợ lý AI để tạo kịch bản.',
-  'segments_and_status': '{{count}} đoạn · {{status}}',
+  'storyboard_count_and_status': '{{count}} cảnh quay · {{status}}',
+  'video_unit_count_and_status': '{{count}} đơn vị video · {{status}}',
+  'storyboard_count': '{{count}} cảnh quay',
+  'video_unit_count': '{{count}} đơn vị video',
 
   // ProjectSettingsPage
   'project_settings': 'Cài đặt dự án',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -32,7 +32,6 @@ export default {
   'content_mode_ad_desc': '单条成片——按目标总时长规划镜头脚本，每个镜头携带口播文案，适合带货短视频与创意短片。',
   'target_duration_label': '目标总时长',
   'ad_video_section_title': '视频',
-  'shots_and_status': '{{count}} 镜头 · {{status}}',
   'content_mode_narration_desc': '旁白驱动——一条旁白贯穿整集叙事，画面配合旁白推进，适合说书、纪实、知识类短片。',
   'content_mode_drama_desc': '内容驱动——角色对话与剧情推动画面，适合剧集动画、小说改编等故事型内容。',
   'source_kind': '源文件性质',
@@ -712,7 +711,10 @@ export default {
   'cost_estimate_failed': '费用估算失败: {{message}}',
   'episodes_title': '剧集',
   'no_episodes_ai_hint': '暂无剧集。使用 AI 助手生成脚本。',
-  'segments_and_status': '{{count}} 片段 · {{status}}',
+  'storyboard_count_and_status': '{{count}} 分镜 · {{status}}',
+  'video_unit_count_and_status': '{{count}} 视频单元 · {{status}}',
+  'storyboard_count': '{{count}} 分镜',
+  'video_unit_count': '{{count}} 视频单元',
 
   // ProjectSettingsPage
   'project_settings': '项目设置',

--- a/frontend/src/onboarding/demo-project.test.ts
+++ b/frontend/src/onboarding/demo-project.test.ts
@@ -113,7 +113,7 @@ describe("demo project data", () => {
       (s) => s.generated_assets?.storyboard_image,
     );
 
-    expect(segments.length).toBe(episode.scenes_count);
+    expect(segments.length).toBe(episode.item_count);
     expect(segments.length).toBeGreaterThanOrEqual(6);
     expect(withStoryboard.length).toBe(episode.storyboards?.available);
     expect(episode.videos?.available).toBe(0);

--- a/frontend/src/onboarding/demo-project.ts
+++ b/frontend/src/onboarding/demo-project.ts
@@ -211,7 +211,7 @@ export function buildDemoProjectData(t: DemoT): ProjectData {
       ...(isScripted
         ? {
             script_status: "generated" as const,
-            scenes_count: segmentCount,
+            item_count: segmentCount,
             duration_seconds: SEGMENT_SKELETONS.reduce((sum, s) => sum + s.duration, 0),
             storyboards: {
               total: segmentCount,

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -112,8 +112,11 @@ export interface EpisodeMeta {
    * Per-episode fields below come from the project summary at read time, on the artifact
    * manifest's terms — the same numbers the studio reads, never persisted to project.json.
    * Optional because the fallback meta some canvases build has no summary behind it.
+   *
+   * item_count 是该集的内容规模：分镜图生视频路线是分镜数，参考生视频路线是视频单元数。
+   * 计数口径由项目的 generation_mode 决定，三种创作类型一致。
    */
-  scenes_count?: number;
+  item_count?: number;
   /** Script progress derived from the step1 and final-script artifact states */
   script_status?: "none" | "segmented" | "generated";
   status?: "draft" | "scripted" | "in_production" | "completed" | "missing";

--- a/frontend/src/utils/generation-mode.ts
+++ b/frontend/src/utils/generation-mode.ts
@@ -30,3 +30,17 @@ export function gridStoryboardEnabled(
   if (!project) return false;
   return normalizeRoute(project.generation_mode) === "storyboard" && project.grid_storyboard === true;
 }
+
+/**
+ * 条目数的文案 key — 名词按生成路线定，与创作类型无关：分镜路线报「分镜数」、
+ * 参考路线报「视频单元数」。所有展示条目数的位置读同一份映射，不各自写三元判断。
+ *
+ * `withStatus` 取带状态后缀的那条（「N 分镜 · 制作中」），否则取裸计数那条。
+ */
+export function itemCountKey(
+  route: GenerationRoute,
+  { withStatus = false }: { withStatus?: boolean } = {},
+): string {
+  const noun = route === "reference_video" ? "video_unit_count" : "storyboard_count";
+  return withStatus ? `${noun}_and_status` : noun;
+}

--- a/frontend/src/utils/generation-mode.ts
+++ b/frontend/src/utils/generation-mode.ts
@@ -37,10 +37,15 @@ export function gridStoryboardEnabled(
  *
  * `withStatus` 取带状态后缀的那条（「N 分镜 · 制作中」），否则取裸计数那条。
  */
+const ITEM_COUNT_NOUNS: Record<GenerationRoute, string> = {
+  storyboard: "storyboard_count",
+  reference_video: "video_unit_count",
+};
+
 export function itemCountKey(
   route: GenerationRoute,
   { withStatus = false }: { withStatus?: boolean } = {},
 ): string {
-  const noun = route === "reference_video" ? "video_unit_count" : "storyboard_count";
+  const noun = ITEM_COUNT_NOUNS[route];
   return withStatus ? `${noun}_and_status` : noun;
 }

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -2352,7 +2352,7 @@ class ProjectManager:
         """
         [已废弃] 同步项目状态
 
-        此方法已废弃。status、progress、scenes_count 等统计字段
+        此方法已废弃。status、progress、item_count 等统计字段
         现在由项目摘要读时计算，不再存储在 JSON 文件中。
 
         保留此方法仅为向后兼容，实际不执行任何写入操作。

--- a/lib/workflow_state.py
+++ b/lib/workflow_state.py
@@ -202,7 +202,9 @@ class EpisodeSummary(BaseModel):
     episode: int
     script_status: EpisodeScriptStatus
     status: EpisodeProductionStatus
-    scenes_count: int
+    # 该集的内容规模：分镜图生视频路线报分镜数、参考生视频路线报视频单元数，
+    # 三种创作类型同一口径。读时按脚本条目数算，不落盘。
+    item_count: int
     duration_seconds: int
     storyboards: ArtifactCount
     videos: ArtifactCount
@@ -917,7 +919,7 @@ class WorkflowStateService:
                 except ValueError:
                     kind = None
                 if kind is not None:
-                    raw_items = script.get(kind)
+                    raw_items, _id_field, _kind = resolve_kind_items(script, kind=kind)
                     items = (
                         [item for item in raw_items if isinstance(item, dict)] if isinstance(raw_items, list) else []
                     )
@@ -957,7 +959,7 @@ class WorkflowStateService:
             episode=number,
             script_status=script_status,
             status=_episode_production_status(script_status, storyboards, videos),
-            scenes_count=len(items),
+            item_count=len(items),
             duration_seconds=script_duration_total(kind, items) if kind is not None else 0,
             storyboards=storyboards,
             videos=videos,
@@ -1089,7 +1091,7 @@ class WorkflowStateService:
                 episode=number,
                 script_status="none",
                 status="draft",
-                scenes_count=0,
+                item_count=0,
                 duration_seconds=0,
                 storyboards=ArtifactCount.zero(),
                 videos=ArtifactCount.zero(),

--- a/public/skill.md.template
+++ b/public/skill.md.template
@@ -42,8 +42,14 @@ curl {{BASE_URL}}/api/v1/projects \
     {
       "name": "my-novel",
       "title": "我的小说",
-      "scenes_count": 12,
-      "status": "ready"
+      "style": "国漫写实",
+      "thumbnail": "projects/my-novel/videos/E1S01.jpg",
+      "status": {
+        "phase": "production",
+        "phase_progress": 0.6,
+        "needs_repair": false,
+        "episodes_summary": { "total": 3, "scripted": 1, "in_production": 1, "completed": 1 }
+      }
     }
   ]
 }

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -205,7 +205,7 @@ class EpisodePatch(BaseModel):
     """PATCH body entry for a single episode.
 
     The declared fields are the writable set; derived fields the API serves on
-    episodes (scenes_count, status, storyboards, etc.) are not declared here and
+    episodes (item_count, status, storyboards, etc.) are not declared here and
     are silently dropped via extra='ignore', so they can never be written back.
     """
 

--- a/tests/integration/test_project_summary.py
+++ b/tests/integration/test_project_summary.py
@@ -25,7 +25,9 @@ from tests.integration.test_workflow_state import (
     _count_source_reads,
     _make_project,
     _register_produced_artifacts,
+    _valid_ad_shot,
     _valid_narration_segment,
+    _valid_video_unit,
     _write_artifact,
     _write_episode_source,
     _write_registered_script,
@@ -134,10 +136,63 @@ def test_script_without_media_is_in_production(tmp_path: Path) -> None:
     episode = summary.episodes[0]
     assert episode.script_status == "generated"
     assert episode.status == "scripted"
-    assert episode.scenes_count == 1
+    assert episode.item_count == 1
     assert episode.duration_seconds == 4
     assert (episode.storyboards.total, episode.storyboards.available) == (1, 0)
     assert (episode.videos.total, episode.videos.available) == (1, 0)
+
+
+def test_item_count_reports_the_storyboard_count_on_the_storyboard_route(tmp_path: Path) -> None:
+    """分镜图生视频路线报分镜数——广告/短片的 shots 与旁白/解说的 segments 同一口径。"""
+
+    pm, project_path = _make_project(tmp_path, "ad")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+    _plan_one_episode(pm, project_path, source_text)
+    _write_registered_script(
+        project_path,
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "ad",
+            "shots": [_valid_ad_shot(), _valid_ad_shot(shot_id="E1S02")],
+        },
+    )
+    _register_produced_artifacts(project_path)
+
+    episode = WorkflowStateService(pm).get_project_summary("demo").episodes[0]
+
+    assert episode.item_count == 2
+    assert episode.storyboards.total == 2
+
+
+def test_item_count_reports_the_video_unit_count_on_the_reference_route(tmp_path: Path) -> None:
+    """参考生视频路线报视频单元数，且该路线没有分镜图这一档产物。"""
+
+    pm, project_path = _make_project(tmp_path, "drama", generation_mode="reference_video")
+    source_text = "完整原文"
+    _write_source_and_complete(pm, project_path, source_text)
+    _plan_one_episode(pm, project_path, source_text)
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    _write_episode_source(project_path, 1)
+    atomic_write_json(draft_dir / "step1_reference_units.json", {"units": []})
+    _write_registered_script(
+        project_path,
+        {
+            "episode": 1,
+            "title": "第一集",
+            "content_mode": "drama",
+            "video_units": [_valid_video_unit(), _valid_video_unit(unit_id="E1U02")],
+        },
+    )
+    _register_produced_artifacts(project_path)
+
+    episode = WorkflowStateService(pm).get_project_summary("demo").episodes[0]
+
+    assert episode.item_count == 2
+    assert episode.storyboards.total == 0
+    assert episode.videos.total == 2
 
 
 def test_all_artifacts_usable_reports_completed(tmp_path: Path) -> None:

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -422,7 +422,7 @@ class _FakeSummaries:
                     episode=1,
                     script_status="generated",
                     status="in_production",
-                    scenes_count=1,
+                    item_count=1,
                     duration_seconds=8,
                     storyboards=ArtifactCount(total=1, available=1, stale=0),
                     videos=ArtifactCount(total=1, available=0, stale=0),
@@ -2251,7 +2251,9 @@ class TestProjectsRouter:
         # 摘要侧字段按产物清单口径注入：可用 = current ∪ stale，stale 另计
         assert episode["script_status"] == "generated"
         assert episode["status"] == "in_production"
-        assert episode["scenes_count"] == 1
+        assert episode["item_count"] == 1
+        # 旧的场景数字段已退场，响应里不再出现
+        assert "scenes_count" not in episode
         assert episode["duration_seconds"] == 8
         assert episode["storyboards"] == {"total": 1, "available": 1, "stale": 0}
         assert episode["videos"] == {"total": 1, "available": 0, "stale": 0}
@@ -2447,7 +2449,8 @@ class TestProjectsRouter:
                             "script_file": "scripts/ep1_v2.json",  # 合法白名单字段
                             "title": "新标题",  # title 不再可经 PATCH /projects 写入
                             # 以下为项目摘要读时注入的统计字段，不应写入磁盘
-                            "scenes_count": 999,
+                            "item_count": 999,
+                            "scenes_count": 999,  # 已退场的旧字段，同样不得落盘
                             "status": "completed",
                             "storyboards": {"total": 5, "available": 3, "stale": 0},
                             "videos": {"total": 5, "available": 5, "stale": 1},
@@ -2464,6 +2467,7 @@ class TestProjectsRouter:
             # title 不可经此端点改写，保持原值（改名走 PATCH /episodes/{episode}）
             assert ep1["title"] == "原标题"
             # 计算字段不得写入
+            assert "item_count" not in ep1
             assert "scenes_count" not in ep1
             assert "status" not in ep1
             assert "storyboards" not in ep1


### PR DESCRIPTION
每集卡片和项目总览上那个「有多少内容」的数字，过去三种创作类型各说一套：广告/短片写「镜头」、其余写「片段」，参考生视频项目也套用同一批说法。现在这个数字按项目的生成路线报口径统一的名词——分镜图生视频项目报**分镜数**，参考生视频项目报**视频单元数**，剧情演绎、旁白解说、广告短片三种创作类型在同一路线下说法一致。

数字本身仍然只在读取时由脚本条目算出，不落盘、生成流程不写回任何计数。

## 改动范围

- 项目摘要与剧集详情接口把每集的 `scenes_count` 改为 `item_count`；旧字段从响应、前端类型与文档示例中退场，经 PATCH 传入也不落盘
- 剧集卡（侧栏）与项目总览按 `generation_mode` 选名词，路线到文案的映射收在 `frontend/src/utils/generation-mode.ts` 的 `itemCountKey()` 一处
- 剧集卡的 `route` 为必填 prop：漏接线在类型检查阶段暴露，不会静默显示错误名词
- zh / en / vi 三语同步新增分镜数与视频单元数文案，旧的两条按创作类型分叉的文案删除
- 智能体系统提示中的数据分层说明同步改用新字段名与名词
- `public/skill.md.template` 的项目列表响应示例更新为真实响应形状（原示例仍写着早已不存在的 `scenes_count` 与字符串 `status`）

## 验证

- `uv run ruff check . && uv run ruff format --check .`、`uv run lint-imports`、`uv run basedpyright`（0 error）
- `uv run python -m pytest`：10221 passed, 2 skipped
- `cd frontend && pnpm lint && pnpm check`：156 files / 1890 tests 全通过
- 新增行为测试：分镜路线（含广告/短片）报分镜数、参考路线报视频单元数（`tests/integration/test_project_summary.py`）；详情接口不再出现 `scenes_count`、PATCH 传入计数字段不落盘（`tests/test_projects_router.py`）；剧集卡与总览按路线选名词（`EpisodeCard.test.tsx` / `OverviewCanvas.test.tsx`）

Closes #1942


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 按生成路线显示准确的条目数量：分镜路线显示分镜数，参考视频路线显示视频单元数。
  - 剧集卡片、项目概览和时间线的数量及状态文案更加准确。
  - 项目摘要、演示项目及相关接口统一使用新的条目计数字段。

- **测试**
  - 新增并更新多种生成路线的数量统计验证，覆盖广告、旁白和参考视频场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->