### PR TITLE
fix(i18n): 越南文源文件类型描述补齐 gốc

### DIFF
--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -38,7 +38,7 @@ export default {
   'source_kind_novel': 'Tiểu thuyết',
   'source_kind_screenplay': 'Kịch bản gốc',
   'source_kind_novel_desc': 'Tải lên tiểu thuyết; AI sẽ chuyển thể thành kịch bản.',
-  'source_kind_screenplay_desc': 'Tải lên kịch bản hoàn chỉnh; lời thoại và lời dẫn được giữ nguyên từng chữ, không chuyển thể.',
+  'source_kind_screenplay_desc': 'Tải lên kịch bản gốc hoàn chỉnh; lời thoại và lời dẫn được giữ nguyên từng chữ, không chuyển thể.',
   'optional': 'Tùy chọn',
   'creating': 'Đang tạo...',
   'rebirth_empress_example': 'Ví dụ: Trùng sinh vĩ đại Hoàng hậu',


### PR DESCRIPTION
## 变更

`source_kind_screenplay_desc`（vi）：\`Tải lên kịch bản hoàn chỉnh\` → \`Tải lên kịch bản gốc hoàn chỉnh\`。

该文案描述的是用户上传的成品剧本源文件。按「剧本 → 脚本」改名批次（Spec #1908）确立的越南文译法，系统生成的脚本为 kịch bản、用户上传的剧本为 kịch bản gốc；此处漏加 gốc，会与相邻的 \`source_kind_screenplay\`（Kịch bản gốc）指代分裂。批次复盘裁决 DEC-03 = A（认可现译法并补齐此处）。

## 校验

- \`tests/test_i18n_consistency.py\` 16 passed
- \`pnpm lint\` / \`pnpm check\` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新越南语界面翻译，完善剧本文件类型的描述，明确包含“原创剧本”含义。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->