### PR TITLE
refactor(docs-scripts): 三份 markdown 目录遍历收编进 markdown-scan

### DIFF
--- a/.claude/skills/translate-docs/scripts/translation-lock.mjs
+++ b/.claude/skills/translate-docs/scripts/translation-lock.mjs
@@ -2,28 +2,17 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname, relative, resolve, sep } from "node:path";
+import { dirname, resolve } from "node:path";
+
+// 与页面库存、锚点扫描共用同一个遍历器，三道 CI 闸门对「哪些文件算文档」给同一答案。
+// 该模块零 npm 依赖，本脚本仍可用 node 直接运行；代价是耦合仓库文件布局——本脚本
+// 本就硬编码 website/i18n 等仓库路径，不追求脱库复用。
+import { walkMarkdownFiles } from "../../../../website/scripts/markdown-scan.mjs";
 
 const I18N_ROOT = "website/i18n";
 const DOCS_TRANSLATION_SUBDIRECTORY = "docusaurus-plugin-content-docs/current";
 const DOCS_TRANSLATION_ROOT = `${I18N_ROOT}/en/${DOCS_TRANSLATION_SUBDIRECTORY}`;
 const LOCK_PATH = "website/i18n/translation.lock.json";
-
-function toPosix(path) {
-  return path.split(sep).join("/");
-}
-
-function walkMarkdown(root, directory) {
-  const absoluteDirectory = resolve(root, directory);
-  if (!existsSync(absoluteDirectory)) return [];
-
-  return readdirSync(absoluteDirectory, { withFileTypes: true }).flatMap((entry) => {
-    const path = resolve(absoluteDirectory, entry.name);
-    if (entry.isDirectory()) return walkMarkdown(root, toPosix(relative(root, path)));
-    if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) return [];
-    return [toPosix(relative(root, path))];
-  });
-}
 
 // Forward mapping registers English targets only, while the orphan scan walks every locale
 // directory under website/i18n/. Extend this mapping before adding another documentation
@@ -50,7 +39,7 @@ function sourceTargets(root) {
   const mappings = [
     ["CONTRIBUTING.md", targetForSource("CONTRIBUTING.md")],
     ["README.md", targetForSource("README.md")],
-    ...walkMarkdown(root, "website/docs")
+    ...walkMarkdownFiles(root, "website/docs")
       .filter((source) => source !== "website/docs/dev/contributing.md")
       .map((source) => [source, targetForSource(source)]),
   ];
@@ -65,7 +54,7 @@ function documentTranslationTargets(root) {
 
   return readdirSync(absoluteI18nRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .flatMap((entry) => walkMarkdown(root, `${I18N_ROOT}/${entry.name}/${DOCS_TRANSLATION_SUBDIRECTORY}`))
+    .flatMap((entry) => walkMarkdownFiles(root, `${I18N_ROOT}/${entry.name}/${DOCS_TRANSLATION_SUBDIRECTORY}`))
     .sort((left, right) => left.localeCompare(right));
 }
 

--- a/website/scripts/check-consistency.mjs
+++ b/website/scripts/check-consistency.mjs
@@ -8,7 +8,7 @@ import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "no
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { scanMarkdownLines } from "./markdown-scan.mjs";
+import { scanMarkdownLines, walkMarkdownFiles } from "./markdown-scan.mjs";
 import { checkUpdateDocsInventory } from "./update-docs-inventory.mjs";
 
 const websiteDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -64,17 +64,6 @@ function docRoots() {
   return ["docs", ...localeRoots];
 }
 
-function walkDocFiles(directory) {
-  const absoluteDirectory = resolve(websiteDir, directory);
-  if (!existsSync(absoluteDirectory)) return [];
-  return readdirSync(absoluteDirectory, { withFileTypes: true }).flatMap((entry) => {
-    const path = resolve(absoluteDirectory, entry.name);
-    if (entry.isDirectory()) return walkDocFiles(toPosix(relative(websiteDir, path)));
-    if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) return [];
-    return [toPosix(relative(websiteDir, path))];
-  });
-}
-
 function checkAnchors() {
   const problems = [];
   const exemptDocsFound = new Set();
@@ -83,7 +72,7 @@ function checkAnchors() {
     const jsxHeadingDocs = new Set();
     const docPaths = new Set();
 
-    for (const file of walkDocFiles(root)) {
+    for (const file of walkMarkdownFiles(websiteDir, root)) {
       const docPath = toPosix(relative(root, file));
       docPaths.add(docPath);
       const seenAnchors = new Set();

--- a/website/scripts/markdown-scan.mjs
+++ b/website/scripts/markdown-scan.mjs
@@ -1,7 +1,39 @@
-// 文档脚本共用的 Markdown 基础解析：读取简单 frontmatter 标量，并在逐行扫描时识别围栏代码块、
-// 跳过其内容，对正文行给出标题解析结果。
+// 文档脚本共用的 Markdown 基元：目录遍历，读取简单 frontmatter 标量，以及逐行扫描时识别
+// 围栏代码块、跳过其内容，对正文行给出标题解析结果。
 // 围栏与标题的识别规则只在这里定义一次——check-consistency 与 sync-contributing 必须对
 // 「哪一行算标题」给出同一答案，否则一处认得的标题在另一处漏检。
+// 同理，「哪些文件算文档」也只在这里回答一次——页面库存、锚点扫描、翻译登记三道闸门
+// 各自实现时，任一处单独加排除规则都会让闸门之间自相矛盾（一道放行、另一道报错）。
+
+import { existsSync, readdirSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+function toPosix(path) {
+  return path.split(sep).join("/");
+}
+
+/**
+ * 递归列出 `root` 下 `directory` 里的全部 Markdown 文件（.md / .mdx），返回相对 `root` 的
+ * POSIX 路径并按字典序排序；目录不存在时返回空数组。
+ * 排除规则（如 Docusaurus 的 `_` 前缀 partial）若将来引入，在这里加调用方参数，
+ * 不在各闸门自行过滤。
+ *
+ * @param {string} root 绝对路径基准，返回值相对它
+ * @param {string} directory 相对 `root` 的目录
+ * @returns {string[]}
+ */
+export function walkMarkdownFiles(root, directory) {
+  const absoluteDirectory = resolve(root, directory);
+  if (!existsSync(absoluteDirectory)) return [];
+  return readdirSync(absoluteDirectory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = resolve(absoluteDirectory, entry.name);
+      if (entry.isDirectory()) return walkMarkdownFiles(root, toPosix(relative(root, path)));
+      if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) return [];
+      return [toPosix(relative(root, path))];
+    })
+    .sort();
+}
 
 // CommonMark 允许标题与围栏有 0–3 个前导空格；4 个及以上是缩进代码块，其中的 ``` 不开围栏。
 // 开栏捕获完整的重复字符（长度 ≥3），闭栏要求同字符、长度 ≥ 开栏长度、且行内除前导空格与

--- a/website/scripts/markdown-scan.mjs
+++ b/website/scripts/markdown-scan.mjs
@@ -15,7 +15,8 @@ function toPosix(path) {
 /**
  * 递归列出 `root` 下 `directory` 里的全部 Markdown 文件（.md / .mdx），返回相对 `root` 的
  * POSIX 路径并按字典序排序；目录不存在时返回空数组。
- * 「哪些文件算文档」的取舍（含一切排除规则）只属于本函数，调用方不得在结果上自行过滤。
+ * 本函数只回答「哪些文件算 Markdown 文档」；各闸门的业务性排除（如生成的 CONTRIBUTING
+ * 副本不进页面库存与翻译登记、但参与锚点扫描）由调用方在结果上自行收窄。
  *
  * @param {string} root 绝对路径基准，返回值相对它
  * @param {string} directory 相对 `root` 的目录

--- a/website/scripts/markdown-scan.mjs
+++ b/website/scripts/markdown-scan.mjs
@@ -15,8 +15,7 @@ function toPosix(path) {
 /**
  * 递归列出 `root` 下 `directory` 里的全部 Markdown 文件（.md / .mdx），返回相对 `root` 的
  * POSIX 路径并按字典序排序；目录不存在时返回空数组。
- * 排除规则（如 Docusaurus 的 `_` 前缀 partial）若将来引入，在这里加调用方参数，
- * 不在各闸门自行过滤。
+ * 「哪些文件算文档」的取舍（含一切排除规则）只属于本函数，调用方不得在结果上自行过滤。
  *
  * @param {string} root 绝对路径基准，返回值相对它
  * @param {string} directory 相对 `root` 的目录

--- a/website/scripts/markdown-scan.test.mjs
+++ b/website/scripts/markdown-scan.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+import { walkMarkdownFiles } from "./markdown-scan.mjs";
+
+function withTree(files, run) {
+  const root = mkdtempSync(join(tmpdir(), "arcreel-markdown-scan-"));
+  try {
+    for (const path of files) {
+      const absolutePath = join(root, path);
+      mkdirSync(resolve(absolutePath, ".."), { recursive: true });
+      writeFileSync(absolutePath, "content\n", "utf8");
+    }
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("walkMarkdownFiles recurses, keeps only .md/.mdx, and sorts POSIX-relative paths", () => {
+  withTree(
+    [
+      "docs/zebra.md",
+      "docs/alpha.mdx",
+      "docs/nested/deep/page.md",
+      "docs/nested/_category_.json",
+      "docs/readme.txt",
+      "outside.md",
+    ],
+    (root) => {
+      assert.deepEqual(walkMarkdownFiles(root, "docs"), [
+        "docs/alpha.mdx",
+        "docs/nested/deep/page.md",
+        "docs/zebra.md",
+      ]);
+    },
+  );
+});
+
+test("walkMarkdownFiles returns an empty list for a missing directory", () => {
+  withTree([], (root) => {
+    assert.deepEqual(walkMarkdownFiles(root, "no-such-dir"), []);
+  });
+});

--- a/website/scripts/update-docs-inventory.mjs
+++ b/website/scripts/update-docs-inventory.mjs
@@ -1,29 +1,15 @@
 #!/usr/bin/env node
 // update-docs 的上站页面库存：frontmatter 声明覆盖档位，CONTRIBUTING「各页职责」必须与库存一致。
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { relative, resolve, sep } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { readFrontMatterScalar, scanMarkdownLines } from "./markdown-scan.mjs";
+import { readFrontMatterScalar, scanMarkdownLines, walkMarkdownFiles } from "./markdown-scan.mjs";
 
 const UPDATE_DOCS_VALUES = new Set(["full", "fact-check", "none"]);
 // CONTRIBUTING 的中文副本由 sync-contributing 在构建期生成，真相源不在 website/docs，不能进入库存。
 const GENERATED_DOCS = new Set(["website/docs/dev/contributing.md"]);
-
-function toPosix(path) {
-  return path.split(sep).join("/");
-}
-
-function walkMarkdownFiles(directory) {
-  if (!existsSync(directory)) return [];
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = resolve(directory, entry.name);
-    if (entry.isDirectory()) return walkMarkdownFiles(path);
-    if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) return [];
-    return [path];
-  });
-}
 
 function responsibilityDocPaths(content) {
   const scannedLines = [...scanMarkdownLines(content)];
@@ -57,15 +43,13 @@ function responsibilityDocPaths(content) {
  * @returns {{ entries: Array<{ path: string, updateDocs: string }>, problems: string[] }}
  */
 export function checkUpdateDocsInventory(repoRoot) {
-  const docsDir = resolve(repoRoot, "website/docs");
-  const entries = walkMarkdownFiles(docsDir)
+  // walkMarkdownFiles 已按 POSIX 相对路径排序，清单顺序在各平台一致。
+  const entries = walkMarkdownFiles(repoRoot, "website/docs")
     .map((path) => ({
-      path: toPosix(relative(repoRoot, path)),
-      updateDocs: readFrontMatterScalar(readFileSync(path, "utf8"), "update_docs"),
+      path,
+      updateDocs: readFrontMatterScalar(readFileSync(resolve(repoRoot, path), "utf8"), "update_docs"),
     }))
-    .filter((entry) => !GENERATED_DOCS.has(entry.path))
-    // 按 POSIX 相对路径排序：目录分隔符已归一，清单顺序在各平台一致。
-    .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+    .filter((entry) => !GENERATED_DOCS.has(entry.path));
   const problems = [];
 
   for (const entry of entries) {


### PR DESCRIPTION
## 背景

AFK 批次 docsite-fu-20260814 复盘报告 FU-04 的落地（用户已裁决可做，排在 #1987 合并后避免与刚改过的脚本自我冲突）。

## 问题

`update-docs-inventory.mjs`、`check-consistency.mjs`、`translation-lock.mjs` 各自持有一份逐字相同的递归 markdown 遍历（差异只在返回路径基准：绝对 / 相对 websiteDir / 相对 repoRoot）。三份遍历分别喂给三道会 fail CI 的闸门——任一处单独加排除规则都会让闸门对「哪些文件算文档」给出不同答案，出现一道放行、另一道报错的自相矛盾故障。

## 改动

- **收编落点**：`website/scripts/markdown-scan.mjs`（既有的文档脚本共享基元模块，frontmatter 读取与标题/围栏扫描已在此收敛）。统一签名 `walkMarkdownFiles(root, directory)`，返回相对 `root` 的 POSIX 路径并排序。
- **三个调用方**全部删除本地实现改用共享函数；inventory 顺带删掉调用处的手写排序（共享函数已保证跨平台确定顺序）。
- **新增 `markdown-scan.test.mjs`**：直接钉住递归、扩展名过滤、排序、目录缺失返回空四个行为（CI 的 `node --test website/scripts/*.test.mjs` 自动纳入）。

## 设计取舍

- **跨包边界**：translation-lock 原「零仓内依赖」让位于三道闸同答案，改为相对路径 import。该脚本本就硬编码 `website/i18n` 等仓库路径、不追求脱库复用；markdown-scan 零 npm 依赖，skill 脚本仍可用 node 直接运行。取舍已注释在 import 处。
- **过滤策略不参数化**（YAGNI）：复盘 FU-07 已判 `_` 前缀 partial 排除当前不可达、无需处理。共享函数注释声明：排除规则若将来引入，在此加调用方参数，不在闸门各自过滤。

## 验证

- `node --test website/scripts/*.test.mjs`（含新增 2 例）与 `translation-lock.test.mjs`（10 例）全过
- 行为不变性：`translation-lock status` 仍报 11 条 stale（与改前一致）、`check-consistency` 通过、`collect-changes.sh` 实跑输出与改前一致（baseline 不变）
- website `pnpm check`（typecheck + eslint + prettier）全绿

https://claude.ai/code/session_01KxAhi7GEdFknZZcqEVTjJn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 统一文档扫描规则，支持递归发现 Markdown 和 MDX 文件。
  * 规范化相对路径格式并按字典序排列，提升跨平台一致性。
  * 目录不存在时可安全返回空结果，减少文档检查异常。

* **测试**
  * 新增文档扫描行为验证，覆盖文件筛选、递归扫描、路径排序及空目录场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->