### PR TITLE
fix(project-migration): 升级失败的项目在剧本编辑入口就被拒并说明原因

### DIFF
--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -108,12 +108,14 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
 )
 
 # Tools refused outright while the project's schema migration verdict is a failure.
-# Everything that generates output or writes formal content is closed; the read-only
-# tools stay open so the agent can still diagnose what needs repairing. The script
-# editors are declared here too even though their shared ``ScriptBatchEditor.execute``
-# already refuses internally for the same verdict -- entry declaration is the source
-# of truth (阻断以入口声明为准), the inner check is only a fallback, never a reason
-# for an entry to skip declaring the block itself.
+# Everything that generates output or writes script content is closed; the read-only
+# tools stay open so the agent can still diagnose what needs repairing, and the
+# controlled project/metadata editors (``patch_project``, ``patch_episode_meta``,
+# ``rename_asset``) stay open because repairing is done through them. The script batch
+# editors are named here even though their shared ``ScriptBatchEditor.execute`` already
+# refuses internally on the same verdict: the entry declares the block, the inner check
+# is only a fallback, and an entry never skips declaring the block just because some
+# callee happens to check too.
 MIGRATION_BLOCKED_TOOL_IDS: frozenset[str] = frozenset(
     {
         "complete_asset_inventory",

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -109,8 +109,11 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
 
 # Tools refused outright while the project's schema migration verdict is a failure.
 # Everything that generates output or writes formal content is closed; the read-only
-# tools stay open so the agent can still diagnose what needs repairing, and the
-# controlled script/project editors stay open because repairing is done through them.
+# tools stay open so the agent can still diagnose what needs repairing. The script
+# editors are declared here too even though their shared ``ScriptBatchEditor.execute``
+# already refuses internally for the same verdict -- entry declaration is the source
+# of truth (阻断以入口声明为准), the inner check is only a fallback, never a reason
+# for an entry to skip declaring the block itself.
 MIGRATION_BLOCKED_TOOL_IDS: frozenset[str] = frozenset(
     {
         "complete_asset_inventory",
@@ -133,6 +136,10 @@ MIGRATION_BLOCKED_TOOL_IDS: frozenset[str] = frozenset(
         "split_narration_segments",
         "plan_episodes",
         "reset_episode_planning",
+        "patch_episode_script",
+        "insert_segment",
+        "remove_segment",
+        "split_segment",
     }
 )
 

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1063,7 +1063,7 @@ class UpdateSceneRequest(BaseModel):
     updates: dict
 
 
-@router.patch("/projects/{name}/script-scenes/{scene_id}")
+@router.patch("/projects/{name}/script-scenes/{scene_id}", dependencies=[Depends(require_project_migration_ok)])
 async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _t: Translator):
     """更新 drama 模式剧本中的单个场景镜头（按 scene_id 定位）。
 
@@ -1180,7 +1180,7 @@ def _require_ad_script(script: dict, _t: Translator) -> list[dict]:
     return shots
 
 
-@router.patch("/projects/{name}/script-shots/{shot_id}")
+@router.patch("/projects/{name}/script-shots/{shot_id}", dependencies=[Depends(require_project_migration_ok)])
 async def update_shot(name: str, shot_id: str, req: UpdateShotRequest, _t: Translator):
     """更新 ad 模式剧本中的单个镜头（按 shot_id 定位）。
 
@@ -1238,7 +1238,7 @@ class ReorderShotsRequest(BaseModel):
     shot_ids: list[str]
 
 
-@router.post("/projects/{name}/script-shots/reorder")
+@router.post("/projects/{name}/script-shots/reorder", dependencies=[Depends(require_project_migration_ok)])
 async def reorder_shots(name: str, req: ReorderShotsRequest, _t: Translator):
     """按给定全排列重排 ad 剧本的 shots 顺序（与参考视频 units/reorder 同语义）。"""
     try:
@@ -1310,7 +1310,7 @@ class UpdateEpisodeRequest(BaseModel):
     title: str
 
 
-@router.patch("/projects/{name}/segments/{segment_id}")
+@router.patch("/projects/{name}/segments/{segment_id}", dependencies=[Depends(require_project_migration_ok)])
 async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, _t: Translator):
     """更新旁白/解说片段"""
     try:

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -28,6 +28,12 @@ from lib.project_migrations.runner import migrate_project_with_verdict, run_proj
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from lib.workflow_plan import WorkflowPlanRequest
 from lib.workflow_state import WorkflowStateService
+from server.agent_runtime.sdk_tools.patch_script import (
+    insert_segment_tool,
+    patch_episode_script_tool,
+    remove_segment_tool,
+    split_segment_tool,
+)
 from server.dependencies import require_project_migration_ok
 from server.error_handlers import register_error_handlers
 from server.services.workflow_planner import WorkflowPlanner
@@ -216,6 +222,50 @@ async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_
     # The blocked set names real tools, and never the retry tool — it is the way out.
     assert sdk_tools.MIGRATION_BLOCKED_TOOL_IDS <= set(sdk_tools.ARCREEL_MCP_TOOL_IDS)
     assert "retry_project_migration" not in sdk_tools.MIGRATION_BLOCKED_TOOL_IDS
+
+
+@pytest.mark.parametrize(
+    "tool_factory",
+    [
+        patch_episode_script_tool,
+        insert_segment_tool,
+        remove_segment_tool,
+        split_segment_tool,
+    ],
+)
+async def test_script_edit_mcp_tools_refuse_at_registration_on_a_migration_blocked_project(
+    tmp_path: Path, monkeypatch, tool_factory
+) -> None:
+    """四个受控剧本编辑工具经 MIGRATION_BLOCKED_TOOL_IDS 在注册期挡下——不落到
+
+    ScriptBatchEditor.execute 的内层裁决（那条仍在，作兜底，但这里不该是命中路径：
+    命中内层会返回 ``script_edit`` 信封而不是 ``problem``，与本测试的形状断言矛盾）。
+    """
+
+    import lib.project_migration_guard as guard
+    from server.agent_runtime import sdk_tools
+
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    project_dir, *_ = _project(projects_root)
+    _break_episode_script(project_dir)
+    failure = migrate_project_with_verdict(project_dir)
+    assert failure is not None
+
+    pm = ProjectManager(str(projects_root))
+    monkeypatch.setattr(guard, "get_project_manager", lambda: pm)
+    ctx = sdk_tools.ToolContext(project_name="demo", projects_root=projects_root, pm=pm)
+
+    sdk_tool = tool_factory(ctx)
+    assert sdk_tool.name in sdk_tools.MIGRATION_BLOCKED_TOOL_IDS
+    guarded = sdk_tools._refuse_while_migration_failed(sdk_tool, ctx)  # pyright: ignore[reportPrivateUsage]
+    blocked = await guarded.handler({})
+
+    assert blocked["is_error"] is True
+    assert blocked["problem"]["code"] == GenerationProblemCode.PROJECT_MIGRATION_FAILED
+    assert blocked["problem"]["action"] == GenerationAction.RETRY_PROJECT_MIGRATION
+    assert blocked["problem"]["detail"] == failure.reason
+    assert "script_edit" not in blocked
 
 
 async def test_mcp_guard_reads_the_session_projects_root_not_the_global_one(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -236,10 +236,11 @@ async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_
 async def test_script_edit_mcp_tools_refuse_at_registration_on_a_migration_blocked_project(
     tmp_path: Path, monkeypatch, tool_factory
 ) -> None:
-    """四个受控剧本编辑工具经 MIGRATION_BLOCKED_TOOL_IDS 在注册期挡下——不落到
+    """四个受控剧本编辑工具登记在 MIGRATION_BLOCKED_TOOL_IDS 里，注册期包上守卫后直接拒。
 
-    ScriptBatchEditor.execute 的内层裁决（那条仍在，作兜底，但这里不该是命中路径：
-    命中内层会返回 ``script_edit`` 信封而不是 ``problem``，与本测试的形状断言矛盾）。
+    断言两件事：工具 id 在阻断集内（``build_arcreel_mcp_server`` 就按这个集合决定包不包守卫），
+    以及包上后的回执是 problem 形状。不落到 ScriptBatchEditor.execute 的内层裁决——那条仍在，
+    作兜底，但命中它会返回 ``script_edit`` 信封而不是 ``problem``，与这里的形状断言矛盾。
     """
 
     import lib.project_migration_guard as guard

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1674,40 +1674,46 @@ class TestProjectsRouter:
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
-        ("method", "endpoint", "body"),
+        ("method", "project_name", "endpoint", "body"),
         [
             (
                 "patch",
+                "ready",
                 "/api/v1/projects/ready/script-scenes/001",
                 {"script_file": "episode_1.json", "updates": {}},
             ),
             (
                 "patch",
+                "ad-ready",
                 "/api/v1/projects/ad-ready/script-shots/E1S01",
                 {"script_file": "episode_1.json", "updates": {}},
             ),
             (
                 "post",
+                "ad-ready",
                 "/api/v1/projects/ad-ready/script-shots/reorder",
                 {"script_file": "episode_1.json", "shot_ids": ["E1S01"]},
             ),
             (
                 "patch",
+                "ready",
                 "/api/v1/projects/ready/segments/E1S01",
                 {"script_file": "narration.json"},
             ),
         ],
     )
     def test_script_edit_routes_refuse_on_a_migration_blocked_project(
-        self, tmp_path, monkeypatch, method: str, endpoint: str, body: dict
+        self, tmp_path, monkeypatch, method: str, project_name: str, endpoint: str, body: dict
     ):
-        """入口守卫先于内层 ScriptBatchEditor 裁决：四条手动编辑路由与同文件其它写入路由同守卫。"""
+        """入口守卫先于内层 ScriptBatchEditor 裁决：四条手动编辑路由与同文件其它写入路由同守卫。
+
+        409 的 detail 要同时带项目名与迁移失败原因——阻断回执得让人知道该修哪个项目的什么。
+        """
 
         import lib.project_migration_guard as guard
         from lib.project_migration_failure import record_migration_failure
 
         fake_pm = _FakePM(tmp_path)
-        project_name = endpoint.split("/projects/")[1].split("/")[0]
         record_migration_failure(fake_pm.base / project_name, ValueError("坏数据"), schema_version=7)
         monkeypatch.setattr(guard, "get_project_manager", lambda: fake_pm)
         client = _client(monkeypatch, fake_pm)
@@ -1716,7 +1722,9 @@ class TestProjectsRouter:
             response = getattr(client, method)(endpoint, json=body)
 
         assert response.status_code == 409
-        assert project_name in response.json()["detail"]
+        detail = response.json()["detail"]
+        assert project_name in detail
+        assert "坏数据" in detail
 
     @pytest.mark.unit
     def test_get_project_includes_asset_fingerprints(self, tmp_path, monkeypatch):

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1673,6 +1673,52 @@ class TestProjectsRouter:
             assert dup_id.status_code == 422
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("method", "endpoint", "body"),
+        [
+            (
+                "patch",
+                "/api/v1/projects/ready/script-scenes/001",
+                {"script_file": "episode_1.json", "updates": {}},
+            ),
+            (
+                "patch",
+                "/api/v1/projects/ad-ready/script-shots/E1S01",
+                {"script_file": "episode_1.json", "updates": {}},
+            ),
+            (
+                "post",
+                "/api/v1/projects/ad-ready/script-shots/reorder",
+                {"script_file": "episode_1.json", "shot_ids": ["E1S01"]},
+            ),
+            (
+                "patch",
+                "/api/v1/projects/ready/segments/E1S01",
+                {"script_file": "narration.json"},
+            ),
+        ],
+    )
+    def test_script_edit_routes_refuse_on_a_migration_blocked_project(
+        self, tmp_path, monkeypatch, method: str, endpoint: str, body: dict
+    ):
+        """入口守卫先于内层 ScriptBatchEditor 裁决：四条手动编辑路由与同文件其它写入路由同守卫。"""
+
+        import lib.project_migration_guard as guard
+        from lib.project_migration_failure import record_migration_failure
+
+        fake_pm = _FakePM(tmp_path)
+        project_name = endpoint.split("/projects/")[1].split("/")[0]
+        record_migration_failure(fake_pm.base / project_name, ValueError("坏数据"), schema_version=7)
+        monkeypatch.setattr(guard, "get_project_manager", lambda: fake_pm)
+        client = _client(monkeypatch, fake_pm)
+
+        with client:
+            response = getattr(client, method)(endpoint, json=body)
+
+        assert response.status_code == 409
+        assert project_name in response.json()["detail"]
+
+    @pytest.mark.unit
     def test_get_project_includes_asset_fingerprints(self, tmp_path, monkeypatch):
         """项目 API 应返回 asset_fingerprints 字段"""
         fake_pm = _FakePM(tmp_path)


### PR DESCRIPTION
Closes #2005

## 改了什么

数据升级（schema migration）失败的项目此前在剧本编辑上依赖被调用方 `ScriptBatchEditor.execute` 的内层裁决拦截，与同文件其它写入入口的守卫挂载方式不一致。按批次复盘裁决 DEC-05「阻断以入口声明为准」统一到入口层：

- **REST**：`update_scene` / `update_shot` / `reorder_shots` / `update_segment` 四条路由补挂 `require_project_migration_ok`，写法与同文件 `edit_script_batch`、`generate-overview` 一致。
- **MCP**：`patch_script` 模块导出的四个写入工具 `patch_episode_script` / `insert_segment` / `remove_segment` / `split_segment` 全部进 `MIGRATION_BLOCKED_TOOL_IDS`，注册期即包上守卫。issue 正文写的 `patch_script` 指的是这个工具族——四者同根因、同入口性质，只加其一会留下同样的层级不一致。
- `ScriptBatchEditor.execute` 的内层裁决**保留为兜底**，未删除。
- `MIGRATION_BLOCKED_TOOL_IDS` 上方注释同步改写：入口声明为准、内层只作兜底；同时如实交代仍开着的三个受控编辑工具（`patch_project` / `patch_episode_meta` / `rename_asset`）为什么开着——被阻断项目的修复要走它们。

### 有意排除

- `get_episode_script_revision` 是同模块的只读查询工具，不写盘、不经 `ScriptBatchEditor.execute`，不在本次阻断集内；只读工具的阻断形状归 #2009。
- ADR 0062「激活门」一节的入口声明口径补记（issue AC 第 2 条）已随 PR #2007 落地，本 PR 不含 ADR 改动。

## 行为变化

被阻断项目上，这四条路由现在返回 409（detail 含项目名与升级失败原因），四个 MCP 工具返回统一的 `problem` 回执（`code=PROJECT_MIGRATION_FAILED`、`action=RETRY_PROJECT_MIGRATION`、`detail=失败原因`）而不再是内层的 `script_edit` 信封。两处都指向 `retry_project_migration`。

## 验证

- `tests/test_projects_router.py::test_script_edit_routes_refuse_on_a_migration_blocked_project`：四条路由参数化，断言 409 且 detail 同时带项目名与失败原因。
- `tests/test_project_migration_blocking.py::test_script_edit_mcp_tools_refuse_at_registration_on_a_migration_blocked_project`：四个工具工厂参数化，断言 id 在阻断集内（`build_arcreel_mcp_server` 按该集合决定是否包守卫）、回执为 problem 形状、且不含 `script_edit`（证明没落到内层兜底）。
- 全量闸门本地通过：`ruff check` / `ruff format --check` / `basedpyright`（0 errors）/ `lint-imports`（1 kept, 0 broken）/ `pytest`（10260 passed, 2 skipped）。

## 已知薄弱点

- 上述四个工具经注册期守卫拦下后，`lib/script_batch_edit.py` 内层裁决对它们成为不可达兜底。按 issue 要求有意保留，作为「万一某个入口漏挂」的第二道防线，未加单独用例覆盖（该分支是既有代码，本 PR 未改动）。
- `build_arcreel_mcp_server` 实际把守卫包到阻断集成员上这条装配线，仓库里没有直接用例覆盖（对既有 20 个阻断工具同样如此），本 PR 未扩大到这块。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 项目迁移失败时，阻止脚本编辑、场景修改、广告镜头调整及旁白片段更新，避免在不完整状态下继续操作。
  * 相关操作现在返回明确的迁移失败原因、项目名称及重试提示。
  * 优化迁移失败提示，覆盖脚本生成、写入和受控项目或元数据编辑等场景。

* **测试**
  * 增加对上述编辑操作拦截和错误响应的覆盖，确保行为一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->