### PR TITLE
fix(sdk-tools): 只读诊断工具在数据升级未完成的项目上给出可执行的拒绝回执

### DIFF
--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -109,15 +109,22 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
     "retry_project_migration",
 )
 
-# Tools refused outright while the project's schema migration verdict is a failure.
-# Everything that generates output or writes script content is closed; the read-only
-# tools stay open so the agent can still diagnose what needs repairing, and the
-# controlled project/metadata editors (``patch_project``, ``patch_episode_meta``,
-# ``rename_asset``) stay open because repairing is done through them. The script batch
-# editors are named here even though their shared ``ScriptBatchEditor.execute`` already
-# refuses internally on the same verdict: the entry declares the block, the inner check
-# is only a fallback, and an entry never skips declaring the block just because some
-# callee happens to check too.
+# Tools wrapped at registration so they report the verdict instead of running while the
+# project's schema migration verdict is a failure. Everything that generates output or
+# writes script content is named here; the controlled project/metadata editors
+# (``patch_project``, ``patch_episode_meta``, ``rename_asset``) are not, because
+# repairing is done through them. The script batch editors are named here even though
+# their shared ``ScriptBatchEditor.execute`` already refuses internally on the same
+# verdict: the entry declares the block, the inner check is only a fallback, and an
+# entry never skips declaring the block just because some callee happens to check too.
+#
+# The read-only tools are outside this set on purpose — they answer the verdict inside
+# their own handlers, so this frozenset stays exactly the registration-time blocks.
+# ``list_pending_assets`` and ``get_episode_script_revision`` read it via
+# ``migration_failure_for`` and return the same ``migration_refusal_response`` envelope
+# the wrapper does; ``get_workflow_plan`` carries it as the plan's single problem rather
+# than refusing; ``get_video_capabilities`` reads model capability only, never the
+# project's artifacts, and stays fully available.
 MIGRATION_BLOCKED_TOOL_IDS: frozenset[str] = frozenset(
     {
         "complete_asset_inventory",

--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -11,15 +11,17 @@ different project via prompt injection.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 from claude_agent_sdk import create_sdk_mcp_server
 
-from lib.project_migration_guard import project_migration_failure
-from server.agent_runtime.sdk_tools._context import ToolContext, migration_refusal_response
+from server.agent_runtime.sdk_tools._context import (
+    ToolContext,
+    migration_failure_for,
+    migration_refusal_response,
+)
 from server.agent_runtime.sdk_tools.asset_inventory import complete_asset_inventory_tool
 from server.agent_runtime.sdk_tools.enqueue_assets import (
     generate_assets_tool,
@@ -156,7 +158,7 @@ def _refuse_while_migration_failed(sdk_tool: Any, ctx: ToolContext) -> Any:
     inner = sdk_tool.handler
 
     async def _guarded(args: Any) -> dict[str, Any]:
-        failure = await asyncio.to_thread(project_migration_failure, ctx.project_name, ctx.pm)
+        failure = await migration_failure_for(ctx)
         if failure is not None:
             return migration_refusal_response(
                 failure,

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -42,9 +42,10 @@ class ToolContext:
 async def migration_failure_for(ctx: ToolContext) -> MigrationFailureRecord | None:
     """This session's project migration verdict, or ``None`` when it is healthy.
 
-    Single read shared by the registration-time write guard and any read-only
-    tool that chooses to check for itself: both need the same disk-backed
-    verdict, not two independent readings of it.
+    The registration-time write guard and the read-only tools that answer the
+    verdict inside their own handlers both go through here, so every refusal in
+    the tool layer rests on the same persisted record read the same way, off the
+    event loop.
     """
     return await asyncio.to_thread(project_migration_failure, ctx.project_name, ctx.pm)
 

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -14,6 +15,7 @@ from lib.db import async_session_factory
 from lib.generation_result import GenerationBatchResult, migration_problem, render_generation_result
 from lib.project_manager import ProjectManager
 from lib.project_migration_failure import MigrationFailureRecord
+from lib.project_migration_guard import project_migration_failure
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +37,16 @@ class ToolContext:
     @property
     def project_path(self) -> Path:
         return self.pm.get_project_path(self.project_name)
+
+
+async def migration_failure_for(ctx: ToolContext) -> MigrationFailureRecord | None:
+    """This session's project migration verdict, or ``None`` when it is healthy.
+
+    Single read shared by the registration-time write guard and any read-only
+    tool that chooses to check for itself: both need the same disk-backed
+    verdict, not two independent readings of it.
+    """
+    return await asyncio.to_thread(project_migration_failure, ctx.project_name, ctx.pm)
 
 
 def tool_error(name: str, exc: BaseException, log: list[str] | None = None) -> dict[str, Any]:

--- a/server/agent_runtime/sdk_tools/enqueue_assets.py
+++ b/server/agent_runtime/sdk_tools/enqueue_assets.py
@@ -34,6 +34,8 @@ from lib.project_manager import ProjectManager
 from server.agent_runtime.sdk_tools._context import (
     ToolContext,
     generation_result_response,
+    migration_failure_for,
+    migration_refusal_response,
     tool_error,
 )
 
@@ -137,6 +139,12 @@ def list_pending_assets_tool(ctx: ToolContext):
     )
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
+            failure = await migration_failure_for(ctx)
+            if failure is not None:
+                return migration_refusal_response(
+                    failure,
+                    text="❌ 项目数据升级未完成，产物清单不可读，无法列出待生成资产。请按明细修复后调用 retry_project_migration：",
+                )
             asset_type = args.get("type")
             types = (asset_type,) if asset_type else ALL_TYPES
             lines: list[str] = []

--- a/server/agent_runtime/sdk_tools/patch_script.py
+++ b/server/agent_runtime/sdk_tools/patch_script.py
@@ -155,6 +155,8 @@ def get_episode_script_revision_tool(ctx: ToolContext):
     )
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
+            # revision 的唯一用途是当 patch_episode_script 的并发令牌，而剧本写入工具在阻断期
+            # 全部关闭：签发出去无处可用，故直接答复裁决，省掉一轮必然被拒的写入往返。
             failure = await migration_failure_for(ctx)
             if failure is not None:
                 return migration_refusal_response(

--- a/server/agent_runtime/sdk_tools/patch_script.py
+++ b/server/agent_runtime/sdk_tools/patch_script.py
@@ -19,7 +19,13 @@ from lib.script_editor import (
     resolve_items,
     split_segment,
 )
-from server.agent_runtime.sdk_tools._context import ToolContext, tool_error, validate_script_filename
+from server.agent_runtime.sdk_tools._context import (
+    ToolContext,
+    migration_failure_for,
+    migration_refusal_response,
+    tool_error,
+    validate_script_filename,
+)
 
 _OPERATIONS_SCHEMA: dict[str, Any] = {
     "type": "array",
@@ -149,6 +155,13 @@ def get_episode_script_revision_tool(ctx: ToolContext):
     )
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
+            failure = await migration_failure_for(ctx)
+            if failure is not None:
+                return migration_refusal_response(
+                    failure,
+                    text="❌ 项目数据升级未完成，剧本编辑已全部关闭，revision 不再签发。"
+                    "请按明细修复后调用 retry_project_migration：",
+                )
             script_filename = validate_script_filename(args["script"])
             revision = script_revision(ctx.pm.load_script(ctx.project_name, script_filename))
             return {

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -26,8 +26,10 @@ from lib.project_migration_failure import (
 )
 from lib.project_migrations.runner import migrate_project_with_verdict, run_project_migrations
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
+from lib.script_batch_edit import script_revision
 from lib.workflow_plan import WorkflowPlanRequest
 from lib.workflow_state import WorkflowStateService
+from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.enqueue_assets import list_pending_assets_tool
 from server.agent_runtime.sdk_tools.patch_script import (
     get_episode_script_revision_tool,
@@ -191,22 +193,36 @@ async def test_retry_tool_returns_details_then_unblocks_once_repaired(tmp_path: 
     assert unblocked["workflow_plan"]["status"]["blockers"] == []
 
 
+def _assert_list_pending_assets_unblocked(unblocked: dict, ctx: ToolContext) -> None:
+    text = unblocked["content"][0]["text"]
+    assert ctx.project_name in text
+    assert "✅" in text
+
+
+def _assert_get_episode_script_revision_unblocked(unblocked: dict, ctx: ToolContext) -> None:
+    assert unblocked["script"] == "episode_1.json"
+    assert unblocked["revision"] == script_revision(ctx.pm.load_script_readonly("demo", "episode_1.json"))
+
+
 @pytest.mark.parametrize(
-    "tool_factory,args,unblocked_fields",
+    "tool_factory,args,unblocked_fields,assert_unblocked",
     [
-        (list_pending_assets_tool, {}, ()),
-        (get_episode_script_revision_tool, {"script": "episode_1.json"}, ("script", "revision")),
+        (list_pending_assets_tool, {}, (), _assert_list_pending_assets_unblocked),
+        (
+            get_episode_script_revision_tool,
+            {"script": "episode_1.json"},
+            ("script", "revision"),
+            _assert_get_episode_script_revision_unblocked,
+        ),
     ],
 )
 async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of_raising(
-    tmp_path: Path, tool_factory, args, unblocked_fields
+    tmp_path: Path, tool_factory, args, unblocked_fields, assert_unblocked
 ) -> None:
     """只读诊断工具不在 MIGRATION_BLOCKED_TOOL_IDS 里、不经注册期守卫包装，各自在 handler 内
 
     读一次迁移裁决：命中则返回与生成类工具同构的 problem 回执，裁决清空后照常给出结果。
     """
-
-    from server.agent_runtime.sdk_tools._context import ToolContext
 
     projects_root = tmp_path / "projects"
     projects_root.mkdir()
@@ -224,7 +240,8 @@ async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of
     assert blocked["problem"]["code"] == MIGRATION_FAILURE_CODE
     assert blocked["problem"]["action"] == RETRY_MIGRATION_ACTION
     assert blocked["problem"]["detail"] == failure.reason
-    assert json.loads(blocked["content"][0]["text"].split("\n", 1)[1]) == blocked["problem"]
+    problem_text = blocked["content"][0]["text"]
+    assert json.loads(problem_text[problem_text.index("{") :]) == blocked["problem"]
 
     _repair_episode_script(project_dir)
     assert migrate_project_with_verdict(project_dir) is None
@@ -234,6 +251,7 @@ async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of
     assert "problem" not in unblocked
     for field in unblocked_fields:
         assert unblocked[field]
+    assert_unblocked(unblocked, ctx)
 
 
 async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -201,7 +201,7 @@ def _assert_list_pending_assets_unblocked(unblocked: dict, ctx: ToolContext) -> 
 
 def _assert_get_episode_script_revision_unblocked(unblocked: dict, ctx: ToolContext) -> None:
     assert unblocked["script"] == "episode_1.json"
-    assert unblocked["revision"] == script_revision(ctx.pm.load_script_readonly("demo", "episode_1.json"))
+    assert unblocked["revision"] == script_revision(ctx.pm.load_script_readonly(ctx.project_name, "episode_1.json"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -28,7 +28,9 @@ from lib.project_migrations.runner import migrate_project_with_verdict, run_proj
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from lib.workflow_plan import WorkflowPlanRequest
 from lib.workflow_state import WorkflowStateService
+from server.agent_runtime.sdk_tools.enqueue_assets import list_pending_assets_tool
 from server.agent_runtime.sdk_tools.patch_script import (
+    get_episode_script_revision_tool,
     insert_segment_tool,
     patch_episode_script_tool,
     remove_segment_tool,
@@ -187,6 +189,50 @@ async def test_retry_tool_returns_details_then_unblocks_once_repaired(tmp_path: 
     assert unblocked.get("is_error") is not True
     assert load_migration_failure(project_dir) is None
     assert unblocked["workflow_plan"]["status"]["blockers"] == []
+
+
+@pytest.mark.parametrize(
+    "tool_factory,args",
+    [
+        (list_pending_assets_tool, {}),
+        (get_episode_script_revision_tool, {"script": "episode_1.json"}),
+    ],
+)
+async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of_raising(
+    tmp_path: Path, tool_factory, args
+) -> None:
+    """只读诊断工具（不在 MIGRATION_BLOCKED_TOOL_IDS 里，不经注册期守卫包装）在阻断项目上
+
+    自行读一次迁移裁决，命中即返回与生成类工具同构的 problem 回执，而不是把内部异常
+    （list_pending_assets 原先会撞上的 ProjectMigrationError）或过期数据（未加检查前
+    get_episode_script_revision 会静默放行）透给 agent。
+    """
+
+    from server.agent_runtime.sdk_tools._context import ToolContext
+
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    project_dir, *_ = _project(projects_root)
+    _break_episode_script(project_dir)
+    failure = migrate_project_with_verdict(project_dir)
+    assert failure is not None
+
+    ctx = ToolContext(project_name="demo", projects_root=projects_root, pm=ProjectManager(str(projects_root)))
+    handler = tool_factory(ctx).handler
+
+    blocked = await handler(args)
+
+    assert blocked["is_error"] is True
+    assert blocked["problem"]["code"] == MIGRATION_FAILURE_CODE
+    assert blocked["problem"]["action"] == RETRY_MIGRATION_ACTION
+    assert blocked["problem"]["detail"] == failure.reason
+    assert json.loads(blocked["content"][0]["text"].split("\n", 1)[1]) == blocked["problem"]
+
+    _repair_episode_script(project_dir)
+    assert migrate_project_with_verdict(project_dir) is None
+    unblocked = await handler(args)
+
+    assert unblocked.get("is_error") is not True
 
 
 async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -192,20 +192,18 @@ async def test_retry_tool_returns_details_then_unblocks_once_repaired(tmp_path: 
 
 
 @pytest.mark.parametrize(
-    "tool_factory,args",
+    "tool_factory,args,unblocked_fields",
     [
-        (list_pending_assets_tool, {}),
-        (get_episode_script_revision_tool, {"script": "episode_1.json"}),
+        (list_pending_assets_tool, {}, ()),
+        (get_episode_script_revision_tool, {"script": "episode_1.json"}, ("script", "revision")),
     ],
 )
 async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of_raising(
-    tmp_path: Path, tool_factory, args
+    tmp_path: Path, tool_factory, args, unblocked_fields
 ) -> None:
-    """只读诊断工具（不在 MIGRATION_BLOCKED_TOOL_IDS 里，不经注册期守卫包装）在阻断项目上
+    """只读诊断工具不在 MIGRATION_BLOCKED_TOOL_IDS 里、不经注册期守卫包装，各自在 handler 内
 
-    自行读一次迁移裁决，命中即返回与生成类工具同构的 problem 回执，而不是把内部异常
-    （list_pending_assets 原先会撞上的 ProjectMigrationError）或过期数据（未加检查前
-    get_episode_script_revision 会静默放行）透给 agent。
+    读一次迁移裁决：命中则返回与生成类工具同构的 problem 回执，裁决清空后照常给出结果。
     """
 
     from server.agent_runtime.sdk_tools._context import ToolContext
@@ -233,6 +231,9 @@ async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of
     unblocked = await handler(args)
 
     assert unblocked.get("is_error") is not True
+    assert "problem" not in unblocked
+    for field in unblocked_fields:
+        assert unblocked[field]
 
 
 async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_project_migration_blocking.py
+++ b/tests/test_project_migration_blocking.py
@@ -240,8 +240,9 @@ async def test_readonly_diagnostic_tools_report_the_migration_problem_instead_of
     assert blocked["problem"]["code"] == MIGRATION_FAILURE_CODE
     assert blocked["problem"]["action"] == RETRY_MIGRATION_ACTION
     assert blocked["problem"]["detail"] == failure.reason
-    problem_text = blocked["content"][0]["text"]
-    assert json.loads(problem_text[problem_text.index("{") :]) == blocked["problem"]
+    # migration_refusal_response 按 text + "\n" + json.dumps(payload, ...) 拼接，直接比对该已知
+    # 序列化结果，不靠猜切分点（提示文本或缩进 JSON 内部各自可能出现 "\n"/"{"，两者都不是可靠锚点）。
+    assert blocked["content"][0]["text"].endswith(json.dumps(blocked["problem"], ensure_ascii=False, indent=2))
 
     _repair_episode_script(project_dir)
     assert migrate_project_with_verdict(project_dir) is None


### PR DESCRIPTION
Closes #2009

## 变更

迁移阻断的项目上，只读诊断工具此前的回执各不相同：`list_pending_assets` 撞上 `ProjectMigrationError`、被外层通用 `except` 收成一行裸文本；`get_episode_script_revision` 则完全不检查裁决，照常签出 revision。本 PR 让这两个工具在 handler 内先读一次迁移裁决，命中则返回与生成类工具完全同一个 `migration_refusal_response()` 信封——同一份 `problem`（`code` / `detail` 原样透出 failure.reason / `action=retry_project_migration` / `params.details` 指向出问题的集与文件），文本块同样点名 `retry_project_migration` 作为修复出口。

`get_episode_script_revision` 由「静默放行」改为拒签：revision 的唯一用途是当 `patch_episode_script` 的并发令牌，而全部剧本写入工具在阻断期已经关闭，签发出去无处可用。

只读工具不进 `MIGRATION_BLOCKED_TOOL_IDS`——那个集合是注册期包装名单，两者是不同机制。该集合的注释相应改写，逐一记下四个只读工具各自如何答复裁决，读注释即可看到全景。

## 只读工具盘点

`ARCREEL_MCP_TOOL_IDS`（32）− `MIGRATION_BLOCKED_TOOL_IDS`（24）− 三个受控编辑工具（`patch_project` / `patch_episode_meta` / `rename_asset`，阻断期的修复通道）− `retry_project_migration`（修复出口本身）= 4 个只读工具，逐个核实并处置：

| 工具 | 阻断项目上的行为 | 处置 |
|---|---|---|
| `list_pending_assets` | 抛 `ProjectMigrationError`，被通用 except 收成裸文本 | 改为结构化拒绝 |
| `get_episode_script_revision` | 静默放行，签出 revision | 改为结构化拒绝 |
| `get_workflow_plan` | 已有既定设计：返回完整 plan，裁决作为唯一 `structure_problems` 条目（与 `migration_problem()` 同源）+ `next_action` 指向重试 | 已对齐，未改 |
| `get_video_capabilities` | 只解析视频模型能力与项目偏好，调用链不触达 Artifact Manifest / migration guard，结果与 schema 版本无关 | 照常可用，未改 |

`migration_failure_for(ctx)` 抽到 `_context.py`：注册期守卫与这两个只读工具走同一份持久化裁决、同样的读法，而不是各自拼一套。

## 验证

- `uv run ruff check .` / `ruff format --check .` / `basedpyright`（0 errors）/ `lint-imports`（1 kept, 0 broken）/ `python -m pytest`（10262 passed, 2 skipped），rebase 到 `a522d4937` 后重跑一遍全绿。
- 新增 `tests/test_project_migration_blocking.py::test_readonly_diagnostic_tools_report_the_migration_problem_instead_of_raising`，对两个工具参数化，覆盖阻断与放行两条分支：阻断断言 `problem` 的 code / action / detail 且文本块内的 JSON 与 `problem` 逐字段相等；放行断言回执里没有 `problem` 信封，且 `get_episode_script_revision` 真的签出 `script` + `revision`。
- 本 PR 只改后端，未跑前端与文档站闸门。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 项目迁移未完成或失败时，资产列表与剧本修订工具会暂停操作，并返回统一的迁移问题提示。
  * 迁移修复后，相关工具可恢复正常使用并返回诊断结果。
  * 优化迁移阻断说明，提供明确的修复与重试指引。

* **测试**
  * 增加迁移失败、问题修复后恢复等场景的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->