### PR TITLE
fix(project-migration): update_episode 路由补挂迁移守卫

### DIFF
--- a/server/agent_runtime/sdk_tools/__init__.py
+++ b/server/agent_runtime/sdk_tools/__init__.py
@@ -113,10 +113,13 @@ ARCREEL_MCP_TOOL_IDS: tuple[str, ...] = (
 # project's schema migration verdict is a failure. Everything that generates output or
 # writes script content is named here; the controlled project/metadata editors
 # (``patch_project``, ``patch_episode_meta``, ``rename_asset``) are not, because
-# repairing is done through them. The script batch editors are named here even though
-# their shared ``ScriptBatchEditor.execute`` already refuses internally on the same
-# verdict: the entry declares the block, the inner check is only a fallback, and an
-# entry never skips declaring the block just because some callee happens to check too.
+# repairing is done through them. The exception belongs to this MCP repair channel
+# alone and does not carry over to REST: a route that writes script content stays
+# behind ``require_project_migration_ok`` rather than inheriting this exemption.
+# The script batch editors are named here even though their shared
+# ``ScriptBatchEditor.execute`` already refuses internally on the same verdict:
+# the entry declares the block, the inner check is only a fallback, and an entry
+# never skips declaring the block just because some callee happens to check too.
 #
 # The read-only tools are outside this set on purpose — they answer the verdict inside
 # their own handlers, so this frozenset stays exactly the registration-time blocks.

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -1380,7 +1380,7 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
         raise HTTPException(status_code=500, detail=_t("internal_server_error"))
 
 
-@router.patch("/projects/{name}/episodes/{episode}")
+@router.patch("/projects/{name}/episodes/{episode}", dependencies=[Depends(require_project_migration_ok)])
 async def update_episode(name: str, episode: int, req: UpdateEpisodeRequest, _t: Translator):
     """更新分集顶层元数据（当前仅标题）。
 

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1726,6 +1726,8 @@ class TestProjectsRouter:
         record_migration_failure(fake_pm.base / project_name, ValueError("坏数据"), schema_version=7)
         monkeypatch.setattr(guard, "get_project_manager", lambda: fake_pm)
         client = _client(monkeypatch, fake_pm)
+        before_project_data = deepcopy(fake_pm.project_data)
+        before_scripts = deepcopy(fake_pm.scripts)
 
         with client:
             response = getattr(client, method)(endpoint, json=body)
@@ -1734,6 +1736,9 @@ class TestProjectsRouter:
         detail = response.json()["detail"]
         assert project_name in detail
         assert "坏数据" in detail
+        # 阻断必须发生在惰性迁移读写之前：project.json 与 scripts/*.json 都不能被动过
+        assert fake_pm.project_data == before_project_data
+        assert fake_pm.scripts == before_scripts
 
     @pytest.mark.unit
     def test_get_project_includes_asset_fingerprints(self, tmp_path, monkeypatch):

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1700,12 +1700,21 @@ class TestProjectsRouter:
                 "/api/v1/projects/ready/segments/E1S01",
                 {"script_file": "narration.json"},
             ),
+            (
+                "patch",
+                "ready",
+                "/api/v1/projects/ready/episodes/1",
+                {"title": "新集名"},
+            ),
         ],
     )
     def test_script_edit_routes_refuse_on_a_migration_blocked_project(
         self, tmp_path, monkeypatch, method: str, project_name: str, endpoint: str, body: dict
     ):
-        """入口守卫先于内层 ScriptBatchEditor 裁决：四条手动编辑路由与同文件其它写入路由同守卫。
+        """写剧本的路由一律在入口层被拒：五条手动编辑路由与同文件其它写入路由同守卫。
+
+        阻断由入口声明，不指望内层兜底：其中四条经 ScriptBatchEditor 另有一道内部裁决，
+        改分集标题那条走 locked_episode_script，全程不读裁决，入口守卫是它唯一的一道。
 
         409 的 detail 要同时带项目名与迁移失败原因——阻断回执得让人知道该修哪个项目的什么。
         """


### PR DESCRIPTION
`PATCH /projects/{name}/episodes/{episode}` 是 `server/routers/projects.py` 里唯一直接写 `scripts/*.json` 却没挂 `require_project_migration_ok` 的写入路由，内层也没有兜底：它走 `ProjectManager.locked_episode_script`，该路径不读迁移裁决。阻断态项目在 WebUI 里照常打开，画布上双击改分集标题即可直接落盘——而临界区内会跑 `migrate_script_unit_durations` 并写回，同时对 `project.json` 跑三个惰性迁移后 `atomic_write_json`，让升级链已判失败的项目被半迁移落盘。

## 改动

- `update_episode` 补挂 `dependencies=[Depends(require_project_migration_ok)]`，写法与同文件另外六条守卫路由一致。
- 该路由并入 `tests/test_projects_router.py` 既有的迁移阻断 parametrize 用例（四条 → 五条），断言 409 且 detail 同时带项目名与迁移失败原因。
- `sdk_tools/__init__.py` 受控编辑工具例外注释补记：该例外属 MCP 修复通道，不外溢到 REST，写剧本的路由一律留在守卫之后。

MCP 侧 `patch_episode_meta` 写同一个字段但刻意留在 `MIGRATION_BLOCKED_TOOL_IDS` 之外，是阻断期的修复通道，本 PR 不动它。口径：WebUI 改标题不是修复通道，Agent 的修复工具不受影响。

## 验证

- `ruff check` / `ruff format --check` / `basedpyright`（0 errors）/ `lint-imports`（2 contracts kept）全绿。
- `python -m pytest`：10279 passed, 2 skipped。
- 结构性用例 `test_every_guarded_router_route_can_name_its_project` 自动覆盖新路由（路径参数名为 `name`）；正常项目改标题仍返回 200，由既有 `test_update_episode_title_renames_script_and_mirror` 守住。

Closes #2021


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 项目迁移未完成时，分集标题更新等手动编辑操作将被阻止，避免迁移期间修改内容。
* **测试**
  * 扩展迁移阻断场景的覆盖范围，确保相关编辑接口行为一致。
* **文档**
  * 明确修复通道与脚本批量编辑操作的适用规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->