### PR TITLE
fix(agent): 迁移阻断期文案不再点名已被阻断的写入工具

### DIFF
--- a/agent_runtime_profile/.claude/references/workflow-plan.md
+++ b/agent_runtime_profile/.claude/references/workflow-plan.md
@@ -54,9 +54,10 @@ mcp__arcreel__get_workflow_plan({
 处理顺序：
 
 1. 把 `details[]` 逐条讲给用户：哪一集的哪个文件、违了什么约，不要压成一句「升级失败」。
-2. 用既有的受控编辑工具（`mcp__arcreel__patch_episode_script`、`mcp__arcreel__patch_project`、
-   `mcp__arcreel__patch_episode_meta` 等）按明细修。**没有裸文件写入这条路**，也不要用 `Edit`
-   直接改正式脚本。
+2. 阻断期仍可用的写入工具只有 `mcp__arcreel__patch_project`、`mcp__arcreel__patch_episode_meta`、
+   `mcp__arcreel__rename_asset`；`mcp__arcreel__patch_episode_script` 等正式写入工具与所有生成
+   工具一律被拒。按明细用前三个能修的先修，够不着的（如剧本正文类违约）按第 4 步如实告知用户。
+   **没有裸文件写入这条路**，也不要用 `Edit` 直接改正式脚本。
 3. 调用 `mcp__arcreel__retry_project_migration` 重跑升级链。它幂等，重复调用不会造成损失。
 4. 成功时工具返回新的制作计划，项目解除阻断，照常按 `next_action` 继续；失败时返回新的结构化
    明细，回到第 1 步。修不动时如实告诉用户卡在哪里，不要反复空跑重试。

--- a/agent_runtime_profile/.claude/references/workflow-plan.md
+++ b/agent_runtime_profile/.claude/references/workflow-plan.md
@@ -55,8 +55,9 @@ mcp__arcreel__get_workflow_plan({
 
 1. 把 `details[]` 逐条讲给用户：哪一集的哪个文件、违了什么约，不要压成一句「升级失败」。
 2. 阻断期仍可用的写入工具只有 `mcp__arcreel__patch_project`、`mcp__arcreel__patch_episode_meta`、
-   `mcp__arcreel__rename_asset`；`mcp__arcreel__patch_episode_script` 等正式写入工具与所有生成
-   工具一律被拒。按明细用前三个能修的先修，够不着的（如剧本正文类违约）按第 4 步如实告知用户。
+   `mcp__arcreel__rename_asset`；`mcp__arcreel__patch_episode_script`、`mcp__arcreel__insert_segment`、
+   `mcp__arcreel__remove_segment`、`mcp__arcreel__split_segment` 与所有生成工具一律被拒。按明细用
+   前三个能修的先修，够不着的（如剧本正文类违约）按第 4 步如实告知用户。
    **没有裸文件写入这条路**，也不要用 `Edit` 直接改正式脚本。
 3. 调用 `mcp__arcreel__retry_project_migration` 重跑升级链。它幂等，重复调用不会造成损失。
 4. 成功时工具返回新的制作计划，项目解除阻断，照常按 `next_action` 继续；失败时返回新的结构化

--- a/server/agent_runtime/sdk_tools/retry_project_migration.py
+++ b/server/agent_runtime/sdk_tools/retry_project_migration.py
@@ -20,7 +20,8 @@ def retry_project_migration_tool(ctx: ToolContext):
         "重跑本项目的数据升级链（含产物补录）。升级失败时项目被阻断，阻断期仍可用的写入工具只有"
         "patch_project / patch_episode_meta / rename_asset；patch_episode_script / insert_segment / "
         "remove_segment / split_segment 一律被拒。按失败明细用前三个修好被点名的集 / 文件，再调用"
-        "本工具。幂等：已是最新版本时直接返回成功。成功返回新的制作计划；失败返回结构化明细"
+        "本工具；这三个工具改不到的位置（如剧本正文类违约）如实报告卡点给用户，不要反复重试。"
+        "幂等：已是最新版本时直接返回成功。成功返回新的制作计划；失败返回结构化明细"
         "（episode / file / violation）。",
         {"type": "object", "properties": {}},
     )

--- a/server/agent_runtime/sdk_tools/retry_project_migration.py
+++ b/server/agent_runtime/sdk_tools/retry_project_migration.py
@@ -17,9 +17,11 @@ from server.services import workflow_planner
 def retry_project_migration_tool(ctx: ToolContext):
     @tool(
         "retry_project_migration",
-        "重跑本项目的数据升级链（含产物补录）。升级失败时项目被阻断，先用受控编辑工具按失败明细"
-        "修好被点名的集 / 文件，再调用本工具。幂等：已是最新版本时直接返回成功。成功返回新的制作"
-        "计划；失败返回结构化明细（episode / file / violation）。",
+        "重跑本项目的数据升级链（含产物补录）。升级失败时项目被阻断，阻断期仍可用的写入工具只有"
+        "patch_project / patch_episode_meta / rename_asset；patch_episode_script / insert_segment / "
+        "remove_segment / split_segment 一律被拒。按失败明细用前三个修好被点名的集 / 文件，再调用"
+        "本工具。幂等：已是最新版本时直接返回成功。成功返回新的制作计划；失败返回结构化明细"
+        "（episode / file / violation）。",
         {"type": "object", "properties": {}},
     )
     async def _handler(_args: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## 问题

迁移阻断期的修复指引点名了已被阻断的工具，agent 按指引走进死路。

`server/agent_runtime/sdk_tools/retry_project_migration.py` 的工具描述与 `agent_runtime_profile/.claude/references/workflow-plan.md` 的处理顺序第 2 步，都让 agent「用受控编辑工具按明细修」——这个词无处定义，且 workflow-plan 里把 `patch_episode_script` 排在第一位。该工具在 `MIGRATION_BLOCKED_TOOL_IDS` 内，阻断期一律被拒。agent 照指引调用 → 收到阻断回执 → 重试仍失败 → 回到第 1 步空转。

同一份文档 `:51` 又写着「所有生成工具与正式写入工具在这个状态下一律返回同一条问题、不做任何事」，与第 2 步自相矛盾。

## 改动

两处文案改为显式点名，不再使用「受控编辑工具」这个无处定义的词：

- **`retry_project_migration.py`**：写明阻断期仍可用的写入工具只有 `patch_project` / `patch_episode_meta` / `rename_asset`；`patch_episode_script` / `insert_segment` / `remove_segment` / `split_segment` 一律被拒。
- **`workflow-plan.md` 第 2 步**：同步为同一份名单。`patch_episode_script` 保留但改标为「一律被拒」而非删除——与工具描述对称，且明确告诉 agent 别去试。够不着的（如剧本正文类违约）指回第 4 步既有的「修不动时如实告诉用户卡在哪里，不要反复空跑重试」。

不改任何工具的阻断状态，不碰 `sdk_tools/__init__.py`。

## 验证

- 三个仍开放的工具逐一比对 `MIGRATION_BLOCKED_TOOL_IDS`（`sdk_tools/__init__.py:128-155`）确认不在其中，并与其上方例外注释逐字一致；四个被拒的剧本工具确认在集合内。
- 枚举 `build_arcreel_mcp_server` 注册的全部 32 个工具：未被阻断的 8 个中，`get_workflow_plan` / `list_pending_assets` / `get_video_capabilities` / `get_episode_script_revision` 是只读工具，`retry_project_migration` 是重试入口本身——「仍可用的写入工具只有三个」属实。
- 两处文案均面向 agent，不经 UI 呈现：前端渲染的是 `dashboard:tool_name_<id>` 本地化工具名（`ToolCallWithResult.tsx:73-78`），工具 `description` 不进 UI，故无需补 `frontend/src/i18n/` 翻译 key。
- 后端全量闸门：`ruff check` / `ruff format --check` / `basedpyright`（0 errors）/ `lint-imports`（2 kept, 0 broken）/ `pytest`（10278 passed, 2 skipped）。本 PR 纯后端文案，未跑前端闸门。

## 范围

本 PR 只把话说对。「剧本正文类违约在阻断期怎么修」改完后确实无路可走——`patch_project` / `rename_asset` 够不着剧本正文，`patch_episode_meta` 白名单只有 `title`。那是产品决策（承认只能人工介入，或给 `patch_episode_script` 开修复专用豁免），已单独转呈，不在本 PR 范围。本 PR 的价值是让 agent 立刻报告卡点，而不是空转数轮后才卡住。

Closes #2023


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 明确数据升级失败期间可执行的修复操作范围。
  * 仅支持修复项目、剧集元数据和资源名称；正式剧本及生成内容仍不可直接修改。
  * 对于无法通过允许操作修复的问题，将直接向用户说明，避免重复尝试。
  * 继续禁止直接写入文件或绕过规范修改正式剧本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->