### PR TITLE
fix(frontend): 视频候选下拉的音轨能力线按各下拉自身的路径取值

### DIFF
--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -333,8 +333,7 @@ describe("MediaModelSection", () => {
 
         await user.click(screen.getAllByText("按用途指定模型")[0]);
         expect(await omniRowIn(user, "图生视频")).toContain("有声");
-        // 与同屏 r2vAudioControl（always_off）一致；此前这一格固定读 i2v 位标「有声」，
-        // 与它下方被置灰为恒无声的勾选框自相矛盾
+        // 与同屏 r2vAudioControl（always_off）判定的勾选框一致：一屏之内两句话不能互相矛盾
         expect(await omniRowIn(user, "参考生视频")).toContain("无声");
       });
     });

--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -292,6 +292,52 @@ describe("MediaModelSection", () => {
       expect(box).not.toBeChecked();
       expect(screen.getByText(/没有声音/)).toBeInTheDocument();
     });
+
+    // 全局页无项目上下文，默认模型两条路径都会用到，能力线只能给目录位；但两个细分项下拉
+    // 各自就是一条路径，与上方按桶取值的勾选框判据同源，不能共用默认层那一个答案。
+    describe("候选下拉的音轨能力线", () => {
+      function mockOmni() {
+        vi.spyOn(API, "getSystemConfig").mockResolvedValue({
+          options: { ...CONFIG.options, video_backends: ["kling/v3-omni"] },
+          settings: { ...CONFIG.settings, default_video_backend: "" },
+        } as unknown as Awaited<ReturnType<typeof API.getSystemConfig>>);
+        vi.spyOn(API, "getModelCandidates").mockResolvedValue({
+          ...CANDIDATES,
+          video: {
+            default: ["kling/v3-omni"],
+            buckets: { i2v: ["kling/v3-omni"], r2v: ["kling/v3-omni"] },
+          },
+        } as unknown as Awaited<ReturnType<typeof API.getModelCandidates>>);
+        vi.spyOn(providerModels, "getProviderModels").mockResolvedValue([
+          videoProvider("kling", "v3-omni", {
+            audio_track: "controllable",
+            reference_route_audio_track: "always_off",
+          }),
+        ]);
+      }
+
+      /** 打开指定下拉，读出 v3-omni 那一行的能力线，再关掉——同时只开一个下拉。 */
+      async function omniRowIn(user: ReturnType<typeof userEvent.setup>, comboboxName: string) {
+        await user.click(screen.getByRole("combobox", { name: comboboxName }));
+        const text = screen.getByRole("option", { name: /v3-omni/ }).textContent ?? "";
+        await user.keyboard("{Escape}");
+        return text;
+      }
+
+      it("默认模型按目录位标有声，两个细分项各按自己的路径标注", async () => {
+        const user = userEvent.setup();
+        mockOmni();
+        render(<MediaModelSection />);
+        await screen.findByRole("combobox", { name: "默认视频模型" });
+        expect(await omniRowIn(user, "默认视频模型")).toContain("有声");
+
+        await user.click(screen.getAllByText("按用途指定模型")[0]);
+        expect(await omniRowIn(user, "图生视频")).toContain("有声");
+        // 与同屏 r2vAudioControl（always_off）一致；此前这一格固定读 i2v 位标「有声」，
+        // 与它下方被置灰为恒无声的勾选框自相矛盾
+        expect(await omniRowIn(user, "参考生视频")).toContain("无声");
+      });
+    });
   });
 
   it("auto-expands a channel whose sub-field is already configured", async () => {

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -238,6 +238,9 @@ export function MediaModelSection() {
     ? lookupResolutions(providers, currentVideo, customProviders, endpointToMediaType).options
     : [];
 
+  // 不传 defaultRoute：全局默认模型两条路径都会用到，取任一条都会误报另一条；无项目上下文
+  // 时按目录 i2v 位展示。两个细分项下拉各按自己的桶取值，与上方 i2vAudioControl / r2vAudioControl
+  // 同口径。
   const renderVideoOptionMeta = videoOptionMetaRenderer({ t, providers, customProviders, endpointToMediaType });
   const currentAudioBackend = draft.default_audio_backend ?? settings.default_audio_backend ?? "";
   const currentNarrationVoice = draft.narration_voice ?? settings.narration_voice ?? "";

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -112,49 +112,45 @@ describe("LayeredModelFields", () => {
   });
 
   // 默认层与各细分项共用一个 renderOptionMeta。路径相关的取值（音轨）只有拿到「是哪个细分项
-  // 在问」才算得对，所以这里锁住转发本身：默认层不带 key，细分项带且只带自己的 key。
+  // 在问」才算得对，所以这里锁住转发本身：默认层不带 key，细分项带且只带自己的 key。断言走
+  // 渲染出的选项文本（renderOptionMeta 的返回值会显示在下拉选项里），不读 mock 调用记录。
   describe("renderOptionMeta 的细分项归属", () => {
+    const keyProbe = (_fullValue: string, subFieldKey?: string) => subFieldKey ?? "no-key";
+
     it("默认层下拉不带细分项 key——它跨全部用途，没有单一生成路径", async () => {
       const user = userEvent.setup();
-      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
-      renderFields({ renderOptionMeta });
+      renderFields({ renderOptionMeta: keyProbe });
       await user.click(screen.getByRole("combobox", { name: "默认视频模型" }));
-      expect(renderOptionMeta).toHaveBeenCalled();
-      for (const call of renderOptionMeta.mock.calls) {
-        expect(call[1]).toBeUndefined();
+      for (const option of screen.getAllByRole("option", { name: /veo-3|seedance/ })) {
+        expect(option.textContent).toContain("no-key");
       }
     });
 
     it("每个细分项下拉带上自己的 key，互不串用", async () => {
       const user = userEvent.setup();
-      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
       renderFields({
-        renderOptionMeta,
+        renderOptionMeta: keyProbe,
         subFields: [subField(), subField({ key: "r2v", label: "参考生视频" })],
       });
       await user.click(screen.getByText("按用途指定模型"));
 
-      renderOptionMeta.mockClear();
       await user.click(screen.getByRole("combobox", { name: "图生视频" }));
-      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "i2v");
+      expect(screen.getByRole("option", { name: /veo-3/ }).textContent).toContain("i2v");
       await user.keyboard("{Escape}");
 
-      renderOptionMeta.mockClear();
       await user.click(screen.getByRole("combobox", { name: "参考生视频" }));
-      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "r2v");
+      expect(screen.getByRole("option", { name: /veo-3/ }).textContent).toContain("r2v");
     });
 
     it("转发的是原样的 key，不限于视频桶——图片桶同样拿到自己的 key", async () => {
       const user = userEvent.setup();
-      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
       renderFields({
-        renderOptionMeta,
+        renderOptionMeta: keyProbe,
         subFields: [subField({ key: "t2i", label: "文生图" })],
       });
       await user.click(screen.getByText("按用途指定模型"));
-      renderOptionMeta.mockClear();
       await user.click(screen.getByRole("combobox", { name: "文生图" }));
-      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "t2i");
+      expect(screen.getByRole("option", { name: /veo-3/ }).textContent).toContain("t2i");
     });
   });
 

--- a/frontend/src/components/shared/LayeredModelFields.test.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.test.tsx
@@ -111,6 +111,53 @@ describe("LayeredModelFields", () => {
     expect(onDefaultChange).not.toHaveBeenCalled();
   });
 
+  // 默认层与各细分项共用一个 renderOptionMeta。路径相关的取值（音轨）只有拿到「是哪个细分项
+  // 在问」才算得对，所以这里锁住转发本身：默认层不带 key，细分项带且只带自己的 key。
+  describe("renderOptionMeta 的细分项归属", () => {
+    it("默认层下拉不带细分项 key——它跨全部用途，没有单一生成路径", async () => {
+      const user = userEvent.setup();
+      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
+      renderFields({ renderOptionMeta });
+      await user.click(screen.getByRole("combobox", { name: "默认视频模型" }));
+      expect(renderOptionMeta).toHaveBeenCalled();
+      for (const call of renderOptionMeta.mock.calls) {
+        expect(call[1]).toBeUndefined();
+      }
+    });
+
+    it("每个细分项下拉带上自己的 key，互不串用", async () => {
+      const user = userEvent.setup();
+      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
+      renderFields({
+        renderOptionMeta,
+        subFields: [subField(), subField({ key: "r2v", label: "参考生视频" })],
+      });
+      await user.click(screen.getByText("按用途指定模型"));
+
+      renderOptionMeta.mockClear();
+      await user.click(screen.getByRole("combobox", { name: "图生视频" }));
+      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "i2v");
+      await user.keyboard("{Escape}");
+
+      renderOptionMeta.mockClear();
+      await user.click(screen.getByRole("combobox", { name: "参考生视频" }));
+      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "r2v");
+    });
+
+    it("转发的是原样的 key，不限于视频桶——图片桶同样拿到自己的 key", async () => {
+      const user = userEvent.setup();
+      const renderOptionMeta = vi.fn((_fullValue: string, _subFieldKey?: string) => null);
+      renderFields({
+        renderOptionMeta,
+        subFields: [subField({ key: "t2i", label: "文生图" })],
+      });
+      await user.click(screen.getByText("按用途指定模型"));
+      renderOptionMeta.mockClear();
+      await user.click(screen.getByRole("combobox", { name: "文生图" }));
+      expect(renderOptionMeta).toHaveBeenCalledWith("gemini/veo-3", "t2i");
+    });
+  });
+
   it("force-opens the disclosure and shows an error notice with retry when subFieldsError is set, even with no sub-fields", () => {
     const onRetry = vi.fn();
     const { container } = renderFields({ subFields: [], subFieldsError: { onRetry } });

--- a/frontend/src/components/shared/LayeredModelFields.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.tsx
@@ -105,7 +105,12 @@ export interface LayeredModelFieldsProps {
   /** 默认层留空时的生效模型（项目层 = 全局默认层）；全局层是基准、不传。 */
   defaultEffective?: string;
   providerNames: Record<string, string>;
-  renderOptionMeta?: (fullValue: string) => React.ReactNode;
+  /**
+   * 下拉选项行的补充信息。第二个参数是发起该下拉的细分项 `key`；默认层不传——它跨全部用途，
+   * 没有单一生成路径。同屏的默认层与各细分项共用一个渲染器，路径相关的取值必须按此参数分流，
+   * 否则一个下拉的路径会被当成全部下拉的路径。
+   */
+  renderOptionMeta?: (fullValue: string, subFieldKey?: string) => React.ReactNode;
   /** 默认层下拉与折叠区之间的附加内容（模型规格条、分辨率、时长等）。 */
   children?: React.ReactNode;
   /** 细分项；省略或空数组即不渲染折叠区（创建向导只暴露默认层）。 */
@@ -175,7 +180,7 @@ export function LayeredModelFields({
         placeholder={emptyLabel}
         fallbackValue={defaultEffective}
         aria-label={defaultLabel}
-        renderOptionMeta={renderOptionMeta}
+        renderOptionMeta={renderOptionMeta && ((fullValue: string) => renderOptionMeta(fullValue))}
       />
 
       {children}
@@ -226,7 +231,9 @@ export function LayeredModelFields({
                   fallbackValue={field.effective}
                   fallbackLabel={t("follow_model_default")}
                   aria-label={field.label}
-                  renderOptionMeta={renderOptionMeta}
+                  renderOptionMeta={
+                    renderOptionMeta && ((fullValue: string) => renderOptionMeta(fullValue, field.key))
+                  }
                 />
                 <p className="mt-1.5 text-[11px] leading-[1.5] text-text-4">{field.caption}</p>
               </div>

--- a/frontend/src/components/shared/LayeredModelFields.tsx
+++ b/frontend/src/components/shared/LayeredModelFields.tsx
@@ -180,7 +180,7 @@ export function LayeredModelFields({
         placeholder={emptyLabel}
         fallbackValue={defaultEffective}
         aria-label={defaultLabel}
-        renderOptionMeta={renderOptionMeta && ((fullValue: string) => renderOptionMeta(fullValue))}
+        renderOptionMeta={renderOptionMeta}
       />
 
       {children}

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -1145,11 +1145,15 @@ describe("音频开关的模型可控性", () => {
       expect(await omniRowIn(user, "参考生视频")).toContain("无声");
     });
 
-    it("图片下拉不带音轨格——音轨是视频概念，图片桶不消费执行路径", async () => {
+    it("图片侧的默认层与细分项下拉都不带音轨格——音轨是视频概念，图片桶不消费执行路径", async () => {
       const user = userEvent.setup();
       renderDropdowns(true);
-      await user.click(screen.getByRole("combobox", { name: "默认图片模型" }));
-      expect(screen.getByRole("option", { name: /v3-omni/ })).not.toHaveTextContent(/有声|无声/);
+      expect(await omniRowIn(user, "默认图片模型")).not.toMatch(/有声|无声/);
+
+      // 图片折叠区排在视频之后
+      await user.click(screen.getAllByText("按用途指定模型")[1]);
+      expect(await omniRowIn(user, "文生图")).not.toMatch(/有声|无声/);
+      expect(await omniRowIn(user, "图生图")).not.toMatch(/有声|无声/);
     });
   });
 });

--- a/frontend/src/components/shared/ModelConfigSection.test.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.test.tsx
@@ -1077,4 +1077,79 @@ describe("音频开关的模型可控性", () => {
     expect(screen.getByRole("radio", { name: "关闭" })).toBeChecked();
     expect(screen.getByText(/没有声音/)).toBeInTheDocument();
   });
+
+  // 同屏三个视频下拉分属三条不同路径：默认层跟着项目实际执行的那条，两个细分项各按自己的桶。
+  // 音轨格与下方开关必须给出同一个答案——一屏之内两句话互相矛盾，用户按下拉预览选型就会选错。
+  describe("候选下拉的音轨能力线", () => {
+    const OMNI_CANDIDATES = {
+      image: {
+        default: ["kling/v3-omni"],
+        buckets: { t2i: ["kling/v3-omni"], i2i: ["kling/v3-omni"] },
+      },
+      video: {
+        default: ["kling/v3-omni"],
+        buckets: { i2v: ["kling/v3-omni"], r2v: ["kling/v3-omni"] },
+      },
+      provider_names: {},
+    };
+
+    function renderDropdowns(usesReferenceImages: boolean) {
+      render(
+        <ModelConfigSection
+          value={EMPTY_VALUE}
+          onChange={() => {}}
+          providers={AUDIO_PROVIDERS}
+          usesReferenceImages={usesReferenceImages}
+          options={{
+            videoBackends: ["kling/v3-omni"],
+            // 图片下拉刻意放同一个模型：音轨格若被错接到图片侧，这里会显形。
+            imageBackends: ["kling/v3-omni"],
+            textBackends: [],
+            providerNames: { kling: "Kling" },
+          }}
+          candidates={OMNI_CANDIDATES}
+          globalDefaults={EMPTY_GLOBALS}
+          enable={{ text: false }}
+        />,
+      );
+    }
+
+    /** 打开指定下拉，读出 v3-omni 那一行的能力线，再关掉——同时只开一个下拉。 */
+    async function omniRowIn(user: ReturnType<typeof userEvent.setup>, comboboxName: string) {
+      await user.click(screen.getByRole("combobox", { name: comboboxName }));
+      const text = screen.getByRole("option", { name: /v3-omni/ }).textContent ?? "";
+      await user.keyboard("{Escape}");
+      return text;
+    }
+
+    it("参考生视频项目：默认层与参考生桶标无声，图生桶不受牵连仍标有声", async () => {
+      const user = userEvent.setup();
+      renderDropdowns(true);
+      // 默认层留空时执行的是 r2v 桶，能力线跟着走
+      expect(await omniRowIn(user, "默认视频模型")).toContain("无声");
+
+      await user.click(screen.getAllByText("按用途指定模型")[0]);
+      expect(await omniRowIn(user, "参考生视频")).toContain("无声");
+      // 项目走参考生路线不代表「图生视频」这一格也该按参考生标注——它就是图生路径本身
+      expect(await omniRowIn(user, "图生视频")).toContain("有声");
+    });
+
+    it("图生视频项目：默认层与图生桶标有声，参考生桶仍标无声", async () => {
+      const user = userEvent.setup();
+      renderDropdowns(false);
+      expect(await omniRowIn(user, "默认视频模型")).toContain("有声");
+
+      await user.click(screen.getAllByText("按用途指定模型")[0]);
+      expect(await omniRowIn(user, "图生视频")).toContain("有声");
+      // 项目当前不走参考生路线，但这一格描述的是参考生路径的能力，与项目设置无关
+      expect(await omniRowIn(user, "参考生视频")).toContain("无声");
+    });
+
+    it("图片下拉不带音轨格——音轨是视频概念，图片桶不消费执行路径", async () => {
+      const user = userEvent.setup();
+      renderDropdowns(true);
+      await user.click(screen.getByRole("combobox", { name: "默认图片模型" }));
+      expect(screen.getByRole("option", { name: /v3-omni/ })).not.toHaveTextContent(/有声|无声/);
+    });
+  });
 });

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -295,12 +295,14 @@ export function ModelConfigSection({
     endpointToMediaType,
   ).options;
 
+  // 默认层下拉展示的是本项目实际会执行的那条路径（与上方 audioControl 同口径）；两个细分项
+  // 下拉各按自己的桶取值，不受此处影响。
   const renderVideoOptionMeta = videoOptionMetaRenderer({
     t,
     providers,
     customProviders,
     endpointToMediaType,
-    route: usesReferenceImages ? "r2v" : "i2v",
+    defaultRoute: usesReferenceImages ? "r2v" : "i2v",
   });
 
   const handleVideoChange = (next: string) => applyVideoLayer({ videoBackend: next });

--- a/frontend/src/components/shared/ModelConfigSection.tsx
+++ b/frontend/src/components/shared/ModelConfigSection.tsx
@@ -295,7 +295,13 @@ export function ModelConfigSection({
     endpointToMediaType,
   ).options;
 
-  const renderVideoOptionMeta = videoOptionMetaRenderer({ t, providers, customProviders, endpointToMediaType });
+  const renderVideoOptionMeta = videoOptionMetaRenderer({
+    t,
+    providers,
+    customProviders,
+    endpointToMediaType,
+    route: usesReferenceImages ? "r2v" : "i2v",
+  });
 
   const handleVideoChange = (next: string) => applyVideoLayer({ videoBackend: next });
 

--- a/frontend/src/components/shared/VideoModelSpecBar.test.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { VideoModelSpecBar, VoiceConsistencyBadge } from "./VideoModelSpecBar";
+import type { TFunction } from "i18next";
+import { VideoModelSpecBar, videoOptionMetaRenderer, VoiceConsistencyBadge } from "./VideoModelSpecBar";
+import type { ModelInfoResponse, ProviderInfo } from "@/types";
 
 describe("VideoModelSpecBar", () => {
   it("renders duration / resolution / audio / voice consistency cells", () => {
@@ -20,6 +22,62 @@ describe("VideoModelSpecBar", () => {
     render(<VideoModelSpecBar durations={[5]} resolutions={[]} tier="none" />);
     // 音轨格与档位徽章共用「无声」文案，两处均须渲染。
     expect(screen.getAllByText("无声")).toHaveLength(2);
+  });
+});
+
+// key 回显：断言选中的 key 而非其中文译文，与 task-target.test.ts 同口径。
+const t = ((key: string) => key) as unknown as TFunction;
+
+function makeOmniModel(overrides: Partial<ModelInfoResponse> = {}): ModelInfoResponse {
+  return {
+    display_name: "v3-omni",
+    media_type: "video",
+    capabilities: ["video"],
+    default: false,
+    supported_durations: [5],
+    duration_resolution_constraints: {},
+    resolutions: ["720p"],
+    // 可灵 v3-omni：图生可控、参考生恒无声——issue #2022 的取值场景。
+    audio_track: "controllable",
+    reference_route_audio_track: "always_off",
+    voice_consistency: "soft",
+    ...overrides,
+  };
+}
+
+function makeKlingProviders(model: ModelInfoResponse): ProviderInfo[] {
+  return [
+    {
+      id: "kling",
+      display_name: "可灵",
+      description: "",
+      status: "ready",
+      media_types: ["video"],
+      capabilities: ["video"],
+      configured_keys: [],
+      missing_keys: [],
+      models: { "v3-omni": model },
+    },
+  ];
+}
+
+describe("videoOptionMetaRenderer", () => {
+  it("i2v 路线读 audio_track：v3-omni 可控音轨，能力线标有声", () => {
+    const providers = makeKlingProviders(makeOmniModel());
+    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [], route: "i2v" });
+    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_has");
+  });
+
+  it("r2v 路线读 reference_route_audio_track：同一模型参考生恒无声，能力线标无声", () => {
+    const providers = makeKlingProviders(makeOmniModel());
+    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [], route: "r2v" });
+    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_none");
+  });
+
+  it("省略 route 时回退目录 i2v 位（全局设置页现行口径），行为与 lookupCatalogVideoAudio 一致", () => {
+    const providers = makeKlingProviders(makeOmniModel());
+    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [] });
+    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_has");
   });
 });
 

--- a/frontend/src/components/shared/VideoModelSpecBar.test.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { TFunction } from "i18next";
 import { VideoModelSpecBar, videoOptionMetaRenderer, VoiceConsistencyBadge } from "./VideoModelSpecBar";
+import { lookupCatalogVideoAudio } from "@/utils/provider-models";
 import type { ModelInfoResponse, ProviderInfo, VideoRoute } from "@/types";
 
 describe("VideoModelSpecBar", () => {
@@ -37,7 +38,7 @@ function makeOmniModel(overrides: Partial<ModelInfoResponse> = {}): ModelInfoRes
     supported_durations: [5],
     duration_resolution_constraints: {},
     resolutions: ["720p"],
-    // 可灵 v3-omni：图生可控、参考生恒无声——issue #2022 的取值场景。
+    // 可灵 v3-omni：图生可控、参考生恒无声，两条路径给出不同答案的那一类模型。
     audio_track: "controllable",
     reference_route_audio_track: "always_off",
     voice_consistency: "soft",
@@ -78,8 +79,15 @@ describe("videoOptionMetaRenderer", () => {
     expect(renderer("r2v")("kling/v3-omni")).toContain("video_spec_audio_none");
   });
 
-  it("省略 defaultRoute 时回退目录 i2v 位（全局设置页现行口径），行为与 lookupCatalogVideoAudio 一致", () => {
-    expect(renderer()("kling/v3-omni")).toContain("video_spec_audio_has");
+  // 无路径上下文（全局设置页的默认模型）时读目录位。这里连带钉住它与 lookupCatalogVideoAudio
+  // 同解：目录的 audio_track 就是 i2v 位，两处各算一遍，其中一处改了另一处必须跟着改。
+  it("省略 defaultRoute 时按目录位取值，与 lookupCatalogVideoAudio 同解", () => {
+    const providers = makeKlingProviders(makeOmniModel());
+    const catalog = lookupCatalogVideoAudio(providers, "kling/v3-omni");
+    expect(catalog?.hasAudioTrack).toBe(true);
+    expect(renderer()("kling/v3-omni")).toContain(
+      catalog?.hasAudioTrack ? "video_spec_audio_has" : "video_spec_audio_none",
+    );
   });
 
   // 同屏三个视频下拉共用一个渲染器，细分项自己的路径必须压过默认层的：否则参考生项目里

--- a/frontend/src/components/shared/VideoModelSpecBar.test.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { TFunction } from "i18next";
 import { VideoModelSpecBar, videoOptionMetaRenderer, VoiceConsistencyBadge } from "./VideoModelSpecBar";
-import type { ModelInfoResponse, ProviderInfo } from "@/types";
+import type { ModelInfoResponse, ProviderInfo, VideoRoute } from "@/types";
 
 describe("VideoModelSpecBar", () => {
   it("renders duration / resolution / audio / voice consistency cells", () => {
@@ -62,22 +62,41 @@ function makeKlingProviders(model: ModelInfoResponse): ProviderInfo[] {
 }
 
 describe("videoOptionMetaRenderer", () => {
+  const renderer = (defaultRoute?: VideoRoute) =>
+    videoOptionMetaRenderer({
+      t,
+      providers: makeKlingProviders(makeOmniModel()),
+      customProviders: [],
+      defaultRoute,
+    });
+
   it("i2v 路线读 audio_track：v3-omni 可控音轨，能力线标有声", () => {
-    const providers = makeKlingProviders(makeOmniModel());
-    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [], route: "i2v" });
-    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_has");
+    expect(renderer("i2v")("kling/v3-omni")).toContain("video_spec_audio_has");
   });
 
   it("r2v 路线读 reference_route_audio_track：同一模型参考生恒无声，能力线标无声", () => {
-    const providers = makeKlingProviders(makeOmniModel());
-    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [], route: "r2v" });
-    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_none");
+    expect(renderer("r2v")("kling/v3-omni")).toContain("video_spec_audio_none");
   });
 
-  it("省略 route 时回退目录 i2v 位（全局设置页现行口径），行为与 lookupCatalogVideoAudio 一致", () => {
-    const providers = makeKlingProviders(makeOmniModel());
-    const renderMeta = videoOptionMetaRenderer({ t, providers, customProviders: [] });
-    expect(renderMeta("kling/v3-omni")).toContain("video_spec_audio_has");
+  it("省略 defaultRoute 时回退目录 i2v 位（全局设置页现行口径），行为与 lookupCatalogVideoAudio 一致", () => {
+    expect(renderer()("kling/v3-omni")).toContain("video_spec_audio_has");
+  });
+
+  // 同屏三个视频下拉共用一个渲染器，细分项自己的路径必须压过默认层的：否则参考生项目里
+  // 「图生视频」那一格会按 r2v 标成无声。
+  it("细分项 key 压过 defaultRoute：参考生项目里 i2v 桶仍按图生路径标有声", () => {
+    expect(renderer("r2v")("kling/v3-omni", "i2v")).toContain("video_spec_audio_has");
+  });
+
+  it("细分项 key 压过 defaultRoute：图生项目里 r2v 桶仍按参考生路径标无声", () => {
+    expect(renderer("i2v")("kling/v3-omni", "r2v")).toContain("video_spec_audio_none");
+  });
+
+  it("图片桶的 key 不是视频路径，取值仍按 defaultRoute 判定", () => {
+    // 渲染器由 LayeredModelFields 逐细分项调用，图片桶的 key 同样会传进来；t2i / i2i 不得
+    // 被当成视频路径解读。
+    expect(renderer("r2v")("kling/v3-omni", "t2i")).toContain("video_spec_audio_none");
+    expect(renderer("i2v")("kling/v3-omni", "i2i")).toContain("video_spec_audio_has");
   });
 });
 

--- a/frontend/src/components/shared/VideoModelSpecBar.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.tsx
@@ -3,9 +3,13 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { formatDurationsLabel } from "@/utils/duration_format";
 import { catalogDurations } from "@/hooks/useModelCapabilities";
-import { lookupCatalogVideoAudio, lookupResolutions } from "@/utils/provider-models";
+import {
+  lookupCatalogVideoAudio,
+  lookupResolutions,
+  lookupVideoAudioControl,
+} from "@/utils/provider-models";
 import type { CustomProviderInfo } from "@/types/custom-provider";
-import type { MediaType, ProviderInfo, VoiceConsistencyTier } from "@/types";
+import type { MediaType, ProviderInfo, VideoRoute, VoiceConsistencyTier } from "@/types";
 
 // ---------------------------------------------------------------------------
 // 声音一致性档位元数据。
@@ -71,11 +75,16 @@ export function videoOptionMetaRenderer({
   providers,
   customProviders,
   endpointToMediaType,
+  route,
 }: {
   t: TFunction;
   providers: ProviderInfo[];
   customProviders: CustomProviderInfo[];
   endpointToMediaType?: Record<string, MediaType>;
+  /** 执行路径；有路线上下文的调用点须传入，音轨格按路径取值，与该屏其余控件同口径
+   *  （见 ModelConfigSection.tsx 的 audioControl）。省略时回退目录 i2v 位——全局设置页
+   *  无路线上下文，这是其现行正确口径。 */
+  route?: VideoRoute;
 }) {
   return (fullValue: string) => {
     const durations = catalogDurations(providers, customProviders, fullValue);
@@ -85,15 +94,22 @@ export function videoOptionMetaRenderer({
       customProviders,
       endpointToMediaType,
     ).options;
-    const audio = lookupCatalogVideoAudio(providers, fullValue);
+    const hasAudioTrack = route
+      ? nullableBool(lookupVideoAudioControl(providers, fullValue, route), (c) => c !== "always_off")
+      : (lookupCatalogVideoAudio(providers, fullValue)?.hasAudioTrack ?? null);
     const parts: string[] = [];
     if (durations?.length) parts.push(formatDurationsLabel(durations));
     if (resolutions.length) parts.push(resolutions.join(" / "));
-    if (audio) {
-      parts.push(t(audio.hasAudioTrack ? "dashboard:video_spec_audio_has" : "dashboard:video_spec_audio_none"));
+    if (hasAudioTrack !== null) {
+      parts.push(t(hasAudioTrack ? "dashboard:video_spec_audio_has" : "dashboard:video_spec_audio_none"));
     }
     return parts.length > 0 ? parts.join(" · ") : t("dashboard:video_option_caps_unknown");
   };
+}
+
+/** `value` 为 null 时短路为 null，否则套用 `map`——查表结果向布尔态收窄的通用写法。 */
+function nullableBool<T>(value: T | null, map: (value: T) => boolean): boolean | null {
+  return value === null ? null : map(value);
 }
 
 export interface VideoModelSpecBarProps {

--- a/frontend/src/components/shared/VideoModelSpecBar.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.tsx
@@ -75,18 +75,21 @@ export function videoOptionMetaRenderer({
   providers,
   customProviders,
   endpointToMediaType,
-  route,
+  defaultRoute,
 }: {
   t: TFunction;
   providers: ProviderInfo[];
   customProviders: CustomProviderInfo[];
   endpointToMediaType?: Record<string, MediaType>;
-  /** 执行路径；有路线上下文的调用点须传入，音轨格按路径取值，与该屏其余控件同口径
-   *  （见 ModelConfigSection.tsx 的 audioControl）。省略时回退目录 i2v 位——全局设置页
-   *  无路线上下文，这是其现行正确口径。 */
-  route?: VideoRoute;
+  /** 默认层下拉的执行路径。默认层跨全部用途，路径只能由调用方的上下文给出（项目是否走参考生
+   *  视频）；全局设置页无项目上下文，省略即回退目录 i2v 位。细分项下拉不看此值——它们各自的
+   *  `key` 就是路径，见下方 `asVideoRoute`。 */
+  defaultRoute?: VideoRoute;
 }) {
-  return (fullValue: string) => {
+  return (fullValue: string, subFieldKey?: string) => {
+    // 细分项下拉自带路径，默认层才回落到调用方给的路径：同屏三个视频下拉分属不同路径，
+    // 共用一条会让「图生视频」那一格按参考生的口径标注（或反之）。
+    const route = asVideoRoute(subFieldKey) ?? defaultRoute;
     const durations = catalogDurations(providers, customProviders, fullValue);
     const resolutions = lookupResolutions(
       providers,
@@ -105,6 +108,14 @@ export function videoOptionMetaRenderer({
     }
     return parts.length > 0 ? parts.join(" · ") : t("dashboard:video_option_caps_unknown");
   };
+}
+
+/**
+ * 细分项 `key` 中的视频执行路径。`LayeredModelFields` 的细分项按任务类型桶命名，视频两个桶
+ * 恰好就是两条路径；图片桶（t2i / i2i）与文本档位不是视频路径，返回 null 交由默认层路径兜底。
+ */
+function asVideoRoute(subFieldKey: string | undefined): VideoRoute | null {
+  return subFieldKey === "i2v" || subFieldKey === "r2v" ? subFieldKey : null;
 }
 
 /** `value` 为 null 时短路为 null，否则套用 `map`——查表结果向布尔态收窄的通用写法。 */

--- a/frontend/src/components/shared/VideoModelSpecBar.tsx
+++ b/frontend/src/components/shared/VideoModelSpecBar.tsx
@@ -97,8 +97,10 @@ export function videoOptionMetaRenderer({
       customProviders,
       endpointToMediaType,
     ).options;
+    // 查不到模型时为 null，音轨格整格不渲染——两条分支都不臆造一个答案。
+    const audioControl = route ? lookupVideoAudioControl(providers, fullValue, route) : null;
     const hasAudioTrack = route
-      ? nullableBool(lookupVideoAudioControl(providers, fullValue, route), (c) => c !== "always_off")
+      ? (audioControl === null ? null : audioControl !== "always_off")
       : (lookupCatalogVideoAudio(providers, fullValue)?.hasAudioTrack ?? null);
     const parts: string[] = [];
     if (durations?.length) parts.push(formatDurationsLabel(durations));
@@ -116,11 +118,6 @@ export function videoOptionMetaRenderer({
  */
 function asVideoRoute(subFieldKey: string | undefined): VideoRoute | null {
   return subFieldKey === "i2v" || subFieldKey === "r2v" ? subFieldKey : null;
-}
-
-/** `value` 为 null 时短路为 null，否则套用 `map`——查表结果向布尔态收窄的通用写法。 */
-function nullableBool<T>(value: T | null, map: (value: T) => boolean): boolean | null {
-  return value === null ? null : map(value);
 }
 
 export interface VideoModelSpecBarProps {


### PR DESCRIPTION
Closes #2022

## 问题

`kling-v3-omni` 的 `audio_track` 可控、`reference_route_audio_track` 恒无声（`lib/video_backends/kling.py:254`、`:294`），但视频候选下拉的音轨能力线固定读目录 i2v 位，参考生视频项目里这一行标「有声」，与同屏下方已置灰为恒无声的音频开关自相矛盾。

## 本 PR 与 issue 正文的差异（范围经 review 修正）

issue 的 What to build 提出给 `videoOptionMetaRenderer` 加一个 `route` 参数。本地审查发现该形状修不好这张票：

`LayeredModelFields` 把**同一个** `renderOptionMeta` 同时喂给默认层下拉与「按用途指定模型」里的每个细分项下拉（`LayeredModelFields.tsx:178`、`:229`），而这三个下拉分属不同路径。把 route 挂在渲染器上会让同屏三个下拉共用一条路径：

- 参考生视频项目里「图生视频」桶被按 r2v 标成「无声」——新引入的错值，违反验收标准第 2 条
- 图生视频项目里「参考生视频」桶仍按 i2v 标「有声」——原缺陷残留

而 issue 正文的复现路径「展开『按用途指定模型』→ 打开视频候选下拉」指的正是细分项下拉。

同时，issue 中「全局设置页本就无路线上下文，`MediaModelSection` 不改」的前提不成立：该文件 `:225-228` 自己就按桶取 `i2vAudioControl` / `r2vAudioControl` 判定音频勾选框，`:168-188` 也定义了 `i2v` / `r2v` 两个桶下拉。只有它的**默认模型**下拉才真正跨路径。所以同一缺陷在全局设置页也存在一份。

范围修正已经过裁决，issue 上另有一条 comment 记录前提证伪。

## 改动

route 下推到各下拉自身：

- `LayeredModelFields.tsx`：`renderOptionMeta` 增加第二个参数，即发起该下拉的细分项 `key`；默认层不传（它跨全部用途，没有单一路径）
- `VideoModelSpecBar.tsx`：`route` 更名 `defaultRoute`，语义收窄为「默认层下拉的路径」；细分项下拉的路径由 `asVideoRoute(subFieldKey)` 从桶名取得，图片桶与文本档位不是视频路径，交由默认层兜底
- `ModelConfigSection.tsx`：默认层按项目是否走参考生视频取值
- `MediaModelSection.tsx`：默认层不传（无项目上下文，按目录位展示），两个细分项各按自己的桶自解析——仅新增一条说明注释，无逻辑改动

共 6 个视频下拉（两屏各 3 个）取值就位。

## 验证

`pnpm check`（typecheck + lint + 全量 vitest）：155 文件 / 1889 测试全绿。

测试补在**组合层**——上一版只覆盖渲染器函数本身，三个下拉共用一条路径的缺陷全落在组合层，质量门因而全绿却带着回归：

- `ModelConfigSection.test.tsx`：参考生项目下默认层与 r2v 桶标「无声」、i2v 桶仍标「有声」；图生项目下默认层与 i2v 桶标「有声」、r2v 桶仍标「无声」
- `MediaModelSection.test.tsx`：全局页默认层按目录位标「有声」，两个细分项各按自己的路径标注
- `LayeredModelFields.test.tsx`：默认层不带 key、各细分项只带自己的 key（含图片桶）
- `VideoModelSpecBar.test.tsx`：细分项 key 压过 `defaultRoute`；图片桶 key 不被当作视频路径

以上判据均做过变异验证：把 `asVideoRoute` 改成恒返回 null 后，两屏共 5 条组合层用例全部失败。

图片侧闸门另做变异验证：把视频渲染器接进图片通道后，「图片侧的默认层与细分项下拉都不带音轨格」用例失败。

## 边界

- 纯展示层。`lib/reference_video/request_projection.py` 与 `lib/video_backends/kling.py` 的 `_effective_audio` 一行未动，成片音轨与计费本就正确
- 未新增用户可见文案，复用既有 `dashboard:video_spec_audio_has` / `video_spec_audio_none`，不触发 i18n 校验
- 未改任何术语措辞，`ModelConfigSection.tsx` 的「参考路线」旧叫法留给 #2024


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 视频模型下拉选项会根据使用场景显示对应音轨能力，包括“有声”或“无声”。
  * 默认模型及图生视频、参考生视频等细分模型会分别展示对应路径的规格信息。
  * 图片模型选项不会显示不适用的音轨能力标注。

* **错误修复**
  * 优化不同视频模型路径的规格识别，避免将图片路径误判为视频路径，并确保细分模型优先使用自身配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->