### PR TITLE
ci: 撤除覆盖率合入闸门，Codecov status 全转 informational（#1990）

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -70,6 +70,7 @@ component_management:
       - type: project
         target: auto
         threshold: 1%
+        informational: true
   individual_components:
     - component_id: backend
       name: Backend

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,19 +4,21 @@ coverage:
       backend:
         flags:
           - backend
-        target: 80%
+        target: auto
         threshold: 1%
         if_ci_failed: error
+        informational: true
       frontend:
         flags:
           - frontend
-        target: 60%
+        target: auto
         threshold: 1%
         if_ci_failed: error
+        informational: true
       postgres:
         flags:
           - postgres
-        target: 40%
+        target: auto
         threshold: 5%
         if_ci_failed: error
         informational: true
@@ -24,19 +26,21 @@ coverage:
       backend:
         flags:
           - backend
-        target: 80%
+        target: auto
         threshold: 1%
         if_ci_failed: error
+        informational: true
       frontend:
         flags:
           - frontend
-        target: 60%
+        target: auto
         threshold: 1%
         if_ci_failed: error
+        informational: true
       postgres:
         flags:
           - postgres
-        target: 40%
+        target: auto
         threshold: 5%
         if_ci_failed: error
         informational: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage
-        run: uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+        run: uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-report=term-missing --cov-report=xml
 
       - name: Upload backend coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ cd frontend && pnpm check
 
 pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
-> **过渡期说明**：本章描述整改完成后的目标态，存量测试与相关工程配置正按整改 Spec 分批对齐；条目与现状不符时（存量的目录与档位、前端绕过 `API` class 的直接 `fetch`/`EventSource` 调用、覆盖率与 eslint 强制项的现行 CI/lint 配置、`testTimeout` 等 vitest 配置、尚未建立的 `src/test/` 共享设施），以本章为改造方向。`scripts/audit_tests.py` 与 CI 的 `test-lint` 步骤当前尚不存在，随首道闸门落地，每道闸门与对应存量清零同一 PR 上线；目录迁移与 marker 自动注入落地前，分类 marker 仍需手写（收集期强制恰好一个，语义见下文分层表）。整改完成后删除本段。
+> **过渡期说明**：本章描述整改完成后的目标态，存量测试与相关工程配置正按整改 Spec 分批对齐；条目与现状不符时（存量的目录与档位、前端绕过 `API` class 的直接 `fetch`/`EventSource` 调用、eslint 强制项的现行 CI/lint 配置、`testTimeout` 等 vitest 配置、尚未建立的 `src/test/` 共享设施），以本章为改造方向。`scripts/audit_tests.py` 与 CI 的 `test-lint` 步骤当前尚不存在，随首道闸门落地，每道闸门与对应存量清零同一 PR 上线；目录迁移与 marker 自动注入落地前，分类 marker 仍需手写（收集期强制恰好一个，语义见下文分层表）。整改完成后删除本段。
 
 ### 分层与目录
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -28,9 +28,6 @@ export default defineConfig({
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/test/**", "src/__mocks__/**", "src/main.tsx", "src/vite-env.d.ts"],
       reporter: ["text", "json-summary", "lcov"],
-      thresholds: {
-        lines: 73,
-      },
     },
   },
 });


### PR DESCRIPTION
Closes #1990

## 改动

覆盖率从合入闸门降级为纯信号，CI 不再因覆盖率数字失败，为后续删除负价值测试解除反向阻拦。

- `.github/workflows/test.yml`：后端主 pytest job 去掉 `--cov-fail-under=80`；上报路径（`coverage.xml` / `coverage-pg.xml` / `frontend/coverage/lcov.info`）与三个 `codecov-action` 步骤原样保留。`postgres-compat` job 本就不带该参数。
- `frontend/vitest.config.ts`：删除 `coverage.thresholds.lines: 73`。
- `.codecov.yml`：`coverage.status` 下 project / patch 各 3 条（backend / frontend / postgres）全部改为 `target: auto` + `informational: true`；`component_management.default_rules.statuses` 的 project 状态同样补 `informational: true`——它会产出独立的 `codecov/project/<Component>` 检查，不转 informational 就仍是潜在的红叉来源。`flag_management` 段只有 `carryforward` / `paths`，不产出 status，无需改动。
- `CONTRIBUTING.md`：过渡期说明的「条目与现状不符」清单里移除「覆盖率」——L126「覆盖率是信号，不是闸门……status 一律 informational」自本 PR 起与现状一致，eslint 那半句尚未落地故保留。

## 验证

- Codecov 配置合法性：`POST https://codecov.io/validate` 返回 `Valid!`，回读的解析结果确认 `component_management.default_rules.statuses[0].informational` 被识别并保留。
- `uv run ruff check .` / `uv run ruff format --check .`：通过（1291 files already formatted）。
- `uv run basedpyright`：0 errors（1284 warnings 均为存量，与本改动无关）。
- `uv run lint-imports`：Contracts 2 kept, 0 broken。
- `uv run python -m pytest -m "not e2e"`：10279 passed, 2 skipped。
- `pnpm lint`：通过。
- `pnpm check`（typecheck + vitest）：155 test files / 1889 tests passed。
- `pnpm test:coverage`：正常跑完并输出覆盖率汇总（Lines 77.11%），不再有 threshold 失败——这是「前端 vitest 配置无 thresholds」的直接验证。

验收标准「全量 CI 绿」需以本 PR 的实际 CI 运行为准，本地无法静态验证。

## 已知遗留（未在本 PR 处理）

- 6 条 status 仍保留 `if_ci_failed: error` 与 `threshold: 1%/5%`。`informational: true` 下这些键已不产生阻断效果，属死配置；`postgres` 块在 main 上本就是 `informational` 与 `if_ci_failed: error` 并存，本 PR 只是延续既有写法，未新引入。清理超出本议题验收范围，留作 follow-up。
- `.codecov.yml` 里 6 个 status 块结构完全相同，一次语义变更要改 6 处。可用 Codecov 的 `default` 规则键把共有形状上提、各 flag 只留差异项，属独立重构，未在本 PR 顺带做。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 调整覆盖率检查策略，改为自动评估并提供信息性报告。
  - 后端测试不再因覆盖率低于固定阈值而导致流程失败。
  - 前端测试移除固定的行覆盖率要求。

- **文档**
  - 更新贡献指南中的覆盖率相关过渡说明，使指导内容与当前检查流程保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->