### PR TITLE
ci: 后端测试改并行执行形态，补 collect-only 前置闸与超时保护（#1991）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,18 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Classification marker gate (collect-only)
+        # 必须在并行步骤之前、且不带 -n：xdist 的收集发生在各 worker 内，conftest
+        # 的 UsageError 会撞上 dsession 的断言退化成 INTERNALERROR，违规清单一个字
+        # 都不剩。--collect-only 由 controller 本地收集，清单完整、全量约 2s。
+        run: uv run python -m pytest --collect-only -q
+
       - name: Run tests with coverage
-        run: uv run python -m pytest -m "not e2e" --cov=lib --cov=server --cov-report=term-missing --cov-report=xml
+        # -n 固定 4 而非 auto：-n auto 优先取 psutil 的物理核数，一旦某传递依赖带进
+        # psutil，CI worker 数会静默减半。loadfile 而非默认 load：仓库根共享路径
+        # （PROJECT_ROOT 下 mkdir/rmdir、module 级 autouse fixture）要求同文件用例
+        # 留在同一 worker。
+        run: uv run python -m pytest -m "not e2e" -n 4 --dist loadfile --cov=lib --cov=server --cov-report=term-missing --cov-report=xml
 
       - name: Upload backend coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -160,6 +170,9 @@ jobs:
           uv run alembic upgrade head           # 4. 再次正向，验证 downgrade 真清掉了
 
       - name: Run dialect-sensitive tests against Postgres
+        # 保持单进程：92 个用例约 2m44s，可省时间小于并行风险——其中
+        # tests/test_agent_credential_repo.py 的用例共用 alembic 建出的 public
+        # schema，两 worker 写同一主键会互相阻塞。
         run: |
           uv run python -m pytest -v \
             -m "uses_db and not sqlite_only" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,10 @@ jobs:
         # 必须在并行步骤之前、且不带 -n：xdist 的收集发生在各 worker 内，conftest
         # 的 UsageError 会撞上 dsession 的断言退化成 INTERNALERROR，违规清单一个字
         # 都不剩。--collect-only 由 controller 本地收集，清单完整、全量约 2s。
-        run: uv run python -m pytest --collect-only -q
+        # -qq 而非 -q：-q 会把上万条 nodeid 打进日志，淹掉这一步唯一有消费方的输出。
+        # -qq 只列各文件用例数，违规清单（stderr）与 import 失败的 traceback（stdout）
+        # 都不受影响；不能改成丢弃 stdout，那会连收集期 import 错误一起吞掉。
+        run: uv run python -m pytest --collect-only -qq
 
       - name: Run tests with coverage
         # -n 固定 4 而非 auto：-n auto 优先取 psutil 的物理核数，一旦某传递依赖带进

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dev = [
     "python-docx>=1.2.0",
     "basedpyright>=1.39.4",
     "import-linter>=2.13",
+    "pytest-xdist>=3.8.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [build-system]
@@ -60,8 +62,16 @@ packages = ["lib", "server"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--strict-markers"
+addopts = "--strict-markers --durations=25"
 asyncio_mode = "auto"
+# 卡死保护，不是耗时预算：当前最慢用例 30s，留 4 倍余量。个别用例需要更大预算时用
+# `@pytest.mark.timeout(N)` 单独放宽，不抬全局值。
+timeout = 120
+# signal 法对 async 与 sync 用例均生效，超时表现为普通 failure（会话继续、teardown
+# 正常、可归因）；thread 法以 os._exit 硬杀进程，xdist 下等价于 worker crash。
+timeout_method = "signal"
+# 并行不写进 addopts，只在 CI 命令里显式开（-n 4 --dist loadfile）：小选集并行更慢，
+# 每 worker 重新 import server.app 的固定开销吃掉全部收益，而本地调试几乎都是小选集。
 markers = [
     "unit: 快速、隔离、不触达真实 I/O 或外部服务的测试",
     "integration: 跨模块真实协作测试；禁止 mock 被测 module 的公共入口（否则是在测 mock 本身）",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,32 @@ def make_translator(locale: str = "zh") -> Callable[..., str]:
 
 
 import os
+import shutil
 import subprocess
+import tempfile
 import wave
 from io import BytesIO
 from pathlib import Path
 
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+# `lib.db.engine` 的模块级 engine 在 import 期就按 `DATABASE_URL` 绑定，进程内不再重建，
+# 所以覆写必须发生在下方任何会传染到该模块的 import 之前。未显式指定时它落在仓库根的
+# `projects/.arcreel.db`：一份文件被 xdist 的多个 worker 共用，且 schema 只由某个先跑到
+# 的用例顺带建出——用例间因此存在隐式顺序依赖。钉到本进程独占的临时库上，schema 由
+# `_shared_db_schema` 显式建立。DATABASE_URL 已由外部给定（postgres-compat job、
+# 逐个用例 monkeypatch 的 alembic 用例）时不介入。
+#
+# xdist 的 worker 从 controller 继承 environ，会连这里写下的 URL 一起带过去；
+# `_OWNED_DB_MARKER` 让 worker 认出「这是测试自己铸的、不是外部给的」，各自另铸一份，
+# 从而每个进程都独占一个库。
+_OWNED_DB_MARKER = "ARCREEL_TEST_OWNED_DB"
+_OWNED_TEST_DB_DIR: str | None = None
+if not os.environ.get("DATABASE_URL", "").strip() or os.environ.get(_OWNED_DB_MARKER) == "1":
+    _OWNED_TEST_DB_DIR = tempfile.mkdtemp(prefix="arcreel-test-db-")
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{_OWNED_TEST_DB_DIR}/.arcreel.db"
+    os.environ[_OWNED_DB_MARKER] = "1"
 
 import lib.generation_queue as generation_queue_module
 from lib.db.base import Base
@@ -193,6 +212,30 @@ def fd_count():
 # ---------------------------------------------------------------------------
 # Shared database fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _shared_db_schema():
+    """把模块级 engine 所指的库迁到 head，使任何用例都能直接用它。
+
+    只对本 conftest 自建的临时库执行：外部给定 DATABASE_URL 时（postgres-compat job）
+    schema 由该 job 的 alembic 步骤负责。走 alembic 而非 ``create_all``，因为
+    ``lib.db.init_db()`` 对「有表无 alembic_version」的库会先 stamp base 再 upgrade，
+    预置的 create_all schema 会让它重复建表。
+    """
+    if _OWNED_TEST_DB_DIR is None:
+        yield
+        return
+
+    from alembic.config import Config
+
+    from alembic import command
+
+    cfg = Config()
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "alembic"))
+    command.upgrade(cfg, "head")
+    yield
+    shutil.rmtree(_OWNED_TEST_DB_DIR, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def make_translator(locale: str = "zh") -> Callable[..., str]:
     return translate
 
 
+import atexit
 import os
 import shutil
 import subprocess
@@ -42,6 +43,9 @@ if not os.environ.get("DATABASE_URL", "").strip() or os.environ.get(_OWNED_DB_MA
     _OWNED_TEST_DB_DIR = tempfile.mkdtemp(prefix="arcreel-test-db-")
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{_OWNED_TEST_DB_DIR}/.arcreel.db"
     os.environ[_OWNED_DB_MARKER] = "1"
+    # 回收挂在 atexit 而非 fixture teardown 上：`--collect-only`（CI 的分类 marker 闸门）
+    # 与收集期中断都只 import conftest、不跑 fixture。
+    atexit.register(shutil.rmtree, _OWNED_TEST_DB_DIR, ignore_errors=True)
 
 import lib.generation_queue as generation_queue_module
 from lib.db.base import Base
@@ -224,7 +228,6 @@ def _shared_db_schema():
     预置的 create_all schema 会让它重复建表。
     """
     if _OWNED_TEST_DB_DIR is None:
-        yield
         return
 
     from alembic.config import Config
@@ -234,8 +237,6 @@ def _shared_db_schema():
     cfg = Config()
     cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "alembic"))
     command.upgrade(cfg, "head")
-    yield
-    shutil.rmtree(_OWNED_TEST_DB_DIR, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "python-docx" },
     { name = "ruff" },
 ]
@@ -277,6 +279,8 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "ruff", specifier = ">=0.16.0" },
 ]
@@ -885,6 +889,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/85/322e8882a582d4b707220d1929cfb74c125f2ba513991edbce40dbc462de/ebooklib-0.20.tar.gz", hash = "sha256:35e2f9d7d39907be8d39ae2deb261b19848945903ae3dbb6577b187ead69e985", size = 127066, upload-time = "2025-10-26T20:56:20.968Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl", hash = "sha256:fff5322517a37e31c972d27be7d982cc3928c16b3dcc5fd7e8f7c0f5d7bcf42b", size = 40995, upload-time = "2025-10-26T20:56:19.104Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2434,6 +2447,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1991

## 改了什么

后端测试 CI 换执行形态：

- `backend-tests` 新增 `Classification marker gate (collect-only)` 独立步骤，跑在并行步骤之前且不带 `-n`——xdist 的收集发生在各 worker 内，conftest 的 `UsageError` 会撞上 `dsession` 的断言退化成 `INTERNALERROR`，中文违规清单一个字都不剩；controller 本地收集才保得住清单。
- 全量后端测试改 `-n 4 --dist loadfile`。固定 4 而非 `auto`：`-n auto` 优先取 psutil 的物理核数，一旦某传递依赖带进 psutil，CI worker 数会静默减半。`loadfile` 而非默认 `load`：仓库根共享路径（`PROJECT_ROOT` 下 mkdir/rmdir、module 级 autouse fixture）要求同文件用例留在同一 worker。
- pytest-timeout 走 ini（`timeout = 120` / `timeout_method = "signal"`）。这是卡死保护、不是耗时预算，按当前最慢用例 30s 留 4 倍余量；个别用例需要更大预算时用 `@pytest.mark.timeout(N)` 单独放宽，不抬全局值。`thread` 法以 `os._exit` 硬杀进程、不做 teardown，xdist 下等价于 worker crash，故显式写 `signal` 而不靠平台默认。
- `addopts` 加 `--durations=25`。超时与慢用例清单要求本地与 CI 一致，故进 ini；并行参数反过来只写在 CI 命令里，不进 `addopts`——小选集并行更慢，每 worker 重新 import `server.app` 的固定开销吃掉全部收益，而本地调试几乎都是小选集。
- `postgres-compat` 保持单进程：92 个用例约 2m44s，可省时间小于并行风险，其中 `tests/test_agent_credential_repo.py` 的用例共用 alembic 建出的 public schema，两 worker 写同一主键会互相阻塞。

ini 的 `timeout = 120` 对 `postgres-compat` 同样生效，这是有意的——卡死保护不分 job。

## 本地验证

| 项 | 结果 |
|---|---|
| 串行基线 `-m "not e2e"` | 198.95s，10279 passed / 2 skipped |
| 并行（无 cov）`-n 4 --dist loadfile` | 70.27s，同样 10279 passed / 2 skipped → **2.83×** |
| 3 轮全量（CI 完整命令，含 `--cov`） | 103.47s / 142.14s / 110.94s，三轮均 10279 passed、2 skipped，零 flaky |
| 审查后复跑（CI 完整命令） | 92.47s，10279 passed / 2 skipped |
| `--durations` | 每次运行均输出「slowest 25 durations」 |

- **闸门可读性**：临时探针（一个漏标 marker 的用例）令 `--collect-only` 以退出码 4 失败，原样打出中文清单（违规条数 + 逐条 nodeid + 修复指引）。探针未进 commit。
- **超时可归因**：临时探针含 `await asyncio.sleep(600)` 与 `time.sleep(600)`，在 `-n 4 --dist loadfile` 下两者都在 120s 被终止，表现为普通 `FAILED ... Failed: Timeout (>120.0s) from pytest-timeout` 并带栈；同文件后续用例照常 PASSED，会话未崩。探针未进 commit。

本机为 macOS arm64，CI 是 ubuntu-latest，上述墙钟只能作相对倍率参考。「耗时显著低于单进程基线」的 CI 实证以本 PR 的实际 `backend-tests` 墙钟为准（CI 基线：单进程时该 job 为 20m22s，job 上限 25 分钟）。

## 本地审查发现与修复

闸门原写作 `--collect-only -q`，绿灯与红灯都会把上万条 nodeid 打进日志（实测 10290 行 stdout），而唯一有消费方的违规清单只有 4 行且走 stderr，在 CI 合并日志里被淹没。改为 `-qq`：输出降到各文件用例数共 431 行，违规清单与退出码 4 不变。

未采用「丢弃 stdout」的写法：探针验证收集期 import 错误的完整 traceback 走的是 stdout（退出码 2、stderr 为空），丢弃后一个坏掉的测试模块会变成无法归因的红灯。

## 未收编的越界项（不在本票）

1. `tests/test_generation_worker_module.py::TestGenerationWorker::test_claim_requeue_on_full_pool_refreshes_provider_projection` 用 `asyncio.sleep(30)` 造占位任务再 `gather`，是一次真实 30 秒等待，独占全量耗时头名，违反 CONTRIBUTING「时序」条。属 B6 的 server API/services 域。
2. `.gitignore` 覆盖了 `.coverage` 与 `coverage/`，未覆盖 `coverage.xml` / `coverage-pg.xml`。本票把「本地跑 CI 同款命令」变成常规动作后，这两个产物会以未跟踪文件出现在 `git status`。
3. CONTRIBUTING「测试」章节未记录全局 120s 超时——它是对写测试者的真实约束（长用例须自带 `@pytest.mark.timeout`）。宜并入 B7 收尾批的文档整理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试改进**
  * 新增测试收集阶段的分类标记检查，提前发现标记配置问题。
  * 支持并行执行测试，并固定覆盖率测试的并发配置。
  * 增加全局测试超时限制与耗时统计，提升测试稳定性和可观测性。
  * 自动创建并隔离临时数据库，减少测试间相互影响。
  * PostgreSQL 方言测试继续保持单进程运行。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->