### PR TITLE
test(frontend): 整模块 vi.mock 清零，子组件 mock 白名单收敛（#2002）

### DIFF
--- a/frontend/src/components/assets/AssetCard.test.tsx
+++ b/frontend/src/components/assets/AssetCard.test.tsx
@@ -2,14 +2,6 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { AssetCard } from "./AssetCard";
 
-// Mock i18next
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: { language: "en" },
-  }),
-}));
-
 const asset = {
   id: "1", type: "scene" as const, name: "庙宇", description: "阴森古朴",
   voice_style: "", image_path: null, audio_path: null, source_project: "demo", updated_at: null,
@@ -25,14 +17,14 @@ describe("AssetCard", () => {
   it("invokes onEdit on edit button click", () => {
     const onEdit = vi.fn();
     render(<AssetCard asset={asset} onEdit={onEdit} onDelete={() => {}} />);
-    fireEvent.click(screen.getByRole("button", { name: /edit/ }));
+    fireEvent.click(screen.getByRole("button", { name: "编辑" }));
     expect(onEdit).toHaveBeenCalledWith(asset);
   });
 
   it("invokes onDelete on delete button click", () => {
     const onDelete = vi.fn();
     render(<AssetCard asset={asset} onEdit={() => {}} onDelete={onDelete} />);
-    fireEvent.click(screen.getByRole("button", { name: /delete/ }));
+    fireEvent.click(screen.getByRole("button", { name: "删除" }));
     expect(onDelete).toHaveBeenCalledWith(asset);
   });
 });

--- a/frontend/src/components/assets/AssetFormModal.test.tsx
+++ b/frontend/src/components/assets/AssetFormModal.test.tsx
@@ -2,22 +2,6 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { AssetFormModal } from "./AssetFormModal";
 
-// Mock i18next to return keys as values
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => {
-      if (opts) {
-        let result = key;
-        for (const [k, v] of Object.entries(opts)) {
-          result = result.replace(`{{${k}}}`, String(v));
-        }
-        return result;
-      }
-      return key;
-    },
-  }),
-}));
-
 describe("AssetFormModal", () => {
   it("create mode renders empty fields and calls onSubmit", async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
@@ -25,8 +9,8 @@ describe("AssetFormModal", () => {
       <AssetFormModal type="character" mode="create"
         onClose={() => {}} onSubmit={onSubmit} />
     );
-    fireEvent.change(screen.getByLabelText(/field\.name/), { target: { value: "王小明" } });
-    fireEvent.click(screen.getByRole("button", { name: /create/ }));
+    fireEvent.change(screen.getByLabelText(/名称/), { target: { value: "王小明" } });
+    fireEvent.click(screen.getByRole("button", { name: "创建" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ name: "王小明" })));
   });
 
@@ -51,8 +35,8 @@ describe("AssetFormModal", () => {
         onClose={() => {}} onSubmit={vi.fn()}
       />
     );
-    expect(screen.getByText(/conflict_warning/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /overwrite_existing/ })).toBeInTheDocument();
+    expect(screen.getByText(/已有同名资产/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "覆盖已有" })).toBeInTheDocument();
   });
 
   it("shows voice_style field only for character type", () => {
@@ -60,12 +44,12 @@ describe("AssetFormModal", () => {
       <AssetFormModal type="character" mode="create"
         onClose={() => {}} onSubmit={vi.fn()} />
     );
-    expect(screen.getByLabelText(/field\.voice_style/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/声音风格/)).toBeInTheDocument();
 
     rerender(
       <AssetFormModal type="scene" mode="create"
         onClose={() => {}} onSubmit={vi.fn()} />
     );
-    expect(screen.queryByLabelText(/field\.voice_style/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/声音风格/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/assets/AssetPickerModal.test.tsx
+++ b/frontend/src/components/assets/AssetPickerModal.test.tsx
@@ -3,22 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AssetPickerModal } from "./AssetPickerModal";
 import { API } from "@/api";
 
-// Mock i18next
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => {
-      if (opts) {
-        let result = key;
-        for (const [k, v] of Object.entries(opts)) {
-          result = result.replace(`{{${k}}}`, String(v));
-        }
-        return result;
-      }
-      return key;
-    },
-  }),
-}));
-
 const fixtures = [
   { id: "1", type: "character" as const, name: "王小明", description: "", voice_style: "", image_path: null, audio_path: null, source_project: null, updated_at: null },
   { id: "2", type: "character" as const, name: "小师妹", description: "", voice_style: "", image_path: null, audio_path: null, source_project: null, updated_at: null },
@@ -43,9 +27,7 @@ describe("AssetPickerModal", () => {
     await waitFor(() => screen.getByText("王小明"));
     fireEvent.click(screen.getByText("王小明"));
     fireEvent.click(screen.getByText("小师妹"));
-    const buttons = screen.getAllByRole("button");
-    const importButton = buttons.find(b => b.textContent?.includes("confirm_import") && !(b as HTMLButtonElement).disabled);
-    fireEvent.click(importButton!);
+    fireEvent.click(screen.getByRole("button", { name: /确认入库/ }));
     await waitFor(() => expect(onImport).toHaveBeenCalledWith(["1", "2"]));
   });
 

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -286,37 +286,6 @@ vi.mock("./lorebook/ProductsPage", () => ({
   ),
 }));
 
-vi.mock("./lorebook/AddCharacterForm", () => ({
-  AddCharacterForm: ({
-    onSubmit,
-    onCancel,
-  }: {
-    onSubmit: (
-      name: string,
-      description: string,
-      voice: string,
-      referenceFile?: File | null,
-    ) => Promise<void>;
-    onCancel: () => void;
-  }) => (
-    <div data-testid="add-character-form">
-      <button
-        onClick={() =>
-          void onSubmit(
-            "NewHero",
-            "desc",
-            "voice",
-            new File(["ref"], "new-hero.png", { type: "image/png" }),
-          )
-        }
-      >
-        submit-add-character
-      </button>
-      <button onClick={onCancel}>cancel-add-character</button>
-    </div>
-  ),
-}));
-
 function makeProjectData(overrides: Partial<ProjectData> = {}): ProjectData {
   return {
     title: "Demo",

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -785,7 +785,6 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "updateCharacter").mockResolvedValue({ success: true });
     vi.spyOn(API, "uploadFile").mockResolvedValue({ success: true, path: "x", url: "y" });
     vi.spyOn(API, "generateCharacter").mockResolvedValue({ success: true, task_id: "t-1", deduped: false, message: "已提交" });
-    vi.spyOn(API, "addCharacter").mockResolvedValue({ success: true });
 
     renderAt("/characters");
 
@@ -819,10 +818,6 @@ describe("StudioCanvasRouter", () => {
       const { tasks, optimisticActive } = useTasksStore.getState();
       expect(selectActiveResourceIds(tasks, "character", "demo", optimisticActive).has("Hero")).toBe(true);
     });
-
-    // Test add character flow: click "add" button is not directly accessible in CharacterCard mock;
-    // instead, we test the AddCharacterForm path by navigating with the form already showing.
-    // The add-character button is on CharactersPage which is not directly exposed; we test the form submit instead.
   });
 
   it("refreshes the project even when the audio upload step fails partway through save", async () => {

--- a/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
+++ b/frontend/src/components/canvas/timeline/DialogueListEditor.test.tsx
@@ -4,13 +4,6 @@ import { describe, it, expect, vi } from "vitest";
 import { DialogueListEditor } from "./DialogueListEditor";
 import type { Dialogue } from "@/types";
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: { language: "en" },
-  }),
-}));
-
 const dialogue: Dialogue[] = [
   { speaker: "韩青", line: "好险的关隘！田单未能攻破，正面尚未被攻破？" },
 ];
@@ -62,7 +55,7 @@ describe("DialogueListEditor", () => {
   it("appends an empty pair on add", () => {
     const onChange = vi.fn();
     render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "add_dialogue" }));
+    fireEvent.click(screen.getByRole("button", { name: "添加对话" }));
     expect(onChange).toHaveBeenCalledWith([
       ...dialogue,
       { speaker: "", line: "" },
@@ -72,7 +65,7 @@ describe("DialogueListEditor", () => {
   it("removes a pair on delete", () => {
     const onChange = vi.fn();
     render(<DialogueListEditor dialogue={dialogue} onChange={onChange} />);
-    fireEvent.click(screen.getByRole("button", { name: "dialogue_remove" }));
+    fireEvent.click(screen.getByRole("button", { name: "删除对话" }));
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
@@ -93,7 +86,7 @@ describe("DialogueListEditor", () => {
     const thirdLineNode = screen.getByDisplayValue("第三行");
 
     // Delete the middle row (乙/第二行).
-    const removeButtons = screen.getAllByRole("button", { name: "dialogue_remove" });
+    const removeButtons = screen.getAllByRole("button", { name: "删除对话" });
     fireEvent.click(removeButtons[1]);
 
     // With a stable per-row key, the surviving rows keep their own DOM nodes

--- a/frontend/src/components/layout/GlobalHeader.test.tsx
+++ b/frontend/src/components/layout/GlobalHeader.test.tsx
@@ -24,44 +24,17 @@ vi.mock("./WorkspaceNotificationsDrawer", () => ({
     open ? <div data-testid="notifications-drawer" /> : null,
 }));
 
-vi.mock("./ExportScopeDialog", () => ({
-  ExportScopeDialog: ({
-    open,
-    onSelect,
-    onJianyingExport,
-  }: {
-    open: boolean;
-    onClose: () => void;
-    onSelect: (scope: "current" | "full") => void;
-    anchorRef: React.RefObject<HTMLElement | null>;
-    episodes?: unknown[];
-    onJianyingExport?: (
-      episode: number,
-      draftPath: string,
-      jianyingVersion: string,
-      narrationDelivery: "post_production" | "use_tts",
-    ) => void;
-    jianyingExporting?: boolean;
-  }) =>
-    open ? (
-      <div data-testid="export-scope-dialog">
-        <button data-testid="scope-current" onClick={() => onSelect("current")}>
-          仅当前版本
-        </button>
-        <button data-testid="scope-full" onClick={() => onSelect("full")}>
-          全部数据
-        </button>
-        {onJianyingExport && (
-          <button
-            data-testid="scope-jianying"
-            onClick={() => onJianyingExport(1, "/drafts", "6", "post_production")}
-          >
-            剪映草稿
-          </button>
-        )}
-      </div>
-    ) : null,
-}));
+/** 打开导出弹窗，并在剪映分支上走完「选剪映草稿 → 提交表单」两步。 */
+async function openExportScope(option: "current" | "full" | "jianying") {
+  screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
+  if (option === "jianying") {
+    (await screen.findByRole("button", { name: /导出为剪映草稿/ })).click();
+    (await screen.findByRole("button", { name: "导出草稿" })).click();
+    return;
+  }
+  const name = option === "current" ? /仅当前版本/ : /全部数据/;
+  (await screen.findByRole("button", { name })).click();
+}
 
 function renderHeader() {
   const { hook } = memoryLocation({ path: "/characters" });
@@ -175,12 +148,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    // Click export button to open dialog
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-
-    // Wait for dialog to appear then click "仅当前版本"
-    const scopeBtn = await screen.findByTestId("scope-current");
-    scopeBtn.click();
+    await openExportScope("current");
 
     await waitFor(() => {
       expect(API.requestExportToken).toHaveBeenCalledWith("demo", "current");
@@ -236,8 +204,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-    (await screen.findByTestId("scope-jianying")).click();
+    await openExportScope("jianying");
 
     await waitFor(() => {
       expect(anchorClick).toHaveBeenCalled();
@@ -276,8 +243,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-    (await screen.findByTestId("scope-jianying")).click();
+    await openExportScope("jianying");
 
     await waitFor(() => {
       expect(API.requestExportToken).toHaveBeenCalledWith("ad-demo", "current");
@@ -316,8 +282,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-    (await screen.findByTestId("scope-jianying")).click();
+    await openExportScope("jianying");
 
     await waitFor(() => {
       expect(anchorClick).toHaveBeenCalled();
@@ -355,8 +320,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-    (await screen.findByTestId("scope-jianying")).click();
+    await openExportScope("jianying");
 
     await waitFor(() => {
       expect(anchorClick).toHaveBeenCalled();
@@ -388,14 +352,14 @@ describe("GlobalHeader", () => {
 
     renderHeader();
     screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-    expect(await screen.findByTestId("export-scope-dialog")).toBeInTheDocument();
+    expect(await screen.findByText("选择导出范围")).toBeInTheDocument();
 
     // 浏览器前进/后退等场景会复用同一个 GlobalHeader 实例切到演示项目——已打开的
     // 导出弹窗须随之关闭，不能继续展示可点击的导出/剪映草稿操作
     useProjectsStore.setState({ currentProjectName: DEMO_PROJECT_NAME });
 
     await waitFor(() => {
-      expect(screen.queryByTestId("export-scope-dialog")).not.toBeInTheDocument();
+      expect(screen.queryByText("选择导出范围")).not.toBeInTheDocument();
     });
   });
 
@@ -480,10 +444,7 @@ describe("GlobalHeader", () => {
     });
 
     renderHeader();
-    screen.getByRole("button", { name: "导出当前项目 ZIP" }).click();
-
-    const scopeBtn = await screen.findByTestId("scope-full");
-    scopeBtn.click();
+    await openExportScope("full");
 
     await waitFor(() => {
       expect(useAppStore.getState().toast?.text).toContain("导出失败");

--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -7,10 +7,6 @@ import { useAssetsStore } from "@/stores/assets-store";
 import type { Asset } from "@/types/asset";
 import { AssetLibraryPage } from "./AssetLibraryPage";
 
-vi.mock("@/components/assets/AssetFormModal", () => ({
-  AssetFormModal: () => <div data-testid="asset-form-modal" />,
-}));
-
 function renderPage(initialPath = "/app/assets") {
   const location = memoryLocation({ path: initialPath, record: true });
   return {

--- a/frontend/src/components/shared/PresentationPlayer.test.tsx
+++ b/frontend/src/components/shared/PresentationPlayer.test.tsx
@@ -7,14 +7,6 @@ import type { ProjectData } from "@/types";
 import type { PresentationReadModel } from "@/types/presentation";
 import { PresentationPlayer } from "./PresentationPlayer";
 
-vi.mock("@/api", () => ({
-  API: {
-    getPresentation: vi.fn(),
-    getFileUrl: vi.fn((_project: string, path: string) => `/media/${path}`),
-    downloadPresentationBundle: vi.fn(),
-  },
-}));
-
 const post: PresentationReadModel = {
   schema_version: 1,
   provenance: "verified",
@@ -76,10 +68,10 @@ const tts: PresentationReadModel = {
 describe("PresentationPlayer", () => {
   beforeEach(() => {
     useProjectsStore.setState({ assetFingerprints: {}, projectSnapshotRevisions: {} });
-    vi.mocked(API.getPresentation).mockImplementation(async (_project, _type, _id, options) =>
+    vi.spyOn(API, "getPresentation").mockImplementation(async (_project, _type, _id, options) =>
       options?.variant === "use_tts" ? tts : post,
     );
-    vi.mocked(API.downloadPresentationBundle).mockResolvedValue({
+    vi.spyOn(API, "downloadPresentationBundle").mockResolvedValue({
       blob: new Blob(["zip"]),
       filename: "presentation.zip",
     });
@@ -94,7 +86,10 @@ describe("PresentationPlayer", () => {
     );
 
     const video = await screen.findByLabelText("E1S01 成片预览");
-    expect(video).toHaveAttribute("src", "/media/versions/videos/E1S01_v3.mp4");
+    expect(video).toHaveAttribute(
+      "src",
+      "/api/v1/files/demo/versions/videos/E1S01_v3.mp4?v=sha256-v1%3Avideo",
+    );
     expect(video).toHaveProperty("muted", true);
     await waitFor(() => expect(video).toHaveProperty("volume", 0));
     Object.defineProperty(video, "muted", { configurable: true, writable: true, value: false });
@@ -128,7 +123,10 @@ describe("PresentationPlayer", () => {
     expect(screen.getByText("当前版本")).toBeInTheDocument();
     expect(screen.getByText("与当前内容一致")).toBeInTheDocument();
     expect(video).toHaveProperty("muted", false);
-    expect(audio).toHaveAttribute("src", "/media/versions/audio/E1S01_v2.wav");
+    expect(audio).toHaveAttribute(
+      "src",
+      "/api/v1/files/demo/versions/audio/E1S01_v2.wav?v=sha256-v1%3Aaudio",
+    );
     fireEvent.play(video);
     await waitFor(() => expect(play).toHaveBeenCalled());
 
@@ -186,7 +184,7 @@ describe("PresentationPlayer", () => {
   });
 
   it("keeps TTS at unity when the provider track is explicitly disabled", async () => {
-    vi.mocked(API.getPresentation).mockResolvedValue({
+    vi.spyOn(API, "getPresentation").mockResolvedValue({
       ...tts,
       video: { ...tts.video, audio_enabled: false, gain: 0 },
     });
@@ -247,7 +245,7 @@ describe("PresentationPlayer", () => {
   });
 
   it("keeps rendition recovery available when a TTS presentation cannot be built", async () => {
-    vi.mocked(API.getPresentation).mockImplementation(async (_project, _type, _id, options) => {
+    vi.spyOn(API, "getPresentation").mockImplementation(async (_project, _type, _id, options) => {
       if (options?.variant === "use_tts") throw new Error("TTS unavailable");
       return post;
     });
@@ -286,7 +284,7 @@ describe("PresentationPlayer", () => {
   it("discards a late response after the requested unit changes", async () => {
     let resolveFirst: ((value: PresentationReadModel) => void) | undefined;
     let resolveSecond: ((value: PresentationReadModel) => void) | undefined;
-    vi.mocked(API.getPresentation).mockImplementation(
+    vi.spyOn(API, "getPresentation").mockImplementation(
       (_project, _type, id) =>
         new Promise<PresentationReadModel>((resolve) => {
           if (id === "E1S01") resolveFirst = resolve;
@@ -305,17 +303,12 @@ describe("PresentationPlayer", () => {
       unit_id: "E1S02",
       video: { ...post.video, artifact_path: "versions/videos/E1S02_v1.mp4" },
     });
-    expect(await screen.findByLabelText("E1S02 成片预览")).toHaveAttribute(
-      "src",
-      "/media/versions/videos/E1S02_v1.mp4",
-    );
+    const secondUrl = "/api/v1/files/demo/versions/videos/E1S02_v1.mp4?v=sha256-v1%3Avideo";
+    expect(await screen.findByLabelText("E1S02 成片预览")).toHaveAttribute("src", secondUrl);
 
     resolveFirst?.(post);
     await waitFor(() => {
-      expect(screen.getByLabelText("E1S02 成片预览")).toHaveAttribute(
-        "src",
-        "/media/versions/videos/E1S02_v1.mp4",
-      );
+      expect(screen.getByLabelText("E1S02 成片预览")).toHaveAttribute("src", secondUrl);
     });
     expect(screen.queryByLabelText("E1S01 成片预览")).not.toBeInTheDocument();
   });

--- a/frontend/src/onboarding/anchors.test.tsx
+++ b/frontend/src/onboarding/anchors.test.tsx
@@ -40,7 +40,6 @@ vi.mock("@/components/pages/CreateProjectModal", () => ({
 vi.mock("@/components/task-hud/TaskHud", () => ({ TaskHud: () => <div data-testid="task-hud" /> }));
 vi.mock("@/components/layout/UsageDrawer", () => ({ UsageDrawer: () => null }));
 vi.mock("@/components/layout/WorkspaceNotificationsDrawer", () => ({ WorkspaceNotificationsDrawer: () => null }));
-vi.mock("@/components/layout/ExportScopeDialog", () => ({ ExportScopeDialog: () => null }));
 vi.mock("@/components/canvas/timeline/ScriptReviewGate", async () => {
   const { scriptReviewGateMock } = await import("@/__mocks__/ScriptReviewGate");
   return scriptReviewGateMock();


### PR DESCRIPTION
Closes #2002

前端禁令存量清理（Spec #1989 的 F2），四个提交按改动性质单一拆分。

## 改动

**AC1 之 `@/api`（`PresentationPlayer.test.tsx`）** —— 全仓唯一一处整模块 `vi.mock("@/api")`。`getPresentation` / `downloadPresentationBundle` 1:1 迁为 `beforeEach` 里的 `vi.spyOn`；`getFileUrl` 不再打桩：它是 `api.ts` 的纯 URL 拼装函数（无 fetch、无副作用），给纯函数打桩正是本 Spec 要消除的形状。代价是 4 处 `src` 断言由 `/media/<path>` 改为真实形态 `/api/v1/files/demo/<path>?v=<encodeURIComponent(digest)>`，改后反而覆盖了真实的 cacheBust 契约。文件内 `vi.mocked(API.x)` 一并统一为 `vi.spyOn(API, "x")`。

**AC1 之 `react-i18next`** —— `AssetCard` / `AssetFormModal` / `AssetPickerModal` / `DialogueListEditor` 四处整模块 mock 全部删除，不引入新设施：`src/test/setup.ts` 早已 `await i18nReady` + `changeLanguage("zh")`，真实中文 i18n 本就是全仓默认路径。断言由 raw key 改为真实中文文案；插值文案 `conflict_warning` 取稳定子串 `/已有同名资产/` 以避开插值段。

**AC2 子组件 mock 白名单收敛** —— 判据取 `CONTRIBUTING.md:138` 的字面三类：重量级（虚拟化/动画/canvas）、有副作用（发起请求/启动定时器）、与本测试无关的纯展示。第三类的字面含「纯展示」，因此轻量纯展示组件的 mock 合规，AC2 是审计并裁剪而非大规模去 mock。逐一核了 13 项灰区（判据是被替身组件 effect 的函数体），撤除三处违规：

- `ExportScopeDialog`（双态状态机 + localStorage 草稿 + 表单校验，两个 effect 都只是 UI 状态重置）—— `anchors.test.tsx` 场景 `open=false`，零成本删除；`GlobalHeader.test.tsx` 的 5 个用例改走真实弹窗，三条路径收敛进本地 `openExportScope(option)` 辅助函数（只服务本文件，未达 ≥3 文件上提门槛）。`expect` 主体逐字未变。
- `AddCharacterForm`（六个本地 state + 必填校验 + submitting 门闩）—— `StudioCanvasRouter.test.tsx` 内该替身无任何消费方，直接删；连带清理其撤除后悬空的注释与失去锚点的 `vi.spyOn(API, "addCharacter")` 死打桩。
- `AssetFormModal`（六个本地 state + create/edit/import 三态 + overwrite 分支）—— `AssetLibraryPage.test.tsx` 从未打开过 modal，直接删。

## 本地审查裁定

`ShotSplitView` 被 3 个测试文件内联 mock 而未上提 `src/__mocks__/`，触及 `CONTRIBUTING.md:138` 的 ≥3 从句。经裁定不在本票处理：AC2 字面限于「三类白名单」，而 `ShotSplitView` 本身白名单合规（子树含 `API.getFileUrl` / `uploadShotMedia` 与媒体，另订阅 app-store）；且三处替身语义各异（prop 探针 / 烤死 fixture 参数的点击按钮 / `() => null`），机械合并为共享替身会把具体 fixture 塞进公共模块并向 `anchors.test.tsx` 注入多余 DOM，形态反而更差。已记入 follow-up 候选。

## 验证

- `grep -rn 'vi.mock("react-i18next"\|vi.mock("@/api"' frontend/src` 零命中（AC1）
- 全仓 `vi.mock(` 存量 56 处逐项核对，保留项均落在三类白名单内（AC2）
- rebase 到 `ae5f551d5` 后重跑：`tsc --noEmit` 与 `eslint .` 均 exit 0，前端全量 155 files / 1889 tests 全绿（AC3）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 更新资产、对话、导出及引导流程测试，改用用户可见的中文文本和可访问名称进行交互验证。
  - 减少对界面组件和翻译的模拟，改为覆盖更接近真实使用场景的操作流程。
  - 更新媒体资源地址及演示文稿相关断言，确保测试符合当前资源访问行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->