### PR TITLE
refactor(test): 重试与轮询时钟改显式注入 seam，with_retry_async 留兼容壳（#1994）

### DIFF
--- a/lib/retry.py
+++ b/lib/retry.py
@@ -98,11 +98,13 @@ def with_retry_async(
     clock: AsyncClock | None = None,
     jitter: Callable[[float, float], float] | None = None,
 ):
-    """兼容既有调用方的异步重试装饰器。
+    """异步函数重试装饰器兼容壳，等待逻辑委托给 ``retry_async``。
 
-    新代码应迁移到显式调用 ``retry_async(operation, clock=..., jitter=...)``，避免装饰器
-    在定义期隐藏依赖。既有装饰器调用在分批迁移期间继续保留；其重试行为委托给
-    ``retry_async``，未注入时仍使用系统时钟与 ``random.uniform``。
+    等价的显式入口是 ``retry_async(operation, clock=..., jitter=...)``：装饰器在定义期就绑死
+    clock 与 jitter，调用方无法按调用现场替换，显式入口没有这一限制。
+
+    当指定 retry_if 时，用该谓词替代默认的 _should_retry 进行重试判定，
+    允许调用方精确控制哪些异常应当重试（如仅重试特定 HTTP 状态码）。
     """
 
     predicate = retry_if if retry_if is not None else lambda e: _should_retry(e, retryable_errors)
@@ -147,6 +149,8 @@ async def retry_async[T](
             is_last = attempt >= max_attempts - 1
             if is_last or isinstance(exc, NonRetryableError) or not predicate(exc):
                 raise
+            # 未注入 jitter 时按两个位置参调用：仍有测试把 `_compute_wait` 整体替换成
+            # 只接 (attempt, backoff) 的确定化替身，多传 jitter= 会让它们 TypeError。
             wait_time = (
                 _compute_wait(attempt, backoff_seconds)
                 if jitter is None

--- a/lib/retry.py
+++ b/lib/retry.py
@@ -12,7 +12,9 @@ import asyncio
 import functools
 import logging
 import random
-from collections.abc import Callable
+import time
+from collections.abc import Awaitable, Callable
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +62,24 @@ DOWNLOAD_MAX_ATTEMPTS = 5
 DOWNLOAD_BACKOFF_SECONDS: tuple[int, ...] = (5, 10, 20, 40)
 
 
+class AsyncClock(Protocol):
+    """异步等待与单调计时的显式 seam。"""
+
+    def monotonic(self) -> float: ...
+
+    async def sleep(self, delay: float) -> None: ...
+
+
+class SystemClock:
+    """生产默认时钟。"""
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+    async def sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+
+
 def _should_retry(exc: Exception, retryable_errors: tuple[type[Exception], ...]) -> bool:
     """判断异常是否应当重试。"""
     if isinstance(exc, NonRetryableError):
@@ -75,11 +95,14 @@ def with_retry_async(
     backoff_seconds: tuple[int, ...] = DEFAULT_BACKOFF_SECONDS,
     retryable_errors: tuple[type[Exception], ...] = BASE_RETRYABLE_ERRORS,
     retry_if: Callable[[Exception], bool] | None = None,
+    clock: AsyncClock | None = None,
+    jitter: Callable[[float, float], float] | None = None,
 ):
-    """异步函数重试装饰器，带指数退避和随机抖动。
+    """兼容既有调用方的异步重试装饰器。
 
-    当指定 retry_if 时，用该谓词替代默认的 _should_retry 进行重试判定，
-    允许调用方精确控制哪些异常应当重试（如仅重试特定 HTTP 状态码）。
+    新代码应迁移到显式调用 ``retry_async(operation, clock=..., jitter=...)``，避免装饰器
+    在定义期隐藏依赖。既有装饰器调用在分批迁移期间继续保留；其重试行为委托给
+    ``retry_async``，未注入时仍使用系统时钟与 ``random.uniform``。
     """
 
     predicate = retry_if if retry_if is not None else lambda e: _should_retry(e, retryable_errors)
@@ -87,26 +110,62 @@ def with_retry_async(
     def decorator(func):
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
-            for attempt in range(max_attempts):
-                try:
-                    return await func(*args, **kwargs)
-                except Exception as e:
-                    is_last = attempt >= max_attempts - 1
-                    if is_last or isinstance(e, NonRetryableError) or not predicate(e):
-                        raise
-                    wait_time = _compute_wait(attempt, backoff_seconds)
-                    logger.warning("API 调用异常: %s - %s", type(e).__name__, str(e)[:200])
-                    logger.warning("重试 %d/%d, %.1f 秒后...", attempt + 1, max_attempts - 1, wait_time)
-                    await asyncio.sleep(wait_time)
-
-            raise RuntimeError(f"with_retry_async: max_attempts={max_attempts}，未执行任何尝试")
+            if max_attempts <= 0:
+                raise RuntimeError(f"with_retry_async: max_attempts={max_attempts}，未执行任何尝试")
+            return await retry_async(
+                lambda: func(*args, **kwargs),
+                max_attempts=max_attempts,
+                backoff_seconds=backoff_seconds,
+                retry_if=predicate,
+                clock=clock,
+                jitter=jitter,
+            )
 
         return wrapper
 
     return decorator
 
 
-def _compute_wait(attempt: int, backoff_seconds: tuple[int, ...]) -> float:
+async def retry_async[T](
+    operation: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    backoff_seconds: tuple[int, ...] = DEFAULT_BACKOFF_SECONDS,
+    retryable_errors: tuple[type[Exception], ...] = BASE_RETRYABLE_ERRORS,
+    retry_if: Callable[[Exception], bool] | None = None,
+    clock: AsyncClock | None = None,
+    jitter: Callable[[float, float], float] | None = None,
+) -> T:
+    """执行可重试异步操作，允许显式注入时钟与随机抖动。"""
+    active_clock = clock if clock is not None else SystemClock()
+    predicate = retry_if if retry_if is not None else lambda e: _should_retry(e, retryable_errors)
+
+    for attempt in range(max_attempts):
+        try:
+            return await operation()
+        except Exception as exc:
+            is_last = attempt >= max_attempts - 1
+            if is_last or isinstance(exc, NonRetryableError) or not predicate(exc):
+                raise
+            wait_time = (
+                _compute_wait(attempt, backoff_seconds)
+                if jitter is None
+                else _compute_wait(attempt, backoff_seconds, jitter=jitter)
+            )
+            logger.warning("API 调用异常: %s - %s", type(exc).__name__, str(exc)[:200])
+            logger.warning("重试 %d/%d, %.1f 秒后...", attempt + 1, max_attempts - 1, wait_time)
+            await active_clock.sleep(wait_time)
+
+    raise RuntimeError(f"retry_async: max_attempts={max_attempts}，未执行任何尝试")
+
+
+def _compute_wait(
+    attempt: int,
+    backoff_seconds: tuple[int, ...],
+    *,
+    jitter: Callable[[float, float], float] | None = None,
+) -> float:
     """计算第 attempt 次重试的等待时间（含随机抖动）。"""
     backoff_idx = min(attempt, len(backoff_seconds) - 1)
-    return backoff_seconds[backoff_idx] + random.uniform(0, 2)
+    uniform = jitter if jitter is not None else random.uniform
+    return backoff_seconds[backoff_idx] + uniform(0, 2)

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
@@ -15,7 +14,7 @@ import httpx
 from sqlalchemy.exc import InterfaceError, OperationalError
 
 from lib.data_uri import file_to_data_uri
-from lib.retry import BASE_RETRYABLE_ERRORS, AsyncClock, _should_retry, with_retry_async
+from lib.retry import BASE_RETRYABLE_ERRORS, AsyncClock, SystemClock, _should_retry, with_retry_async
 
 # `_should_retry` 默认会做字符串模式兜底（"timeout"/"503" 等），
 # 而 persist 重试要严格"DB 瞬态错误"语义——业务异常（如
@@ -23,16 +22,6 @@ from lib.retry import BASE_RETRYABLE_ERRORS, AsyncClock, _should_retry, with_ret
 # 显式传 `retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS)` 关掉兜底。
 
 logger = logging.getLogger(__name__)
-
-
-class _SystemPollClock:
-    """轮询的生产默认时钟；保留既有默认调用路径的运行时查找语义。"""
-
-    def monotonic(self) -> float:
-        return time.monotonic()
-
-    async def sleep(self, delay: float) -> None:
-        await asyncio.sleep(delay)
 
 
 # DB 瞬态错误集合：sqlite "database is locked"、pg "could not connect" / 连接已关闭。
@@ -491,7 +480,7 @@ async def poll_with_retry[T](
         on_progress: 可选的进度回调，每次非终态轮询后调用。
         clock: 单调计时与异步等待 seam；生产默认使用系统时钟。
     """
-    active_clock = clock if clock is not None else _SystemPollClock()
+    active_clock = clock if clock is not None else SystemClock()
     start = active_clock.monotonic()
     prefix = f"{label} " if label else ""
     predicate = retry_if if retry_if is not None else (lambda e: _should_retry(e, retryable_errors))

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -15,7 +15,7 @@ import httpx
 from sqlalchemy.exc import InterfaceError, OperationalError
 
 from lib.data_uri import file_to_data_uri
-from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
+from lib.retry import BASE_RETRYABLE_ERRORS, AsyncClock, _should_retry, with_retry_async
 
 # `_should_retry` 默认会做字符串模式兜底（"timeout"/"503" 等），
 # 而 persist 重试要严格"DB 瞬态错误"语义——业务异常（如
@@ -23,6 +23,17 @@ from lib.retry import BASE_RETRYABLE_ERRORS, _should_retry, with_retry_async
 # 显式传 `retry_if=lambda e: isinstance(e, _PERSIST_RETRYABLE_ERRORS)` 关掉兜底。
 
 logger = logging.getLogger(__name__)
+
+
+class _SystemPollClock:
+    """轮询的生产默认时钟；保留既有默认调用路径的运行时查找语义。"""
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+    async def sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+
 
 # DB 瞬态错误集合：sqlite "database is locked"、pg "could not connect" / 连接已关闭。
 # 故意不收 DBAPIError 父类——会兜住 IntegrityError/DataError/ProgrammingError 等非瞬态
@@ -463,6 +474,7 @@ async def poll_with_retry[T](
     retry_if: Callable[[Exception], bool] | None = None,
     label: str = "",
     on_progress: Callable[[T, float], None] | None = None,
+    clock: AsyncClock | None = None,
 ) -> T:
     """通用异步轮询辅助函数，带瞬态错误重试和超时控制。
 
@@ -477,8 +489,10 @@ async def poll_with_retry[T](
             哪些异常应当重试（如按 HTTP status_code 区分确定性 4xx 与瞬态 5xx）。
         label: 日志前缀（如 "Ark"、"Gemini"）。
         on_progress: 可选的进度回调，每次非终态轮询后调用。
+        clock: 单调计时与异步等待 seam；生产默认使用系统时钟。
     """
-    start = time.monotonic()
+    active_clock = clock if clock is not None else _SystemPollClock()
+    start = active_clock.monotonic()
     prefix = f"{label} " if label else ""
     predicate = retry_if if retry_if is not None else (lambda e: _should_retry(e, retryable_errors))
 
@@ -497,11 +511,11 @@ async def poll_with_retry[T](
             if is_done(result):
                 return result
             if on_progress is not None:
-                on_progress(result, time.monotonic() - start)
+                on_progress(result, active_clock.monotonic() - start)
 
-        if time.monotonic() - start >= max_wait:
+        if active_clock.monotonic() - start >= max_wait:
             raise TimeoutError(f"{prefix}任务超时（{max_wait:.0f}秒）")
-        await asyncio.sleep(poll_interval)
+        await active_clock.sleep(poll_interval)
 
 
 @with_retry_async()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -438,7 +438,7 @@ def bounded_poll_clock(step: float = 30.0):
     """
     clock = itertools.count(0.0, step)
     with (
-        patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
-        patch("lib.video_backends.base.time.monotonic", side_effect=lambda: next(clock)),
+        patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+        patch("lib.retry.time.monotonic", side_effect=lambda: next(clock)),
     ):
         yield

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -314,7 +314,7 @@ class TestWithRetryAsync:
             await fn()
         assert mock_fn.call_count == 1
 
-    async def test_explicit_clock_and_jitter_avoid_patching_runtime_globals(self):
+    async def test_waits_backoff_plus_injected_jitter_on_injected_clock(self):
         mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
         clock = _FakeClock()
 
@@ -332,7 +332,7 @@ class TestWithRetryAsync:
 
 
 class TestRetryAsync:
-    async def test_explicit_clock_and_jitter_avoid_patching_runtime_globals(self):
+    async def test_waits_backoff_plus_injected_jitter_on_injected_clock(self):
         operation = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
         clock = _FakeClock()
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -13,10 +13,22 @@ from lib.retry import (
     RETRYABLE_STATUS_PATTERNS,
     NonRetryableError,
     _should_retry,
+    retry_async,
     with_retry_async,
 )
 
 pytestmark = pytest.mark.unit
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return 0.0
+
+    async def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
 
 
 class TestShouldRetry:
@@ -301,6 +313,39 @@ class TestWithRetryAsync:
         with pytest.raises(_Truncated):
             await fn()
         assert mock_fn.call_count == 1
+
+    async def test_explicit_clock_and_jitter_avoid_patching_runtime_globals(self):
+        mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
+        clock = _FakeClock()
+
+        @with_retry_async(
+            max_attempts=3,
+            backoff_seconds=(5, 10),
+            clock=clock,
+            jitter=lambda _low, _high: 0.25,
+        )
+        async def fn():
+            return await mock_fn()
+
+        assert await fn() == "ok"
+        assert clock.sleeps == [5.25]
+
+
+class TestRetryAsync:
+    async def test_explicit_clock_and_jitter_avoid_patching_runtime_globals(self):
+        operation = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
+        clock = _FakeClock()
+
+        result = await retry_async(
+            operation,
+            max_attempts=3,
+            backoff_seconds=(5, 10),
+            clock=clock,
+            jitter=lambda _low, _high: 0.25,
+        )
+
+        assert result == "ok"
+        assert clock.sleeps == [5.25]
 
 
 class TestDownloadConstants:

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -32,6 +32,18 @@ from lib.video_backends.base import (
 pytestmark = pytest.mark.unit
 
 
+class _FakeClock:
+    def __init__(self, times: list[float]) -> None:
+        self._times = iter(times)
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return next(self._times)
+
+    async def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
+
+
 def _http_status_error(status_code: int, *, text: str = "boom") -> httpx.HTTPStatusError:
     """构造真实 httpx.HTTPStatusError；URL 故意含 "503" 子串以验证不再走字符串误判。"""
     request = httpx.Request("GET", "https://relay.example/v2/video/generations?generation_id=task-503")
@@ -166,22 +178,36 @@ class TestPollWithRetry:
     async def test_timeout_raises(self):
         """超时抛出 TimeoutError。"""
         poll_fn = AsyncMock(return_value="pending")
+        clock = _FakeClock([0.0, 0.0, 100.0])
 
-        # 用 monotonic mock 模拟时间流逝
-        times = iter([0, 0, 100, 100])  # 第二轮超时
+        with pytest.raises(TimeoutError, match="超时"):
+            await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: False,
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=10,
+                clock=clock,
+            )
 
-        with (
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
-            patch("lib.video_backends.base.time.monotonic", side_effect=times),
-        ):
-            with pytest.raises(TimeoutError, match="超时"):
-                await poll_with_retry(
-                    poll_fn=poll_fn,
-                    is_done=lambda r: False,
-                    is_failed=lambda r: None,
-                    poll_interval=1,
-                    max_wait=10,
-                )
+        assert clock.sleeps == [1]
+
+    async def test_explicit_clock_drives_polling_without_patching_or_waiting(self):
+        poll_fn = AsyncMock(side_effect=["pending", "done"])
+        clock = _FakeClock([0.0, 1.0, 2.0, 3.0])
+
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done",
+            is_failed=lambda r: None,
+            poll_interval=5,
+            max_wait=10,
+            on_progress=lambda _result, _elapsed: None,
+            clock=clock,
+        )
+
+        assert result == "done"
+        assert clock.sleeps == [5]
 
     async def test_failed_status_raises(self):
         """is_failed 返回错误信息时抛出 RuntimeError。"""

--- a/tests/test_video_backend_base.py
+++ b/tests/test_video_backend_base.py
@@ -192,7 +192,7 @@ class TestPollWithRetry:
 
         assert clock.sleeps == [1]
 
-    async def test_explicit_clock_drives_polling_without_patching_or_waiting(self):
+    async def test_sleeps_poll_interval_on_injected_clock_between_polls(self):
         poll_fn = AsyncMock(side_effect=["pending", "done"])
         clock = _FakeClock([0.0, 1.0, 2.0, 3.0])
 


### PR DESCRIPTION
Closes #1994

Spec #1989 的 B5a：把重试与轮询的时钟按 #1967 定下的**形状 A**（显式参数注入，带生产默认值）落地。生产代码只做注入式改形，不改行为。

## 改动

**`lib/retry.py`**

- 新增 `AsyncClock` Protocol（`monotonic` / `sleep`）与生产默认实现 `SystemClock`。
- 新增 `retry_async(operation, *, max_attempts, backoff_seconds, retryable_errors, retry_if, clock, jitter)`，即 #1967 Resolution 采纳的显式入口。
- `with_retry_async` 保留为兼容壳：同样接受 `clock` / `jitter`，等待逻辑委托给 `retry_async`，docstring 指明等价的显式入口。
- `_compute_wait` 增加关键字参数 `jitter`，默认仍走 `random.uniform`。

**`lib/video_backends/base.py`**

- `poll_with_retry` 新增 `clock` 参数；`time.monotonic` / `asyncio.sleep` 三处调用改走注入的时钟，默认落到 `lib.retry.SystemClock`。

**测试**

- `tests/test_retry.py` / `tests/test_video_backend_base.py` 新增用例：用普通假时钟对象驱动退避与轮询，断言注入时钟收到的 sleep 序列；`poll_with_retry` 的超时用例从 `patch("...base.time.monotonic")` 改为传入假时钟。
- `tests/fakes.py::bounded_poll_clock` 的 patch 目标改指 `lib.retry`，与默认时钟所在模块对齐。

## 本地审查修复（第二个提交）

- 实现初版在 `base.py` 里另建了一个私有 `_SystemPollClock`，与 `lib/retry.py` 的 `SystemClock` 逐行同构，理由写作「保留既有默认调用路径的运行时查找语义」。该理由不成立：`patch("lib.video_backends.base.time.monotonic")` 与 `patch("lib.video_backends.base.asyncio.sleep")` 都是在共享的 `time` / `asyncio` 模块对象上改属性，`SystemClock` 在调用时从 `lib.retry` 取同一模块，可见同样的 patch。已删除重复类改用 `SystemClock`，并实测既有 patch 点全部照常生效。
- `with_retry_async` docstring 去掉迁移计划与时间性措辞（`CONTRIBUTING.md`「注释规范」：注释只描述当前行为与约束），改述当前约束；同时补回初版误删的 `retry_if` 语义说明。
- `retry_async` 中 `_compute_wait` 保留「未注入 jitter 时按两个位置参调用」的分支并补约束注释：仍有测试把 `_compute_wait` 整体替换成只接 `(attempt, backoff)` 的确定化替身，多传 `jitter=` 会让它们 `TypeError`。该分支应在 B5c/B6 清掉旧 patch 后一并收敛。
- 三个新增用例名从描述测试手法改为描述被测行为。

## 验证

在 `.claude/worktrees/issue-1994`（`issue/1994` @ `9f5236194`）执行：

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 1291 files already formatted
- `uv run lint-imports` — Contracts: 2 kept, 0 broken
- `uv run basedpyright` — 0 errors, 1284 warnings（均为存量）
- `uv run python -m pytest` — **10282 passed, 2 skipped**，与改动前基线一致

针对性复核：删除 `_SystemPollClock` 后单跑全部相关 patch 点所在文件（`test_retry` / `test_video_backend_base` / `test_openai_video_backend` / `test_video_backend_gemini` / `test_video_backend_ark` / `test_v2_video_generations_backend` / `test_agnes_video_backend` / `test_vidu_video_backend` / `test_dashscope_video_backend`）—— 524 passed。

## 范围说明

各调用通道迁移到显式 `retry_async` / 假时钟属 B5c/B6，本 PR 不扩张。兼容壳 `with_retry_async` 与旧 patch helper 只能在全部调用方迁完后删除。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增可复用的异步重试能力，支持自定义最大尝试次数、退避等待、错误判断及抖动策略。
  - 重试等待和视频轮询现支持注入时钟，便于在不同运行环境中控制时间与等待行为。
- **错误修复**
  - 当最大尝试次数设置为零或负数时，将立即返回明确错误。
  - 视频轮询的超时判断、进度计时和轮询间隔更加一致可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->