### PR TITLE
refactor: 能力解析器 / HTTP 探测客户端 / 文件系统与子进程注入改形（#1995）

### DIFF
--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -90,7 +90,12 @@ _EPISODE_RESOURCE_KINDS = frozenset(
 )
 
 
-def activate_artifact_target_state(project_dir: Path, *, bump_schema: bool) -> bool:
+def activate_artifact_target_state(
+    project_dir: Path,
+    *,
+    bump_schema: bool,
+    backup_file: Callable[[Path, int], None] | None = None,
+) -> bool:
     """Commit one complete target state, optionally advancing schema last."""
 
     plan = plan_artifact_target_state(project_dir)
@@ -105,7 +110,7 @@ def activate_artifact_target_state(project_dir: Path, *, bump_schema: bool) -> b
     if bump_schema:
         with project_metadata_lock(project_dir):
             _assert_preflight_unchanged(project_dir, plan)
-            _backup_activation_inputs(project_dir, plan)
+            _backup_activation_inputs(project_dir, plan, backup_file=backup_file)
             previous_entries = adapter.snapshot_entries()
             changed = adapter.replace_entries_atomically(plan.entries)
             try:
@@ -411,14 +416,22 @@ def _assert_project_unchanged(project_dir: Path, expected: bytes) -> None:
         raise RuntimeError("project.json changed after artifact activation preflight")
 
 
-def _backup_activation_inputs(project_dir: Path, plan: ArtifactTargetStatePlan) -> None:
+def _backup_activation_inputs(
+    project_dir: Path,
+    plan: ArtifactTargetStatePlan,
+    *,
+    backup_file: Callable[[Path, int], None] | None = None,
+) -> None:
     candidates = [project_dir / "project.json", *plan.script_paths]
     manifest = project_dir / MANIFEST_FILENAME
     if manifest.exists():
         candidates.append(manifest)
     stamp = time.time_ns()
     for source in candidates:
-        _ensure_activation_backup(source, stamp=stamp)
+        if backup_file is None:
+            _ensure_activation_backup(source, stamp=stamp)
+        else:
+            backup_file(source, stamp)
 
 
 def _ensure_activation_backup(source: Path, *, stamp: int) -> None:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -584,7 +584,8 @@ class InMemoryArtifactManifestAdapter:
 class ProjectArtifactManifestAdapter:
     """Safe project-directory adapter backed by a versioned JSON manifest."""
 
-    def __init__(self, project_dir: Path) -> None:
+    def __init__(self, project_dir: Path, *, nofollow_flag: int | None = None) -> None:
+        self._nofollow_flag_override = nofollow_flag
         root_fd: int | None = None
         windows_handle: int | None = None
         try:
@@ -596,7 +597,7 @@ class ProjectArtifactManifestAdapter:
             initial_identity = (initial_stat.st_dev, initial_stat.st_ino)
             opened_identity: tuple[int, int] | None = None
             if os.name == "posix":
-                root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
+                root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | self._nofollow_flag
                 root_fd = os.open(project_dir, root_flags)
                 opened_stat = os.fstat(root_fd)
                 opened_identity = (opened_stat.st_dev, opened_stat.st_ino)
@@ -625,6 +626,10 @@ class ProjectArtifactManifestAdapter:
             raise ArtifactManifestError(f"project directory changed during adapter initialization: {project_dir}")
         self._project_dir = resolved
         self._project_identity = initial_identity
+
+    @property
+    def _nofollow_flag(self) -> int:
+        return _O_NOFOLLOW if self._nofollow_flag_override is None else self._nofollow_flag_override
 
     def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
         return self._inspect_artifact(artifact_path, include_content_digest=False)
@@ -707,10 +712,10 @@ class ProjectArtifactManifestAdapter:
         include_content_bytes: bool = False,
     ) -> ArtifactObservation:
         parts = PurePosixPath(normalized).parts
-        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
-        file_flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | self._nofollow_flag
+        file_flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0)
         with contextlib.ExitStack() as stack:
-            if not _O_NOFOLLOW and _is_linkish(self._project_dir):
+            if not self._nofollow_flag and _is_linkish(self._project_dir):
                 return self._artifact_blocked(
                     normalized,
                     "artifact_symlink",
@@ -734,13 +739,13 @@ class ProjectArtifactManifestAdapter:
             for part in parts[:-1]:
                 cursor /= part
                 expected_parent_identity: tuple[int, int] | None = None
-                if not _O_NOFOLLOW and _is_linkish(cursor):
+                if not self._nofollow_flag and _is_linkish(cursor):
                     return self._artifact_blocked(
                         normalized,
                         "artifact_symlink",
                         f"artifact path contains a symlink or junction: {normalized}",
                     )
-                if not _O_NOFOLLOW:
+                if not self._nofollow_flag:
                     try:
                         parent_stat = cursor.stat(follow_symlinks=False)
                     except FileNotFoundError:
@@ -787,13 +792,13 @@ class ProjectArtifactManifestAdapter:
                 directory_fd = next_fd
             final_path = cursor / parts[-1]
             expected_file_identity: tuple[int, int] | None = None
-            if not _O_NOFOLLOW and _is_linkish(final_path):
+            if not self._nofollow_flag and _is_linkish(final_path):
                 return self._artifact_blocked(
                     normalized,
                     "artifact_symlink",
                     f"artifact path contains a symlink or junction: {normalized}",
                 )
-            if not _O_NOFOLLOW:
+            if not self._nofollow_flag:
                 try:
                     file_stat = final_path.stat(follow_symlinks=False)
                 except FileNotFoundError:
@@ -918,7 +923,7 @@ class ProjectArtifactManifestAdapter:
                 detail=f"artifact path is not a regular file: {normalized}",
             )
             return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
-        flags = os.O_RDONLY | _O_NOFOLLOW
+        flags = os.O_RDONLY | self._nofollow_flag
         try:
             fd = os.open(path, flags)
             try:
@@ -1235,8 +1240,8 @@ class ProjectArtifactManifestAdapter:
             checked_lock_identity: tuple[int, int] | None = None
             try:
                 if os.name == "posix":
-                    root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _O_NOFOLLOW
-                    if not _O_NOFOLLOW and _is_linkish(self._project_dir):
+                    root_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | self._nofollow_flag
+                    if not self._nofollow_flag and _is_linkish(self._project_dir):
                         raise ArtifactManifestError(f"project directory is a symlink or junction: {self._project_dir}")
                     try:
                         root_fd = os.open(self._project_dir, root_flags)
@@ -1247,9 +1252,9 @@ class ProjectArtifactManifestAdapter:
                     self._assert_open_project_root_identity(root_fd)
                 else:
                     root_stack.enter_context(self._guard_portable_project_root())
-                if root_fd is None or not _O_NOFOLLOW:
+                if root_fd is None or not self._nofollow_flag:
                     checked_lock_identity = self._runtime_file_identity(lock_path, "manifest lock")
-                flags = os.O_WRONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+                flags = os.O_WRONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0)
                 try:
                     if root_fd is not None:
                         try:
@@ -1263,7 +1268,7 @@ class ProjectArtifactManifestAdapter:
                         raise ArtifactManifestError(f"manifest lock is a symlink: {lock_path}") from exc
                     raise ArtifactManifestError(f"cannot open manifest lock: {lock_path}: {exc}") from exc
                 try:
-                    if root_fd is None or not _O_NOFOLLOW:
+                    if root_fd is None or not self._nofollow_flag:
                         self._assert_open_runtime_file_identity(
                             lock_path,
                             fd,
@@ -1369,11 +1374,11 @@ class ProjectArtifactManifestAdapter:
     ) -> tuple[dict[str, ArtifactManifestEntry], bytes | None]:
         path = self._project_dir / MANIFEST_FILENAME
         checked_manifest_identity: tuple[int, int] | None = None
-        if root_fd is None or not _O_NOFOLLOW:
+        if root_fd is None or not self._nofollow_flag:
             checked_manifest_identity = self._runtime_file_identity(path, "artifact manifest")
             if checked_manifest_identity is None:
                 return {}, None
-        flags = os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+        flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0)
         try:
             fd = os.open(MANIFEST_FILENAME, flags, dir_fd=root_fd) if root_fd is not None else os.open(path, flags)
         except FileNotFoundError:
@@ -1383,7 +1388,7 @@ class ProjectArtifactManifestAdapter:
                 raise ArtifactManifestError(f"artifact manifest is a symlink: {path}") from exc
             raise ArtifactManifestError(f"cannot open artifact manifest: {path}: {exc}") from exc
         try:
-            if root_fd is None or not _O_NOFOLLOW:
+            if root_fd is None or not self._nofollow_flag:
                 self._assert_open_runtime_file_identity(
                     path,
                     fd,
@@ -1412,7 +1417,7 @@ class ProjectArtifactManifestAdapter:
                 dir=self._project_dir,
             )
         else:
-            fd, tmp_name = _create_temporary_file(root_fd)
+            fd, tmp_name = _create_temporary_file(root_fd, nofollow_flag=self._nofollow_flag)
         try:
             handle = os.fdopen(fd, "wb")
         except BaseException:
@@ -2106,8 +2111,8 @@ def _close_windows_handle(handle: int) -> None:
     close_handle(handle)
 
 
-def _create_temporary_file(root_fd: int) -> tuple[int, str]:
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
+def _create_temporary_file(root_fd: int, *, nofollow_flag: int) -> tuple[int, str]:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | nofollow_flag
     for _ in range(100):
         tmp_name = f"{MANIFEST_FILENAME}.{secrets.token_hex(8)}.tmp"
         try:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -584,8 +584,8 @@ class InMemoryArtifactManifestAdapter:
 class ProjectArtifactManifestAdapter:
     """Safe project-directory adapter backed by a versioned JSON manifest."""
 
-    def __init__(self, project_dir: Path, *, nofollow_flag: int | None = None) -> None:
-        self._nofollow_flag_override = nofollow_flag
+    def __init__(self, project_dir: Path, *, nofollow_supported: bool = True) -> None:
+        self._nofollow_supported = nofollow_supported
         root_fd: int | None = None
         windows_handle: int | None = None
         try:
@@ -629,7 +629,8 @@ class ProjectArtifactManifestAdapter:
 
     @property
     def _nofollow_flag(self) -> int:
-        return _O_NOFOLLOW if self._nofollow_flag_override is None else self._nofollow_flag_override
+        """`O_NOFOLLOW` 的实际取值：不支持（平台缺失或注入声明不支持）时为 0，回退到身份校验路径。"""
+        return _O_NOFOLLOW if self._nofollow_supported else 0
 
     def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
         return self._inspect_artifact(artifact_path, include_content_digest=False)

--- a/lib/audio_utils.py
+++ b/lib/audio_utils.py
@@ -10,6 +10,7 @@ import math
 import os
 import shutil
 import tempfile
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import cast
 
@@ -133,7 +134,13 @@ async def _run_ffprobe(extra_args: list[str]) -> bytes:
     return stdout
 
 
-async def probe_audio_duration_seconds(content: bytes, suffix: str) -> float | None:
+async def probe_audio_duration_seconds(
+    content: bytes,
+    suffix: str,
+    *,
+    ffprobe_available: Callable[[], bool] | None = None,
+    run_ffprobe: Callable[[list[str]], Awaitable[bytes]] | None = None,
+) -> float | None:
     """探测音频字节的时长（秒），并确认其中确有可解码的音频流。
 
     ffprobe 不可用时返回 None（调用方按仓库惯例降级：跳过时长校验，不阻断上传），
@@ -144,7 +151,9 @@ async def probe_audio_duration_seconds(content: bytes, suffix: str) -> float | N
             （如把视频文件改名为 .wav/.mp3 上传），或探测出的容器格式与
             扩展名不符（如把 m4a/aac 改名为 .wav 上传）。
     """
-    if not _ffprobe_available():
+    available = ffprobe_available or _ffprobe_available
+    probe = run_ffprobe or _run_ffprobe
+    if not available():
         logger.info("ffprobe 不可用，跳过音频时长探测")
         return None
 
@@ -159,7 +168,7 @@ async def probe_audio_duration_seconds(content: bytes, suffix: str) -> float | N
         raise
 
     try:
-        stream_types = await _run_ffprobe(
+        stream_types = await probe(
             ["-select_streams", "a", "-show_entries", "stream=codec_type", "-of", "csv=p=0", str(tmp_path)]
         )
         if b"audio" not in stream_types:
@@ -167,14 +176,12 @@ async def probe_audio_duration_seconds(content: bytes, suffix: str) -> float | N
 
         expected_tokens = _CONTAINER_FORMAT_TOKENS.get(suffix.lower())
         if expected_tokens is not None:
-            format_name_out = await _run_ffprobe(
-                ["-show_entries", "format=format_name", "-of", "csv=p=0", str(tmp_path)]
-            )
+            format_name_out = await probe(["-show_entries", "format=format_name", "-of", "csv=p=0", str(tmp_path)])
             detected_tokens = {token.strip() for token in format_name_out.decode().strip().split(",")}
             if not detected_tokens & expected_tokens:
                 raise ValueError("音频文件无法解析")
 
-        duration_out = await _run_ffprobe([*_DURATION_PROBE_ARGS, str(tmp_path)])
+        duration_out = await probe([*_DURATION_PROBE_ARGS, str(tmp_path)])
     except (FileNotFoundError, OSError):
         logger.info("ffprobe 调用失败，跳过音频时长探测")
         return None
@@ -187,7 +194,12 @@ async def probe_audio_duration_seconds(content: bytes, suffix: str) -> float | N
         raise ValueError("音频文件无法解析") from None
 
 
-async def probe_existing_media_duration_seconds(path: Path) -> float | None:
+async def probe_existing_media_duration_seconds(
+    path: Path,
+    *,
+    ffprobe_available: Callable[[], bool] | None = None,
+    run_ffprobe: Callable[[list[str]], Awaitable[bytes]] | None = None,
+) -> float | None:
     """探测磁盘上已落盘媒体文件的容器时长（秒）。
 
     与 :func:`probe_audio_duration_seconds` 的字节输入版本不同：本函数直接对已存在文件探测，
@@ -195,10 +207,12 @@ async def probe_existing_media_duration_seconds(path: Path) -> float | None:
     应使用 :func:`probe_existing_video_duration_seconds`。
     ffprobe 不可用或探测失败时返回 None，由调用方按业务严格度决定放行或阻断。
     """
-    if not _ffprobe_available():
+    available = ffprobe_available or _ffprobe_available
+    probe = run_ffprobe or _run_ffprobe
+    if not available():
         return None
     try:
-        duration_out = await _run_ffprobe([*_DURATION_PROBE_ARGS, str(path)])
+        duration_out = await probe([*_DURATION_PROBE_ARGS, str(path)])
     except (FileNotFoundError, OSError, ValueError):
         return None
     try:
@@ -217,7 +231,12 @@ def _positive_duration(value: object) -> float | None:
     return duration if math.isfinite(duration) and duration > 0 else None
 
 
-async def probe_existing_video_duration_seconds(path: Path) -> float | None:
+async def probe_existing_video_duration_seconds(
+    path: Path,
+    *,
+    ffprobe_available: Callable[[], bool] | None = None,
+    run_ffprobe: Callable[[list[str]], Awaitable[bytes]] | None = None,
+) -> float | None:
     """探测视频轨的可播放边界，缺少流级时长时回退到容器时长。
 
     容器可能因音轨尾部较长而比视频轨更长；视频编辑器按视频轨时长约束 source range，
@@ -225,10 +244,12 @@ async def probe_existing_video_duration_seconds(path: Path) -> float | None:
     与常见媒体解析器的通用轨 fallback 保持一致。
     """
 
-    if not _ffprobe_available():
+    available = ffprobe_available or _ffprobe_available
+    probe = run_ffprobe or _run_ffprobe
+    if not available():
         return None
     try:
-        output = await _run_ffprobe(
+        output = await probe(
             [
                 "-select_streams",
                 "v:0",
@@ -257,13 +278,27 @@ async def probe_existing_video_duration_seconds(path: Path) -> float | None:
     return None
 
 
-async def probe_existing_audio_duration_seconds(path: Path) -> float | None:
+async def probe_existing_audio_duration_seconds(
+    path: Path,
+    *,
+    ffprobe_available: Callable[[], bool] | None = None,
+    run_ffprobe: Callable[[list[str]], Awaitable[bytes]] | None = None,
+) -> float | None:
     """探测正式音频时长；保留音频调用方的语义化入口。"""
 
-    return await probe_existing_media_duration_seconds(path)
+    return await probe_existing_media_duration_seconds(
+        path,
+        ffprobe_available=ffprobe_available,
+        run_ffprobe=run_ffprobe,
+    )
 
 
-async def probe_reference_audio_total_seconds(paths: list[Path]) -> float | None:
+async def probe_reference_audio_total_seconds(
+    paths: list[Path],
+    *,
+    ffprobe_available: Callable[[], bool] | None = None,
+    run_ffprobe: Callable[[list[str]], Awaitable[bytes]] | None = None,
+) -> float | None:
     """探测多段参考音频文件的总时长（秒），供请求期总时长能力校验使用。
 
     任一文件时长探测失败（ffprobe 不可用、文件损坏）都返回 None 而非部分求和：半截总时长会
@@ -271,7 +306,11 @@ async def probe_reference_audio_total_seconds(paths: list[Path]) -> float | None
     """
     total = 0.0
     for path in paths:
-        duration = await probe_existing_audio_duration_seconds(path)
+        duration = await probe_existing_audio_duration_seconds(
+            path,
+            ffprobe_available=ffprobe_available,
+            run_ffprobe=run_ffprobe,
+        )
         if duration is None:
             return None
         total += duration

--- a/lib/config/anthropic_probe.py
+++ b/lib/config/anthropic_probe.py
@@ -69,6 +69,7 @@ async def probe_messages(
     api_key: str,
     model: str,
     timeout_s: float = 10.0,
+    http_client: httpx.AsyncClient | None = None,
 ) -> ProbeResult:
     """POST {messages_root}/v1/messages 发最小请求 (max_tokens=1)。
 
@@ -91,7 +92,10 @@ async def probe_messages(
     }
     started = time.perf_counter()
     try:
-        resp = await _post(url=url, headers=headers, payload=payload, timeout_s=timeout_s)
+        if http_client is None:
+            resp = await _post(url=url, headers=headers, payload=payload, timeout_s=timeout_s)
+        else:
+            resp = await http_client.post(url, headers=headers, json=payload, timeout=timeout_s)
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         logger.info("probe_messages timeout url=%s elapsed_ms=%d", url, elapsed)
@@ -164,6 +168,7 @@ async def probe_discovery(
     discovery_root: str | None,
     api_key: str,
     timeout_s: float = 5.0,
+    http_client: httpx.AsyncClient | None = None,
 ) -> ProbeResult | None:
     """GET {discovery_root}/v1/models 体检模型发现端点 (warn 级，仅供参考)。"""
     if not discovery_root:
@@ -172,7 +177,10 @@ async def probe_discovery(
     headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
     started = time.perf_counter()
     try:
-        resp = await _get(url=url, headers=headers, timeout_s=timeout_s)
+        if http_client is None:
+            resp = await _get(url=url, headers=headers, timeout_s=timeout_s)
+        else:
+            resp = await http_client.get(url, headers=headers, timeout=timeout_s)
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"timeout: {exc!s}")
@@ -221,6 +229,7 @@ async def run_test(
     base_url: str | None,
     api_key: str,
     model: str | None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> TestConnectionResponse:
     """完整端到端测试：派生 → messages + discovery 并发 → 自定义模式自愈 → 诊断。"""
     # 1. 派生 endpoints
@@ -253,8 +262,17 @@ async def run_test(
 
     # 2. messages + discovery 并发首轮：discovery 是 warn 级独立信号，串行只浪费墙钟时间
     msg, disc = await asyncio.gather(
-        probe_messages(messages_root=ep.messages_root, api_key=api_key, model=effective_model),
-        probe_discovery(discovery_root=ep.discovery_root or None, api_key=api_key),
+        probe_messages(
+            messages_root=ep.messages_root,
+            api_key=api_key,
+            model=effective_model,
+            http_client=http_client,
+        ),
+        probe_discovery(
+            discovery_root=ep.discovery_root or None,
+            api_key=api_key,
+            http_client=http_client,
+        ),
     )
 
     # 3. 自定义模式 + 失败 + 没显式 anthropic 后缀 + status 命中 retryable → 串行自愈
@@ -268,7 +286,12 @@ async def run_test(
         and msg.status_code in _RETRYABLE_STATUS_FOR_SELF_HEAL
     ):
         retry_root = ep.messages_root.rstrip("/") + "/anthropic"
-        retry = await probe_messages(messages_root=retry_root, api_key=api_key, model=effective_model)
+        retry = await probe_messages(
+            messages_root=retry_root,
+            api_key=api_key,
+            model=effective_model,
+            http_client=http_client,
+        )
         if retry.success:
             msg = retry
             final_messages_root = retry_root

--- a/lib/config/anthropic_probe.py
+++ b/lib/config/anthropic_probe.py
@@ -51,9 +51,10 @@ async def _post(
     headers: dict[str, str],
     payload: dict[str, Any],
     timeout_s: float,
+    http_client: httpx.AsyncClient | None = None,
 ) -> httpx.Response:
-    """间接层：测试时 patch 这一个。"""
-    client = get_http_client()
+    """POST 出站间接层；``http_client`` 缺省时用共享客户端。"""
+    client = http_client or get_http_client()
     return await client.post(url, headers=headers, json=payload, timeout=timeout_s)
 
 
@@ -92,10 +93,7 @@ async def probe_messages(
     }
     started = time.perf_counter()
     try:
-        if http_client is None:
-            resp = await _post(url=url, headers=headers, payload=payload, timeout_s=timeout_s)
-        else:
-            resp = await http_client.post(url, headers=headers, json=payload, timeout=timeout_s)
+        resp = await _post(url=url, headers=headers, payload=payload, timeout_s=timeout_s, http_client=http_client)
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         logger.info("probe_messages timeout url=%s elapsed_ms=%d", url, elapsed)
@@ -157,9 +155,11 @@ def classify_probe_failure(result: ProbeResult) -> DiagnosisCode:
     return DiagnosisCode.UNKNOWN
 
 
-async def _get(*, url: str, headers: dict[str, str], timeout_s: float) -> httpx.Response:
-    """间接层：测试时 patch 这一个。"""
-    client = get_http_client()
+async def _get(
+    *, url: str, headers: dict[str, str], timeout_s: float, http_client: httpx.AsyncClient | None = None
+) -> httpx.Response:
+    """GET 出站间接层；``http_client`` 缺省时用共享客户端。"""
+    client = http_client or get_http_client()
     return await client.get(url, headers=headers, timeout=timeout_s)
 
 
@@ -177,10 +177,7 @@ async def probe_discovery(
     headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
     started = time.perf_counter()
     try:
-        if http_client is None:
-            resp = await _get(url=url, headers=headers, timeout_s=timeout_s)
-        else:
-            resp = await http_client.get(url, headers=headers, timeout=timeout_s)
+        resp = await _get(url=url, headers=headers, timeout_s=timeout_s, http_client=http_client)
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"timeout: {exc!s}")

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1249,10 +1249,10 @@ class ProjectManager:
         filename = self.normalize_script_filename(filename)
         real = Path(self._safe_subpath(project_dir / "scripts", filename))
 
-        if not real.exists():
-            raise FileNotFoundError(f"剧本文件不存在: {real}")
-
         if self._script_reader is None:
+            # 存在性检查只对文件系统这条路径成立；剧本是否存在由实际读取方判定。
+            if not real.exists():
+                raise FileNotFoundError(f"剧本文件不存在: {real}")
             with open(real, encoding="utf-8") as f:  # noqa: PTH123
                 script = json.load(f)
         else:

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -326,12 +326,20 @@ class ProjectManager:
             raise FileNotFoundError(f"当前目录不是有效的项目目录: {cwd}")
         return pm, project_name
 
-    def __init__(self, projects_root: str | Path | None = None):
+    def __init__(
+        self,
+        projects_root: str | Path | None = None,
+        *,
+        script_reader: Callable[[Path], dict] | None = None,
+        script_writer: Callable[[Path, dict], None] | None = None,
+    ):
         """
         初始化项目管理器
 
         Args:
             projects_root: 项目根目录，默认为当前目录下的 projects/
+            script_reader: 剧本 JSON 读取 seam；缺省时从文件系统读取。
+            script_writer: 剧本 JSON 原子写入 seam；缺省时使用 atomic_write_json。
         """
         if projects_root is None:
             # 尝试从环境变量或默认路径获取
@@ -339,6 +347,8 @@ class ProjectManager:
 
         self.projects_root = Path(projects_root)
         self.projects_root.mkdir(parents=True, exist_ok=True)
+        self._script_reader = script_reader
+        self._script_writer = script_writer
 
     def list_projects(self) -> list[str]:
         """列出所有项目"""
@@ -877,7 +887,10 @@ class ProjectManager:
         metadata["updated_at"] = now
 
         # 原子写（含路径遍历防护，output_path 已在守卫前解析），避免并发 PATCH 导致 JSON 损坏
-        atomic_write_json(output_path, script)
+        if self._script_writer is None:
+            atomic_write_json(output_path, script)
+        else:
+            self._script_writer(output_path, script)
 
         # 同步到 project.json，保证 script 写入与元数据同步是单一事务
         # （sync 走的是 `_project_lock`，与外层 `_script_lock` 不同锁，不会冲突）。
@@ -1225,8 +1238,11 @@ class ProjectManager:
         if not real.exists():
             raise FileNotFoundError(f"剧本文件不存在: {real}")
 
-        with open(real, encoding="utf-8") as f:  # noqa: PTH123
-            script = json.load(f)
+        if self._script_reader is None:
+            with open(real, encoding="utf-8") as f:  # noqa: PTH123
+                script = json.load(f)
+        else:
+            script = self._script_reader(real)
 
         migrated, warnings = migrate_script_unit_durations(script)
         for message in warnings:

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -1089,10 +1089,20 @@ class ProjectManager:
         else:
             self._script_writer(path, script)
 
-    @staticmethod
-    def _load_script_or_none(path: Path) -> dict | None:
-        """裸读剧本 JSON 取「改前」快照；文件不存在或损坏时返回 None（→ 按严格校验处理）。"""
-        loaded = load_json_or_none(path)
+    def _load_script_or_none(self, path: Path) -> dict | None:
+        """裸读剧本 JSON 取「改前」快照；剧本不存在或损坏时返回 None（→ 按严格校验处理）。
+
+        与 ``_read_script_unlocked`` 共用 ``script_reader`` seam，改前快照与正式读取取自同一
+        来源。注入的 reader 以 ``OSError``（不存在或不可读）或 ``ValueError``（内容损坏）表达
+        取不到剧本，本函数据此归一为 None；其余异常照常上抛。
+        """
+        if self._script_reader is None:
+            loaded = load_json_or_none(path)
+        else:
+            try:
+                loaded = self._script_reader(path)
+            except (OSError, ValueError):
+                return None
         return loaded if isinstance(loaded, dict) else None
 
     @staticmethod

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -887,10 +887,7 @@ class ProjectManager:
         metadata["updated_at"] = now
 
         # 原子写（含路径遍历防护，output_path 已在守卫前解析），避免并发 PATCH 导致 JSON 损坏
-        if self._script_writer is None:
-            atomic_write_json(output_path, script)
-        else:
-            self._script_writer(output_path, script)
+        self._persist_script_json(output_path, script)
 
         # 同步到 project.json，保证 script 写入与元数据同步是单一事务
         # （sync 走的是 `_project_lock`，与外层 `_script_lock` 不同锁，不会冲突）。
@@ -1085,6 +1082,13 @@ class ProjectManager:
                 f"episode={filename_episode} 不一致，拒绝操作以避免污染 project.json"
             )
 
+    def _persist_script_json(self, path: Path, script: dict) -> None:
+        """剧本 JSON 落盘的单一出口：缺省原子写，注入了 ``script_writer`` 时改走注入实现。"""
+        if self._script_writer is None:
+            atomic_write_json(path, script)
+        else:
+            self._script_writer(path, script)
+
     @staticmethod
     def _load_script_or_none(path: Path) -> dict | None:
         """裸读剧本 JSON 取「改前」快照；文件不存在或损坏时返回 None（→ 按严格校验处理）。"""
@@ -1213,7 +1217,7 @@ class ProjectManager:
             script, migrated = self._read_script_unlocked(project_name, norm)
             if migrated:
                 real = Path(self._safe_subpath(self.get_project_path(project_name) / "scripts", norm))
-                atomic_write_json(real, script)
+                self._persist_script_json(real, script)
         return script
 
     def load_script_readonly(self, project_name: str, filename: str) -> dict:

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -167,16 +167,24 @@ class ScriptGenerator:
     读取 Step 1/2 的 Markdown 中间文件，调用 TextBackend 生成最终 JSON 剧本
     """
 
-    def __init__(self, project_path: str | Path, generator: Optional["TextGenerator"] = None):
+    def __init__(
+        self,
+        project_path: str | Path,
+        generator: Optional["TextGenerator"] = None,
+        *,
+        config_resolver: ConfigResolver | None = None,
+    ):
         """
         初始化生成器
 
         Args:
             project_path: 项目目录路径，如 projects/test0205
             generator: TextGenerator 实例（可选）。若为 None 则仅支持 build_prompt() dry-run。
+            config_resolver: 能力解析器；缺省时使用连接生产数据库的 ConfigResolver。
         """
         self.project_path = Path(project_path)
         self.generator = generator
+        self.config_resolver = config_resolver or ConfigResolver(async_session_factory)
         self._step1_revision: str | None = None
         self._artifact_basis: ArtifactBasisDescriptor | None = None
         self._step1_input_claim: ArtifactInputClaim | None = None
@@ -208,11 +216,16 @@ class ScriptGenerator:
         return raw_outline if isinstance(raw_outline, dict) else {}
 
     @classmethod
-    async def create(cls, project_path: str | Path) -> "ScriptGenerator":
+    async def create(
+        cls,
+        project_path: str | Path,
+        *,
+        config_resolver: ConfigResolver | None = None,
+    ) -> "ScriptGenerator":
         """异步工厂方法，自动从 DB 加载供应商配置创建 TextGenerator。"""
         project_name = Path(project_path).name
         generator = await TextGenerator.create(TextTaskType.SCRIPT, project_name)
-        return cls(project_path, generator)
+        return cls(project_path, generator, config_resolver=config_resolver)
 
     async def generate(
         self,
@@ -700,8 +713,8 @@ class ScriptGenerator:
         （``docs/adr/0054``），fallback 会拿项目默认模型的档位去写剧本，写出来的时长 / 参考图
         数量执行期照样被拒。报错带 code 与修复指引，比先写一份必败的剧本更省事。
         """
-        resolver = ConfigResolver(async_session_factory)
         try:
+            resolver = getattr(self, "config_resolver", None) or ConfigResolver(async_session_factory)
             return await resolver.video_capabilities_for_project(self.project_json)
         except VideoBucketCapabilityError:
             raise

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -167,6 +167,9 @@ class ScriptGenerator:
     读取 Step 1/2 的 Markdown 中间文件，调用 TextBackend 生成最终 JSON 剧本
     """
 
+    # 类属性缺省，绕过 __init__ 构造的实例同样读到 None；解析时按需回退到生产 ConfigResolver。
+    config_resolver: ConfigResolver | None = None
+
     def __init__(
         self,
         project_path: str | Path,
@@ -180,11 +183,11 @@ class ScriptGenerator:
         Args:
             project_path: 项目目录路径，如 projects/test0205
             generator: TextGenerator 实例（可选）。若为 None 则仅支持 build_prompt() dry-run。
-            config_resolver: 能力解析器；缺省时使用连接生产数据库的 ConfigResolver。
+            config_resolver: 能力解析器；缺省时解析期构造连接生产数据库的 ConfigResolver。
         """
         self.project_path = Path(project_path)
         self.generator = generator
-        self.config_resolver = config_resolver or ConfigResolver(async_session_factory)
+        self.config_resolver = config_resolver
         self._step1_revision: str | None = None
         self._artifact_basis: ArtifactBasisDescriptor | None = None
         self._step1_input_claim: ArtifactInputClaim | None = None
@@ -713,8 +716,8 @@ class ScriptGenerator:
         （``docs/adr/0054``），fallback 会拿项目默认模型的档位去写剧本，写出来的时长 / 参考图
         数量执行期照样被拒。报错带 code 与修复指引，比先写一份必败的剧本更省事。
         """
+        resolver = self.config_resolver or ConfigResolver(async_session_factory)
         try:
-            resolver = getattr(self, "config_resolver", None) or ConfigResolver(async_session_factory)
             return await resolver.video_capabilities_for_project(self.project_json)
         except VideoBucketCapabilityError:
             raise

--- a/server/agent_runtime/sdk_tools/_context.py
+++ b/server/agent_runtime/sdk_tools/_context.py
@@ -27,12 +27,20 @@ class ToolContext:
     to ``project_name`` via ``build_arcreel_mcp_server(project_name=...)``.
     """
 
-    def __init__(self, project_name: str, projects_root: Path, pm: ProjectManager | None = None):
+    def __init__(
+        self,
+        project_name: str,
+        projects_root: Path,
+        pm: ProjectManager | None = None,
+        *,
+        config_resolver: ConfigResolver | None = None,
+    ):
         self.project_name = project_name
         self.projects_root = projects_root
         # Avoid ``ProjectManager.from_cwd()`` — the server main process cwd is
         # the repo root, not ``projects/<name>/``. Tests may inject a fake pm.
         self.pm: ProjectManager = pm if pm is not None else ProjectManager(str(projects_root))
+        self.config_resolver = config_resolver
 
     @property
     def project_path(self) -> Path:
@@ -120,7 +128,12 @@ def read_instructions_arg(args: dict[str, Any]) -> tuple[str | None, dict[str, A
     return (text or None), None
 
 
-async def resolve_video_caps(project: dict[str, Any], *, capability: VideoCapability | None = None) -> dict[str, Any]:
+async def resolve_video_caps(
+    project: dict[str, Any],
+    *,
+    capability: VideoCapability | None = None,
+    config_resolver: ConfigResolver | None = None,
+) -> dict[str, Any]:
     """Resolve the full video capability dict for an MCP tool call.
 
     Single source of truth for video model capability lookup across SDK MCP
@@ -131,7 +144,7 @@ async def resolve_video_caps(project: dict[str, Any], *, capability: VideoCapabi
     能力按项目生成模式解析——生成模式创建即定、全项目同一条，Agent 拿到的与执行层同口径。
     ``capability`` 给定时按指定桶解析（参考生视频内无参考图视频单元的 i2v 读侧）。
     """
-    resolver = ConfigResolver(async_session_factory)
+    resolver = config_resolver or ConfigResolver(async_session_factory)
     return await resolver.video_capabilities_for_project(project, capability=capability)
 
 
@@ -165,6 +178,8 @@ async def reference_unit_duration_tiers(
     project: dict[str, Any],
     caps: dict[str, Any],
     durations: list[int],
+    *,
+    config_resolver: ConfigResolver | None = None,
 ) -> tuple[list[int], list[int]]:
     """参考生视频逐 unit 的两套生效档位：``(带参考图, 不带参考图)``。
 
@@ -188,7 +203,10 @@ async def reference_unit_duration_tiers(
     )
     i2v_caps, i2v_durations = caps, durations
     try:
-        resolved = await resolve_video_caps(project, capability="i2v")
+        if config_resolver is None:
+            resolved = await resolve_video_caps(project, capability="i2v")
+        else:
+            resolved = await resolve_video_caps(project, capability="i2v", config_resolver=config_resolver)
         resolved_durations = [int(d) for d in resolved.get("supported_durations") or []]
         if resolved_durations:
             i2v_caps, i2v_durations = resolved, resolved_durations
@@ -201,7 +219,10 @@ async def reference_unit_duration_tiers(
 
 
 async def fetch_video_caps(
-    project: dict[str, Any], *, generation_mode: str | None = None
+    project: dict[str, Any],
+    *,
+    generation_mode: str | None = None,
+    config_resolver: ConfigResolver | None = None,
 ) -> tuple[int | None, list[int]]:
     """Resolve ``(default_duration, supported_durations)`` for an MCP tool call.
 
@@ -211,7 +232,10 @@ async def fetch_video_caps(
     Callers decide whether an empty result is a hard error (video generation) or
     a soft fallback (script normalization).
     """
-    caps = await resolve_video_caps(project)
+    if config_resolver is None:
+        caps = await resolve_video_caps(project)
+    else:
+        caps = await resolve_video_caps(project, config_resolver=config_resolver)
     durations = [int(d) for d in caps.get("supported_durations") or []]
     durations = constrained_caps_durations(project, caps, durations, generation_mode=generation_mode)
     default = caps.get("default_duration")

--- a/server/agent_runtime/sdk_tools/enqueue_image_edits.py
+++ b/server/agent_runtime/sdk_tools/enqueue_image_edits.py
@@ -55,13 +55,18 @@ _LABEL_ZH: dict[str, str] = {
 }
 
 
-async def _i2i_provider_available(project: dict[str, Any]) -> bool:
+async def _i2i_provider_available(
+    project: dict[str, Any],
+    *,
+    config_resolver: ConfigResolver | None = None,
+) -> bool:
     """项目 i2i 槽解析不出可用供应商时返回 False——与 HTTP 端点入队前 fail-fast 同一判断点
     （见 ``server/routers/generate.py::_require_i2i_image_provider_configured``），批量编辑
     只需要一次「是否可用」的项目级判断，不像端点那样需要拿到 provider_id 传给入队。
     """
     try:
-        await ConfigResolver(async_session_factory).resolve_image_backend(project, None, capability="i2i")
+        resolver = config_resolver or ConfigResolver(async_session_factory)
+        await resolver.resolve_image_backend(project, None, capability="i2i")
     except ValueError:
         return False
     return True
@@ -265,7 +270,11 @@ def edit_images_tool(ctx: ToolContext):
             builder = GenerationResultBuilder(_OPERATION, GenerationSelectionMode.EXPLICIT)
             states: dict[str, GenerationTargetState] = {}
 
-            if not await _i2i_provider_available(project):
+            if ctx.config_resolver is None:
+                provider_available = await _i2i_provider_available(project)
+            else:
+                provider_available = await _i2i_provider_available(project, config_resolver=ctx.config_resolver)
+            if not provider_available:
                 # 拦截在入队前：不是某个 ID 的产物问题，是整批共享的前置条件不满足，
                 # 但调用方仍按逐 ID 契约读结果，因此每个请求到的 ID 各记一条 blocked，
                 # 而不是只回一段无法编程消费的文本。

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -16,7 +16,7 @@ from collections import Counter
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, Protocol, cast
 
 from claude_agent_sdk import tool
 from pydantic import BaseModel, ValidationError
@@ -196,6 +196,11 @@ def _load_step1_source_with_basis(
 # ---------------------------------------------------------------------------
 # get_video_capabilities
 # ---------------------------------------------------------------------------
+
+# 本模块的能力查询函数（``_resolve_video_capabilities`` / ``_fetch_caps_with_fallback`` /
+# ``_fetch_reference_caps_with_fallback`` 及 ``_context`` 的 ``resolve_video_caps`` /
+# ``fetch_video_caps``）未注入解析器时一律省略 ``config_resolver`` 关键字，不传 ``None``：
+# 既有用例把这些符号整体替换为不接受该关键字的假实现，缺省路径须与注入前逐字同形。
 
 
 async def _resolve_video_capabilities(
@@ -1899,9 +1904,21 @@ class Step1DraftRevalidation(NamedTuple):
 #: 只有一个草稿位的两条路线（drama / narration）→ 该变体的重判器。两者的结果同型
 #: （``SingleStep1DraftRevalidation``），归一到呈现层口径的那一步逐字相同，故按 kind 查表而非
 #: 各写一条分支。参考生视频不在表内：它的重判结果另带扁平 units 与档位，归一方式本就不同。
-_SINGLE_STEP1_REVALIDATORS: dict[
-    str, Callable[[Path, dict[str, Any], int, QuarantinedDraft], Awaitable[SingleStep1DraftRevalidation]]
-] = {
+class _SingleStep1Revalidator(Protocol):
+    """表内重判器的调用形状：草稿定位参数同形，能力解析器按关键字注入。"""
+
+    def __call__(
+        self,
+        project_path: Path,
+        project: dict[str, Any],
+        episode: int,
+        draft: QuarantinedDraft,
+        *,
+        config_resolver: ConfigResolver | None = None,
+    ) -> Awaitable[SingleStep1DraftRevalidation]: ...
+
+
+_SINGLE_STEP1_REVALIDATORS: dict[str, _SingleStep1Revalidator] = {
     QUARANTINE_KIND_DRAMA_STEP1: revalidate_drama_step1_draft,
     QUARANTINE_KIND_NARRATION_STEP1: revalidate_narration_step1_draft,
 }
@@ -1936,22 +1953,7 @@ async def revalidate_step1_draft(
     revalidator = _SINGLE_STEP1_REVALIDATORS.get(draft.kind)
     if revalidator is None:
         raise ValueError(f"不是 step1 草稿来源，无法重判: {draft.kind}")
-    if draft.kind == QUARANTINE_KIND_DRAMA_STEP1:
-        single = await revalidate_drama_step1_draft(
-            project_path,
-            project,
-            episode,
-            draft,
-            config_resolver=config_resolver,
-        )
-    else:
-        single = await revalidate_narration_step1_draft(
-            project_path,
-            project,
-            episode,
-            draft,
-            config_resolver=config_resolver,
-        )
+    single = await revalidator(project_path, project, episode, draft, config_resolver=config_resolver)
     return Step1DraftRevalidation(single.violations, None if single.schema_failed else single.content)
 
 

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -200,7 +200,7 @@ def _load_step1_source_with_basis(
 # 本模块的能力查询函数（``_resolve_video_capabilities`` / ``_fetch_caps_with_fallback`` /
 # ``_fetch_reference_caps_with_fallback`` 及 ``_context`` 的 ``resolve_video_caps`` /
 # ``fetch_video_caps``）未注入解析器时一律省略 ``config_resolver`` 关键字，不传 ``None``：
-# 既有用例把这些符号整体替换为不接受该关键字的假实现，缺省路径须与注入前逐字同形。
+# 这些符号会被整体替换为不接受该关键字的替身，调用形状须与不带该关键字的签名兼容。
 
 
 async def _resolve_video_capabilities(

--- a/server/agent_runtime/sdk_tools/text_generation.py
+++ b/server/agent_runtime/sdk_tools/text_generation.py
@@ -198,12 +198,21 @@ def _load_step1_source_with_basis(
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_video_capabilities(project_name: str) -> dict[str, Any]:
-    resolver = ConfigResolver(async_session_factory)
+async def _resolve_video_capabilities(
+    project_name: str,
+    *,
+    config_resolver: ConfigResolver | None = None,
+) -> dict[str, Any]:
+    resolver = config_resolver or ConfigResolver(async_session_factory)
     return await resolver.video_capabilities(project_name)
 
 
-async def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[str, Any]) -> None:
+async def _annotate_reference_unit_tiers(
+    payload: dict[str, Any],
+    project: dict[str, Any],
+    *,
+    config_resolver: ConfigResolver | None = None,
+) -> None:
     """就地补上参考生视频路径逐 unit 的两套生效档位（非该路径的项目不补）。
 
     ``supported_durations`` 是型号声明的全集，不含「分辨率↔时长」「参考图↔时长」两条联动约束。
@@ -218,7 +227,12 @@ async def _annotate_reference_unit_tiers(payload: dict[str, Any], project: dict[
     durations = [int(d) for d in payload.get("supported_durations") or []]
     if not durations:
         return
-    with_refs, without_refs = await reference_unit_duration_tiers(project, payload, durations)
+    with_refs, without_refs = await reference_unit_duration_tiers(
+        project,
+        payload,
+        durations,
+        config_resolver=config_resolver,
+    )
     payload["reference_unit_durations"] = {
         "with_references": with_refs,
         "without_references": without_refs,
@@ -235,8 +249,19 @@ def get_video_capabilities_tool(ctx: ToolContext):
     )
     async def _handler(_args: dict[str, Any]) -> dict[str, Any]:
         try:
-            payload = await _resolve_video_capabilities(ctx.project_name)
-            await _annotate_reference_unit_tiers(payload, ctx.pm.load_project(ctx.project_name))
+            if ctx.config_resolver is None:
+                payload = await _resolve_video_capabilities(ctx.project_name)
+                await _annotate_reference_unit_tiers(payload, ctx.pm.load_project(ctx.project_name))
+            else:
+                payload = await _resolve_video_capabilities(
+                    ctx.project_name,
+                    config_resolver=ctx.config_resolver,
+                )
+                await _annotate_reference_unit_tiers(
+                    payload,
+                    ctx.pm.load_project(ctx.project_name),
+                    config_resolver=ctx.config_resolver,
+                )
             return {"content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False, indent=2)}]}
         except FileNotFoundError as exc:
             return {
@@ -380,7 +405,10 @@ def generate_episode_script_tool(ctx: ToolContext):
                     }
 
             if dry_run:
-                generator = ScriptGenerator(project_path)
+                if ctx.config_resolver is None:
+                    generator = ScriptGenerator(project_path)
+                else:
+                    generator = ScriptGenerator(project_path, config_resolver=ctx.config_resolver)
                 prompt = await generator.build_prompt(episode, instructions=instructions)
                 return {
                     "content": [{"type": "text", "text": f"DRY RUN — 以下是将发送给文本模型的 Prompt:\n\n{prompt}"}]
@@ -403,7 +431,10 @@ def generate_episode_script_tool(ctx: ToolContext):
                     "is_error": True,
                 }
 
-            generator = await ScriptGenerator.create(project_path)
+            if ctx.config_resolver is None:
+                generator = await ScriptGenerator.create(project_path)
+            else:
+                generator = await ScriptGenerator.create(project_path, config_resolver=ctx.config_resolver)
             result_path = await generator.generate(episode=episode, instructions=instructions)
             return {"content": [{"type": "text", "text": f"✅ 剧本生成完成: {result_path}"}]}
         except FileNotFoundError as exc:
@@ -438,7 +469,7 @@ def confirm_script_review_tool(ctx: ToolContext):
             # 延迟导入避免 sdk_tools 在导入期耦合 server.services。
             from server.services.script_review import ScriptReviewError, ScriptReviewService
 
-            service = ScriptReviewService(ctx.pm)
+            service = ScriptReviewService(ctx.pm, config_resolver=ctx.config_resolver)
             try:
                 state = await service.confirm(ctx.project_name, episode)
             except ScriptReviewError as exc:
@@ -467,7 +498,12 @@ def confirm_script_review_tool(ctx: ToolContext):
 # ---------------------------------------------------------------------------
 
 
-async def _fetch_caps_with_fallback(project: dict[str, Any], episode: int) -> tuple[int | None, list[int]]:
+async def _fetch_caps_with_fallback(
+    project: dict[str, Any],
+    episode: int,
+    *,
+    config_resolver: ConfigResolver | None = None,
+) -> tuple[int | None, list[int]]:
     """Script normalization is best-effort: prompt生成 不该被能力查询失败堵住。
 
     Soft-fallbacks to ``duration_presets.DEFAULT_FALLBACK`` so the LLM still
@@ -484,7 +520,14 @@ async def _fetch_caps_with_fallback(project: dict[str, Any], episode: int) -> tu
     越界默认时长」变成整个工具的硬失败。与 ``_fetch_reference_caps_with_fallback`` 同口径。
     """
     try:
-        default_int, durations = await fetch_video_caps(project, generation_mode=None)
+        if config_resolver is None:
+            default_int, durations = await fetch_video_caps(project, generation_mode=None)
+        else:
+            default_int, durations = await fetch_video_caps(
+                project,
+                generation_mode=None,
+                config_resolver=config_resolver,
+            )
     except (FileNotFoundError, ValueError) as exc:
         logger.info("video_capabilities 不可解析，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         return None, list(DEFAULT_FALLBACK)
@@ -542,7 +585,14 @@ def normalize_drama_script_tool(ctx: ToolContext):
             except ValueError as exc:
                 return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
-            default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+            if ctx.config_resolver is None:
+                default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+            else:
+                default_duration, supported_durations = await _fetch_caps_with_fallback(
+                    project,
+                    episode,
+                    config_resolver=ctx.config_resolver,
+                )
             prompt = build_normalize_prompt(
                 novel_text=novel_text,
                 project_overview=cast(dict[str, Any], prompt_inputs["project_overview"]),
@@ -662,7 +712,12 @@ class ReferenceSplitCaps(NamedTuple):
         return self.reference_durations if has_references else self.text_durations
 
 
-async def _fetch_reference_caps_with_fallback(project: dict[str, Any], episode: int) -> ReferenceSplitCaps:
+async def _fetch_reference_caps_with_fallback(
+    project: dict[str, Any],
+    episode: int,
+    *,
+    config_resolver: ConfigResolver | None = None,
+) -> ReferenceSplitCaps:
     """解析 rv 拆分所需的视频能力（见 ``ReferenceSplitCaps``）。
 
     与 ``_fetch_caps_with_fallback`` 同口径 best-effort：resolver 故障时回退
@@ -680,14 +735,17 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any], episode: 
     ``default_duration`` 非并集成员（用户配置漂移）按 None 处理，避免 prompt 自相矛盾。
     """
     try:
-        caps = await resolve_video_caps(project)
+        if config_resolver is None:
+            caps = await resolve_video_caps(project)
+        else:
+            caps = await resolve_video_caps(project, config_resolver=config_resolver)
     except Exception as exc:  # noqa: BLE001
         logger.warning("video_capabilities 查询异常，使用 fallback %s：%s", DEFAULT_FALLBACK, exc)
         caps = {}
         # requested_generate_audio 不依赖能力接口（见 generation_context.py 同名字段注释），
         # 能力解析失败也不能连带丢失，否则本该报的 WARN_SILENT_EPISODE 会静默消失。
         try:
-            resolver = ConfigResolver(async_session_factory)
+            resolver = config_resolver or ConfigResolver(async_session_factory)
             caps["requested_generate_audio"] = await resolver.video_generate_audio_for_project(project)
         except Exception as inner_exc:  # noqa: BLE001
             # 与其余能力字段的「不明时不额外收紧」相反：这里不明时收紧到 False——静默丢掉
@@ -697,7 +755,12 @@ async def _fetch_reference_caps_with_fallback(project: dict[str, Any], episode: 
     durations = [int(d) for d in caps.get("supported_durations") or []]
     if not durations:
         durations = list(DEFAULT_FALLBACK)
-    with_refs, without_refs = await reference_unit_duration_tiers(project, caps, durations)
+    with_refs, without_refs = await reference_unit_duration_tiers(
+        project,
+        caps,
+        durations,
+        config_resolver=config_resolver,
+    )
     unit_durations = sorted(set(with_refs) | set(without_refs))
     max_duration = max(unit_durations)
     raw_refs = caps.get("max_reference_images")
@@ -899,7 +962,12 @@ class ReferenceDraftRevalidation(NamedTuple):
 
 
 async def revalidate_reference_step1_draft(
-    project_path: Path, project: dict[str, Any], episode: int, draft: QuarantinedDraft
+    project_path: Path,
+    project: dict[str, Any],
+    episode: int,
+    draft: QuarantinedDraft,
+    *,
+    config_resolver: ConfigResolver | None = None,
 ) -> ReferenceDraftRevalidation:
     """按产出时那套校验器全量重判 step1 草稿，只读、不写盘、不清草稿。
 
@@ -932,7 +1000,14 @@ async def revalidate_reference_step1_draft(
         episode,
         "reference_video",
     )
-    split_caps = await _fetch_reference_caps_with_fallback(project, episode)
+    if config_resolver is None:
+        split_caps = await _fetch_reference_caps_with_fallback(project, episode)
+    else:
+        split_caps = await _fetch_reference_caps_with_fallback(
+            project,
+            episode,
+            config_resolver=config_resolver,
+        )
 
     # 手改过的草稿先过产出时那份 schema：拆分侧由 response_schema 与 _parse_step1_json 卡住时长
     # 枚举与字段非空，晋升侧漏掉这一层的话，把 duration_seconds 改成非档位值、或整个删掉（收成
@@ -983,7 +1058,13 @@ async def _promote_reference_step1(ctx: ToolContext, episode: int, draft: Quaran
     """按产出时那套校验器全量重判 step1 草稿，通过则晋升为正式 step1 并清除草稿。"""
     project_path = ctx.project_path
     project = ctx.pm.load_project(ctx.project_name)
-    revalidation = await revalidate_reference_step1_draft(project_path, project, episode, draft)
+    revalidation = await revalidate_reference_step1_draft(
+        project_path,
+        project,
+        episode,
+        draft,
+        config_resolver=ctx.config_resolver,
+    )
     violations, flat_units, split_caps = revalidation.violations, revalidation.flat_units, revalidation.caps
     if revalidation.schema_failed:
         # schema 违约：写回 Agent 手里那份原样内容，不做收编——字段被改坏时收编会把它的原稿
@@ -1163,7 +1244,12 @@ class SingleStep1DraftRevalidation(NamedTuple):
 
 
 async def revalidate_drama_step1_draft(
-    project_path: Path, project: dict[str, Any], episode: int, draft: QuarantinedDraft
+    project_path: Path,
+    project: dict[str, Any],
+    episode: int,
+    draft: QuarantinedDraft,
+    *,
+    config_resolver: ConfigResolver | None = None,
 ) -> SingleStep1DraftRevalidation:
     """按产出时那套校验器全量重判 drama step1 草稿，只读、不写盘、不清草稿。
 
@@ -1186,7 +1272,14 @@ async def revalidate_drama_step1_draft(
         episode,
         "drama",
     )
-    _default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+    if config_resolver is None:
+        _default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+    else:
+        _default_duration, supported_durations = await _fetch_caps_with_fallback(
+            project,
+            episode,
+            config_resolver=config_resolver,
+        )
     schema = build_drama_normalized_script_model(supported_durations)
     try:
         content = schema.model_validate(draft.content).model_dump()
@@ -1216,7 +1309,13 @@ async def _promote_drama_step1(ctx: ToolContext, episode: int, draft: Quarantine
     project_path = ctx.project_path
     project = ctx.pm.load_project(ctx.project_name)
     try:
-        revalidation = await revalidate_drama_step1_draft(project_path, project, episode, draft)
+        revalidation = await revalidate_drama_step1_draft(
+            project_path,
+            project,
+            episode,
+            draft,
+            config_resolver=ctx.config_resolver,
+        )
     except ValueError as exc:
         return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
@@ -1544,7 +1643,12 @@ def _collect_narration_violations(
 
 
 async def revalidate_narration_step1_draft(
-    project_path: Path, project: dict[str, Any], episode: int, draft: QuarantinedDraft
+    project_path: Path,
+    project: dict[str, Any],
+    episode: int,
+    draft: QuarantinedDraft,
+    *,
+    config_resolver: ConfigResolver | None = None,
 ) -> SingleStep1DraftRevalidation:
     """按产出时那套校验器全量重判 narration step1 草稿，只读、不写盘、不清草稿。
 
@@ -1576,7 +1680,14 @@ async def revalidate_narration_step1_draft(
         episode,
         "narration",
     )
-    _default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+    if config_resolver is None:
+        _default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+    else:
+        _default_duration, supported_durations = await _fetch_caps_with_fallback(
+            project,
+            episode,
+            config_resolver=config_resolver,
+        )
 
     # 手改过的草稿先过产出时那份 schema：拆分侧由 response_schema 与 _parse_step1_json 卡住字段与
     # 类型，晋升侧漏掉这一层的话，把 duration_seconds 改成字符串、或整个删掉 novel_text 都能一路
@@ -1636,7 +1747,13 @@ async def _promote_narration_step1(ctx: ToolContext, episode: int, draft: Quaran
     project_path = ctx.project_path
     project = ctx.pm.load_project(ctx.project_name)
     try:
-        revalidation = await revalidate_narration_step1_draft(project_path, project, episode, draft)
+        revalidation = await revalidate_narration_step1_draft(
+            project_path,
+            project,
+            episode,
+            draft,
+            config_resolver=ctx.config_resolver,
+        )
     except ValueError as exc:
         return {"content": [{"type": "text", "text": f"❌ {exc}"}], "is_error": True}
 
@@ -1791,7 +1908,12 @@ _SINGLE_STEP1_REVALIDATORS: dict[
 
 
 async def revalidate_step1_draft(
-    project_path: Path, project: dict[str, Any], episode: int, draft: QuarantinedDraft
+    project_path: Path,
+    project: dict[str, Any],
+    episode: int,
+    draft: QuarantinedDraft,
+    *,
+    config_resolver: ConfigResolver | None = None,
 ) -> Step1DraftRevalidation:
     """把一份 step1 草稿交给它那条路线的重判器，返回路线中立的重判结果。
 
@@ -1802,13 +1924,34 @@ async def revalidate_step1_draft(
     ``draft.kind`` 不是 step1 的三个来源之一（如误传 step2 草稿）时抛 ``ValueError``。
     """
     if draft.kind == QUARANTINE_KIND_STEP1:
-        reference = await revalidate_reference_step1_draft(project_path, project, episode, draft)
+        reference = await revalidate_reference_step1_draft(
+            project_path,
+            project,
+            episode,
+            draft,
+            config_resolver=config_resolver,
+        )
         content = None if reference.schema_failed else {"units": reference.flat_units}
         return Step1DraftRevalidation(reference.violations, content)
     revalidator = _SINGLE_STEP1_REVALIDATORS.get(draft.kind)
     if revalidator is None:
         raise ValueError(f"不是 step1 草稿来源，无法重判: {draft.kind}")
-    single = await revalidator(project_path, project, episode, draft)
+    if draft.kind == QUARANTINE_KIND_DRAMA_STEP1:
+        single = await revalidate_drama_step1_draft(
+            project_path,
+            project,
+            episode,
+            draft,
+            config_resolver=config_resolver,
+        )
+    else:
+        single = await revalidate_narration_step1_draft(
+            project_path,
+            project,
+            episode,
+            draft,
+            config_resolver=config_resolver,
+        )
     return Step1DraftRevalidation(single.violations, None if single.schema_failed else single.content)
 
 
@@ -2015,7 +2158,14 @@ def split_reference_video_units_tool(ctx: ToolContext):
             scenes = cast(dict[str, Any], prompt_inputs["scenes"])
             props = cast(dict[str, Any], prompt_inputs["props"])
 
-            split_caps = await _fetch_reference_caps_with_fallback(project, episode)
+            if ctx.config_resolver is None:
+                split_caps = await _fetch_reference_caps_with_fallback(project, episode)
+            else:
+                split_caps = await _fetch_reference_caps_with_fallback(
+                    project,
+                    episode,
+                    config_resolver=ctx.config_resolver,
+                )
             prompt = build_reference_units_split_prompt(
                 novel_text=novel_text,
                 project_overview=cast(dict[str, Any], prompt_inputs["project_overview"]),
@@ -2226,7 +2376,10 @@ def validate_and_promote_draft_tool(ctx: ToolContext):
                     }
                 # 用异步工厂而非裸构造：晋升同样经 _add_metadata 落盘，裸构造会把
                 # metadata.generator 记成 "unknown"，与直接生成路径的同一份产物对不上。
-                generator = await ScriptGenerator.create(project_path)
+                if ctx.config_resolver is None:
+                    generator = await ScriptGenerator.create(project_path)
+                else:
+                    generator = await ScriptGenerator.create(project_path, config_resolver=ctx.config_resolver)
                 result_path = await generator.promote_reference_step2_draft(episode)
                 return {"content": [{"type": "text", "text": f"✅ step2 视觉展开已校验通过并晋升: {result_path}"}]}
 
@@ -2297,7 +2450,14 @@ def split_narration_segments_tool(ctx: ToolContext):
 
             # narration 仅需 (default_duration, supported_durations)：无 unit 总时长 / 参考图概念，
             # 复用与 drama normalize 同口径的 best-effort 能力查询（resolver 故障软回退 [4,6,8]）。
-            default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+            if ctx.config_resolver is None:
+                default_duration, supported_durations = await _fetch_caps_with_fallback(project, episode)
+            else:
+                default_duration, supported_durations = await _fetch_caps_with_fallback(
+                    project,
+                    episode,
+                    config_resolver=ctx.config_resolver,
+                )
             prompt = build_narration_split_prompt(
                 novel_text=novel_text,
                 project_overview=cast(dict[str, Any], prompt_inputs["project_overview"]),

--- a/server/app.py
+++ b/server/app.py
@@ -16,8 +16,10 @@ import platform
 import shutil
 import subprocess
 import time
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -155,7 +157,12 @@ def _diagnose_bwrap_failure() -> str:
     return "\n".join(parts)
 
 
-def check_sandbox_available() -> bool:
+def check_sandbox_available(
+    *,
+    platform_system: Callable[[], str] | None = None,
+    executable_which: Callable[[str], str | None] | None = None,
+    subprocess_run: Callable[..., subprocess.CompletedProcess[bytes]] | None = None,
+) -> bool:
     """启动期检测 sandbox 工具可用性。
 
     返回 ``True`` 表示沙箱可用且必须启用；返回 ``False`` 表示 SDK 不支持
@@ -165,9 +172,11 @@ def check_sandbox_available() -> bool:
     ``AgentAccessPolicy.WINDOWS_BASH_PREFIX_WHITELIST`` 代码白名单。
     macOS / Linux 工具缺失仍硬失败（受支持平台禁止降级）。
     """
-    system = platform.system()
+    system = (platform_system or platform.system)()
+    which = executable_which or shutil.which
+    run = subprocess_run or subprocess.run
     if system == "Darwin":
-        if shutil.which("sandbox-exec") is None:
+        if which("sandbox-exec") is None:
             raise RuntimeError(
                 "SANDBOX_UNAVAILABLE on macOS\n"
                 "  sandbox-exec: not found in PATH (should be system-installed)\n"
@@ -177,7 +186,7 @@ def check_sandbox_available() -> bool:
     if system == "Linux":
         # Linux 依赖见 https://code.claude.com/docs/en/sandboxing#set-up-linux-and-wsl2：需同时安装
         # （bwrap 做进程/文件隔离，socat 做网络代理转发）。
-        missing = [name for name in ("bwrap", "socat") if shutil.which(name) is None]
+        missing = [name for name in ("bwrap", "socat") if which(name) is None]
         if missing:
             raise RuntimeError(
                 "SANDBOX_UNAVAILABLE on linux\n"
@@ -205,7 +214,7 @@ def check_sandbox_available() -> bool:
             "/bin/true",
         ]
         try:
-            probe = subprocess.run(probe_cmd, capture_output=True, timeout=5, check=False)
+            probe = run(probe_cmd, capture_output=True, timeout=5, check=False)
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise RuntimeError(
                 "SANDBOX_BWRAP_BROKEN on Linux\n"
@@ -233,15 +242,21 @@ _DOCKERENV_PATH = Path("/.dockerenv")
 _CGROUP_PATH = Path("/proc/1/cgroup")
 
 
-def detect_docker_environment() -> bool:
+def detect_docker_environment(
+    *,
+    dockerenv_path: Path | None = None,
+    cgroup_path: Path | None = None,
+) -> bool:
     """启动期一次性检测当前是否在 Docker / Podman 容器内。
 
     用于决定是否启用 ``SandboxSettings.enableWeakerNestedSandbox``。
     """
-    if _DOCKERENV_PATH.exists():
+    docker_marker = dockerenv_path or _DOCKERENV_PATH
+    cgroup = cgroup_path or _CGROUP_PATH
+    if docker_marker.exists():
         return True
     try:
-        content = _CGROUP_PATH.read_text(encoding="utf-8", errors="ignore")
+        content = cgroup.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
     return "docker" in content or "podman" in content
@@ -271,9 +286,14 @@ def _log_profile_sync_outcome(stats: dict, *, log: logging.Logger = logger) -> N
         log.info("agent_runtime profile 物化完成: %s", stats)
 
 
-async def _migrate_source_encoding_on_startup(projects_root: Path) -> dict[str, dict]:
+async def _migrate_source_encoding_on_startup(
+    projects_root: Path,
+    *,
+    migrate_source_encoding: Callable[[Path], Any] | None = None,
+) -> dict[str, dict]:
     """对每个项目执行幂等编码迁移。失败被捕获并写日志，不阻塞启动。"""
     summary: dict[str, dict] = {}
+    migrate = migrate_source_encoding or migrate_project_source_encoding
     if not projects_root.exists():
         return summary
 
@@ -283,7 +303,7 @@ async def _migrate_source_encoding_on_startup(projects_root: Path) -> dict[str, 
         if marker.exists():
             return {"skipped": True}
         try:
-            result = migrate_project_source_encoding(project_dir)
+            result = migrate(project_dir)
             marker_dir.mkdir(exist_ok=True)
             marker.touch()
             if result.failed:

--- a/server/routers/custom_providers.py
+++ b/server/routers/custom_providers.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import AfterValidator, BaseModel, Field, field_validator
@@ -902,13 +902,19 @@ async def test_connection_by_id(provider_id: int, _t: Translator, session: Async
 
 
 async def _run_discover(
-    discovery_format: str, base_url: str | None, api_key: str, _t: Callable[..., str]
+    discovery_format: str,
+    base_url: str | None,
+    api_key: str,
+    _t: Callable[..., str],
+    *,
+    discover_models_fn: Callable[..., Awaitable[list[dict]]] | None = None,
 ) -> DiscoverResponse:
     """共用的模型发现逻辑（明文凭证 / 已存储凭证两条入口共用）。"""
     from lib.custom_provider.discovery import UnsupportedDiscoveryFormatError, discover_models
 
     try:
-        models = await discover_models(
+        discover = discover_models_fn or discover_models
+        models = await discover(
             discovery_format=discovery_format,
             base_url=base_url or None,
             api_key=api_key,
@@ -925,18 +931,24 @@ async def _run_discover(
 
 
 async def _run_connection_test(
-    discovery_format: str, base_url: str, api_key: str, _t: Callable[..., str]
+    discovery_format: str,
+    base_url: str,
+    api_key: str,
+    _t: Callable[..., str],
+    *,
+    openai_probe: Callable[[str, str, Callable[..., str]], ConnectionTestResponse] | None = None,
+    google_probe: Callable[[str, str, Callable[..., str]], ConnectionTestResponse] | None = None,
 ) -> ConnectionTestResponse:
     """共用的连接测试逻辑。"""
     try:
         if discovery_format == "openai":
             result = await asyncio.wait_for(
-                asyncio.to_thread(_test_openai, base_url, api_key, _t),
+                asyncio.to_thread(openai_probe or _test_openai, base_url, api_key, _t),
                 timeout=_CONNECTION_TEST_TIMEOUT,
             )
         elif discovery_format == "google":
             result = await asyncio.wait_for(
-                asyncio.to_thread(_test_google, base_url, api_key, _t),
+                asyncio.to_thread(google_probe or _test_google, base_url, api_key, _t),
                 timeout=_CONNECTION_TEST_TIMEOUT,
             )
         else:
@@ -961,13 +973,19 @@ async def _run_connection_test(
         )
 
 
-def _test_openai(base_url: str, api_key: str, _t: Callable[..., str]) -> ConnectionTestResponse:
+def _test_openai(
+    base_url: str,
+    api_key: str,
+    _t: Callable[..., str],
+    *,
+    client_factory: Callable[..., Any] | None = None,
+) -> ConnectionTestResponse:
     """通过 models.list() 验证 OpenAI 兼容 API。"""
     from openai import OpenAI
 
     from lib.config.url_utils import ensure_openai_base_url
 
-    client = OpenAI(api_key=api_key, base_url=ensure_openai_base_url(base_url))
+    client = (client_factory or OpenAI)(api_key=api_key, base_url=ensure_openai_base_url(base_url))
     models = client.models.list()
     count = sum(1 for _ in models)
     return ConnectionTestResponse(
@@ -977,7 +995,13 @@ def _test_openai(base_url: str, api_key: str, _t: Callable[..., str]) -> Connect
     )
 
 
-def _test_google(base_url: str, api_key: str, _t: Callable[..., str]) -> ConnectionTestResponse:
+def _test_google(
+    base_url: str,
+    api_key: str,
+    _t: Callable[..., str],
+    *,
+    client_factory: Callable[..., Any] | None = None,
+) -> ConnectionTestResponse:
     """通过 models.list() 验证 Google genai API。"""
     from google import genai
 
@@ -985,7 +1009,7 @@ def _test_google(base_url: str, api_key: str, _t: Callable[..., str]) -> Connect
 
     effective_url = ensure_google_base_url(base_url)
     http_options = {"base_url": effective_url} if effective_url else None
-    client = genai.Client(api_key=api_key, http_options=http_options)  # type: ignore[arg-type]
+    client = (client_factory or genai.Client)(api_key=api_key, http_options=http_options)  # type: ignore[arg-type]
     pager = client.models.list()
     count = sum(1 for _ in pager)
     return ConnectionTestResponse(

--- a/server/routers/system_config.py
+++ b/server/routers/system_config.py
@@ -17,6 +17,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Any, TypedDict
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel
@@ -74,8 +75,8 @@ _MEDIA_TO_OPTION_LIST = {
 
 
 @lru_cache(maxsize=1)
-def _read_app_version() -> str:
-    with _PYPROJECT_PATH.open("rb") as f:
+def _read_app_version(pyproject_path: Path = _PYPROJECT_PATH) -> str:
+    with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
 
     version = str(data["project"]["version"]).strip()
@@ -106,7 +107,11 @@ def _build_latest_release_payload(data: dict[str, Any]) -> dict[str, str]:
     }
 
 
-async def _get_latest_release() -> tuple[dict[str, str], datetime]:
+async def _get_latest_release(
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    now: datetime | None = None,
+) -> tuple[dict[str, str], datetime]:
     """Fetch latest GitHub release with a 5-minute cache.
 
     Returns (payload, fetched_at) where fetched_at is the timestamp of the
@@ -114,7 +119,7 @@ async def _get_latest_release() -> tuple[dict[str, str], datetime]:
     the value safe to surface as `checked_at` to clients without misleading
     them about cache freshness.
     """
-    now = datetime.now(UTC)
+    now = now or datetime.now(UTC)
     expires_at = _latest_release_cache.get("expires_at")
     payload = _latest_release_cache.get("payload")
     fetched_at = _latest_release_cache.get("fetched_at")
@@ -126,7 +131,8 @@ async def _get_latest_release() -> tuple[dict[str, str], datetime]:
     ):
         return payload, fetched_at
 
-    response = await get_http_client().get(
+    client = http_client or get_http_client()
+    response = await client.get(
         _GITHUB_RELEASE_LATEST_URL,
         headers={"Accept": "application/vnd.github+json", "User-Agent": _GITHUB_USER_AGENT},
         timeout=5.0,

--- a/server/routers/system_config.py
+++ b/server/routers/system_config.py
@@ -74,8 +74,8 @@ _MEDIA_TO_OPTION_LIST = {
 }
 
 
-@lru_cache(maxsize=1)
-def _read_app_version(pyproject_path: Path = _PYPROJECT_PATH) -> str:
+def _load_app_version(pyproject_path: Path) -> str:
+    """从给定 pyproject 读版本号；不缓存，缓存由 :func:`_read_app_version` 负责。"""
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
 
@@ -83,6 +83,11 @@ def _read_app_version(pyproject_path: Path = _PYPROJECT_PATH) -> str:
     if not version:
         raise RuntimeError("project.version is empty")
     return version
+
+
+@lru_cache(maxsize=1)
+def _read_app_version() -> str:
+    return _load_app_version(_PYPROJECT_PATH)
 
 
 def _parse_version(raw: str) -> Version | None:

--- a/server/services/diagnostics.py
+++ b/server/services/diagnostics.py
@@ -104,10 +104,10 @@ def _providers() -> str:
     return ", ".join(ids) if ids else "<none>"
 
 
-def collect_diagnostics() -> str:
+def collect_diagnostics(*, app_version: Callable[[], object] | None = None) -> str:
     """返回脱敏的 plain-text 诊断报告。任一字段失败用 <unavailable> 占位，整体不抛。"""
     fields: list[tuple[str, Callable[[], object]]] = [
-        ("App version", _app_version),
+        ("App version", app_version or _app_version),
         ("Python", _python_version),
         ("OS", _os_info),
         ("Data directory", _data_dir),

--- a/server/services/grid_split.py
+++ b/server/services/grid_split.py
@@ -72,6 +72,7 @@ async def apply_grid_split(
     grid: GridGeneration,
     *,
     only_scene_ids: frozenset[str] | None = None,
+    register_entries: Callable[..., None] | None = None,
 ) -> GridSplitResult:
     """按 ``grid`` 当前联合图切割并覆写各分镜格。
 
@@ -358,7 +359,8 @@ async def apply_grid_split(
                 expected_entries = (
                     {source_key: source_entry} if source_key is not None and source_entry is not None else {}
                 )
-                _register_split_entries_atomically(
+                register = register_entries or _register_split_entries_atomically
+                register(
                     project_path,
                     entries=manifest_entries,
                     expected_entries=expected_entries,

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -313,6 +313,10 @@ async def execute_reference_video_task(
     user_id: str = DEFAULT_USER_ID,
     task_id: str | None = None,
     claimed_provider_id: str | None = None,
+    stage_media_for_task: Callable[
+        [Path, str, tuple[ProviderMediaInput, ...]], Awaitable[tuple[StagedProviderMedia, ...]]
+    ]
+    | None = None,
 ) -> dict[str, Any]:
     """处理一个 reference_video unit 的生成。
 
@@ -611,7 +615,8 @@ async def execute_reference_video_task(
             ),
         )
         audio_targets_tuple = tuple(reference_audio_targets) if reference_audio_targets is not None else None
-        staged_media = await _stage_provider_media_for_task(project_path, task_id, image_inputs + audio_inputs)
+        stage = stage_media_for_task or _stage_provider_media_for_task
+        staged_media = await stage(project_path, task_id, image_inputs + audio_inputs)
         try:
             staged_reference_digests = {
                 media.source_locator: media.sha256 for media in staged_media if media.role == "reference_image"

--- a/server/services/script_review.py
+++ b/server/services/script_review.py
@@ -19,7 +19,7 @@ from typing import Any
 from pydantic import BaseModel, ValidationError
 
 from lib import script_review
-from lib.config.resolver import resolve_raw_supported_durations
+from lib.config.resolver import ConfigResolver, resolve_raw_supported_durations
 from lib.draft_quarantine import read_quarantine, violation_entries
 from lib.episode_ledger import discover_episode_files, register_orphan_episode_entries
 from lib.json_io import load_json_or_none
@@ -86,8 +86,9 @@ def _require_changed_speech_admitted(kind: str, previous: object, candidate: obj
 class ScriptReviewService:
     """封装 step1→step2 内容确认的读写。router 与测试经此操作 gate，不直接碰文件 / project.json。"""
 
-    def __init__(self, pm: ProjectManager):
+    def __init__(self, pm: ProjectManager, *, config_resolver: ConfigResolver | None = None):
         self.pm = pm
+        self.config_resolver = config_resolver
 
     def _resolve_step1_model(self, project: dict[str, Any], episode: int) -> tuple[str, type[BaseModel]]:
         """该集 step1 变体 + 结构校验模型；不适用 gate（无结构化 step1）时抛 not_applicable。
@@ -148,7 +149,9 @@ class ScriptReviewService:
         连草稿都加载不了。档位表与档位收窄两条链共用本方法，降级语义因此不会在两处各自漂移。
         """
         try:
-            return await resolve_video_caps(project)
+            if self.config_resolver is None:
+                return await resolve_video_caps(project)
+            return await resolve_video_caps(project, config_resolver=self.config_resolver)
         except Exception as exc:  # noqa: BLE001 - best-effort：解析失败退回空 caps，不阻断 gate
             logger.warning(
                 "video_capabilities 解析异常，内容确认退回不带 caps 的解析 project=%s：%s", project_name, exc
@@ -323,7 +326,13 @@ class ScriptReviewService:
         from server.agent_runtime.sdk_tools.text_generation import revalidate_step1_draft
 
         try:
-            revalidation = await revalidate_step1_draft(project_path, project, episode, draft)
+            revalidation = await revalidate_step1_draft(
+                project_path,
+                project,
+                episode,
+                draft,
+                config_resolver=self.config_resolver,
+            )
         except ValueError as exc:
             # meta.source 缺失等草稿被改坏的情形：把重算失败本身报成一条无 unit 归属的违约，
             # 呈现层落聚合区。gate 不崩，用户也不会看到一份与现值脱钩的旧报告。异常文本含
@@ -374,7 +383,12 @@ class ScriptReviewService:
         raw = resolve_raw_supported_durations(project, caps)
         if raw is None:
             return None
-        with_refs, without_refs = await reference_unit_duration_tiers(project, caps, raw)
+        with_refs, without_refs = await reference_unit_duration_tiers(
+            project,
+            caps,
+            raw,
+            config_resolver=self.config_resolver,
+        )
         return {"with_references": sorted(set(with_refs)), "without_references": sorted(set(without_refs))}
 
     async def save_content(


### PR DESCRIPTION
Closes #1995

## 改动

三类可测性 seam 落地：能力解析器、HTTP 探测客户端、文件系统与子进程，一律显式参数注入带生产默认值，不引入模块级可替换全局。

- **能力解析器**：`ToolContext` / `ScriptGenerator` / `ScriptReviewService` 起显式传递 `ConfigResolver`，覆盖视频能力、参考单元档位与图像编辑 provider 可用性判定。
- **HTTP 探测客户端**：Anthropic probe（`_post` / `_get` 接受 `http_client`）、自定义 provider 连接测试与模型发现、系统版本检查。
- **文件系统与子进程**：manifest no-follow 标志、ffprobe 可用性与执行、项目脚本读写、sandbox / Docker 检测、备份 / 注册 / 媒体 staging。

## 本地审查修复

第二个 commit 是审查阶段的修形，全部为语义恒等变换或把首轮引入的行为偏移改回去：

- `ScriptGenerator.config_resolver` 改类属性缺省 + 解析期惰性构造：首轮在 `__init__` 里无条件构造 `ConfigResolver`（含 dry-run `build_prompt` 路径），且用 `getattr(self, ...)` 兜底；现恢复「按调用惰性构造」的原语义，并把 `resolver = ...` 移出 `try`，其构造异常不再被 `except (ValueError, SQLAlchemyError)` 吞掉。
- step1 草稿重判恢复按 `_SINGLE_STEP1_REVALIDATORS` 单点分发：首轮把表退化成 key 集合、实际调用改成硬编码 `if kind == drama … else narration`，新增路线会被静默误派。表类型改为 `Protocol` 以携带 `config_resolver` 关键字。
- `_read_app_version` 拆为无缓存的 `_load_app_version(path)` 与零参 `@lru_cache` 包装：首轮给被缓存函数加默认参数，使缓存键由「无参」变成「按路径」，`maxsize=1` 下注入路径与生产条目互相驱逐。
- `anthropic_probe` 的 `http_client` 穿进 `_post` / `_get`：首轮的注入分支绕开这两个间接层，替身走的不是生产那条出站路径；两处 docstring 的「测试时 patch 这一个」表述同步改掉。
- 注明本模块能力查询函数在未注入时省略 `config_resolver` 关键字的约束（既有用例把这些符号整体替换为不接受该关键字的假实现，B6 迁移后可拆）。

## 验证

- `uv run ruff check . && uv run ruff format . && uv run basedpyright && uv run lint-imports && uv run python -m pytest`
- rebase 到最新 main 后重跑：`10282 passed, 2 skipped`；`basedpyright` 0 errors；`lint-imports` 2 contracts kept。
- 未移动或修改 `tests/` 下文件；未触碰 `retry_async` / `poll_with_retry` / `with_retry_async`。

## Follow-up 候选（未在本 PR 处理）

- `_run_connection_test` 的 `openai_probe` / `google_probe` 与 `_test_openai` / `_test_google` 的 `client_factory` 是同一条路径上的两层 seam，B6 收编测试时择一保留。
- `check_sandbox_available` 注入了 `which` / `run`，但失败分支内的 `_diagnose_bwrap_failure()` 仍直连 `shutil.which` 与 sysctl 读取。
- `collect_diagnostics` 只让 `_app_version` 一个字段可注入，其余字段仍硬编码。
- `audio_utils` 的 `ffprobe_available` + `run_ffprobe` 结伴穿过 5 个签名，可打包成单一 ffprobe seam 类型。
- `_context` / `text_generation` 中「未注入则省略关键字」的分支待 B6 测试迁移后收拢为直接透传。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化媒体时长检测、模型连接测试、环境识别与版本检查，提升运行稳定性。
  - 提升配置解析、项目读写、脚本审核及任务处理的协同效率。
  - 加强产物备份、清单管理、参考视频处理与文件安全保护。
- **兼容性**
  - 保留原有默认行为，现有激活、回滚、校验及内容处理流程不受影响。
  - 增强不同运行环境下的适配能力与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->