### PR TITLE
test: 测试侧共享设施收编（#1996）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,7 @@ updates:
           - "pre-commit"
           - "python-docx"
           - "import-linter"
+          - "respx"
         update-types:
           - "minor"
           - "patch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 - **三角色**：`tests/conftest.py` 只放 fixture 与收集期钩子，禁止被 import（闸门）；`tests/fakes.py` 放替身实现，不含 fixture；`tests/factories.py` 放测试输入构造器（数据与媒体文件 builder）。专题共享模块（如 `tests/auth_deps.py`）允许存在；fakes / factories / 专题模块的公开符号须被 ≥2 个测试文件使用（闸门），仅单个文件使用的移回该文件。
 - **局部 conftest**：只为本目录提供 fixture；不得与根 conftest 的 fixture 同名；跨目录共用的 fixture 上提到根 conftest；conftest 之间不互相 import（闸门）。
 - **fixture 覆写与重复**（闸门）：测试文件不得定义与任一 conftest 同名的 fixture——供给同一实体的改为直接消费 conftest 版本，供给不同实体的改一个有区分度的名字；同一实体的 fixture 在 ≥3 个测试文件重复定义时上提 conftest。
-- **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `test_engine`。`session_factory` / `async_session` 方言感知，`DATABASE_URL` 指向 PostgreSQL 时走真实 PG；`file_session_factory` 恒为文件 SQLite，消费方是标了 `sqlite_only` 的边界用例。三者携带 `uses_db` 标记，构成 PostgreSQL 兼容选集。`db_engine` / `db_session` / `db_factory`（内存）与 `file_db_factory`（文件）固定走 SQLite、不带 `uses_db`，供不进该选集的 models 与 repositories 单测使用。唯一登记的例外是 `async_session` 的 PG 分支：它绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层事务 + SAVEPOINT，与 `test_engine` 的 per-test schema + `create_all` 不同，故自建 engine。
+- **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `test_engine`。`session_factory` / `async_session` 方言感知，`DATABASE_URL` 指向 PostgreSQL 时走真实 PG；`file_session_factory` 恒为文件 SQLite，消费方是标了 `sqlite_only` 的边界用例。三者携带 `uses_db` 标记，构成需要数据库的选择集；PostgreSQL 兼容 job 取其中 `uses_db and not sqlite_only` 的部分，`file_session_factory` 的消费方不在其内。`db_engine` / `db_session` / `db_factory`（内存）与 `file_db_factory`（文件）固定走 SQLite、不带 `uses_db`，供不进该选集的 models 与 repositories 单测使用。唯一登记的例外是 `async_session` 的 PG 分支：它绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层事务 + SAVEPOINT，与 `test_engine` 的 per-test schema + `create_all` 不同，故自建 engine。
 
 ### 时序与偶发失败
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,8 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 - **三角色**：`tests/conftest.py` 只放 fixture 与收集期钩子，禁止被 import（闸门）；`tests/fakes.py` 放替身实现，不含 fixture；`tests/factories.py` 放测试输入构造器（数据与媒体文件 builder）。专题共享模块（如 `tests/auth_deps.py`）允许存在；fakes / factories / 专题模块的公开符号须被 ≥2 个测试文件使用（闸门），仅单个文件使用的移回该文件。
 - **局部 conftest**：只为本目录提供 fixture；不得与根 conftest 的 fixture 同名；跨目录共用的 fixture 上提到根 conftest；conftest 之间不互相 import（闸门）。
-- **fixture 覆写与重复**（闸门）：测试文件不得定义与任一 conftest 同名的 fixture；同名 fixture 在 ≥3 个测试文件重复定义时上提 conftest。
-- **DB fixture**：一律派生自唯一的方言感知 engine fixture，由此自动获得 `uses_db` 标记与 PostgreSQL 兼容选集。
+- **fixture 覆写与重复**（闸门）：测试文件不得定义与任一 conftest 同名的 fixture——供给同一实体的改为直接消费 conftest 版本，供给不同实体的改一个有区分度的名字；同一实体的 fixture 在 ≥3 个测试文件重复定义时上提 conftest。
+- **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `test_engine`。方言感知的 `session_factory` / `async_session` / `file_session_factory` 携带 `uses_db` 标记并进 PostgreSQL 兼容选集；`db_engine` / `db_session` / `db_factory` 固定走内存 SQLite，供不进该选集的 models 与 repositories 单测使用。
 
 ### 时序与偶发失败
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ cd frontend && pnpm check
 
 pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
-> **过渡期说明**：本章描述整改完成后的目标态，存量测试与相关工程配置正按整改 Spec 分批对齐；条目与现状不符时（前端绕过 `API` class 的直接 `fetch`/`EventSource` 调用、eslint 强制项的现行 CI/lint 配置、`testTimeout` 等 vitest 配置、尚未建立的 `src/test/` 共享设施），以本章为改造方向。`scripts/audit_tests.py` 与 CI 的 `test-lint` 步骤当前尚不存在，随首道闸门落地，每道闸门与对应存量清零同一 PR 上线。整改完成后删除本段。
+> **过渡期说明**：本章描述整改完成后的目标态，存量测试与相关工程配置正按整改 Spec 分批对齐；条目与现状不符时（前端绕过 `API` class 的直接 `fetch`/`EventSource` 调用、eslint 强制项的现行 CI/lint 配置、`testTimeout` 等 vitest 配置、尚未建立的 `src/test/` 共享设施），以本章为改造方向。`scripts/audit_tests.py` 的 `--check` 形态与 CI 的 `test-lint` 步骤当前尚不存在，随首道闸门落地，每道闸门与对应存量清零同一 PR 上线。整改完成后删除本段。
 
 ### 分层与目录
 
@@ -113,7 +113,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 - **三角色**：`tests/conftest.py` 只放 fixture 与收集期钩子，禁止被 import（闸门）；`tests/fakes.py` 放替身实现，不含 fixture；`tests/factories.py` 放测试输入构造器（数据与媒体文件 builder）。专题共享模块（如 `tests/auth_deps.py`）允许存在；fakes / factories / 专题模块的公开符号须被 ≥2 个测试文件使用（闸门），仅单个文件使用的移回该文件。
 - **局部 conftest**：只为本目录提供 fixture；不得与根 conftest 的 fixture 同名；跨目录共用的 fixture 上提到根 conftest；conftest 之间不互相 import（闸门）。
 - **fixture 覆写与重复**（闸门）：测试文件不得定义与任一 conftest 同名的 fixture——供给同一实体的改为直接消费 conftest 版本，供给不同实体的改一个有区分度的名字；同一实体的 fixture 在 ≥3 个测试文件重复定义时上提 conftest。
-- **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `test_engine`。方言感知的 `session_factory` / `async_session` / `file_session_factory` 携带 `uses_db` 标记并进 PostgreSQL 兼容选集；`db_engine` / `db_session` / `db_factory` 固定走内存 SQLite，供不进该选集的 models 与 repositories 单测使用。
+- **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `test_engine`。`session_factory` / `async_session` 方言感知，`DATABASE_URL` 指向 PostgreSQL 时走真实 PG；`file_session_factory` 恒为文件 SQLite，消费方是标了 `sqlite_only` 的边界用例。三者携带 `uses_db` 标记，构成 PostgreSQL 兼容选集。`db_engine` / `db_session` / `db_factory`（内存）与 `file_db_factory`（文件）固定走 SQLite、不带 `uses_db`，供不进该选集的 models 与 repositories 单测使用。唯一登记的例外是 `async_session` 的 PG 分支：它绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层事务 + SAVEPOINT，与 `test_engine` 的 per-test schema + `create_all` 不同，故自建 engine。
 
 ### 时序与偶发失败
 

--- a/lib/retry.py
+++ b/lib/retry.py
@@ -149,13 +149,7 @@ async def retry_async[T](
             is_last = attempt >= max_attempts - 1
             if is_last or isinstance(exc, NonRetryableError) or not predicate(exc):
                 raise
-            # 未注入 jitter 时按两个位置参调用：仍有测试把 `_compute_wait` 整体替换成
-            # 只接 (attempt, backoff) 的确定化替身，多传 jitter= 会让它们 TypeError。
-            wait_time = (
-                _compute_wait(attempt, backoff_seconds)
-                if jitter is None
-                else _compute_wait(attempt, backoff_seconds, jitter=jitter)
-            )
+            wait_time = _compute_wait(attempt, backoff_seconds, jitter=jitter)
             logger.warning("API 调用异常: %s - %s", type(exc).__name__, str(exc)[:200])
             logger.warning("重试 %d/%d, %.1f 秒后...", attempt + 1, max_attempts - 1, wait_time)
             await active_clock.sleep(wait_time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "import-linter>=2.13",
     "pytest-xdist>=3.8.0",
     "pytest-timeout>=2.4.0",
+    "respx>=0.22.0",
 ]
 
 [build-system]

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -274,6 +274,23 @@ def marks_of(decorators: list[ast.expr]) -> list[str]:
     return out
 
 
+TIER_MARKS = ("unit", "integration", "e2e")
+
+
+def tier_from_path(path: Path, tests_dir: Path) -> str | None:
+    """档位 marker 取 `tests/unit|integration|e2e/` 的第一段目录名。
+
+    该 marker 由 `tests/conftest.py` 在收集期按路径注入、从不写成装饰器，因此只能
+    从路径还原，扫描装饰器永远拿不到。
+    """
+    try:
+        rel = path.relative_to(tests_dir)
+    except ValueError:
+        return None
+    head = rel.parts[0] if rel.parts else ""
+    return head if head in TIER_MARKS else None
+
+
 def _is_empty_container(node: ast.expr) -> bool:
     if isinstance(node, ast.List) and not node.elts:
         return True
@@ -644,14 +661,15 @@ class ProductionIndex:
 
 
 class FileScanner:
-    def __init__(self, path: Path, root: Path, prod: ProductionIndex) -> None:
+    def __init__(self, path: Path, root: Path, tests_dir: Path, prod: ProductionIndex) -> None:
         self.path = path
         self.prod = prod
         self.rel = str(path.relative_to(root))
         self.tree = ast.parse(path.read_text(encoding="utf-8"))
         self.aliases = AliasIndex(self.tree)
         self.mut = self.aliases.module_under_test(path, prod.is_module)
-        self.module_marks = self._module_marks()
+        tier = tier_from_path(path, tests_dir)
+        self.module_marks = ([tier] if tier else []) + self._module_marks()
         self.stat = FileStat(path=self.rel)
         self.double_only: list[DoubleOnlyTest] = []
         self.patches: list[PatchSite] = []
@@ -970,7 +988,7 @@ def run(root: Path, tests_dir: Path, top: int) -> dict[str, object]:
 
     for path in files:
         try:
-            scanner = FileScanner(path, root, prod)
+            scanner = FileScanner(path, root, tests_dir, prod)
             scanner.scan()
         except SyntaxError as exc:  # pragma: no cover
             failures.append(f"{path}: {exc}")

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -319,7 +319,7 @@ class AliasIndex:
                         self.import_counter[alias.name] += 1
             elif isinstance(node, ast.ImportFrom) and node.module:
                 self.imported_modules.add(node.module)
-                if node.module.startswith(("lib", "server")):
+                if node.module.split(".")[0] in ("lib", "server"):
                     for alias in node.names:
                         # `from lib.x import y`：y 可能是子模块也可能是符号，两种都登记
                         self.import_counter[f"{node.module}.{alias.name}"] += 1
@@ -728,7 +728,9 @@ class FileScanner:
                     qual = f"{class_name}::{node.name}" if class_name else node.name
                     local = alias_map_from(node)
                     end = node.end_lineno or node.lineno
-                    for line in range(node.lineno, end + 1):
+                    # 起点取装饰器行：`@patch(...)` 写在 def 上方，落在函数区间外会被归到 <module>
+                    start = min([node.lineno] + [d.lineno for d in node.decorator_list])
+                    for line in range(start, end + 1):
                         out.setdefault(line, (qual, marks, local))
                     walk(node.body, class_marks, class_name)
 
@@ -850,6 +852,11 @@ def conftest_import_lines(tree: ast.Module) -> list[tuple[int, str]]:
             module = node.module or ""
             if module.split(".")[-1] == "conftest":
                 out.append((node.lineno, module))
+                continue
+            # `from tests import conftest`：模块名在 names 里
+            for alias in node.names:
+                if alias.name == "conftest":
+                    out.append((node.lineno, f"{module}.conftest" if module else "conftest"))
     return out
 
 

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -872,10 +872,6 @@ def scan_shared_facilities(root: Path, tests_dir: Path) -> list[StructureFinding
             continue
         rel = path.relative_to(root).as_posix()
         fixtures = module_level_fixtures(tree)
-        if path.name == "conftest.py":
-            conftest_fixtures[path.parent] = {name: line for name, line in fixtures}
-            continue
-        test_fixtures[path] = fixtures
         for lineno, module in conftest_import_lines(tree):
             findings.append(
                 StructureFinding(
@@ -883,10 +879,14 @@ def scan_shared_facilities(root: Path, tests_dir: Path) -> list[StructureFinding
                     rel,
                     lineno,
                     f"import 了 {module}",
-                    "conftest 只放 fixture 与收集期钩子；被 import 的 helper 移到 tests/fakes.py、"
-                    "tests/factories.py 或专题共享模块",
+                    "conftest 只放 fixture 与收集期钩子，且 conftest 之间不互相 import；"
+                    "被 import 的 helper 移到 tests/fakes.py、tests/factories.py 或专题共享模块",
                 )
             )
+        if path.name == "conftest.py":
+            conftest_fixtures[path.parent] = {name: line for name, line in fixtures}
+            continue
+        test_fixtures[path] = fixtures
 
     def ancestor_conftests(path: Path) -> list[Path]:
         return [d for d in conftest_fixtures if d == path.parent or d in path.parents]

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -26,6 +26,7 @@ import sys
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 
 # ---------------------------------------------------------------- 常量表
@@ -272,6 +273,17 @@ def marks_of(decorators: list[ast.expr]) -> list[str]:
             if idx + 1 < len(parts):
                 out.append(parts[idx + 1])
     return out
+
+
+COLLECTED_TEST_FILE_GLOBS = ("test_*.py", "*_test.py")
+
+
+def is_collected_test_module(path: Path) -> bool:
+    """pytest 只从 `test_*.py` / `*_test.py` 收集用例。
+
+    conftest 与支持模块里 `test` 开头的函数是工具函数，按名字当成用例会虚增类 1 计数。
+    """
+    return any(fnmatch(path.name, pattern) for pattern in COLLECTED_TEST_FILE_GLOBS)
 
 
 TIER_MARKS = ("unit", "integration", "e2e")
@@ -694,7 +706,8 @@ class FileScanner:
         return out
 
     def scan(self) -> None:
-        self._scan_scope(self.tree.body, [], None)
+        if is_collected_test_module(self.path):
+            self._scan_scope(self.tree.body, [], None)
         self._scan_patch_sites()
 
     def _scan_scope(self, body: list[ast.stmt], class_marks: list[str], class_name: str | None) -> None:

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -298,7 +298,8 @@ def alias_map_from(node: ast.AST) -> dict[str, str]:
                     out[alias.asname] = alias.name
                 else:
                     out[alias.name.split(".")[0]] = alias.name.split(".")[0]
-        elif isinstance(sub, ast.ImportFrom) and sub.module:
+        elif isinstance(sub, ast.ImportFrom) and sub.module and sub.level == 0:
+            # 相对导入的 module 不是顶层点分路径，还原不出绝对模块名
             for alias in sub.names:
                 out[alias.asname or alias.name] = f"{sub.module}.{alias.name}"
     return out
@@ -317,7 +318,7 @@ class AliasIndex:
                     self.imported_modules.add(alias.name)
                     if alias.name.startswith(("lib.", "server.")):
                         self.import_counter[alias.name] += 1
-            elif isinstance(node, ast.ImportFrom) and node.module:
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
                 self.imported_modules.add(node.module)
                 if node.module.split(".")[0] in ("lib", "server"):
                     for alias in node.names:

--- a/scripts/audit_tests.py
+++ b/scripts/audit_tests.py
@@ -1,0 +1,1122 @@
+#!/usr/bin/env python3
+"""静态审计 tests/ 中两类可机械识别的负价值测试形态。
+
+类 1「测 mock 本身」：一个 test 函数内所有断言都作用于替身对象的调用记录
+（`assert_called*` / `assert_awaited*` / `call_args*` / `call_count` / `await_count`，
+或 monkeypatch 注入的调用记录容器），没有任何针对返回值、状态、副作用的断言。
+
+类 2「patch 被测公共入口或私有符号」：`patch(...)` / `patch.object(...)` /
+`monkeypatch.setattr(...)` 的目标以 `lib.` / `server.` 开头且命中 `_` 前缀私有符号；
+以及 integration 标记用例 patch 了被测 module 自身的公共入口。
+
+类 3「共享设施结构」：conftest 被 import；测试文件定义与生效 conftest 同名的 fixture；
+同名 fixture 在 ≥3 个测试文件重复定义；局部 conftest 与祖先 conftest 同名 fixture。
+只统计模块顶层 fixture——类内 fixture 的作用域限于该类，不构成跨文件的共享设施重复。
+
+零第三方依赖，只用 `ast`。用法见 `--help`。
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------- 常量表
+
+MOCK_FACTORIES = {
+    "MagicMock",
+    "AsyncMock",
+    "Mock",
+    "NonCallableMock",
+    "NonCallableMagicMock",
+    "PropertyMock",
+    "create_autospec",
+    "mock_open",
+}
+
+PATCH_FUNCS = {"patch", "mock.patch", "unittest.mock.patch", "mocker.patch"}
+
+PATCH_OBJECT_FUNCS = {f"{prefix}.object" for prefix in PATCH_FUNCS}
+
+DOUBLE_ASSERT_METHODS = {
+    "assert_called",
+    "assert_called_once",
+    "assert_called_with",
+    "assert_called_once_with",
+    "assert_any_call",
+    "assert_has_calls",
+    "assert_not_called",
+    "assert_awaited",
+    "assert_awaited_once",
+    "assert_awaited_with",
+    "assert_awaited_once_with",
+    "assert_any_await",
+    "assert_has_awaits",
+    "assert_not_awaited",
+}
+
+DOUBLE_ATTRS = {
+    "call_args",
+    "call_args_list",
+    "call_count",
+    "await_args",
+    "await_args_list",
+    "await_count",
+    "mock_calls",
+    "method_calls",
+    "called",
+    "awaited",
+    "call_list",
+}
+
+# 断言辅助函数：调用即视为实质断言（保守，倾向压低类 1 误报）
+ASSERT_HELPER_PREFIXES = ("assert", "_assert", "check_", "_check", "verify_", "_verify", "expect_")
+
+BUILTIN_NAMES = {
+    "len",
+    "any",
+    "all",
+    "str",
+    "int",
+    "float",
+    "bool",
+    "list",
+    "dict",
+    "set",
+    "tuple",
+    "sorted",
+    "isinstance",
+    "type",
+    "abs",
+    "min",
+    "max",
+    "sum",
+    "range",
+    "enumerate",
+    "zip",
+    "repr",
+    "getattr",
+    "hasattr",
+    "pytest",
+    "math",
+    "json",
+    "re",
+}
+
+# 类 2 动机分档。按顺序匹配：轮询/重试 > 外部 I/O > 被测逻辑本身。
+TIMING_RE = re.compile(
+    r"(?i)(sleep|poll|interval|delay|timeout|backoff|retry|retries|max_attempts|attempts"
+    r"|wait|deadline|_seconds$|_secs$|_ms$|tick|schedule|monotonic|perf_counter)"
+)
+
+IO_RE = re.compile(
+    r"(?i)(http|requests?|aiohttp|client|session|urlopen|download|upload|fetch|subprocess"
+    r"|popen|ffmpeg|ffprobe|probe|socket|smtp|s3|oss|bucket|storage|blob|boto|openai|anthropic"
+    r"|dashscope|volc|ark|gemini|vertex|minimax|kling|veo|sdk|api|invoke|submit|dispatch"
+    r"|_post|_get|_put|_delete|_request|_query|_execute|engine|connect|conn|cursor"
+    r"|read_bytes|write_bytes|read_text|write_text|copy2|rmtree|unlink|which|check_output"
+    r"|getenv|environ|utcnow|now$|uuid|token|credential|env$|load_env|shell|command|exec)"
+)
+
+IO_MODULE_HINTS = (
+    "_backends",
+    ".storage",
+    ".db",
+    ".database",
+    ".http",
+    ".client",
+    "lib.media",
+    "lib.ffmpeg",
+    "server.db",
+)
+
+MOTIVE_TIMING = "绕轮询/重试等待常量"
+MOTIVE_IO = "绕外部 I/O"
+MOTIVE_LOGIC = "绕被测逻辑本身"
+
+# 正则只看符号名，命中率有限。下表是逐符号读过生产代码后的人工判定，覆盖正则判错的目标；
+# 其余目标按正则归档。改动这张表就改动了报告里的三档数字，增删条目请附判定依据。
+MOTIVE_OVERRIDES = {
+    # 名字不像 I/O，实际经 ConfigResolver / 文件系统 / 远端探测
+    "server.agent_runtime.sdk_tools._context.resolve_video_caps": MOTIVE_IO,
+    "server.agent_runtime.sdk_tools.enqueue_image_edits._i2i_provider_available": MOTIVE_IO,
+    "server.agent_runtime.sdk_tools.text_generation._resolve_video_capabilities": MOTIVE_IO,
+    "lib.artifact_manifest._O_NOFOLLOW": MOTIVE_IO,
+    "server.routers.system_config._read_app_version": MOTIVE_IO,
+    "server.services.diagnostics._app_version": MOTIVE_IO,
+    "server.app._DOCKERENV_PATH": MOTIVE_IO,
+    "server.app._CGROUP_PATH": MOTIVE_IO,
+    "server.app._migrate_source_encoding_on_startup": MOTIVE_IO,
+    "server.routers.custom_providers._run_discover": MOTIVE_IO,
+    "server.routers.custom_providers._test_google": MOTIVE_IO,
+    "lib.project_manager.ProjectManager._write_script_unlocked": MOTIVE_IO,
+    "lib.project_manager.ProjectManager._read_script_unlocked": MOTIVE_IO,
+    "lib.artifact_activation._ensure_activation_backup": MOTIVE_IO,
+    "server.services.reference_video_tasks._stage_provider_media_for_task": MOTIVE_IO,
+    "server.services.grid_split._register_split_entries_atomically": MOTIVE_IO,
+    # 名字像 I/O，实际是纯判断 / 阈值常量 / 内部编排
+    "server.agent_runtime.event_log._is_client_key_violation": MOTIVE_LOGIC,
+    "lib.video_backends.v2_video_generations._LARGE_IMAGE_WARN_BYTES": MOTIVE_LOGIC,
+    "server.services.cost_estimation.quote_video_request_from_price": MOTIVE_LOGIC,
+    "server.services.generation_tasks._execute_reference_video_task_proxy": MOTIVE_LOGIC,
+    "lib.generation_worker.GenerationWorker._dispatch_resume_orphans_background": MOTIVE_LOGIC,
+}
+
+MONKEYPATCH_SETTERS = {"setattr", "delattr"}
+
+
+# ---------------------------------------------------------------- 数据结构
+
+
+@dataclass
+class DoubleOnlyTest:
+    path: str
+    line: int
+    func: str
+    marks: list[str]
+    double_assertions: int
+    evidence: list[str]
+    subjects: list[str]
+
+
+@dataclass
+class PatchSite:
+    path: str
+    line: int
+    func: str
+    marks: list[str]
+    target: str
+    kind: str
+    private: bool
+    module: str | None
+    symbol_origin: str
+    module_under_test: str | None
+    hits_module_under_test: bool
+    motive: str
+
+
+@dataclass
+class FileStat:
+    path: str
+    test_funcs: int = 0
+    double_only: int = 0
+    no_assertion: int = 0
+    private_patches: int = 0
+    integration_self_patches: int = 0
+
+
+# ---------------------------------------------------------------- 工具函数
+
+
+def dotted(node: ast.expr | None) -> str | None:
+    """把 Name / Attribute 链还原成点分字符串。"""
+    if node is None:
+        return None
+    parts: list[str] = []
+    cur: ast.expr = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    parts.append(cur.id)
+    return ".".join(reversed(parts))
+
+
+def const_str(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def call_name(node: ast.Call) -> str | None:
+    return dotted(node.func)
+
+
+def is_patch_object_call(node: ast.Call) -> bool:
+    name = call_name(node)
+    return name in PATCH_OBJECT_FUNCS
+
+
+def is_patch_call(node: ast.Call) -> bool:
+    """严格白名单。不能按 `.patch` 后缀判定：`client.patch(...)` 是 HTTP 方法，
+    误判会把真实 HTTP 响应当成替身，进而把大量有效用例错划进类 1。"""
+    name = call_name(node)
+    return name in PATCH_FUNCS or name in PATCH_OBJECT_FUNCS
+
+
+def is_mock_factory_call(node: ast.Call) -> bool:
+    name = call_name(node)
+    if name is None:
+        return False
+    return name.split(".")[-1] in MOCK_FACTORIES
+
+
+def marks_of(decorators: list[ast.expr]) -> list[str]:
+    out: list[str] = []
+    for dec in decorators:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = dotted(target)
+        if not name:
+            continue
+        parts = name.split(".")
+        if "mark" in parts:
+            idx = parts.index("mark")
+            if idx + 1 < len(parts):
+                out.append(parts[idx + 1])
+    return out
+
+
+def _is_empty_container(node: ast.expr) -> bool:
+    if isinstance(node, ast.List) and not node.elts:
+        return True
+    if isinstance(node, ast.Dict) and not node.keys:
+        return True
+    if isinstance(node, ast.Call):
+        name = call_name(node)
+        return name in {"list", "dict", "set"} and not node.args
+    return False
+
+
+# ---------------------------------------------------------------- 模块别名解析
+
+
+def alias_map_from(node: ast.AST) -> dict[str, str]:
+    """收集一个 AST 子树里的 import 别名 -> 点分模块映射。"""
+    out: dict[str, str] = {}
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Import):
+            for alias in sub.names:
+                if alias.asname:
+                    out[alias.asname] = alias.name
+                else:
+                    out[alias.name.split(".")[0]] = alias.name.split(".")[0]
+        elif isinstance(sub, ast.ImportFrom) and sub.module:
+            for alias in sub.names:
+                out[alias.asname or alias.name] = f"{sub.module}.{alias.name}"
+    return out
+
+
+class AliasIndex:
+    """把测试文件里的 import 还原成 别名 -> 点分模块 的映射（模块级视角）。"""
+
+    def __init__(self, tree: ast.Module) -> None:
+        self.alias_to_module: dict[str, str] = alias_map_from(tree)
+        self.imported_modules: set[str] = set()
+        self.import_counter: Counter[str] = Counter()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.imported_modules.add(alias.name)
+                    if alias.name.startswith(("lib.", "server.")):
+                        self.import_counter[alias.name] += 1
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                self.imported_modules.add(node.module)
+                if node.module.startswith(("lib", "server")):
+                    for alias in node.names:
+                        # `from lib.x import y`：y 可能是子模块也可能是符号，两种都登记
+                        self.import_counter[f"{node.module}.{alias.name}"] += 1
+
+    def resolve(self, name: str, overrides: dict[str, str] | None = None) -> str:
+        head, _, rest = name.partition(".")
+        base = (overrides or {}).get(head) or self.alias_to_module.get(head)
+        if base is None:
+            return name
+        return f"{base}.{rest}" if rest else base
+
+    def module_under_test(self, path: Path, is_module: Callable[[str], bool]) -> str | None:
+        """被测 module 启发式：测试文件名去掉 `test_` 前缀后与文件内 `lib.` / `server.`
+        import 的模块末段做前缀匹配，取匹配最长者；无匹配时取被 import 次数最多的
+        `lib.` / `server.` 模块。候选先用磁盘上是否存在同名模块文件过滤掉符号 import。"""
+        stem = path.stem
+        if stem.startswith("test_"):
+            stem = stem[5:]
+        pool = {m for m in self.imported_modules if m.startswith(("lib.", "server."))}
+        pool |= {m for m in self.import_counter if m.startswith(("lib.", "server."))}
+        # 必须排序后遍历：并列长度下不定的迭代顺序会让「被测 module」在多次运行间抖动。
+        candidates = sorted(m for m in pool if is_module(m))
+        best: str | None = None
+        best_len = 0
+        for mod in candidates:
+            last = mod.split(".")[-1]
+            if not last:
+                continue
+            if stem == last or stem.startswith(last + "_") or last.startswith(stem):
+                if len(last) > best_len:
+                    best, best_len = mod, len(last)
+        if best:
+            return best
+        for module, _count in self.import_counter.most_common():
+            if is_module(module):
+                return module
+        return None
+
+
+# ---------------------------------------------------------------- 类 1 识别
+
+
+class TestFunctionAnalyzer:
+    """在单个 test 函数体内识别替身绑定并给断言分类。"""
+
+    def __init__(self, func: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.func = func
+        self.doubles: set[str] = set()
+        self.recorders: set[str] = set()
+        self._collect_doubles()
+
+    # -- 替身绑定 ------------------------------------------------
+
+    def _collect_doubles(self) -> None:
+        injected = 0
+        for dec in self.func.decorator_list:
+            if isinstance(dec, ast.Call) and is_patch_call(dec):
+                if not any(kw.arg == "new" for kw in dec.keywords):
+                    injected += 1
+        args = [a.arg for a in self.func.args.args if a.arg not in {"self", "cls"}]
+        # patch 装饰器自下而上注入到 self 之后的位置参数
+        self.doubles.update(args[:injected])
+
+        for node in ast.walk(self.func):
+            if isinstance(node, (ast.With, ast.AsyncWith)):
+                for item in node.items:
+                    if (
+                        isinstance(item.context_expr, ast.Call)
+                        and is_patch_call(item.context_expr)
+                        and isinstance(item.optional_vars, ast.Name)
+                    ):
+                        self.doubles.add(item.optional_vars.id)
+            elif isinstance(node, ast.Assign):
+                self._collect_from_assign(node)
+
+        self._collect_recorders()
+
+    def _collect_from_assign(self, node: ast.Assign) -> None:
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if not targets:
+            return
+        value = node.value
+        if isinstance(value, ast.Call):
+            if is_mock_factory_call(value) or is_patch_call(value):
+                self.doubles.update(targets)
+                return
+            fname = call_name(value)
+            if fname and fname.endswith(".start") and fname.split(".")[0] in self.doubles:
+                self.doubles.update(targets)
+                return
+        if isinstance(value, ast.Attribute):
+            base = dotted(value)
+            if base and base.split(".")[0] in self.doubles:
+                self.doubles.update(targets)
+
+    def _collect_recorders(self) -> None:
+        """monkeypatch / patch 注入的调用记录容器：函数体内 `x = []`，且在嵌套
+        lambda / def 中被 append / add / 下标赋值，同时该函数确实做过替身注入。"""
+        containers = {
+            t.id
+            for node in ast.walk(self.func)
+            if isinstance(node, ast.Assign)
+            for t in node.targets
+            if isinstance(t, ast.Name) and _is_empty_container(node.value)
+        }
+        if not containers:
+            return
+        has_injection = any(
+            isinstance(node, ast.Call) and (is_patch_call(node) or (call_name(node) or "").endswith(".setattr"))
+            for node in ast.walk(self.func)
+        )
+        if not has_injection:
+            return
+        for node in ast.walk(self.func):
+            if node is self.func or not isinstance(node, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Call):
+                    recv = dotted(inner.func)
+                    if recv and "." in recv:
+                        root, attr = recv.split(".")[0], recv.split(".")[-1]
+                        if root in containers and attr in {"append", "add", "extend", "update", "setdefault"}:
+                            self.recorders.add(root)
+                elif isinstance(inner, ast.Subscript) and isinstance(inner.ctx, ast.Store):
+                    if isinstance(inner.value, ast.Name) and inner.value.id in containers:
+                        self.recorders.add(inner.value.id)
+                elif isinstance(inner, ast.AugAssign) and isinstance(inner.target, ast.Name):
+                    if inner.target.id in containers:
+                        self.recorders.add(inner.target.id)
+
+    # -- 断言分类 ------------------------------------------------
+
+    def classify(self) -> tuple[int, int, list[str], list[str]]:
+        """返回 (替身断言数, 实质断言数, 替身断言证据, 被断言的替身主体)。"""
+        double_hits = 0
+        real_hits = 0
+        evidence: list[str] = []
+        subjects: set[str] = set()
+        double_names = self.doubles | self.recorders
+
+        for node in ast.walk(self.func):
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                fname = dotted(node.value.func)
+                if fname:
+                    last = fname.split(".")[-1]
+                    if last in DOUBLE_ASSERT_METHODS:
+                        double_hits += 1
+                        subjects.add(fname.rsplit(".", 1)[0])
+                        if len(evidence) < 3:
+                            evidence.append(f"L{node.lineno} {fname}(...)")
+                        continue
+                    if last.startswith(ASSERT_HELPER_PREFIXES):
+                        real_hits += 1
+                        continue
+            elif isinstance(node, ast.Assert):
+                kind = self._classify_assert(node, double_names, subjects)
+                if kind == "double":
+                    double_hits += 1
+                    if len(evidence) < 3:
+                        evidence.append(f"L{node.lineno} assert")
+                elif kind == "real":
+                    real_hits += 1
+            elif isinstance(node, (ast.With, ast.AsyncWith)):
+                for item in node.items:
+                    ctx = item.context_expr
+                    if isinstance(ctx, ast.Call):
+                        cname = dotted(ctx.func) or ""
+                        if cname.endswith(("raises", "warns", "deprecated_call")):
+                            real_hits += 1
+        return double_hits, real_hits, evidence, sorted(subjects)
+
+    def _classify_assert(self, node: ast.Assert, double_names: set[str], subjects: set[str]) -> str:
+        attrs = {n.attr for n in ast.walk(node.test) if isinstance(n, ast.Attribute)}
+        called = {(dotted(n.func) or "").split(".")[-1] for n in ast.walk(node.test) if isinstance(n, ast.Call)}
+        if attrs & DOUBLE_ATTRS or called & DOUBLE_ASSERT_METHODS:
+            for sub in ast.walk(node.test):
+                if isinstance(sub, ast.Attribute) and (sub.attr in DOUBLE_ATTRS or sub.attr in DOUBLE_ASSERT_METHODS):
+                    owner = dotted(sub.value)
+                    if owner:
+                        subjects.add(owner)
+            return "double"
+        roots = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)} - BUILTIN_NAMES
+        if not roots:
+            return "trivial"
+        if roots <= double_names:
+            subjects.update(roots)
+            return "double"
+        return "real"
+
+
+# ---------------------------------------------------------------- 类 2 识别
+
+
+def classify_motive(target: str) -> str:
+    override = MOTIVE_OVERRIDES.get(target)
+    if override:
+        return override
+    symbol = target.split(".")[-1]
+    if TIMING_RE.search(symbol):
+        return MOTIVE_TIMING
+    if IO_RE.search(symbol):
+        return MOTIVE_IO
+    if any(hint in target for hint in IO_MODULE_HINTS):
+        return MOTIVE_IO
+    return MOTIVE_LOGIC
+
+
+def is_private_target(target: str) -> bool:
+    if not target.startswith(("lib.", "server.")):
+        return False
+    return any(seg.startswith("_") and not seg.startswith("__") for seg in target.split(".")[1:])
+
+
+def target_module_prefix(target: str, known_modules: set[str]) -> str:
+    """取点分目标里最长的、已知是模块的前缀；否则退化为「去掉最后一段」。"""
+    parts = target.split(".")
+    for cut in range(len(parts) - 1, 0, -1):
+        prefix = ".".join(parts[:cut])
+        if prefix in known_modules:
+            return prefix
+    return ".".join(parts[:-1])
+
+
+class ProductionIndex:
+    """按 `lib/` `server/` 源码判定 patch 目标落在哪个模块、符号是模块自身定义还是
+    从别处 import 进来的引用。区分二者是关键：`patch("被测module.自身符号")` 是把被测
+    实现挖空，`patch("被测module.协作者")` 只是在既有 import 边界上换实现。"""
+
+    ORIGIN_DEFINED = "defined"
+    ORIGIN_IMPORTED = "imported"
+    ORIGIN_UNKNOWN = "unknown"
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self._cache: dict[str, tuple[dict[str, str], dict[str, set[str]]] | None] = {}
+
+    def is_module(self, dotted_name: str) -> bool:
+        return self._module_file(dotted_name) is not None
+
+    def _module_file(self, module: str) -> Path | None:
+        rel = module.replace(".", "/")
+        for candidate in (self.root / f"{rel}.py", self.root / rel / "__init__.py"):
+            if candidate.is_file():
+                return candidate
+        return None
+
+    def _load(self, module: str) -> tuple[dict[str, str], dict[str, set[str]]] | None:
+        """返回 (顶层名 -> defined/imported, 类名 -> 成员集合)。"""
+        if module in self._cache:
+            return self._cache[module]
+        path = self._module_file(module)
+        result: tuple[dict[str, str], dict[str, set[str]]] | None = None
+        if path is not None:
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover
+                tree = None
+            if tree is not None:
+                names: dict[str, str] = {}
+                classes: dict[str, set[str]] = {}
+                for node in tree.body:
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        names[node.name] = self.ORIGIN_DEFINED
+                    elif isinstance(node, ast.ClassDef):
+                        names[node.name] = self.ORIGIN_DEFINED
+                        members: set[str] = set()
+                        for item in node.body:
+                            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                                members.add(item.name)
+                            elif isinstance(item, ast.Assign):
+                                members.update(t.id for t in item.targets if isinstance(t, ast.Name))
+                            elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                                members.add(item.target.id)
+                        classes[node.name] = members
+                    elif isinstance(node, ast.Assign):
+                        names.update({t.id: self.ORIGIN_DEFINED for t in node.targets if isinstance(t, ast.Name)})
+                    elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                        names[node.target.id] = self.ORIGIN_DEFINED
+                    elif isinstance(node, ast.Import):
+                        for alias in node.names:
+                            names[alias.asname or alias.name.split(".")[0]] = self.ORIGIN_IMPORTED
+                    elif isinstance(node, ast.ImportFrom):
+                        for alias in node.names:
+                            names[alias.asname or alias.name] = self.ORIGIN_IMPORTED
+                result = (names, classes)
+        self._cache[module] = result
+        return result
+
+    def split(self, target: str) -> tuple[str | None, str]:
+        """把点分目标切成 (模块, 模块内符号路径)。取最长的、磁盘上存在的模块前缀。"""
+        parts = target.split(".")
+        for cut in range(len(parts) - 1, 0, -1):
+            module = ".".join(parts[:cut])
+            if self._module_file(module) is not None:
+                return module, ".".join(parts[cut:])
+        return None, target
+
+    def origin(self, target: str) -> str:
+        module, symbol = self.split(target)
+        if module is None or not symbol:
+            return self.ORIGIN_UNKNOWN
+        loaded = self._load(module)
+        if loaded is None:
+            return self.ORIGIN_UNKNOWN
+        names, classes = loaded
+        head, _, rest = symbol.partition(".")
+        kind = names.get(head)
+        if kind is None:
+            return self.ORIGIN_UNKNOWN
+        if kind == self.ORIGIN_IMPORTED:
+            return self.ORIGIN_IMPORTED
+        if not rest:
+            return self.ORIGIN_DEFINED
+        members = classes.get(head)
+        if members is None:
+            return self.ORIGIN_UNKNOWN
+        return self.ORIGIN_DEFINED if rest.split(".")[0] in members else self.ORIGIN_UNKNOWN
+
+
+# ---------------------------------------------------------------- 主扫描
+
+
+class FileScanner:
+    def __init__(self, path: Path, root: Path, prod: ProductionIndex) -> None:
+        self.path = path
+        self.prod = prod
+        self.rel = str(path.relative_to(root))
+        self.tree = ast.parse(path.read_text(encoding="utf-8"))
+        self.aliases = AliasIndex(self.tree)
+        self.mut = self.aliases.module_under_test(path, prod.is_module)
+        self.module_marks = self._module_marks()
+        self.stat = FileStat(path=self.rel)
+        self.double_only: list[DoubleOnlyTest] = []
+        self.patches: list[PatchSite] = []
+
+    def _module_marks(self) -> list[str]:
+        out: list[str] = []
+        for node in self.tree.body:
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == "pytestmark" for t in node.targets):
+                continue
+            values = list(node.value.elts) if isinstance(node.value, (ast.List, ast.Tuple)) else [node.value]
+            for v in values:
+                name = dotted(v.func) if isinstance(v, ast.Call) else dotted(v)
+                if not name:
+                    continue
+                parts = name.split(".")
+                if "mark" in parts:
+                    idx = parts.index("mark")
+                    if idx + 1 < len(parts):
+                        out.append(parts[idx + 1])
+        return out
+
+    def scan(self) -> None:
+        self._scan_scope(self.tree.body, [], None)
+        self._scan_patch_sites()
+
+    def _scan_scope(self, body: list[ast.stmt], class_marks: list[str], class_name: str | None) -> None:
+        for node in body:
+            if isinstance(node, ast.ClassDef):
+                self._scan_scope(node.body, class_marks + marks_of(node.decorator_list), node.name)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+                self._analyze_test(node, class_marks, class_name)
+
+    def _analyze_test(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        class_marks: list[str],
+        class_name: str | None,
+    ) -> None:
+        self.stat.test_funcs += 1
+        marks = sorted(set(self.module_marks + class_marks + marks_of(node.decorator_list)))
+        double_hits, real_hits, evidence, subjects = TestFunctionAnalyzer(node).classify()
+        qual = f"{class_name}::{node.name}" if class_name else node.name
+        if double_hits == 0 and real_hits == 0:
+            self.stat.no_assertion += 1
+        elif real_hits == 0:
+            self.stat.double_only += 1
+            self.double_only.append(
+                DoubleOnlyTest(
+                    path=self.rel,
+                    line=node.lineno,
+                    func=qual,
+                    marks=marks,
+                    double_assertions=double_hits,
+                    evidence=evidence,
+                    subjects=subjects,
+                )
+            )
+
+    # -- patch 站点 ----------------------------------------------
+
+    def _enclosing_map(self) -> dict[int, tuple[str, list[str], dict[str, str]]]:
+        """行号 -> (所属函数限定名, 生效的 marks, 该函数内的 import 别名覆盖)。
+        函数内 `from x import y as mod` 这类局部 import 必须覆盖模块级同名别名，
+        否则同一文件里反复重绑定的 `mod` 会被解析成最后一次 import 的模块。"""
+        out: dict[int, tuple[str, list[str], dict[str, str]]] = {}
+
+        def walk(body: list[ast.stmt], class_marks: list[str], class_name: str | None) -> None:
+            for node in body:
+                if isinstance(node, ast.ClassDef):
+                    walk(node.body, class_marks + marks_of(node.decorator_list), node.name)
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    marks = sorted(set(self.module_marks + class_marks + marks_of(node.decorator_list)))
+                    qual = f"{class_name}::{node.name}" if class_name else node.name
+                    local = alias_map_from(node)
+                    end = node.end_lineno or node.lineno
+                    for line in range(node.lineno, end + 1):
+                        out.setdefault(line, (qual, marks, local))
+                    walk(node.body, class_marks, class_name)
+
+        walk(self.tree.body, [], None)
+        return out
+
+    def _scan_patch_sites(self) -> None:
+        enclosing = self._enclosing_map()
+        known = self.aliases.imported_modules
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Call):
+                continue
+            target, kind = self._patch_target(node)
+            if target is None or kind is None:
+                continue
+            func, marks, local_aliases = enclosing.get(node.lineno, ("<module>", self.module_marks, {}))
+            resolved = self.aliases.resolve(target, local_aliases)
+            private = is_private_target(resolved)
+            module, _symbol = self.prod.split(resolved)
+            if module is None:
+                module = target_module_prefix(resolved, known) or None
+            hits_mut = bool(self.mut) and (module == self.mut or resolved.startswith(f"{self.mut}."))
+            site = PatchSite(
+                path=self.rel,
+                line=node.lineno,
+                func=func,
+                marks=marks,
+                target=resolved,
+                kind=kind,
+                private=private,
+                module=module,
+                symbol_origin=self.prod.origin(resolved),
+                module_under_test=self.mut,
+                hits_module_under_test=hits_mut,
+                motive=classify_motive(resolved),
+            )
+            self.patches.append(site)
+            if private:
+                self.stat.private_patches += 1
+            elif "integration" in marks and hits_mut and site.symbol_origin == ProductionIndex.ORIGIN_DEFINED:
+                self.stat.integration_self_patches += 1
+
+    def _patch_target(self, node: ast.Call) -> tuple[str | None, str | None]:
+        name = call_name(node)
+        if name is None:
+            return None, None
+        if is_patch_object_call(node):
+            if len(node.args) >= 2:
+                base = dotted(node.args[0])
+                attr = const_str(node.args[1])
+                if base and attr:
+                    return f"{base}.{attr}", "patch.object"
+            return None, None
+        if is_patch_call(node):
+            literal = const_str(node.args[0]) if node.args else None
+            return (literal, "patch") if literal else (None, None)
+        if "monkeypatch" in name and name.split(".")[-1] in MONKEYPATCH_SETTERS:
+            if not node.args:
+                return None, None
+            literal = const_str(node.args[0])
+            if literal:
+                return literal, "monkeypatch.setattr"
+            base = dotted(node.args[0])
+            attr = const_str(node.args[1]) if len(node.args) >= 2 else None
+            if base and attr:
+                return f"{base}.{attr}", "monkeypatch.setattr"
+        return None, None
+
+
+# ---------------------------------------------------------------- 类 3：共享设施结构
+
+DUPLICATE_FIXTURE_THRESHOLD = 3
+
+
+@dataclass
+class StructureFinding:
+    rule: str
+    path: str
+    line: int
+    detail: str
+    guidance: str
+
+
+def module_level_fixtures(tree: ast.Module) -> list[tuple[str, int]]:
+    """模块顶层的 fixture 定义 (name, lineno)。
+
+    `@pytest.fixture(name="x")` 以 name= 为准；类内 fixture 不计入。
+    """
+    out: list[tuple[str, int]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            name = dotted(target)
+            if not name or name.split(".")[-1] != "fixture":
+                continue
+            fixture_name = node.name
+            if isinstance(dec, ast.Call):
+                for kw in dec.keywords:
+                    if kw.arg == "name":
+                        literal = const_str(kw.value)
+                        if literal:
+                            fixture_name = literal
+            out.append((fixture_name, node.lineno))
+            break
+    return out
+
+
+def conftest_import_lines(tree: ast.Module) -> list[tuple[int, str]]:
+    """import 到 conftest 的语句 (lineno, 模块名)。"""
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[-1] == "conftest":
+                    out.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.split(".")[-1] == "conftest":
+                out.append((node.lineno, module))
+    return out
+
+
+def scan_shared_facilities(root: Path, tests_dir: Path) -> list[StructureFinding]:
+    """扫描共享设施三角色的结构违规。
+
+    conftest 的生效范围按目录祖先关系判定：`tests/unit/lib/conftest.py` 的 fixture 对
+    `tests/unit/lib/**` 生效，测试文件与其祖先 conftest 同名即构成覆写。
+    """
+    conftest_fixtures: dict[Path, dict[str, int]] = {}
+    test_fixtures: dict[Path, list[tuple[str, int]]] = {}
+    findings: list[StructureFinding] = []
+
+    for path in sorted(tests_dir.rglob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        fixtures = module_level_fixtures(tree)
+        if path.name == "conftest.py":
+            conftest_fixtures[path.parent] = {name: line for name, line in fixtures}
+            continue
+        test_fixtures[path] = fixtures
+        for lineno, module in conftest_import_lines(tree):
+            findings.append(
+                StructureFinding(
+                    "CONFTEST-IMPORT",
+                    rel,
+                    lineno,
+                    f"import 了 {module}",
+                    "conftest 只放 fixture 与收集期钩子；被 import 的 helper 移到 tests/fakes.py、"
+                    "tests/factories.py 或专题共享模块",
+                )
+            )
+
+    def ancestor_conftests(path: Path) -> list[Path]:
+        return [d for d in conftest_fixtures if d == path.parent or d in path.parents]
+
+    for path, fixtures in sorted(test_fixtures.items()):
+        rel = path.relative_to(root).as_posix()
+        for name, line in fixtures:
+            for conftest_dir in sorted(ancestor_conftests(path), key=lambda d: len(d.parts), reverse=True):
+                if name in conftest_fixtures[conftest_dir]:
+                    owner = (conftest_dir / "conftest.py").relative_to(root).as_posix()
+                    findings.append(
+                        StructureFinding(
+                            "FIXTURE-OVERRIDE",
+                            rel,
+                            line,
+                            f"fixture `{name}` 与 {owner} 同名",
+                            "复用 conftest 的 fixture；语义确实不同的改用不同名字",
+                        )
+                    )
+                    break
+
+    for conftest_dir, fixtures in sorted(conftest_fixtures.items()):
+        rel = (conftest_dir / "conftest.py").relative_to(root).as_posix()
+        ancestors = [d for d in conftest_fixtures if d in conftest_dir.parents]
+        for name, line in sorted(fixtures.items()):
+            for other in sorted(ancestors, key=lambda d: len(d.parts), reverse=True):
+                if name in conftest_fixtures[other]:
+                    owner = (other / "conftest.py").relative_to(root).as_posix()
+                    findings.append(
+                        StructureFinding(
+                            "CONFTEST-SHADOW",
+                            rel,
+                            line,
+                            f"fixture `{name}` 与祖先 {owner} 同名",
+                            "局部 conftest 不得与祖先 conftest 的 fixture 同名",
+                        )
+                    )
+                    break
+
+    by_name: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    for path, fixtures in sorted(test_fixtures.items()):
+        rel = path.relative_to(root).as_posix()
+        for name, line in fixtures:
+            by_name[name].append((rel, line))
+    for name, sites in sorted(by_name.items()):
+        files = {rel for rel, _ in sites}
+        if len(files) < DUPLICATE_FIXTURE_THRESHOLD:
+            continue
+        for rel, line in sites:
+            findings.append(
+                StructureFinding(
+                    "FIXTURE-DUP",
+                    rel,
+                    line,
+                    f"fixture `{name}` 在 {len(files)} 个测试文件重复定义",
+                    "同一实体上提到 conftest；恰好重名的不同实体改用区分性名字",
+                )
+            )
+
+    return sorted(findings, key=lambda f: (f.rule, f.path, f.line))
+
+
+# ---------------------------------------------------------------- 汇总输出
+
+
+def run(root: Path, tests_dir: Path, top: int) -> dict[str, object]:
+    files = sorted(p for p in tests_dir.rglob("*.py") if p.name != "__init__.py")
+    stats: list[FileStat] = []
+    double_only: list[DoubleOnlyTest] = []
+    patches: list[PatchSite] = []
+    failures: list[str] = []
+    prod = ProductionIndex(root)
+
+    for path in files:
+        try:
+            scanner = FileScanner(path, root, prod)
+            scanner.scan()
+        except SyntaxError as exc:  # pragma: no cover
+            failures.append(f"{path}: {exc}")
+            continue
+        stats.append(scanner.stat)
+        double_only.extend(scanner.double_only)
+        patches.extend(scanner.patches)
+
+    private = [p for p in patches if p.private]
+    private_own = [p for p in private if p.symbol_origin == ProductionIndex.ORIGIN_DEFINED]
+    integ_self = [
+        p
+        for p in patches
+        if not p.private
+        and "integration" in p.marks
+        and p.hits_module_under_test
+        and p.symbol_origin == ProductionIndex.ORIGIN_DEFINED
+    ]
+    integ_collaborator = [
+        p
+        for p in patches
+        if not p.private
+        and "integration" in p.marks
+        and p.hits_module_under_test
+        and p.symbol_origin == ProductionIndex.ORIGIN_IMPORTED
+    ]
+    flagged = private + integ_self
+
+    by_symbol = Counter(p.target for p in private)
+    by_symbol_integ = Counter(p.target for p in integ_self)
+    motive_counter = Counter(p.motive for p in flagged)
+    motive_private = Counter(p.motive for p in private)
+    motive_integ = Counter(p.motive for p in integ_self)
+    module_counter = Counter(p.module or "<未解析>" for p in private)
+    kind_counter = Counter(p.kind for p in flagged)
+    origin_counter = Counter(p.symbol_origin for p in private)
+
+    samples_by_motive: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for p in flagged:
+        if len(samples_by_motive[p.motive]) < 10:
+            samples_by_motive[p.motive].append(asdict(p))
+
+    double_by_file = Counter(d.path for d in double_only)
+    structure = scan_shared_facilities(root, tests_dir)
+    structure_counter = Counter(f.rule for f in structure)
+
+    return {
+        "totals": {
+            "test_files": len(stats),
+            "test_functions": sum(s.test_funcs for s in stats),
+            "double_only_tests": len(double_only),
+            "no_assertion_tests": sum(s.no_assertion for s in stats),
+            "files_with_double_only": len(double_by_file),
+            "patch_sites_total": len(patches),
+            "private_patch_sites": len(private),
+            "private_patch_sites_defined_in_module": len(private_own),
+            "integration_self_public_patch_sites": len(integ_self),
+            "integration_collaborator_patch_sites": len(integ_collaborator),
+            "files_with_private_patch": len({p.path for p in private}),
+            "distinct_private_symbols": len(by_symbol),
+            "conftest_import_sites": structure_counter["CONFTEST-IMPORT"],
+            "conftest_fixture_override_sites": structure_counter["FIXTURE-OVERRIDE"],
+            "conftest_shadow_sites": structure_counter["CONFTEST-SHADOW"],
+            "duplicate_fixture_sites": structure_counter["FIXTURE-DUP"],
+        },
+        "double_only_by_file": [
+            {"path": s.path, "double_only": s.double_only, "test_funcs": s.test_funcs}
+            for s in sorted(stats, key=lambda s: (-s.double_only, s.path))
+            if s.double_only
+        ][:top],
+        "double_only_cases": [asdict(d) for d in double_only],
+        "double_only_subjects_top": Counter(s for d in double_only for s in d.subjects).most_common(top),
+        "private_targets_top": by_symbol.most_common(top),
+        "integration_self_targets_top": by_symbol_integ.most_common(top),
+        "motive_counts": dict(motive_counter),
+        "motive_counts_private_only": dict(motive_private),
+        "motive_counts_integration_self": dict(motive_integ),
+        "motive_samples": dict(samples_by_motive),
+        "private_modules_top": module_counter.most_common(15),
+        "patch_kind_counts": dict(kind_counter),
+        "private_symbol_origin_counts": dict(origin_counter),
+        "private_patch_sites": [asdict(p) for p in private],
+        "integration_self_patch_sites": [asdict(p) for p in integ_self],
+        "integration_collaborator_patch_sites": [asdict(p) for p in integ_collaborator],
+        "shared_facility_findings": [asdict(f) for f in structure],
+        "parse_failures": failures,
+    }
+
+
+def _print_ranking(title: str, rows: object) -> None:
+    print(title)
+    assert isinstance(rows, list)
+    for row in rows:
+        name, count = row
+        print(f"{count:4d}  {name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="审计 tests/ 中「测 mock 本身」与「patch 私有符号/被测公共入口」的用例",
+    )
+    parser.add_argument("--root", default=".", help="仓库根目录（默认当前目录）")
+    parser.add_argument("--tests", default="tests", help="测试目录，相对 root（默认 tests）")
+    parser.add_argument("--top", type=int, default=30, help="Top N 榜单长度（默认 30）")
+    parser.add_argument("--json", dest="json_out", help="把完整明细写入该 JSON 文件")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    tests_dir = root / args.tests
+    if not tests_dir.is_dir():
+        print(f"测试目录不存在：{tests_dir}", file=sys.stderr)
+        return 2
+
+    result = run(root, tests_dir, args.top)
+    totals = result["totals"]
+    assert isinstance(totals, dict)
+
+    print("== 总量 ==")
+    for key, value in totals.items():
+        print(f"{key:38s} {value}")
+
+    print("\n== 类 1：仅断言替身的用例（按文件 Top） ==")
+    by_file = result["double_only_by_file"]
+    assert isinstance(by_file, list)
+    for row in by_file:
+        print(f"{row['double_only']:4d}/{row['test_funcs']:<4d} {row['path']}")
+
+    _print_ranking("\n== 类 1：被断言的替身主体 Top ==", result["double_only_subjects_top"])
+    _print_ranking("\n== 类 2：patch 私有符号 Top ==", result["private_targets_top"])
+    _print_ranking(
+        "\n== 类 2：integration 用例 patch 被测 module 公共入口 Top ==", result["integration_self_targets_top"]
+    )
+
+    print("\n== 类 2：动机分档 ==")
+    motives = result["motive_counts"]
+    assert isinstance(motives, dict)
+    for motive, count in sorted(motives.items(), key=lambda kv: -kv[1]):
+        print(f"{count:4d}  {motive}")
+
+    _print_ranking("\n== 类 2：私有符号最集中的生产模块 ==", result["private_modules_top"])
+
+    print("\n== 类 3：共享设施结构 ==")
+    structure = result["shared_facility_findings"]
+    assert isinstance(structure, list)
+    for row in structure:
+        print(f"{row['rule']:17s} {row['path']}:{row['line']}  {row['detail']}  → {row['guidance']}")
+    if not structure:
+        print("无命中")
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"\n明细已写入 {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,12 @@ import shutil
 import tempfile
 import uuid as _uuid
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 from sqlalchemy import event, pool, text
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 # `lib.db.engine` 的模块级 engine 在 import 期就按 `DATABASE_URL` 绑定，进程内不再重建，
 # 所以覆写必须发生在下方任何会传染到该模块的 import 之前。未显式指定时它落在仓库根的
@@ -134,17 +135,6 @@ def _shared_db_schema():
     command.upgrade(cfg, "head")
 
 
-@pytest.fixture()
-async def db_factory():
-    """Create an async session factory backed by an isolated in-memory database."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
-
-
 def _pg_url_from_env() -> str | None:
     """Return DATABASE_URL iff it's a PostgreSQL+asyncpg URL, else None."""
     url = os.environ.get("DATABASE_URL")
@@ -159,7 +149,7 @@ def _pg_url_from_env() -> str | None:
 _PG_TEST_USER_IDS = ("default", "u1", "conformance", "e2e", "crash-recover", "long-turn")
 
 
-async def _seed_pg_users(engine) -> None:
+async def _seed_pg_users(engine: AsyncEngine) -> None:
     async with engine.begin() as conn:
         for uid in _PG_TEST_USER_IDS:
             await conn.execute(
@@ -172,56 +162,99 @@ async def _seed_pg_users(engine) -> None:
             )
 
 
-@pytest.fixture
-async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
-    """Session factory with all tables created.
+def _register_models() -> None:
+    """把全部 ORM 模型登记到 ``Base.metadata``。
 
-    By default uses in-memory SQLite. When ``DATABASE_URL`` points at PG
-    (postgresql+asyncpg://...), uses a per-test isolated PG schema so
-    dialect-specific code paths (partial unique indexes + ON CONFLICT,
-    SELECT ... FOR UPDATE) are actually exercised.
+    不这么做时建表范围取决于被测模块的 import 链，同一 fixture 在不同文件下建出的
+    schema 不同。
     """
-    pg_url = _pg_url_from_env()
+    import lib.agent_session_store.models  # noqa: F401
+    import lib.db.models  # noqa: F401  (users / agent_sessions / config etc.)
+
+
+@asynccontextmanager
+async def test_engine(*, dialect_aware: bool = True, file_path: Path | None = None) -> AsyncIterator[AsyncEngine]:
+    """全部 DB fixture 的唯一 engine 来源。
+
+    ``dialect_aware`` 且 ``DATABASE_URL`` 指向 PG 时建 per-test schema 并按 search_path
+    建表、播种 FK 依赖的 user 行，退出时 ``DROP SCHEMA CASCADE``——方言相关代码路径
+    （partial unique index + ON CONFLICT、SELECT ... FOR UPDATE）由此被真实覆盖。
+
+    其余情况建 SQLite：``file_path`` 为 None 时用内存库；给了路径则用 NullPool 文件库，
+    供必须绕开 StaticPool 串行化的并发用例。``dialect_aware=False`` 固定走 SQLite，
+    postgres-compat job 里也不改道——unit 档用例不该被拉去跑 PG。
+    """
+    pg_url = _pg_url_from_env() if dialect_aware else None
     if pg_url:
-        # Per-test schema for isolation; tables created against it via search_path.
         schema = f"test_{_uuid.uuid4().hex[:12]}"
-        engine = create_async_engine(
-            pg_url,
-            connect_args={"server_settings": {"search_path": schema}},
-        )
+        engine = create_async_engine(pg_url, connect_args={"server_settings": {"search_path": schema}})
         async with engine.begin() as conn:
             await conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
         async with engine.begin() as conn:
-            import lib.agent_session_store.models  # noqa: F401
-            import lib.db.models  # noqa: F401
-
+            _register_models()
             await conn.run_sync(Base.metadata.create_all)
         # PG enforces FK constraints (SQLite tests run with PRAGMA foreign_keys=OFF).
-        # Seed the user rows that test cases attribute writes to so FK checks pass.
         await _seed_pg_users(engine)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
         try:
-            yield factory
+            yield engine
         finally:
             async with engine.begin() as conn:
                 await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
             await engine.dispose()
         return
 
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        # Import model modules to register tables on Base.metadata.
-        import lib.agent_session_store.models  # noqa: F401
-        import lib.db.models  # noqa: F401  (users / agent_sessions / config etc.)
+    if file_path is None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    else:
+        engine = create_async_engine(f"sqlite+aiosqlite:///{file_path}", poolclass=pool.NullPool)
 
+        @event.listens_for(engine.sync_engine, "connect")
+        def _set_sqlite_pragma(dbapi_conn, _record):
+            cursor = dbapi_conn.cursor()
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA busy_timeout=30000")
+            cursor.execute("PRAGMA foreign_keys=OFF")
+            cursor.close()
+
+    async with engine.begin() as conn:
+        _register_models()
         await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture()
+async def db_engine() -> AsyncIterator[AsyncEngine]:
+    """内存 SQLite engine —— models / repositories 单测的共享入口。"""
+    async with test_engine(dialect_aware=False) as engine:
+        yield engine
+
+
+@pytest.fixture()
+async def db_session(db_engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
+    """``db_engine`` 上的 AsyncSession。"""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+
+
+@pytest.fixture()
+async def db_factory(db_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """``db_engine`` 上的 session factory。"""
+    return async_sessionmaker(db_engine, expire_on_commit=False)
 
 
 @pytest.fixture
-async def file_session_factory(tmp_path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """方言敏感的 session factory：PG 下走 per-test schema，否则内存 SQLite。"""
+    async with test_engine() as engine:
+        yield async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+async def file_session_factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
     """File-backed SQLite with NullPool — each connection is independent.
 
     Required for concurrency tests that must NOT serialize via StaticPool
@@ -230,28 +263,8 @@ async def file_session_factory(tmp_path) -> AsyncIterator[async_sessionmaker[Asy
     Always SQLite regardless of ``DATABASE_URL`` — tests that depend on this
     fixture are SQLite-specific edge cases marked ``@pytest.mark.sqlite_only``.
     """
-    db_path = tmp_path / "concurrency.db"
-    engine = create_async_engine(
-        f"sqlite+aiosqlite:///{db_path}",
-        poolclass=pool.NullPool,
-    )
-
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _record):
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.execute("PRAGMA foreign_keys=OFF")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        import lib.agent_session_store.models  # noqa: F401
-        import lib.db.models  # noqa: F401
-
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
+    async with test_engine(dialect_aware=False, file_path=tmp_path / "concurrency.db") as engine:
+        yield async_sessionmaker(engine, expire_on_commit=False)
 
 
 # ---------------------------------------------------------------------------
@@ -260,16 +273,9 @@ async def file_session_factory(tmp_path) -> AsyncIterator[async_sessionmaker[Asy
 
 
 @pytest.fixture()
-async def meta_store():
+async def meta_store(db_factory: async_sessionmaker[AsyncSession]) -> SessionMetaStore:
     """Create an async SessionMetaStore backed by in-memory SQLite."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    store = SessionMetaStore(session_factory=factory)
-    yield store
-    await engine.dispose()
+    return SessionMetaStore(session_factory=db_factory)
 
 
 @pytest.fixture()
@@ -395,6 +401,8 @@ async def async_session():
     """
     url = os.environ.get("DATABASE_URL", "")
     if url.startswith("postgresql"):
+        # 唯一不走 `test_engine` 的分支：它绑定 CI job 已 alembic 建好的 public schema，
+        # 而 `test_engine` 建 per-test schema 并 create_all，两者的隔离原语不同。
         # Per-test engine with NullPool: avoids cross-event-loop reuse of
         # asyncpg connections (each pytest-asyncio test runs on a fresh loop).
         from sqlalchemy.pool import NullPool
@@ -418,13 +426,10 @@ async def async_session():
         return
 
     # SQLite in-memory — engine is throwaway, ORM-driven schema.
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-    await engine.dispose()
+    async with test_engine(dialect_aware=False) as engine:
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as session:
+            yield session
 
 
 # ---------------------------------------------------------------------------
@@ -433,18 +438,12 @@ async def async_session():
 
 
 @pytest.fixture()
-async def generation_queue():
+async def generation_queue(db_factory: async_sessionmaker[AsyncSession]):
     """Create an async GenerationQueue backed by in-memory SQLite.
 
     Automatically resets the module singleton on teardown.
     """
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    queue = generation_queue_module.GenerationQueue(session_factory=factory)
+    queue = generation_queue_module.GenerationQueue(session_factory=db_factory)
     generation_queue_module._QUEUE_INSTANCE = queue
     yield queue
     generation_queue_module._QUEUE_INSTANCE = None
-    await engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,28 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
-
-def make_translator(locale: str = "zh") -> Callable[..., str]:
-    """Create a translator function bound to a fixed locale for testing."""
-    from lib.i18n import _ as i18n_translate
-
-    def translate(key: str, **kwargs) -> str:
-        return i18n_translate(key, locale=locale, **kwargs)
-
-    return translate
-
-
 import atexit
 import os
 import shutil
-import subprocess
 import tempfile
 import uuid as _uuid
-import wave
 from collections.abc import AsyncIterator
-from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -54,98 +38,6 @@ import lib.generation_queue as generation_queue_module
 from lib.db.base import Base
 from server.agent_runtime.session_manager import SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
-
-# ---------------------------------------------------------------------------
-# General utilities
-# ---------------------------------------------------------------------------
-
-
-def _wav_bytes(duration_seconds: float, sample_rate: int = 8000) -> bytes:
-    """纯 stdlib 生成 wav 字节（不依赖 ffmpeg），供不要求真实音频编解码的用例使用。"""
-    buf = BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(sample_rate)
-        wf.writeframes(b"\x00\x00" * int(duration_seconds * sample_rate))
-    return buf.getvalue()
-
-
-def make_test_video(path: Path, *, duration_sec: float = 1.0, fps: int = 30) -> None:
-    """使用 ffmpeg 生成极短测试视频（64x64 像素）"""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            f"color=black:size=64x64:duration={duration_sec}:rate={fps}",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            str(path),
-        ],
-        capture_output=True,
-        check=True,
-    )
-
-
-def make_test_video_with_audio_tail(
-    path: Path,
-    *,
-    video_duration_sec: float = 1.0,
-    audio_duration_sec: float = 1.5,
-    fps: int = 30,
-) -> None:
-    """生成音轨/容器尾部比视频轨更长的极短 MP4。"""
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            f"color=black:size=64x64:duration={video_duration_sec}:rate={fps}",
-            "-f",
-            "lavfi",
-            "-i",
-            f"sine=frequency=440:duration={audio_duration_sec}",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-c:a",
-            "aac",
-            str(path),
-        ],
-        capture_output=True,
-        check=True,
-    )
-
-
-def make_test_audio(path: Path, *, duration_sec: float = 1.0) -> None:
-    """使用 ffmpeg 生成极短测试音频（正弦波 wav，pcm_s16le 为 ffmpeg 内置编码器）"""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            f"sine=frequency=440:duration={duration_sec}",
-            "-c:a",
-            "pcm_s16le",
-            str(path),
-        ],
-        capture_output=True,
-        check=True,
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,6 +241,17 @@ async def db_session(db_engine: AsyncEngine) -> AsyncIterator[AsyncSession]:
 
 
 @pytest.fixture()
+async def file_db_factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """文件 SQLite + NullPool 的 factory —— 需要独立连接的并发用例用它。
+
+    与 ``file_session_factory`` 的差别只在不带 `uses_db`：unit 档的并发用例
+    不该被拉进 postgres-compat 选集。
+    """
+    async with test_engine(dialect_aware=False, file_path=tmp_path / "concurrency.db") as engine:
+        yield async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture()
 async def db_factory(db_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     """``db_engine`` 上的 session factory。"""
     return async_sessionmaker(db_engine, expire_on_commit=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,10 @@ def _register_models() -> None:
 
 @asynccontextmanager
 async def test_engine(*, dialect_aware: bool = True, file_path: Path | None = None) -> AsyncIterator[AsyncEngine]:
-    """全部 DB fixture 的唯一 engine 来源。
+    """DB fixture 的 engine 构造点，唯一例外是 `async_session` 的 PG 分支。
+
+    那条分支绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层
+    事务 + SAVEPOINT，与这里的 per-test schema + `create_all` 不同，故自建 engine。
 
     ``dialect_aware`` 且 ``DATABASE_URL`` 指向 PG 时建 per-test schema 并按 search_path
     建表、播种 FK 依赖的 user 行，退出时 ``DROP SCHEMA CASCADE``——方言相关代码路径

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,10 +2,112 @@
 
 from __future__ import annotations
 
+import subprocess
+import wave
+from collections.abc import Callable
 from datetime import UTC, datetime
+from io import BytesIO
+from pathlib import Path
 from typing import Any
 
 from server.agent_runtime.models import SessionMeta
+
+
+def make_translator(locale: str = "zh") -> Callable[..., str]:
+    """Create a translator function bound to a fixed locale for testing."""
+    from lib.i18n import _ as i18n_translate
+
+    def translate(key: str, **kwargs) -> str:
+        return i18n_translate(key, locale=locale, **kwargs)
+
+    return translate
+
+
+def wav_bytes(duration_seconds: float, sample_rate: int = 8000) -> bytes:
+    """纯 stdlib 生成 wav 字节（不依赖 ffmpeg），供不要求真实音频编解码的用例使用。"""
+    buf = BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00\x00" * int(duration_seconds * sample_rate))
+    return buf.getvalue()
+
+
+def make_test_video(path: Path, *, duration_sec: float = 1.0, fps: int = 30) -> None:
+    """使用 ffmpeg 生成极短测试视频（64x64 像素）"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=black:size=64x64:duration={duration_sec}:rate={fps}",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+
+def make_test_video_with_audio_tail(
+    path: Path,
+    *,
+    video_duration_sec: float = 1.0,
+    audio_duration_sec: float = 1.5,
+    fps: int = 30,
+) -> None:
+    """生成音轨/容器尾部比视频轨更长的极短 MP4。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=black:size=64x64:duration={video_duration_sec}:rate={fps}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={audio_duration_sec}",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+
+def make_test_audio(path: Path, *, duration_sec: float = 1.0) -> None:
+    """使用 ffmpeg 生成极短测试音频（正弦波 wav，pcm_s16le 为 ffmpeg 内置编码器）"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={duration_sec}",
+            "-c:a",
+            "pcm_s16le",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
 
 
 def make_session_meta(**overrides) -> SessionMeta:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -90,26 +90,6 @@ def make_test_video_with_audio_tail(
     )
 
 
-def make_test_audio(path: Path, *, duration_sec: float = 1.0) -> None:
-    """使用 ffmpeg 生成极短测试音频（正弦波 wav，pcm_s16le 为 ffmpeg 内置编码器）"""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            f"sine=frequency=440:duration={duration_sec}",
-            "-c:a",
-            "pcm_s16le",
-            str(path),
-        ],
-        capture_output=True,
-        check=True,
-    )
-
-
 def make_session_meta(**overrides) -> SessionMeta:
     """Build a SessionMeta with sensible defaults.
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -430,7 +430,10 @@ def instructor_api_call_exhausted(cause: Exception) -> InstructorRetryException:
 
 @contextmanager
 def bounded_poll_clock(step: float = 30.0):
-    """把 ``poll_with_retry`` 的时钟换成假表：sleep 不真等，每读一次表推进 step 秒。
+    """轮询与重试等待的唯一替身入口：sleep 不真等，每读一次表推进 step 秒。
+
+    ``retry_async`` 的退避与 ``poll_with_retry`` 的轮询间隔都经 ``lib.retry`` 的
+    ``SystemClock`` 落到这两个符号上，压缩等待无需触碰 ``_compute_wait`` 等私有符号。
 
     终态判定失灵时（把已就绪的任务当成"仍在跑"），真实时钟下 sleep 被 mock 掉的轮询会以近乎
     为零的真实耗时空转到天荒地老——测试表现为挂起而不是失败。假表让这类回归在几十次轮询内

--- a/tests/http_capture.py
+++ b/tests/http_capture.py
@@ -32,11 +32,6 @@ def request_json(request: httpx.Request) -> Any:
     return json.loads(request.content)
 
 
-def sent_json(route: respx.Route) -> list[Any]:
-    """该路由收到的全部请求体，按发出顺序。"""
-    return [request_json(call.request) for call in route.calls]
-
-
 def only_request(route: respx.Route) -> httpx.Request:
     """断言该路由恰好收到一次请求并返回它。"""
     assert route.call_count == 1, f"期望 1 次请求，实际 {route.call_count} 次"

--- a/tests/http_capture.py
+++ b/tests/http_capture.py
@@ -1,0 +1,43 @@
+"""出站 HTTP 断言的统一去向：respx 在 transport 层拦截真实 httpx 客户端。
+
+与 `patch("httpx.AsyncClient")` 的区别是断言对象：替身记录的是调用参数，respx 捕获的是
+真实序列化后的请求，因此 URL 拼接、header 合并、body 编码这些出错在线上的环节都在断言
+范围内；`AsyncOpenAI` 等自带 httpx 客户端的 SDK 流量同样被捕获。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+import respx
+
+
+@contextmanager
+def capture_http(*, assert_all_called: bool = False) -> Iterator[respx.MockRouter]:
+    """拦截全部出站 httpx 流量；未声明路由的请求直接抛错，不会静默放行到真实网络。
+
+    `assert_all_called` 缺省关闭：多数用例只关心其中一条路由是否收到预期请求，声明了
+    错误分支路由却不触发是常态，退出时强制全部命中会把这类用例判红。
+    """
+    with respx.mock(assert_all_called=assert_all_called) as router:
+        yield router
+
+
+def request_json(request: httpx.Request) -> Any:
+    """请求体按 JSON 解码。"""
+    return json.loads(request.content)
+
+
+def sent_json(route: respx.Route) -> list[Any]:
+    """该路由收到的全部请求体，按发出顺序。"""
+    return [request_json(call.request) for call in route.calls]
+
+
+def only_request(route: respx.Route) -> httpx.Request:
+    """断言该路由恰好收到一次请求并返回它。"""
+    assert route.call_count == 1, f"期望 1 次请求，实际 {route.call_count} 次"
+    return route.calls.last.request

--- a/tests/integration/lib/custom_provider/test_custom_provider_loader.py
+++ b/tests/integration/lib/custom_provider/test_custom_provider_loader.py
@@ -9,29 +9,16 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.custom_provider import make_provider_id
 from lib.custom_provider.backends import CustomImageBackend
 from lib.custom_provider.capabilities import system_video_capabilities
 from lib.custom_provider.loader import load_custom_backend
-from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
 
-@pytest.fixture()
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-async def _seed(session, *, models: list[dict]) -> str:
-    repo = CustomProviderRepository(session)
+async def _seed(db_session, *, models: list[dict]) -> str:
+    repo = CustomProviderRepository(db_session)
     # display_name 列 NOT NULL：缺省补 model_id 作显示名
     for m in models:
         m.setdefault("display_name", m["model_id"])
@@ -42,49 +29,51 @@ async def _seed(session, *, models: list[dict]) -> str:
         api_key="sk-relay",
         models=models,
     )
-    await session.commit()
+    await db_session.commit()
     return make_provider_id(provider.id)
 
 
 class TestLoadCustomBackend:
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    async def test_resolves_named_model_and_delegates(self, mock_cls, session):
+    async def test_resolves_named_model_and_delegates(self, mock_cls, db_session):
         pid = await _seed(
-            session,
+            db_session,
             models=[{"model_id": "dall-e-3", "endpoint": "openai-images", "is_enabled": True}],
         )
-        result = await load_custom_backend(session=session, provider_id=pid, model_id="dall-e-3", media_type="image")
+        result = await load_custom_backend(session=db_session, provider_id=pid, model_id="dall-e-3", media_type="image")
         assert isinstance(result, CustomImageBackend)
         assert result.model == "dall-e-3"
         mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")
 
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    async def test_falls_back_to_default_when_model_disabled(self, mock_cls, session):
+    async def test_falls_back_to_default_when_model_disabled(self, mock_cls, db_session):
         # 请求的 model 已禁用 → 回退到该 media_type 的默认启用 model
         pid = await _seed(
-            session,
+            db_session,
             models=[
                 {"model_id": "disabled-m", "endpoint": "openai-images", "is_enabled": False},
                 {"model_id": "active-m", "endpoint": "openai-images", "is_enabled": True, "is_default": True},
             ],
         )
-        result = await load_custom_backend(session=session, provider_id=pid, model_id="disabled-m", media_type="image")
+        result = await load_custom_backend(
+            session=db_session, provider_id=pid, model_id="disabled-m", media_type="image"
+        )
         assert result.model == "active-m"
 
-    async def test_provider_not_found_fails_loud(self, session):
+    async def test_provider_not_found_fails_loud(self, db_session):
         with pytest.raises(ValueError, match="不存在"):
             await load_custom_backend(
-                session=session, provider_id=make_provider_id(999), model_id="x", media_type="image"
+                session=db_session, provider_id=make_provider_id(999), model_id="x", media_type="image"
             )
 
-    async def test_no_default_model_for_media_fails_loud(self, session):
+    async def test_no_default_model_for_media_fails_loud(self, db_session):
         # 只有 image model，请求 video → 无默认 video model
         pid = await _seed(
-            session,
+            db_session,
             models=[{"model_id": "dall-e-3", "endpoint": "openai-images", "is_enabled": True}],
         )
         with pytest.raises(ValueError, match="没有默认"):
-            await load_custom_backend(session=session, provider_id=pid, model_id=None, media_type="video")
+            await load_custom_backend(session=db_session, provider_id=pid, model_id=None, media_type="video")
 
 
 class TestVideoCapabilityOverridesReachExecution:
@@ -92,10 +81,10 @@ class TestVideoCapabilityOverridesReachExecution:
 
     @staticmethod
     async def _load_video_backend(
-        session, *, overrides: object | None, endpoint: str = "openai-video", model_id: str = "sora-2"
+        db_session, *, overrides: object | None, endpoint: str = "openai-video", model_id: str = "sora-2"
     ):
         pid = await _seed(
-            session,
+            db_session,
             models=[
                 {
                     "model_id": model_id,
@@ -107,35 +96,35 @@ class TestVideoCapabilityOverridesReachExecution:
             ],
         )
         # 清 identity map，逼装载重新 SELECT：覆盖字典要真经过 JSON 编解码往返才算验到 DB 语义
-        session.expunge_all()
-        return await load_custom_backend(session=session, provider_id=pid, model_id=model_id, media_type="video")
+        db_session.expunge_all()
+        return await load_custom_backend(session=db_session, provider_id=pid, model_id=model_id, media_type="video")
 
     @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
-    async def test_null_overrides_follow_system_judgement(self, _mock_cls, session):
-        backend = await self._load_video_backend(session, overrides=None)
+    async def test_null_overrides_follow_system_judgement(self, _mock_cls, db_session):
+        backend = await self._load_video_backend(db_session, overrides=None)
         assert backend.video_capabilities == system_video_capabilities(endpoint="openai-video", model_id="sora-2")
 
     @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    async def test_override_forces_capability_on(self, _mock_cls, session):
+    async def test_override_forces_capability_on(self, _mock_cls, db_session):
         # 系统判定 last_frame=False；覆盖强制开启后执行层看到 True，且不再转发被包装 backend
         # endpoint 须支持尾帧（end_image_capable）覆盖才会生效，openai-video 不满足此前提
         backend = await self._load_video_backend(
-            session, overrides={"last_frame": True}, endpoint="ark-seedance", model_id="seedance-1-pro"
+            db_session, overrides={"last_frame": True}, endpoint="ark-seedance", model_id="seedance-1-pro"
         )
         assert backend.video_capabilities.last_frame is True
         assert backend.video_capabilities.max_reference_images == 0
 
     @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
-    async def test_override_forces_capability_off(self, _mock_cls, session):
-        backend = await self._load_video_backend(session, overrides={"max_reference_images": 0})
+    async def test_override_forces_capability_off(self, _mock_cls, db_session):
+        backend = await self._load_video_backend(db_session, overrides={"max_reference_images": 0})
         assert backend.video_capabilities.max_reference_images == 0
         assert backend.video_capabilities.first_frame is True
 
     @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    async def test_unknown_key_in_stored_overrides_does_not_break_loading(self, _mock_cls, session):
+    async def test_unknown_key_in_stored_overrides_does_not_break_loading(self, _mock_cls, db_session):
         # 存量行可能带已下线的键，装载不得失败，该维度按系统判定走
         backend = await self._load_video_backend(
-            session,
+            db_session,
             overrides={"retired_dimension": True, "last_frame": True},
             endpoint="ark-seedance",
             model_id="seedance-1-pro",
@@ -143,9 +132,9 @@ class TestVideoCapabilityOverridesReachExecution:
         assert backend.video_capabilities.last_frame is True
 
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    async def test_non_video_backend_untouched_by_overrides(self, _mock_cls, session):
+    async def test_non_video_backend_untouched_by_overrides(self, _mock_cls, db_session):
         pid = await _seed(
-            session,
+            db_session,
             models=[
                 {
                     "model_id": "dall-e-3",
@@ -155,5 +144,5 @@ class TestVideoCapabilityOverridesReachExecution:
                 }
             ],
         )
-        result = await load_custom_backend(session=session, provider_id=pid, model_id="dall-e-3", media_type="image")
+        result = await load_custom_backend(session=db_session, provider_id=pid, model_id="dall-e-3", media_type="image")
         assert isinstance(result, CustomImageBackend)

--- a/tests/integration/lib/db/repositories/test_task_repo.py
+++ b/tests/integration/lib/db/repositories/test_task_repo.py
@@ -18,22 +18,6 @@ def _translator(locale: str):
     return translate
 
 
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def db_session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-
-
 class TestTaskRepository:
     async def test_enqueue_dedupe_claim_succeed(self, db_session):
         repo = TaskRepository(db_session)
@@ -356,17 +340,17 @@ class TestTaskRepository:
 
     async def test_worker_lease_concurrent_first_acquire(self, tmp_path):
         db_path = tmp_path / "lease-race.db"
-        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-        async with engine.begin() as conn:
+        db_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        async with db_engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
-        factory = async_sessionmaker(engine, expire_on_commit=False)
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
         start = asyncio.Event()
 
         async def _attempt(owner_id: str) -> bool:
             await start.wait()
-            async with factory() as session:
-                repo = TaskRepository(session)
+            async with factory() as db_session:
+                repo = TaskRepository(db_session)
                 return await repo.acquire_or_renew_lease(
                     name="default",
                     owner_id=owner_id,
@@ -380,13 +364,13 @@ class TestTaskRepository:
         a_ok, b_ok = await asyncio.gather(first, second)
         assert sorted([a_ok, b_ok]) == [False, True]
 
-        async with factory() as session:
-            repo = TaskRepository(session)
+        async with factory() as db_session:
+            repo = TaskRepository(db_session)
             lease = await repo.get_worker_lease(name="default")
             assert lease is not None
             assert lease["owner_id"] in {"worker-a", "worker-b"}
 
-        await engine.dispose()
+        await db_engine.dispose()
 
     async def test_list_tasks_with_filters(self, db_session):
         repo = TaskRepository(db_session)

--- a/tests/integration/lib/db/repositories/test_task_repo.py
+++ b/tests/integration/lib/db/repositories/test_task_repo.py
@@ -655,7 +655,7 @@ class TestPersistApiCallId:
 
 
 class TestCancelCascadeAcrossCancelling:
-    """fix #647 #4：cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)
+    """cancel 级联跨过 cancelling 节点，A(running)→B(queued)→C(queued)
     在 A 落 cancelled 时通过 finalize_cancelled 自动级联到 B/C。"""
 
     async def _chain_3(self, repo: TaskRepository) -> tuple[str, str, str]:

--- a/tests/integration/lib/db/repositories/test_usage_repo.py
+++ b/tests/integration/lib/db/repositories/test_usage_repo.py
@@ -2,27 +2,9 @@
 
 import pytest
 from sqlalchemy import update
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
-
-
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def db_session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
 
 
 class TestUsageRepository:

--- a/tests/integration/lib/test_audio_utils.py
+++ b/tests/integration/lib/test_audio_utils.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import lib.audio_utils as audio_utils_module
-from tests.conftest import _wav_bytes, make_test_video_with_audio_tail
+from tests.factories import make_test_video_with_audio_tail, wav_bytes
 
 
 @pytest.fixture(autouse=True)
@@ -72,7 +72,7 @@ class TestFfprobeUnavailable:
     async def test_returns_none_without_spawning(self):
         with patch("lib.audio_utils.shutil.which", return_value=None):
             with patch("lib.audio_utils.asyncio.create_subprocess_exec") as spawn:
-                result = await audio_utils_module.probe_audio_duration_seconds(_wav_bytes(3), ".wav")
+                result = await audio_utils_module.probe_audio_duration_seconds(wav_bytes(3), ".wav")
         assert result is None
         spawn.assert_not_called()
 
@@ -86,7 +86,7 @@ class TestFfprobeAvailable:
             pytest.skip("ffprobe not available")
 
     async def test_probes_real_duration(self):
-        duration = await audio_utils_module.probe_audio_duration_seconds(_wav_bytes(3), ".wav")
+        duration = await audio_utils_module.probe_audio_duration_seconds(wav_bytes(3), ".wav")
         assert duration is not None
         assert 2.5 < duration < 3.5
 
@@ -118,7 +118,7 @@ class TestFfprobeAvailable:
             return await orig_exec(*args, **kwargs)
 
         with patch("lib.audio_utils.asyncio.create_subprocess_exec", side_effect=_spy):
-            await audio_utils_module.probe_audio_duration_seconds(_wav_bytes(3), ".wav")
+            await audio_utils_module.probe_audio_duration_seconds(wav_bytes(3), ".wav")
 
         assert calls, "ffprobe 应至少被调用一次"
         for call_args in calls:
@@ -177,8 +177,8 @@ class TestProbeReferenceAudioTotalSeconds:
     async def test_sums_durations_of_existing_files(self, tmp_path):
         path_a = tmp_path / "a.wav"
         path_b = tmp_path / "b.wav"
-        path_a.write_bytes(_wav_bytes(3))
-        path_b.write_bytes(_wav_bytes(5))
+        path_a.write_bytes(wav_bytes(3))
+        path_b.write_bytes(wav_bytes(5))
 
         total = await audio_utils_module.probe_reference_audio_total_seconds([path_a, path_b])
 
@@ -194,7 +194,7 @@ class TestProbeReferenceAudioTotalSeconds:
         """半截总时长比跳过校验更危险：任一文件探测失败就整体判 None，不能只算成功的部分。"""
         path_a = tmp_path / "a.wav"
         path_missing = tmp_path / "missing.wav"
-        path_a.write_bytes(_wav_bytes(3))
+        path_a.write_bytes(wav_bytes(3))
 
         total = await audio_utils_module.probe_reference_audio_total_seconds([path_a, path_missing])
 
@@ -202,7 +202,7 @@ class TestProbeReferenceAudioTotalSeconds:
 
     async def test_ffprobe_unavailable_returns_none(self, tmp_path):
         path_a = tmp_path / "a.wav"
-        path_a.write_bytes(_wav_bytes(3))
+        path_a.write_bytes(wav_bytes(3))
         with patch("lib.audio_utils.shutil.which", return_value=None):
             total = await audio_utils_module.probe_reference_audio_total_seconds([path_a])
         assert total is None

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -3,10 +3,8 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.artifact_manifest import ArtifactBasis, compose_video_artifact_basis
-from lib.db import Base
 from lib.generation_worker import (
     _ORPHAN_RESCAN_LEASE_LOST_MULT,
     DEFAULT_PROVIDER,
@@ -264,19 +262,14 @@ def _patch_pm(monkeypatch, project: dict | None):
 
 
 @pytest.fixture()
-async def _patch_empty_db(monkeypatch):
+async def _patch_empty_db(db_factory, monkeypatch):
     """把全局 async_session_factory 换成空内存库，隔离掉真实数据库。
 
     无 project_name 的 _extract_provider 会用 lib.db.async_session_factory 经 ConfigResolver
     解析全局默认供应商；不隔离时它读真实 dev 库，本机一旦配了其它 ready 供应商，回退断言就被污染。
     """
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    monkeypatch.setattr("lib.db.async_session_factory", factory)
-    yield factory
-    await engine.dispose()
+    monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+    return db_factory
 
 
 class TestExtractProvider:

--- a/tests/integration/lib/test_media_generator_module.py
+++ b/tests/integration/lib/test_media_generator_module.py
@@ -1379,7 +1379,7 @@ class TestReferenceCompressionSeam:
             pytest.skip("ffprobe not available")
 
         from lib.video_backends.base import ReferenceAudioMode, VideoCapabilities, VideoCapabilityError
-        from tests.conftest import _wav_bytes
+        from tests.factories import wav_bytes
 
         gen = _build_generator(tmp_path)
 
@@ -1406,8 +1406,8 @@ class TestReferenceCompressionSeam:
         ref = _solid_png(tmp_path, "ref.png", 3000, 3000)
         first = tmp_path / "alice.wav"
         second = tmp_path / "bob.wav"
-        first.write_bytes(_wav_bytes(10))
-        second.write_bytes(_wav_bytes(10))
+        first.write_bytes(wav_bytes(10))
+        second.write_bytes(wav_bytes(10))
 
         with pytest.raises(VideoCapabilityError) as exc:
             await gen.generate_video_async(

--- a/tests/integration/lib/test_project_asset_namespace.py
+++ b/tests/integration/lib/test_project_asset_namespace.py
@@ -12,7 +12,7 @@ from lib.project_manager import ProjectManager
 
 
 @pytest.fixture
-def pm(tmp_path: Path) -> ProjectManager:
+def demo_pm(tmp_path: Path) -> ProjectManager:
     manager = ProjectManager(str(tmp_path))
     manager.create_project("demo")
     manager.create_project_metadata("demo", "Demo", "Anime", "narration")
@@ -30,87 +30,87 @@ def pm(tmp_path: Path) -> ProjectManager:
         ("prop", "product"),
     ],
 )
-def test_every_asset_type_pair_shares_one_namespace(pm: ProjectManager, first: str, second: str) -> None:
+def test_every_asset_type_pair_shares_one_namespace(demo_pm: ProjectManager, first: str, second: str) -> None:
     table = {"character": "characters", "scene": "scenes", "prop": "props", "product": "products"}
-    pm.upsert_assets("demo", table[first], {"Shared": {"description": "first"}})
+    demo_pm.upsert_assets("demo", table[first], {"Shared": {"description": "first"}})
     with pytest.raises(ProjectAssetNameConflictError, match="Shared") as exc_info:
-        pm.upsert_assets("demo", table[second], {"Shared": {"description": "second"}})
+        demo_pm.upsert_assets("demo", table[second], {"Shared": {"description": "second"}})
     assert exc_info.value.requested_asset_type == second
     assert exc_info.value.existing.asset_type == first
-    assert pm.load_project("demo").get(table[second], {}) == {}
+    assert demo_pm.load_project("demo").get(table[second], {}) == {}
 
 
-def test_namespace_uses_strip_nfc_and_is_case_sensitive(pm: ProjectManager) -> None:
+def test_namespace_uses_strip_nfc_and_is_case_sensitive(demo_pm: ProjectManager) -> None:
     nfd = unicodedata.normalize("NFD", "café")
-    pm.add_character("demo", " café ", "first")
+    demo_pm.add_character("demo", " café ", "first")
     with pytest.raises(ProjectAssetNameConflictError):
-        pm.add_project_scene("demo", nfd, "second")
-    assert pm.add_project_scene("demo", "CAFÉ", "case differs") is True
+        demo_pm.add_project_scene("demo", nfd, "second")
+    assert demo_pm.add_project_scene("demo", "CAFÉ", "case differs") is True
 
 
-def test_batch_conflict_is_atomic(pm: ProjectManager) -> None:
-    pm.add_character("demo", "Taken", "character")
+def test_batch_conflict_is_atomic(demo_pm: ProjectManager) -> None:
+    demo_pm.add_character("demo", "Taken", "character")
     with pytest.raises(ProjectAssetNameConflictError):
-        pm.add_scenes_batch(
+        demo_pm.add_scenes_batch(
             "demo",
             {"Fresh": {"description": "would be valid"}, "Taken": {"description": "conflict"}},
         )
-    assert pm.load_project("demo")["scenes"] == {}
+    assert demo_pm.load_project("demo")["scenes"] == {}
 
 
-def test_cross_type_rename_conflict_is_rejected(pm: ProjectManager) -> None:
-    pm.add_character("demo", "Character", "character")
-    pm.add_project_scene("demo", "Scene", "scene")
+def test_cross_type_rename_conflict_is_rejected(demo_pm: ProjectManager) -> None:
+    demo_pm.add_character("demo", "Character", "character")
+    demo_pm.add_project_scene("demo", "Scene", "scene")
     with pytest.raises(ProjectAssetNameConflictError):
-        pm.rename_asset("demo", "scenes", "Scene", "Character")
-    project = pm.load_project("demo")
+        demo_pm.rename_asset("demo", "scenes", "Scene", "Character")
+    project = demo_pm.load_project("demo")
     assert list(project["scenes"]) == ["Scene"]
 
 
-def test_validator_reports_cross_type_and_equivalent_duplicates(pm: ProjectManager) -> None:
-    project = pm.load_project("demo")
+def test_validator_reports_cross_type_and_equivalent_duplicates(demo_pm: ProjectManager) -> None:
+    project = demo_pm.load_project("demo")
     nfd = unicodedata.normalize("NFD", "café")
     project["characters"] = {" café ": {"description": "a"}}
     project["products"] = {nfd: {"description": "b"}}
 
-    result = DataValidator(str(pm.projects_root)).validate_project_payload(project)
+    result = DataValidator(str(demo_pm.projects_root)).validate_project_payload(project)
 
     assert any(message.key == "val_asset_name_duplicate" for message in result.error_messages)
 
 
-def _write_corrupt_v6_project(pm: ProjectManager, *, with_episode: bool = False) -> Path:
-    project = pm.load_project("demo")
+def _write_corrupt_v6_project(demo_pm: ProjectManager, *, with_episode: bool = False) -> Path:
+    project = demo_pm.load_project("demo")
     project["characters"] = {"Shared": {"description": "character"}}
     project["scenes"] = {"Shared": {"description": "scene"}}
     if with_episode:
         project["episodes"] = [{"episode": 1, "script_file": "scripts/episode_1.json", "title": "Episode 1"}]
-    project_file = pm.get_project_path("demo") / "project.json"
+    project_file = demo_pm.get_project_path("demo") / "project.json"
     project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
     return project_file
 
 
-def test_rename_rejects_a_corrupt_v6_namespace_before_writing(pm: ProjectManager) -> None:
-    project_file = _write_corrupt_v6_project(pm)
+def test_rename_rejects_a_corrupt_v6_namespace_before_writing(demo_pm: ProjectManager) -> None:
+    project_file = _write_corrupt_v6_project(demo_pm)
     project = json.loads(project_file.read_text(encoding="utf-8"))
     project["props"] = {"Old": {"description": "prop"}}
     project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
     before = project_file.read_bytes()
 
     with pytest.raises(ProjectAssetNameConflictError):
-        pm.rename_asset("demo", "props", "Old", "Renamed")
+        demo_pm.rename_asset("demo", "props", "Old", "Renamed")
 
     assert project_file.read_bytes() == before
 
 
-def test_locked_episode_write_rejects_a_corrupt_v6_namespace_before_writing(pm: ProjectManager) -> None:
-    project_file = _write_corrupt_v6_project(pm, with_episode=True)
-    script_file = pm.get_project_path("demo") / "scripts" / "episode_1.json"
+def test_locked_episode_write_rejects_a_corrupt_v6_namespace_before_writing(demo_pm: ProjectManager) -> None:
+    project_file = _write_corrupt_v6_project(demo_pm, with_episode=True)
+    script_file = demo_pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_file.write_text('{"episode": 1}', encoding="utf-8")
     before_project = project_file.read_bytes()
     before_script = script_file.read_bytes()
 
     with pytest.raises(ProjectAssetNameConflictError):
-        with pm.locked_episode_script("demo", lambda project: project["episodes"][0]["script_file"]):
+        with demo_pm.locked_episode_script("demo", lambda project: project["episodes"][0]["script_file"]):
             pytest.fail("corrupt namespace must fail before yielding the script")
 
     assert project_file.read_bytes() == before_project

--- a/tests/integration/lib/test_task_terminal_events.py
+++ b/tests/integration/lib/test_task_terminal_events.py
@@ -5,9 +5,7 @@
 """
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.repositories.task_repo import TaskRepository
 from lib.generation_queue import GenerationQueue
 from lib.project_change_hints import register_project_change_batch_listener
@@ -15,14 +13,8 @@ from lib.task_terminal_events import build_task_terminal_change
 
 
 @pytest.fixture
-async def queue():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield GenerationQueue(session_factory=factory)
-    await engine.dispose()
+async def queue(db_factory):
+    return GenerationQueue(session_factory=db_factory)
 
 
 @pytest.fixture

--- a/tests/integration/server/routers/test_assets_router.py
+++ b/tests/integration/server/routers/test_assets_router.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.artifact_activation import ArtifactCurrencyResolver
 from lib.artifact_manifest import ArtifactKey, ArtifactManifestEntry, ArtifactStatus, ProjectArtifactManifestAdapter
-from lib.db.base import Base
 from lib.i18n import _ as translate_message
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
@@ -19,18 +17,12 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 
 
 @pytest.fixture
-async def _assets_env(tmp_path, monkeypatch):
-    # 1) per-test in-memory DB
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-
-    # 2) per-test ProjectManager pointed at tmp_path/projects
+async def _assets_env(db_factory, tmp_path, monkeypatch):
+    # 1) per-test ProjectManager pointed at tmp_path/projects
     pm = ProjectManager(tmp_path / "projects")
 
-    # 3) monkeypatch symbols used inside assets router
-    monkeypatch.setattr(assets, "async_session_factory", factory)
+    # 2) monkeypatch symbols used inside assets router
+    monkeypatch.setattr(assets, "async_session_factory", db_factory)
     monkeypatch.setattr(assets, "get_project_manager", lambda: pm)
 
     app = FastAPI()
@@ -38,8 +30,7 @@ async def _assets_env(tmp_path, monkeypatch):
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(assets.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
 
-    yield {"client": TestClient(app), "pm": pm}
-    await engine.dispose()
+    return {"client": TestClient(app), "pm": pm}
 
 
 class TestAssetsCRUD:

--- a/tests/integration/server/routers/test_capability_overrides_api.py
+++ b/tests/integration/server/routers/test_capability_overrides_api.py
@@ -7,19 +7,18 @@ TestClient 范式，同源侧沿用 test_custom_provider_loader.py 的真 repo �
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.custom_provider import make_provider_id
 from lib.custom_provider.capabilities import synthesize_video_capabilities, system_video_capabilities
 from lib.custom_provider.loader import load_custom_backend
 from lib.db import get_async_session
-from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
@@ -40,26 +39,17 @@ LAST_FRAME_MODEL = "doubao-seedance-1-0-pro-fast-251015"
 
 
 @pytest.fixture()
-async def db_engine():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture()
-async def session_factory(db_engine):
+async def app_session_factory(db_engine):
     return async_sessionmaker(db_engine, expire_on_commit=False)
 
 
 @pytest.fixture()
-def app(session_factory) -> FastAPI:
+def app(app_session_factory) -> FastAPI:
     _app = FastAPI()
 
     async def _override_session():
-        async with session_factory() as session:
-            yield session
+        async with app_session_factory() as db_session:
+            yield db_session
 
     _app.dependency_overrides[get_async_session] = _override_session
     _app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="test", sub="test", role="admin")
@@ -69,19 +59,13 @@ def app(session_factory) -> FastAPI:
 
 
 @pytest.fixture()
-async def session(session_factory) -> AsyncGenerator[AsyncSession, None]:
-    async with session_factory() as s:
-        yield s
-
-
-@pytest.fixture()
-def client(app) -> Generator[TestClient, None, None]:
+def capability_client(app) -> Generator[TestClient, None, None]:
     with TestClient(app) as c:
         yield c
 
 
-def _post_provider(client: TestClient, models: list[dict]):
-    return client.post(
+def _post_provider(capability_client: TestClient, models: list[dict]):
+    return capability_client.post(
         "/api/v1/custom-providers",
         json={
             "display_name": "Relay",
@@ -93,16 +77,16 @@ def _post_provider(client: TestClient, models: list[dict]):
     )
 
 
-def _create_provider(client: TestClient, models: list[dict]) -> int:
-    resp = _post_provider(client, models)
+def _create_provider(capability_client: TestClient, models: list[dict]) -> int:
+    resp = _post_provider(capability_client, models)
     assert resp.status_code == 201, resp.text
     return resp.json()["id"]
 
 
-async def _seed_provider_with_raw_models(session_factory, models: list[dict]) -> int:
+async def _seed_provider_with_raw_models(app_session_factory, models: list[dict]) -> int:
     """绕过 API 直接落库：模拟手工改库产生的、界面无从产生的覆盖字典。"""
-    async with session_factory() as session:
-        repo = CustomProviderRepository(session)
+    async with app_session_factory() as db_session:
+        repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="Relay",
             discovery_format="openai",
@@ -110,7 +94,7 @@ async def _seed_provider_with_raw_models(session_factory, models: list[dict]) ->
             api_key="sk-relay",
             models=models,
         )
-        await session.commit()
+        await db_session.commit()
         return provider.id
 
 
@@ -129,10 +113,10 @@ def _video_model(**overrides) -> dict:
 class TestModelListExposesCapabilities:
     """models 列表同时给出系统判定与用户覆盖，设置页平凡合并即可展示。"""
 
-    def test_video_model_reports_system_capabilities(self, client: TestClient):
-        pid = _create_provider(client, [_video_model()])
+    def test_video_model_reports_system_capabilities(self, capability_client: TestClient):
+        pid = _create_provider(capability_client, [_video_model()])
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["system_capabilities"] == {
             "first_frame": True,
             "last_frame": False,
@@ -146,11 +130,11 @@ class TestModelListExposesCapabilities:
         }
         assert models[0]["capability_overrides"] is None
 
-    def test_system_capabilities_matches_synthesis_source(self, client: TestClient):
+    def test_system_capabilities_matches_synthesis_source(self, capability_client: TestClient):
         """判定值不是 API 里另写一份，而是合成函数的系统判定分支。"""
-        pid = _create_provider(client, [_video_model()])
+        pid = _create_provider(capability_client, [_video_model()])
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         expected = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
         assert models[0]["system_capabilities"] == {
             "first_frame": expected.first_frame,
@@ -164,18 +148,18 @@ class TestModelListExposesCapabilities:
             "first_frame_ratio_adaptive_only": expected.first_frame_ratio_adaptive_only,
         }
 
-    def test_non_video_model_has_no_system_capabilities(self, client: TestClient):
+    def test_non_video_model_has_no_system_capabilities(self, capability_client: TestClient):
         pid = _create_provider(
-            client,
+            capability_client,
             [{"model_id": "dall-e-3", "display_name": "D3", "endpoint": "openai-images", "is_enabled": True}],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["system_capabilities"] is None
 
-    def test_overrides_round_trip_through_create(self, client: TestClient):
+    def test_overrides_round_trip_through_create(self, capability_client: TestClient):
         pid = _create_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     capability_overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
@@ -183,18 +167,20 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
         # 判定值不受覆盖影响：设置页要能同时显示"判定 False / 生效 True"
         assert models[0]["system_capabilities"]["last_frame"] is False
 
-    async def test_stale_incompatible_override_filtered_from_response(self, client: TestClient, session_factory):
+    async def test_stale_incompatible_override_filtered_from_response(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """存量行 / 非 API 写入可能留下已不兼容的覆盖（如 openai-video 上的 last_frame=True，
         endpoint 不 end_image_capable）：写入侧挡不住这条已落库的数据，回显前须过滤，
         不能让界面呈现"覆盖已生效"而执行层其实静默忽略——原样回显还会让下次普通保存被
         写入校验拒为 422，堵住与该覆盖无关的编辑。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": VIDEO_MODEL,
@@ -207,10 +193,12 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] is None
 
-    async def test_stale_incoherent_audio_override_filtered_from_response(self, client: TestClient, session_factory):
+    async def test_stale_incoherent_audio_override_filtered_from_response(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """存量行的 direct ⊕ 上限 0：两维各自合法，故过得了逐键过滤，但执行层会降级到 none。
 
         原样回显有两个后果，与 last_frame 那条同源：界面显示"直传音色已生效"而生成其实不带
@@ -218,7 +206,7 @@ class TestModelListExposesCapabilities:
         把整次保存拒成 422。
         """
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": LAST_FRAME_MODEL,
@@ -231,17 +219,19 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         # 音频两维整组剔除，与音频无关的 last_frame 覆盖原样保留
         assert models[0]["capability_overrides"] == {"last_frame": True}
 
-    async def test_corrupted_non_dict_override_does_not_500_response(self, client: TestClient, session_factory):
+    async def test_corrupted_non_dict_override_does_not_500_response(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """存量行 / 手工 SQL 可能让 JSON 列存了非字典值（字符串、列表等）：执行层的
         synthesize_video_capabilities 按容错设计忽略它，响应边界须同样容错，不能把原值
         直接塞进只接受 dict | None 的 ModelResponse 触发 Pydantic 校验错误，让整个列表/详情
         请求 500——用户也就无法进入设置页清理这条坏值。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": VIDEO_MODEL,
@@ -254,15 +244,17 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = capability_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         assert resp.json()["models"][0]["capability_overrides"] is None
 
-    async def test_retired_endpoint_override_does_not_500_response(self, client: TestClient, session_factory):
+    async def test_retired_endpoint_override_does_not_500_response(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """endpoint 已从注册表下线（升级移除）时，get_endpoint_spec 会抛 ValueError；响应边界
         过滤 last_frame 覆盖时须容错这条查表失败，不能让存量脏配置把列表/详情请求也炸成 500。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": "retired-model",
@@ -275,16 +267,16 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = capability_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         assert resp.json()["models"][0]["capability_overrides"] is None
 
-    async def test_unallowlisted_key_dropped_from_response(self, client: TestClient, session_factory):
+    async def test_unallowlisted_key_dropped_from_response(self, capability_client: TestClient, app_session_factory):
         """DB 遗留的白名单外键（如 first_frame，语义合法但未开放给用户覆盖）不该在回显中
         原样带出：否则界面呈现"覆盖已生效"，而写入侧一保存这条键就会被剔除——GET 与 PUT
         的键集合必须一致，调用方不该额外知道"回显可能含脏键但写回会被剔除"这条隐藏知识。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": VIDEO_MODEL,
@@ -297,14 +289,16 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] is None
 
-    async def test_allowlisted_key_kept_when_mixed_with_unallowlisted(self, client: TestClient, session_factory):
+    async def test_allowlisted_key_kept_when_mixed_with_unallowlisted(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """混合了白名单内外键的存量行：白名单内键（last_frame）回显不变，白名单外键
         （first_frame）被剔除，回显集合与写入落库集合一致。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": LAST_FRAME_MODEL,
@@ -317,7 +311,7 @@ class TestModelListExposesCapabilities:
             ],
         )
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
 
 
@@ -328,23 +322,25 @@ class TestSaveDropsUnlistedOverrides:
     自己无法处置的 422 上，连改显示名都保存不了。
     """
 
-    def test_unknown_key_stripped_on_create(self, client: TestClient):
-        pid = _create_provider(client, [_video_model(capability_overrides={"no_such_capability": True})])
+    def test_unknown_key_stripped_on_create(self, capability_client: TestClient):
+        pid = _create_provider(capability_client, [_video_model(capability_overrides={"no_such_capability": True})])
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] is None
 
-    def test_known_but_unallowlisted_key_stripped_on_create(self, client: TestClient):
+    def test_known_but_unallowlisted_key_stripped_on_create(self, capability_client: TestClient):
         """first_frame 是合法 VideoCapabilities 字段，但首批未开放覆盖。"""
-        pid = _create_provider(client, [_video_model(capability_overrides={"first_frame": False})])
+        pid = _create_provider(capability_client, [_video_model(capability_overrides={"first_frame": False})])
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] is None
 
-    async def test_legacy_key_stripped_while_editing_last_frame(self, client: TestClient, session_factory):
+    async def test_legacy_key_stripped_while_editing_last_frame(
+        self, capability_client: TestClient, app_session_factory
+    ):
         """AC：含遗留键的行改动 last_frame 后保存不再 422，落库覆盖字典只剩白名单内的键。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": LAST_FRAME_MODEL,
@@ -357,7 +353,7 @@ class TestSaveDropsUnlistedOverrides:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -373,14 +369,14 @@ class TestSaveDropsUnlistedOverrides:
         assert resp.status_code == 200, resp.text
         assert resp.json()[0]["capability_overrides"] == {"last_frame": True}
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
 
-    async def test_legacy_key_stripped_on_full_update(self, client: TestClient, session_factory):
+    async def test_legacy_key_stripped_on_full_update(self, capability_client: TestClient, app_session_factory):
         """同上，覆盖 PUT /{provider_id}（原子更新 provider 元数据 + 模型列表）这条写入路径：
         只改 display_name 时，历史脏值既不该挡住保存，也不该被原样写回去。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": VIDEO_MODEL,
@@ -393,7 +389,7 @@ class TestSaveDropsUnlistedOverrides:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}",
             json={
                 "display_name": "Relay Renamed",
@@ -415,33 +411,35 @@ class TestSaveValidatesOpenOverrides:
     """白名单内的键仍按 endpoint 与值类型从严校验，报错用户能在界面上处置。"""
 
     @pytest.mark.parametrize("bad_value", ["true", 1, 0, None, [], {}])
-    def test_wrong_value_type_rejected_on_create(self, client: TestClient, bad_value):
-        resp = _post_provider(client, [_video_model(capability_overrides={"last_frame": bad_value})])
+    def test_wrong_value_type_rejected_on_create(self, capability_client: TestClient, bad_value):
+        resp = _post_provider(capability_client, [_video_model(capability_overrides={"last_frame": bad_value})])
         assert resp.status_code == 422
 
-    def test_last_frame_rejected_on_endpoint_without_end_image_support(self, client: TestClient):
+    def test_last_frame_rejected_on_endpoint_without_end_image_support(self, capability_client: TestClient):
         """openai-video 的 delegate 不下传 end_image：开启覆盖只会让 UI 宣称支持、执行层仍静默丢帧。"""
-        resp = _post_provider(client, [_video_model(capability_overrides={"last_frame": True})])
+        resp = _post_provider(capability_client, [_video_model(capability_overrides={"last_frame": True})])
         assert resp.status_code == 422
         assert "last_frame" in resp.json()["detail"]
 
-    def test_reference_audio_direct_rejected_on_endpoint_without_audio_support(self, client: TestClient):
+    def test_reference_audio_direct_rejected_on_endpoint_without_audio_support(self, capability_client: TestClient):
         """openai-video 的 delegate 不下传 reference_audio_files：开启覆盖只会让 UI 宣称支持
         音色输入，执行层照旧生成随机音色的视频。"""
-        resp = _post_provider(client, [_video_model(capability_overrides={"reference_audio_mode": "direct"})])
+        resp = _post_provider(
+            capability_client, [_video_model(capability_overrides={"reference_audio_mode": "direct"})]
+        )
         assert resp.status_code == 422
         assert "reference_audio_mode" in resp.json()["detail"]
 
-    def test_reference_audio_none_accepted_on_endpoint_without_audio_support(self, client: TestClient):
+    def test_reference_audio_none_accepted_on_endpoint_without_audio_support(self, capability_client: TestClient):
         """守卫只拦「宣称支持」的方向：关掉音色能力无需运输能力背书。"""
-        pid = _create_provider(client, [_video_model(capability_overrides={"reference_audio_mode": "none"})])
+        pid = _create_provider(capability_client, [_video_model(capability_overrides={"reference_audio_mode": "none"})])
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"reference_audio_mode": "none"}
 
-    def test_reference_audio_direct_accepted_on_audio_capable_endpoint(self, client: TestClient):
+    def test_reference_audio_direct_accepted_on_audio_capable_endpoint(self, capability_client: TestClient):
         resp = _post_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     endpoint=LAST_FRAME_ENDPOINT,
@@ -452,14 +450,14 @@ class TestSaveValidatesOpenOverrides:
         )
         assert resp.status_code == 201
 
-    def test_direct_without_positive_count_rejected(self, client: TestClient):
+    def test_direct_without_positive_count_rejected(self, capability_client: TestClient):
         """合并后不变式：宣称支持音色输入却限 0 段的组合在写入侧就拒。
 
         放行则执行期只能静默降级，用户拿到的是「最多支持 0 段」这种无从遵循的提示。
         该 endpoint 的系统判定上限为 0，只覆盖模式即凑出该组合。
         """
         resp = _post_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     endpoint=LAST_FRAME_ENDPOINT,
@@ -472,10 +470,10 @@ class TestSaveValidatesOpenOverrides:
         assert "max_reference_audio_count" in resp.json()["detail"]
 
     @pytest.mark.parametrize("bad_value", ["DIRECT", "native", True, 1, None])
-    def test_invalid_reference_audio_mode_rejected(self, client: TestClient, bad_value):
+    def test_invalid_reference_audio_mode_rejected(self, capability_client: TestClient, bad_value):
         """枚举值两侧同判定：写入侧拒的与合成层忽略的必须是同一集合，否则「界面允许、执行反悔」。"""
         resp = _post_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     endpoint=LAST_FRAME_ENDPOINT,
@@ -486,9 +484,9 @@ class TestSaveValidatesOpenOverrides:
         )
         assert resp.status_code == 422
 
-    def test_non_video_endpoint_rejected(self, client: TestClient):
+    def test_non_video_endpoint_rejected(self, capability_client: TestClient):
         resp = _post_provider(
-            client,
+            capability_client,
             [
                 {
                     "model_id": "dall-e-3",
@@ -501,9 +499,9 @@ class TestSaveValidatesOpenOverrides:
         )
         assert resp.status_code == 422
 
-    def test_rejected_save_leaves_stored_overrides_intact(self, client: TestClient):
+    def test_rejected_save_leaves_stored_overrides_intact(self, capability_client: TestClient):
         pid = _create_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     capability_overrides={"last_frame": True},
@@ -513,7 +511,7 @@ class TestSaveValidatesOpenOverrides:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -527,16 +525,16 @@ class TestSaveValidatesOpenOverrides:
         )
         assert resp.status_code == 422
 
-        models = client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
+        models = capability_client.get(f"/api/v1/custom-providers/{pid}").json()["models"]
         assert models[0]["capability_overrides"] == {"last_frame": True}
 
 
 class TestReplaceModelsOverrideSemantics:
     """保存模型列表是整体替换：覆盖必须随列表回传，否则被清空。"""
 
-    def test_overrides_survive_when_resubmitted(self, client: TestClient):
+    def test_overrides_survive_when_resubmitted(self, capability_client: TestClient):
         pid = _create_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     capability_overrides={"last_frame": True},
@@ -546,7 +544,7 @@ class TestReplaceModelsOverrideSemantics:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -561,10 +559,10 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] == {"last_frame": True}
 
-    def test_overrides_dropped_when_omitted(self, client: TestClient):
+    def test_overrides_dropped_when_omitted(self, capability_client: TestClient):
         """整体替换语义的直接后果，前端保存模型列表时必须回传覆盖字段。"""
         pid = _create_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     capability_overrides={"last_frame": True},
@@ -574,30 +572,30 @@ class TestReplaceModelsOverrideSemantics:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={"models": [_video_model(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL)]},
         )
         assert resp.status_code == 200
         assert resp.json()[0]["capability_overrides"] is None
 
-    def test_invalid_override_rejected_on_replace(self, client: TestClient):
-        pid = _create_provider(client, [_video_model()])
+    def test_invalid_override_rejected_on_replace(self, capability_client: TestClient):
+        pid = _create_provider(capability_client, [_video_model()])
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={"models": [_video_model(capability_overrides={"last_frame": "yes"})]},
         )
         assert resp.status_code == 422
 
-    def test_invalid_override_rejected_on_create(self, client: TestClient):
-        resp = _post_provider(client, [_video_model(capability_overrides={"last_frame": 1})])
+    def test_invalid_override_rejected_on_create(self, capability_client: TestClient):
+        resp = _post_provider(capability_client, [_video_model(capability_overrides={"last_frame": 1})])
         assert resp.status_code == 422
 
-    def test_invalid_override_rejected_on_full_update(self, client: TestClient):
-        pid = _create_provider(client, [_video_model()])
+    def test_invalid_override_rejected_on_full_update(self, capability_client: TestClient):
+        pid = _create_provider(capability_client, [_video_model()])
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}",
             json={
                 "display_name": "Relay",
@@ -607,15 +605,15 @@ class TestReplaceModelsOverrideSemantics:
         )
         assert resp.status_code == 422
 
-    def test_override_written_and_read_back_through_full_update(self, client: TestClient):
+    def test_override_written_and_read_back_through_full_update(self, capability_client: TestClient):
         """设置页表单的覆盖编辑就走这条整表 PUT：从「跟随判定」改成「强制开」保存后，
         重新加载页面（GET）必须还能读回同一个覆盖，否则用户的选择保存了个寂寞。"""
         pid = _create_provider(
-            client,
+            capability_client,
             [_video_model(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL)],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}",
             json={
                 "display_name": "Relay",
@@ -632,15 +630,15 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 200, resp.text
         assert resp.json()["models"][0]["capability_overrides"] == {"last_frame": True}
 
-        reloaded = client.get(f"/api/v1/custom-providers/{pid}")
+        reloaded = capability_client.get(f"/api/v1/custom-providers/{pid}")
         assert reloaded.status_code == 200
         assert reloaded.json()["models"][0]["capability_overrides"] == {"last_frame": True}
 
-    def test_override_cleared_to_null_through_full_update(self, client: TestClient):
+    def test_override_cleared_to_null_through_full_update(self, capability_client: TestClient):
         """控件回到「跟随判定」时前端把该键从稀疏字典移除、字典空则整体收敛回 null。
         这条 PUT 必须真的把落库的覆盖清掉，生效值才会重新跟随系统判定。"""
         pid = _create_provider(
-            client,
+            capability_client,
             [
                 _video_model(
                     capability_overrides={"last_frame": True},
@@ -650,7 +648,7 @@ class TestReplaceModelsOverrideSemantics:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}",
             json={
                 "display_name": "Relay",
@@ -667,17 +665,17 @@ class TestReplaceModelsOverrideSemantics:
         assert resp.status_code == 200, resp.text
         assert resp.json()["models"][0]["capability_overrides"] is None
 
-        reloaded = client.get(f"/api/v1/custom-providers/{pid}")
+        reloaded = capability_client.get(f"/api/v1/custom-providers/{pid}")
         assert reloaded.json()["models"][0]["capability_overrides"] is None
 
     async def test_endpoint_change_validated_even_when_override_dict_unchanged(
-        self, client: TestClient, session_factory
+        self, capability_client: TestClient, app_session_factory
     ):
         """每行都按提交上来的 (endpoint, 覆盖值) 校验：model_id 与覆盖字典原样不动、只切 endpoint
         时，校验结果天然随新 endpoint 变化（last_frame=True 是否合法依赖 endpoint 的
         end_image_capable），须针对新 endpoint 拒绝。"""
         pid = await _seed_provider_with_raw_models(
-            session_factory,
+            app_session_factory,
             [
                 {
                     "model_id": LAST_FRAME_MODEL,
@@ -690,7 +688,7 @@ class TestReplaceModelsOverrideSemantics:
             ],
         )
 
-        resp = client.put(
+        resp = capability_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -711,9 +709,13 @@ class TestResolverReturnsEffectiveCapabilities:
 
     @staticmethod
     async def _seed(
-        session: AsyncSession, *, overrides: object | None, endpoint: str = VIDEO_ENDPOINT, model_id: str = VIDEO_MODEL
+        db_session: AsyncSession,
+        *,
+        overrides: object | None,
+        endpoint: str = VIDEO_ENDPOINT,
+        model_id: str = VIDEO_MODEL,
     ) -> str:
-        repo = CustomProviderRepository(session)
+        repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="Relay",
             discovery_format="openai",
@@ -731,58 +733,58 @@ class TestResolverReturnsEffectiveCapabilities:
                 }
             ],
         )
-        await session.commit()
+        await db_session.commit()
         return make_provider_id(provider.id)
 
     @staticmethod
-    async def _resolve(session: AsyncSession, provider_id: str, model_id: str = VIDEO_MODEL) -> dict:
+    async def _resolve(db_session: AsyncSession, provider_id: str, model_id: str = VIDEO_MODEL) -> dict:
         from lib.config.resolver import ConfigResolver
         from lib.config.service import ConfigService
 
-        factory = async_sessionmaker(bind=session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
-        resolver = ConfigResolver(factory, _bound_session=session)
+        factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+        resolver = ConfigResolver(factory, _bound_session=db_session)
         return await resolver._resolve_video_caps_for_model(
-            ConfigService(session), session, provider_id, model_id, None
+            ConfigService(db_session), db_session, provider_id, model_id, None
         )
 
-    async def test_custom_model_without_overrides_follows_system(self, session: AsyncSession):
-        pid = await self._seed(session, overrides=None)
+    async def test_custom_model_without_overrides_follows_system(self, db_session: AsyncSession):
+        pid = await self._seed(db_session, overrides=None)
 
-        caps = await self._resolve(session, pid)
+        caps = await self._resolve(db_session, pid)
         system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
         assert caps["last_frame"] is system.last_frame
         assert caps["first_frame"] is system.first_frame
         assert caps["max_reference_images"] == system.max_reference_images
 
-    async def test_override_changes_resolver_output(self, session: AsyncSession):
+    async def test_override_changes_resolver_output(self, db_session: AsyncSession):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
         pid = await self._seed(
-            session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+            db_session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
         )
 
-        caps = await self._resolve(session, pid, model_id=LAST_FRAME_MODEL)
+        caps = await self._resolve(db_session, pid, model_id=LAST_FRAME_MODEL)
         assert system_video_capabilities(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL).last_frame is False
         assert caps["last_frame"] is True
 
-    async def test_override_ignored_when_endpoint_lacks_end_image_support(self, session: AsyncSession):
+    async def test_override_ignored_when_endpoint_lacks_end_image_support(self, db_session: AsyncSession):
         """openai-video 的 delegate 不下传 end_image：即便存量行/非 API 写入把 last_frame 写成 True，
         resolver 也须回退系统判定，而不是把「合成层宣称支持、执行层静默丢帧」的错误状态当作生效。"""
-        pid = await self._seed(session, overrides={"last_frame": True})
+        pid = await self._seed(db_session, overrides={"last_frame": True})
 
-        caps = await self._resolve(session, pid)
+        caps = await self._resolve(db_session, pid)
         assert caps["last_frame"] is False
 
     @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    async def test_resolver_matches_execution_layer(self, _mock_cls, session: AsyncSession):
+    async def test_resolver_matches_execution_layer(self, _mock_cls, db_session: AsyncSession):
         """展示层与执行层出自同一合成函数：逐字段比对 resolver 与装载出的 backend。"""
         pid = await self._seed(
-            session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+            db_session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
         )
 
-        caps = await self._resolve(session, pid, model_id=LAST_FRAME_MODEL)
-        session.expunge_all()
+        caps = await self._resolve(db_session, pid, model_id=LAST_FRAME_MODEL)
+        db_session.expunge_all()
         backend = await load_custom_backend(
-            session=session, provider_id=pid, model_id=LAST_FRAME_MODEL, media_type="video"
+            session=db_session, provider_id=pid, model_id=LAST_FRAME_MODEL, media_type="video"
         )
 
         executed = backend.video_capabilities
@@ -795,11 +797,11 @@ class TestResolverReturnsEffectiveCapabilities:
         )
         assert executed == expected
 
-    async def test_disabled_model_falls_back_to_default_model(self, session: AsyncSession):
+    async def test_disabled_model_falls_back_to_default_model(self, db_session: AsyncSession):
         """请求的 model 被禁用时,与执行层同一条回退规则:改用该 provider 的默认启用 video
         model,而不是报错——否则 /video-capabilities 会 4xx,而实际生成请求会静默用默认模型
         成功,展示层与执行层因此漂移。"""
-        repo = CustomProviderRepository(session)
+        repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="Relay",
             discovery_format="openai",
@@ -826,18 +828,18 @@ class TestResolverReturnsEffectiveCapabilities:
                 },
             ],
         )
-        await session.commit()
+        await db_session.commit()
         pid = make_provider_id(provider.id)
 
-        caps = await self._resolve(session, pid, model_id="disabled-model")
+        caps = await self._resolve(db_session, pid, model_id="disabled-model")
         system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
         assert caps["last_frame"] is system.last_frame
         assert caps["first_frame"] is system.first_frame
 
-    async def test_media_type_mismatch_falls_back_to_default_model(self, session: AsyncSession):
+    async def test_media_type_mismatch_falls_back_to_default_model(self, db_session: AsyncSession):
         """请求的 model 仍启用,但它的 endpoint 不是 video 类型时,与执行层同样
         回退到该 provider 的默认启用 video model，避免展示层与执行层漂移。"""
-        repo = CustomProviderRepository(session)
+        repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="Relay",
             discovery_format="openai",
@@ -864,24 +866,26 @@ class TestResolverReturnsEffectiveCapabilities:
                 },
             ],
         )
-        await session.commit()
+        await db_session.commit()
         pid = make_provider_id(provider.id)
 
-        caps = await self._resolve(session, pid, model_id="repurposed-model")
+        caps = await self._resolve(db_session, pid, model_id="repurposed-model")
         system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
         assert caps["last_frame"] is system.last_frame
         assert caps["first_frame"] is system.first_frame
 
-    async def test_builtin_boolean_caps_come_from_backend(self, session: AsyncSession):
+    async def test_builtin_boolean_caps_come_from_backend(self, db_session: AsyncSession):
         """内置分支的布尔位来自 backend 纯函数，注册表不存第二份。"""
         from lib.backend_assembly.specs import get_provider_spec
         from lib.config.resolver import ConfigResolver
         from lib.config.service import ConfigService
         from lib.video_backends.registry import video_capabilities_for_model
 
-        factory = async_sessionmaker(bind=session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
-        resolver = ConfigResolver(factory, _bound_session=session)
-        caps = await resolver._resolve_video_caps_for_model(ConfigService(session), session, "openai", "sora-2", None)
+        factory = async_sessionmaker(bind=db_session.get_bind(), class_=AsyncSession, expire_on_commit=False)  # type: ignore[call-overload]
+        resolver = ConfigResolver(factory, _bound_session=db_session)
+        caps = await resolver._resolve_video_caps_for_model(
+            ConfigService(db_session), db_session, "openai", "sora-2", None
+        )
 
         spec = get_provider_spec("openai", "video")
         backend_caps = video_capabilities_for_model(spec.registry_backend, "sora-2")
@@ -923,7 +927,7 @@ class TestVideoCapabilitiesEndpoint:
     """
 
     @staticmethod
-    def _client(monkeypatch, session_factory, provider_id: str, model_id: str = VIDEO_MODEL) -> TestClient:
+    def _client(monkeypatch, app_session_factory, provider_id: str, model_id: str = VIDEO_MODEL) -> TestClient:
         from fastapi import FastAPI
 
         from lib.config import resolver as resolver_mod
@@ -933,7 +937,7 @@ class TestVideoCapabilitiesEndpoint:
             def load_project(self, name: str) -> dict:
                 return {"name": name, "video_backend": f"{provider_id}/{model_id}"}
 
-        monkeypatch.setattr(projects_mod, "async_session_factory", session_factory)
+        monkeypatch.setattr(projects_mod, "async_session_factory", app_session_factory)
         monkeypatch.setattr(resolver_mod, "get_project_manager", lambda: _FakePM())
 
         app = FastAPI()
@@ -942,26 +946,26 @@ class TestVideoCapabilitiesEndpoint:
         register_error_handlers(app)
         return TestClient(app)
 
-    async def test_endpoint_returns_effective_boolean_caps(self, session_factory, monkeypatch):
-        async with session_factory() as session:
-            pid = await TestResolverReturnsEffectiveCapabilities._seed(session, overrides=None)
+    async def test_endpoint_returns_effective_boolean_caps(self, app_session_factory, monkeypatch):
+        async with app_session_factory() as db_session:
+            pid = await TestResolverReturnsEffectiveCapabilities._seed(db_session, overrides=None)
 
-        with self._client(monkeypatch, session_factory, pid) as client:
-            body = client.get("/api/v1/projects/demo/video-capabilities").json()
+        with self._client(monkeypatch, app_session_factory, pid) as capability_client:
+            body = capability_client.get("/api/v1/projects/demo/video-capabilities").json()
 
         system = system_video_capabilities(endpoint=VIDEO_ENDPOINT, model_id=VIDEO_MODEL)
         assert body["first_frame"] is system.first_frame
         assert body["last_frame"] is system.last_frame is False
 
-    async def test_endpoint_follows_written_override(self, session_factory, monkeypatch):
+    async def test_endpoint_follows_written_override(self, app_session_factory, monkeypatch):
         """AC：对自定义模型写入覆盖后，该接口返回值随之变化。"""
-        async with session_factory() as session:
+        async with app_session_factory() as db_session:
             pid = await TestResolverReturnsEffectiveCapabilities._seed(
-                session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
+                db_session, overrides={"last_frame": True}, endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL
             )
 
-        with self._client(monkeypatch, session_factory, pid, model_id=LAST_FRAME_MODEL) as client:
-            body = client.get("/api/v1/projects/demo/video-capabilities").json()
+        with self._client(monkeypatch, app_session_factory, pid, model_id=LAST_FRAME_MODEL) as capability_client:
+            body = capability_client.get("/api/v1/projects/demo/video-capabilities").json()
 
         assert system_video_capabilities(endpoint=LAST_FRAME_ENDPOINT, model_id=LAST_FRAME_MODEL).last_frame is False
         assert body["last_frame"] is True

--- a/tests/integration/server/routers/test_end_frames_router.py
+++ b/tests/integration/server/routers/test_end_frames_router.py
@@ -82,27 +82,27 @@ def _build_client(pm: ProjectManager, monkeypatch) -> TestClient:
 
 
 @pytest.fixture
-def client(tmp_path, monkeypatch):
+def end_frames_client(tmp_path, monkeypatch):
     pm = _seed_project(tmp_path)
     return _build_client(pm, monkeypatch), pm
 
 
-def _upload(client, content: bytes, filename="frame.jpg", shot_id="E1S01"):
-    return client.post(
+def _upload(end_frames_client, content: bytes, filename="frame.jpg", shot_id="E1S01"):
+    return end_frames_client.post(
         f"/api/v1/projects/demo/shots/{shot_id}/end-frame/upload?script_file=episode_1.json",
         files={"file": (filename, BytesIO(content), "application/octet-stream")},
     )
 
 
-def _select(client, source_path: str, shot_id="E1S01"):
-    return client.post(
+def _select(end_frames_client, source_path: str, shot_id="E1S01"):
+    return end_frames_client.post(
         f"/api/v1/projects/demo/shots/{shot_id}/end-frame/select",
         json={"script_file": "episode_1.json", "source_path": source_path},
     )
 
 
-def _delete(client, shot_id="E1S01"):
-    return client.delete(f"/api/v1/projects/demo/shots/{shot_id}/end-frame?script_file=episode_1.json")
+def _delete(end_frames_client, shot_id="E1S01"):
+    return end_frames_client.delete(f"/api/v1/projects/demo/shots/{shot_id}/end-frame?script_file=episode_1.json")
 
 
 def _segment(pm: ProjectManager, index: int = 0) -> dict:
@@ -116,8 +116,8 @@ def _write_source_image(pm: ProjectManager, rel: str, content: bytes) -> None:
 
 
 class TestUploadChannel:
-    def test_upload_writes_normalized_png_snapshot_and_field(self, client):
-        c, pm = client
+    def test_upload_writes_normalized_png_snapshot_and_field(self, end_frames_client):
+        c, pm = end_frames_client
         resp = _upload(c, _img_bytes("JPEG"))
         assert resp.status_code == 200, resp.text
         assert resp.json()["end_frame_image"] == END_FRAME_REL
@@ -127,8 +127,8 @@ class TestUploadChannel:
         with Image.open(pm.get_project_path("demo") / END_FRAME_REL) as img:
             assert img.format == "PNG"
 
-    def test_replacing_overwrites_in_place(self, client):
-        c, pm = client
+    def test_replacing_overwrites_in_place(self, end_frames_client):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("JPEG", size=(8, 8)))
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 200, resp.text
@@ -137,24 +137,24 @@ class TestUploadChannel:
         with Image.open(pm.get_project_path("demo") / END_FRAME_REL) as img:
             assert img.size == (16, 16)
 
-    def test_undecodable_bytes_rejected(self, client):
-        c, pm = client
+    def test_undecodable_bytes_rejected(self, end_frames_client):
+        c, pm = end_frames_client
         resp = _upload(c, b"not an image", filename="frame.png")
         assert resp.status_code == 400
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_unsupported_extension_rejected(self, client):
-        c, _pm = client
+    def test_unsupported_extension_rejected(self, end_frames_client):
+        c, _pm = end_frames_client
         assert _upload(c, _img_bytes("PNG"), filename="frame.gif").status_code == 400
 
-    def test_unknown_shot_returns_404(self, client):
-        c, _pm = client
+    def test_unknown_shot_returns_404(self, end_frames_client):
+        c, _pm = end_frames_client
         assert _upload(c, _img_bytes("PNG"), shot_id="E9S99").status_code == 404
 
 
 class TestSelectChannel:
-    def test_select_project_image_snapshots_to_end_frames(self, client):
-        c, pm = client
+    def test_select_project_image_snapshots_to_end_frames(self, end_frames_client):
+        c, pm = end_frames_client
         _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(12, 12)))
 
         resp = _select(c, "storyboards/scene_E1S02.png")
@@ -166,23 +166,23 @@ class TestSelectChannel:
             assert img.format == "PNG"
             assert img.size == (12, 12)
 
-    def test_traversal_path_rejected(self, client):
-        c, pm = client
+    def test_traversal_path_rejected(self, end_frames_client):
+        c, pm = end_frames_client
         resp = _select(c, "../../../etc/passwd")
         assert resp.status_code == 400
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_missing_source_returns_404(self, client):
-        c, _pm = client
+    def test_missing_source_returns_404(self, end_frames_client):
+        c, _pm = end_frames_client
         assert _select(c, "storyboards/scene_E1S99.png").status_code == 404
 
-    def test_oversized_source_image_rejected(self, client, monkeypatch):
+    def test_oversized_source_image_rejected(self, end_frames_client, monkeypatch):
         """项目内选图源超过上传通道同一上限时须拒绝（见 read_project_image）。
 
         专属文案 + 400：选图请求体只是路径字符串，413（请求体过大）语义不适用，
         与上传通道自身的 413 + upload_too_large 分流（见 test_shot_uploads_router）。
         """
-        c, pm = client
+        c, pm = end_frames_client
         monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
         _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
 
@@ -194,9 +194,9 @@ class TestSelectChannel:
         )
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_source_image_read_is_bounded(self, client, monkeypatch):
+    def test_source_image_read_is_bounded(self, end_frames_client, monkeypatch):
         """超限源图不得整读入内存：单次 read 请求的字节数以上限 +1 为界，够判超限即止。"""
-        _c, pm = client
+        _c, pm = end_frames_client
         _write_source_image(pm, "storyboards/scene_E1S02.png", _img_bytes("PNG", size=(64, 64)))
         project_path = pm.get_project_path("demo")
         monkeypatch.setattr(end_frame_service, "UPLOAD_IMAGE_MAX_BYTES", 16)
@@ -227,8 +227,8 @@ class TestSelectChannel:
 
 
 class TestClear:
-    def test_clear_deletes_snapshot_and_nulls_field(self, client):
-        c, pm = client
+    def test_clear_deletes_snapshot_and_nulls_field(self, end_frames_client):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         assert snapshot.exists()
@@ -238,21 +238,21 @@ class TestClear:
         assert _segment(pm)["end_frame_image"] is None
         assert not snapshot.exists()
 
-    def test_clear_without_end_frame_is_idempotent(self, client):
-        c, pm = client
+    def test_clear_without_end_frame_is_idempotent(self, end_frames_client):
+        c, pm = end_frames_client
         assert _delete(c).status_code == 200
         assert _segment(pm)["end_frame_image"] is None
 
-    def test_clear_unknown_shot_returns_404(self, client):
-        c, _pm = client
+    def test_clear_unknown_shot_returns_404(self, end_frames_client):
+        c, _pm = end_frames_client
         assert _delete(c, shot_id="E9S99").status_code == 404
 
 
 class TestSnapshotDecoupling:
     """快照与源图彻底解耦：源图后续被改写或删除都动不到已定尾帧。"""
 
-    def test_source_rewrite_and_delete_leave_end_frame_intact(self, client):
-        c, pm = client
+    def test_source_rewrite_and_delete_leave_end_frame_intact(self, end_frames_client):
+        c, pm = end_frames_client
         source_rel = "storyboards/scene_E1S02.png"
         _write_source_image(pm, source_rel, _img_bytes("PNG", size=(12, 12), color=(255, 0, 0)))
         _select(c, source_rel)
@@ -267,9 +267,9 @@ class TestSnapshotDecoupling:
         assert snapshot.read_bytes() == before
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
 
-    def test_source_version_rollback_leaves_end_frame_intact(self, client):
+    def test_source_version_rollback_leaves_end_frame_intact(self, end_frames_client):
         """源图回滚到旧版本后已定尾帧不变——尾帧存的是快照路径，与源图的版本轴无关。"""
-        c, pm = client
+        c, pm = end_frames_client
         source_rel = "storyboards/scene_E1S02.png"
         source_abs = pm.get_project_path("demo") / source_rel
         vm = VersionManager(pm.get_project_path("demo"))
@@ -289,8 +289,8 @@ class TestSnapshotDecoupling:
         assert snapshot.read_bytes() == before
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
 
-    def test_per_shot_snapshots_are_independent(self, client):
-        c, pm = client
+    def test_per_shot_snapshots_are_independent(self, end_frames_client):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG", size=(8, 8)), shot_id="E1S01")
         _upload(c, _img_bytes("PNG", size=(16, 16)), shot_id="E1S02")
 
@@ -381,9 +381,9 @@ def _interleave_across_critical_section(
 class TestConcurrentSetClear:
     """设置与清除并发交错时，字段与快照文件必须同进同退，不留悬空引用。"""
 
-    def test_clear_blocked_until_set_leaves_critical_section(self, client, monkeypatch):
+    def test_clear_blocked_until_set_leaves_critical_section(self, end_frames_client, monkeypatch):
         """设置先进临界区：清除被挡到设置整段完成之后，最终状态是「清除赢」且无残留引用。"""
-        c, pm = client
+        c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
         results = _interleave_across_critical_section(
@@ -398,9 +398,9 @@ class TestConcurrentSetClear:
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
 
-    def test_set_blocked_until_clear_leaves_critical_section(self, client, monkeypatch):
+    def test_set_blocked_until_clear_leaves_critical_section(self, end_frames_client, monkeypatch):
         """清除先进临界区：设置被挡到清除整段完成之后，最终字段非空且快照文件在位。"""
-        c, pm = client
+        c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         assert _upload(c, _img_bytes("PNG")).status_code == 200
 
@@ -466,8 +466,8 @@ def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, 
 class TestPersistFailureRestoresSnapshot:
     """剧本持久化在临界区内失败时，快照文件须回滚到操作前状态，不留悬空引用或静默丢失。"""
 
-    def test_set_failure_restores_previous_snapshot_bytes(self, client, monkeypatch):
-        c, pm = client
+    def test_set_failure_restores_previous_snapshot_bytes(self, end_frames_client, monkeypatch):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG", size=(8, 8)))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
@@ -480,9 +480,9 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
         assert snapshot.read_bytes() == before
 
-    def test_set_failure_on_first_write_removes_snapshot(self, client, monkeypatch):
+    def test_set_failure_on_first_write_removes_snapshot(self, end_frames_client, monkeypatch):
         """此前未设置过尾帧时失败：快照文件此前不存在，须整段撤回而非留下孤儿文件。"""
-        c, pm = client
+        c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
         _fail_first_persist(monkeypatch)
@@ -492,8 +492,8 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
 
-    def test_clear_failure_restores_deleted_snapshot(self, client, monkeypatch):
-        c, pm = client
+    def test_clear_failure_restores_deleted_snapshot(self, end_frames_client, monkeypatch):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
@@ -507,10 +507,10 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == before
 
-    def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, client, monkeypatch):
+    def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, end_frames_client, monkeypatch):
         """回滚重新过锁时若该分镜的操作代次已前移，说明并发请求已经接管，
         必须跳过回滚——否则会用陈旧字节覆盖对方刚成功落盘的内容。"""
-        c, pm = client
+        c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(32, 32))
@@ -524,8 +524,8 @@ class TestPersistFailureRestoresSnapshot:
 
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, client, monkeypatch):
-        c, pm = client
+    def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, end_frames_client, monkeypatch):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         key = ("demo", "episode_1.json", "E1S01")
@@ -541,12 +541,12 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, client, monkeypatch):
+    def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, end_frames_client, monkeypatch):
         """退化值场景：清除失败后文件已被删（期望内容与「无人接手」的期望值同为 None），
         并发的另一次清除随后也成功完成，结果同样是文件不存在——若
         仅比对文件内容将无法区分两者，误判为无人接手并把旧快照字节回滚出孤儿文件。
         代次判定下，并发清除会推进代次，回滚据此正确跳过。"""
-        c, pm = client
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         key = ("demo", "episode_1.json", "E1S01")
@@ -560,11 +560,11 @@ class TestPersistFailureRestoresSnapshot:
         # 回滚跳过：文件保持并发清除后的「已删除」结果，没有被旧字节重新写回制造孤儿文件
         assert not snapshot.exists()
 
-    def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, client, monkeypatch):
+    def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, end_frames_client, monkeypatch):
         """别名归一：失败的这次操作用 `scripts/episode_1.json` 这个别名，
         代次键若不归一化会与并发接管（用 `episode_1.json` 归一后的键）各自生成一把代次，
         互相看不见——回滚会误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。"""
-        c, pm = client
+        c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         normalized_key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(48, 48))
@@ -581,13 +581,13 @@ class TestPersistFailureRestoresSnapshot:
         # 未归一化则代次键不同，回滚会看不到接管、用旧字节覆盖并发写入的新内容
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, client, monkeypatch):
+    def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, end_frames_client, monkeypatch):
         """陈旧基线问题：`old_bytes` 若在取得剧本锁之前预读，读到的是「进入临界区之前」
         而非「进入临界区那一刻」的文件内容。这里不推进代次，只在本次操作自己的
         `_read_script_unlocked` 调用（进入临界区的时点）直接改写文件——代次检查不会拦截
         （因为没有别的操作声称接管），能否回滚出这份改写后的内容，才真正区分基线是在
         锁内读还是锁外预读：锁外预读会读到改写前的旧内容，回滚会把改写后的内容覆盖掉。"""
-        c, pm = client
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG", size=(8, 8)))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
@@ -616,8 +616,8 @@ class TestPersistFailureRestoresSnapshot:
 class TestErrorMapping:
     """领域错误到 HTTP 的映射：三个端点行为一致，不泄漏服务器路径。"""
 
-    def test_unknown_script_file_returns_404(self, client):
-        c, _pm = client
+    def test_unknown_script_file_returns_404(self, end_frames_client):
+        c, _pm = end_frames_client
         assert (
             c.post(
                 "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=missing.json",
@@ -635,29 +635,29 @@ class TestErrorMapping:
         resp = c.delete("/api/v1/projects/demo/shots/E1S01/end-frame?script_file=missing.json")
         assert resp.status_code == 404
 
-    def test_unknown_project_returns_404(self, client):
-        c, _pm = client
+    def test_unknown_project_returns_404(self, end_frames_client):
+        c, _pm = end_frames_client
         resp = c.post(
             "/api/v1/projects/nope/shots/E1S01/end-frame/upload?script_file=episode_1.json",
             files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
         )
         assert resp.status_code == 404
 
-    def test_empty_source_path_rejected(self, client):
-        c, pm = client
+    def test_empty_source_path_rejected(self, end_frames_client):
+        c, pm = end_frames_client
         assert _select(c, "   ").status_code == 400
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_oversized_upload_rejected(self, client, monkeypatch):
-        c, pm = client
+    def test_oversized_upload_rejected(self, end_frames_client, monkeypatch):
+        c, pm = end_frames_client
         monkeypatch.setattr(upload_finalize, "UPLOAD_IMAGE_MAX_BYTES", 16)
         resp = _upload(c, _img_bytes("PNG", size=(64, 64)))
         assert resp.status_code == 413
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_traversal_shot_id_rejected_before_write(self, client):
+    def test_traversal_shot_id_rejected_before_write(self, end_frames_client):
         """剧本里存在越界形状的镜头 id 时，快照路径解析必须拒绝而非写出项目目录。"""
-        _c, pm = client
+        _c, pm = end_frames_client
         script = pm.load_script("demo", "episode_1.json")
         script["segments"][0]["segment_id"] = "../../../../evil"
         pm.save_script("demo", script, "episode_1.json", validate=False)
@@ -673,15 +673,15 @@ class TestErrorMapping:
             )
         assert exc.value.key == "invalid_resource_id"
 
-    def test_body_exceeding_limit_rejected_after_read(self, client, monkeypatch):
+    def test_body_exceeding_limit_rejected_after_read(self, end_frames_client, monkeypatch):
         """Content-Length 缺失/被绕过时，按实际读入字节数兜底拒绝。"""
-        c, pm = client
+        c, pm = end_frames_client
         monkeypatch.setattr(end_frames, "validate_upload", lambda *a, **k: 16)
         assert _upload(c, _img_bytes("PNG", size=(64, 64))).status_code == 413
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_script_edit_error_maps_to_400(self, client, monkeypatch):
-        c, _pm = client
+    def test_script_edit_error_maps_to_400(self, end_frames_client, monkeypatch):
+        c, _pm = end_frames_client
 
         async def _boom(**_kwargs):
             raise ScriptEditError("坏掉的剧本结构")
@@ -689,8 +689,8 @@ class TestErrorMapping:
         monkeypatch.setattr(end_frames, "set_end_frame_from_bytes", _boom)
         assert _upload(c, _img_bytes("PNG")).status_code == 400
 
-    def test_unexpected_error_maps_to_500_without_internals(self, client, monkeypatch):
-        c, _pm = client
+    def test_unexpected_error_maps_to_500_without_internals(self, end_frames_client, monkeypatch):
+        c, _pm = end_frames_client
 
         async def _boom(**_kwargs):
             raise RuntimeError("/absolute/server/path/leaked")
@@ -700,18 +700,18 @@ class TestErrorMapping:
         assert resp.status_code == 500
         assert "leaked" not in resp.text
 
-    def test_illegal_project_name_returns_400(self, client):
+    def test_illegal_project_name_returns_400(self, end_frames_client):
         """`get_project_path` 对非法项目名（正则不匹配）抛 ValueError，须映射为 400 而非落 500 兜底。"""
-        c, _pm = client
+        c, _pm = end_frames_client
         resp = c.post(
             "/api/v1/projects/demo.evil/shots/E1S01/end-frame/upload?script_file=episode_1.json",
             files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
         )
         assert resp.status_code == 400
 
-    def test_illegal_script_file_returns_400(self, client):
+    def test_illegal_script_file_returns_400(self, end_frames_client):
         """`load_script` 底层 `_safe_subpath` 对越界 script_file 抛 ValueError，须映射为 400。"""
-        c, pm = client
+        c, pm = end_frames_client
         resp = c.post(
             "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=../../../../etc/passwd",
             files={"file": ("f.png", BytesIO(_img_bytes("PNG")), "application/octet-stream")},
@@ -719,9 +719,9 @@ class TestErrorMapping:
         assert resp.status_code == 400
         assert _segment(pm).get("end_frame_image") is None
 
-    def test_illegal_path_returns_400_on_select_and_clear(self, client):
+    def test_illegal_path_returns_400_on_select_and_clear(self, end_frames_client):
         """三个端点共用 `_locate_shot`，选图与清除通道同样须落 400 而非 500。"""
-        c, _pm = client
+        c, _pm = end_frames_client
         select_resp = c.post(
             "/api/v1/projects/demo.evil/shots/E1S01/end-frame/select",
             json={"script_file": "episode_1.json", "source_path": "storyboards/scene_E1S01.png"},
@@ -733,18 +733,18 @@ class TestErrorMapping:
         )
         assert clear_resp.status_code == 400
 
-    def test_corrupt_script_still_maps_to_500(self, client):
+    def test_corrupt_script_still_maps_to_500(self, end_frames_client):
         """`JSONDecodeError` 是 `ValueError` 子类：剧本文件损坏须落 500 兜底，
         不能被非法 script_file 的 400 分支吞掉，否则错误原因对排查完全失真。"""
-        c, pm = client
+        c, pm = end_frames_client
         (pm.get_project_path("demo") / "scripts" / "episode_1.json").write_text("{ not json", encoding="utf-8")
 
         assert _upload(c, _img_bytes("PNG")).status_code == 500
 
-    def test_non_utf8_script_still_maps_to_500(self, client):
+    def test_non_utf8_script_still_maps_to_500(self, end_frames_client):
         """`UnicodeDecodeError` 同样是 `ValueError` 子类：剧本文件含非法 UTF-8 字节须落 500 兜底，
         不能被非法 script_file 的 400 分支吞掉。"""
-        c, pm = client
+        c, pm = end_frames_client
         (pm.get_project_path("demo") / "scripts" / "episode_1.json").write_bytes(b"\xff\xfe not utf-8")
 
         assert _upload(c, _img_bytes("PNG")).status_code == 500
@@ -886,8 +886,8 @@ class TestReferenceVideoRejection:
 
 
 class TestValidatorAcceptsWrittenSnapshot:
-    def test_written_project_passes_tree_validation(self, client):
-        c, pm = client
+    def test_written_project_passes_tree_validation(self, end_frames_client):
+        c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         # end_frames 已登记为允许的项目根目录条目，不被判为未知目录
         assert "end_frames" in DataValidator.ALLOWED_ROOT_ENTRIES

--- a/tests/integration/server/routers/test_files_router.py
+++ b/tests/integration/server/routers/test_files_router.py
@@ -20,7 +20,7 @@ from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import files
-from tests.conftest import _wav_bytes
+from tests.factories import wav_bytes
 
 
 class _FakeTextBackend:
@@ -310,7 +310,7 @@ class TestFilesRouter:
         with client:
             resp = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
-                files={"file": ("alice_voice.wav", _wav_bytes(3), "audio/wav")},
+                files={"file": ("alice_voice.wav", wav_bytes(3), "audio/wav")},
             )
             assert resp.status_code == 200
             assert resp.json()["path"] == "characters/refs_audio/Alice.wav"
@@ -322,7 +322,7 @@ class TestFilesRouter:
         with client:
             resp = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref",
-                files={"file": ("orphan.wav", _wav_bytes(3), "audio/wav")},
+                files={"file": ("orphan.wav", wav_bytes(3), "audio/wav")},
             )
 
             assert resp.status_code == 404
@@ -362,7 +362,7 @@ class TestFilesRouter:
         with client:
             resp = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
-                files={"file": ("alice_voice.wav", _wav_bytes(1), "audio/wav")},
+                files={"file": ("alice_voice.wav", wav_bytes(1), "audio/wav")},
             )
             assert resp.status_code == 400
             assert resp.json()["detail"] == zh_errors.MESSAGES["audio_duration_out_of_range"].format(
@@ -446,7 +446,7 @@ class TestFilesRouter:
         with client:
             upload = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
-                files={"file": ("alice_voice.wav", _wav_bytes(3), "audio/wav")},
+                files={"file": ("alice_voice.wav", wav_bytes(3), "audio/wav")},
             )
             assert upload.status_code == 200
             project_dir = pm.get_project_path("demo")
@@ -464,7 +464,7 @@ class TestFilesRouter:
         with client:
             upload = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
-                files={"file": ("alice_voice.wav", _wav_bytes(3), "audio/wav")},
+                files={"file": ("alice_voice.wav", wav_bytes(3), "audio/wav")},
             )
             assert upload.status_code == 200
             project_dir = pm.get_project_path("demo")
@@ -490,7 +490,7 @@ class TestFilesRouter:
         with client:
             upload = client.post(
                 "/api/v1/projects/demo/upload/character_audio_ref?name=Alice",
-                files={"file": ("alice_voice.wav", _wav_bytes(3), "audio/wav")},
+                files={"file": ("alice_voice.wav", wav_bytes(3), "audio/wav")},
             )
             assert upload.status_code == 200
             project_dir = pm.get_project_path("demo")
@@ -820,7 +820,7 @@ class TestFilesRouter:
             "ctrl\x01char",
         ]
         payloads = {
-            "character_audio_ref": ("v.wav", _wav_bytes(3), "audio/wav"),
+            "character_audio_ref": ("v.wav", wav_bytes(3), "audio/wav"),
             # source 不使用 name，但校验在其早返分支之前，同样应拒
             "source": ("novel.txt", b"chapter one", "text/plain"),
         }

--- a/tests/integration/server/routers/test_model_candidates_api.py
+++ b/tests/integration/server/routers/test_model_candidates_api.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.capability_buckets import builtin_model_buckets, custom_model_buckets
 from lib.config.registry import PROVIDER_REGISTRY
@@ -73,9 +72,8 @@ def _make_mock_svc(ready_providers: list[str]) -> ConfigService:
 
 
 @pytest.fixture()
-def session_factory_and_engine():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    return async_sessionmaker(engine, expire_on_commit=False), engine
+def session_factory_and_engine(db_engine, db_factory):
+    return db_factory, db_engine
 
 
 def _make_app(mock_svc: ConfigService, engine, factory) -> FastAPI:

--- a/tests/integration/server/routers/test_model_candidates_api.py
+++ b/tests/integration/server/routers/test_model_candidates_api.py
@@ -73,7 +73,7 @@ def _make_mock_svc(ready_providers: list[str]) -> ConfigService:
 
 
 @pytest.fixture()
-def session_factory():
+def session_factory_and_engine():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     return async_sessionmaker(engine, expire_on_commit=False), engine
 
@@ -100,8 +100,8 @@ def _make_app(mock_svc: ConfigService, engine, factory) -> FastAPI:
 
 
 @pytest.fixture()
-def make_client(session_factory):
-    factory, engine = session_factory
+def make_client(session_factory_and_engine):
+    factory, engine = session_factory_and_engine
 
     def _make(ready_providers: list[str] | None = None) -> TestClient:
         return TestClient(_make_app(_make_mock_svc(ready_providers or []), engine, factory))
@@ -189,8 +189,10 @@ class TestBuiltinBucketFiltering:
 
 
 class TestCustomProviderBucketFiltering:
-    async def test_custom_video_model_enters_buckets_by_endpoint_judgement(self, make_client, session_factory):
-        factory, _engine = session_factory
+    async def test_custom_video_model_enters_buckets_by_endpoint_judgement(
+        self, make_client, session_factory_and_engine
+    ):
+        factory, _engine = session_factory_and_engine
         with make_client([]) as client:
             # openai-video 系统判定 max_reference_images=1、first_frame=True
             await _seed_custom_models(
@@ -203,8 +205,8 @@ class TestCustomProviderBucketFiltering:
         assert option in body["video"]["buckets"]["i2v"]
         assert option in body["video"]["default"]
 
-    async def test_capability_override_removes_model_from_r2v(self, make_client, session_factory):
-        factory, _engine = session_factory
+    async def test_capability_override_removes_model_from_r2v(self, make_client, session_factory_and_engine):
+        factory, _engine = session_factory_and_engine
         with make_client([]) as client:
             await _seed_custom_models(
                 factory,
@@ -225,8 +227,8 @@ class TestCustomProviderBucketFiltering:
         assert option in body["video"]["buckets"]["i2v"]
         assert option in body["video"]["default"]
 
-    async def test_custom_image_model_filtered_by_endpoint_capabilities(self, make_client, session_factory):
-        factory, _engine = session_factory
+    async def test_custom_image_model_filtered_by_endpoint_capabilities(self, make_client, session_factory_and_engine):
+        factory, _engine = session_factory_and_engine
         with make_client([]) as client:
             # openai-images-edits 只声明 image_to_image
             await _seed_custom_models(
@@ -246,8 +248,8 @@ class TestCustomProviderBucketFiltering:
         assert option not in body["image"]["buckets"]["t2i"]
         assert option in body["image"]["default"]
 
-    async def test_disabled_custom_models_absent(self, make_client, session_factory):
-        factory, _engine = session_factory
+    async def test_disabled_custom_models_absent(self, make_client, session_factory_and_engine):
+        factory, _engine = session_factory_and_engine
         with make_client([]) as client:
             await _seed_custom_models(
                 factory,

--- a/tests/integration/server/routers/test_onboarding_router.py
+++ b/tests/integration/server/routers/test_onboarding_router.py
@@ -6,11 +6,9 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.config.service import ConfigService
 from lib.db import get_async_session
-from lib.db.base import Base
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import onboarding
 from tests.auth_deps import AUTH_DEPENDENCIES
@@ -31,18 +29,8 @@ def _make_app(session_factory) -> FastAPI:
 
 
 @pytest_asyncio.fixture
-async def _session_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
-
-
-@pytest_asyncio.fixture
-async def authed_client(_session_factory):
-    app = _make_app(_session_factory)
+async def onboarding_client(db_factory):
+    app = _make_app(db_factory)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -50,62 +38,62 @@ async def authed_client(_session_factory):
 
 
 @pytest_asyncio.fixture
-async def unauth_client(_session_factory, monkeypatch):
+async def unauth_client(db_factory, monkeypatch):
     """No dependency override → real auth applies → expects 401/403."""
     # AUTH_ENABLED=false 时 get_current_user 直接返回匿名 admin，本 fixture 就测不到拒绝。
     monkeypatch.setenv("AUTH_ENABLED", "true")
-    app = _make_app(_session_factory)
+    app = _make_app(db_factory)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
 
 @pytest.mark.asyncio
-async def test_status_reports_not_seen_when_flag_missing(authed_client) -> None:
-    resp = await authed_client.get("/api/v1/onboarding/status")
+async def test_status_reports_not_seen_when_flag_missing(onboarding_client) -> None:
+    resp = await onboarding_client.get("/api/v1/onboarding/status")
     assert resp.status_code == 200
     assert resp.json() == {"seen": False}
 
 
 @pytest.mark.asyncio
-async def test_mark_seen_then_status_reports_seen(authed_client) -> None:
-    marked = await authed_client.post("/api/v1/onboarding/seen")
+async def test_mark_seen_then_status_reports_seen(onboarding_client) -> None:
+    marked = await onboarding_client.post("/api/v1/onboarding/seen")
     assert marked.status_code == 200
     assert marked.json() == {"seen": True}
 
-    resp = await authed_client.get("/api/v1/onboarding/status")
+    resp = await onboarding_client.get("/api/v1/onboarding/status")
     assert resp.json() == {"seen": True}
 
 
 @pytest.mark.asyncio
-async def test_mark_seen_is_idempotent(authed_client) -> None:
+async def test_mark_seen_is_idempotent(onboarding_client) -> None:
     for _ in range(3):
-        resp = await authed_client.post("/api/v1/onboarding/seen")
+        resp = await onboarding_client.post("/api/v1/onboarding/seen")
         assert resp.status_code == 200
         assert resp.json() == {"seen": True}
 
-    assert (await authed_client.get("/api/v1/onboarding/status")).json() == {"seen": True}
+    assert (await onboarding_client.get("/api/v1/onboarding/status")).json() == {"seen": True}
 
 
 @pytest.mark.asyncio
-async def test_mark_seen_persists_flag_under_expected_key(authed_client, _session_factory) -> None:
+async def test_mark_seen_persists_flag_under_expected_key(onboarding_client, db_factory) -> None:
     """标记写在实例级 SystemSetting 的 `onboarding_seen` 上，不是内存态。"""
-    await authed_client.post("/api/v1/onboarding/seen")
+    await onboarding_client.post("/api/v1/onboarding/seen")
 
-    async with _session_factory() as session:
+    async with db_factory() as session:
         stored = await ConfigService(session).get_setting(onboarding.ONBOARDING_SEEN_KEY)
     assert stored == "true"
 
 
 @pytest.mark.asyncio
-async def test_mark_seen_writes_only_the_flag(authed_client, _session_factory) -> None:
+async def test_mark_seen_writes_only_the_flag(onboarding_client, db_factory) -> None:
     """零副作用：标记引导只落一个 setting，不碰其他配置。"""
-    async with _session_factory() as session:
+    async with db_factory() as session:
         before = await ConfigService(session).get_all_settings()
 
-    await authed_client.post("/api/v1/onboarding/seen")
+    await onboarding_client.post("/api/v1/onboarding/seen")
 
-    async with _session_factory() as session:
+    async with db_factory() as session:
         after = await ConfigService(session).get_all_settings()
     assert set(after) - set(before) == {onboarding.ONBOARDING_SEEN_KEY}
     assert {k: v for k, v in after.items() if k != onboarding.ONBOARDING_SEEN_KEY} == before

--- a/tests/integration/server/routers/test_reference_videos_router.py
+++ b/tests/integration/server/routers/test_reference_videos_router.py
@@ -21,7 +21,7 @@ from tests.speech_contract_cases import SPEECH_CONTRACT_CASES, SpeechContractCas
 
 
 @pytest.fixture
-def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def reference_videos_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # 重定向 projects_root 到 tmp_path
     projects_root = tmp_path / "projects"
     projects_root.mkdir()
@@ -86,19 +86,19 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
-def test_list_units_empty(client: TestClient):
-    resp = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units")
+def test_list_units_empty(reference_videos_client: TestClient):
+    resp = reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units")
     assert resp.status_code == 200
     assert resp.json() == {"units": []}
 
 
-def test_list_units_404_for_unknown_project(client: TestClient):
-    resp = client.get("/api/v1/projects/missing/reference-videos/episodes/1/units")
+def test_list_units_404_for_unknown_project(reference_videos_client: TestClient):
+    resp = reference_videos_client.get("/api/v1/projects/missing/reference-videos/episodes/1/units")
     assert resp.status_code == 404
 
 
-def test_add_unit_creates_minimal_entry(client: TestClient):
-    resp = client.post(
+def test_add_unit_creates_minimal_entry(reference_videos_client: TestClient):
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 推门", "duration_seconds": 3},
     )
@@ -109,21 +109,23 @@ def test_add_unit_creates_minimal_entry(client: TestClient):
     assert payload["unit"]["text"] == "镜头1：@张三 推门"
 
 
-def test_add_unit_refuses_a_blank_body(client: TestClient):
+def test_add_unit_refuses_a_blank_body(reference_videos_client: TestClient):
     """正文是单元的唯一内容真相：空正文的单元不可执行，创建时即以 needs_replan 拒绝。"""
-    response = client.post(
+    response = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "", "duration_seconds": 3},
     )
 
     assert response.status_code == 409, response.text
     assert response.json()["detail"]["problems"][0]["code"] == "needs_replan"
-    assert client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json() == {"units": []}
+    assert reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json() == {
+        "units": []
+    }
 
 
-def test_add_unit_rejects_a_stored_reference_list(client: TestClient):
+def test_add_unit_rejects_a_stored_reference_list(reference_videos_client: TestClient):
     """正文是参考图的唯一来源；仍带 ``references`` 的旧客户端须拿到 422 而非被静默忽略。"""
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={
             "prompt": "镜头1：@张三 推门",
@@ -134,19 +136,21 @@ def test_add_unit_rejects_a_stored_reference_list(client: TestClient):
     assert resp.status_code == 422, resp.text
 
 
-def test_patch_unit_rejects_a_stored_reference_list(client: TestClient):
-    uid = _seed_unit(client)
-    resp = client.patch(
+def test_patch_unit_rejects_a_stored_reference_list(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"references": [{"type": "scene", "name": "酒馆"}]},
     )
     assert resp.status_code == 422, resp.text
 
 
-def test_add_unit_without_duration_falls_back_to_model_slot(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_add_unit_without_duration_falls_back_to_model_slot(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """请求不给时长 → 取项目能力解析出的档位首项（与执行层解析申请秒数的回退序同源）。"""
     _patch_supported_durations(monkeypatch, [6, 9])
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 推门"},
     )
@@ -155,7 +159,7 @@ def test_add_unit_without_duration_falls_back_to_model_slot(client: TestClient, 
 
 
 def test_add_unit_derives_references_from_text_before_selecting_duration_bucket(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ):
     """默认时长按正文派生出的参考图定桶：正文提到已登记资产即走 r2v 档。"""
     from server.routers import reference_videos as router_mod
@@ -165,7 +169,7 @@ def test_add_unit_derives_references_from_text_before_selecting_duration_bucket(
     resolve_context = AsyncMock(return_value=ctx)
     monkeypatch.setattr(router_mod, "resolve_project_duration_context", resolve_context)
 
-    response = client.post(
+    response = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@[张三] 推门"},
     )
@@ -176,28 +180,30 @@ def test_add_unit_derives_references_from_text_before_selecting_duration_bucket(
 
 
 @pytest.mark.parametrize("duration_seconds", [0, -1])
-def test_add_unit_rejects_non_positive_duration(client: TestClient, duration_seconds: int):
+def test_add_unit_rejects_non_positive_duration(reference_videos_client: TestClient, duration_seconds: int):
     """显式非正时长须在请求边界被拒，不静默改写成 1 秒。"""
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 推门", "duration_seconds": duration_seconds},
     )
     assert resp.status_code == 422, resp.text
 
 
-def test_add_unit_atomically_rejects_mixed_speech(client: TestClient):
-    response = client.post(
+def test_add_unit_atomically_rejects_mixed_speech(reference_videos_client: TestClient):
+    response = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：张三推门\n@[张三]：{快走。}\n{风吹过旷野。}", "duration_seconds": 3},
     )
 
     assert response.status_code == 409
     assert response.json()["detail"]["problems"][0]["code"] == "mixed_speech"
-    assert client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json() == {"units": []}
+    assert reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json() == {
+        "units": []
+    }
 
 
-def _seed_unit(client: TestClient) -> str:
-    resp = client.post(
+def _seed_unit(reference_videos_client: TestClient) -> str:
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 推门", "duration_seconds": 3},
     )
@@ -205,7 +211,7 @@ def _seed_unit(client: TestClient) -> str:
     return resp.json()["unit"]["unit_id"]
 
 
-def _derived_references(client: TestClient, unit: dict[str, Any]) -> list[tuple[str, str]]:
+def _derived_references(reference_videos_client: TestClient, unit: dict[str, Any]) -> list[tuple[str, str]]:
     """执行期会用到的参考图引用：正文的唯一派生出口，不落盘。"""
     from lib.reference_video.request_projection import unit_reference_declarations
     from server.routers import reference_videos as router_mod
@@ -214,10 +220,10 @@ def _derived_references(client: TestClient, unit: dict[str, Any]) -> list[tuple[
     return [(ref.type, ref.name) for ref in unit_reference_declarations(project, unit)]
 
 
-def test_patch_unit_prompt_keeps_duration(client: TestClient):
+def test_patch_unit_prompt_keeps_duration(reference_videos_client: TestClient):
     """时长与正文互不牵连；正文换掉后参考图按新正文重新派生。"""
-    uid = _seed_unit(client)
-    resp = client.patch(
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": "镜头1：@酒馆 门口\n镜头2：@酒馆 全景"},
     )
@@ -225,19 +231,19 @@ def test_patch_unit_prompt_keeps_duration(client: TestClient):
     unit = resp.json()["unit"]
     assert unit["text"] == "镜头1：@酒馆 门口\n镜头2：@酒馆 全景"
     assert unit["duration_seconds"] == 3
-    assert _derived_references(client, unit) == [("scene", "酒馆")]
+    assert _derived_references(reference_videos_client, unit) == [("scene", "酒馆")]
 
 
-def test_patch_unit_derives_non_character_references_before_speech_admission(client: TestClient):
-    uid = _seed_unit(client)
+def test_patch_unit_derives_non_character_references_before_speech_admission(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
 
-    response = client.patch(
+    response = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": "镜头1：@[酒馆]：木门被风吹开"},
     )
 
     assert response.status_code == 200, response.text
-    assert _derived_references(client, response.json()["unit"]) == [("scene", "酒馆")]
+    assert _derived_references(reference_videos_client, response.json()["unit"]) == [("scene", "酒馆")]
 
 
 @pytest.mark.parametrize(
@@ -246,10 +252,10 @@ def test_patch_unit_derives_non_character_references_before_speech_admission(cli
     ids=lambda case: case.route_id,
 )
 def test_three_reference_route_web_manual_edits_atomically_reject_mixed_speech_on_save(
-    client: TestClient, tmp_path: Path, case: SpeechContractCase
+    reference_videos_client: TestClient, tmp_path: Path, case: SpeechContractCase
 ):
-    uid = _seed_unit(client)
-    before = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"][0]
+    uid = _seed_unit(reference_videos_client)
+    before = reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"][0]
     before["generated_assets"] = {"video_clip": f"reference_videos/{uid}.mp4", "status": "completed"}
     # 模拟已有付费生成历史；人工正文修改失败时 locked_script 不得写回任何候选字段。
     from server.routers import reference_videos as router_mod
@@ -264,20 +270,20 @@ def test_three_reference_route_web_manual_edits_atomically_reject_mixed_speech_o
     script["video_units"][0]["generated_assets"] = before["generated_assets"]
     pm.save_script("demo", script, "episode_1.json")
 
-    response = client.patch(
+    response = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": "镜头1：张三推门\n@[张三]：{快走。}\n{风吹过旷野。}"},
     )
 
     assert response.status_code == 409
     assert response.json()["detail"]["problems"][0]["code"] == "mixed_speech"
-    after = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"][0]
+    after = reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"][0]
     assert after["text"] == before["text"]
     assert after["generated_assets"] == before["generated_assets"]
 
 
-def test_patch_allows_unchanged_legacy_mixed_prompt(client: TestClient):
-    uid = _seed_unit(client)
+def test_patch_allows_unchanged_legacy_mixed_prompt(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
     prompt = "镜头1：张三推门\n@[张三]：{快走。}\n{风吹过旷野。}"
     from server.routers import reference_videos as router_mod
 
@@ -287,7 +293,7 @@ def test_patch_allows_unchanged_legacy_mixed_prompt(client: TestClient):
     script["video_units"][0]["needs_replan"] = True
     pm.save_script("demo", script, "episode_1.json")
 
-    response = client.patch(
+    response = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": prompt, "note": "保留历史媒体"},
     )
@@ -297,10 +303,10 @@ def test_patch_allows_unchanged_legacy_mixed_prompt(client: TestClient):
     assert response.json()["unit"]["needs_replan"] is True
 
 
-def test_patch_unit_duration_only(client: TestClient):
+def test_patch_unit_duration_only(reference_videos_client: TestClient):
     """只改时长：正文原样保留。"""
-    uid = _seed_unit(client)
-    resp = client.patch(
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"duration_seconds": 9},
     )
@@ -311,27 +317,27 @@ def test_patch_unit_duration_only(client: TestClient):
 
 
 @pytest.mark.parametrize("duration_seconds", [0, -1])
-def test_patch_unit_rejects_non_positive_duration(client: TestClient, duration_seconds: int):
+def test_patch_unit_rejects_non_positive_duration(reference_videos_client: TestClient, duration_seconds: int):
     """显式非正时长须在请求边界被拒，不静默改写成 1 秒。"""
-    uid = _seed_unit(client)
-    resp = client.patch(
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"duration_seconds": duration_seconds},
     )
     assert resp.status_code == 422, resp.text
 
 
-def test_add_nonblank_unit_derives_registered_references_from_text(client: TestClient):
-    response = client.post(
+def test_add_nonblank_unit_derives_registered_references_from_text(reference_videos_client: TestClient):
+    response = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "@[酒馆]：木门被风吹开", "duration_seconds": 5},
     )
 
     assert response.status_code == 201, response.text
-    assert _derived_references(client, response.json()["unit"]) == [("scene", "酒馆")]
+    assert _derived_references(reference_videos_client, response.json()["unit"]) == [("scene", "酒馆")]
 
 
-def test_patch_unit_derives_nfc_reference_for_nfd_registered_name(client: TestClient):
+def test_patch_unit_derives_nfc_reference_for_nfd_registered_name(reference_videos_client: TestClient):
     """资产以 NFD 形式登记、正文写的是 NFC 名字：派生须按归一形式比对判「已登记」。"""
     from server.routers import reference_videos as router_mod
 
@@ -343,68 +349,68 @@ def test_patch_unit_derives_nfc_reference_for_nfd_registered_name(client: TestCl
     project["characters"][name_nfd] = {"description": "x"}
     pm.save_project("demo", project)
 
-    uid = _seed_unit(client)
-    resp = client.patch(
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": f"镜头1：@[{name_nfc}] 推门"},
     )
     assert resp.status_code == 200, resp.text
-    assert _derived_references(client, resp.json()["unit"]) == [("character", name_nfc)]
+    assert _derived_references(reference_videos_client, resp.json()["unit"]) == [("character", name_nfc)]
 
 
-def test_patch_unknown_unit_404(client: TestClient):
-    resp = client.patch(
+def test_patch_unknown_unit_404(reference_videos_client: TestClient):
+    resp = reference_videos_client.patch(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9",
         json={"note": "hi"},
     )
     assert resp.status_code == 404
 
 
-def test_delete_unit_removes_entry(client: TestClient):
-    uid = _seed_unit(client)
-    resp = client.delete(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}")
+def test_delete_unit_removes_entry(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.delete(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}")
     assert resp.status_code == 204
-    resp = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units")
+    resp = reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units")
     assert resp.json()["units"] == []
 
 
-def test_delete_unknown_unit_404(client: TestClient):
-    resp = client.delete("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9")
+def test_delete_unknown_unit_404(reference_videos_client: TestClient):
+    resp = reference_videos_client.delete("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9")
     assert resp.status_code == 404
 
 
-def test_reorder_units_applies_new_order(client: TestClient):
-    uid1 = _seed_unit(client)
-    uid2 = _seed_unit(client)
-    resp = client.post(
+def test_reorder_units_applies_new_order(reference_videos_client: TestClient):
+    uid1 = _seed_unit(reference_videos_client)
+    uid2 = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid2, uid1]},
     )
     assert resp.status_code == 200, resp.text
-    units = client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"]
+    units = reference_videos_client.get("/api/v1/projects/demo/reference-videos/episodes/1/units").json()["units"]
     assert [u["unit_id"] for u in units] == [uid2, uid1]
 
 
-def test_reorder_units_rejects_length_mismatch(client: TestClient):
-    uid = _seed_unit(client)
-    resp = client.post(
+def test_reorder_units_rejects_length_mismatch(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid, "E1U999"]},
     )
     assert resp.status_code == 400
 
 
-def test_reorder_units_rejects_duplicates(client: TestClient):
-    uid = _seed_unit(client)
-    resp = client.post(
+def test_reorder_units_rejects_duplicates(reference_videos_client: TestClient):
+    uid = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid, uid]},
     )
     assert resp.status_code == 400
 
 
-def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.MonkeyPatch):
-    uid = _seed_unit(client)
+def test_generate_unit_enqueues_task(reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    uid = _seed_unit(reference_videos_client)
 
     enqueued: list[dict] = []
 
@@ -417,7 +423,7 @@ def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.Mon
 
     monkeypatch.setattr(router_mod, "get_generation_queue", lambda: _FakeQueue())
 
-    resp = client.post(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate")
+    resp = reference_videos_client.post(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate")
     assert resp.status_code == 202, resp.text
     assert resp.json()["task_id"] == "task-xyz"
     assert enqueued[0]["task_type"] == "reference_video"
@@ -429,9 +435,9 @@ def test_generate_unit_enqueues_task(client: TestClient, monkeypatch: pytest.Mon
 
 
 def test_generate_unit_requires_and_persists_explicit_duration_confirmation(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    uid = _seed_unit(client)  # 3s
+    uid = _seed_unit(reference_videos_client)  # 3s
     _patch_supported_durations(monkeypatch, [4, 8])
     enqueued: list[dict[str, object]] = []
 
@@ -444,11 +450,13 @@ def test_generate_unit_requires_and_persists_explicit_duration_confirmation(
 
     monkeypatch.setattr(router_mod, "get_generation_queue", lambda: _FakeQueue())
 
-    unconfirmed = client.post(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate")
+    unconfirmed = reference_videos_client.post(
+        f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate"
+    )
     assert unconfirmed.status_code == 400
     assert enqueued == []
 
-    confirmed = client.post(
+    confirmed = reference_videos_client.post(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate",
         json={"confirmed_request_duration_seconds": 4},
     )
@@ -466,13 +474,13 @@ def test_generate_unit_requires_and_persists_explicit_duration_confirmation(
 
 
 def test_generate_unit_use_tts_returns_the_current_cross_tier_quote_before_enqueue(
-    client: TestClient,
+    reference_videos_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from server.routers import reference_videos as router_mod
     from server.services.cost_estimation import VideoRequestQuote
 
-    unit_id = _seed_unit(client)
+    unit_id = _seed_unit(reference_videos_client)
     _patch_supported_durations(monkeypatch, [4, 8, 12])
     enqueued: list[dict[str, object]] = []
 
@@ -497,7 +505,7 @@ def test_generate_unit_use_tts_returns_the_current_cross_tier_quote_before_enque
     monkeypatch.setattr(router_mod, "get_generation_queue", lambda: _FakeQueue())
     endpoint = f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/generate"
 
-    pending = client.post(endpoint, json={"narration_delivery": "use_tts"})
+    pending = reference_videos_client.post(endpoint, json={"narration_delivery": "use_tts"})
     assert pending.status_code == 400
     assert pending.json()["detail"]["request_cost"] == {
         "amount": 0.8,
@@ -508,7 +516,7 @@ def test_generate_unit_use_tts_returns_the_current_cross_tier_quote_before_enque
     }
     assert enqueued == []
 
-    accepted = client.post(
+    accepted = reference_videos_client.post(
         endpoint,
         json={"narration_delivery": "use_tts", "confirmed_request_duration_seconds": 8},
     )
@@ -529,7 +537,7 @@ def test_generate_unit_use_tts_returns_the_current_cross_tier_quote_before_enque
     ids=lambda case: case.route_id,
 )
 def test_three_reference_route_web_video_entries_share_structured_speech_admission(
-    client: TestClient,
+    reference_videos_client: TestClient,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     case: SpeechContractCase,
@@ -553,7 +561,7 @@ def test_three_reference_route_web_video_entries_share_structured_speech_admissi
 
     monkeypatch.setattr(router_mod, "get_generation_queue", get_generation_queue)
 
-    response = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
+    response = reference_videos_client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
 
     assert response.status_code == 409
     detail = response.json()["detail"]
@@ -568,12 +576,14 @@ def test_three_reference_route_web_video_entries_share_structured_speech_admissi
     enqueue.assert_not_awaited()
 
 
-def test_generate_unit_bucket_capability_error_returns_400(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_generate_unit_bucket_capability_error_returns_400(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """公共投影返回 r2v 能力 blocker 时提交入口不入队。"""
     from lib.i18n import _ as i18n_message
     from lib.reference_video.request_projection import ProjectionProblem
 
-    uid = _seed_unit(client)
+    uid = _seed_unit(reference_videos_client)
     enqueued: list[dict] = []
 
     class _FakeQueue:
@@ -603,7 +613,7 @@ def test_generate_unit_bucket_capability_error_returns_400(client: TestClient, m
 
     monkeypatch.setattr(router_mod, "project_reference_unit_request", _reject)
 
-    resp = client.post(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate")
+    resp = reference_videos_client.post(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/generate")
     assert resp.status_code == 400, resp.text
     detail = resp.json()["detail"]
     assert detail == {
@@ -635,7 +645,7 @@ def test_generate_unit_bucket_capability_error_returns_400(client: TestClient, m
 
 
 def test_generate_unit_degenerate_precheck_uses_i2v_bucket(
-    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """无参考图退化 unit 的入队预检按降级后的 i2v 桶过解析闸，与执行侧分流同口径。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
@@ -661,24 +671,24 @@ def test_generate_unit_degenerate_precheck_uses_i2v_bucket(
 
     monkeypatch.setattr(router_mod, "project_reference_unit_request", _record)
 
-    resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
+    resp = reference_videos_client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
     assert resp.status_code == 202, resp.text
     assert checked == ["i2v"]
 
 
-def test_generate_unit_rejects_blank_prompt(client: TestClient, tmp_path: Path):
+def test_generate_unit_rejects_blank_prompt(reference_videos_client: TestClient, tmp_path: Path):
     """正文全空白的 unit 在入队时被守卫点拒绝（400），不漏到执行层失败。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     script["video_units"] = [{"unit_id": "E1U1", "text": "  ", "duration_seconds": 3}]
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
+    resp = reference_videos_client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E1U1/generate")
     assert resp.status_code == 400, resp.text
 
 
-def test_generate_unit_missing_returns_404(client: TestClient):
-    resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9/generate")
+def test_generate_unit_missing_returns_404(reference_videos_client: TestClient):
+    resp = reference_videos_client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/E9U9/generate")
     assert resp.status_code == 404
 
 
@@ -705,16 +715,20 @@ def _patch_supported_durations(monkeypatch: pytest.MonkeyPatch, durations: list[
     )
 
 
-def _precheck(client: TestClient, unit_id: str):
-    return client.get(f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/duration-precheck")
+def _precheck(reference_videos_client: TestClient, unit_id: str):
+    return reference_videos_client.get(
+        f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/duration-precheck"
+    )
 
 
-def test_precheck_slot_member_needs_no_confirmation(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_precheck_slot_member_needs_no_confirmation(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """总时长本身是档位成员 → 直接入队，无确认。"""
-    uid = _seed_unit(client)  # shots 求和 = 3s
+    uid = _seed_unit(reference_videos_client)  # shots 求和 = 3s
     _patch_supported_durations(monkeypatch, [3, 6, 9])
 
-    body = _precheck(client, uid).json()
+    body = _precheck(reference_videos_client, uid).json()
     assert body == {
         "allowed": True,
         "kind": "reference_request_projection",
@@ -735,12 +749,14 @@ def test_precheck_slot_member_needs_no_confirmation(client: TestClient, monkeypa
     }
 
 
-def test_precheck_rounds_up_and_needs_confirmation(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_precheck_rounds_up_and_needs_confirmation(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """总时长非档位成员且有档位能装下 → 需确认，申请能装下它的最小档位。"""
-    uid = _seed_unit(client)  # 3s
+    uid = _seed_unit(reference_videos_client)  # 3s
     _patch_supported_durations(monkeypatch, [4, 8, 12])
 
-    body = _precheck(client, uid).json()
+    body = _precheck(reference_videos_client, uid).json()
     assert body["needs_confirmation"] is True
     assert body["script_duration"] == 3
     assert body["request_duration"] == 4
@@ -752,7 +768,7 @@ def test_precheck_rounds_up_and_needs_confirmation(client: TestClient, monkeypat
     [(8, 8, False, 0.0), (8, None, False, 0.8), (4, None, True, 0.8)],
 )
 def test_precheck_prices_the_latest_tts_tier_against_the_selected_visual(
-    client: TestClient,
+    reference_videos_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     current_visual_tier: int,
     reusable_visual_tier: int | None,
@@ -762,7 +778,7 @@ def test_precheck_prices_the_latest_tts_tier_against_the_selected_visual(
     from server.routers import reference_videos as router_mod
     from server.services.cost_estimation import VideoRequestQuote
 
-    unit_id = _seed_unit(client)
+    unit_id = _seed_unit(reference_videos_client)
     _patch_supported_durations(monkeypatch, [4, 8, 12])
 
     async def _current_options(**kwargs):
@@ -788,7 +804,7 @@ def test_precheck_prices_the_latest_tts_tier_against_the_selected_visual(
         ),
     )
 
-    response = client.get(
+    response = reference_videos_client.get(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/duration-precheck",
         params={"narration_delivery": "use_tts"},
     )
@@ -807,12 +823,12 @@ def test_precheck_prices_the_latest_tts_tier_against_the_selected_visual(
 
 
 def test_precheck_blocks_cross_tier_tts_when_exact_cost_is_unavailable(
-    client: TestClient,
+    reference_videos_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from server.routers import reference_videos as router_mod
 
-    unit_id = _seed_unit(client)
+    unit_id = _seed_unit(reference_videos_client)
     _patch_supported_durations(monkeypatch, [4, 8, 12])
 
     async def _current_options(**kwargs):
@@ -825,7 +841,7 @@ def test_precheck_blocks_cross_tier_tts_when_exact_cost_is_unavailable(
     monkeypatch.setattr(router_mod, "prepare_current_reference_video_request_options", _current_options)
     monkeypatch.setattr(router_mod, "quote_video_request", AsyncMock(return_value=None))
 
-    response = client.get(
+    response = reference_videos_client.get(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/duration-precheck",
         params={"narration_delivery": "use_tts"},
     )
@@ -838,14 +854,14 @@ def test_precheck_blocks_cross_tier_tts_when_exact_cost_is_unavailable(
 
 
 def test_precheck_use_tts_while_regenerating_returns_canonical_problem(
-    client: TestClient,
+    reference_videos_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An active explicit regeneration shadows the old formal audio for Web requests."""
     from lib.reference_video.request_projection import ProjectionProblem
     from server.routers import reference_videos as router_mod
 
-    unit_id = _seed_unit(client)
+    unit_id = _seed_unit(reference_videos_client)
     base_project = _projection_with_durations([3, 6, 9])
 
     async def _project(**kwargs):
@@ -867,7 +883,7 @@ def test_precheck_use_tts_while_regenerating_returns_canonical_problem(
     monkeypatch.setattr(router_mod, "tts_task_in_progress", AsyncMock(return_value=True))
     monkeypatch.setattr(router_mod, "project_reference_unit_request", _project)
 
-    response = client.get(
+    response = reference_videos_client.get(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{unit_id}/duration-precheck",
         params={"narration_delivery": "use_tts"},
     )
@@ -885,8 +901,10 @@ def test_precheck_use_tts_while_regenerating_returns_canonical_problem(
     }
 
 
-def test_precheck_uses_actual_tts_duration_as_floor(client: TestClient, monkeypatch: pytest.MonkeyPatch):
-    created = client.post(
+def test_precheck_uses_actual_tts_duration_as_floor(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    created = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：海面\n{旁白正文。}", "duration_seconds": 3},
     )
@@ -928,7 +946,7 @@ def test_precheck_uses_actual_tts_duration_as_floor(client: TestClient, monkeypa
     monkeypatch.setattr(router_mod, "prepare_current_reference_video_request_options", _options_identity)
     monkeypatch.setattr(router_mod, "project_reference_unit_request", _project_with_current_tts)
 
-    response = client.get(
+    response = reference_videos_client.get(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}/duration-precheck",
         params={"narration_delivery": "use_tts"},
     )
@@ -941,12 +959,14 @@ def test_precheck_uses_actual_tts_duration_as_floor(client: TestClient, monkeypa
     assert body["adjustment"] == "up"
 
 
-def test_precheck_over_largest_slot_requires_replan(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_precheck_over_largest_slot_requires_replan(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """总时长超过最大档位时不得截断，返回结构化重新规划 blocker。"""
-    uid = _seed_unit(client)  # 3s
+    uid = _seed_unit(reference_videos_client)  # 3s
     _patch_supported_durations(monkeypatch, [1, 2])
 
-    response = _precheck(client, uid)
+    response = _precheck(reference_videos_client, uid)
     assert response.status_code == 400
     detail = response.json()["detail"]
     assert detail["request_duration"] == 2
@@ -955,15 +975,15 @@ def test_precheck_over_largest_slot_requires_replan(client: TestClient, monkeypa
 
 
 def test_precheck_empty_duration_metadata_returns_structured_blocker(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ):
     """档位集为空时 fail loud，不返回伪可执行的 unconstrained 结果。"""
     from lib.i18n import _ as i18n_message
 
-    uid = _seed_unit(client)
+    uid = _seed_unit(reference_videos_client)
     _patch_supported_durations(monkeypatch, [])
 
-    response = _precheck(client, uid)
+    response = _precheck(reference_videos_client, uid)
     assert response.status_code == 400
     detail = response.json()["detail"]
     assert detail["kind"] == "reference_request_projection"
@@ -979,13 +999,13 @@ def test_precheck_empty_duration_metadata_returns_structured_blocker(
     }
 
 
-def test_precheck_formats_missing_asset_message_for_people(client: TestClient, tmp_path: Path) -> None:
+def test_precheck_formats_missing_asset_message_for_people(reference_videos_client: TestClient, tmp_path: Path) -> None:
     from lib.i18n import _ as i18n_message
 
-    uid = _seed_unit(client)
+    uid = _seed_unit(reference_videos_client)
     (tmp_path / "projects" / "demo" / "characters" / "张三.png").unlink()
 
-    response = _precheck(client, uid)
+    response = _precheck(reference_videos_client, uid)
 
     assert response.status_code == 400, response.text
     problems = response.json()["detail"]["problems"]
@@ -995,37 +1015,37 @@ def test_precheck_formats_missing_asset_message_for_people(client: TestClient, t
     assert missing["message"] == i18n_message("reference_asset_missing", missing_text="character: 张三")
 
 
-def test_precheck_missing_unit_returns_404(client: TestClient):
-    assert _precheck(client, "E9U9").status_code == 404
+def test_precheck_missing_unit_returns_404(reference_videos_client: TestClient):
+    assert _precheck(reference_videos_client, "E9U9").status_code == 404
 
 
-def test_add_unit_stale_script_file_returns_404(client: TestClient, tmp_path: Path):
+def test_add_unit_stale_script_file_returns_404(reference_videos_client: TestClient, tmp_path: Path):
     """project.json 残留指向已删除文件的 script_file 时，写端点应返回 404 而非 500。"""
     (tmp_path / "projects" / "demo" / "scripts" / "episode_1.json").unlink()
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 出现"},
     )
     assert resp.status_code == 404, resp.text
 
 
-def test_add_unit_unknown_project_returns_404(client: TestClient):
-    resp = client.post(
+def test_add_unit_unknown_project_returns_404(reference_videos_client: TestClient):
+    resp = reference_videos_client.post(
         "/api/v1/projects/missing/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@张三 出现"},
     )
     assert resp.status_code == 404
 
 
-def test_add_unit_unknown_episode_returns_404(client: TestClient):
-    resp = client.post(
+def test_add_unit_unknown_episode_returns_404(reference_videos_client: TestClient):
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/99/units",
         json={"prompt": "镜头1：空镜"},
     )
     assert resp.status_code == 404
 
 
-def test_write_endpoint_rejects_non_reference_video_mode(client: TestClient, tmp_path: Path):
+def test_write_endpoint_rejects_non_reference_video_mode(reference_videos_client: TestClient, tmp_path: Path):
     """episode 非 参考生视频时，写端点应返回 409。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
@@ -1036,16 +1056,16 @@ def test_write_endpoint_rejects_non_reference_video_mode(client: TestClient, tmp
     proj["generation_mode"] = "image"
     proj_path.write_text(json.dumps(proj, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：空镜"},
     )
     assert resp.status_code == 409
 
 
-def test_patch_unit_duration_override_without_header(client: TestClient):
+def test_patch_unit_duration_override_without_header(reference_videos_client: TestClient):
     """无 header 的 prompt → override=True，duration_seconds 直接生效。"""
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "@张三 推门", "duration_seconds": 5},
     )
@@ -1054,7 +1074,7 @@ def test_patch_unit_duration_override_without_header(client: TestClient):
     assert resp.json()["unit"]["duration_seconds"] == 5
 
     # 仅改 duration_seconds（无 prompt）：走 elif 分支按已有 override 直接覆盖时长
-    resp = client.patch(
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"duration_seconds": 8, "transition_to_next": "fade", "note": "hi"},
     )
@@ -1065,7 +1085,7 @@ def test_patch_unit_duration_override_without_header(client: TestClient):
     assert unit["note"] == "hi"
 
     # 带无 header 的新 prompt + duration_seconds：走 prompt 分支并对单镜头 override 时长
-    resp = client.patch(
+    resp = reference_videos_client.patch(
         f"/api/v1/projects/demo/reference-videos/episodes/1/units/{uid}",
         json={"prompt": "@张三 转身离开", "duration_seconds": 7},
     )
@@ -1073,11 +1093,11 @@ def test_patch_unit_duration_override_without_header(client: TestClient):
     assert resp.json()["unit"]["duration_seconds"] == 7
 
 
-def test_reorder_units_rejects_true_duplicate(client: TestClient):
+def test_reorder_units_rejects_true_duplicate(reference_videos_client: TestClient):
     """长度匹配但含重复 ID → 命中 duplicate 校验分支。"""
-    uid1 = _seed_unit(client)
-    _uid2 = _seed_unit(client)
-    resp = client.post(
+    uid1 = _seed_unit(reference_videos_client)
+    _uid2 = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid1, uid1]},
     )
@@ -1085,11 +1105,11 @@ def test_reorder_units_rejects_true_duplicate(client: TestClient):
     assert "重复" in resp.json()["detail"]
 
 
-def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
+def test_reorder_units_rejects_unknown_id_set_mismatch(reference_videos_client: TestClient):
     """长度匹配、无重复，但 ID 集合与现有不一致 → set mismatch 分支。"""
-    uid1 = _seed_unit(client)
-    _uid2 = _seed_unit(client)
-    resp = client.post(
+    uid1 = _seed_unit(reference_videos_client)
+    _uid2 = _seed_unit(reference_videos_client)
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid1, "E1U999"]},
     )
@@ -1097,7 +1117,7 @@ def test_reorder_units_rejects_unknown_id_set_mismatch(client: TestClient):
     assert "不匹配" in resp.json()["detail"]
 
 
-def test_add_unit_concurrent_rebind_returns_409(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_add_unit_concurrent_rebind_returns_409(reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch):
     """加锁前后 episode→script_file 被并发改绑 → 写端点返回 409（前端可重试）。"""
     from server.routers import reference_videos as router_mod
 
@@ -1112,7 +1132,7 @@ def test_add_unit_concurrent_rebind_returns_409(client: TestClient, monkeypatch:
 
     monkeypatch.setattr(pm, "_read_project_raw_unlocked", _rebound)
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：空镜"},
     )
@@ -1128,17 +1148,19 @@ def _patch_video_caps(monkeypatch: pytest.MonkeyPatch, caps: dict) -> None:
     monkeypatch.setattr(router_mod, "project_video_caps", AsyncMock(return_value=caps))
 
 
-def _preview(client: TestClient, prompt: str):
-    return client.post(
+def _preview(reference_videos_client: TestClient, prompt: str):
+    return reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/script-preview",
         json={"prompt": prompt},
     )
 
 
-def test_script_preview_derives_utterances_in_reading_order(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_script_preview_derives_utterances_in_reading_order(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """预览只回发声派生：utterances 按正文顺序 1-based 编号，另加降级 warning。"""
     _patch_video_caps(monkeypatch, {})
-    body = _preview(client, "镜头1：@[酒馆] 内景。\n@[张三]：{我来了}\n{那年冬天格外冷}").json()
+    body = _preview(reference_videos_client, "镜头1：@[酒馆] 内景。\n@[张三]：{我来了}\n{那年冬天格外冷}").json()
 
     assert set(body) == {"utterances", "warnings"}
     assert body["utterances"] == [
@@ -1148,21 +1170,27 @@ def test_script_preview_derives_utterances_in_reading_order(client: TestClient, 
     assert body["warnings"] == []
 
 
-def test_script_preview_returns_localized_warnings(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_script_preview_returns_localized_warnings(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     _patch_video_caps(monkeypatch, {})
-    body = _preview(client, "镜头1：@[王五] 推门。").json()
+    body = _preview(reference_videos_client, "镜头1：@[王五] 推门。").json()
     assert [w["key"] for w in body["warnings"]] == ["ref_warn_unregistered_mention"]
     assert "王五" in body["warnings"][0]["message"]
 
 
-def test_script_preview_uses_project_voice_capabilities(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_script_preview_uses_project_voice_capabilities(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     _patch_video_caps(monkeypatch, {"voice_consistency": "none", "model": "silent-01"})
-    body = _preview(client, "镜头1：开场。\n@[张三]：{我来了}").json()
+    body = _preview(reference_videos_client, "镜头1：开场。\n@[张三]：{我来了}").json()
     assert [w["key"] for w in body["warnings"]] == ["ref_warn_silent_model"]
     assert "silent-01" in body["warnings"][0]["message"]
 
 
-def test_script_preview_warns_when_episode_is_silent(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_script_preview_warns_when_episode_is_silent(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
     """本集设为无声视频时，预览面板告知声音一致性不生效（模型仍是 A 类）。"""
     _patch_video_caps(
         monkeypatch,
@@ -1173,16 +1201,16 @@ def test_script_preview_warns_when_episode_is_silent(client: TestClient, monkeyp
             "model": "doubao-seedance-2-0",
         },
     )
-    body = _preview(client, "镜头1：开场。\n@[张三]：{我来了}").json()
+    body = _preview(reference_videos_client, "镜头1：开场。\n@[张三]：{我来了}").json()
     assert [w["key"] for w in body["warnings"]] == ["ref_warn_silent_episode"]
     assert body["warnings"][0]["message"] != "ref_warn_silent_episode"
     # 台词照常派生：无声只影响参考音频，不影响下发给供应商的台词文本
     assert [u["text"] for u in body["utterances"]] == ["我来了"]
 
 
-def test_script_preview_404_for_unknown_episode(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+def test_script_preview_404_for_unknown_episode(reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch):
     _patch_video_caps(monkeypatch, {})
-    resp = client.post(
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/9/script-preview",
         json={"prompt": "镜头1：开场。"},
     )
@@ -1238,8 +1266,8 @@ def _record_finished_clip(unit_id: str) -> None:
     )
 
 
-def _seed_second_unit(client: TestClient) -> str:
-    resp = client.post(
+def _seed_second_unit(reference_videos_client: TestClient) -> str:
+    resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units",
         json={"prompt": "镜头1：@酒馆 全景", "duration_seconds": 3},
     )
@@ -1306,13 +1334,13 @@ def _patch_batch_admission(
 
 
 def test_generate_batch_creates_the_whole_task_set_in_one_admission(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1333,18 +1361,18 @@ def test_generate_batch_creates_the_whole_task_set_in_one_admission(
 
 
 def test_generate_batch_keeps_created_tasks_when_the_enqueue_is_interrupted(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """入队中断不撤销已创建的任务：它们是准入通过的完整付费单元，照常执行。
 
     没轮到的 unit 逐 ID 报出来，界面据此只释放它自己的占用标记。
     """
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9], fail_enqueue_after=1)
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1360,22 +1388,22 @@ def test_generate_batch_keeps_created_tasks_when_the_enqueue_is_interrupted(
 
 
 def test_generate_batch_after_an_interruption_only_queues_what_never_reached_the_queue(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """下次「缺失即生成」只补没入队的那个：已建任务产出的成片是现行产物，不重复付费。"""
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     _patch_batch_admission(monkeypatch, durations=[3, 6, 9], fail_enqueue_after=1)
 
-    interrupted = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"}).json()
+    interrupted = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"}).json()
     assert [entry["unit_id"] for entry in interrupted["enqueue_failures"]] == [second]
 
     # 第一个 unit 的任务照常跑完并落盘，第二个从未创建任务、也从未计费。
     _record_finished_clip(first)
 
     retried = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1386,19 +1414,19 @@ def test_generate_batch_after_an_interruption_only_queues_what_never_reached_the
 
 
 def test_generate_batch_creates_zero_tasks_when_one_unit_is_blocked(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """一个单元有问题即整批不成立，另一个单元如实报告是被谁扣下的。"""
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(
         monkeypatch,
         durations=[3, 6, 9],
         active_tasks=[{"resource_id": second, "id": "task-running", "status": "running"}],
     )
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1411,19 +1439,19 @@ def test_generate_batch_creates_zero_tasks_when_one_unit_is_blocked(
 
 
 def test_generate_batch_reports_every_gap_not_only_the_first(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """UI 要一次看到全部缺口；只报第一个会让用户逐轮试错。"""
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(
         monkeypatch,
         durations=[3, 6, 9],
         active_tasks=[{"resource_id": second, "id": "task-running", "status": "running"}],
     )
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         BATCH_ENDPOINT, json={"narration_delivery": "post_production", "unit_ids": [first, second, "E9U9"]}
     )
 
@@ -1439,13 +1467,13 @@ def test_generate_batch_reports_every_gap_not_only_the_first(
 
 
 def test_generate_batch_aggregates_the_confirmation_by_tier_then_enqueues_on_consent(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[4, 8], quote_amount=0.8)
 
-    pending = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    pending = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert pending.status_code == 200, pending.text
     body = pending.json()
@@ -1460,7 +1488,7 @@ def test_generate_batch_aggregates_the_confirmation_by_tier_then_enqueues_on_con
     assert tiers[0]["cost_amount"] == pytest.approx(1.6)
     assert tiers[0]["cost_currency"] == "USD"
 
-    accepted = client.post(
+    accepted = reference_videos_client.post(
         BATCH_ENDPOINT,
         json={"narration_delivery": "post_production", "confirmed_request_durations": {first: 4, second: 4}},
     )
@@ -1477,12 +1505,14 @@ def test_generate_batch_aggregates_the_confirmation_by_tier_then_enqueues_on_con
 
 
 @pytest.mark.parametrize("invalid", [0, -4, 4.5])
-def test_generate_batch_rejects_non_positive_confirmed_duration(client: TestClient, invalid: object) -> None:
+def test_generate_batch_rejects_non_positive_confirmed_duration(
+    reference_videos_client: TestClient, invalid: object
+) -> None:
     """确认的档位是秒数，0 / 负数在边界拒绝，不落到请求选项构造里变成 500。"""
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         BATCH_ENDPOINT, json={"narration_delivery": "post_production", "confirmed_request_durations": {first: invalid}}
     )
 
@@ -1490,15 +1520,15 @@ def test_generate_batch_rejects_non_positive_confirmed_duration(client: TestClie
 
 
 def test_generate_batch_partial_consent_still_creates_nothing(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """只确认了一半的档位不算通过：剩下那个仍在等用户拍板。"""
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[4, 8], quote_amount=0.8)
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         BATCH_ENDPOINT, json={"narration_delivery": "post_production", "confirmed_request_durations": {first: 4}}
     )
 
@@ -1509,11 +1539,11 @@ def test_generate_batch_partial_consent_still_creates_nothing(
 
 
 def test_generate_batch_repeating_an_admitted_request_reports_dedup(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """重复提交不产生第二批任务：队列去重命中即如实报告。"""
 
-    _seed_unit(client)
+    _seed_unit(reference_videos_client)
     _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
     created: list[str] = []
 
@@ -1524,8 +1554,8 @@ def test_generate_batch_repeating_an_admitted_request_reports_dedup(
 
     monkeypatch.setattr("lib.generation_queue_client.enqueue_task_only", _enqueue_task_only)
 
-    first = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
-    second = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    first = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    second = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert first.json()["deduped"] is False
     assert second.json()["deduped"] is True
@@ -1533,11 +1563,11 @@ def test_generate_batch_repeating_an_admitted_request_reports_dedup(
 
 
 def test_generate_batch_post_production_does_not_consult_tts(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """后期配音不以 TTS 为输入：未配置或过期都不该拦住这批。"""
 
-    _seed_unit(client)
+    _seed_unit(reference_videos_client)
     _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
     probed: list[object] = []
 
@@ -1549,18 +1579,18 @@ def test_generate_batch_post_production_does_not_consult_tts(
 
     monkeypatch.setattr(admission_mod, "active_tts_resource_ids", _tts)
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.json()["decision"] == "admitted"
     assert probed == []
 
 
 def test_generate_batch_use_tts_resolves_every_target_against_current_tts(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """选了「使用当前 TTS」就按当前 TTS 取档：整批一次探明在途 TTS，逐 unit 按该口径投影。"""
 
-    unit_id = _seed_unit(client)
+    unit_id = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     from server.services import video_batch_admission as admission_mod
@@ -1580,7 +1610,7 @@ def test_generate_batch_use_tts_resolves_every_target_against_current_tts(
     monkeypatch.setattr(admission_mod, "active_tts_resource_ids", _tts)
     monkeypatch.setattr(admission_mod, "project_reference_unit_request", _project)
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "use_tts"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "use_tts"})
 
     body = resp.json()
     assert resp.status_code == 200, resp.text
@@ -1591,27 +1621,27 @@ def test_generate_batch_use_tts_resolves_every_target_against_current_tts(
     assert options["narration_delivery"] == "use_tts"
 
 
-def test_generate_batch_rejects_an_empty_selection(client: TestClient) -> None:
+def test_generate_batch_rejects_an_empty_selection(reference_videos_client: TestClient) -> None:
     """空数组不是「全部」：它是一次没有目标的请求，静默按全集处理会超出用户本意。"""
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production", "unit_ids": []})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production", "unit_ids": []})
 
     assert resp.status_code == 400
     assert resp.json()["detail"]
 
 
 def test_generate_batch_skips_units_that_already_have_a_clip(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """陈旧但可用的旧产物不自动重生：缺失即生成的语义里它本就不是目标。"""
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     _record_finished_clip(first)
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     body = resp.json()
     assert body["decision"] == "admitted"
@@ -1620,7 +1650,7 @@ def test_generate_batch_skips_units_that_already_have_a_clip(
 
 
 def test_generate_batch_regenerates_a_unit_whose_recorded_clip_is_gone(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """旧 schema 项目里剧本仍登记着成片路径、文件却已被删：该 unit 判为缺失重新入队。
 
@@ -1628,8 +1658,8 @@ def test_generate_batch_regenerates_a_unit_whose_recorded_clip_is_gone(
     用户删掉文件后整批永远补不回这一个 unit。
     """
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     from lib.project_manager import ProjectManager
@@ -1644,7 +1674,7 @@ def test_generate_batch_regenerates_a_unit_whose_recorded_clip_is_gone(
     # 登记了路径但目录里没有这个文件——正是用户在文件系统里删掉成片后的形态。
     assert not (pm.get_project_path("demo") / "reference_videos" / f"{first}.mp4").exists()
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     body = resp.json()
     assert body["decision"] == "admitted"
@@ -1653,7 +1683,7 @@ def test_generate_batch_regenerates_a_unit_whose_recorded_clip_is_gone(
 
 
 def test_generate_batch_creates_zero_tasks_when_one_artifact_state_is_unreadable(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """产物状态读不出的 unit 属于这次请求：它带着自己的问题进准入，整批停下，健康的 unit 不计费。"""
 
@@ -1661,8 +1691,8 @@ def test_generate_batch_creates_zero_tasks_when_one_artifact_state_is_unreadable
     from lib.generation_result import GenerationCandidate, GenerationTargetState
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
-    second = _seed_second_unit(client)
+    first = _seed_unit(reference_videos_client)
+    second = _seed_second_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     resolve_targets = router_mod.resolve_reference_batch_targets
@@ -1682,7 +1712,7 @@ def test_generate_batch_creates_zero_tasks_when_one_artifact_state_is_unreadable
 
     monkeypatch.setattr(router_mod, "resolve_reference_batch_targets", _one_unavailable)
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1704,14 +1734,14 @@ def test_reference_unit_task_spec_rejects_a_non_string_text() -> None:
 
 
 def test_generate_batch_reports_malformed_units_instead_of_shrinking_the_batch(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """缺 id、重复 id、脏 duration 的 unit 都进结论：把它们丢出目标集合，健康的 unit 会独自计费。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1727,7 +1757,7 @@ def test_generate_batch_reports_malformed_units_instead_of_shrinking_the_batch(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1743,14 +1773,14 @@ def test_generate_batch_reports_malformed_units_instead_of_shrinking_the_batch(
 
 
 def test_generate_batch_explicit_ids_ignore_unrelated_malformed_units(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """点名重做的目标集合由调用方给定：剧本别处的坏条目不参与判定，不否决这次点名。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1760,7 +1790,9 @@ def test_generate_batch_explicit_ids_ignore_unrelated_malformed_units(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production", "unit_ids": [first]})
+    resp = reference_videos_client.post(
+        BATCH_ENDPOINT, json={"narration_delivery": "post_production", "unit_ids": [first]}
+    )
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1769,14 +1801,14 @@ def test_generate_batch_explicit_ids_ignore_unrelated_malformed_units(
 
 
 def test_generate_batch_reports_non_object_units_instead_of_dropping_them(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """非对象条目同样成不了目标：它被记名报告，健康的 unit 不会独自入队计费。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1786,7 +1818,7 @@ def test_generate_batch_reports_non_object_units_instead_of_dropping_them(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1797,13 +1829,15 @@ def test_generate_batch_reports_non_object_units_instead_of_dropping_them(
     assert codes[first] == ["generation_batch_admission_withheld"]
 
 
-def test_generate_batch_reports_a_non_scalar_unit_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_batch_reports_a_non_scalar_unit_id(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """unit_id 是对象/数组时在入队前拒收：它能混过字符串化进队列，执行期比对原值才找不到 unit。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1814,7 +1848,7 @@ def test_generate_batch_reports_a_non_scalar_unit_id(client: TestClient, monkeyp
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1825,13 +1859,15 @@ def test_generate_batch_reports_a_non_scalar_unit_id(client: TestClient, monkeyp
     assert codes[first] == ["generation_batch_admission_withheld"]
 
 
-def test_generate_batch_reports_a_duplicated_unit_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_batch_reports_a_duplicated_unit_id(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """同一个 unit_id 出现两次时无从判定要做哪一条：整批拒收，不默认拿第一份去计费。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1841,7 +1877,7 @@ def test_generate_batch_reports_a_duplicated_unit_id(client: TestClient, monkeyp
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1851,24 +1887,26 @@ def test_generate_batch_reports_a_duplicated_unit_id(client: TestClient, monkeyp
     assert codes[f"{first}#1"] == ["generation_unit_request_invalid"]
 
 
-def test_generate_batch_requires_an_explicit_narration_delivery(client: TestClient) -> None:
+def test_generate_batch_requires_an_explicit_narration_delivery(reference_videos_client: TestClient) -> None:
     """不声明旁白交付方式的批量请求直接拒收：默认成后期配音等于替调用方做了这个选择。"""
 
-    _seed_unit(client)
+    _seed_unit(reference_videos_client)
 
-    resp = client.post(BATCH_ENDPOINT, json={})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={})
 
     assert resp.status_code == 422, resp.text
     assert any(item["loc"][-1] == "narration_delivery" for item in resp.json()["detail"])
 
 
-def test_generate_batch_reports_a_numeric_unit_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_batch_reports_a_numeric_unit_id(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """数字 unit_id 同样在入队前拒收：字符串化后执行期按原值比对找不到 unit。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1878,7 +1916,7 @@ def test_generate_batch_reports_a_numeric_unit_id(client: TestClient, monkeypatc
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1889,13 +1927,15 @@ def test_generate_batch_reports_a_numeric_unit_id(client: TestClient, monkeypatc
     assert codes[first] == ["generation_batch_admission_withheld"]
 
 
-def test_a_duplicate_marker_never_shadows_a_requested_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_duplicate_marker_never_shadows_a_requested_id(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """点名了一个剧本里没有的名字时，重复条目的诊断名不能与它撞上：两条结论各占一行。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1905,7 +1945,7 @@ def test_a_duplicate_marker_never_shadows_a_requested_id(client: TestClient, mon
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(
+    resp = reference_videos_client.post(
         BATCH_ENDPOINT,
         json={"narration_delivery": "post_production", "unit_ids": [first, f"{first}#1"]},
     )
@@ -1919,13 +1959,15 @@ def test_a_duplicate_marker_never_shadows_a_requested_id(client: TestClient, mon
     assert codes[f"{first}#1*"] == ["generation_unit_request_invalid"]
 
 
-def test_a_duplicate_marker_never_shadows_a_real_unit_id(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_duplicate_marker_never_shadows_a_real_unit_id(
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """重复条目按 `id#序号` 记名，剧本里恰好有同名 unit 时另起一个名字。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1935,7 +1977,7 @@ def test_a_duplicate_marker_never_shadows_a_real_unit_id(client: TestClient, mon
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1949,14 +1991,14 @@ def test_a_duplicate_marker_never_shadows_a_real_unit_id(client: TestClient, mon
 
 
 def test_generate_batch_refuses_a_path_like_unit_id_before_enqueue(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """unit_id 带路径片段的条目在建任务之前拒收：交给 worker 拼路径时才拒，健康的兄弟已经在跑并计费。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    first = _seed_unit(client)
+    first = _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1966,7 +2008,7 @@ def test_generate_batch_refuses_a_path_like_unit_id_before_enqueue(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -1977,14 +2019,14 @@ def test_generate_batch_refuses_a_path_like_unit_id_before_enqueue(
 
 
 def test_generate_batch_reports_a_non_list_video_units_container(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """video_units 不是数组时报成结构问题：遍历它会把请求打成 500，假值又会被当作空批次报成通过。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    _seed_unit(client)
+    _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -1993,7 +2035,7 @@ def test_generate_batch_reports_a_non_list_video_units_container(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -2003,26 +2045,26 @@ def test_generate_batch_reports_a_non_list_video_units_container(
     assert codes["video_units"] == ["generation_unit_request_invalid"]
 
 
-def test_generate_unit_rejects_a_path_like_unit_id(client: TestClient, tmp_path: Path):
+def test_generate_unit_rejects_a_path_like_unit_id(reference_videos_client: TestClient, tmp_path: Path):
     """unit_id 带路径分隔符时当场拒绝（400），不漏到执行层拼产物路径时才失败。"""
     script_path = tmp_path / "projects" / "demo" / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     script["video_units"] = [{"unit_id": "a\\b", "text": "镜头平移", "duration_seconds": 3}]
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/a%5Cb/generate")
+    resp = reference_videos_client.post("/api/v1/projects/demo/reference-videos/episodes/1/units/a%5Cb/generate")
     assert resp.status_code == 400, resp.text
 
 
 def test_generate_batch_reports_a_falsy_video_units_container(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    reference_videos_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """video_units 是假值（如 false）时同样报成结构问题，不被当作空批次报成通过。"""
 
     from lib.project_manager import ProjectManager
     from server.routers import reference_videos as router_mod
 
-    _seed_unit(client)
+    _seed_unit(reference_videos_client)
     enqueued = _patch_batch_admission(monkeypatch, durations=[3, 6, 9])
 
     pm: ProjectManager = router_mod.get_project_manager()
@@ -2031,7 +2073,7 @@ def test_generate_batch_reports_a_falsy_video_units_container(
     script_path = pm.get_project_path("demo") / "scripts" / "episode_1.json"
     script_path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
-    resp = client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
+    resp = reference_videos_client.post(BATCH_ENDPOINT, json={"narration_delivery": "post_production"})
 
     assert resp.status_code == 200, resp.text
     body = resp.json()

--- a/tests/integration/server/routers/test_reference_videos_router.py
+++ b/tests/integration/server/routers/test_reference_videos_router.py
@@ -1654,8 +1654,8 @@ def test_generate_batch_regenerates_a_unit_whose_recorded_clip_is_gone(
 ) -> None:
     """旧 schema 项目里剧本仍登记着成片路径、文件却已被删：该 unit 判为缺失重新入队。
 
-    这条腿上「另一条可复用的判定」（手动上传/登记路径可用）曾能越过存在性核实，
-    用户删掉文件后整批永远补不回这一个 unit。
+    这条腿上「另一条可复用的判定」（手动上传/登记路径可用）同样要过存在性核实：
+    登记路径指向的文件已删时该 unit 不算可复用，否则整批永远补不回它。
     """
 
     first = _seed_unit(reference_videos_client)

--- a/tests/integration/server/routers/test_reference_videos_router.py
+++ b/tests/integration/server/routers/test_reference_videos_router.py
@@ -1096,7 +1096,7 @@ def test_patch_unit_duration_override_without_header(reference_videos_client: Te
 def test_reorder_units_rejects_true_duplicate(reference_videos_client: TestClient):
     """长度匹配但含重复 ID → 命中 duplicate 校验分支。"""
     uid1 = _seed_unit(reference_videos_client)
-    _uid2 = _seed_unit(reference_videos_client)
+    _seed_unit(reference_videos_client)
     resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid1, uid1]},
@@ -1108,7 +1108,7 @@ def test_reorder_units_rejects_true_duplicate(reference_videos_client: TestClien
 def test_reorder_units_rejects_unknown_id_set_mismatch(reference_videos_client: TestClient):
     """长度匹配、无重复，但 ID 集合与现有不一致 → set mismatch 分支。"""
     uid1 = _seed_unit(reference_videos_client)
-    _uid2 = _seed_unit(reference_videos_client)
+    _seed_unit(reference_videos_client)
     resp = reference_videos_client.post(
         "/api/v1/projects/demo/reference-videos/episodes/1/units/reorder",
         json={"unit_ids": [uid1, "E1U999"]},

--- a/tests/integration/server/services/test_generation_context.py
+++ b/tests/integration/server/services/test_generation_context.py
@@ -14,14 +14,12 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from lib.audio_backends.base import VoiceOption
 from lib.backend_assembly.specs import get_provider_spec
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.resolver import ConfigResolver, ProviderModel, VoiceConsistency, get_provider_fallback
 from lib.custom_provider import make_provider_id
-from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.media_generator import MediaGenerator
 from lib.project_manager import ProjectManager
@@ -64,15 +62,10 @@ class _FakeBackend:
 
 
 @pytest.fixture
-async def patched_session_factory(monkeypatch):
+async def patched_session_factory(db_factory, monkeypatch):
     """真实内存 DB：建全部 ORM 表，并把 lib.db.async_session_factory 指向它。"""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    monkeypatch.setattr("lib.db.async_session_factory", factory)
-    yield factory
-    await engine.dispose()
+    monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+    return db_factory
 
 
 @pytest.fixture

--- a/tests/integration/server/services/test_generation_context.py
+++ b/tests/integration/server/services/test_generation_context.py
@@ -64,7 +64,7 @@ class _FakeBackend:
 
 
 @pytest.fixture
-async def session_factory(monkeypatch):
+async def patched_session_factory(monkeypatch):
     """真实内存 DB：建全部 ORM 表，并把 lib.db.async_session_factory 指向它。"""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -116,9 +116,9 @@ def fake_assemble(monkeypatch):
     return calls
 
 
-async def _seed_custom_video_provider(session_factory) -> str:
+async def _seed_custom_video_provider(patched_session_factory) -> str:
     """种一个自定义供应商：目标 model 已禁用、默认 model 存活（带 resolution 与时长表）。"""
-    async with session_factory() as session:
+    async with patched_session_factory() as session:
         provider = CustomProvider(
             display_name="Prov",
             discovery_format="openai",
@@ -154,7 +154,7 @@ async def _seed_custom_video_provider(session_factory) -> str:
 
 
 class TestLaneDeclaration:
-    async def test_only_declared_lanes_are_constructed(self, session_factory, project_env, fake_assemble):
+    async def test_only_declared_lanes_are_constructed(self, patched_session_factory, project_env, fake_assemble):
         """只声明 image lane：不解析、不构造 video/audio，视频供应商缺配置不影响图片任务。"""
         project = {"image_provider_t2i": "ark/img-model-x"}
         ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
@@ -168,7 +168,7 @@ class TestLaneDeclaration:
         with pytest.raises(RuntimeError, match="audio lane 未声明"):
             _ = ctx.audio
 
-    async def test_no_lane_declared_still_returns_generator(self, session_factory, project_env, fake_assemble):
+    async def test_no_lane_declared_still_returns_generator(self, patched_session_factory, project_env, fake_assemble):
         ctx = await resolve_generation_context("demo", None, project={})
         assert isinstance(ctx.generator, MediaGenerator)
         assert fake_assemble == []
@@ -177,7 +177,7 @@ class TestLaneDeclaration:
 
     async def test_preloaded_project_path_avoids_the_default_executor(
         self,
-        session_factory,
+        patched_session_factory,
         project_env,
         fake_assemble,
         monkeypatch,
@@ -199,7 +199,7 @@ class TestLaneDeclaration:
 
         assert ctx.generator.project_path == project_path
 
-    async def test_i2i_capability_selects_i2i_slot(self, session_factory, project_env, fake_assemble):
+    async def test_i2i_capability_selects_i2i_slot(self, patched_session_factory, project_env, fake_assemble):
         project = {
             "image_provider_t2i": "ark/img-t2i",
             "image_provider_i2i": "ark/img-i2i",
@@ -207,7 +207,7 @@ class TestLaneDeclaration:
         ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
         assert ctx.image.provider_model == ProviderModel("ark", "img-i2i")
 
-    async def test_all_three_lanes(self, session_factory, project_env, fake_assemble):
+    async def test_all_three_lanes(self, patched_session_factory, project_env, fake_assemble):
         video_model = _registry_video_model("ark")
         project = {
             "image_provider_t2i": "ark/img-model-x",
@@ -228,7 +228,9 @@ class TestLaneDeclaration:
 
 
 class TestVideoLane:
-    async def test_registry_capabilities_and_fallback_resolution(self, session_factory, project_env, fake_assemble):
+    async def test_registry_capabilities_and_fallback_resolution(
+        self, patched_session_factory, project_env, fake_assemble
+    ):
         video_model = _registry_video_model("ark")
         expected = PROVIDER_REGISTRY["ark"].models[video_model]
         ctx = await resolve_generation_context(
@@ -242,7 +244,7 @@ class TestVideoLane:
         assert ctx.video.resolution is None
         assert ctx.video.resolution_or_fallback == get_provider_fallback("ark")
 
-    async def test_resolution_from_model_settings(self, session_factory, project_env, fake_assemble):
+    async def test_resolution_from_model_settings(self, patched_session_factory, project_env, fake_assemble):
         video_model = _registry_video_model("ark")
         project = {
             "video_backend": f"ark/{video_model}",
@@ -252,7 +254,7 @@ class TestVideoLane:
         assert ctx.video.resolution == "480p"
         assert ctx.video.resolution_or_fallback == "480p"
 
-    async def test_capability_query_failure_degrades_to_empty(self, session_factory, project_env, monkeypatch):
+    async def test_capability_query_failure_degrades_to_empty(self, patched_session_factory, project_env, monkeypatch):
         """fake backend 报告 registry 之外的 model：能力查询失败降级空值，整次调用照常成功。"""
 
         async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
@@ -269,7 +271,9 @@ class TestVideoLane:
         assert ctx.video.generate_audio is False
         assert ctx.video.backend_model == "mystery-model"
 
-    async def test_requested_generate_audio_follows_project_override(self, session_factory, project_env, fake_assemble):
+    async def test_requested_generate_audio_follows_project_override(
+        self, patched_session_factory, project_env, fake_assemble
+    ):
         """本集无声开关随 project.json 覆盖进 lane，编排层据此决定要不要组装参考音频。"""
         video_model = _registry_video_model("ark")
         ctx = await resolve_generation_context(
@@ -281,7 +285,7 @@ class TestVideoLane:
         assert ctx.video.requested_generate_audio is False
 
     async def test_requested_generate_audio_survives_capability_failure(
-        self, session_factory, project_env, monkeypatch
+        self, patched_session_factory, project_env, monkeypatch
     ):
         """能力查询失败不得连带丢失用户的无声意图：它不来自能力接口，独立解析。"""
 
@@ -298,7 +302,7 @@ class TestVideoLane:
         )
         assert ctx.video.requested_generate_audio is False
 
-    async def test_payload_overrides_project(self, session_factory, project_env, fake_assemble):
+    async def test_payload_overrides_project(self, patched_session_factory, project_env, fake_assemble):
         """payload > project：显式的请求身份（如 checkpoint 回放）决定实际解析身份。"""
         ark_model = _registry_video_model("ark")
         grok_model = _registry_video_model("grok")
@@ -312,9 +316,11 @@ class TestVideoLane:
 
 
 class TestActualIdentityQueries:
-    async def test_custom_model_fallback_queries_by_actual_model(self, session_factory, project_env, monkeypatch):
+    async def test_custom_model_fallback_queries_by_actual_model(
+        self, patched_session_factory, project_env, monkeypatch
+    ):
         """自定义供应商目标 model 被禁用回退：resolution 与能力按 backend 实际 model 查询。"""
-        provider_id = await _seed_custom_video_provider(session_factory)
+        provider_id = await _seed_custom_video_provider(patched_session_factory)
 
         async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
             # 模拟 load_custom_backend 的回退：请求 m-dead，实际构造出默认启用的 m-live
@@ -337,7 +343,7 @@ class TestActualIdentityQueries:
 
 
 class TestAudioLane:
-    async def test_narration_voice_and_speed_from_project(self, session_factory, project_env, fake_assemble):
+    async def test_narration_voice_and_speed_from_project(self, patched_session_factory, project_env, fake_assemble):
         project = {
             "audio_backend": "dashscope/tts-model-x",
             "narration_voice": "Cherry",
@@ -349,13 +355,13 @@ class TestAudioLane:
         assert ctx.audio.backend_name == "dashscope"
         assert ctx.audio.backend_model == "tts-model-x"
 
-    async def test_narration_defaults_when_unset(self, session_factory, project_env, fake_assemble):
+    async def test_narration_defaults_when_unset(self, patched_session_factory, project_env, fake_assemble):
         project = {"audio_backend": "dashscope/tts-model-x"}
         ctx = await resolve_generation_context("demo", None, project=project, audio=AudioLaneRequest())
         assert isinstance(ctx.audio.narration_voice, str) and ctx.audio.narration_voice
         assert ctx.audio.narration_speed is None
 
-    async def test_voice_catalog_snapshot_passed_through(self, session_factory, project_env, monkeypatch):
+    async def test_voice_catalog_snapshot_passed_through(self, patched_session_factory, project_env, monkeypatch):
         """ctx.audio.voices 须是 backend.list_voices() 的真实快照，而非默认的空元组——
         断言字段存在不够，须证明 resolve_generation_context 确实转发了 backend 的音色目录。
         """
@@ -372,7 +378,9 @@ class TestAudioLane:
 
 
 class TestAtomicFailure:
-    async def test_declared_lane_construction_failure_fails_whole_call(self, session_factory, project_env, monkeypatch):
+    async def test_declared_lane_construction_failure_fails_whole_call(
+        self, patched_session_factory, project_env, monkeypatch
+    ):
         """image 成功后 video 构造失败：整次调用原样上抛，无部分结果。"""
 
         async def _assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
@@ -391,13 +399,13 @@ class TestAtomicFailure:
                 video=VideoLaneRequest(),
             )
 
-    async def test_missing_project_dir_raises(self, session_factory, project_env, fake_assemble):
+    async def test_missing_project_dir_raises(self, patched_session_factory, project_env, fake_assemble):
         with pytest.raises(FileNotFoundError):
             await resolve_generation_context("nope", None, project={}, image=ImageLaneRequest())
 
 
 class TestBackendCache:
-    async def test_backend_reused_until_invalidated(self, session_factory, project_env, fake_assemble):
+    async def test_backend_reused_until_invalidated(self, patched_session_factory, project_env, fake_assemble):
         project = {"image_provider_t2i": "ark/img-model-x"}
         await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())
         await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest())

--- a/tests/integration/server/services/test_jianying_draft_routes.py
+++ b/tests/integration/server/services/test_jianying_draft_routes.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from lib.project_manager import ProjectManager
 from server.auth import create_download_token
-from tests.conftest import make_test_video
+from tests.factories import make_test_video
 
 
 def _setup_project(pm: ProjectManager):

--- a/tests/integration/server/services/test_jianying_draft_service.py
+++ b/tests/integration/server/services/test_jianying_draft_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 import zipfile
 from pathlib import Path
 
@@ -23,7 +24,27 @@ from lib.speech_presentation import (
 )
 from server.services.jianying_draft_service import JianyingDraftService, NoCompletedSegmentsError
 from server.services.presentation_read_model import MaterializedEpisode, MaterializedPresentation
-from tests.factories import make_test_audio, make_test_video, make_test_video_with_audio_tail
+from tests.factories import make_test_video, make_test_video_with_audio_tail
+
+
+def make_test_audio(path: Path, *, duration_sec: float = 1.0) -> None:
+    """使用 ffmpeg 生成极短测试音频（正弦波 wav，pcm_s16le 为 ffmpeg 内置编码器）"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={duration_sec}",
+            "-c:a",
+            "pcm_s16le",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
 
 
 def _basis(kind: str, identity: str) -> ArtifactBasisDescriptor:

--- a/tests/integration/server/services/test_jianying_draft_service.py
+++ b/tests/integration/server/services/test_jianying_draft_service.py
@@ -23,7 +23,7 @@ from lib.speech_presentation import (
 )
 from server.services.jianying_draft_service import JianyingDraftService, NoCompletedSegmentsError
 from server.services.presentation_read_model import MaterializedEpisode, MaterializedPresentation
-from tests.conftest import make_test_audio, make_test_video, make_test_video_with_audio_tail
+from tests.factories import make_test_audio, make_test_video, make_test_video_with_audio_tail
 
 
 def _basis(kind: str, identity: str) -> ArtifactBasisDescriptor:

--- a/tests/integration/server/test_auth_coverage.py
+++ b/tests/integration/server/test_auth_coverage.py
@@ -74,7 +74,7 @@ def _auth_env():
 
 
 @pytest.fixture(scope="module")
-def client():
+def auth_coverage_client():
     from server.app import app
 
     # 不进 lifespan（不用 with）：认证依赖只读环境变量与 JWT，路由和 openapi 在 import 时即就绪。
@@ -99,7 +99,7 @@ def _all_operations() -> list[str]:
     return [f"{m.upper()} {path}" for path, ops in spec["paths"].items() for m in ops if m in _HTTP_METHODS]
 
 
-def test_every_protected_endpoint_rejects_anonymous(client):
+def test_every_protected_endpoint_rejects_anonymous(auth_coverage_client):
     """豁免清单之外的操作，无 token 请求一律 401。"""
     operations = _all_operations()
     assert len(operations) > 100, "枚举结果异常，覆盖断言会变成空跑"
@@ -109,7 +109,7 @@ def test_every_protected_endpoint_rejects_anonymous(client):
         if op in EXEMPT_OPERATIONS:
             continue
         method, path = op.split(" ", 1)
-        resp = client.request(method, _fill(path), json={})
+        resp = auth_coverage_client.request(method, _fill(path), json={})
         if resp.status_code != 401:
             unprotected.append(f"{op} -> {resp.status_code}")
 
@@ -122,20 +122,20 @@ def test_exempt_operations_are_registered():
     assert not stale, f"豁免清单引用了不存在的操作：{sorted(stale)}"
 
 
-def test_public_endpoints_stay_reachable(client):
+def test_public_endpoints_stay_reachable(auth_coverage_client):
     """公开端点不被 router 级依赖误伤。"""
-    assert client.get("/health").status_code == 200
-    assert client.get("/api/v1/auth/status").status_code == 200
+    assert auth_coverage_client.get("/health").status_code == 200
+    assert auth_coverage_client.get("/api/v1/auth/status").status_code == 200
     assert (
-        client.post(
+        auth_coverage_client.post(
             "/api/v1/auth/token",
             data={"username": "testuser", "password": "testpass"},
         ).status_code
         == 200
     )
     # 静态媒体：项目不存在时是 404，不该是 401。
-    assert client.get("/api/v1/files/demo/x.png").status_code != 401
-    assert client.get("/api/v1/global-assets/characters/x.png").status_code != 401
+    assert auth_coverage_client.get("/api/v1/files/demo/x.png").status_code != 401
+    assert auth_coverage_client.get("/api/v1/global-assets/characters/x.png").status_code != 401
 
 
 @pytest.mark.parametrize(
@@ -146,9 +146,9 @@ def test_public_endpoints_stay_reachable(client):
         "/api/v1/projects/demo/events/stream",
     ],
 )
-def test_sse_endpoints_reject_anonymous(client, path):
+def test_sse_endpoints_reject_anonymous(auth_coverage_client, path):
     """SSE 不挂 router 级依赖，其 CurrentUserFlexible 必须仍拦住无 token 的请求。"""
-    assert client.get(path).status_code == 401
+    assert auth_coverage_client.get(path).status_code == 401
 
 
 @pytest.mark.parametrize(
@@ -158,21 +158,21 @@ def test_sse_endpoints_reject_anonymous(client, path):
         "/api/v1/projects/demo/export/jianying-draft?download_token=not-a-valid-token&episode=1&draft_path=/tmp/d",
     ],
 )
-def test_export_endpoints_reject_forged_token(client, path):
+def test_export_endpoints_reject_forged_token(auth_coverage_client, path):
     """导出走短时效下载 token，伪造的必须被 verify_download_token 拒绝。"""
-    assert client.get(path).status_code in (401, 403)
+    assert auth_coverage_client.get(path).status_code in (401, 403)
 
 
-def test_authenticated_request_passes(client):
+def test_authenticated_request_passes(auth_coverage_client):
     """带合法 token 时 router 级依赖放行。"""
-    token = client.post(
+    token = auth_coverage_client.post(
         "/api/v1/auth/token",
         data={"username": "testuser", "password": "testpass"},
     ).json()["access_token"]
-    assert client.get(_PROBE_ENDPOINT, headers={"Authorization": f"Bearer {token}"}).status_code == 200
+    assert auth_coverage_client.get(_PROBE_ENDPOINT, headers={"Authorization": f"Bearer {token}"}).status_code == 200
 
 
-def test_auth_disabled_bypasses_enforcement(client):
+def test_auth_disabled_bypasses_enforcement(auth_coverage_client):
     """AUTH_ENABLED=false 时不拦截，保持本地无认证部署可用。"""
     with patch.dict(os.environ, {"AUTH_ENABLED": "false"}):
-        assert client.get(_PROBE_ENDPOINT).status_code == 200
+        assert auth_coverage_client.get(_PROBE_ENDPOINT).status_code == 200

--- a/tests/unit/lib/backend_assembly/test_backend_assembly_loader.py
+++ b/tests/unit/lib/backend_assembly/test_backend_assembly_loader.py
@@ -9,23 +9,11 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.backend_assembly import assemble_backend
 from lib.backend_assembly.assembler import _load_builtin_config
 from lib.config.resolver import ConfigResolver
 from lib.config.service import ConfigService
-from lib.db.base import Base
-
-
-@pytest.fixture()
-async def session_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
 
 
 async def _seed_provider_config(factory, provider: str, **kv: str) -> None:
@@ -37,9 +25,9 @@ async def _seed_provider_config(factory, provider: str, **kv: str) -> None:
 
 
 class TestLoadBuiltinConfig:
-    async def test_credential_overlay_enters_envelope(self, session_factory):
-        await _seed_provider_config(session_factory, "ark", api_key="ark-secret", base_url="https://relay.test/api/v3")
-        resolver = ConfigResolver(session_factory)
+    async def test_credential_overlay_enters_envelope(self, db_factory):
+        await _seed_provider_config(db_factory, "ark", api_key="ark-secret", base_url="https://relay.test/api/v3")
+        resolver = ConfigResolver(db_factory)
         config = await _load_builtin_config(resolver, "ark", rate_limiter=None)
         assert config.credentials.get("api_key") == "ark-secret"
         assert config.credentials.get("base_url") == "https://relay.test/api/v3"
@@ -47,37 +35,35 @@ class TestLoadBuiltinConfig:
         assert config.provider_meta is not None
         assert config.provider_meta.default_base_url == "https://ark.cn-beijing.volces.com/api/v3"
 
-    async def test_rate_limiter_carried_into_envelope(self, session_factory):
+    async def test_rate_limiter_carried_into_envelope(self, db_factory):
         sentinel = object()
-        resolver = ConfigResolver(session_factory)
+        resolver = ConfigResolver(db_factory)
         config = await _load_builtin_config(resolver, "grok", rate_limiter=sentinel)
         assert config.rate_limiter is sentinel
 
 
 class TestAssembleBuiltinEndToEnd:
     @patch("lib.image_backends.registry.create_backend")
-    async def test_simple_image_end_to_end(self, mock_create, session_factory):
-        await _seed_provider_config(session_factory, "ark", api_key="ark-secret")
-        resolver = ConfigResolver(session_factory)
+    async def test_simple_image_end_to_end(self, mock_create, db_factory):
+        await _seed_provider_config(db_factory, "ark", api_key="ark-secret")
+        resolver = ConfigResolver(db_factory)
         await assemble_backend(provider_id="ark", media_type="image", model_id="doubao-x", resolver=resolver)
         # 用户未配 base_url → 回落 registry default；凭证 overlay 经装载真进构造参数
         mock_create.assert_called_once_with(
             "ark", api_key="ark-secret", model="doubao-x", base_url="https://ark.cn-beijing.volces.com/api/v3"
         )
 
-    async def test_unknown_provider_media_fails_loud(self, session_factory):
-        resolver = ConfigResolver(session_factory)
+    async def test_unknown_provider_media_fails_loud(self, db_factory):
+        resolver = ConfigResolver(db_factory)
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):
             await assemble_backend(provider_id="ark", media_type="audio", model_id="x", resolver=resolver)
 
     @patch("lib.image_backends.registry.create_backend")
-    async def test_gemini_aistudio_image_end_to_end(self, mock_create, session_factory):
+    async def test_gemini_aistudio_image_end_to_end(self, mock_create, db_factory):
         # gemini 特例族：provider_id 直接决定 backend_type，凭证 overlay + 共享 rate_limiter 经装载进闭包
-        await _seed_provider_config(
-            session_factory, "gemini-aistudio", api_key="g-secret", base_url="https://g.relay.test"
-        )
+        await _seed_provider_config(db_factory, "gemini-aistudio", api_key="g-secret", base_url="https://g.relay.test")
         sentinel = object()
-        resolver = ConfigResolver(session_factory)
+        resolver = ConfigResolver(db_factory)
         await assemble_backend(
             provider_id="gemini-aistudio",
             media_type="image",
@@ -95,20 +81,20 @@ class TestAssembleBuiltinEndToEnd:
         )
 
     @patch("lib.text_backends.registry.create_backend")
-    async def test_text_simple_end_to_end(self, mock_create, session_factory):
+    async def test_text_simple_end_to_end(self, mock_create, db_factory):
         # 文本简单族：凭证 overlay 经装载真进构造参数，base_url 回落 registry default
-        await _seed_provider_config(session_factory, "ark", api_key="ark-secret")
-        resolver = ConfigResolver(session_factory)
+        await _seed_provider_config(db_factory, "ark", api_key="ark-secret")
+        resolver = ConfigResolver(db_factory)
         await assemble_backend(provider_id="ark", media_type="text", model_id="doubao-x", resolver=resolver)
         mock_create.assert_called_once_with(
             "ark", model="doubao-x", api_key="ark-secret", base_url="https://ark.cn-beijing.volces.com/api/v3"
         )
 
     @patch("lib.text_backends.registry.create_backend")
-    async def test_text_dashscope_compat_end_to_end(self, mock_create, session_factory):
+    async def test_text_dashscope_compat_end_to_end(self, mock_create, db_factory):
         # dashscope 文本 OpenAI-compat：base_url 经 helper 派生、透传 provider_name 计费归因，端到端经缝
-        await _seed_provider_config(session_factory, "dashscope", api_key="ds-secret")
-        resolver = ConfigResolver(session_factory)
+        await _seed_provider_config(db_factory, "dashscope", api_key="ds-secret")
+        resolver = ConfigResolver(db_factory)
         await assemble_backend(provider_id="dashscope", media_type="text", model_id="qwen-max", resolver=resolver)
         mock_create.assert_called_once_with(
             "openai",
@@ -119,10 +105,10 @@ class TestAssembleBuiltinEndToEnd:
         )
 
     @patch("lib.image_backends.registry.create_backend")
-    async def test_kling_image_api_model_name_decoupled_end_to_end(self, mock_create, session_factory):
+    async def test_kling_image_api_model_name_decoupled_end_to_end(self, mock_create, db_factory):
         # kling 特例族：双 secret overlay 真进闭包；api_model_name 解耦从 registry models 读到（别名键）
-        await _seed_provider_config(session_factory, "kling", access_key="ak-1", secret_key="sk-1")
-        resolver = ConfigResolver(session_factory)
+        await _seed_provider_config(db_factory, "kling", access_key="ak-1", secret_key="sk-1")
+        resolver = ConfigResolver(db_factory)
         await assemble_backend(
             provider_id="kling", media_type="image", model_id="kling-v3-omni-image", resolver=resolver
         )
@@ -139,12 +125,12 @@ class TestAssembleBuiltinEndToEnd:
 
 class TestAssembleCustomEndToEnd:
     @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    async def test_custom_provider_delegates_to_loader(self, mock_cls, session_factory):
+    async def test_custom_provider_delegates_to_loader(self, mock_cls, db_factory):
         from lib.custom_provider import make_provider_id
         from lib.custom_provider.backends import CustomImageBackend
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
-        async with session_factory() as s:
+        async with db_factory() as s:
             repo = CustomProviderRepository(s)
             provider = await repo.create_provider(
                 display_name="Relay",
@@ -163,19 +149,19 @@ class TestAssembleCustomEndToEnd:
             await s.commit()
             pid = make_provider_id(provider.id)
 
-        resolver = ConfigResolver(session_factory)
+        resolver = ConfigResolver(db_factory)
         result = await assemble_backend(provider_id=pid, media_type="image", model_id="dall-e-3", resolver=resolver)
         assert isinstance(result, CustomImageBackend)
         mock_cls.assert_called_once_with(api_key="sk-relay", base_url="https://relay.test/v1", model="dall-e-3")
 
     @patch("lib.custom_provider.endpoints.OpenAITextBackend")
-    async def test_custom_text_provider_delegates_to_loader(self, mock_cls, session_factory):
+    async def test_custom_text_provider_delegates_to_loader(self, mock_cls, db_factory):
         # 文本自定义路径与媒体共用 load_custom_backend：text media_type 同经统一缝
         from lib.custom_provider import make_provider_id
         from lib.custom_provider.backends import CustomTextBackend
         from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 
-        async with session_factory() as s:
+        async with db_factory() as s:
             repo = CustomProviderRepository(s)
             provider = await repo.create_provider(
                 display_name="Relay",
@@ -194,6 +180,6 @@ class TestAssembleCustomEndToEnd:
             await s.commit()
             pid = make_provider_id(provider.id)
 
-        resolver = ConfigResolver(session_factory)
+        resolver = ConfigResolver(db_factory)
         result = await assemble_backend(provider_id=pid, media_type="text", model_id="gpt-5", resolver=resolver)
         assert isinstance(result, CustomTextBackend)

--- a/tests/unit/lib/config/test_config_migration.py
+++ b/tests/unit/lib/config/test_config_migration.py
@@ -2,22 +2,10 @@ import json
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.migration import migrate_json_to_db
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
-from lib.db.base import Base
-
-
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    sm = async_sessionmaker(engine, expire_on_commit=False)
-    async with sm() as s:
-        yield s
-    await engine.dispose()
 
 
 @pytest.fixture
@@ -46,9 +34,9 @@ def json_file(tmp_path: Path) -> Path:
     return p
 
 
-async def test_migrate_provider_configs(session: AsyncSession, json_file: Path):
-    await migrate_json_to_db(session, json_file)
-    repo = ProviderConfigRepository(session)
+async def test_migrate_provider_configs(db_session: AsyncSession, json_file: Path):
+    await migrate_json_to_db(db_session, json_file)
+    repo = ProviderConfigRepository(db_session)
     config = await repo.get_all("gemini-aistudio")
     assert config["api_key"] == "AIza-test-key"
     assert config["image_rpm"] == "15"
@@ -56,9 +44,9 @@ async def test_migrate_provider_configs(session: AsyncSession, json_file: Path):
     assert config["api_key"] == "ark-test-key"
 
 
-async def test_migrate_system_settings(session: AsyncSession, json_file: Path):
-    await migrate_json_to_db(session, json_file)
-    repo = SystemSettingRepository(session)
+async def test_migrate_system_settings(db_session: AsyncSession, json_file: Path):
+    await migrate_json_to_db(db_session, json_file)
+    repo = SystemSettingRepository(db_session)
     val = await repo.get("default_video_backend")
     assert val == "gemini-vertex/veo-3.1-fast-generate-001"
     val = await repo.get("default_image_backend")
@@ -67,22 +55,22 @@ async def test_migrate_system_settings(session: AsyncSession, json_file: Path):
     assert val == "sk-ant-test"
 
 
-async def test_migrate_renames_file(session: AsyncSession, json_file: Path):
-    await migrate_json_to_db(session, json_file)
+async def test_migrate_renames_file(db_session: AsyncSession, json_file: Path):
+    await migrate_json_to_db(db_session, json_file)
     assert not json_file.exists()
     assert json_file.with_suffix(".json.bak").exists()
 
 
-async def test_migrate_max_workers_to_all_configured_providers(session: AsyncSession, json_file: Path):
-    await migrate_json_to_db(session, json_file)
-    repo = ProviderConfigRepository(session)
+async def test_migrate_max_workers_to_all_configured_providers(db_session: AsyncSession, json_file: Path):
+    await migrate_json_to_db(db_session, json_file)
+    repo = ProviderConfigRepository(db_session)
     ark = await repo.get_all("ark")
     assert ark.get("video_max_workers") == "2"
     grok = await repo.get_all("grok")
     assert "video_max_workers" not in grok
 
 
-async def test_migrate_aistudio_001_to_preview(session: AsyncSession, tmp_path: Path):
+async def test_migrate_aistudio_001_to_preview(db_session: AsyncSession, tmp_path: Path):
     """AI Studio 的 001 后缀应迁移为 preview。"""
     data = {
         "overrides": {
@@ -92,15 +80,15 @@ async def test_migrate_aistudio_001_to_preview(session: AsyncSession, tmp_path: 
     }
     p = tmp_path / ".system_config.json"
     p.write_text(json.dumps(data))
-    await migrate_json_to_db(session, p)
-    repo = SystemSettingRepository(session)
+    await migrate_json_to_db(db_session, p)
+    repo = SystemSettingRepository(db_session)
     val = await repo.get("default_video_backend")
     assert val == "gemini-aistudio/veo-3.1-generate-preview"
 
 
-async def test_migrate_noop_if_no_file(session: AsyncSession, tmp_path: Path):
+async def test_migrate_noop_if_no_file(db_session: AsyncSession, tmp_path: Path):
     nonexistent = tmp_path / ".system_config.json"
-    await migrate_json_to_db(session, nonexistent)  # should not raise
+    await migrate_json_to_db(db_session, nonexistent)  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -110,17 +98,17 @@ async def test_migrate_noop_if_no_file(session: AsyncSession, tmp_path: Path):
 from lib.config.migration import migrate_text_tier_settings  # noqa: E402
 
 
-async def test_tier_migration_noop_when_no_legacy_keys(session: AsyncSession):
-    await migrate_text_tier_settings(session)
-    repo = SystemSettingRepository(session)
+async def test_tier_migration_noop_when_no_legacy_keys(db_session: AsyncSession):
+    await migrate_text_tier_settings(db_session)
+    repo = SystemSettingRepository(db_session)
     assert await repo.get("text_backend_simple") == ""
     assert await repo.get("text_backend_complex") == ""
 
 
-async def test_tier_migration_script_to_complex(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_tier_migration_script_to_complex(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     await repo.set("text_backend_script", "gemini-aistudio/gemini-3.1-pro-preview")
-    await migrate_text_tier_settings(session)
+    await migrate_text_tier_settings(db_session)
     assert await repo.get("text_backend_complex") == "gemini-aistudio/gemini-3.1-pro-preview"
     assert await repo.get("text_backend_simple") == ""
     assert await repo.get("text_backend_script") == ""
@@ -140,36 +128,36 @@ async def test_tier_migration_script_to_complex(session: AsyncSession):
     ],
 )
 async def test_tier_migration_simple_combinations(
-    session: AsyncSession, overview: str, style: str, expected_simple: str
+    db_session: AsyncSession, overview: str, style: str, expected_simple: str
 ):
-    repo = SystemSettingRepository(session)
+    repo = SystemSettingRepository(db_session)
     if overview:
         await repo.set("text_backend_overview", overview)
     if style:
         await repo.set("text_backend_style", style)
-    await migrate_text_tier_settings(session)
+    await migrate_text_tier_settings(db_session)
     assert await repo.get("text_backend_simple") == expected_simple
     assert await repo.get("text_backend_overview") == ""
     assert await repo.get("text_backend_style") == ""
 
 
-async def test_tier_migration_does_not_overwrite_existing_tier_keys(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_tier_migration_does_not_overwrite_existing_tier_keys(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     await repo.set("text_backend_script", "gemini-aistudio/old")
     await repo.set("text_backend_style", "gemini-aistudio/old-style")
     await repo.set("text_backend_complex", "gemini-aistudio/new")
     await repo.set("text_backend_simple", "gemini-aistudio/new-simple")
-    await migrate_text_tier_settings(session)
+    await migrate_text_tier_settings(db_session)
     assert await repo.get("text_backend_complex") == "gemini-aistudio/new"
     assert await repo.get("text_backend_simple") == "gemini-aistudio/new-simple"
     assert await repo.get("text_backend_script") == ""
 
 
-async def test_tier_migration_idempotent_on_rerun(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_tier_migration_idempotent_on_rerun(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     await repo.set("text_backend_script", "gemini-aistudio/x")
-    await migrate_text_tier_settings(session)
+    await migrate_text_tier_settings(db_session)
     # 第二次启动：旧键已删除，不再改写
     await repo.set("text_backend_complex", "gemini-aistudio/user-changed")
-    await migrate_text_tier_settings(session)
+    await migrate_text_tier_settings(db_session)
     assert await repo.get("text_backend_complex") == "gemini-aistudio/user-changed"

--- a/tests/unit/lib/config/test_config_repository.py
+++ b/tests/unit/lib/config/test_config_repository.py
@@ -1,49 +1,35 @@
-import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
-from lib.db.base import Base
-
-
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    sm = async_sessionmaker(engine, expire_on_commit=False)
-    async with sm() as s:
-        yield s
-    await engine.dispose()
-
 
 # --- ProviderConfigRepository ---
 
 
-async def test_set_and_get(session: AsyncSession):
-    repo = ProviderConfigRepository(session)
+async def test_set_and_get(db_session: AsyncSession):
+    repo = ProviderConfigRepository(db_session)
     await repo.set("gemini-aistudio", "api_key", "AIza-test", is_secret=True)
     config = await repo.get_all("gemini-aistudio")
     assert config == {"api_key": "AIza-test"}
 
 
-async def test_set_overwrites(session: AsyncSession):
-    repo = ProviderConfigRepository(session)
+async def test_set_overwrites(db_session: AsyncSession):
+    repo = ProviderConfigRepository(db_session)
     await repo.set("gemini-aistudio", "api_key", "old", is_secret=True)
     await repo.set("gemini-aistudio", "api_key", "new", is_secret=True)
     config = await repo.get_all("gemini-aistudio")
     assert config == {"api_key": "new"}
 
 
-async def test_delete(session: AsyncSession):
-    repo = ProviderConfigRepository(session)
+async def test_delete(db_session: AsyncSession):
+    repo = ProviderConfigRepository(db_session)
     await repo.set("grok", "api_key", "xai-test", is_secret=True)
     await repo.delete("grok", "api_key")
     config = await repo.get_all("grok")
     assert config == {}
 
 
-async def test_get_secrets_masked(session: AsyncSession):
-    repo = ProviderConfigRepository(session)
+async def test_get_secrets_masked(db_session: AsyncSession):
+    repo = ProviderConfigRepository(db_session)
     await repo.set("gemini-aistudio", "api_key", "AIzaSyD-longkey123", is_secret=True)
     await repo.set("gemini-aistudio", "base_url", "https://example.com", is_secret=False)
     masked = await repo.get_all_masked("gemini-aistudio")
@@ -53,8 +39,8 @@ async def test_get_secrets_masked(session: AsyncSession):
     assert masked["base_url"]["value"] == "https://example.com"
 
 
-async def test_get_configured_keys(session: AsyncSession):
-    repo = ProviderConfigRepository(session)
+async def test_get_configured_keys(db_session: AsyncSession):
+    repo = ProviderConfigRepository(db_session)
     await repo.set("ark", "api_key", "ark-test", is_secret=True)
     keys = await repo.get_configured_keys("ark")
     assert keys == ["api_key"]
@@ -63,21 +49,21 @@ async def test_get_configured_keys(session: AsyncSession):
 # --- SystemSettingRepository ---
 
 
-async def test_setting_set_and_get(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_setting_set_and_get(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     await repo.set("default_video_backend", "gemini-vertex/veo-3.1-fast-generate-001")
     val = await repo.get("default_video_backend")
     assert val == "gemini-vertex/veo-3.1-fast-generate-001"
 
 
-async def test_setting_get_default(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_setting_get_default(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     val = await repo.get("nonexistent", default="fallback")
     assert val == "fallback"
 
 
-async def test_setting_get_all(session: AsyncSession):
-    repo = SystemSettingRepository(session)
+async def test_setting_get_all(db_session: AsyncSession):
+    repo = SystemSettingRepository(db_session)
     await repo.set("key1", "val1")
     await repo.set("key2", "val2")
     all_settings = await repo.get_all()

--- a/tests/unit/lib/config/test_config_resolver_resolution.py
+++ b/tests/unit/lib/config/test_config_resolver_resolution.py
@@ -8,7 +8,7 @@ project.model_settings → legacy video_model_settings → 自定义供应商默
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.config.resolver import (
     ConfigResolver,
@@ -17,19 +17,7 @@ from lib.config.resolver import (
     get_provider_fallback,
 )
 from lib.custom_provider import make_provider_id
-from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
-
-
-@pytest.fixture
-async def db_session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-    await engine.dispose()
 
 
 @pytest.fixture

--- a/tests/unit/lib/config/test_config_service.py
+++ b/tests/unit/lib/config/test_config_service.py
@@ -1,25 +1,13 @@
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.service import ConfigService
-from lib.db.base import Base
 from lib.db.repositories.credential_repository import CredentialRepository
 
 
 @pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    sm = async_sessionmaker(engine, expire_on_commit=False)
-    async with sm() as s:
-        yield s
-    await engine.dispose()
-
-
-@pytest.fixture
-def config_service(session: AsyncSession) -> ConfigService:
-    return ConfigService(session)
+def config_service(db_session: AsyncSession) -> ConfigService:
+    return ConfigService(db_session)
 
 
 async def test_get_all_providers_status_empty(config_service: ConfigService):
@@ -44,11 +32,11 @@ async def test_provider_status_models_isolated_from_registry(config_service: Con
     assert PROVIDER_REGISTRY[target.name].models[mid].capabilities == before
 
 
-async def test_provider_becomes_ready(config_service: ConfigService, session: AsyncSession):
+async def test_provider_becomes_ready(config_service: ConfigService, db_session: AsyncSession):
     # status 由凭证表中的生效凭证决定，而不是 ProviderConfig 表
-    cred_repo = CredentialRepository(session)
+    cred_repo = CredentialRepository(db_session)
     await cred_repo.create("gemini-aistudio", "default", api_key="AIza-test")
-    await session.flush()
+    await db_session.flush()
     statuses = await config_service.get_all_providers_status()
     aistudio = next(s for s in statuses if s.name == "gemini-aistudio")
     assert aistudio.status == "ready"

--- a/tests/unit/lib/custom_provider/test_custom_provider_resolution.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_resolution.py
@@ -3,21 +3,9 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from lib.db.base import Base
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
-
-
-@pytest.fixture
-async def db_session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-    await engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/lib/db/models/test_asset_model.py
+++ b/tests/unit/lib/db/models/test_asset_model.py
@@ -3,30 +3,13 @@
 import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 import lib.db.models  # noqa: F401 — ensure all models registered for Base.metadata
-from lib.db.base import Base
 from lib.db.models.asset import Asset
 
 
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-
-
-async def test_asset_create_and_fetch(session):
+async def test_asset_create_and_fetch(db_session):
     asset = Asset(
         id="00000000-0000-0000-0000-000000000001",
         type="character",
@@ -36,10 +19,10 @@ async def test_asset_create_and_fetch(session):
         image_path="_global_assets/character/abc.png",
         source_project="demo",
     )
-    session.add(asset)
-    await session.commit()
+    db_session.add(asset)
+    await db_session.commit()
 
-    row = (await session.execute(select(Asset).where(Asset.name == "王小明"))).scalar_one()
+    row = (await db_session.execute(select(Asset).where(Asset.name == "王小明"))).scalar_one()
     assert row.type == "character"
     assert row.voice_style == "清亮"
     assert row.image_path == "_global_assets/character/abc.png"
@@ -49,13 +32,13 @@ async def test_asset_create_and_fetch(session):
     assert row.updated_at is not None
 
 
-async def test_asset_unique_type_name(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        session.add(Asset(id="id-1", type="prop", name="玉佩", description=""))
-        await session.commit()
+async def test_asset_unique_type_name(db_engine):
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with factory() as db_session:
+        db_session.add(Asset(id="id-1", type="prop", name="玉佩", description=""))
+        await db_session.commit()
 
-    async with factory() as session:
-        session.add(Asset(id="id-2", type="prop", name="玉佩", description=""))
+    async with factory() as db_session:
+        db_session.add(Asset(id="id-2", type="prop", name="玉佩", description=""))
         with pytest.raises(IntegrityError):
-            await session.commit()
+            await db_session.commit()

--- a/tests/unit/lib/db/models/test_config_models.py
+++ b/tests/unit/lib/db/models/test_config_models.py
@@ -1,33 +1,21 @@
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from lib.db.base import Base
 from lib.db.models.config import ProviderConfig, SystemSetting
 
 
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    async_session = async_sessionmaker(engine, expire_on_commit=False)
-    async with async_session() as s:
-        yield s
-    await engine.dispose()
-
-
-async def test_provider_config_crud(session: AsyncSession):
+async def test_provider_config_crud(db_session: AsyncSession):
     row = ProviderConfig(
         provider="gemini-aistudio",
         key="api_key",
         value="AIza-test",
         is_secret=True,
     )
-    session.add(row)
-    await session.flush()
+    db_session.add(row)
+    await db_session.flush()
 
-    result = await session.execute(select(ProviderConfig).where(ProviderConfig.provider == "gemini-aistudio"))
+    result = await db_session.execute(select(ProviderConfig).where(ProviderConfig.provider == "gemini-aistudio"))
     found = result.scalar_one()
     assert found.key == "api_key"
     assert found.value == "AIza-test"
@@ -35,21 +23,21 @@ async def test_provider_config_crud(session: AsyncSession):
     assert found.updated_at is not None
 
 
-async def test_provider_config_unique_constraint(session: AsyncSession):
+async def test_provider_config_unique_constraint(db_session: AsyncSession):
     row1 = ProviderConfig(provider="gemini-aistudio", key="api_key", value="v1", is_secret=True)
     row2 = ProviderConfig(provider="gemini-aistudio", key="api_key", value="v2", is_secret=True)
-    session.add(row1)
-    await session.flush()
-    session.add(row2)
+    db_session.add(row1)
+    await db_session.flush()
+    db_session.add(row2)
     with pytest.raises(Exception):  # IntegrityError
-        await session.flush()
+        await db_session.flush()
 
 
-async def test_system_setting_crud(session: AsyncSession):
+async def test_system_setting_crud(db_session: AsyncSession):
     row = SystemSetting(key="default_video_backend", value="gemini-vertex/veo-3.1-fast-generate-001")
-    session.add(row)
-    await session.flush()
+    db_session.add(row)
+    await db_session.flush()
 
-    result = await session.execute(select(SystemSetting).where(SystemSetting.key == "default_video_backend"))
+    result = await db_session.execute(select(SystemSetting).where(SystemSetting.key == "default_video_backend"))
     found = result.scalar_one()
     assert found.value == "gemini-vertex/veo-3.1-fast-generate-001"

--- a/tests/unit/lib/db/models/test_custom_provider_models.py
+++ b/tests/unit/lib/db/models/test_custom_provider_models.py
@@ -4,37 +4,19 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import inspect, select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import lib.db.models  # noqa: F401 — ensure all models registered
-from lib.db.base import Base
 from lib.db.models import CustomProvider, CustomProviderModel
 
 
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-
-
 class TestCustomProviderTable:
-    async def test_table_exists(self, engine):
-        async with engine.connect() as conn:
+    async def test_table_exists(self, db_engine):
+        async with db_engine.connect() as conn:
             table_names = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names())
         assert "custom_provider" in table_names
 
-    async def test_table_columns(self, engine):
-        async with engine.connect() as conn:
+    async def test_table_columns(self, db_engine):
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("custom_provider")}
             )
@@ -54,17 +36,17 @@ class TestCustomProviderTable:
 
 
 class TestCustomProviderRoundTrip:
-    async def test_create_and_read_back(self, session):
+    async def test_create_and_read_back(self, db_session):
         provider = CustomProvider(
             display_name="My Ollama",
             discovery_format="openai",
             base_url="http://localhost:11434/v1",
             api_key="sk-local-test",
         )
-        session.add(provider)
-        await session.commit()
+        db_session.add(provider)
+        await db_session.commit()
 
-        result = await session.execute(select(CustomProvider).where(CustomProvider.display_name == "My Ollama"))
+        result = await db_session.execute(select(CustomProvider).where(CustomProvider.display_name == "My Ollama"))
         loaded = result.scalar_one()
         assert loaded.display_name == "My Ollama"
         assert loaded.discovery_format == "openai"
@@ -74,29 +56,29 @@ class TestCustomProviderRoundTrip:
         assert loaded.created_at is not None
         assert loaded.updated_at is not None
 
-    async def test_provider_id_property(self, session):
+    async def test_provider_id_property(self, db_session):
         provider = CustomProvider(
             display_name="Test Provider",
             discovery_format="openai",
             base_url="http://example.com/v1",
             api_key="sk-test",
         )
-        session.add(provider)
-        await session.commit()
+        db_session.add(provider)
+        await db_session.commit()
 
-        result = await session.execute(select(CustomProvider).where(CustomProvider.display_name == "Test Provider"))
+        result = await db_session.execute(select(CustomProvider).where(CustomProvider.display_name == "Test Provider"))
         loaded = result.scalar_one()
         assert loaded.provider_id == f"custom-{loaded.id}"
 
 
 class TestCustomProviderModelTable:
-    async def test_table_exists(self, engine):
-        async with engine.connect() as conn:
+    async def test_table_exists(self, db_engine):
+        async with db_engine.connect() as conn:
             table_names = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names())
         assert "custom_provider_model" in table_names
 
-    async def test_table_columns(self, engine):
-        async with engine.connect() as conn:
+    async def test_table_columns(self, db_engine):
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("custom_provider_model")}
             )
@@ -122,7 +104,7 @@ class TestCustomProviderModelTable:
 
 
 class TestCustomProviderModelRoundTrip:
-    async def test_create_linked_model(self, session):
+    async def test_create_linked_model(self, db_session):
         """Create a CustomProviderModel linked to a provider and read back."""
         provider = CustomProvider(
             display_name="OpenRouter",
@@ -130,8 +112,8 @@ class TestCustomProviderModelRoundTrip:
             base_url="https://openrouter.ai/api/v1",
             api_key="sk-or-xxx",
         )
-        session.add(provider)
-        await session.commit()
+        db_session.add(provider)
+        await db_session.commit()
 
         model = CustomProviderModel(
             provider_id=provider.id,
@@ -145,10 +127,10 @@ class TestCustomProviderModelRoundTrip:
             price_output=15.0,
             currency="USD",
         )
-        session.add(model)
-        await session.commit()
+        db_session.add(model)
+        await db_session.commit()
 
-        result = await session.execute(
+        result = await db_session.execute(
             select(CustomProviderModel).where(CustomProviderModel.provider_id == provider.id)
         )
         loaded = result.scalar_one()
@@ -164,7 +146,7 @@ class TestCustomProviderModelRoundTrip:
         assert loaded.created_at is not None
         assert loaded.updated_at is not None
 
-    async def test_price_fields_nullable(self, session):
+    async def test_price_fields_nullable(self, db_session):
         """Price fields should be nullable for local/free providers (e.g., Ollama)."""
         provider = CustomProvider(
             display_name="Local Ollama",
@@ -172,8 +154,8 @@ class TestCustomProviderModelRoundTrip:
             base_url="http://localhost:11434/v1",
             api_key="ollama",
         )
-        session.add(provider)
-        await session.commit()
+        db_session.add(provider)
+        await db_session.commit()
 
         model = CustomProviderModel(
             provider_id=provider.id,
@@ -181,10 +163,10 @@ class TestCustomProviderModelRoundTrip:
             display_name="Llama 3",
             endpoint="openai-chat",
         )
-        session.add(model)
-        await session.commit()
+        db_session.add(model)
+        await db_session.commit()
 
-        result = await session.execute(select(CustomProviderModel).where(CustomProviderModel.model_id == "llama3"))
+        result = await db_session.execute(select(CustomProviderModel).where(CustomProviderModel.model_id == "llama3"))
         loaded = result.scalar_one()
         assert loaded.price_unit is None
         assert loaded.price_input is None
@@ -193,7 +175,7 @@ class TestCustomProviderModelRoundTrip:
         assert loaded.is_default is False
         assert loaded.is_enabled is True
 
-    async def test_unique_constraint_provider_model(self, session):
+    async def test_unique_constraint_provider_model(self, db_session):
         """UniqueConstraint on (provider_id, model_id) should prevent duplicates."""
         provider = CustomProvider(
             display_name="Dup Test",
@@ -201,8 +183,8 @@ class TestCustomProviderModelRoundTrip:
             base_url="http://example.com/v1",
             api_key="sk-test",
         )
-        session.add(provider)
-        await session.commit()
+        db_session.add(provider)
+        await db_session.commit()
 
         model1 = CustomProviderModel(
             provider_id=provider.id,
@@ -210,8 +192,8 @@ class TestCustomProviderModelRoundTrip:
             display_name="GPT-4o",
             endpoint="openai-chat",
         )
-        session.add(model1)
-        await session.commit()
+        db_session.add(model1)
+        await db_session.commit()
 
         model2 = CustomProviderModel(
             provider_id=provider.id,
@@ -219,6 +201,6 @@ class TestCustomProviderModelRoundTrip:
             display_name="GPT-4o Dup",
             endpoint="openai-chat",
         )
-        session.add(model2)
+        db_session.add(model2)
         with pytest.raises(Exception):  # IntegrityError
-            await session.commit()
+            await db_session.commit()

--- a/tests/unit/lib/db/models/test_db_models.py
+++ b/tests/unit/lib/db/models/test_db_models.py
@@ -2,41 +2,23 @@
 
 from datetime import UTC, datetime
 
-import pytest
 from sqlalchemy import inspect, select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import lib.db.models  # noqa: F401 — ensure all models registered for Base.metadata
-from lib.db.base import Base, TimestampMixin, UserOwnedMixin
+from lib.db.base import TimestampMixin, UserOwnedMixin
 from lib.db.models import AgentSession, Task, User
 
 
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-
-
 class TestModelsCreateTables:
-    async def test_all_tables_exist(self, engine):
-        async with engine.connect() as conn:
+    async def test_all_tables_exist(self, db_engine):
+        async with db_engine.connect() as conn:
             table_names = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names())
         assert "tasks" in table_names
         assert "worker_lease" in table_names
         assert "api_calls" in table_names
         assert "agent_sessions" in table_names
 
-    async def test_task_round_trip(self, session):
+    async def test_task_round_trip(self, db_session):
         now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
         task = Task(
             task_id="abc123",
@@ -48,17 +30,17 @@ class TestModelsCreateTables:
             queued_at=now,
             updated_at=now,
         )
-        session.add(task)
-        await session.commit()
+        db_session.add(task)
+        await db_session.commit()
 
         from sqlalchemy import select
 
-        result = await session.execute(select(Task).where(Task.task_id == "abc123"))
+        result = await db_session.execute(select(Task).where(Task.task_id == "abc123"))
         loaded = result.scalar_one()
         assert loaded.project_name == "demo"
         assert loaded.status == "queued"
 
-    async def test_agent_session_round_trip(self, session):
+    async def test_agent_session_round_trip(self, db_session):
         now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
         s = AgentSession(
             id="sess123",
@@ -68,31 +50,31 @@ class TestModelsCreateTables:
             created_at=now,
             updated_at=now,
         )
-        session.add(s)
-        await session.commit()
+        db_session.add(s)
+        await db_session.commit()
 
         from sqlalchemy import select
 
-        result = await session.execute(select(AgentSession).where(AgentSession.id == "sess123"))
+        result = await db_session.execute(select(AgentSession).where(AgentSession.id == "sess123"))
         loaded = result.scalar_one()
         assert loaded.project_name == "demo"
 
 
 class TestUserModel:
-    async def test_user_model_columns(self, engine):
+    async def test_user_model_columns(self, db_engine):
         """Verify User table has correct columns."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("users")}
             )
         assert columns == {"id", "username", "role", "is_active", "created_at", "updated_at"}
 
-    async def test_user_round_trip(self, session):
+    async def test_user_round_trip(self, db_session):
         user = User(id="u1", username="alice")
-        session.add(user)
-        await session.commit()
+        db_session.add(user)
+        await db_session.commit()
 
-        result = await session.execute(select(User).where(User.id == "u1"))
+        result = await db_session.execute(select(User).where(User.id == "u1"))
         loaded = result.scalar_one()
         assert loaded.username == "alice"
         assert loaded.role == "user"  # server_default
@@ -124,17 +106,17 @@ class TestUserOwnedMixin:
 class TestMixinApplicationToModels:
     """Verify Mixin columns are present on ORM models after refactoring."""
 
-    async def test_task_has_user_id(self, engine):
+    async def test_task_has_user_id(self, db_engine):
         """Task model should have user_id from UserOwnedMixin."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("tasks")}
             )
         assert "user_id" in columns
 
-    async def test_api_call_has_timestamp_and_user_id(self, engine):
+    async def test_api_call_has_timestamp_and_user_id(self, db_engine):
         """ApiCall should have created_at (NOT NULL), updated_at, and user_id from Mixins."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             col_info = await conn.run_sync(
                 lambda sync_conn: {c["name"]: c for c in inspect(sync_conn).get_columns("api_calls")}
             )
@@ -143,18 +125,18 @@ class TestMixinApplicationToModels:
         assert "updated_at" in col_info
         assert "user_id" in col_info
 
-    async def test_api_key_has_timestamp_and_user_id(self, engine):
+    async def test_api_key_has_timestamp_and_user_id(self, db_engine):
         """ApiKey should have updated_at and user_id from Mixins."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("api_keys")}
             )
         assert "updated_at" in columns
         assert "user_id" in columns
 
-    async def test_agent_session_has_timestamp_and_user_id(self, engine):
+    async def test_agent_session_has_timestamp_and_user_id(self, db_engine):
         """AgentSession should have created_at, updated_at, and user_id from Mixins."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("agent_sessions")}
             )
@@ -162,9 +144,9 @@ class TestMixinApplicationToModels:
         assert "updated_at" in columns
         assert "user_id" in columns
 
-    async def test_worker_lease_no_user_id(self, engine):
+    async def test_worker_lease_no_user_id(self, db_engine):
         """WorkerLease should NOT have user_id — it was not given UserOwnedMixin."""
-        async with engine.connect() as conn:
+        async with db_engine.connect() as conn:
             columns = await conn.run_sync(
                 lambda sync_conn: {c["name"] for c in inspect(sync_conn).get_columns("worker_lease")}
             )

--- a/tests/unit/lib/db/repositories/test_asset_repo.py
+++ b/tests/unit/lib/db/repositories/test_asset_repo.py
@@ -3,26 +3,13 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.repositories.asset_repo import AssetRepository
 
 
 @pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-@pytest.fixture
-async def repo(session):
-    return AssetRepository(session)
+async def repo(db_session):
+    return AssetRepository(db_session)
 
 
 async def test_create_and_get_by_id(repo):

--- a/tests/unit/lib/db/repositories/test_credential_repository.py
+++ b/tests/unit/lib/db/repositories/test_credential_repository.py
@@ -2,159 +2,146 @@
 
 from __future__ import annotations
 
-import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from lib.db.base import Base
 from lib.db.repositories.credential_repository import CredentialRepository
 
 
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with async_session() as s:
-        yield s
-    await engine.dispose()
-
-
 class TestCredentialRepository:
-    async def test_create_and_list(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_create_and_list(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         cred = await repo.create(provider="gemini-aistudio", name="测试Key", api_key="AIza-test")
-        await session.flush()
+        await db_session.flush()
         creds = await repo.list_by_provider("gemini-aistudio")
         assert len(creds) == 1
         assert creds[0].name == "测试Key"
         assert creds[0].api_key == "AIza-test"
         assert creds[0].id == cred.id
 
-    async def test_first_credential_is_active(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_first_credential_is_active(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         cred = await repo.create(provider="gemini-aistudio", name="第一个", api_key="AIza-1")
-        await session.flush()
+        await db_session.flush()
         assert cred.is_active is True
 
-    async def test_second_credential_is_not_active(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_second_credential_is_not_active(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         await repo.create(provider="gemini-aistudio", name="第一个", api_key="AIza-1")
         cred2 = await repo.create(provider="gemini-aistudio", name="第二个", api_key="AIza-2")
-        await session.flush()
+        await db_session.flush()
         assert cred2.is_active is False
 
-    async def test_activate(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_activate(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c1 = await repo.create(provider="gemini-aistudio", name="第一个", api_key="AIza-1")
         c2 = await repo.create(provider="gemini-aistudio", name="第二个", api_key="AIza-2")
-        await session.flush()
+        await db_session.flush()
 
         await repo.activate(c2.id, "gemini-aistudio")
-        await session.flush()
+        await db_session.flush()
 
         creds = await repo.list_by_provider("gemini-aistudio")
         active_map = {c.id: c.is_active for c in creds}
         assert active_map[c1.id] is False
         assert active_map[c2.id] is True
 
-    async def test_get_active(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_get_active(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         await repo.create(provider="gemini-aistudio", name="Key1", api_key="AIza-1")
-        await session.flush()
+        await db_session.flush()
         active = await repo.get_active("gemini-aistudio")
         assert active is not None
         assert active.name == "Key1"
 
-    async def test_get_active_returns_none_when_empty(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_get_active_returns_none_when_empty(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         active = await repo.get_active("gemini-aistudio")
         assert active is None
 
-    async def test_get_by_id(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_get_by_id(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(provider="gemini-aistudio", name="Key1", api_key="AIza-1")
-        await session.flush()
+        await db_session.flush()
         found = await repo.get_by_id(c.id)
         assert found is not None
         assert found.name == "Key1"
 
-    async def test_update(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_update(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(provider="gemini-aistudio", name="旧名", api_key="AIza-old")
-        await session.flush()
+        await db_session.flush()
         await repo.update(c.id, name="新名", api_key="AIza-new")
-        await session.flush()
+        await db_session.flush()
         updated = await repo.get_by_id(c.id)
         assert updated is not None
         assert updated.name == "新名"
         assert updated.api_key == "AIza-new"
 
-    async def test_delete(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_delete(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(provider="gemini-aistudio", name="Key1", api_key="AIza-1")
-        await session.flush()
+        await db_session.flush()
         await repo.delete(c.id)
-        await session.flush()
+        await db_session.flush()
         assert await repo.get_by_id(c.id) is None
 
-    async def test_delete_active_promotes_oldest(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_delete_active_promotes_oldest(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c1 = await repo.create(provider="gemini-aistudio", name="Key1", api_key="AIza-1")
         await repo.create(provider="gemini-aistudio", name="Key2", api_key="AIza-2")
-        await session.flush()
+        await db_session.flush()
         await repo.delete(c1.id)
-        await session.flush()
+        await db_session.flush()
         remaining = await repo.list_by_provider("gemini-aistudio")
         assert len(remaining) == 1
         assert remaining[0].is_active is True
 
-    async def test_has_active_credential(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_has_active_credential(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         assert await repo.has_active_credential("gemini-aistudio") is False
         await repo.create(provider="gemini-aistudio", name="Key1", api_key="AIza-1")
-        await session.flush()
+        await db_session.flush()
         assert await repo.has_active_credential("gemini-aistudio") is True
 
-    async def test_get_active_credentials_bulk(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_get_active_credentials_bulk(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         await repo.create(provider="gemini-aistudio", name="K1", api_key="AIza-1")
         await repo.create(provider="ark", name="K2", api_key="ark-key")
-        await session.flush()
+        await db_session.flush()
         bulk = await repo.get_active_credentials_bulk()
         assert "gemini-aistudio" in bulk
         assert "ark" in bulk
 
-    async def test_create_and_update_two_secrets(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_create_and_update_two_secrets(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(
             provider="kling",
             name="可灵账号",
             access_key="AK-original",
             secret_key="SK-original",
         )
-        await session.flush()
+        await db_session.flush()
         assert c.access_key == "AK-original"
         assert c.secret_key == "SK-original"
         assert c.api_key is None
 
         await repo.update(c.id, access_key="AK-new")
-        await session.flush()
+        await db_session.flush()
         updated = await repo.get_by_id(c.id)
         assert updated is not None
         # 只更新传入的 secret，另一个保持原值
         assert updated.access_key == "AK-new"
         assert updated.secret_key == "SK-original"
 
-    async def test_overlay_config_emits_both_secrets_by_key_name(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_overlay_config_emits_both_secrets_by_key_name(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(
             provider="kling",
             name="可灵账号",
             access_key="AK-1",
             secret_key="SK-1",
         )
-        await session.flush()
+        await db_session.flush()
         config: dict[str, str] = {}
         c.overlay_config(config)
         # 列名即 config key，逐字段原样产出
@@ -162,20 +149,20 @@ class TestCredentialRepository:
         assert config["secret_key"] == "SK-1"
         assert "api_key" not in config
 
-    async def test_update_can_explicitly_clear_secret_fields(self, session: AsyncSession):
+    async def test_update_can_explicitly_clear_secret_fields(self, db_session: AsyncSession):
         """显式传 None 清空 api_key/access_key/secret_key/base_url；省略参数（默认）不动它们。"""
-        repo = CredentialRepository(session)
+        repo = CredentialRepository(db_session)
         c = await repo.create(
             provider="kling",
             name="可灵账号",
             api_key="AK-legacy",
             base_url="https://proxy.example.com/v1",
         )
-        await session.flush()
+        await db_session.flush()
 
         # 省略 access_key/secret_key：保持未设置，不受影响
         await repo.update(c.id, name="改名")
-        await session.flush()
+        await db_session.flush()
         untouched = await repo.get_by_id(c.id)
         assert untouched is not None
         assert untouched.api_key == "AK-legacy"
@@ -183,7 +170,7 @@ class TestCredentialRepository:
 
         # 显式传 None：清空该字段
         await repo.update(c.id, api_key=None, base_url=None, access_key="AK-new", secret_key="SK-new")
-        await session.flush()
+        await db_session.flush()
         switched = await repo.get_by_id(c.id)
         assert switched is not None
         assert switched.api_key is None
@@ -191,13 +178,13 @@ class TestCredentialRepository:
         assert switched.access_key == "AK-new"
         assert switched.secret_key == "SK-new"
 
-    async def test_base_url_normalized_on_create(self, session: AsyncSession):
-        repo = CredentialRepository(session)
+    async def test_base_url_normalized_on_create(self, db_session: AsyncSession):
+        repo = CredentialRepository(db_session)
         c = await repo.create(
             provider="gemini-aistudio",
             name="Key",
             api_key="AIza-1",
             base_url="https://proxy.example.com/v1",
         )
-        await session.flush()
+        await db_session.flush()
         assert c.base_url == "https://proxy.example.com/v1/"

--- a/tests/unit/lib/db/repositories/test_custom_provider_repo.py
+++ b/tests/unit/lib/db/repositories/test_custom_provider_repo.py
@@ -3,41 +3,29 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderPrice, CustomProviderRepository
 
 
-@pytest.fixture
-async def session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
 class TestProviderCRUD:
-    async def test_create_provider_without_models(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_create_provider_without_models(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="My OpenAI",
             discovery_format="openai",
             base_url="https://api.openai.com/v1",
             api_key="sk-test-123",
         )
-        await session.flush()
+        await db_session.flush()
         assert provider.id is not None
         assert provider.display_name == "My OpenAI"
         assert provider.discovery_format == "openai"
         assert provider.base_url == "https://api.openai.com/v1"
         assert provider.api_key == "sk-test-123"
 
-    async def test_create_provider_with_models(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_create_provider_with_models(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         models = [
             {
                 "model_id": "gpt-4o",
@@ -64,7 +52,7 @@ class TestProviderCRUD:
             api_key="sk-test-123",
             models=models,
         )
-        await session.flush()
+        await db_session.flush()
 
         result = await repo.list_models(provider.id)
         assert len(result) == 2
@@ -73,25 +61,25 @@ class TestProviderCRUD:
         assert result[1].price_unit == "image"
         assert result[1].price_input == 0.04
 
-    async def test_get_provider(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_provider(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         created = await repo.create_provider(
             display_name="Test",
             discovery_format="openai",
             base_url="https://example.com",
             api_key="key",
         )
-        await session.flush()
+        await db_session.flush()
         found = await repo.get_provider(created.id)
         assert found is not None
         assert found.display_name == "Test"
 
-    async def test_get_provider_returns_none(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_provider_returns_none(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         assert await repo.get_provider(999) is None
 
-    async def test_list_providers(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_list_providers(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         await repo.create_provider(
             display_name="Provider A",
             discovery_format="openai",
@@ -104,24 +92,24 @@ class TestProviderCRUD:
             base_url="https://b.com",
             api_key="key-b",
         )
-        await session.flush()
+        await db_session.flush()
         providers = await repo.list_providers()
         assert len(providers) == 2
         assert providers[0].display_name == "Provider A"
         assert providers[1].display_name == "Provider B"
 
-    async def test_update_provider(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_update_provider(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="Old Name",
             discovery_format="openai",
             base_url="https://old.com",
             api_key="old-key",
         )
-        await session.flush()
+        await db_session.flush()
 
         await repo.update_provider(p.id, display_name="New Name", api_key="new-key")
-        await session.flush()
+        await db_session.flush()
 
         updated = await repo.get_provider(p.id)
         assert updated is not None
@@ -129,13 +117,13 @@ class TestProviderCRUD:
         assert updated.api_key == "new-key"
         assert updated.base_url == "https://old.com"  # unchanged
 
-    async def test_update_provider_nonexistent(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_update_provider_nonexistent(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         result = await repo.update_provider(999, display_name="Nope")
         assert result is None
 
-    async def test_delete_provider_cascades_to_models(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_delete_provider_cascades_to_models(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="ToDelete",
             discovery_format="openai",
@@ -154,38 +142,38 @@ class TestProviderCRUD:
                 },
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         await repo.delete_provider(p.id)
-        await session.flush()
+        await db_session.flush()
 
         assert await repo.get_provider(p.id) is None
         assert await repo.list_models(p.id) == []
 
-    async def test_delete_provider_nonexistent(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_delete_provider_nonexistent(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         # Should not raise
         await repo.delete_provider(999)
 
 
 class TestConcurrencyColumns:
-    async def test_create_without_workers_defaults_to_null(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_create_without_workers_defaults_to_null(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="P",
             discovery_format="openai",
             base_url="https://x",
             api_key="k",
         )
-        await session.flush()
+        await db_session.flush()
         got = await repo.get_provider(p.id)
         assert got is not None
         assert got.image_max_workers is None
         assert got.video_max_workers is None
         assert got.audio_max_workers is None
 
-    async def test_create_with_workers_round_trip(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_create_with_workers_round_trip(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="P",
             discovery_format="openai",
@@ -195,15 +183,15 @@ class TestConcurrencyColumns:
             video_max_workers=7,
             audio_max_workers=1,
         )
-        await session.flush()
+        await db_session.flush()
         got = await repo.get_provider(p.id)
         assert got is not None
         assert got.image_max_workers == 2
         assert got.video_max_workers == 7
         assert got.audio_max_workers == 1
 
-    async def test_update_workers_including_clear_to_null(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_update_workers_including_clear_to_null(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="P",
             discovery_format="openai",
@@ -211,10 +199,10 @@ class TestConcurrencyColumns:
             api_key="k",
             image_max_workers=5,
         )
-        await session.flush()
+        await db_session.flush()
 
         await repo.update_provider(p.id, image_max_workers=None, video_max_workers=4)
-        await session.flush()
+        await db_session.flush()
 
         got = await repo.get_provider(p.id)
         assert got is not None
@@ -224,12 +212,12 @@ class TestConcurrencyColumns:
     @pytest.mark.parametrize("field", ["image_max_workers", "video_max_workers", "audio_max_workers"])
     @pytest.mark.parametrize("value", [-1, 0])
     async def test_create_non_positive_workers_rejected_by_check_constraint(
-        self, session: AsyncSession, field: str, value: int
+        self, db_session: AsyncSession, field: str, value: int
     ):
         """DB 层 CHECK 约束拦截 0 与负值，repo 直写也无法绕过（create_provider 内部 flush 即触发）。"""
         from sqlalchemy.exc import IntegrityError
 
-        repo = CustomProviderRepository(session)
+        repo = CustomProviderRepository(db_session)
         with pytest.raises(IntegrityError):
             await repo.create_provider(
                 display_name="P",
@@ -241,23 +229,23 @@ class TestConcurrencyColumns:
 
 
 class TestModelManagement:
-    async def _make_provider(self, repo: CustomProviderRepository, session: AsyncSession) -> int:
+    async def _make_provider(self, repo: CustomProviderRepository, db_session: AsyncSession) -> int:
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
             base_url="https://example.com",
             api_key="key",
         )
-        await session.flush()
+        await db_session.flush()
         return p.id
 
-    async def test_list_models_empty(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
-        pid = await self._make_provider(repo, session)
+    async def test_list_models_empty(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
+        pid = await self._make_provider(repo, db_session)
         assert await repo.list_models(pid) == []
 
-    async def test_replace_models(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_replace_models(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -267,14 +255,14 @@ class TestModelManagement:
                 {"model_id": "old-model", "display_name": "Old", "endpoint": "openai-chat"},
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         new_models = [
             {"model_id": "new-1", "display_name": "New 1", "endpoint": "openai-chat", "is_default": True},
             {"model_id": "new-2", "display_name": "New 2", "endpoint": "openai-images"},
         ]
         await repo.replace_models(p.id, new_models)
-        await session.flush()
+        await db_session.flush()
 
         models = await repo.list_models(p.id)
         assert len(models) == 2
@@ -283,8 +271,8 @@ class TestModelManagement:
         assert "new-1" in model_ids
         assert "new-2" in model_ids
 
-    async def test_replace_models_with_empty_list(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_replace_models_with_empty_list(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -294,15 +282,15 @@ class TestModelManagement:
                 {"model_id": "m1", "display_name": "M1", "endpoint": "openai-chat"},
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         await repo.replace_models(p.id, [])
-        await session.flush()
+        await db_session.flush()
 
         assert await repo.list_models(p.id) == []
 
-    async def test_delete_model(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_delete_model(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -313,23 +301,23 @@ class TestModelManagement:
                 {"model_id": "m2", "display_name": "M2", "endpoint": "openai-chat"},
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         models = await repo.list_models(p.id)
         await repo.delete_model(models[0].id)
-        await session.flush()
+        await db_session.flush()
 
         remaining = await repo.list_models(p.id)
         assert len(remaining) == 1
         assert remaining[0].model_id == "m2"
 
-    async def test_delete_model_nonexistent(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_delete_model_nonexistent(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         # Should not raise
         await repo.delete_model(999)
 
-    async def test_list_enabled_models_by_media_type(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_list_enabled_models_by_media_type(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         await repo.create_provider(
             display_name="Provider1",
             discovery_format="openai",
@@ -351,7 +339,7 @@ class TestModelManagement:
                 {"model_id": "vid-1", "display_name": "Vid 1", "endpoint": "newapi-video", "is_enabled": True},
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         text_models = await repo.list_enabled_models_by_media_type("text")
         assert len(text_models) == 2
@@ -366,13 +354,13 @@ class TestModelManagement:
         assert len(video_models) == 1
         assert video_models[0].model_id == "vid-1"
 
-    async def test_list_enabled_models_by_media_type_empty(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_list_enabled_models_by_media_type_empty(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         result = await repo.list_enabled_models_by_media_type("text")
         assert result == []
 
-    async def test_get_default_model(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_default_model(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -402,7 +390,7 @@ class TestModelManagement:
                 },
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         default_text = await repo.get_default_model(p.id, "text")
         assert default_text is not None
@@ -412,8 +400,8 @@ class TestModelManagement:
         assert default_image is not None
         assert default_image.model_id == "m3"
 
-    async def test_get_default_model_returns_none_when_no_default(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_default_model_returns_none_when_no_default(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -429,12 +417,12 @@ class TestModelManagement:
                 },
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         assert await repo.get_default_model(p.id, "text") is None
 
-    async def test_get_default_model_ignores_disabled(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_default_model_ignores_disabled(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         p = await repo.create_provider(
             display_name="TestProvider",
             discovery_format="openai",
@@ -450,19 +438,19 @@ class TestModelManagement:
                 },
             ],
         )
-        await session.flush()
+        await db_session.flush()
 
         assert await repo.get_default_model(p.id, "text") is None
 
-    async def test_get_default_model_nonexistent_provider(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_get_default_model_nonexistent_provider(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         assert await repo.get_default_model(999, "text") is None
 
 
 class TestResolvePrice:
     """resolve_price：记账与预估共用的价格取数，全部降级路径归为无价、绝不抛错。"""
 
-    async def _provider_with_model(self, repo: CustomProviderRepository, session: AsyncSession, **model_over) -> str:
+    async def _provider_with_model(self, repo: CustomProviderRepository, db_session: AsyncSession, **model_over) -> str:
         model = {
             "model_id": "m1",
             "display_name": "M1",
@@ -481,32 +469,34 @@ class TestResolvePrice:
             api_key="k",
             models=[model],
         )
-        await session.flush()
+        await db_session.flush()
         return f"custom-{p.id}"
 
-    async def test_non_custom_provider_returns_no_price(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
+    async def test_non_custom_provider_returns_no_price(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
         assert await repo.resolve_price("gemini-aistudio", "gemini-3-flash-preview") == CustomProviderPrice()
 
-    async def test_valid_custom_provider_returns_declared_price(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
-        provider = await self._provider_with_model(repo, session)
+    async def test_valid_custom_provider_returns_declared_price(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
+        provider = await self._provider_with_model(repo, db_session)
         assert await repo.resolve_price(provider, "m1") == CustomProviderPrice(2.0, 4.0, "CNY")
 
-    async def test_missing_model_returns_no_price(self, session: AsyncSession):
-        repo = CustomProviderRepository(session)
-        provider = await self._provider_with_model(repo, session)
+    async def test_missing_model_returns_no_price(self, db_session: AsyncSession):
+        repo = CustomProviderRepository(db_session)
+        provider = await self._provider_with_model(repo, db_session)
         assert await repo.resolve_price(provider, "ghost") == CustomProviderPrice()
 
-    async def test_malformed_id_degrades_to_no_price(self, session: AsyncSession):
+    async def test_malformed_id_degrades_to_no_price(self, db_session: AsyncSession):
         """畸形 custom- id（parse_provider_id 抛 ValueError）降级为无价，不抛错。"""
-        repo = CustomProviderRepository(session)
+        repo = CustomProviderRepository(db_session)
         assert await repo.resolve_price("custom-abc/ghost", "m1") == CustomProviderPrice()
 
-    async def test_query_exception_degrades_to_no_price(self, session: AsyncSession, monkeypatch: pytest.MonkeyPatch):
+    async def test_query_exception_degrades_to_no_price(
+        self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ):
         """底层查询异常（如 DB 瞬时不可用）降级为无价，不冒泡。"""
-        repo = CustomProviderRepository(session)
-        provider = await self._provider_with_model(repo, session)
+        repo = CustomProviderRepository(db_session)
+        provider = await self._provider_with_model(repo, db_session)
 
         async def _boom(*_args, **_kwargs):
             raise RuntimeError("db down")
@@ -514,17 +504,17 @@ class TestResolvePrice:
         monkeypatch.setattr(repo, "get_model_by_ids", _boom)
         assert await repo.resolve_price(provider, "m1") == CustomProviderPrice()
 
-    async def test_disabled_model_still_priced(self, session: AsyncSession):
+    async def test_disabled_model_still_priced(self, db_session: AsyncSession):
         """刻意豁免 enabled 校验：停用模型仍按其声明价取价（记账按实际调用的模型计费）。"""
-        repo = CustomProviderRepository(session)
-        provider = await self._provider_with_model(repo, session, is_enabled=False)
+        repo = CustomProviderRepository(db_session)
+        provider = await self._provider_with_model(repo, db_session, is_enabled=False)
         assert await repo.resolve_price(provider, "m1") == CustomProviderPrice(2.0, 4.0, "CNY")
 
 
 @pytest.mark.asyncio
-async def test_list_enabled_models_by_media_type_uses_endpoint(session):
+async def test_list_enabled_models_by_media_type_uses_endpoint(db_session):
     """list_enabled_models_by_media_type 应按 endpoint 推算 media_type 过滤。"""
-    repo = CustomProviderRepository(session)
+    repo = CustomProviderRepository(db_session)
     await repo.create_provider(
         display_name="P",
         discovery_format="openai",
@@ -559,7 +549,7 @@ async def test_list_enabled_models_by_media_type_uses_endpoint(session):
             },
         ],
     )
-    await session.commit()
+    await db_session.commit()
 
     text_models = await repo.list_enabled_models_by_media_type("text")
     assert {m.model_id for m in text_models} == {"gpt-4o"}

--- a/tests/unit/lib/db/repositories/test_session_repo.py
+++ b/tests/unit/lib/db/repositories/test_session_repo.py
@@ -1,26 +1,6 @@
 """Tests for SessionRepository."""
 
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
-from lib.db.base import Base
 from lib.db.repositories.session_repo import SessionRepository
-
-
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def db_session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
 
 
 class TestSessionRepository:

--- a/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
+++ b/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
@@ -6,26 +6,8 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.repositories.task_repo import TaskRepository
-
-
-@pytest.fixture
-async def engine():
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with eng.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield eng
-    await eng.dispose()
-
-
-@pytest.fixture
-async def db_session(engine):
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
 
 
 @pytest.mark.asyncio

--- a/tests/unit/lib/image_backends/test_agnes_image_backend.py
+++ b/tests/unit/lib/image_backends/test_agnes_image_backend.py
@@ -1,13 +1,16 @@
-"""AgnesImageBackend 单元测试（mock httpx，单步同步 OpenAI 兼容端点，不打真实 HTTP）。"""
+"""AgnesImageBackend 单元测试（respx 捕获出站请求，单步同步 OpenAI 兼容端点）。"""
 
 from __future__ import annotations
 
 import base64
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import respx
 
 from lib.image_backends.base import (
     ImageCapability,
@@ -16,28 +19,18 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_AGNES
+from tests.fakes import bounded_poll_clock
+from tests.http_capture import capture_http, only_request, request_json
+
+_ENDPOINT = "https://apihub.agnes-ai.com/v1/images/generations"
 
 
-def _img_response(url: str = "https://x/out.png") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"created": 1, "data": [{"url": url}]}
-    return resp
+def _img_response(url: str = "https://x/out.png") -> httpx.Response:
+    return httpx.Response(200, json={"created": 1, "data": [{"url": url}]})
 
 
-def _b64_response(b64: str) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"created": 1, "data": [{"b64_json": b64}]}
-    return resp
-
-
-def _mock_client(resp: MagicMock | httpx.Response) -> AsyncMock:
-    client = AsyncMock()
-    client.post = AsyncMock(return_value=resp)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+def _b64_response(b64: str) -> httpx.Response:
+    return httpx.Response(200, json={"created": 1, "data": [{"b64_json": b64}]})
 
 
 def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
@@ -46,16 +39,16 @@ def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
     return ReferenceImage(path=str(p))
 
 
-def _error_response(status_code: int) -> httpx.Response:
-    request = httpx.Request("POST", "https://x/v1/images/generations")
-    return httpx.Response(status_code, request=request, text="boom")
-
-
-def _patches(client: AsyncMock, download: AsyncMock):
-    return (
-        patch("httpx.AsyncClient", return_value=client),
-        patch("lib.image_backends.agnes.download_image_to_path", download),
-    )
+@contextmanager
+def _generate_route(response: httpx.Response, download: AsyncMock | None = None) -> Iterator[respx.Route]:
+    """拦截建图 POST 并（可选）挡住产物下载，产出该路由供断言真实请求。"""
+    with capture_http() as router:
+        route = router.post(_ENDPOINT).mock(return_value=response)
+        if download is None:
+            yield route
+        else:
+            with patch("lib.image_backends.agnes.download_image_to_path", download):
+                yield route
 
 
 class TestCapabilities:
@@ -82,16 +75,15 @@ class TestCapabilities:
 
 class TestTextToImage:
     async def test_t2i_request_build(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk", model="agnes-image-2.1-flash", base_url="https://apihub.agnes-ai.com")
             result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
 
-        body = client.post.call_args.kwargs["json"]
+        request = only_request(route)
+        body = request_json(request)
         assert body["model"] == "agnes-image-2.1-flash"
         assert body["prompt"] == "a fox"
         assert body["n"] == 1
@@ -101,37 +93,33 @@ class TestTextToImage:
         # 默认 aspect_ratio=9:16 精确算、受单边 2048 收口
         assert body["size"] == "1152x2048"
         # 端点：base host 派生 /v1 + /images/generations
-        assert client.post.call_args.args[0] == "https://apihub.agnes-ai.com/v1/images/generations"
-        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
+        assert str(request.url) == _ENDPOINT
+        assert request.headers["Authorization"] == "Bearer sk"
         assert result.provider == PROVIDER_AGNES
         assert result.model == "agnes-image-2.1-flash"
         assert result.image_uri == "https://x/out.png"
         download.assert_called_once()
 
     async def test_default_endpoint(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert client.post.call_args.args[0] == "https://apihub.agnes-ai.com/v1/images/generations"
+        assert str(only_request(route).url) == _ENDPOINT
 
 
 class TestDimensions:
     async def _size(self, tmp_path: Path, **req_kwargs) -> str:
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", **req_kwargs))
-        return client.post.call_args.kwargs["json"]["size"]
+        return request_json(only_request(route))["size"]
 
     async def test_landscape_picks_wide(self, tmp_path: Path):
         assert await self._size(tmp_path, aspect_ratio="16:9") == "2048x1152"
@@ -158,11 +146,9 @@ class TestDimensions:
 
 class TestImageToImage:
     async def test_i2i_reference_images_as_data_uri_list(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(2)]
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -170,12 +156,13 @@ class TestImageToImage:
                 ImageGenerationRequest(prompt="hero", output_path=tmp_path / "o.png", reference_images=refs)
             )
 
-        images = client.post.call_args.kwargs["json"]["image"]
+        body = request_json(only_request(route))
+        images = body["image"]
         assert isinstance(images, list)
         assert len(images) == 2
         assert all(item.startswith("data:image/png;base64,") for item in images)
         # I2I 仍显式下发 size
-        assert "size" in client.post.call_args.kwargs["json"]
+        assert "size" in body
 
     async def test_missing_ref_raises_unreadable(self, tmp_path: Path):
         from lib.image_backends.agnes import AgnesImageBackend
@@ -208,9 +195,8 @@ class TestResponseHandling:
     async def test_base64_response_decoded_and_saved(self, tmp_path: Path):
         raw = b"\x89PNG\r\nhello-bytes"
         b64 = base64.b64encode(raw).decode("ascii")
-        client = _mock_client(_b64_response(b64))
         out = tmp_path / "o.png"
-        with patch("httpx.AsyncClient", return_value=client):
+        with _generate_route(_b64_response(b64)):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -223,9 +209,8 @@ class TestResponseHandling:
     async def test_base64_data_uri_prefix_stripped(self, tmp_path: Path):
         raw = b"PNGDATA"
         b64 = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
-        client = _mock_client(_b64_response(b64))
         out = tmp_path / "o.png"
-        with patch("httpx.AsyncClient", return_value=client):
+        with _generate_route(_b64_response(b64)):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -234,13 +219,8 @@ class TestResponseHandling:
         assert out.read_bytes() == raw
 
     async def test_empty_data_raises_runtime(self, tmp_path: Path):
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {"created": 1, "data": []}
-        client = _mock_client(resp)
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(httpx.Response(200, json={"created": 1, "data": []}), download):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -251,14 +231,10 @@ class TestResponseHandling:
         # URL 下载失败但同响应带 b64_json：回退落盘，不丢弃已计费的成功生成
         raw = b"\x89PNG\r\nfallback"
         b64 = base64.b64encode(raw).decode("ascii")
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {"created": 1, "data": [{"url": "https://x/out.png", "b64_json": b64}]}
-        client = _mock_client(resp)
+        response = httpx.Response(200, json={"created": 1, "data": [{"url": "https://x/out.png", "b64_json": b64}]})
         download = AsyncMock(side_effect=RuntimeError("download boom"))
         out = tmp_path / "o.png"
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(response, download):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -271,10 +247,8 @@ class TestResponseHandling:
 
     async def test_url_download_failure_without_b64_still_raises(self, tmp_path: Path):
         # 仅有 url 且下载失败、无 b64 兜底：照常上抛，不静默吞错
-        client = _mock_client(_img_response())
         download = AsyncMock(side_effect=RuntimeError("download boom"))
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -283,17 +257,16 @@ class TestResponseHandling:
 
     async def test_missing_url_b64_log_redacts_body(self, tmp_path: Path, caplog):
         # 响应缺 url/b64 时只记键名与 data 条数，敏感字段值不落日志
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {
-            "created": 1,
-            "data": [{"prompt": "secret-prompt"}],
-            "signed_url": "https://x/secret?sig=abc",
-        }
-        client = _mock_client(resp)
+        response = httpx.Response(
+            200,
+            json={
+                "created": 1,
+                "data": [{"prompt": "secret-prompt"}],
+                "signed_url": "https://x/secret?sig=abc",
+            },
+        )
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2, caplog.at_level("ERROR"):
+        with _generate_route(response, download), caplog.at_level("ERROR"):
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
@@ -309,37 +282,32 @@ class TestResponseHandling:
 
 class TestHttpErrors:
     async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):
-        client = _mock_client(_error_response(400))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(httpx.Response(400, text="boom"), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         assert ei.value.response.status_code == 400
-        assert client.post.call_count == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
 
 class TestRetryScope:
-    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, monkeypatch):
+    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path):
         # 下载阶段瞬态失败只在下载层重试，绝不回退到重跑非幂等的生成 POST（防重复建图 + 重复计费）。
         from lib.retry import DOWNLOAD_MAX_ATTEMPTS
 
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
-        client = _mock_client(_img_response())
         download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with bounded_poll_clock(), _generate_route(_img_response(), download) as route:
             from lib.image_backends.agnes import AgnesImageBackend
 
             b = AgnesImageBackend(api_key="sk")
             with pytest.raises(httpx.ConnectError):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
-        assert client.post.call_count == 1
+        assert route.call_count == 1
         assert download.call_count == DOWNLOAD_MAX_ATTEMPTS
 
 

--- a/tests/unit/lib/image_backends/test_dashscope_image_backend.py
+++ b/tests/unit/lib/image_backends/test_dashscope_image_backend.py
@@ -1,12 +1,15 @@
-"""DashScopeImageBackend 单元测试（mock httpx，同步端点）。"""
+"""DashScopeImageBackend 单元测试（respx 捕获出站请求，同步端点）。"""
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import respx
 
 from lib.image_backends.base import (
     ImageCapability,
@@ -15,21 +18,30 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_DASHSCOPE
+from tests.fakes import bounded_poll_clock
+from tests.http_capture import capture_http, only_request, request_json
+
+_DEFAULT_HOST = "https://dashscope.aliyuncs.com"
+_IMAGE_PATH = "/api/v1/services/aigc/multimodal-generation/generation"
 
 
-def _img_response(url: str = "https://x/out.png") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"output": {"choices": [{"message": {"content": [{"image": url}]}}]}}
-    return resp
+def _img_response(url: str = "https://x/out.png") -> httpx.Response:
+    return httpx.Response(200, json={"output": {"choices": [{"message": {"content": [{"image": url}]}}]}})
 
 
-def _mock_client(resp: MagicMock) -> AsyncMock:
-    client = AsyncMock()
-    client.post = AsyncMock(return_value=resp)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+@contextmanager
+def _generate_route(
+    response: httpx.Response,
+    download: AsyncMock,
+    *,
+    host: str = _DEFAULT_HOST,
+) -> Iterator[respx.Route]:
+    """拦截建图 POST 并挡住产物下载，产出该路由供断言真实请求。"""
+    with (
+        capture_http() as router,
+        patch("lib.image_backends.dashscope.download_image_to_path", download),
+    ):
+        yield router.post(f"{host}{_IMAGE_PATH}").mock(return_value=response)
 
 
 def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
@@ -38,40 +50,8 @@ def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
     return ReferenceImage(path=str(p))
 
 
-def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://x/api/v1/x")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
-
-
-def _error_response(status_code: int) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.text = "Request Entity Too Large"
-    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "Request Entity Too Large"))
-    return resp
-
-
-def _http_error_transient_substring(status_code: int) -> httpx.HTTPStatusError:
-    """状态码为 status_code 但 str() 含 "503" 子串（请求 URL/task_id）的真实 HTTPStatusError。
-
-    raise_for_status 的消息携带请求 URL，旧字符串兜底会据此误判重试；状态码谓词只读
-    response.status_code，不受 URL/消息里的瞬态子串影响。
-    """
-    request = httpx.Request("POST", "https://x/api/v1/tasks/job-503")
-    response = httpx.Response(status_code, request=request)
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        return exc
-    raise AssertionError("unreachable")
-
-
-def _patches(client: AsyncMock, download: AsyncMock):
-    return (
-        patch("httpx.AsyncClient", return_value=client),
-        patch("lib.image_backends.dashscope.download_image_to_path", download),
-    )
+def _sent_size(route: respx.Route) -> str:
+    return request_json(only_request(route))["parameters"]["size"]
 
 
 class TestCapabilities:
@@ -98,16 +78,15 @@ class TestCapabilities:
 
 class TestTextToImage:
     async def test_t2i_content_text_only(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
-            b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0", base_url="https://dashscope.aliyuncs.com")
+            b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0", base_url=_DEFAULT_HOST)
             result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
 
-        body = client.post.call_args.kwargs["json"]
+        request = only_request(route)
+        body = request_json(request)
         content = body["input"]["messages"][0]["content"]
         assert content == [{"text": "a fox"}]
         # qwen 融合系列按默认 aspect_ratio=9:16 算精确比例，受 2048² 预算夹取
@@ -116,31 +95,27 @@ class TestTextToImage:
         assert body["parameters"]["watermark"] is False
         assert body["parameters"]["prompt_extend"] is False
         # 端点正确（host 派生 /api/v1 + 路径）
-        assert client.post.call_args.args[0].endswith("/api/v1/services/aigc/multimodal-generation/generation")
-        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
-        assert "X-DashScope-Async" not in client.post.call_args.kwargs["headers"]
+        assert request.url.path == _IMAGE_PATH
+        assert request.headers["Authorization"] == "Bearer sk"
+        assert "X-DashScope-Async" not in request.headers
         assert result.provider == PROVIDER_DASHSCOPE
         assert result.image_uri == "https://x/out.png"
         download.assert_called_once()
 
     async def test_wan_default_size_follows_aspect(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image")
             # 默认 aspect_ratio=9:16，wan 方式二像素值按比例精确算（默认 2K 档短边 1440）
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "1440*2560"
+        assert _sent_size(route) == "1440*2560"
 
     async def test_explicit_tier_translated_to_aspect_pixels(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image")
@@ -149,13 +124,11 @@ class TestTextToImage:
                 ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", aspect_ratio="9:16", image_size="2K")
             )
 
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "1440*2560"
+        assert _sent_size(route) == "1440*2560"
 
     async def test_custom_pixel_size_strips_embedded_ratio(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image")
@@ -167,16 +140,14 @@ class TestTextToImage:
             )
 
         # min(1920,1080)=1080 → 9:16 精确（t=8）→ 1152*2048，而非输入的 16:9
-        size = client.post.call_args.kwargs["json"]["parameters"]["size"]
+        size = _sent_size(route)
         w, h = (int(x) for x in size.split("*"))
         assert w * 16 == h * 9 and w < h
         assert size == "1152*2048"
 
     async def test_low_tier_translated_to_aspect_pixels(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image")
@@ -185,26 +156,22 @@ class TestTextToImage:
                 ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", aspect_ratio="16:9", image_size="1K")
             )
 
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "1792*1008"
+        assert _sent_size(route) == "1792*1008"
 
     async def test_landscape_aspect_picks_wide_size(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", aspect_ratio="16:9"))
 
         # 16:9 精确，受 2048² 预算夹取 → 2560*1440
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "2560*1440"
+        assert _sent_size(route) == "2560*1440"
 
     async def test_qwen_fusion_custom_pixel_strips_embedded_ratio(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
@@ -216,7 +183,7 @@ class TestTextToImage:
                 )
             )
 
-        size = client.post.call_args.kwargs["json"]["parameters"]["size"]
+        size = _sent_size(route)
         w, h = (int(x) for x in size.split("*"))
         assert w * 16 == h * 9 and w < h  # 精确 9:16，非输入的 16:9
         assert size == "1440*2560"
@@ -224,11 +191,9 @@ class TestTextToImage:
 
 class TestEditSeriesSize:
     async def test_edit_plus_precise_size_within_per_dim_limit(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         ref = _make_ref(tmp_path, "ref.png")
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             # 编辑系列宽高均 ∈ [512, 2048]：9:16 受 max_long_edge=2048 收口 → 1152*2048（精确）
@@ -239,7 +204,7 @@ class TestEditSeriesSize:
                 )
             )
 
-        size = client.post.call_args.kwargs["json"]["parameters"]["size"]
+        size = _sent_size(route)
         w, h = (int(x) for x in size.split("*"))
         assert w * 16 == h * 9 and max(w, h) <= 2048
         assert size == "1152*2048"
@@ -247,11 +212,9 @@ class TestEditSeriesSize:
 
 class TestImageToImage:
     async def test_i2i_content_with_images(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         ref = _make_ref(tmp_path, "ref.png")
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
@@ -259,37 +222,33 @@ class TestImageToImage:
                 ImageGenerationRequest(prompt="edit it", output_path=tmp_path / "o.png", reference_images=[ref])
             )
 
-        content = client.post.call_args.kwargs["json"]["input"]["messages"][0]["content"]
+        content = request_json(only_request(route))["input"]["messages"][0]["content"]
         assert content[0]["image"].startswith("data:image/png;base64,")
         assert content[-1] == {"text": "edit it"}
 
     async def test_qwen_ref_limit_3(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(5)]
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=refs))
 
-        content = client.post.call_args.kwargs["json"]["input"]["messages"][0]["content"]
+        content = request_json(only_request(route))["input"]["messages"][0]["content"]
         images = [c for c in content if "image" in c]
         assert len(images) == 3  # qwen 上限裁剪
 
     async def test_wan_ref_limit_9(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(11)]
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image-pro")
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=refs))
 
-        content = client.post.call_args.kwargs["json"]["input"]["messages"][0]["content"]
+        content = request_json(only_request(route))["input"]["messages"][0]["content"]
         images = [c for c in content if "image" in c]
         assert len(images) == 9
 
@@ -317,10 +276,8 @@ class TestCapabilityGating:
         assert ei.value.code == "image_dashscope_4k_t2i_only"
 
     async def test_wan_pro_4k_t2i_allowed(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image-pro")
@@ -328,7 +285,7 @@ class TestCapabilityGating:
             await b.generate(
                 ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", aspect_ratio="16:9", image_size="4K")
             )
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "3840*2160"
+        assert _sent_size(route) == "3840*2160"
 
     async def test_wan_non_pro_4k_t2i_raises(self, tmp_path: Path):
         from lib.image_backends.dashscope import DashScopeImageBackend
@@ -382,10 +339,8 @@ class TestCapabilityGating:
             assert ei.value.code == "image_dashscope_4k_t2i_only"
 
     async def test_narrow_size_within_budget_not_gated(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(_img_response(), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             # 窄幅尺寸总像素在 2048×2048 预算内（4096*512=2.1M < 4.19M）→ 门控不误拒
@@ -393,7 +348,7 @@ class TestCapabilityGating:
             # 当短边、比例由默认 aspect_ratio=9:16 决定（剥离自带的 8:1）。
             b = DashScopeImageBackend(api_key="sk", model="wan2.7-image")
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", image_size="4096*512"))
-        assert client.post.call_args.kwargs["json"]["parameters"]["size"] == "576*1024"
+        assert _sent_size(route) == "576*1024"
 
     async def test_all_refs_unreadable_oserror_raises(self, tmp_path: Path):
         from lib.image_backends.dashscope import DashScopeImageBackend
@@ -409,7 +364,6 @@ class TestCapabilityGating:
         assert ei.value.code == "image_reference_images_unreadable"
 
     async def test_partial_unreadable_refs_fail_loud(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         r1, r2 = _make_ref(tmp_path, "a.png"), _make_ref(tmp_path, "b.png")
 
@@ -418,8 +372,10 @@ class TestCapabilityGating:
                 raise OSError("io error")
             return "data:image/png;base64,OK"
 
-        p1, p2 = _patches(client, download)
-        with p1, p2, patch("lib.image_backends.dashscope.image_to_data_uri", side_effect=fake_uri):
+        with (
+            _generate_route(_img_response(), download) as route,
+            patch("lib.image_backends.dashscope.image_to_data_uri", side_effect=fake_uri),
+        ):
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
@@ -430,7 +386,7 @@ class TestCapabilityGating:
                 )
         assert ei.value.code == "image_reference_images_unreadable"
         assert "a.png" in ei.value.params["names"]
-        client.post.assert_not_called()
+        assert route.call_count == 0
 
     async def test_unreadable_names_locale_neutral_separator(self, tmp_path: Path):
         from lib.image_backends.dashscope import DashScopeImageBackend
@@ -449,10 +405,8 @@ class TestCapabilityGating:
 
 class TestErrorResponse:
     async def test_http_error_surfaces_httpstatuserror(self, tmp_path: Path):
-        client = _mock_client(_error_response(400))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(httpx.Response(400, text="bad request"), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
@@ -460,36 +414,33 @@ class TestErrorResponse:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # raise_for_status 透出保留状态码：4xx fail-fast，不再吞成无状态码的 RuntimeError
         assert ei.value.response.status_code == 400
-        assert client.post.call_count == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
-    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, monkeypatch):
-        # 4xx 错误消息带 "503" 子串（请求 URL/task_id）：旧字符串兜底会据此误判重试到超时，
-        # 新状态码谓词只读 response.status_code，按 400 fail-fast——计费的建图 POST 只发一次、不连带下载。
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
-        resp = MagicMock()
-        resp.status_code = 400
-        resp.raise_for_status = MagicMock(side_effect=_http_error_transient_substring(400))
-        client = _mock_client(resp)
+    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path):
+        # 4xx 但 raise_for_status 的消息带请求 URL、URL 恰好含 "503" 子串：旧字符串兜底会据此
+        # 误判重试到超时，新状态码谓词只读 response.status_code，按 400 fail-fast——计费的建图
+        # POST 只发一次、不连带下载。
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        host = "https://dashscope-503.example.com"
+        with (
+            bounded_poll_clock(),
+            _generate_route(httpx.Response(400, text="bad request"), download, host=host) as route,
+        ):
             from lib.image_backends.dashscope import DashScopeImageBackend
 
-            b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
+            b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0", base_url=host)
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # 异常字符串确实带瞬态子串（旧兜底据此误判重试的前提）；新谓词按状态码单次 fail-fast
         assert "503" in str(ei.value)
         assert ei.value.response.status_code == 400
-        assert client.post.call_count == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
     async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
-        client = _mock_client(_error_response(413))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generate_route(httpx.Response(413, text="Request Entity Too Large"), download) as route:
             from lib.image_backends.dashscope import DashScopeImageBackend
 
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
@@ -497,5 +448,5 @@ class TestErrorResponse:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # 保留 status_code 让咽喉层识别 413 走降档；413 不在 retryable 模式中 → fail-fast 单次
         assert ei.value.response.status_code == 413
-        assert client.post.call_count == 1
+        assert route.call_count == 1
         download.assert_not_called()

--- a/tests/unit/lib/image_backends/test_dashscope_image_backend.py
+++ b/tests/unit/lib/image_backends/test_dashscope_image_backend.py
@@ -412,15 +412,15 @@ class TestErrorResponse:
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0")
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
-        # raise_for_status 透出保留状态码：4xx fail-fast，不再吞成无状态码的 RuntimeError
+        # raise_for_status 透出保留状态码：4xx fail-fast
         assert ei.value.response.status_code == 400
         assert route.call_count == 1
         download.assert_not_called()
 
     async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path):
-        # 4xx 但 raise_for_status 的消息带请求 URL、URL 恰好含 "503" 子串：旧字符串兜底会据此
-        # 误判重试到超时，新状态码谓词只读 response.status_code，按 400 fail-fast——计费的建图
-        # POST 只发一次、不连带下载。
+        # 4xx 但 raise_for_status 的消息带请求 URL、URL 恰好含 "503" 子串：瞬态判定只读
+        # response.status_code，不看异常字符串，按 400 fail-fast——计费的建图 POST 只发一次、
+        # 不连带下载。
         download = AsyncMock()
         host = "https://dashscope-503.example.com"
         with (
@@ -432,7 +432,7 @@ class TestErrorResponse:
             b = DashScopeImageBackend(api_key="sk", model="qwen-image-2.0", base_url=host)
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
-        # 异常字符串确实带瞬态子串（旧兜底据此误判重试的前提）；新谓词按状态码单次 fail-fast
+        # 异常字符串确实带瞬态子串，而瞬态判定只认状态码，故仍单次 fail-fast
         assert "503" in str(ei.value)
         assert ei.value.response.status_code == 400
         assert route.call_count == 1

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -22,7 +22,7 @@ def _patch_xai_sdk():
 
 
 @pytest.fixture()
-def backend(_patch_xai_sdk):
+def grok_backend(_patch_xai_sdk):
     from lib.image_backends.grok import GrokImageBackend
 
     return GrokImageBackend(api_key="fake-xai-key")
@@ -41,17 +41,17 @@ def backend_pro(_patch_xai_sdk):
 
 
 class TestProperties:
-    def test_name(self, backend):
-        assert backend.name == "grok"
+    def test_name(self, grok_backend):
+        assert grok_backend.name == "grok"
 
-    def test_model_default(self, backend):
-        assert backend.model == "grok-imagine-image"
+    def test_model_default(self, grok_backend):
+        assert grok_backend.model == "grok-imagine-image"
 
     def test_model_custom(self, backend_pro):
         assert backend_pro.model == "grok-imagine-image-pro"
 
-    def test_capabilities(self, backend):
-        assert backend.capabilities == {
+    def test_capabilities(self, grok_backend):
+        assert grok_backend.capabilities == {
             ImageCapability.TEXT_TO_IMAGE,
             ImageCapability.IMAGE_TO_IMAGE,
         }
@@ -84,13 +84,13 @@ class TestInit:
 
 
 class TestGenerateT2I:
-    async def test_t2i_calls_image_sample(self, backend, tmp_path):
+    async def test_t2i_calls_image_sample(self, grok_backend, tmp_path):
         """T2I 调用 client.image.sample 并下载结果。"""
         output = tmp_path / "output.png"
         mock_response = MagicMock()
         mock_response.respect_moderation = True
         mock_response.url = "https://example.com/generated.png"
-        backend._client.image.sample = AsyncMock(return_value=mock_response)
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 
@@ -109,10 +109,10 @@ class TestGenerateT2I:
                 aspect_ratio="16:9",
                 image_size="2K",
             )
-            result = await backend.generate(request)
+            result = await grok_backend.generate(request)
 
         # 验证 SDK 调用参数（image_size 透传，不再做小写映射）
-        backend._client.image.sample.assert_awaited_once_with(
+        grok_backend._client.image.sample.assert_awaited_once_with(
             prompt="A beautiful sunset",
             model="grok-imagine-image",
             aspect_ratio="16:9",
@@ -132,7 +132,7 @@ class TestGenerateT2I:
 
 
 class TestGenerateI2I:
-    async def test_i2i_sends_image_urls(self, backend, tmp_path):
+    async def test_i2i_sends_image_urls(self, grok_backend, tmp_path):
         """I2I 将参考图转为 data URI 列表传给 image_urls。"""
         ref_image = tmp_path / "ref.png"
         ref_image.write_bytes(b"\x89PNG\r\n\x1a\nfake_png_data")
@@ -141,7 +141,7 @@ class TestGenerateI2I:
         mock_response = MagicMock()
         mock_response.respect_moderation = True
         mock_response.url = "https://example.com/edited.png"
-        backend._client.image.sample = AsyncMock(return_value=mock_response)
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
@@ -159,16 +159,16 @@ class TestGenerateI2I:
                 output_path=output,
                 reference_images=[ReferenceImage(path=str(ref_image), label="base")],
             )
-            result = await backend.generate(request)
+            result = await grok_backend.generate(request)
 
-        call_kwargs = backend._client.image.sample.call_args.kwargs
+        call_kwargs = grok_backend._client.image.sample.call_args.kwargs
         assert "image_urls" in call_kwargs
         assert "image_url" not in call_kwargs
         assert len(call_kwargs["image_urls"]) == 1
         assert call_kwargs["image_urls"][0].startswith("data:image/png;base64,")
         assert result.provider == "grok"
 
-    async def test_i2i_multiple_refs(self, backend, tmp_path):
+    async def test_i2i_multiple_refs(self, grok_backend, tmp_path):
         """多张参考图全部通过 image_urls 传递。"""
         ref1 = tmp_path / "ref1.png"
         ref1.write_bytes(b"\x89PNG\r\n\x1a\nfake1")
@@ -179,7 +179,7 @@ class TestGenerateI2I:
         mock_response = MagicMock()
         mock_response.respect_moderation = True
         mock_response.url = "https://example.com/merged.png"
-        backend._client.image.sample = AsyncMock(return_value=mock_response)
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
@@ -200,18 +200,18 @@ class TestGenerateI2I:
                     ReferenceImage(path=str(ref2)),
                 ],
             )
-            await backend.generate(request)
+            await grok_backend.generate(request)
 
-        call_kwargs = backend._client.image.sample.call_args.kwargs
+        call_kwargs = grok_backend._client.image.sample.call_args.kwargs
         assert len(call_kwargs["image_urls"]) == 2
 
-    async def test_i2i_skips_missing_ref(self, backend, tmp_path):
+    async def test_i2i_skips_missing_ref(self, grok_backend, tmp_path):
         """参考图不存在时退化为 T2I。"""
         output = tmp_path / "output.png"
         mock_response = MagicMock()
         mock_response.respect_moderation = True
         mock_response.url = "https://example.com/generated.png"
-        backend._client.image.sample = AsyncMock(return_value=mock_response)
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n"
 
@@ -229,9 +229,9 @@ class TestGenerateI2I:
                 output_path=output,
                 reference_images=[ReferenceImage(path="/nonexistent/ref.png")],
             )
-            await backend.generate(request)
+            await grok_backend.generate(request)
 
-        call_kwargs = backend._client.image.sample.call_args.kwargs
+        call_kwargs = grok_backend._client.image.sample.call_args.kwargs
         assert "image_urls" not in call_kwargs
         assert "image_url" not in call_kwargs
 
@@ -242,19 +242,19 @@ class TestGenerateI2I:
 
 
 class TestModeration:
-    async def test_moderation_failure_raises(self, backend, tmp_path):
+    async def test_moderation_failure_raises(self, grok_backend, tmp_path):
         """respect_moderation=False 时抛出 RuntimeError。"""
         output = tmp_path / "output.png"
         mock_response = MagicMock()
         mock_response.respect_moderation = False
-        backend._client.image.sample = AsyncMock(return_value=mock_response)
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
 
         request = ImageGenerationRequest(
             prompt="Something problematic",
             output_path=output,
         )
         with pytest.raises(RuntimeError, match="内容审核"):
-            await backend.generate(request)
+            await grok_backend.generate(request)
 
 
 # ---------------------------------------------------------------------------
@@ -264,14 +264,14 @@ class TestModeration:
 
 class TestResolutionPassthrough:
     @pytest.mark.asyncio
-    async def test_image_size_none_omits_resolution_kwarg(self, backend, tmp_path):
+    async def test_image_size_none_omits_resolution_kwarg(self, grok_backend, tmp_path):
         captured: dict = {}
 
         async def fake_sample(**kwargs):
             captured.update(kwargs)
             raise RuntimeError("stop")
 
-        backend._client.image.sample = fake_sample
+        grok_backend._client.image.sample = fake_sample
         request = ImageGenerationRequest(
             prompt="hi",
             output_path=tmp_path / "o.png",
@@ -279,19 +279,19 @@ class TestResolutionPassthrough:
             image_size=None,
         )
         with pytest.raises(RuntimeError):
-            await backend.generate(request)
+            await grok_backend.generate(request)
 
         assert "resolution" not in captured
 
     @pytest.mark.asyncio
-    async def test_image_size_passed_as_is(self, backend, tmp_path):
+    async def test_image_size_passed_as_is(self, grok_backend, tmp_path):
         captured: dict = {}
 
         async def fake_sample(**kwargs):
             captured.update(kwargs)
             raise RuntimeError("stop")
 
-        backend._client.image.sample = fake_sample
+        grok_backend._client.image.sample = fake_sample
         request = ImageGenerationRequest(
             prompt="hi",
             output_path=tmp_path / "o.png",
@@ -299,7 +299,7 @@ class TestResolutionPassthrough:
             image_size="2K",
         )
         with pytest.raises(RuntimeError):
-            await backend.generate(request)
+            await grok_backend.generate(request)
 
         assert captured["resolution"] == "2K"
 

--- a/tests/unit/lib/image_backends/test_vidu_image_backend.py
+++ b/tests/unit/lib/image_backends/test_vidu_image_backend.py
@@ -24,7 +24,7 @@ from lib.providers import PROVIDER_VIDU
 
 
 @pytest.fixture
-def output_path(tmp_path: Path) -> Path:
+def image_output_path(tmp_path: Path) -> Path:
     return tmp_path / "out.png"
 
 
@@ -76,13 +76,15 @@ class TestWhitelistConfig:
 
 
 class TestCapabilityMismatchRaises:
-    async def test_q1_without_refs_rejects_t2i(self, output_path: Path):
+    async def test_q1_without_refs_rejects_t2i(self, image_output_path: Path):
         backend = ViduImageBackend(api_key="test-key", model="viduq1")
-        request = ImageGenerationRequest(prompt="hello", output_path=output_path)
+        request = ImageGenerationRequest(prompt="hello", output_path=image_output_path)
         with pytest.raises(ImageCapabilityError):
             await backend.generate(request)
 
-    async def test_q2_with_refs_path_does_not_raise_capability(self, tmp_path: Path, output_path: Path, monkeypatch):
+    async def test_q2_with_refs_path_does_not_raise_capability(
+        self, tmp_path: Path, image_output_path: Path, monkeypatch
+    ):
         # 仅校验 capability 检查不会先拦下来；实际生成走 mock。
         # 让 create_vidu_client 抛错是为了快速短路，避免真正发请求。
         from lib.image_backends import vidu as mod
@@ -96,7 +98,7 @@ class TestCapabilityMismatchRaises:
         backend = ViduImageBackend(api_key="test-key", model="viduq2")
         request = ImageGenerationRequest(
             prompt="hello",
-            output_path=output_path,
+            output_path=image_output_path,
             reference_images=[ReferenceImage(path=str(ref_file))],
         )
         # 不应是 ImageCapabilityError；应是我们注入的 RuntimeError

--- a/tests/unit/lib/test_accounting_characterization.py
+++ b/tests/unit/lib/test_accounting_characterization.py
@@ -28,11 +28,10 @@ from typing import Any, cast
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 from lib.audio_backends.base import AudioCapability, AudioSynthesisRequest, AudioSynthesisResult
 from lib.config.resolver import ConfigResolver
-from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
 from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
@@ -111,14 +110,8 @@ class _AccountingDb:
 
 
 @pytest.fixture
-async def acct(frozen_clock: _SteppingClock) -> Any:
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    db = _AccountingDb(engine=engine, factory=factory)
-    yield db
-    await engine.dispose()
+async def acct(frozen_clock: _SteppingClock, db_engine: AsyncEngine, db_factory) -> Any:
+    return _AccountingDb(engine=db_engine, factory=db_factory)
 
 
 def _assert_full_row(actual: dict[str, Any], expected: dict[str, Any]) -> None:

--- a/tests/unit/lib/test_asset_name_validation.py
+++ b/tests/unit/lib/test_asset_name_validation.py
@@ -131,7 +131,7 @@ class TestResolveAssetKey:
 
 
 @pytest.fixture
-def pm(tmp_path):
+def demo_pm(tmp_path):
     manager = ProjectManager(tmp_path / "projects")
     manager.create_project("demo")
     manager.create_project_metadata("demo", "Demo")
@@ -139,105 +139,105 @@ def pm(tmp_path):
 
 
 class TestProjectManagerCreationEntryPoints:
-    def test_add_character_rejects_slash(self, pm):
+    def test_add_character_rejects_slash(self, demo_pm):
         with pytest.raises(ValueError):
-            pm.add_character("demo", "李白/诗人", "desc")
-        assert "李白/诗人" not in pm.load_project("demo")["characters"]
+            demo_pm.add_character("demo", "李白/诗人", "desc")
+        assert "李白/诗人" not in demo_pm.load_project("demo")["characters"]
 
-    def test_add_project_character_rejects_slash(self, pm):
+    def test_add_project_character_rejects_slash(self, demo_pm):
         with pytest.raises(ValueError):
-            pm.add_project_character("demo", "李白/诗人", "desc")
+            demo_pm.add_project_character("demo", "李白/诗人", "desc")
 
-    def test_add_batch_rejects_slash(self, pm):
+    def test_add_batch_rejects_slash(self, demo_pm):
         with pytest.raises(ValueError):
-            pm.add_scenes_batch("demo", {"庙/宇": {"description": "d"}})
-        assert "庙/宇" not in pm.load_project("demo").get("scenes", {})
+            demo_pm.add_scenes_batch("demo", {"庙/宇": {"description": "d"}})
+        assert "庙/宇" not in demo_pm.load_project("demo").get("scenes", {})
 
-    def test_add_batch_rejects_normalized_collision(self, pm):
+    def test_add_batch_rejects_normalized_collision(self, demo_pm):
         """strip 后等价的两个 key 不允许静默覆盖，整批 fail-loud 不落盘（与 upsert_assets 一致）。"""
         with pytest.raises(ValueError, match="冲突"):
-            pm.add_scenes_batch("demo", {"庙宇": {"description": "a"}, "  庙宇  ": {"description": "b"}})
-        assert "庙宇" not in pm.load_project("demo").get("scenes", {})
+            demo_pm.add_scenes_batch("demo", {"庙宇": {"description": "a"}, "  庙宇  ": {"description": "b"}})
+        assert "庙宇" not in demo_pm.load_project("demo").get("scenes", {})
 
-    def test_upsert_assets_rejects_slash(self, pm):
+    def test_upsert_assets_rejects_slash(self, demo_pm):
         with pytest.raises(ValueError):
-            pm.upsert_assets("demo", "props", {"玉/佩": {"description": "d"}})
-        assert "玉/佩" not in pm.load_project("demo").get("props", {})
+            demo_pm.upsert_assets("demo", "props", {"玉/佩": {"description": "d"}})
+        assert "玉/佩" not in demo_pm.load_project("demo").get("props", {})
 
-    def test_add_asset_strips_name(self, pm):
-        assert pm.add_character("demo", "  李白  ", "desc") is True
-        chars = pm.load_project("demo")["characters"]
+    def test_add_asset_strips_name(self, demo_pm):
+        assert demo_pm.add_character("demo", "  李白  ", "desc") is True
+        chars = demo_pm.load_project("demo")["characters"]
         assert "李白" in chars
         assert "  李白  " not in chars
 
-    def test_legal_names_still_work(self, pm):
-        assert pm.add_character("demo", "李白", "desc") is True
-        result = pm.upsert_assets("demo", "scenes", {"庙宇": {"description": "d"}})
+    def test_legal_names_still_work(self, demo_pm):
+        assert demo_pm.add_character("demo", "李白", "desc") is True
+        result = demo_pm.upsert_assets("demo", "scenes", {"庙宇": {"description": "d"}})
         assert "庙宇" in result["added"]
-        assert pm.add_props_batch("demo", {"玉佩": {"description": "d"}}) == 1
+        assert demo_pm.add_props_batch("demo", {"玉佩": {"description": "d"}}) == 1
 
 
-def _seed_nfd_character(pm: ProjectManager) -> None:
+def _seed_nfd_character(demo_pm: ProjectManager) -> None:
     """绕过登记闸口直写 NFD key，模拟存量数据（存量无需迁移，读写按坐标系解析）。"""
 
     def _mutate(project: dict) -> None:
         project.setdefault("characters", {})[_NAME_NFD] = {"description": "legacy", "voice_style": ""}
 
-    pm.update_project("demo", _mutate)
+    demo_pm.update_project("demo", _mutate)
 
 
 class TestNfcConvergence:
-    def test_add_character_nfd_input_lands_nfc(self, pm):
-        assert pm.add_character("demo", _NAME_NFD, "desc") is True
-        chars = pm.load_project("demo")["characters"]
+    def test_add_character_nfd_input_lands_nfc(self, demo_pm):
+        assert demo_pm.add_character("demo", _NAME_NFD, "desc") is True
+        chars = demo_pm.load_project("demo")["characters"]
         assert _NAME_NFC in chars
         assert _NAME_NFD not in chars
 
-    def test_add_character_nfc_input_skips_nfd_registered(self, pm):
-        _seed_nfd_character(pm)
-        assert pm.add_character("demo", _NAME_NFC, "desc") is False
-        chars = pm.load_project("demo")["characters"]
+    def test_add_character_nfc_input_skips_nfd_registered(self, demo_pm):
+        _seed_nfd_character(demo_pm)
+        assert demo_pm.add_character("demo", _NAME_NFC, "desc") is False
+        chars = demo_pm.load_project("demo")["characters"]
         assert list(chars) == [_NAME_NFD]
 
-    def test_add_batch_rejects_nfc_nfd_collision(self, pm):
+    def test_add_batch_rejects_nfc_nfd_collision(self, demo_pm):
         with pytest.raises(ValueError, match="冲突"):
-            pm.add_scenes_batch("demo", {_NAME_NFC: {"description": "a"}, _NAME_NFD: {"description": "b"}})
-        assert pm.load_project("demo").get("scenes", {}) == {}
+            demo_pm.add_scenes_batch("demo", {_NAME_NFC: {"description": "a"}, _NAME_NFD: {"description": "b"}})
+        assert demo_pm.load_project("demo").get("scenes", {}) == {}
 
-    def test_add_batch_nfc_input_skips_nfd_registered(self, pm):
-        _seed_nfd_character(pm)
-        assert pm.add_characters_batch("demo", {_NAME_NFC: {"description": "new"}}) == 0
-        chars = pm.load_project("demo")["characters"]
+    def test_add_batch_nfc_input_skips_nfd_registered(self, demo_pm):
+        _seed_nfd_character(demo_pm)
+        assert demo_pm.add_characters_batch("demo", {_NAME_NFC: {"description": "new"}}) == 0
+        chars = demo_pm.load_project("demo")["characters"]
         assert list(chars) == [_NAME_NFD]
         assert chars[_NAME_NFD]["description"] == "legacy"
 
-    def test_upsert_nfc_updates_nfd_registered_entry_in_place(self, pm):
-        _seed_nfd_character(pm)
-        result = pm.upsert_assets("demo", "characters", {_NAME_NFC: {"description": "updated"}})
+    def test_upsert_nfc_updates_nfd_registered_entry_in_place(self, demo_pm):
+        _seed_nfd_character(demo_pm)
+        result = demo_pm.upsert_assets("demo", "characters", {_NAME_NFC: {"description": "updated"}})
         assert result["merged"] == [_NAME_NFC]
-        chars = pm.load_project("demo")["characters"]
+        chars = demo_pm.load_project("demo")["characters"]
         assert list(chars) == [_NAME_NFD]
         assert chars[_NAME_NFD]["description"] == "updated"
 
-    def test_update_reference_audio_resolves_nfd_registered_key(self, pm):
-        _seed_nfd_character(pm)
-        pm.update_character_reference_audio("demo", _NAME_NFC, "characters/refs_audio/x.wav")
-        chars = pm.load_project("demo")["characters"]
+    def test_update_reference_audio_resolves_nfd_registered_key(self, demo_pm):
+        _seed_nfd_character(demo_pm)
+        demo_pm.update_character_reference_audio("demo", _NAME_NFC, "characters/refs_audio/x.wav")
+        chars = demo_pm.load_project("demo")["characters"]
         assert list(chars) == [_NAME_NFD]
         assert chars[_NAME_NFD]["reference_audio"] == "characters/refs_audio/x.wav"
 
-    def test_collect_reference_images_matches_across_forms(self, pm):
+    def test_collect_reference_images_matches_across_forms(self, demo_pm):
         """剧本里的名字与桶 key 形态可以不同（登记闸口落 NFC，剧本原文未归一）。"""
-        pm.add_character("demo", _NAME_NFD, "desc")
+        demo_pm.add_character("demo", _NAME_NFD, "desc")
         sheet = "characters/sheet.png"
-        sheet_path = pm.get_project_path("demo") / sheet
+        sheet_path = demo_pm.get_project_path("demo") / sheet
         sheet_path.parent.mkdir(parents=True, exist_ok=True)
         sheet_path.write_bytes(b"png")
 
         def _mutate(project: dict) -> None:
             project["characters"][_NAME_NFC]["character_sheet"] = sheet
 
-        pm.update_project("demo", _mutate)
+        demo_pm.update_project("demo", _mutate)
 
-        refs = pm.collect_reference_images("demo", {"characters_in_scene": [_NAME_NFD]})
+        refs = demo_pm.collect_reference_images("demo", {"characters_in_scene": [_NAME_NFD]})
         assert refs == [sheet_path]

--- a/tests/unit/lib/test_asset_rename.py
+++ b/tests/unit/lib/test_asset_rename.py
@@ -140,7 +140,7 @@ def _reference_script(episode: int = 1) -> dict[str, Any]:
 
 
 @pytest.fixture
-def pm(tmp_path: Path) -> ProjectManager:
+def pm_with_assets(tmp_path: Path) -> ProjectManager:
     manager = ProjectManager(str(tmp_path))
     manager.create_project("demo")
     manager.create_project_metadata("demo", "Demo", "Anime", "narration")
@@ -150,12 +150,12 @@ def pm(tmp_path: Path) -> ProjectManager:
     return manager
 
 
-def _project_dir(pm: ProjectManager) -> Path:
-    return pm.get_project_path("demo")
+def _project_dir(pm_with_assets: ProjectManager) -> Path:
+    return pm_with_assets.get_project_path("demo")
 
 
-def _load_script(pm: ProjectManager) -> dict[str, Any]:
-    return pm.load_script("demo", "episode_1.json")
+def _load_script(pm_with_assets: ProjectManager) -> dict[str, Any]:
+    return pm_with_assets.load_script("demo", "episode_1.json")
 
 
 class TestRewritePayloadReferences:
@@ -272,11 +272,11 @@ class TestRewritePayloadReferences:
 
 
 class TestRenameAssetCascade:
-    def test_character_rename_cascades_across_modes(self, pm: ProjectManager) -> None:
-        pm.save_script("demo", _narration_script(), "episode_1.json")
-        pm.save_script("demo", _reference_script(2), "episode_2.json")
+    def test_character_rename_cascades_across_modes(self, pm_with_assets: ProjectManager) -> None:
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
+        pm_with_assets.save_script("demo", _reference_script(2), "episode_2.json")
 
-        project_dir = _project_dir(pm)
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"png")
         ref_dir = project_dir / "characters" / "refs"
@@ -288,15 +288,15 @@ class TestRenameAssetCascade:
             entry["character_sheet"] = "characters/角色A.png"
             entry["reference_image"] = "characters/refs/角色A.png"
 
-        pm.update_project("demo", _set_paths)
+        pm_with_assets.update_project("demo", _set_paths)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert report.episodes == 2
         assert report.references == 2  # 分段引用数组 + 单元正文 mention
         assert report.files == 2
 
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         assert "角色A" not in project["characters"]
         entry = project["characters"]["主角甲"]
         assert entry["character_sheet"] == "characters/主角甲.png"
@@ -305,23 +305,23 @@ class TestRenameAssetCascade:
         assert not sheet.exists()
         assert (ref_dir / "主角甲.png").exists()
 
-        assert _load_script(pm)["segments"][0]["characters_in_segment"] == ["主角甲"]
-        unit = pm.load_script("demo", "episode_2.json")["video_units"][0]
+        assert _load_script(pm_with_assets)["segments"][0]["characters_in_segment"] == ["主角甲"]
+        unit = pm_with_assets.load_script("demo", "episode_2.json")["video_units"][0]
         assert unit["text"] == "@[主角甲] 走进 @[场景A]"
 
-    def test_rename_keeps_reference_integrity(self, pm: ProjectManager) -> None:
+    def test_rename_keeps_reference_integrity(self, pm_with_assets: ProjectManager) -> None:
         from lib.data_validator import DataValidator
 
-        pm.save_script("demo", _narration_script(), "episode_1.json")
-        pm.rename_asset("demo", "scenes", "场景A", "新场景")
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
+        pm_with_assets.rename_asset("demo", "scenes", "场景A", "新场景")
 
-        validator = DataValidator(str(pm.projects_root))
+        validator = DataValidator(str(pm_with_assets.projects_root))
         result = validator.validate_episode("demo", "episode_1.json")
         assert not [e for e in result.errors if "新场景" in e or "场景A" in e]
-        assert _load_script(pm)["segments"][0]["scenes"] == ["新场景"]
+        assert _load_script(pm_with_assets)["segments"][0]["scenes"] == ["新场景"]
 
-    def test_step1_draft_rewritten(self, pm: ProjectManager) -> None:
-        draft_dir = _project_dir(pm) / "drafts" / "episode_1"
+    def test_step1_draft_rewritten(self, pm_with_assets: ProjectManager) -> None:
+        draft_dir = _project_dir(pm_with_assets) / "drafts" / "episode_1"
         draft_dir.mkdir(parents=True)
         draft = {
             "units": [
@@ -334,17 +334,17 @@ class TestRenameAssetCascade:
         }
         atomic_write_json(draft_dir / "step1_reference_units.json", draft)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert report.episodes == 1
         assert report.references == 1
         saved = json.loads((draft_dir / "step1_reference_units.json").read_text(encoding="utf-8"))
         assert saved["units"][0]["text"] == "@[主角甲] 在河边"
 
-    def test_sibling_with_numeric_suffix_untouched(self, pm: ProjectManager) -> None:
+    def test_sibling_with_numeric_suffix_untouched(self, pm_with_assets: ProjectManager) -> None:
         """``旧名_2`` 是合法资产名：兄弟资产的资产图不得被序号形态的 stem 匹配卷走。"""
-        pm.upsert_assets("demo", "characters", {"角色A_2": {"description": "副手"}})
-        project_dir = _project_dir(pm)
+        pm_with_assets.upsert_assets("demo", "characters", {"角色A_2": {"description": "副手"}})
+        project_dir = _project_dir(pm_with_assets)
         sibling = project_dir / "characters" / "角色A_2.png"
         sibling.write_bytes(b"sibling")
         (project_dir / "characters" / "角色A.png").write_bytes(b"png")
@@ -353,25 +353,25 @@ class TestRenameAssetCascade:
             project["characters"]["角色A"]["character_sheet"] = "characters/角色A.png"
             project["characters"]["角色A_2"]["character_sheet"] = "characters/角色A_2.png"
 
-        pm.update_project("demo", _set_paths)
+        pm_with_assets.update_project("demo", _set_paths)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert report.files == 1
         assert sibling.exists()
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         assert project["characters"]["角色A_2"]["character_sheet"] == "characters/角色A_2.png"
         assert project["characters"]["主角甲"]["character_sheet"] == "characters/主角甲.png"
 
     def test_product_sequenced_files_and_paths(self, tmp_path: Path) -> None:
-        pm = ProjectManager(str(tmp_path))
-        pm.create_project("demo", content_mode="ad")
-        pm.create_project_metadata("demo", "Demo", "Anime", "ad")
-        pm.upsert_assets("demo", "products", {"商品A": {"description": "饮料"}})
-        pm.upsert_assets("demo", "characters", {"角色A": {"description": "代言人"}})
-        pm.save_script("demo", _ad_script(), "episode_1.json")
+        pm_with_assets = ProjectManager(str(tmp_path))
+        pm_with_assets.create_project("demo", content_mode="ad")
+        pm_with_assets.create_project_metadata("demo", "Demo", "Anime", "ad")
+        pm_with_assets.upsert_assets("demo", "products", {"商品A": {"description": "饮料"}})
+        pm_with_assets.upsert_assets("demo", "characters", {"角色A": {"description": "代言人"}})
+        pm_with_assets.save_script("demo", _ad_script(), "episode_1.json")
 
-        project_dir = pm.get_project_path("demo")
+        project_dir = pm_with_assets.get_project_path("demo")
         refs = project_dir / "products" / "refs"
         refs.mkdir(parents=True)
         (refs / "商品A_1.png").write_bytes(b"a")
@@ -383,30 +383,30 @@ class TestRenameAssetCascade:
                 "products/refs/商品A_2.png",
             ]
 
-        pm.update_project("demo", _set_paths)
+        pm_with_assets.update_project("demo", _set_paths)
 
-        report = pm.rename_asset("demo", "products", "商品A", "爆款")
+        report = pm_with_assets.rename_asset("demo", "products", "商品A", "爆款")
 
         assert report.files == 2
         assert sorted(f.name for f in refs.iterdir() if f.is_file() and not f.name.startswith(".")) == [
             "爆款_1.png",
             "爆款_2.png",
         ]
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         assert project["products"]["爆款"]["reference_images"] == [
             "products/refs/爆款_1.png",
             "products/refs/爆款_2.png",
         ]
-        assert pm.load_script("demo", "episode_1.json")["shots"][0]["products_in_shot"] == ["爆款"]
+        assert pm_with_assets.load_script("demo", "episode_1.json")["shots"][0]["products_in_shot"] == ["爆款"]
 
-    def test_version_history_migrated(self, pm: ProjectManager) -> None:
-        project_dir = _project_dir(pm)
+    def test_version_history_migrated(self, pm_with_assets: ProjectManager) -> None:
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"v1")
         vm = VersionManager(project_dir)
         vm.add_version("characters", "角色A", "第一版", source_file=sheet)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert report.files == 2  # sheet + 1 个版本快照
         info = vm.get_versions("characters", "主角甲")
@@ -416,11 +416,11 @@ class TestRenameAssetCascade:
         assert version_file.name.startswith("主角甲_v1_")
         assert vm.get_versions("characters", "角色A") == {"current_version": 0, "versions": []}
 
-    def test_active_manifest_claim_migrates_with_sheet_identity(self, pm: ProjectManager) -> None:
-        project_dir = _project_dir(pm)
+    def test_active_manifest_claim_migrates_with_sheet_identity(self, pm_with_assets: ProjectManager) -> None:
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"current-sheet")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"]["角色A"].update({"character_sheet": "characters/角色A.png"}),
         )
@@ -432,7 +432,7 @@ class TestRenameAssetCascade:
         )
         adapter.put_entry(old_key, old_entry)
 
-        pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert adapter.get_entry(old_key) is None
         assert adapter.get_entry(ArtifactKey.asset_sheet("character", "主角甲")) == ArtifactManifestEntry(
@@ -442,13 +442,13 @@ class TestRenameAssetCascade:
 
     def test_project_binding_commits_before_manifest_claim_rekey(
         self,
-        pm: ProjectManager,
+        pm_with_assets: ProjectManager,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        project_dir = _project_dir(pm)
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"current-sheet")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"]["角色A"].update({"character_sheet": "characters/角色A.png"}),
         )
@@ -466,17 +466,17 @@ class TestRenameAssetCascade:
 
         monkeypatch.setattr(ArtifactEntryRekeyPlan, "commit", _commit)
 
-        pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert "主角甲" in project_seen_during_commit["characters"]
         assert "角色A" not in project_seen_during_commit["characters"]
 
-    def test_retry_recovers_claim_after_project_binding_committed_first(self, pm: ProjectManager) -> None:
-        project_dir = _project_dir(pm)
+    def test_retry_recovers_claim_after_project_binding_committed_first(self, pm_with_assets: ProjectManager) -> None:
+        project_dir = _project_dir(pm_with_assets)
         old_sheet = project_dir / "characters" / "角色A.png"
         new_sheet = project_dir / "characters" / "主角甲.png"
         old_sheet.write_bytes(b"current-sheet")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"]["角色A"].update({"character_sheet": "characters/角色A.png"}),
         )
@@ -495,9 +495,9 @@ class TestRenameAssetCascade:
             entry["character_sheet"] = "characters/主角甲.png"
             characters["主角甲"] = entry
 
-        pm.update_project("demo", _commit_project_binding)
+        pm_with_assets.update_project("demo", _commit_project_binding)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert (report.episodes, report.references, report.files, report.dry_run) == (0, 0, 0, False)
         assert adapter.get_entry(old_key) is None
@@ -508,13 +508,13 @@ class TestRenameAssetCascade:
 
     def test_project_write_failure_compensates_manifest_claim_rekey(
         self,
-        pm: ProjectManager,
+        pm_with_assets: ProjectManager,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        project_dir = _project_dir(pm)
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"current-sheet")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"]["角色A"].update({"character_sheet": "characters/角色A.png"}),
         )
@@ -535,22 +535,22 @@ class TestRenameAssetCascade:
         monkeypatch.setattr("lib.project_manager.atomic_write_json", _write_project_then_fail)
 
         with pytest.raises(OSError, match="project write failed"):
-            pm.rename_asset("demo", "characters", "角色A", "主角甲")
+            pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert adapter.get_entry(old_key) == old_entry
         assert adapter.get_entry(ArtifactKey.asset_sheet("character", "主角甲")) is None
         assert (project_dir / "project.json").read_bytes() == project_before
-        assert "角色A" in pm.load_project("demo")["characters"]
+        assert "角色A" in pm_with_assets.load_project("demo")["characters"]
 
     def test_manifest_rekey_retry_updates_path_after_the_file_move_already_completed(
         self,
-        pm: ProjectManager,
+        pm_with_assets: ProjectManager,
     ) -> None:
-        project_dir = _project_dir(pm)
+        project_dir = _project_dir(pm_with_assets)
         old_sheet = project_dir / "characters" / "角色A.png"
         new_sheet = project_dir / "characters" / "主角甲.png"
         old_sheet.write_bytes(b"current-sheet")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"]["角色A"].update({"character_sheet": "characters/角色A.png"}),
         )
@@ -563,7 +563,7 @@ class TestRenameAssetCascade:
         adapter.put_entry(old_key, old_entry)
         old_sheet.replace(new_sheet)
 
-        pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert adapter.get_entry(old_key) is None
         assert adapter.get_entry(ArtifactKey.asset_sheet("character", "主角甲")) == ArtifactManifestEntry(
@@ -571,27 +571,27 @@ class TestRenameAssetCascade:
             basis_digest=old_entry.basis_digest,
         )
 
-    def test_conflict_rejected_atomically(self, pm: ProjectManager) -> None:
-        pm.save_script("demo", _narration_script(), "episode_1.json")
+    def test_conflict_rejected_atomically(self, pm_with_assets: ProjectManager) -> None:
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
         nfd = unicodedata.normalize("NFD", "café")
 
         def _add_nfd_key(project: dict) -> None:
             project["characters"][nfd] = {"description": "存量 NFD key"}
 
-        pm.update_project("demo", _add_nfd_key)
+        pm_with_assets.update_project("demo", _add_nfd_key)
 
         with pytest.raises(AssetRenameConflictError) as exc_info:
-            pm.rename_asset("demo", "characters", "角色A", "café")
+            pm_with_assets.rename_asset("demo", "characters", "角色A", "café")
 
         assert exc_info.value.conflict_name == nfd
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         assert "角色A" in project["characters"]
-        assert _load_script(pm)["segments"][0]["characters_in_segment"] == ["角色A"]
+        assert _load_script(pm_with_assets)["segments"][0]["characters_in_segment"] == ["角色A"]
 
-    def test_orphan_destination_file_rejected_atomically(self, pm: ProjectManager) -> None:
+    def test_orphan_destination_file_rejected_atomically(self, pm_with_assets: ProjectManager) -> None:
         """新名下的孤儿文件没有对应资产，资产桶冲突检查看不见它，须在迁移前独立拦下。"""
-        pm.save_script("demo", _narration_script(), "episode_1.json")
-        project_dir = _project_dir(pm)
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"sheet")
         orphan = project_dir / "characters" / "主角甲.png"
@@ -599,50 +599,50 @@ class TestRenameAssetCascade:
 
         # 预览同样拒绝：占用在扫描阶段就已知，不该等到用户确认后才失败。
         with pytest.raises(AssetRenameFileCollisionError):
-            pm.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
+            pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
 
         with pytest.raises(AssetRenameFileCollisionError) as exc_info:
-            pm.rename_asset("demo", "characters", "角色A", "主角甲")
+            pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert exc_info.value.destination == orphan
         assert orphan.read_bytes() == b"orphan"
         assert sheet.read_bytes() == b"sheet"
-        assert "角色A" in pm.load_project("demo")["characters"]
-        assert _load_script(pm)["segments"][0]["characters_in_segment"] == ["角色A"]
+        assert "角色A" in pm_with_assets.load_project("demo")["characters"]
+        assert _load_script(pm_with_assets)["segments"][0]["characters_in_segment"] == ["角色A"]
 
-    def test_case_only_rename_not_treated_as_collision(self, pm: ProjectManager) -> None:
+    def test_case_only_rename_not_treated_as_collision(self, pm_with_assets: ProjectManager) -> None:
         """大小写不敏感的文件系统上目标解析回源文件自身，那不是占用。
 
         文件系统区分大小写时（多数 Linux）走不到该豁免分支，改名照样通过，断言仍成立。
         """
-        pm.upsert_assets("demo", "characters", {"Alice": {"description": "主角"}})
-        sheet = _project_dir(pm) / "characters" / "Alice.png"
+        pm_with_assets.upsert_assets("demo", "characters", {"Alice": {"description": "主角"}})
+        sheet = _project_dir(pm_with_assets) / "characters" / "Alice.png"
         sheet.write_bytes(b"sheet")
 
-        report = pm.rename_asset("demo", "characters", "Alice", "alice")
+        report = pm_with_assets.rename_asset("demo", "characters", "Alice", "alice")
 
         assert report.files == 1
-        assert "alice" in pm.load_project("demo")["characters"]
-        assert (_project_dir(pm) / "characters" / "alice.png").read_bytes() == b"sheet"
+        assert "alice" in pm_with_assets.load_project("demo")["characters"]
+        assert (_project_dir(pm_with_assets) / "characters" / "alice.png").read_bytes() == b"sheet"
 
-    def test_duplicate_destination_rejected(self, pm: ProjectManager) -> None:
+    def test_duplicate_destination_rejected(self, pm_with_assets: ProjectManager) -> None:
         """两个视觉同名的存量文件（NFC / NFD）会撞到同一目标，后一次迁移吃掉前一次的成果。"""
-        chars = _project_dir(pm) / "characters"
+        chars = _project_dir(pm_with_assets) / "characters"
         nfd = unicodedata.normalize("NFD", "café")
         nfc = unicodedata.normalize("NFC", "café")
         (chars / f"{nfd}.png").write_bytes(b"nfd")
         (chars / f"{nfc}.png").write_bytes(b"nfc")
         if len([p for p in chars.iterdir() if p.suffix == ".png"]) < 2:
             pytest.skip("文件系统归一化文件名，两种编码落到同一文件，构造不出同批撞车")
-        pm.upsert_assets("demo", "characters", {nfc: {"description": "存量"}})
+        pm_with_assets.upsert_assets("demo", "characters", {nfc: {"description": "存量"}})
 
         with pytest.raises(AssetRenameFileCollisionError):
-            pm.rename_asset("demo", "characters", nfc, "主角甲")
+            pm_with_assets.rename_asset("demo", "characters", nfc, "主角甲")
 
         assert (chars / f"{nfd}.png").read_bytes() == b"nfd"
         assert (chars / f"{nfc}.png").read_bytes() == b"nfc"
 
-    def test_quarantine_drafts_rewritten(self, pm: ProjectManager) -> None:
+    def test_quarantine_drafts_rewritten(self, pm_with_assets: ProjectManager) -> None:
         """草稿晋升后会回流为正式内容，漏改会让旧名经晋升重新进入剧本。
 
         三条路线的草稿位逐一覆盖：漏改哪一条，那条路线的草稿就带着旧名走进晋升重判，被判
@@ -650,7 +650,7 @@ class TestRenameAssetCascade:
         ``content.units[].text`` 中的引用语法，结构字段（参考生视频的 ``shots`` / ``references``、
         drama 的 ``needs_replan``）尚未派生，按信封原形构造（见 lib/draft_quarantine.py）。
         """
-        draft_dir = _project_dir(pm) / "drafts" / "episode_1"
+        draft_dir = _project_dir(pm_with_assets) / "drafts" / "episode_1"
         draft_dir.mkdir(parents=True)
         drafts = {
             REFERENCE_VIDEO_STEP1_QUARANTINE_FILENAME: {
@@ -713,7 +713,7 @@ class TestRenameAssetCascade:
         for filename, payload in drafts.items():
             atomic_write_json(draft_dir / filename, payload)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         rewritten = {filename: json.loads((draft_dir / filename).read_text(encoding="utf-8")) for filename in drafts}
         rv_step1 = rewritten[REFERENCE_VIDEO_STEP1_QUARANTINE_FILENAME]
@@ -728,16 +728,16 @@ class TestRenameAssetCascade:
         assert report.references == 5
         assert report.episodes == 1
 
-    def test_history_under_new_name_rejected_atomically(self, pm: ProjectManager) -> None:
+    def test_history_under_new_name_rejected_atomically(self, pm_with_assets: ProjectManager) -> None:
         """删除资产只删资产桶 key、版本历史留存，改名过去会不可恢复地覆盖它——整体拒绝。"""
-        project_dir = _project_dir(pm)
-        pm.upsert_assets("demo", "characters", {"角色B": {"description": "配角"}})
+        project_dir = _project_dir(pm_with_assets)
+        pm_with_assets.upsert_assets("demo", "characters", {"角色B": {"description": "配角"}})
         sheet_b = project_dir / "characters" / "角色B.png"
         sheet_b.write_bytes(b"b1")
         vm = VersionManager(project_dir)
         vm.add_version("characters", "角色B", "配角初版", source_file=sheet_b)
         # 与 delete_entry 路由同形：只删资产桶 key，版本记录与快照留在原地。
-        pm.update_project("demo", lambda project: project["characters"].pop("角色B"))
+        pm_with_assets.update_project("demo", lambda project: project["characters"].pop("角色B"))
         sheet_b.unlink()
 
         sheet_a = project_dir / "characters" / "角色A.png"
@@ -746,16 +746,16 @@ class TestRenameAssetCascade:
 
         for dry_run in (True, False):
             with pytest.raises(AssetRenameHistoryCollisionError):
-                pm.rename_asset("demo", "characters", "角色A", "角色B", dry_run=dry_run)
+                pm_with_assets.rename_asset("demo", "characters", "角色A", "角色B", dry_run=dry_run)
 
         assert vm.get_versions("characters", "角色B")["current_version"] == 1
         assert vm.get_versions("characters", "角色A")["current_version"] == 1
-        assert "角色A" in pm.load_project("demo")["characters"]
+        assert "角色A" in pm_with_assets.load_project("demo")["characters"]
 
-    def test_history_under_equivalent_key_is_same_asset(self, pm: ProjectManager) -> None:
+    def test_history_under_equivalent_key_is_same_asset(self, pm_with_assets: ProjectManager) -> None:
         """新名解析回记录自身（仅换编码形式）时是同一份历史，不算占用。"""
-        project_dir = _project_dir(pm)
-        pm.upsert_assets("demo", "characters", {"café": {"description": "存量"}})
+        project_dir = _project_dir(pm_with_assets)
+        pm_with_assets.upsert_assets("demo", "characters", {"café": {"description": "存量"}})
         nfd = unicodedata.normalize("NFD", "café")
         sheet = project_dir / "characters" / f"{nfd}.png"
         sheet.write_bytes(b"v1")
@@ -768,27 +768,27 @@ class TestRenameAssetCascade:
         assert list(bucket) == ["café"]
         assert vm.get_versions("characters", "café")["current_version"] == 1
 
-    def test_equivalent_bucket_keys_collapsed(self, pm: ProjectManager) -> None:
+    def test_equivalent_bucket_keys_collapsed(self, pm_with_assets: ProjectManager) -> None:
         """NFC / NFD 并存的存量资产桶 key 一并收编，否则等价 key 顶着旧名带失效路径残留。"""
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         nfd = unicodedata.normalize("NFD", "café")
         project["characters"] = {
             nfd: {"description": "存量 NFD", "character_sheet": f"characters/{nfd}.png"},
             "café": {"description": "存量 NFC", "character_sheet": "characters/café.png"},
         }
-        atomic_write_json(_project_dir(pm) / "project.json", project)
+        atomic_write_json(_project_dir(pm_with_assets) / "project.json", project)
 
-        pm.rename_asset("demo", "characters", "café", "主角甲")
+        pm_with_assets.rename_asset("demo", "characters", "café", "主角甲")
 
-        characters = pm.load_project("demo")["characters"]
+        characters = pm_with_assets.load_project("demo")["characters"]
         assert list(characters) == ["主角甲"]
         assert characters["主角甲"]["description"] == "存量 NFC"
 
-    def test_equivalent_version_history_keys_collapsed(self, pm: ProjectManager) -> None:
+    def test_equivalent_version_history_keys_collapsed(self, pm_with_assets: ProjectManager) -> None:
         """版本桶按原始 resource_id 建 key，NFC / NFD 两条记录一并收编到新名下。"""
-        project_dir = _project_dir(pm)
+        project_dir = _project_dir(pm_with_assets)
         nfd = unicodedata.normalize("NFD", "café")
-        pm.upsert_assets("demo", "characters", {"café": {"description": "存量"}})
+        pm_with_assets.upsert_assets("demo", "characters", {"café": {"description": "存量"}})
         sheet = project_dir / "characters" / "café.png"
         sheet.write_bytes(b"v1")
         vm = VersionManager(project_dir)
@@ -800,82 +800,82 @@ class TestRenameAssetCascade:
         bucket = json.loads(vm.versions_file.read_text(encoding="utf-8"))["characters"]
         assert list(bucket) == ["咖啡师"]
 
-    def test_leading_dot_name_files_migrated(self, pm: ProjectManager) -> None:
+    def test_leading_dot_name_files_migrated(self, pm_with_assets: ProjectManager) -> None:
         """前导点是合法资产名：其落盘文件须随改名迁移，否则 entry 路径字段指向不存在的文件。"""
-        project_dir = _project_dir(pm)
-        pm.upsert_assets("demo", "characters", {".甲": {"description": "点号开头"}})
+        project_dir = _project_dir(pm_with_assets)
+        pm_with_assets.upsert_assets("demo", "characters", {".甲": {"description": "点号开头"}})
         sheet = project_dir / "characters" / ".甲.png"
         sheet.write_bytes(b"png")
-        pm.update_project(
+        pm_with_assets.update_project(
             "demo",
             lambda project: project["characters"][".甲"].update({"character_sheet": "characters/.甲.png"}),
         )
 
-        pm.rename_asset("demo", "characters", ".甲", "主角甲")
+        pm_with_assets.rename_asset("demo", "characters", ".甲", "主角甲")
 
         assert not sheet.exists()
         assert (project_dir / "characters" / "主角甲.png").exists()
-        assert pm.load_project("demo")["characters"]["主角甲"]["character_sheet"] == "characters/主角甲.png"
+        assert pm_with_assets.load_project("demo")["characters"]["主角甲"]["character_sheet"] == "characters/主角甲.png"
 
-    def test_missing_old_name_hints_idempotency(self, pm: ProjectManager) -> None:
+    def test_missing_old_name_hints_idempotency(self, pm_with_assets: ProjectManager) -> None:
         with pytest.raises(AssetRenameNotFoundError) as exc_info:
-            pm.rename_asset("demo", "characters", "不存在", "角色A")
+            pm_with_assets.rename_asset("demo", "characters", "不存在", "角色A")
         assert "可能上次重命名已成功" in str(exc_info.value)
 
         with pytest.raises(AssetRenameNotFoundError) as plain:
-            pm.rename_asset("demo", "characters", "不存在", "全新名字")
+            pm_with_assets.rename_asset("demo", "characters", "不存在", "全新名字")
         assert "可能上次重命名已成功" not in str(plain.value)
 
-    def test_dry_run_previews_without_writing(self, pm: ProjectManager) -> None:
-        pm.save_script("demo", _narration_script(), "episode_1.json")
-        project_dir = _project_dir(pm)
+    def test_dry_run_previews_without_writing(self, pm_with_assets: ProjectManager) -> None:
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
+        project_dir = _project_dir(pm_with_assets)
         sheet = project_dir / "characters" / "角色A.png"
         sheet.write_bytes(b"png")
         (project_dir / MANIFEST_FILENAME).unlink(missing_ok=True)
         (project_dir / LOCK_FILENAME).unlink(missing_ok=True)
 
-        preview = pm.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
+        preview = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
 
         assert preview.dry_run is True
         assert sheet.exists()
         assert not (project_dir / MANIFEST_FILENAME).exists()
         assert not (project_dir / LOCK_FILENAME).exists()
-        assert "角色A" in pm.load_project("demo")["characters"]
-        assert _load_script(pm)["segments"][0]["characters_in_segment"] == ["角色A"]
+        assert "角色A" in pm_with_assets.load_project("demo")["characters"]
+        assert _load_script(pm_with_assets)["segments"][0]["characters_in_segment"] == ["角色A"]
 
-        executed = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        executed = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
         assert (executed.episodes, executed.references, executed.files) == (
             preview.episodes,
             preview.references,
             preview.files,
         )
 
-    def test_preexisting_error_naming_the_asset_does_not_block_rename(self, pm: ProjectManager) -> None:
+    def test_preexisting_error_naming_the_asset_does_not_block_rename(self, pm_with_assets: ProjectManager) -> None:
         """历史遗留错误里点名了该资产时，改名不算「更坏」：错误随名字换了措辞，不是新增。"""
-        project = pm.load_project("demo")
+        project = pm_with_assets.load_project("demo")
         project["characters"]["角色A"]["description"] = ""
-        atomic_write_json(_project_dir(pm) / "project.json", project)
+        atomic_write_json(_project_dir(pm_with_assets) / "project.json", project)
 
-        report = pm.rename_asset("demo", "characters", "角色A", "主角甲")
+        report = pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲")
 
         assert report.new_name == "主角甲"
-        assert "主角甲" in pm.load_project("demo")["characters"]
+        assert "主角甲" in pm_with_assets.load_project("demo")["characters"]
 
-    def test_dry_run_leaves_no_version_directory(self, pm: ProjectManager) -> None:
+    def test_dry_run_leaves_no_version_directory(self, pm_with_assets: ProjectManager) -> None:
         """零写入承诺覆盖目录：预演不得在项目下建出空的 ``versions/`` 目录树。"""
-        pm.save_script("demo", _narration_script(), "episode_1.json")
-        versions_dir = _project_dir(pm) / "versions"
+        pm_with_assets.save_script("demo", _narration_script(), "episode_1.json")
+        versions_dir = _project_dir(pm_with_assets) / "versions"
         assert not versions_dir.exists()
 
-        pm.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
+        pm_with_assets.rename_asset("demo", "characters", "角色A", "主角甲", dry_run=True)
 
         assert not versions_dir.exists()
 
-    def test_invalid_new_name_rejected(self, pm: ProjectManager) -> None:
+    def test_invalid_new_name_rejected(self, pm_with_assets: ProjectManager) -> None:
         with pytest.raises(ValueError):
-            pm.rename_asset("demo", "characters", "角色A", "坏/名字")
+            pm_with_assets.rename_asset("demo", "characters", "角色A", "坏/名字")
         with pytest.raises(ValueError):
-            pm.rename_asset("demo", "unknown_table", "角色A", "新名")
+            pm_with_assets.rename_asset("demo", "unknown_table", "角色A", "新名")
 
 
 class TestRenameAgnosticErrors:

--- a/tests/unit/lib/test_generation_queue.py
+++ b/tests/unit/lib/test_generation_queue.py
@@ -3,25 +3,16 @@
 import asyncio
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.generation_admission import generation_admission_lock
 from lib.generation_queue import CompensableGenerationResult, GenerationQueue, reference_projection_for_queued_task
 from lib.task_failure import encode_failure
 
 
 @pytest.fixture
-async def queue():
+async def queue(db_factory):
     """Create a GenerationQueue backed by in-memory SQLite."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    q = GenerationQueue(session_factory=factory)
-    yield q
-    await engine.dispose()
+    return GenerationQueue(session_factory=db_factory)
 
 
 class TestGenerationQueue:

--- a/tests/unit/lib/test_ledger.py
+++ b/tests/unit/lib/test_ledger.py
@@ -15,24 +15,14 @@ from typing import Any
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from lib.db.base import Base
 from lib.db.models.api_call import ApiCall
 from lib.ledger import Ledger, _settlement_from_result
 
 
-@pytest.fixture
-async def factory() -> Any:
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield async_sessionmaker(engine, expire_on_commit=False)
-    await engine.dispose()
-
-
-async def _only_row(factory: async_sessionmaker) -> ApiCall:
-    async with factory() as session:
+async def _only_row(db_factory: async_sessionmaker) -> ApiCall:
+    async with db_factory() as session:
         rows = (await session.execute(select(ApiCall))).scalars().all()
     assert len(rows) == 1, f"期望恰好 1 行，实际 {len(rows)}"
     return rows[0]
@@ -107,42 +97,42 @@ class TestSettlementDispatch:
 
 
 class TestRecordBracket:
-    async def test_call_id_available_in_block_and_success_flips_row(self, factory: async_sessionmaker) -> None:
-        ledger = Ledger(session_factory=factory)
+    async def test_call_id_available_in_block_and_success_flips_row(self, db_factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=db_factory)
         seen_call_id: int | None = None
         async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic") as call:
             seen_call_id = call.call_id
             call.success(_TextResult(input_tokens=100, output_tokens=50))
 
         assert seen_call_id is not None and seen_call_id > 0
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "success"
         assert row.input_tokens == 100
         assert row.output_tokens == 50
 
-    async def test_missing_success_declaration_raises_runtime_error(self, factory: async_sessionmaker) -> None:
-        ledger = Ledger(session_factory=factory)
+    async def test_missing_success_declaration_raises_runtime_error(self, db_factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=db_factory)
         with pytest.raises(RuntimeError, match="未调用 call.success"):
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
                 pass  # 正常退出但未声明成功
 
         # 未声明成功 → 未 finish，行停在 pending（不翻 success/failed）
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "pending"
 
-    async def test_exception_flips_failed_and_reraises(self, factory: async_sessionmaker) -> None:
-        ledger = Ledger(session_factory=factory)
+    async def test_exception_flips_failed_and_reraises(self, db_factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=db_factory)
         with pytest.raises(ValueError, match="boom"):
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
                 raise ValueError("boom" * 200)
 
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "failed"
         assert row.error_message is not None
         assert len(row.error_message) == 500  # 错误信息截断由仓储承担
 
-    async def test_cancellation_passes_through_leaving_pending(self, factory: async_sessionmaker) -> None:
-        ledger = Ledger(session_factory=factory)
+    async def test_cancellation_passes_through_leaving_pending(self, db_factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=db_factory)
         caught = False
         try:
             async with ledger.record(project_name="demo", call_type="text", model="m", provider="anthropic"):
@@ -153,7 +143,7 @@ class TestRecordBracket:
         assert caught, "expected CancelledError to propagate"
 
         # 穿透不记账：行停在 pending，不翻 failed
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "pending"
 
     async def test_accounting_failure_does_not_swallow_original_exception(
@@ -223,10 +213,10 @@ class TestRecordBracket:
 
 
 class TestResumeAndBackfill:
-    async def _seed_pending_video(self, factory: async_sessionmaker) -> int:
+    async def _seed_pending_video(self, db_factory: async_sessionmaker) -> int:
         from lib.db.repositories.usage_repo import UsageRepository
 
-        async with factory() as session:
+        async with db_factory() as session:
             return await UsageRepository(session).start_call(
                 project_name="demo",
                 call_type="video",
@@ -235,41 +225,41 @@ class TestResumeAndBackfill:
                 provider="gemini",
             )
 
-    async def test_resume_success_flips_pending_by_call_id(self, factory: async_sessionmaker) -> None:
-        call_id = await self._seed_pending_video(factory)
-        ledger = Ledger(session_factory=factory)
+    async def test_resume_success_flips_pending_by_call_id(self, db_factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(db_factory)
+        ledger = Ledger(session_factory=db_factory)
 
         affected = await ledger.resume_success(
             call_id=call_id, result=_VideoResult(duration_seconds=6, generate_audio=False)
         )
         assert affected == 1
 
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "success"
         assert row.duration_seconds == 6  # backend 实际计费时长覆盖请求 8s
 
-    async def test_resume_failed_flips_pending_zero_cost(self, factory: async_sessionmaker) -> None:
-        call_id = await self._seed_pending_video(factory)
-        ledger = Ledger(session_factory=factory)
+    async def test_resume_failed_flips_pending_zero_cost(self, db_factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(db_factory)
+        ledger = Ledger(session_factory=db_factory)
 
         affected = await ledger.resume_failed(call_id=call_id)
         assert affected == 1
 
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "failed"
         assert row.cost_amount == 0.0
 
-    async def test_resume_success_idempotent_on_terminal_row(self, factory: async_sessionmaker) -> None:
-        call_id = await self._seed_pending_video(factory)
-        ledger = Ledger(session_factory=factory)
+    async def test_resume_success_idempotent_on_terminal_row(self, db_factory: async_sessionmaker) -> None:
+        call_id = await self._seed_pending_video(db_factory)
+        ledger = Ledger(session_factory=db_factory)
         await ledger.resume_success(call_id=call_id, result=_VideoResult())
 
         # 二次 finalize 命中 0 行（WHERE status='pending' 幂等守卫），不抛异常
         affected = await ledger.resume_success(call_id=call_id, result=_VideoResult())
         assert affected == 0
 
-    async def test_backfill_writes_single_terminal_row(self, factory: async_sessionmaker) -> None:
-        ledger = Ledger(session_factory=factory)
+    async def test_backfill_writes_single_terminal_row(self, db_factory: async_sessionmaker) -> None:
+        ledger = Ledger(session_factory=db_factory)
         await ledger.backfill(
             project_name="demo",
             call_type="text",
@@ -285,7 +275,7 @@ class TestResumeAndBackfill:
             currency="USD",
         )
 
-        row = await _only_row(factory)
+        row = await _only_row(db_factory)
         assert row.status == "success"
         assert row.cost_amount == pytest.approx(0.123)  # SDK 直报费用优先
         assert row.usage_tokens == 1_200_000

--- a/tests/unit/lib/test_project_manager_migration.py
+++ b/tests/unit/lib/test_project_manager_migration.py
@@ -10,39 +10,39 @@ from lib.style_templates import resolve_template_prompt
 
 
 @pytest.fixture
-def pm(tmp_path: Path) -> ProjectManager:
+def bare_pm(tmp_path: Path) -> ProjectManager:
     return ProjectManager(tmp_path)
 
 
-def _write_project(pm: ProjectManager, name: str, data: dict) -> Path:
-    project_dir = pm.projects_root / name
+def _write_project(bare_pm: ProjectManager, name: str, data: dict) -> Path:
+    project_dir = bare_pm.projects_root / name
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "project.json").write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
     return project_dir
 
 
-def test_migrates_photographic_to_live_premium_drama(pm: ProjectManager):
-    _write_project(pm, "p1", {"title": "P1", "style": "Photographic"})
-    data = pm.load_project("p1")
+def test_migrates_photographic_to_live_premium_drama(bare_pm: ProjectManager):
+    _write_project(bare_pm, "p1", {"title": "P1", "style": "Photographic"})
+    data = bare_pm.load_project("p1")
     assert data["style_template_id"] == "live_premium_drama"
     assert data["style"] == resolve_template_prompt("live_premium_drama")
 
 
-def test_migrates_anime_to_kyoto(pm: ProjectManager):
-    _write_project(pm, "p2", {"title": "P2", "style": "Anime"})
-    data = pm.load_project("p2")
+def test_migrates_anime_to_kyoto(bare_pm: ProjectManager):
+    _write_project(bare_pm, "p2", {"title": "P2", "style": "Anime"})
+    data = bare_pm.load_project("p2")
     assert data["style_template_id"] == "anim_kyoto"
 
 
-def test_migrates_3d_animation_to_3d_cg(pm: ProjectManager):
-    _write_project(pm, "p3", {"title": "P3", "style": "3D Animation"})
-    data = pm.load_project("p3")
+def test_migrates_3d_animation_to_3d_cg(bare_pm: ProjectManager):
+    _write_project(bare_pm, "p3", {"title": "P3", "style": "3D Animation"})
+    data = bare_pm.load_project("p3")
     assert data["style_template_id"] == "anim_3d_cg"
 
 
-def test_prefers_style_image_over_template_when_both_present(pm: ProjectManager):
+def test_prefers_style_image_over_template_when_both_present(bare_pm: ProjectManager):
     _write_project(
-        pm,
+        bare_pm,
         "p4",
         {
             "title": "P4",
@@ -51,22 +51,22 @@ def test_prefers_style_image_over_template_when_both_present(pm: ProjectManager)
             "style_description": "已分析",
         },
     )
-    data = pm.load_project("p4")
+    data = bare_pm.load_project("p4")
     assert data["style_template_id"] is None
     assert data["style"] == ""
     assert data["style_image"] == "reference.png"
 
 
-def test_unknown_legacy_value_untouched(pm: ProjectManager):
-    _write_project(pm, "p5", {"title": "P5", "style": "某种自由文本"})
-    data = pm.load_project("p5")
+def test_unknown_legacy_value_untouched(bare_pm: ProjectManager):
+    _write_project(bare_pm, "p5", {"title": "P5", "style": "某种自由文本"})
+    data = bare_pm.load_project("p5")
     assert "style_template_id" not in data  # 未写入
     assert data["style"] == "某种自由文本"
 
 
-def test_already_migrated_project_idempotent(pm: ProjectManager):
+def test_already_migrated_project_idempotent(bare_pm: ProjectManager):
     _write_project(
-        pm,
+        bare_pm,
         "p6",
         {
             "title": "P6",
@@ -74,24 +74,24 @@ def test_already_migrated_project_idempotent(pm: ProjectManager):
             "style_template_id": "live_premium_drama",
         },
     )
-    data = pm.load_project("p6")
+    data = bare_pm.load_project("p6")
     assert data["style_template_id"] == "live_premium_drama"
     # 二次 load 不变
-    data2 = pm.load_project("p6")
+    data2 = bare_pm.load_project("p6")
     assert data2 == data
 
 
-def test_migration_persists_to_disk(pm: ProjectManager, tmp_path: Path):
-    _write_project(pm, "p7", {"title": "P7", "style": "Photographic"})
-    pm.load_project("p7")
+def test_migration_persists_to_disk(bare_pm: ProjectManager, tmp_path: Path):
+    _write_project(bare_pm, "p7", {"title": "P7", "style": "Photographic"})
+    bare_pm.load_project("p7")
     raw = json.loads((tmp_path / "p7" / "project.json").read_text(encoding="utf-8"))
     assert raw["style_template_id"] == "live_premium_drama"
 
 
-def test_legacy_value_with_existing_template_id_untouched(pm: ProjectManager):
+def test_legacy_value_with_existing_template_id_untouched(bare_pm: ProjectManager):
     """若 project 已经带 style_template_id，即使 style 值还是 legacy 标签也不再动。"""
     _write_project(
-        pm,
+        bare_pm,
         "p-existing",
         {
             "title": "PE",
@@ -99,52 +99,52 @@ def test_legacy_value_with_existing_template_id_untouched(pm: ProjectManager):
             "style_template_id": "anim_kyoto",
         },
     )
-    data = pm.load_project("p-existing")
+    data = bare_pm.load_project("p-existing")
     assert data["style_template_id"] == "anim_kyoto"
     assert data["style"] == "Photographic"  # 原样保留
 
 
-def test_migration_does_not_touch_updated_at(pm: ProjectManager, tmp_path: Path):
+def test_migration_does_not_touch_updated_at(bare_pm: ProjectManager, tmp_path: Path):
     """迁移写回不应污染 updated_at。"""
     original = "2020-01-01T00:00:00Z"
     _write_project(
-        pm,
+        bare_pm,
         "p-timestamp",
         {"title": "PT", "style": "Photographic", "updated_at": original},
     )
-    pm.load_project("p-timestamp")
+    bare_pm.load_project("p-timestamp")
     raw = json.loads((tmp_path / "p-timestamp" / "project.json").read_text(encoding="utf-8"))
     assert raw["updated_at"] == original
     assert raw["style_template_id"] == "live_premium_drama"
 
 
-def test_migration_emits_change_hint(pm: ProjectManager):
+def test_migration_emits_change_hint(bare_pm: ProjectManager):
     """迁移写回后应触发 project change hint，供 SSE 订阅者感知。"""
     from lib.project_change_hints import register_project_change_listener
 
     events: list[tuple[str, str, tuple[str, ...]]] = []
     unregister = register_project_change_listener(lambda name, source, paths: events.append((name, source, paths)))
     try:
-        _write_project(pm, "p-hint", {"title": "PH", "style": "Photographic"})
-        pm.load_project("p-hint")
+        _write_project(bare_pm, "p-hint", {"title": "PH", "style": "Photographic"})
+        bare_pm.load_project("p-hint")
     finally:
         unregister()
 
     assert any(name == "p-hint" and "project.json" in paths for name, _source, paths in events)
 
 
-def test_concurrent_migration_does_not_lose_data(pm: ProjectManager):
+def test_concurrent_migration_does_not_lose_data(bare_pm: ProjectManager):
     """两线程同时触发迁移应该保持一致，不会产生竞态。"""
     import threading
 
-    _write_project(pm, "p-concurrent", {"title": "PC", "style": "Photographic"})
+    _write_project(bare_pm, "p-concurrent", {"title": "PC", "style": "Photographic"})
 
     results = []
     errors = []
 
     def worker():
         try:
-            results.append(pm.load_project("p-concurrent"))
+            results.append(bare_pm.load_project("p-concurrent"))
         except Exception as e:
             errors.append(e)
 
@@ -158,5 +158,5 @@ def test_concurrent_migration_does_not_lose_data(pm: ProjectManager):
     # 两个结果一致，都完成了迁移
     assert all(r["style_template_id"] == "live_premium_drama" for r in results)
     # 磁盘上最终也是迁移后状态
-    final = pm.load_project("p-concurrent")
+    final = bare_pm.load_project("p-concurrent")
     assert final["style_template_id"] == "live_premium_drama"

--- a/tests/unit/lib/test_text_generator.py
+++ b/tests/unit/lib/test_text_generator.py
@@ -4,9 +4,8 @@ from dataclasses import dataclass
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from lib.db.base import Base
 from lib.db.repositories.usage_repo import UsageRepository
 from lib.ledger import Ledger
 from lib.text_backends.base import TextGenerationRequest, TextGenerationResult
@@ -26,13 +25,8 @@ class _Wired:
 
 
 @pytest.fixture
-async def wired():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield _Wired(ledger=Ledger(session_factory=factory), session_factory=factory)
-    await engine.dispose()
+async def wired(db_factory):
+    return _Wired(ledger=Ledger(session_factory=db_factory), session_factory=db_factory)
 
 
 def _make_backend(provider="gemini", model="gemini-3-flash-preview"):

--- a/tests/unit/lib/video_backends/test_agnes_video_backend.py
+++ b/tests/unit/lib/video_backends/test_agnes_video_backend.py
@@ -15,6 +15,7 @@ from lib.video_backends.base import (
     VideoCapabilityError,
     VideoGenerationRequest,
 )
+from tests.fakes import bounded_poll_clock
 
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
@@ -881,7 +882,7 @@ class TestSubmitResilience:
         with (
             patch("httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
             patch("lib.video_backends.agnes.download_video", fake_download),
         ):
             from lib.video_backends.agnes import AgnesVideoBackend
@@ -906,7 +907,7 @@ class TestSubmitResilience:
 
         with (
             patch("httpx.AsyncClient", return_value=client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.agnes import AgnesVideoBackend
 
@@ -929,7 +930,7 @@ class TestSubmitResilience:
 
         with (
             patch("httpx.AsyncClient", return_value=client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.agnes import AgnesVideoBackend
 

--- a/tests/unit/lib/video_backends/test_grok_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_video_backend.py
@@ -12,7 +12,7 @@ from lib.video_backends.base import VideoGenerationRequest
 
 
 @pytest.fixture
-def output_path(tmp_path: Path) -> Path:
+def video_output_path(tmp_path: Path) -> Path:
     return tmp_path / "output.mp4"
 
 
@@ -45,7 +45,7 @@ class TestGrokVideoBackend:
         with pytest.raises(ValueError, match="xAI API Key"):
             GrokVideoBackend(api_key=None)
 
-    async def test_text_to_video(self, output_path: Path):
+    async def test_text_to_video(self, video_output_path: Path):
         from lib.video_backends.grok import GrokVideoBackend
 
         mock_response = MagicMock()
@@ -74,7 +74,7 @@ class TestGrokVideoBackend:
             with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
                 request = VideoGenerationRequest(
                     prompt="A cat walking",
-                    output_path=output_path,
+                    output_path=video_output_path,
                     aspect_ratio="16:9",
                     duration_seconds=5,
                     resolution="720p",
@@ -85,7 +85,7 @@ class TestGrokVideoBackend:
             assert result.provider == PROVIDER_GROK
             assert result.model == "grok-imagine-video"
             assert result.duration_seconds == 5
-            assert result.video_path == output_path
+            assert result.video_path == video_output_path
 
             mock_video.generate.assert_awaited_once()
             call_kwargs = mock_video.generate.call_args[1]
@@ -96,7 +96,7 @@ class TestGrokVideoBackend:
             assert call_kwargs["resolution"] == "720p"
             assert "image_url" not in call_kwargs
 
-    async def test_marks_resubmit_unsafe_before_opaque_provider_call(self, output_path: Path):
+    async def test_marks_resubmit_unsafe_before_opaque_provider_call(self, video_output_path: Path):
         from lib.video_backends.grok import GrokVideoBackend
 
         mock_video = MagicMock()
@@ -112,7 +112,7 @@ class TestGrokVideoBackend:
             backend = GrokVideoBackend(api_key="test-key")
             request = VideoGenerationRequest(
                 prompt="A cat walking",
-                output_path=output_path,
+                output_path=video_output_path,
                 duration_seconds=5,
                 on_provider_resubmit_unsafe=resubmit_unsafe,
             )
@@ -123,7 +123,7 @@ class TestGrokVideoBackend:
         resubmit_unsafe.assert_called_once_with()
         assert mock_video.generate.await_count == 1
 
-    async def test_image_to_video(self, output_path: Path, tmp_path: Path):
+    async def test_image_to_video(self, video_output_path: Path, tmp_path: Path):
         from lib.video_backends.grok import GrokVideoBackend
 
         image_path = tmp_path / "start.png"
@@ -155,7 +155,7 @@ class TestGrokVideoBackend:
             with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
                 request = VideoGenerationRequest(
                     prompt="Animate this scene",
-                    output_path=output_path,
+                    output_path=video_output_path,
                     start_image=image_path,
                     duration_seconds=8,
                     resolution="720p",
@@ -186,7 +186,7 @@ class TestGrokVideoBackend:
             (None, 5),  # 缺失回落请求时长
         ],
     )
-    async def test_duration_narrowed_to_int_with_fallback(self, output_path: Path, raw_duration, expected):
+    async def test_duration_narrowed_to_int_with_fallback(self, video_output_path: Path, raw_duration, expected):
         """SDK 回报的 duration 未类型化：可解析数值收窄为 int 作为实际计费时长，否则回落请求时长。"""
         from lib.video_backends.grok import GrokVideoBackend
 
@@ -216,7 +216,7 @@ class TestGrokVideoBackend:
             with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
                 request = VideoGenerationRequest(
                     prompt="A cat walking",
-                    output_path=output_path,
+                    output_path=video_output_path,
                     duration_seconds=5,
                     resolution="720p",
                 )

--- a/tests/unit/lib/video_backends/test_newapi_video_backend.py
+++ b/tests/unit/lib/video_backends/test_newapi_video_backend.py
@@ -592,7 +592,7 @@ class TestNewAPIVideoBackend:
         assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
 
     async def test_poll_recognizes_expired_status(self, tmp_path: Path):
-        """fix #647 #5：poll 返回 status='expired' → 抛 ResumeExpiredError。"""
+        """poll 返回 status='expired' → 抛 ResumeExpiredError。"""
         from lib.video_backends.base import ResumeExpiredError
 
         expired_resp = _make_response(200, {"task_id": "task-x", "status": "expired"})

--- a/tests/unit/lib/video_backends/test_newapi_video_backend.py
+++ b/tests/unit/lib/video_backends/test_newapi_video_backend.py
@@ -388,7 +388,7 @@ class TestNewAPIVideoBackend:
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
             # 压缩重试退避时间到 0，避免测试变慢
             patch("lib.video_backends.newapi.DEFAULT_BACKOFF_SECONDS", (0, 0, 0)),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
             patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
@@ -420,7 +420,7 @@ class TestNewAPIVideoBackend:
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend
 
@@ -444,7 +444,7 @@ class TestNewAPIVideoBackend:
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.base import AmbiguousSubmitError
             from lib.video_backends.newapi import NewAPIVideoBackend
@@ -478,7 +478,7 @@ class TestNewAPIVideoBackend:
         with (
             patch("httpx.AsyncClient", return_value=mock_client),
             patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
             patch("lib.video_backends.newapi.download_video", fake_download),
         ):
             from lib.video_backends.newapi import NewAPIVideoBackend

--- a/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
+++ b/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
@@ -30,6 +30,7 @@ from lib.video_backends.v2_video_generations import (
 from lib.video_backends.v2_video_generations import (
     V2VideoGenerationsBackend as _V2Backend,
 )
+from tests.fakes import bounded_poll_clock
 
 
 def _make_response(status_code: int, json_body: dict) -> MagicMock:
@@ -455,7 +456,7 @@ class TestV2BackendHttp:
         client = _mock_client(post=resp400)
         with (
             patch("httpx.AsyncClient", return_value=client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
             with pytest.raises(httpx.HTTPStatusError):
@@ -484,7 +485,7 @@ class TestV2BackendHttp:
         client = _mock_client(post=[httpx.ReadTimeout("read timed out")])
         with (
             patch("httpx.AsyncClient", return_value=client),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
             with pytest.raises(AmbiguousSubmitError, match="手动重试"):
@@ -508,7 +509,7 @@ class TestV2BackendHttp:
             patch("httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
             patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
             result = await self._backend().generate(req)
@@ -529,7 +530,7 @@ class TestV2BackendHttp:
             patch("httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
             patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
         ):
             req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
             result = await self._backend().generate(req)

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -399,7 +399,7 @@ class TestArkModelCapabilities:
     """测试不同模型的能力映射。"""
 
     def test_seedance_1_5_pro_default_model_supports_last_frame(self):
-        """DEFAULT_MODEL：能力表标首尾帧 ✅，实测 generate() 正常下发 role=last_frame。"""
+        """DEFAULT_MODEL：能力表标首尾帧，generate() 下发 role=last_frame。"""
         caps = ArkVideoBackend.video_capabilities_for_model("doubao-seedance-1-5-pro-251215")
         assert caps.last_frame is True
 
@@ -671,7 +671,7 @@ class TestArkVideoBackendBaseUrl:
 
 
 class TestIsArkNotFound:
-    """fix #647 #6：用 task_not_found / tasknotfound 精确匹配，剔除宽泛 "not found" 兜底；
+    """用 task_not_found / tasknotfound 精确匹配，剔除宽泛 "not found" 兜底；
     保留 "expired" 字串识别（_poll_until_done 把 status=expired 转 RuntimeError）。"""
 
     def test_excludes_business_not_found(self):

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -25,7 +25,7 @@ def mock_ark_client():
 
 
 @pytest.fixture
-def backend(mock_ark_client):
+def ark_backend(mock_ark_client):
     with patch("lib.video_backends.ark.create_ark_client", return_value=mock_ark_client):
         b = ArkVideoBackend(
             api_key="test-ark-key",
@@ -60,18 +60,18 @@ def _mock_httpx_stream(data: bytes = b"fake-mp4-data"):
 
 
 class TestArkProperties:
-    def test_name(self, backend):
-        assert backend.name == "ark"
+    def test_name(self, ark_backend):
+        assert ark_backend.name == "ark"
 
 
 class TestArkGenerate:
-    async def test_text_to_video(self, backend, tmp_path):
+    async def test_text_to_video(self, ark_backend, tmp_path):
         """文生视频：无 start_image。"""
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-20250101-test"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -80,7 +80,7 @@ class TestArkGenerate:
         get_result.seed = 58944
         get_result.usage = MagicMock()
         get_result.usage.completion_tokens = 246840
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -89,7 +89,7 @@ class TestArkGenerate:
                 output_path=output,
                 duration_seconds=5,
             )
-            result = await backend.generate(request)
+            result = await ark_backend.generate(request)
         finally:
             patcher.stop()
 
@@ -100,7 +100,7 @@ class TestArkGenerate:
         assert result.usage_tokens == 246840
         assert result.task_id == "cgt-20250101-test"
 
-    async def test_image_to_video(self, backend, tmp_path):
+    async def test_image_to_video(self, ark_backend, tmp_path):
         """图生视频：有 start_image，必须带 role=first_frame。"""
         output = tmp_path / "out.mp4"
         frame = tmp_path / "scene_E1S01.png"
@@ -108,7 +108,7 @@ class TestArkGenerate:
 
         create_result = MagicMock()
         create_result.id = "cgt-i2v-test"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -117,7 +117,7 @@ class TestArkGenerate:
         get_result.seed = 12345
         get_result.usage = MagicMock()
         get_result.usage.completion_tokens = 200000
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -127,12 +127,12 @@ class TestArkGenerate:
                 start_image=frame,
                 generate_audio=True,
             )
-            result = await backend.generate(request)
+            result = await ark_backend.generate(request)
         finally:
             patcher.stop()
 
         assert result.provider == "ark"
-        create_call = backend._client.content_generation.tasks.create
+        create_call = ark_backend._client.content_generation.tasks.create
         call_kwargs = create_call.call_args
         content_arg = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content")
         assert len(content_arg) == 2
@@ -140,7 +140,7 @@ class TestArkGenerate:
         assert content_arg[1]["image_url"]["url"].startswith("data:image/")
         assert content_arg[1]["role"] == "first_frame"
 
-    async def test_first_last_frame_role_fields(self, backend, tmp_path):
+    async def test_first_last_frame_role_fields(self, ark_backend, tmp_path):
         """首尾帧：start_image/end_image 必须分别带 role=first_frame / role=last_frame，
         且 image_url 对象不再使用 position（由 role 表达位置）。"""
         output = tmp_path / "out.mp4"
@@ -151,7 +151,7 @@ class TestArkGenerate:
 
         create_result = MagicMock()
         create_result.id = "cgt-fl-test"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -159,7 +159,7 @@ class TestArkGenerate:
         get_result.content.video_url = "https://cdn.example.com/video.mp4"
         get_result.seed = None
         get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -169,11 +169,11 @@ class TestArkGenerate:
                 start_image=first,
                 end_image=last,
             )
-            await backend.generate(request)
+            await ark_backend.generate(request)
         finally:
             patcher.stop()
 
-        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        create_kwargs = ark_backend._client.content_generation.tasks.create.call_args.kwargs
         content_arg = create_kwargs["content"]
         image_items = [c for c in content_arg if c["type"] == "image_url"]
         assert len(image_items) == 2
@@ -182,7 +182,7 @@ class TestArkGenerate:
         # role 表达位置后，不应再塞 position 到 image_url
         assert "position" not in image_items[1]["image_url"]
 
-    async def test_reference_images_role(self, backend, tmp_path):
+    async def test_reference_images_role(self, ark_backend, tmp_path):
         """参考图：每张 reference_images 必须带 role=reference_image（Ark 多图触发条件）。"""
         output = tmp_path / "out.mp4"
         ref1 = tmp_path / "ref1.jpg"
@@ -192,7 +192,7 @@ class TestArkGenerate:
 
         create_result = MagicMock()
         create_result.id = "cgt-refs-test"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -200,7 +200,7 @@ class TestArkGenerate:
         get_result.content.video_url = "https://cdn.example.com/video.mp4"
         get_result.seed = None
         get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -209,19 +209,19 @@ class TestArkGenerate:
                 output_path=output,
                 reference_images=[ref1, ref2],
             )
-            await backend.generate(request)
+            await ark_backend.generate(request)
         finally:
             patcher.stop()
 
-        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        create_kwargs = ark_backend._client.content_generation.tasks.create.call_args.kwargs
         content_arg = create_kwargs["content"]
         image_items = [c for c in content_arg if c["type"] == "image_url"]
         assert len(image_items) == 2
         assert all(item["role"] == "reference_image" for item in image_items)
 
-    async def test_missing_end_image_fails_loud(self, backend, tmp_path):
+    async def test_missing_end_image_fails_loud(self, ark_backend, tmp_path):
         """尾帧文件不存在时中止提交：静默跳过会照常计费并产出没有尾帧的成片。"""
-        backend._client.content_generation.tasks.create = MagicMock()
+        ark_backend._client.content_generation.tasks.create = MagicMock()
 
         request = VideoGenerationRequest(
             prompt="morph",
@@ -229,15 +229,15 @@ class TestArkGenerate:
             end_image=tmp_path / "gone.png",
         )
         with pytest.raises(VideoCapabilityError) as exc:
-            await backend.generate(request)
+            await ark_backend.generate(request)
         assert exc.value.code == "video_end_image_unreadable"
-        backend._client.content_generation.tasks.create.assert_not_called()
+        ark_backend._client.content_generation.tasks.create.assert_not_called()
 
-    async def test_missing_reference_image_fails_loud(self, backend, tmp_path):
+    async def test_missing_reference_image_fails_loud(self, ark_backend, tmp_path):
         """参考图缺失时中止提交，理由同尾帧：少一张仍会出片，成片却与意图不符。"""
         present = tmp_path / "ref1.jpg"
         present.write_bytes(b"fake-ref-1")
-        backend._client.content_generation.tasks.create = MagicMock()
+        ark_backend._client.content_generation.tasks.create = MagicMock()
 
         request = VideoGenerationRequest(
             prompt="[图1] 与 [图2] 对话",
@@ -245,32 +245,32 @@ class TestArkGenerate:
             reference_images=[present, tmp_path / "gone.jpg"],
         )
         with pytest.raises(VideoCapabilityError) as exc:
-            await backend.generate(request)
+            await ark_backend.generate(request)
         assert exc.value.code == "video_reference_images_unreadable"
-        backend._client.content_generation.tasks.create.assert_not_called()
+        ark_backend._client.content_generation.tasks.create.assert_not_called()
 
-    async def test_failed_task_raises(self, backend, tmp_path):
+    async def test_failed_task_raises(self, ark_backend, tmp_path):
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-fail"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "failed"
         get_result.error = "content violation"
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(RuntimeError, match="Ark 视频生成失败"):
-            await backend.generate(request)
+            await ark_backend.generate(request)
 
-    async def test_with_seed_and_flex(self, backend, tmp_path):
+    async def test_with_seed_and_flex(self, ark_backend, tmp_path):
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-flex"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -279,7 +279,7 @@ class TestArkGenerate:
         get_result.seed = 42
         get_result.usage = MagicMock()
         get_result.usage.completion_tokens = 100000
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -289,11 +289,11 @@ class TestArkGenerate:
                 seed=42,
                 service_tier="flex",
             )
-            await backend.generate(request)
+            await ark_backend.generate(request)
         finally:
             patcher.stop()
 
-        create_call = backend._client.content_generation.tasks.create
+        create_call = ark_backend._client.content_generation.tasks.create
         call_kwargs = create_call.call_args
         assert call_kwargs.kwargs.get("seed") == 42 or call_kwargs[1].get("seed") == 42
         assert call_kwargs.kwargs.get("service_tier") == "flex" or call_kwargs[1].get("service_tier") == "flex"
@@ -307,13 +307,13 @@ class TestArkGenerate:
 class TestArkRetryBehavior:
     """测试任务创建与轮询的重试分离行为。"""
 
-    async def test_poll_transient_error_retries_without_recreating_task(self, backend, tmp_path):
+    async def test_poll_transient_error_retries_without_recreating_task(self, ark_backend, tmp_path):
         """轮询阶段瞬态错误应重试轮询，而不是重新创建任务。"""
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-retry-test"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_success = MagicMock()
         get_success.status = "succeeded"
@@ -323,7 +323,7 @@ class TestArkRetryBehavior:
         get_success.usage = None
 
         # 第一次轮询抛 ConnectionError，第二次成功
-        backend._client.content_generation.tasks.get = MagicMock(
+        ark_backend._client.content_generation.tasks.get = MagicMock(
             side_effect=[ConnectionError("connection reset"), get_success]
         )
 
@@ -331,24 +331,24 @@ class TestArkRetryBehavior:
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
             with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                result = await backend.generate(request)
+                result = await ark_backend.generate(request)
         finally:
             patcher.stop()
 
         assert result.task_id == "cgt-retry-test"
         # 关键断言：任务只创建了一次
-        assert backend._client.content_generation.tasks.create.call_count == 1
+        assert ark_backend._client.content_generation.tasks.create.call_count == 1
         # 轮询调用了两次（一次失败 + 一次成功）
-        assert backend._client.content_generation.tasks.get.call_count == 2
+        assert ark_backend._client.content_generation.tasks.get.call_count == 2
 
-    async def test_create_retries_on_transient_error(self, backend, tmp_path):
+    async def test_create_retries_on_transient_error(self, ark_backend, tmp_path):
         """任务创建阶段的瞬态错误应由 @with_retry_async 重试。"""
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-create-retry"
         # 第一次创建抛 ConnectionError，第二次成功
-        backend._client.content_generation.tasks.create = MagicMock(
+        ark_backend._client.content_generation.tasks.create = MagicMock(
             side_effect=[ConnectionError("connection reset"), create_result]
         )
 
@@ -358,7 +358,7 @@ class TestArkRetryBehavior:
         get_result.content.video_url = "https://cdn.example.com/video.mp4"
         get_result.seed = None
         get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
@@ -367,32 +367,32 @@ class TestArkRetryBehavior:
                 patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
                 patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
             ):
-                result = await backend.generate(request)
+                result = await ark_backend.generate(request)
         finally:
             patcher.stop()
 
         assert result.task_id == "cgt-create-retry"
         # 创建调用了两次（一次失败 + 一次成功）
-        assert backend._client.content_generation.tasks.create.call_count == 2
+        assert ark_backend._client.content_generation.tasks.create.call_count == 2
 
-    async def test_poll_non_retryable_error_propagates(self, backend, tmp_path):
+    async def test_poll_non_retryable_error_propagates(self, ark_backend, tmp_path):
         """轮询阶段不可重试的错误应直接抛出。"""
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-no-retry"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
-        backend._client.content_generation.tasks.get = MagicMock(side_effect=ValueError("invalid response"))
+        ark_backend._client.content_generation.tasks.get = MagicMock(side_effect=ValueError("invalid response"))
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
             with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await backend.generate(request)
+                await ark_backend.generate(request)
 
         # 创建只调用一次，轮询只尝试一次就抛出
-        assert backend._client.content_generation.tasks.create.call_count == 1
-        assert backend._client.content_generation.tasks.get.call_count == 1
+        assert ark_backend._client.content_generation.tasks.create.call_count == 1
+        assert ark_backend._client.content_generation.tasks.get.call_count == 1
 
 
 class TestArkModelCapabilities:
@@ -535,18 +535,18 @@ class TestArkPollBudget:
         ("duration", "expected_max_wait"),
         [(5, 600), (10, 600), (15, 900), (30, 1800)],
     )
-    async def test_default_tier_max_wait_scales_with_duration(self, backend, tmp_path, duration, expected_max_wait):
+    async def test_default_tier_max_wait_scales_with_duration(self, ark_backend, tmp_path, duration, expected_max_wait):
         request = VideoGenerationRequest(
             prompt="p", output_path=tmp_path / "out.mp4", duration_seconds=duration, service_tier="default"
         )
         with patch("lib.video_backends.ark.poll_with_retry", new_callable=AsyncMock) as poll:
             poll.side_effect = RuntimeError("stop")
             with pytest.raises(RuntimeError):
-                await backend._poll_until_done("task-1", request)
+                await ark_backend._poll_until_done("task-1", request)
         assert poll.call_args.kwargs["max_wait"] == expected_max_wait
         assert poll.call_args.kwargs["poll_interval"] == 10
 
-    async def test_flex_tier_keeps_hour_long_budget(self, backend, tmp_path):
+    async def test_flex_tier_keeps_hour_long_budget(self, ark_backend, tmp_path):
         """flex 队列本就按小时级排队，不随时长缩放。"""
         request = VideoGenerationRequest(
             prompt="p", output_path=tmp_path / "out.mp4", duration_seconds=30, service_tier="flex"
@@ -554,7 +554,7 @@ class TestArkPollBudget:
         with patch("lib.video_backends.ark.poll_with_retry", new_callable=AsyncMock) as poll:
             poll.side_effect = RuntimeError("stop")
             with pytest.raises(RuntimeError):
-                await backend._poll_until_done("task-1", request)
+                await ark_backend._poll_until_done("task-1", request)
         assert poll.call_args.kwargs["max_wait"] == 3600
         assert poll.call_args.kwargs["poll_interval"] == 60
 
@@ -602,12 +602,12 @@ class TestArkServiceTierParam:
         mock_client.content_generation.tasks = MagicMock()
 
         with patch("lib.video_backends.ark.create_ark_client", return_value=mock_client):
-            backend = ArkVideoBackend(api_key="test", model=model)
-        backend._client = mock_client
+            ark_backend = ArkVideoBackend(api_key="test", model=model)
+        ark_backend._client = mock_client
 
         create_result = MagicMock()
         create_result.id = "cgt-seedance2"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -615,25 +615,25 @@ class TestArkServiceTierParam:
         get_result.content.video_url = "https://cdn.example.com/v.mp4"
         get_result.seed = None
         get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
             with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await backend.generate(request)
+                await ark_backend.generate(request)
         finally:
             patcher.stop()
 
-        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        create_kwargs = ark_backend._client.content_generation.tasks.create.call_args.kwargs
         assert "service_tier" not in create_kwargs
 
-    async def test_seedance_1_5_sends_service_tier(self, backend, tmp_path):
+    async def test_seedance_1_5_sends_service_tier(self, ark_backend, tmp_path):
         output = tmp_path / "out.mp4"
 
         create_result = MagicMock()
         create_result.id = "cgt-seedance15"
-        backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
 
         get_result = MagicMock()
         get_result.status = "succeeded"
@@ -641,17 +641,17 @@ class TestArkServiceTierParam:
         get_result.content.video_url = "https://cdn.example.com/v.mp4"
         get_result.seed = None
         get_result.usage = None
-        backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
 
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
             with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await backend.generate(request)
+                await ark_backend.generate(request)
         finally:
             patcher.stop()
 
-        create_kwargs = backend._client.content_generation.tasks.create.call_args.kwargs
+        create_kwargs = ark_backend._client.content_generation.tasks.create.call_args.kwargs
         assert create_kwargs.get("service_tier") == "default"
 
 
@@ -751,7 +751,7 @@ class TestArkReferenceAudio:
 
     async def test_reference_audio_sent_as_audio_url_entries(self, tmp_path):
         """每段音频发一条 type=audio_url + role=reference_audio，且顺序与请求字段一致。"""
-        backend = self._seedance_2_backend()
+        ark_backend = self._seedance_2_backend()
         first_audio = tmp_path / "a.mp3"
         first_audio.write_bytes(b"id3-first")
         second_audio = tmp_path / "b.wav"
@@ -759,7 +759,7 @@ class TestArkReferenceAudio:
         ref = tmp_path / "r.png"
         ref.write_bytes(b"fake-ref")
 
-        backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
+        ark_backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
 
         request = VideoGenerationRequest(
             prompt="两人对话",
@@ -768,9 +768,9 @@ class TestArkReferenceAudio:
             reference_audio_files=[first_audio, second_audio],
         )
         with pytest.raises(RuntimeError):
-            await backend._create_task(request)
+            await ark_backend._create_task(request)
 
-        content = backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        content = ark_backend._client.content_generation.tasks.create.call_args.kwargs["content"]
         audio_items = [c for c in content if c["type"] == "audio_url"]
         assert len(audio_items) == 2
         assert [c["role"] for c in audio_items] == ["reference_audio", "reference_audio"]
@@ -779,37 +779,37 @@ class TestArkReferenceAudio:
         assert audio_items[1]["audio_url"]["url"].startswith("data:audio/wav;base64,")
 
     async def test_no_audio_entries_when_request_has_none(self, tmp_path):
-        backend = self._seedance_2_backend()
+        ark_backend = self._seedance_2_backend()
         ref = tmp_path / "r.png"
         ref.write_bytes(b"fake-ref")
-        backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
+        ark_backend._client.content_generation.tasks.create = MagicMock(side_effect=RuntimeError("stop"))
 
         with pytest.raises(RuntimeError):
-            await backend._create_task(
+            await ark_backend._create_task(
                 VideoGenerationRequest(prompt="x", output_path=tmp_path / "o.mp4", reference_images=[ref])
             )
 
-        content = backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        content = ark_backend._client.content_generation.tasks.create.call_args.kwargs["content"]
         assert not [c for c in content if c["type"] == "audio_url"]
 
     async def test_unsupported_audio_format_raises(self, tmp_path):
         """格式不受支持时抛错而非跳过：跳过会让其后所有音频编号整体前移、错绑角色音色。"""
-        backend = self._seedance_2_backend()
+        ark_backend = self._seedance_2_backend()
         bad = tmp_path / "a.ogg"
         bad.write_bytes(b"ogg")
 
         with pytest.raises(VideoCapabilityError) as exc:
-            await backend._create_task(
+            await ark_backend._create_task(
                 VideoGenerationRequest(prompt="x", output_path=tmp_path / "o.mp4", reference_audio_files=[bad])
             )
 
         assert exc.value.code == "video_reference_audio_format_unsupported"
 
     async def test_missing_audio_file_raises(self, tmp_path):
-        backend = self._seedance_2_backend()
+        ark_backend = self._seedance_2_backend()
 
         with pytest.raises(VideoCapabilityError) as exc:
-            await backend._create_task(
+            await ark_backend._create_task(
                 VideoGenerationRequest(
                     prompt="x",
                     output_path=tmp_path / "o.mp4",

--- a/tests/unit/lib/video_backends/test_video_backend_gemini.py
+++ b/tests/unit/lib/video_backends/test_video_backend_gemini.py
@@ -19,7 +19,7 @@ def mock_rate_limiter():
 
 
 @pytest.fixture
-def backend(mock_rate_limiter):
+def gemini_backend(mock_rate_limiter):
     """创建 aistudio 模式的 GeminiVideoBackend（mock genai SDK）。"""
     with patch("google.genai"), patch("google.genai.types"):
         from lib.video_backends.gemini import GeminiVideoBackend
@@ -38,11 +38,11 @@ def backend(mock_rate_limiter):
 
 
 class TestGeminiVideoBackendProperties:
-    def test_name(self, backend):
-        assert backend.name == "gemini-aistudio"
+    def test_name(self, gemini_backend):
+        assert gemini_backend.name == "gemini-aistudio"
 
-    def test_video_capabilities_aistudio(self, backend):
-        caps = backend.video_capabilities
+    def test_video_capabilities_aistudio(self, gemini_backend):
+        caps = gemini_backend.video_capabilities
         assert caps.last_frame is True
         assert caps.max_reference_images == 3
 
@@ -92,11 +92,11 @@ def _make_done_operation(video_uri="gs://bucket/video.mp4"):
 
 
 class TestGeminiVideoBackendGenerate:
-    async def test_generate_text_to_video(self, backend, tmp_path):
+    async def test_generate_text_to_video(self, gemini_backend, tmp_path):
         output = tmp_path / "out.mp4"
 
         mock_op = _make_done_operation()
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="a cat walking",
@@ -104,7 +104,7 @@ class TestGeminiVideoBackendGenerate:
             duration_seconds=8,
         )
 
-        result = await backend.generate(request)
+        result = await gemini_backend.generate(request)
 
         assert isinstance(result, VideoGenerationResult)
         assert result.provider == "gemini"
@@ -113,15 +113,15 @@ class TestGeminiVideoBackendGenerate:
         assert result.duration_seconds == 8
 
         # 确认调用了 API
-        backend._client.aio.models.generate_videos.assert_awaited_once()
+        gemini_backend._client.aio.models.generate_videos.assert_awaited_once()
 
-    async def test_generate_image_to_video(self, backend, tmp_path):
+    async def test_generate_image_to_video(self, gemini_backend, tmp_path):
         output = tmp_path / "out.mp4"
         frame = tmp_path / "frame.png"
         frame.write_bytes(b"fake-png-data")
 
         mock_op = _make_done_operation(video_uri=None)
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="cat moves forward",
@@ -129,12 +129,12 @@ class TestGeminiVideoBackendGenerate:
             start_image=frame,
         )
 
-        result = await backend.generate(request)
+        result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
         assert result.video_path == output
 
-    async def test_generate_polls_until_done(self, backend, tmp_path):
+    async def test_generate_polls_until_done(self, gemini_backend, tmp_path):
         """测试轮询逻辑：先返回未完成，再返回已完成。"""
         output = tmp_path / "out.mp4"
 
@@ -143,8 +143,8 @@ class TestGeminiVideoBackendGenerate:
 
         done_op = _make_done_operation()
 
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
-        backend._client.aio.operations.get = AsyncMock(return_value=done_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
+        gemini_backend._client.aio.operations.get = AsyncMock(return_value=done_op)
 
         request = VideoGenerationRequest(
             prompt="a sunset",
@@ -153,11 +153,11 @@ class TestGeminiVideoBackendGenerate:
 
         # patch asyncio.sleep 以避免实际等待
         with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await backend.generate(request)
+            result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
 
-    async def test_generate_empty_result_raises(self, backend, tmp_path):
+    async def test_generate_empty_result_raises(self, gemini_backend, tmp_path):
         """API 返回空结果时应抛出 RuntimeError。"""
         output = tmp_path / "out.mp4"
 
@@ -167,7 +167,7 @@ class TestGeminiVideoBackendGenerate:
         mock_op.response.generated_videos = []
         mock_op.error = None
 
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="test",
@@ -175,9 +175,9 @@ class TestGeminiVideoBackendGenerate:
         )
 
         with pytest.raises(RuntimeError, match="API 返回空结果"):
-            await backend.generate(request)
+            await gemini_backend.generate(request)
 
-    async def test_generate_error_in_operation(self, backend, tmp_path):
+    async def test_generate_error_in_operation(self, gemini_backend, tmp_path):
         """operation 包含 error 时应抛出 RuntimeError。"""
         output = tmp_path / "out.mp4"
 
@@ -186,7 +186,7 @@ class TestGeminiVideoBackendGenerate:
         mock_op.response = None
         mock_op.error = "Something went wrong"
 
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="test",
@@ -194,45 +194,45 @@ class TestGeminiVideoBackendGenerate:
         )
 
         with pytest.raises(RuntimeError, match="视频生成失败"):
-            await backend.generate(request)
+            await gemini_backend.generate(request)
 
-    async def test_rate_limiter_called(self, backend, mock_rate_limiter, tmp_path):
+    async def test_rate_limiter_called(self, gemini_backend, mock_rate_limiter, tmp_path):
         """确认 generate 会调用限流器。"""
         output = tmp_path / "out.mp4"
 
         mock_op = _make_done_operation()
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="test",
             output_path=output,
         )
 
-        await backend.generate(request)
-        mock_rate_limiter.acquire_async.assert_called_once_with(backend._video_model)
+        await gemini_backend.generate(request)
+        mock_rate_limiter.acquire_async.assert_called_once_with(gemini_backend._video_model)
 
-    async def test_no_negative_prompt_in_config(self, backend, tmp_path):
+    async def test_no_negative_prompt_in_config(self, gemini_backend, tmp_path):
         """negative_prompt 改走 prompt 文本通道，GenerateVideosConfig 不再带该字段。"""
         output = tmp_path / "out.mp4"
 
         mock_op = _make_done_operation()
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=mock_op)
 
         request = VideoGenerationRequest(
             prompt="test",
             output_path=output,
         )
 
-        await backend.generate(request)
+        await gemini_backend.generate(request)
 
-        config_call = backend._types.GenerateVideosConfig.call_args
+        config_call = gemini_backend._types.GenerateVideosConfig.call_args
         assert "negative_prompt" not in config_call.kwargs
 
 
 class TestGeminiRetryBehavior:
     """测试任务创建与轮询的重试分离行为。"""
 
-    async def test_poll_transient_error_retries_without_recreating_task(self, backend, tmp_path):
+    async def test_poll_transient_error_retries_without_recreating_task(self, gemini_backend, tmp_path):
         """轮询阶段瞬态错误应重试轮询，而不是重新创建任务。"""
         output = tmp_path / "out.mp4"
 
@@ -241,27 +241,29 @@ class TestGeminiRetryBehavior:
 
         done_op = _make_done_operation()
 
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
         # 第一次轮询抛 ConnectionError，第二次返回完成
-        backend._client.aio.operations.get = AsyncMock(side_effect=[ConnectionError("connection reset"), done_op])
+        gemini_backend._client.aio.operations.get = AsyncMock(
+            side_effect=[ConnectionError("connection reset"), done_op]
+        )
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await backend.generate(request)
+            result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
         # 关键断言：任务只创建了一次
-        backend._client.aio.models.generate_videos.assert_awaited_once()
+        gemini_backend._client.aio.models.generate_videos.assert_awaited_once()
         # 轮询调用了两次（一次失败 + 一次成功）
-        assert backend._client.aio.operations.get.await_count == 2
+        assert gemini_backend._client.aio.operations.get.await_count == 2
 
-    async def test_create_retries_on_transient_error(self, backend, tmp_path):
+    async def test_create_retries_on_transient_error(self, gemini_backend, tmp_path):
         """任务创建阶段的瞬态错误应由 @with_retry_async 重试。"""
         output = tmp_path / "out.mp4"
 
         done_op = _make_done_operation()
         # 第一次创建抛 ConnectionError，第二次成功
-        backend._client.aio.models.generate_videos = AsyncMock(
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(
             side_effect=[ConnectionError("connection reset"), done_op]
         )
 
@@ -270,52 +272,52 @@ class TestGeminiRetryBehavior:
             patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
             patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
         ):
-            result = await backend.generate(request)
+            result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
         # 创建调用了两次（一次失败 + 一次成功）
-        assert backend._client.aio.models.generate_videos.await_count == 2
+        assert gemini_backend._client.aio.models.generate_videos.await_count == 2
 
-    async def test_poll_non_retryable_error_propagates(self, backend, tmp_path):
+    async def test_poll_non_retryable_error_propagates(self, gemini_backend, tmp_path):
         """轮询阶段不可重试的错误应直接抛出。"""
         output = tmp_path / "out.mp4"
 
         pending_op = MagicMock()
         pending_op.done = False
 
-        backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
-        backend._client.aio.operations.get = AsyncMock(side_effect=ValueError("invalid response"))
+        gemini_backend._client.aio.models.generate_videos = AsyncMock(return_value=pending_op)
+        gemini_backend._client.aio.operations.get = AsyncMock(side_effect=ValueError("invalid response"))
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
             with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await backend.generate(request)
+                await gemini_backend.generate(request)
 
         # 创建只调用一次
-        backend._client.aio.models.generate_videos.assert_awaited_once()
+        gemini_backend._client.aio.models.generate_videos.assert_awaited_once()
         # 轮询只尝试一次就抛出
-        assert backend._client.aio.operations.get.await_count == 1
+        assert gemini_backend._client.aio.operations.get.await_count == 1
 
 
 # ── _prepare_image_param 测试 ─────────────────────────────
 
 
 class TestPrepareImageParam:
-    def test_none_returns_none(self, backend):
-        assert backend._prepare_image_param(None) is None
+    def test_none_returns_none(self, gemini_backend):
+        assert gemini_backend._prepare_image_param(None) is None
 
-    def test_path_reads_file(self, backend, tmp_path):
+    def test_path_reads_file(self, gemini_backend, tmp_path):
         img_file = tmp_path / "test.jpg"
         img_file.write_bytes(b"\xff\xd8\xff\xe0")  # JPEG magic
 
-        result = backend._prepare_image_param(img_file)
+        result = gemini_backend._prepare_image_param(img_file)
         assert result is not None
 
-    def test_pil_image(self, backend):
+    def test_pil_image(self, gemini_backend):
         from PIL import Image as PILImage
 
         img = PILImage.new("RGB", (10, 10), color="red")
-        result = backend._prepare_image_param(img)
+        result = gemini_backend._prepare_image_param(img)
         assert result is not None
 
 
@@ -323,40 +325,40 @@ class TestPrepareImageParam:
 
 
 class TestDownloadVideo:
-    def test_aistudio_download(self, backend, tmp_path):
+    def test_aistudio_download(self, gemini_backend, tmp_path):
         output = tmp_path / "video.mp4"
         mock_ref = MagicMock()
 
-        backend._download_video(mock_ref, output)
+        gemini_backend._download_video(mock_ref, output)
 
-        backend._client.files.download.assert_called_once_with(file=mock_ref)
+        gemini_backend._client.files.download.assert_called_once_with(file=mock_ref)
         mock_ref.save.assert_called_once_with(str(output))
 
-    def test_vertex_download_from_bytes(self, backend, tmp_path):
-        backend._backend_type = "vertex"
+    def test_vertex_download_from_bytes(self, gemini_backend, tmp_path):
+        gemini_backend._backend_type = "vertex"
         output = tmp_path / "video.mp4"
 
         mock_ref = MagicMock()
         mock_ref.video_bytes = b"video-data"
 
-        backend._download_video(mock_ref, output)
+        gemini_backend._download_video(mock_ref, output)
 
         assert output.read_bytes() == b"video-data"
 
-    def test_vertex_no_data_raises(self, backend, tmp_path):
-        backend._backend_type = "vertex"
+    def test_vertex_no_data_raises(self, gemini_backend, tmp_path):
+        gemini_backend._backend_type = "vertex"
         output = tmp_path / "video.mp4"
 
         mock_ref = MagicMock(spec=[])  # no attributes
 
         with pytest.raises(RuntimeError, match="无法获取视频数据"):
-            backend._download_video(mock_ref, output)
+            gemini_backend._download_video(mock_ref, output)
 
 
 class TestGeminiResumeVideo:
     """resume_video 路径：初次 + mid-poll NOT_FOUND 都归类为 ResumeExpiredError。"""
 
-    async def test_mid_poll_not_found_classified_as_resume_expired(self, backend, tmp_path):
+    async def test_mid_poll_not_found_classified_as_resume_expired(self, gemini_backend, tmp_path):
         from lib.video_backends.base import ResumeExpiredError
 
         # 初次 operations.get 返回 pending 让 poll 进入循环；poll_fn 中抛 NOT_FOUND
@@ -370,25 +372,25 @@ class TestGeminiResumeVideo:
                 return pending_op
             raise RuntimeError("operation not found mid poll")
 
-        backend._client.aio.operations.get = AsyncMock(side_effect=_fake_get)
+        gemini_backend._client.aio.operations.get = AsyncMock(side_effect=_fake_get)
         # GenerateVideosOperation.model_validate 用 MagicMock，返回任意对象即可
-        backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=pending_op)
+        gemini_backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=pending_op)
 
         request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
         with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(ResumeExpiredError) as ei:
-                await backend.resume_video("op-xyz", request)
+                await gemini_backend.resume_video("op-xyz", request)
         assert ei.value.job_id == "op-xyz"
 
-    async def test_initial_get_not_found_classified_as_resume_expired(self, backend, tmp_path):
+    async def test_initial_get_not_found_classified_as_resume_expired(self, gemini_backend, tmp_path):
         from lib.video_backends.base import ResumeExpiredError
 
-        backend._client.aio.operations.get = AsyncMock(side_effect=RuntimeError("operation not found"))
-        backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=MagicMock())
+        gemini_backend._client.aio.operations.get = AsyncMock(side_effect=RuntimeError("operation not found"))
+        gemini_backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=MagicMock())
 
         request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
         with pytest.raises(ResumeExpiredError):
-            await backend.resume_video("op-not-found", request)
+            await gemini_backend.resume_video("op-not-found", request)
 
 
 class TestIsGeminiNotFound:

--- a/tests/unit/lib/video_backends/test_video_backend_gemini.py
+++ b/tests/unit/lib/video_backends/test_video_backend_gemini.py
@@ -394,7 +394,7 @@ class TestGeminiResumeVideo:
 
 
 class TestIsGeminiNotFound:
-    """fix #647 #6：INVALID_ARGUMENT 不归过期，只保留 404 / NOT_FOUND / "not found" / "expired"。"""
+    """INVALID_ARGUMENT 不归过期，只保留 404 / NOT_FOUND / "not found" / "expired"。"""
 
     def test_excludes_invalid_argument(self):
         from lib.video_backends.gemini import _is_gemini_not_found

--- a/tests/unit/lib/video_backends/test_vidu_video_backend.py
+++ b/tests/unit/lib/video_backends/test_vidu_video_backend.py
@@ -24,6 +24,7 @@ from lib.video_backends.vidu import (
     _coerce_duration,
     _coerce_resolution,
 )
+from tests.fakes import bounded_poll_clock
 
 
 @pytest.fixture
@@ -441,7 +442,7 @@ class TestCreateTaskAmbiguity:
 
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
         with (
-            patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0),
+            bounded_poll_clock(),
             pytest.raises(AmbiguousSubmitError, match="手动重试"),
         ):
             await backend._create_task(client, "/text2video", {"model": "viduq3-turbo", "prompt": "x", "duration": 8})
@@ -460,7 +461,7 @@ class TestCreateTaskAmbiguity:
         client.post = AsyncMock(side_effect=[httpx.ConnectError("refused"), httpx.ConnectError("refused"), ok])
 
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
-        with patch("lib.retry._compute_wait", lambda attempt, backoff: 0.0):
+        with bounded_poll_clock():
             data = await backend._create_task(
                 client, "/text2video", {"model": "viduq3-turbo", "prompt": "x", "duration": 8}
             )

--- a/tests/unit/lib/video_backends/test_vidu_video_backend.py
+++ b/tests/unit/lib/video_backends/test_vidu_video_backend.py
@@ -28,7 +28,7 @@ from tests.fakes import bounded_poll_clock
 
 
 @pytest.fixture
-def output_path(tmp_path: Path) -> Path:
+def video_output_path(tmp_path: Path) -> Path:
     return tmp_path / "out.mp4"
 
 
@@ -58,7 +58,7 @@ class TestBackendBasics:
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
         assert backend.video_capabilities.last_frame is True
 
-    async def test_marks_resubmit_unsafe_after_task_creation(self, output_path: Path):
+    async def test_marks_resubmit_unsafe_after_task_creation(self, video_output_path: Path):
         backend = ViduVideoBackend(api_key="test-key")
         client = MagicMock()
         client_context = MagicMock()
@@ -67,7 +67,7 @@ class TestBackendBasics:
         resubmit_unsafe = MagicMock()
         request = VideoGenerationRequest(
             prompt="x",
-            output_path=output_path,
+            output_path=video_output_path,
             on_provider_resubmit_unsafe=resubmit_unsafe,
         )
 
@@ -89,32 +89,32 @@ class TestEndpointSelection:
     def _backend(self, model: str = "viduq3-turbo") -> ViduVideoBackend:
         return ViduVideoBackend(api_key="test-key", model=model)
 
-    def test_text_only_picks_text2video(self, output_path: Path):
+    def test_text_only_picks_text2video(self, video_output_path: Path):
         backend = self._backend()
-        req = VideoGenerationRequest(prompt="x", output_path=output_path)
+        req = VideoGenerationRequest(prompt="x", output_path=video_output_path)
         assert backend._select_endpoint(req) == "/text2video"
 
-    def test_start_image_picks_img2video(self, tmp_path: Path, output_path: Path):
+    def test_start_image_picks_img2video(self, tmp_path: Path, video_output_path: Path):
         backend = self._backend()
         start = tmp_path / "start.png"
         start.write_bytes(b"x")
-        req = VideoGenerationRequest(prompt="x", output_path=output_path, start_image=start)
+        req = VideoGenerationRequest(prompt="x", output_path=video_output_path, start_image=start)
         assert backend._select_endpoint(req) == "/img2video"
 
-    def test_start_and_end_image_picks_start_end2video(self, tmp_path: Path, output_path: Path):
+    def test_start_and_end_image_picks_start_end2video(self, tmp_path: Path, video_output_path: Path):
         backend = self._backend()
         start, end = tmp_path / "s.png", tmp_path / "e.png"
         for p in (start, end):
             p.write_bytes(b"x")
-        req = VideoGenerationRequest(prompt="x", output_path=output_path, start_image=start, end_image=end)
+        req = VideoGenerationRequest(prompt="x", output_path=video_output_path, start_image=start, end_image=end)
         assert backend._select_endpoint(req) == "/start-end2video"
 
-    def test_reference_images_take_priority(self, tmp_path: Path, output_path: Path):
+    def test_reference_images_take_priority(self, tmp_path: Path, video_output_path: Path):
         """有 refs 时即使带 start_image 也应走 reference2video（依实现：refs 先判）。"""
         backend = self._backend()
         ref = tmp_path / "ref.png"
         ref.write_bytes(b"x")
-        req = VideoGenerationRequest(prompt="x", output_path=output_path, reference_images=[ref])
+        req = VideoGenerationRequest(prompt="x", output_path=video_output_path, reference_images=[ref])
         assert backend._select_endpoint(req) == "/reference2video"
 
 
@@ -202,11 +202,11 @@ class TestBuildRequest:
     """_build_request 是核心串联函数：endpoint 选择 + duration/resolution/aspect_ratio/audio 字段拼装。"""
 
     @patch("lib.video_backends.vidu.image_to_data_uri")
-    def test_text2video_body_minimal(self, mock_data_uri, output_path: Path):
+    def test_text2video_body_minimal(self, mock_data_uri, video_output_path: Path):
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
         req = VideoGenerationRequest(
             prompt="hello",
-            output_path=output_path,
+            output_path=video_output_path,
             aspect_ratio="9:16",
             duration_seconds=8,
             resolution="720p",
@@ -225,14 +225,14 @@ class TestBuildRequest:
         assert "images" not in body
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
-    def test_img2video_passes_one_image_no_aspect_ratio(self, _mock, tmp_path: Path, output_path: Path):
+    def test_img2video_passes_one_image_no_aspect_ratio(self, _mock, tmp_path: Path, video_output_path: Path):
         start = tmp_path / "s.png"
         start.write_bytes(b"x")
 
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
         req = VideoGenerationRequest(
             prompt="x",
-            output_path=output_path,
+            output_path=video_output_path,
             start_image=start,
             aspect_ratio="9:16",  # 应被丢弃
             duration_seconds=5,
@@ -245,7 +245,7 @@ class TestBuildRequest:
         assert "aspect_ratio" not in body
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
-    def test_reference2video_with_q3_turbo(self, _mock, tmp_path: Path, output_path: Path):
+    def test_reference2video_with_q3_turbo(self, _mock, tmp_path: Path, video_output_path: Path):
         ref1, ref2 = tmp_path / "r1.png", tmp_path / "r2.png"
         for p in (ref1, ref2):
             p.write_bytes(b"x")
@@ -253,7 +253,7 @@ class TestBuildRequest:
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-turbo")
         req = VideoGenerationRequest(
             prompt="x",
-            output_path=output_path,
+            output_path=video_output_path,
             reference_images=[ref1, ref2],
             aspect_ratio="9:16",
             duration_seconds=5,
@@ -267,28 +267,28 @@ class TestBuildRequest:
         # range 3..16，5 透传
         assert body["duration"] == 5
 
-    def test_reference2video_with_q3_pro_raises_model_mismatch(self, tmp_path: Path, output_path: Path):
+    def test_reference2video_with_q3_pro_raises_model_mismatch(self, tmp_path: Path, video_output_path: Path):
         ref = tmp_path / "r.png"
         ref.write_bytes(b"x")
 
         backend = ViduVideoBackend(api_key="test-key", model="viduq3-pro")
         req = VideoGenerationRequest(
             prompt="x",
-            output_path=output_path,
+            output_path=video_output_path,
             reference_images=[ref],
             duration_seconds=5,
         )
         with pytest.raises(RuntimeError, match="不支持"):
             backend._build_request(req)
 
-    def test_non_q3_model_does_not_send_audio(self, output_path: Path):
+    def test_non_q3_model_does_not_send_audio(self, video_output_path: Path):
         backend = ViduVideoBackend(api_key="test-key", model="vidu2.0")
         # vidu2.0 走 img2video，不能 text2video
         # 这里直接用 reference2video 路径需 ref；走 start-image 演示
         # 用 monkeypatch 跳过 image_to_data_uri
         # 简化：直接构造一个 text2video 请求验证 audio 不写入
         # —— 但 vidu2.0 不在 text2video 集合里，应该 raise
-        req = VideoGenerationRequest(prompt="x", output_path=output_path, duration_seconds=4)
+        req = VideoGenerationRequest(prompt="x", output_path=video_output_path, duration_seconds=4)
         with pytest.raises(RuntimeError, match="不支持"):
             backend._build_request(req)
 
@@ -308,11 +308,11 @@ class TestPromptLength:
         """未登记 model（中转自定义命名）取宽值：能力不明时误拒是更糟的降级。"""
         assert ViduVideoBackend.video_capabilities_for_model("proxy-x").max_prompt_chars == 5000
 
-    def test_reference2video_over_limit_raises(self, output_path: Path):
+    def test_reference2video_over_limit_raises(self, video_output_path: Path):
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
         req = VideoGenerationRequest(
             prompt="字" * 2001,
-            output_path=output_path,
+            output_path=video_output_path,
             duration_seconds=8,
             reference_images=[Path("a.png")],
         )
@@ -328,12 +328,12 @@ class TestPromptLength:
         }
 
     @patch("lib.video_backends.vidu.image_to_data_uri", return_value="data:image/png;base64,XX")
-    def test_reference2video_at_limit_passes_untruncated(self, _mock_data_uri, output_path: Path):
+    def test_reference2video_at_limit_passes_untruncated(self, _mock_data_uri, video_output_path: Path):
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
         prompt = "字" * 2000
         req = VideoGenerationRequest(
             prompt=prompt,
-            output_path=output_path,
+            output_path=video_output_path,
             duration_seconds=8,
             reference_images=[Path("a.png")],
         )
@@ -341,10 +341,10 @@ class TestPromptLength:
 
         assert body["prompt"] == prompt
 
-    def test_text2video_allows_longer_than_reference_limit(self, output_path: Path):
+    def test_text2video_allows_longer_than_reference_limit(self, video_output_path: Path):
         """端点上限按端点各算：t2v 的 5000 不受 /reference2video 的 2000 牵连。"""
         backend = ViduVideoBackend(api_key="k", model="viduq3-turbo")
-        req = VideoGenerationRequest(prompt="字" * 3000, output_path=output_path, duration_seconds=8)
+        req = VideoGenerationRequest(prompt="字" * 3000, output_path=video_output_path, duration_seconds=8)
         _endpoint, body = backend._build_request(req)
 
         assert len(body["prompt"]) == 3000

--- a/tests/unit/server/agent_runtime/test_agent_startup_error.py
+++ b/tests/unit/server/agent_runtime/test_agent_startup_error.py
@@ -44,7 +44,7 @@ def test_agent_startup_error_without_stderr_keeps_message() -> None:
 
 
 @pytest.fixture
-def session_manager(tmp_path: Path) -> SessionManager:
+def seeded_session_manager(tmp_path: Path) -> SessionManager:
     project_root = tmp_path / "repo"
     project_root.mkdir()
     (project_root / "projects").mkdir()
@@ -58,7 +58,7 @@ def session_manager(tmp_path: Path) -> SessionManager:
 
 @pytest.mark.asyncio
 async def test_build_options_forwards_stderr_callback(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+    seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """_build_options 必须把 stderr 回调透传给 ClaudeAgentOptions。"""
 
@@ -72,7 +72,7 @@ async def test_build_options_forwards_stderr_callback(
     def collector(line: str) -> None:
         captured.append(line)
 
-    opts = await session_manager._build_options("demo", stderr=collector)
+    opts = await seeded_session_manager._build_options("demo", stderr=collector)
     assert opts.stderr is collector
 
     # 模拟 SDK 透传一行 stderr
@@ -82,7 +82,7 @@ async def test_build_options_forwards_stderr_callback(
 
 @pytest.mark.asyncio
 async def test_send_new_session_wraps_actor_failure_with_stderr(
-    session_manager: SessionManager,
+    seeded_session_manager: SessionManager,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -130,7 +130,7 @@ async def test_send_new_session_wraps_actor_failure_with_stderr(
     caplog.set_level("ERROR", logger="server.agent_runtime.session_manager")
 
     with pytest.raises(AgentStartupError) as exc_info:
-        await session_manager.send_new_session("demo", "你好")
+        await seeded_session_manager.send_new_session("demo", "你好")
 
     err = exc_info.value
     assert "Git for Windows" in err.sdk_stderr
@@ -154,7 +154,7 @@ async def test_send_new_session_wraps_actor_failure_with_stderr(
 
 @pytest.mark.asyncio
 async def test_send_new_session_no_stderr_still_wraps(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+    seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """即使 SDK 没产生 stderr，actor.start 失败也应包装为 AgentStartupError（保留原因链）。"""
 
@@ -177,7 +177,7 @@ async def test_send_new_session_no_stderr_still_wraps(
     monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
 
     with pytest.raises(AgentStartupError) as exc_info:
-        await session_manager.send_new_session("demo", "你好")
+        await seeded_session_manager.send_new_session("demo", "你好")
 
     assert exc_info.value.sdk_stderr == ""
     assert "ENOENT" in str(exc_info.value)
@@ -187,25 +187,25 @@ async def test_send_new_session_no_stderr_still_wraps(
 
 @pytest.mark.asyncio
 async def test_send_new_session_wraps_option_assembly_failure(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+    seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
     monkeypatch.setattr(SessionManager, "_build_options", AsyncMock(side_effect=LookupError("credential missing")))
 
     with pytest.raises(AgentStartupError) as exc_info:
-        await session_manager.send_new_session("demo", "你好")
+        await seeded_session_manager.send_new_session("demo", "你好")
 
     failure = exc_info.value.failure_observation
     assert failure is not None
     assert failure["phase"] == "startup"
     assert failure["summary"]["type"] == "LookupError"
     assert failure["summary"]["message"] == "credential missing"
-    assert session_manager.sessions == {}
+    assert seeded_session_manager.sessions == {}
 
 
 @pytest.mark.asyncio
 async def test_get_or_connect_wraps_actor_failure_with_stderr(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+    seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """恢复历史会话路径同样要把 actor.start 失败包装为 AgentStartupError。
 
@@ -247,18 +247,18 @@ async def test_get_or_connect_wraps_actor_failure_with_stderr(
     meta = make_session_meta(id="resumed-session", project_name="demo", status="idle")
 
     with pytest.raises(AgentStartupError) as exc_info:
-        await session_manager.get_or_connect("resumed-session", meta=meta)
+        await seeded_session_manager.get_or_connect("resumed-session", meta=meta)
 
     err = exc_info.value
     assert "resume-failed" in err.sdk_stderr
     assert "Command failed with exit code 1" in str(err)
     # 失败后会话不应残留在内存里
-    assert "resumed-session" not in session_manager.sessions
+    assert "resumed-session" not in seeded_session_manager.sessions
 
 
 @pytest.mark.asyncio
 async def test_startup_stderr_is_not_truncated(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
+    seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """启动阶段实际收到的 stderr 必须完整进入故障观测，不做行数裁剪。"""
 
@@ -295,7 +295,7 @@ async def test_startup_stderr_is_not_truncated(
     monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
 
     with pytest.raises(AgentStartupError) as exc_info:
-        await session_manager.send_new_session("demo", "你好")
+        await seeded_session_manager.send_new_session("demo", "你好")
 
     lines = exc_info.value.sdk_stderr.split("\n")
     assert len(lines) == observed_count

--- a/tests/unit/server/agent_runtime/test_entry_stream.py
+++ b/tests/unit/server/agent_runtime/test_entry_stream.py
@@ -19,8 +19,7 @@ from server.agent_runtime.service import AssistantService
 from server.auth import CurrentUserInfo, get_current_user, get_current_user_flexible
 from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
-from tests.factories import make_session_meta
+from tests.factories import make_session_meta, make_translator
 
 SESSION_ID = "entry-stream-s1"
 

--- a/tests/unit/server/agent_runtime/test_entry_stream.py
+++ b/tests/unit/server/agent_runtime/test_entry_stream.py
@@ -9,9 +9,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.sse import ServerSentEvent
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.i18n import DEFAULT_LOCALE, get_translator
 from server.agent_runtime.event_log import EventLogService, EventLogStore
 from server.agent_runtime.models import LiveMessage, SubscriptionReady
@@ -77,20 +75,15 @@ class _FakeEntrySessionManager:
 
 
 @pytest.fixture()
-async def entry_service(tmp_path):
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    store = EventLogStore(session_factory=factory)
+async def entry_service(db_factory, tmp_path):
+    store = EventLogStore(session_factory=db_factory)
 
     service = AssistantService(project_root=tmp_path)
     meta = make_session_meta(id=SESSION_ID, status="running")
     service.meta_store = _FakeMetaStore(meta)
     service.event_log_store = store
     service.event_log = EventLogService(store, _FakeAdapter())
-    yield service, store
-    await engine.dispose()
+    return service, store
 
 
 def _collect(event: ServerSentEvent) -> tuple[str, dict, str | None]:

--- a/tests/unit/server/agent_runtime/test_event_log.py
+++ b/tests/unit/server/agent_runtime/test_event_log.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime.event_log import (
     REPLAYED_USER_ECHO_KEY,
     EventLogService,
@@ -21,36 +19,14 @@ from server.agent_runtime.event_log import (
 
 
 @pytest.fixture()
-async def log_store():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield EventLogStore(session_factory=factory)
-    await engine.dispose()
+async def log_store(db_factory):
+    return EventLogStore(session_factory=db_factory)
 
 
 @pytest.fixture()
-async def file_log_store(tmp_path):
+async def file_log_store(file_db_factory):
     """文件 SQLite + NullPool：并发测试需要独立连接（内存库 StaticPool 会串扰）。"""
-    from sqlalchemy import event, pool
-
-    db_path = tmp_path / "event-log.db"
-    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", poolclass=pool.NullPool)
-
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _record):
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.execute("PRAGMA foreign_keys=OFF")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield EventLogStore(session_factory=factory)
-    await engine.dispose()
+    return EventLogStore(session_factory=file_db_factory)
 
 
 class _FakeDriverError(Exception):

--- a/tests/unit/server/agent_runtime/test_event_log_session_flow.py
+++ b/tests/unit/server/agent_runtime/test_event_log_session_flow.py
@@ -7,41 +7,13 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime.event_log import EventLogStore, build_user_entry
 from server.agent_runtime.session_manager import AgentStartupError, SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.fakes import FakeSDKClient
 
 SDK_ID = "sdk-e2e-1"
-
-
-@pytest.fixture()
-async def file_db_factory(tmp_path):
-    """文件 SQLite + NullPool：本测试的写入（inbox 任务）与轮询读并发，
-    内存库 StaticPool 共享单连接会让事务交错互相破坏。"""
-    from sqlalchemy import event, pool
-
-    engine = create_async_engine(
-        f"sqlite+aiosqlite:///{tmp_path / 'flow.db'}",
-        poolclass=pool.NullPool,
-    )
-
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _record):
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.execute("PRAGMA foreign_keys=OFF")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
 
 
 @pytest.fixture()

--- a/tests/unit/server/agent_runtime/test_event_log_session_flow.py
+++ b/tests/unit/server/agent_runtime/test_event_log_session_flow.py
@@ -19,7 +19,7 @@ SDK_ID = "sdk-e2e-1"
 
 
 @pytest.fixture()
-async def db_factory(tmp_path):
+async def file_db_factory(tmp_path):
     """文件 SQLite + NullPool：本测试的写入（inbox 任务）与轮询读并发，
     内存库 StaticPool 共享单连接会让事务交错互相破坏。"""
     from sqlalchemy import event, pool
@@ -45,11 +45,11 @@ async def db_factory(tmp_path):
 
 
 @pytest.fixture()
-async def manager(tmp_path, db_factory):
+async def manager(tmp_path, file_db_factory):
     return SessionManager(
         project_root=tmp_path,
-        meta_store=SessionMetaStore(session_factory=db_factory),
-        event_log_store=EventLogStore(session_factory=db_factory),
+        meta_store=SessionMetaStore(session_factory=file_db_factory),
+        event_log_store=EventLogStore(session_factory=file_db_factory),
     )
 
 
@@ -552,7 +552,7 @@ class TestNewSessionEventLogFlow:
         finally:
             await manager.close_session(SDK_ID)
 
-    async def test_send_message_writes_user_entry_before_query(self, manager: SessionManager, db_factory):
+    async def test_send_message_writes_user_entry_before_query(self, manager: SessionManager, file_db_factory):
         meta = await manager.meta_store.create("demo", SDK_ID)
         client = FakeSDKClient(messages=[{"type": "result", "subtype": "success", "session_id": SDK_ID, "uuid": "r-1"}])
         fake_options = SimpleNamespace(env=None)

--- a/tests/unit/server/agent_runtime/test_session_manager_sandbox.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_sandbox.py
@@ -16,7 +16,7 @@ from server.agent_runtime.session_store import SessionMetaStore
 
 
 @pytest.fixture
-def session_manager(tmp_path: Path) -> SessionManager:
+def fs_session_manager(tmp_path: Path) -> SessionManager:
     project_root = tmp_path / "repo"
     project_root.mkdir()
     (project_root / "projects").mkdir()
@@ -26,9 +26,9 @@ def session_manager(tmp_path: Path) -> SessionManager:
 
 @pytest.mark.asyncio
 async def test_build_options_includes_sandbox_settings(
-    session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    fs_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    proj_dir = session_manager.project_root / "projects" / "test_proj"
+    proj_dir = fs_session_manager.project_root / "projects" / "test_proj"
     proj_dir.mkdir(parents=True)
     (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
 
@@ -37,7 +37,7 @@ async def test_build_options_includes_sandbox_settings(
 
     monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
 
-    opts = await session_manager._build_options("test_proj")
+    opts = await fs_session_manager._build_options("test_proj")
 
     assert opts.sandbox is not None
     assert opts.sandbox.get("enabled") is True
@@ -103,12 +103,12 @@ def test_configure_sandbox_runtime_swaps_policy(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_bash_env_scrub_hook_wraps_command_with_env_unset(session_manager: SessionManager) -> None:
+async def test_bash_env_scrub_hook_wraps_command_with_env_unset(fs_session_manager: SessionManager) -> None:
     """hook 把 policy 的包装结果塞进 ``updatedInput.command``，且不返回
     permissionDecision——PreToolUse hook 是权限链第 1 步，allow 会短路后续所有步骤。
     包装内容（``env -u <keys> sh -c '<orig>'``）由 test_agent_access_policy.py 的
     ``test_wrap_bash_command_unsets_provider_keys`` 覆盖，此处只验接线。"""
-    result = await session_manager._options_assembler._bash_env_scrub_hook(
+    result = await fs_session_manager._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {"command": "env | grep ANTHROPIC"}},
         None,
         None,
@@ -138,9 +138,9 @@ async def test_bash_env_scrub_hook_skips_wrap_when_sandbox_disabled(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_bash_env_scrub_hook_passthrough_when_no_command(session_manager: SessionManager) -> None:
+async def test_bash_env_scrub_hook_passthrough_when_no_command(fs_session_manager: SessionManager) -> None:
     """空 command 时直接放行，不做包装。"""
-    result = await session_manager._options_assembler._bash_env_scrub_hook(
+    result = await fs_session_manager._options_assembler._bash_env_scrub_hook(
         {"tool_name": "Bash", "tool_input": {}},
         None,
         None,

--- a/tests/unit/server/agent_runtime/test_session_meta_store.py
+++ b/tests/unit/server/agent_runtime/test_session_meta_store.py
@@ -1,22 +1,13 @@
 """Tests for SessionMetaStore (async wrapper over SessionRepository)."""
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime.session_store import SessionMetaStore
 
 
 @pytest.fixture
-async def store():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    s = SessionMetaStore(session_factory=factory)
-    yield s
-    await engine.dispose()
+async def store(db_factory):
+    return SessionMetaStore(session_factory=db_factory)
 
 
 class TestSessionMetaStore:

--- a/tests/unit/server/routers/test_agent_config_router.py
+++ b/tests/unit/server/routers/test_agent_config_router.py
@@ -6,10 +6,8 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.db import get_async_session
-from lib.db.base import Base
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import agent_config
 from tests.auth_deps import AUTH_DEPENDENCIES
@@ -30,18 +28,8 @@ def _make_app(session_factory) -> FastAPI:
 
 
 @pytest_asyncio.fixture
-async def _session_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    yield factory
-    await engine.dispose()
-
-
-@pytest_asyncio.fixture
-async def authed_client(_session_factory):
-    app = _make_app(_session_factory)
+async def agent_config_client(db_factory):
+    app = _make_app(db_factory)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -49,11 +37,11 @@ async def authed_client(_session_factory):
 
 
 @pytest_asyncio.fixture
-async def unauth_client(_session_factory, monkeypatch):
+async def unauth_client(db_factory, monkeypatch):
     """No dependency override → real auth applies → expects 401/403."""
     # AUTH_ENABLED=false 时 get_current_user 直接返回匿名 admin，本 fixture 就测不到拒绝。
     monkeypatch.setenv("AUTH_ENABLED", "true")
-    app = _make_app(_session_factory)
+    app = _make_app(db_factory)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
@@ -63,8 +51,8 @@ async def unauth_client(_session_factory, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_preset_providers_returns_catalog(authed_client) -> None:
-    resp = await authed_client.get("/api/v1/agent/preset-providers")
+async def test_list_preset_providers_returns_catalog(agent_config_client) -> None:
+    resp = await agent_config_client.get("/api/v1/agent/preset-providers")
     assert resp.status_code == 200
     data = resp.json()
     assert "providers" in data
@@ -93,16 +81,16 @@ async def test_list_preset_providers_requires_auth(unauth_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_credentials_initially_empty(authed_client) -> None:
-    resp = await authed_client.get("/api/v1/agent/credentials")
+async def test_list_credentials_initially_empty(agent_config_client) -> None:
+    resp = await agent_config_client.get("/api/v1/agent/credentials")
     assert resp.status_code == 200
     assert resp.json() == {"credentials": []}
 
 
 @pytest.mark.asyncio
-async def test_create_with_preset(authed_client) -> None:
+async def test_create_with_preset(agent_config_client) -> None:
     body = {"preset_id": "deepseek", "api_key": "sk-testkey12345"}
-    resp = await authed_client.post("/api/v1/agent/credentials", json=body)
+    resp = await agent_config_client.post("/api/v1/agent/credentials", json=body)
     assert resp.status_code == 201
     cred = resp.json()
     assert cred["preset_id"] == "deepseek"
@@ -116,14 +104,14 @@ async def test_create_with_preset(authed_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_custom_requires_base_url(authed_client) -> None:
+async def test_create_custom_requires_base_url(agent_config_client) -> None:
     body = {"preset_id": "__custom__", "api_key": "sk"}
-    resp = await authed_client.post("/api/v1/agent/credentials", json=body)
+    resp = await agent_config_client.post("/api/v1/agent/credentials", json=body)
     assert resp.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_create_custom_with_base_url(authed_client) -> None:
+async def test_create_custom_with_base_url(agent_config_client) -> None:
     body = {
         "preset_id": "__custom__",
         "display_name": "My Proxy",
@@ -131,15 +119,15 @@ async def test_create_custom_with_base_url(authed_client) -> None:
         "api_key": "sk",
         "model": "claude-sonnet-4",
     }
-    resp = await authed_client.post("/api/v1/agent/credentials", json=body)
+    resp = await agent_config_client.post("/api/v1/agent/credentials", json=body)
     assert resp.status_code == 201
     assert resp.json()["base_url"] == "https://proxy.example.com/anthropic"
     assert resp.json()["icon_key"] is None
 
 
 @pytest.mark.asyncio
-async def test_create_unknown_preset_rejected(authed_client) -> None:
-    resp = await authed_client.post(
+async def test_create_unknown_preset_rejected(agent_config_client) -> None:
+    resp = await agent_config_client.post(
         "/api/v1/agent/credentials",
         json={"preset_id": "nonexistent", "api_key": "sk"},
     )
@@ -147,15 +135,15 @@ async def test_create_unknown_preset_rejected(authed_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_patch_credential(authed_client) -> None:
+async def test_patch_credential(agent_config_client) -> None:
     created = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "deepseek", "api_key": "sk1"},
         )
     ).json()
     cid = created["id"]
-    resp = await authed_client.patch(
+    resp = await agent_config_client.patch(
         f"/api/v1/agent/credentials/{cid}",
         json={"display_name": "Renamed", "api_key": "sk2"},
     )
@@ -164,38 +152,38 @@ async def test_patch_credential(authed_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_active_blocked(authed_client) -> None:
+async def test_delete_active_blocked(agent_config_client) -> None:
     created = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "deepseek", "api_key": "sk"},
         )
     ).json()
-    resp = await authed_client.delete(f"/api/v1/agent/credentials/{created['id']}")
+    resp = await agent_config_client.delete(f"/api/v1/agent/credentials/{created['id']}")
     assert resp.status_code == 409
 
 
 @pytest.mark.asyncio
-async def test_delete_nonexistent_returns_404(authed_client) -> None:
-    resp = await authed_client.delete("/api/v1/agent/credentials/9999")
+async def test_delete_nonexistent_returns_404(agent_config_client) -> None:
+    resp = await agent_config_client.delete("/api/v1/agent/credentials/9999")
     assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_delete_inactive_returns_204(authed_client) -> None:
+async def test_delete_inactive_returns_204(agent_config_client) -> None:
     # 第一条自动 active
-    await authed_client.post(
+    await agent_config_client.post(
         "/api/v1/agent/credentials",
         json={"preset_id": "deepseek", "api_key": "sk-A"},
     )
     # 第二条显式 activate=False，可删
     second = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "kimi", "api_key": "sk-B", "activate": False},
         )
     ).json()
-    resp = await authed_client.delete(f"/api/v1/agent/credentials/{second['id']}")
+    resp = await agent_config_client.delete(f"/api/v1/agent/credentials/{second['id']}")
     assert resp.status_code == 204
 
 
@@ -203,15 +191,15 @@ async def test_delete_inactive_returns_204(authed_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_activate_credential_switches(authed_client, monkeypatch) -> None:
+async def test_activate_credential_switches(agent_config_client, monkeypatch) -> None:
     a = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "deepseek", "api_key": "sk-A"},
         )
     ).json()
     b = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "kimi", "api_key": "sk-B", "activate": False},
         )
@@ -219,24 +207,24 @@ async def test_activate_credential_switches(authed_client, monkeypatch) -> None:
     assert a["is_active"] is True
     assert b["is_active"] is False
 
-    resp = await authed_client.post(f"/api/v1/agent/credentials/{b['id']}/activate")
+    resp = await agent_config_client.post(f"/api/v1/agent/credentials/{b['id']}/activate")
     assert resp.status_code == 200
     assert resp.json() == {"active_id": b["id"]}
 
-    listing = (await authed_client.get("/api/v1/agent/credentials")).json()["credentials"]
+    listing = (await agent_config_client.get("/api/v1/agent/credentials")).json()["credentials"]
     flags = {c["id"]: c["is_active"] for c in listing}
     assert flags[a["id"]] is False
     assert flags[b["id"]] is True
 
 
 @pytest.mark.asyncio
-async def test_activate_unknown_id(authed_client) -> None:
-    resp = await authed_client.post("/api/v1/agent/credentials/99999/activate")
+async def test_activate_unknown_id(agent_config_client) -> None:
+    resp = await agent_config_client.post("/api/v1/agent/credentials/99999/activate")
     assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_test_connection_draft_calls_run_test(authed_client, monkeypatch) -> None:
+async def test_test_connection_draft_calls_run_test(agent_config_client, monkeypatch) -> None:
     """POST /agent/test-connection 调 run_test 并把结果序列化为 JSON。"""
     from unittest.mock import AsyncMock
 
@@ -254,7 +242,7 @@ async def test_test_connection_draft_calls_run_test(authed_client, monkeypatch) 
     fake = AsyncMock(return_value=expected)
     monkeypatch.setattr("server.routers.agent_config.run_test", fake)
 
-    resp = await authed_client.post(
+    resp = await agent_config_client.post(
         "/api/v1/agent/test-connection",
         json={"preset_id": "deepseek", "api_key": "sk", "model": None, "base_url": None},
     )
@@ -267,7 +255,7 @@ async def test_test_connection_draft_calls_run_test(authed_client, monkeypatch) 
 
 
 @pytest.mark.asyncio
-async def test_test_credential_uses_stored(authed_client, monkeypatch) -> None:
+async def test_test_credential_uses_stored(agent_config_client, monkeypatch) -> None:
     from unittest.mock import AsyncMock
 
     from lib.config import anthropic_probe as probe_mod
@@ -285,12 +273,12 @@ async def test_test_credential_uses_stored(authed_client, monkeypatch) -> None:
     monkeypatch.setattr("server.routers.agent_config.run_test", fake)
 
     cred = (
-        await authed_client.post(
+        await agent_config_client.post(
             "/api/v1/agent/credentials",
             json={"preset_id": "deepseek", "api_key": "sk-stored"},
         )
     ).json()
-    resp = await authed_client.post(f"/api/v1/agent/credentials/{cred['id']}/test")
+    resp = await agent_config_client.post(f"/api/v1/agent/credentials/{cred['id']}/test")
     assert resp.status_code == 200
     body = resp.json()
     assert body["overall"] == "fail"

--- a/tests/unit/server/routers/test_asset_router_factory.py
+++ b/tests/unit/server/routers/test_asset_router_factory.py
@@ -14,7 +14,7 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import characters
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
+from tests.factories import make_translator
 from tests.fakes import FakeProjectAssetMutationMixin
 
 # 兜底 500 的默认 locale 文案：测试未覆盖 get_translator，端点回落到 DEFAULT_LOCALE("zh")，

--- a/tests/unit/server/routers/test_assistant_rewrite_routes.py
+++ b/tests/unit/server/routers/test_assistant_rewrite_routes.py
@@ -20,7 +20,7 @@ from server.auth import CurrentUserInfo, get_current_user, get_current_user_flex
 from server.error_handlers import register_error_handlers
 from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
+from tests.factories import make_translator
 
 PROJECT = "demo"
 PREFIX = f"/api/v1/projects/{PROJECT}/assistant"

--- a/tests/unit/server/routers/test_assistant_router_full.py
+++ b/tests/unit/server/routers/test_assistant_router_full.py
@@ -7,8 +7,7 @@ from server.auth import CurrentUserInfo, get_current_user, get_current_user_flex
 from server.error_handlers import register_error_handlers
 from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
-from tests.factories import make_session_meta
+from tests.factories import make_session_meta, make_translator
 
 PROJECT = "demo"
 PREFIX = f"/api/v1/projects/{PROJECT}/assistant"

--- a/tests/unit/server/routers/test_assistant_routes.py
+++ b/tests/unit/server/routers/test_assistant_routes.py
@@ -10,8 +10,7 @@ from server.auth import CurrentUserInfo, get_current_user, get_current_user_flex
 from server.error_handlers import register_error_handlers
 from server.routers import assistant
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
-from tests.factories import make_session_meta
+from tests.factories import make_session_meta, make_translator
 
 PROJECT = "demo"
 PREFIX = f"/api/v1/projects/{PROJECT}/assistant"

--- a/tests/unit/server/routers/test_custom_providers_api.py
+++ b/tests/unit/server/routers/test_custom_providers_api.py
@@ -6,19 +6,18 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.config.service import ConfigService
 from lib.custom_provider.endpoints import ENDPOINT_REGISTRY
 from lib.db import get_async_session
-from lib.db.base import Base
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import custom_providers
@@ -30,28 +29,18 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 
 
 @pytest.fixture()
-async def db_engine():
-    """内存 SQLite 引擎。"""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture()
-async def session_factory(db_engine):
+async def app_session_factory(db_engine):
     return async_sessionmaker(db_engine, expire_on_commit=False)
 
 
 @pytest.fixture()
-def app(session_factory) -> FastAPI:
+def app(app_session_factory) -> FastAPI:
     """创建绑定内存数据库的 FastAPI 应用。"""
     _app = FastAPI()
 
     async def _override_session():
-        async with session_factory() as session:
-            yield session
+        async with app_session_factory() as db_session:
+            yield db_session
 
     _app.dependency_overrides[get_async_session] = _override_session
     _app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="test", sub="test", role="admin")
@@ -61,13 +50,7 @@ def app(session_factory) -> FastAPI:
 
 
 @pytest.fixture()
-async def session(session_factory) -> AsyncGenerator[AsyncSession, None]:
-    async with session_factory() as s:
-        yield s
-
-
-@pytest.fixture()
-def client(app) -> Generator[TestClient, None, None]:
+def custom_providers_client(app) -> Generator[TestClient, None, None]:
     with TestClient(app) as c:
         yield c
 
@@ -78,8 +61,8 @@ def client(app) -> Generator[TestClient, None, None]:
 
 
 class TestCreateProvider:
-    def test_returns_201(self, client: TestClient):
-        resp = client.post(
+    def test_returns_201(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Test Provider",
@@ -97,8 +80,8 @@ class TestCreateProvider:
         )
         assert resp.status_code == 201
 
-    def test_response_structure(self, client: TestClient):
-        resp = client.post(
+    def test_response_structure(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Test Provider",
@@ -125,8 +108,8 @@ class TestCreateProvider:
         assert body["models"][0]["model_id"] == "gpt-4"
         assert "created_at" in body
 
-    def test_create_without_models(self, client: TestClient):
-        resp = client.post(
+    def test_create_without_models(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Empty Provider",
@@ -138,9 +121,9 @@ class TestCreateProvider:
         assert resp.status_code == 201
         assert resp.json()["models"] == []
 
-    def test_create_openai_discovery_format_provider(self, client: TestClient):
+    def test_create_openai_discovery_format_provider(self, custom_providers_client: TestClient):
         """回归: POST /custom-providers 接受 discovery_format=openai 且持久化正确字段。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "OpenAI Gateway",
@@ -167,14 +150,14 @@ class TestCreateProvider:
 
 
 class TestListProviders:
-    def test_empty_list(self, client: TestClient):
-        resp = client.get("/api/v1/custom-providers")
+    def test_empty_list(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.get("/api/v1/custom-providers")
         assert resp.status_code == 200
         assert resp.json() == {"providers": []}
 
-    def test_lists_created_providers(self, client: TestClient):
+    def test_lists_created_providers(self, custom_providers_client: TestClient):
         # Create two providers
-        client.post(
+        custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Provider A",
@@ -183,7 +166,7 @@ class TestListProviders:
                 "api_key": "sk-aaaa-key-12345678",
             },
         )
-        client.post(
+        custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Provider B",
@@ -192,7 +175,7 @@ class TestListProviders:
                 "api_key": "AIza-bbbb-12345678",
             },
         )
-        resp = client.get("/api/v1/custom-providers")
+        resp = custom_providers_client.get("/api/v1/custom-providers")
         assert resp.status_code == 200
         body = resp.json()["providers"]
         assert len(body) == 2
@@ -203,8 +186,8 @@ class TestListProviders:
 class TestEndpointCatalog:
     """GET /endpoints 暴露 ENDPOINT_REGISTRY 作为前端单一真相源。"""
 
-    def test_lists_all_endpoints(self, client: TestClient):
-        resp = client.get("/api/v1/custom-providers/endpoints")
+    def test_lists_all_endpoints(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.get("/api/v1/custom-providers/endpoints")
         assert resp.status_code == 200
         body = resp.json()
         keys = {e["key"] for e in body["endpoints"]}
@@ -229,8 +212,8 @@ class TestEndpointCatalog:
             "openai-tts",
         }
 
-    def test_descriptor_shape(self, client: TestClient):
-        resp = client.get("/api/v1/custom-providers/endpoints")
+    def test_descriptor_shape(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.get("/api/v1/custom-providers/endpoints")
         assert resp.status_code == 200
         for entry in resp.json()["endpoints"]:
             assert set(entry.keys()) == {
@@ -246,10 +229,10 @@ class TestEndpointCatalog:
             assert entry["request_method"] == "POST"
             assert entry["request_path_template"].startswith("/")
 
-    def test_endpoints_expose_end_image_capable(self, client: TestClient):
+    def test_endpoints_expose_end_image_capable(self, custom_providers_client: TestClient):
         """catalog 带出 end_image_capable：前端据此禁用不下传尾帧的 endpoint 的 last_frame 强制开，
         用户不必撞上写入侧的 422 才知道这条路不通。非 video 类恒为 False。"""
-        resp = client.get("/api/v1/custom-providers/endpoints")
+        resp = custom_providers_client.get("/api/v1/custom-providers/endpoints")
         assert resp.status_code == 200
         by_key = {e["key"]: e for e in resp.json()["endpoints"]}
         assert by_key["kling-video"]["end_image_capable"] is True
@@ -259,9 +242,9 @@ class TestEndpointCatalog:
         for key, spec in ENDPOINT_REGISTRY.items():
             assert by_key[key]["end_image_capable"] is spec.end_image_capable
 
-    def test_endpoints_expose_image_capabilities(self, client: TestClient):
+    def test_endpoints_expose_image_capabilities(self, custom_providers_client: TestClient):
         """每个 entry 上返回 image_capabilities：image 类填能力数组，其他为 None。"""
-        resp = client.get("/api/v1/custom-providers/endpoints")
+        resp = custom_providers_client.get("/api/v1/custom-providers/endpoints")
         assert resp.status_code == 200
         by_key = {e["key"]: e for e in resp.json()["endpoints"]}
         assert by_key["openai-chat"]["image_capabilities"] is None
@@ -270,15 +253,15 @@ class TestEndpointCatalog:
         assert by_key["openai-images-edits"]["image_capabilities"] == ["image_to_image"]
         assert sorted(by_key["gemini-image"]["image_capabilities"]) == ["image_to_image", "text_to_image"]
 
-    def test_endpoint_route_not_shadowed_by_provider_id(self, client: TestClient):
+    def test_endpoint_route_not_shadowed_by_provider_id(self, custom_providers_client: TestClient):
         """回归：/endpoints 必须先于 /{provider_id} 注册，不能被解析为整型 provider_id。"""
-        resp = client.get("/api/v1/custom-providers/endpoints")
+        resp = custom_providers_client.get("/api/v1/custom-providers/endpoints")
         assert resp.status_code == 200, resp.text
 
 
 class TestGetProvider:
-    def test_returns_provider(self, client: TestClient):
-        create_resp = client.post(
+    def test_returns_provider(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "My Provider",
@@ -295,20 +278,20 @@ class TestGetProvider:
             },
         )
         pid = create_resp.json()["id"]
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         body = resp.json()
         assert body["display_name"] == "My Provider"
         assert len(body["models"]) == 1
 
-    def test_returns_404_for_nonexistent(self, client: TestClient):
-        resp = client.get("/api/v1/custom-providers/9999")
+    def test_returns_404_for_nonexistent(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.get("/api/v1/custom-providers/9999")
         assert resp.status_code == 404
 
 
 class TestUpdateProvider:
-    def test_update_display_name(self, client: TestClient):
-        create_resp = client.post(
+    def test_update_display_name(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Old Name",
@@ -318,15 +301,15 @@ class TestUpdateProvider:
             },
         )
         pid = create_resp.json()["id"]
-        resp = client.patch(
+        resp = custom_providers_client.patch(
             f"/api/v1/custom-providers/{pid}",
             json={"display_name": "New Name"},
         )
         assert resp.status_code == 200
         assert resp.json()["display_name"] == "New Name"
 
-    def test_update_api_key_is_masked(self, client: TestClient):
-        create_resp = client.post(
+    def test_update_api_key_is_masked(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Key Test",
@@ -336,7 +319,7 @@ class TestUpdateProvider:
             },
         )
         pid = create_resp.json()["id"]
-        resp = client.patch(
+        resp = custom_providers_client.patch(
             f"/api/v1/custom-providers/{pid}",
             json={"api_key": "sk-new-key-87654321"},
         )
@@ -345,15 +328,15 @@ class TestUpdateProvider:
         assert "sk-new-key-87654321" not in body["api_key_masked"]
         assert body["api_key_masked"].startswith("sk-n")
 
-    def test_returns_404_for_nonexistent(self, client: TestClient):
-        resp = client.patch(
+    def test_returns_404_for_nonexistent(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.patch(
             "/api/v1/custom-providers/9999",
             json={"display_name": "Nope"},
         )
         assert resp.status_code == 404
 
-    def test_returns_400_for_empty_body(self, client: TestClient):
-        create_resp = client.post(
+    def test_returns_400_for_empty_body(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Empty Update",
@@ -363,13 +346,13 @@ class TestUpdateProvider:
             },
         )
         pid = create_resp.json()["id"]
-        resp = client.patch(f"/api/v1/custom-providers/{pid}", json={})
+        resp = custom_providers_client.patch(f"/api/v1/custom-providers/{pid}", json={})
         assert resp.status_code == 400
 
 
 class TestDeleteProvider:
-    def test_delete_existing(self, client: TestClient):
-        create_resp = client.post(
+    def test_delete_existing(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "To Delete",
@@ -379,15 +362,15 @@ class TestDeleteProvider:
             },
         )
         pid = create_resp.json()["id"]
-        resp = client.delete(f"/api/v1/custom-providers/{pid}")
+        resp = custom_providers_client.delete(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 204
 
         # Verify it's gone
-        get_resp = client.get(f"/api/v1/custom-providers/{pid}")
+        get_resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert get_resp.status_code == 404
 
-    def test_returns_404_for_nonexistent(self, client: TestClient):
-        resp = client.delete("/api/v1/custom-providers/9999")
+    def test_returns_404_for_nonexistent(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.delete("/api/v1/custom-providers/9999")
         assert resp.status_code == 404
 
 
@@ -397,8 +380,8 @@ class TestDeleteProvider:
 
 
 class TestReplaceModels:
-    def test_replace_entire_model_list(self, client: TestClient):
-        create_resp = client.post(
+    def test_replace_entire_model_list(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Model Test",
@@ -430,18 +413,18 @@ class TestReplaceModels:
                 "is_default": True,
             },
         ]
-        resp = client.put(f"/api/v1/custom-providers/{pid}/models", json={"models": new_models})
+        resp = custom_providers_client.put(f"/api/v1/custom-providers/{pid}/models", json={"models": new_models})
         assert resp.status_code == 200
         body = resp.json()
         assert len(body) == 2
         assert {m["model_id"] for m in body} == {"new-text", "new-image"}
 
-    def test_returns_404_for_nonexistent_provider(self, client: TestClient):
-        resp = client.put("/api/v1/custom-providers/9999/models", json={"models": []})
+    def test_returns_404_for_nonexistent_provider(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.put("/api/v1/custom-providers/9999/models", json={"models": []})
         assert resp.status_code == 404
 
-    def test_verify_old_models_removed(self, client: TestClient):
-        create_resp = client.post(
+    def test_verify_old_models_removed(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Replace Verify",
@@ -459,7 +442,7 @@ class TestReplaceModels:
         )
         pid = create_resp.json()["id"]
 
-        client.put(
+        custom_providers_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -473,7 +456,7 @@ class TestReplaceModels:
         )
 
         # Verify via get provider
-        get_resp = client.get(f"/api/v1/custom-providers/{pid}")
+        get_resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         models = get_resp.json()["models"]
         assert len(models) == 1
         assert models[0]["model_id"] == "replacement"
@@ -485,7 +468,7 @@ class TestReplaceModels:
 
 
 class TestDiscoverModels:
-    def test_discover_openai(self, client: TestClient):
+    def test_discover_openai(self, custom_providers_client: TestClient):
         fake_models = [
             {
                 "model_id": "gpt-4",
@@ -500,7 +483,7 @@ class TestDiscoverModels:
             new_callable=AsyncMock,
             return_value=fake_models,
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover",
                 json={
                     "discovery_format": "openai",
@@ -512,7 +495,7 @@ class TestDiscoverModels:
         assert len(resp.json()["models"]) == 1
         assert resp.json()["models"][0]["model_id"] == "gpt-4"
 
-    def test_discover_google(self, client: TestClient):
+    def test_discover_google(self, custom_providers_client: TestClient):
         """google discovery_format 透传到 discover_models。"""
         fake_models = [
             {
@@ -528,7 +511,7 @@ class TestDiscoverModels:
             new_callable=AsyncMock,
             return_value=fake_models,
         ) as mock_discover:
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover",
                 json={
                     "discovery_format": "google",
@@ -541,7 +524,7 @@ class TestDiscoverModels:
         # 确认 discovery_format 透传
         assert mock_discover.call_args.kwargs["discovery_format"] == "google"
 
-    def test_discover_invalid_format(self, client: TestClient):
+    def test_discover_invalid_format(self, custom_providers_client: TestClient):
         """discover_models 抛 UnsupportedDiscoveryFormatError 时返回 400。"""
         from lib.custom_provider.discovery import UnsupportedDiscoveryFormatError
 
@@ -550,7 +533,7 @@ class TestDiscoverModels:
             new_callable=AsyncMock,
             side_effect=UnsupportedDiscoveryFormatError("不支持的 discovery_format: 'unknown'"),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover",
                 json={
                     "discovery_format": "openai",
@@ -560,14 +543,14 @@ class TestDiscoverModels:
             )
         assert resp.status_code == 400
 
-    def test_discover_sdk_value_error_returns_502_not_400(self, client: TestClient):
+    def test_discover_sdk_value_error_returns_502_not_400(self, custom_providers_client: TestClient):
         """SDK 内部校验（如 Google 凭证被拒绝）抛的普通 ValueError 不应被误判为格式错误 -> 502。"""
         with patch(
             "lib.custom_provider.discovery.discover_models",
             new_callable=AsyncMock,
             side_effect=ValueError("Invalid API key provided"),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover",
                 json={
                     "discovery_format": "google",
@@ -577,13 +560,13 @@ class TestDiscoverModels:
             )
         assert resp.status_code == 502
 
-    def test_discover_api_failure(self, client: TestClient):
+    def test_discover_api_failure(self, custom_providers_client: TestClient):
         with patch(
             "lib.custom_provider.discovery.discover_models",
             new_callable=AsyncMock,
             side_effect=RuntimeError("Connection refused"),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover",
                 json={
                     "discovery_format": "openai",
@@ -597,8 +580,8 @@ class TestDiscoverModels:
 class TestDiscoverModelsByStoredProvider:
     """回归: 编辑已保存供应商时，前端无法重新提交明文 api_key，需用 stored 凭证调用 by-id 端点。"""
 
-    def _create(self, client: TestClient) -> int:
-        resp = client.post(
+    def _create(self, custom_providers_client: TestClient) -> int:
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Stored Cred Provider",
@@ -609,9 +592,9 @@ class TestDiscoverModelsByStoredProvider:
         )
         return resp.json()["id"]
 
-    def test_uses_stored_credentials(self, client: TestClient):
+    def test_uses_stored_credentials(self, custom_providers_client: TestClient):
         """by-id discover 应把 stored discovery_format/base_url/api_key 透传到 discover_models。"""
-        pid = self._create(client)
+        pid = self._create(custom_providers_client)
         fake_models = [
             {
                 "model_id": "gpt-4",
@@ -626,7 +609,7 @@ class TestDiscoverModelsByStoredProvider:
             new_callable=AsyncMock,
             return_value=fake_models,
         ) as mock_discover:
-            resp = client.post(f"/api/v1/custom-providers/{pid}/discover")
+            resp = custom_providers_client.post(f"/api/v1/custom-providers/{pid}/discover")
         assert resp.status_code == 200
         assert resp.json()["models"][0]["model_id"] == "gpt-4"
         # 验证 stored 凭证被透传（明文 api_key，不是 mask 后的）
@@ -635,18 +618,18 @@ class TestDiscoverModelsByStoredProvider:
         assert kwargs["base_url"] == "https://api.example.com/v1"
         assert kwargs["api_key"] == "sk-stored-discover-1234"
 
-    def test_returns_404_for_nonexistent(self, client: TestClient):
-        resp = client.post("/api/v1/custom-providers/9999/discover")
+    def test_returns_404_for_nonexistent(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post("/api/v1/custom-providers/9999/discover")
         assert resp.status_code == 404
 
-    def test_upstream_failure_returns_502(self, client: TestClient):
-        pid = self._create(client)
+    def test_upstream_failure_returns_502(self, custom_providers_client: TestClient):
+        pid = self._create(custom_providers_client)
         with patch(
             "lib.custom_provider.discovery.discover_models",
             new_callable=AsyncMock,
             side_effect=RuntimeError("Connection refused"),
         ):
-            resp = client.post(f"/api/v1/custom-providers/{pid}/discover")
+            resp = custom_providers_client.post(f"/api/v1/custom-providers/{pid}/discover")
         assert resp.status_code == 502
 
 
@@ -656,12 +639,12 @@ class TestDiscoverModelsByStoredProvider:
 
 
 class TestConnectionTest:
-    def test_openai_success(self, client: TestClient):
+    def test_openai_success(self, custom_providers_client: TestClient):
         with patch(
             "server.routers.custom_providers._test_openai",
             return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=5),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
                     "discovery_format": "openai",
@@ -674,12 +657,12 @@ class TestConnectionTest:
         assert body["success"] is True
         assert body["model_count"] == 5
 
-    def test_google_success(self, client: TestClient):
+    def test_google_success(self, custom_providers_client: TestClient):
         with patch(
             "server.routers.custom_providers._test_google",
             return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=10),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
                     "discovery_format": "google",
@@ -692,13 +675,13 @@ class TestConnectionTest:
         assert body["success"] is True
         assert body["model_count"] == 10
 
-    def test_openai_routes_to_test_openai(self, client: TestClient):
+    def test_openai_routes_to_test_openai(self, custom_providers_client: TestClient):
         """discovery_format=openai 应路由到 _test_openai。"""
         with patch(
             "server.routers.custom_providers._test_openai",
             return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=42),
         ) as mock_openai_test:
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
                     "discovery_format": "openai",
@@ -712,9 +695,9 @@ class TestConnectionTest:
         assert body["model_count"] == 42
         mock_openai_test.assert_called_once()
 
-    def test_unsupported_format_returns_false(self, client: TestClient):
+    def test_unsupported_format_returns_false(self, custom_providers_client: TestClient):
         """不支持的 discovery_format 应返回 success=False。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers/test",
             json={
                 "discovery_format": "unsupported",
@@ -726,12 +709,12 @@ class TestConnectionTest:
         body = resp.json()
         assert body["success"] is False
 
-    def test_connection_failure(self, client: TestClient):
+    def test_connection_failure(self, custom_providers_client: TestClient):
         with patch(
             "server.routers.custom_providers._test_openai",
             side_effect=RuntimeError("Connection refused"),
         ):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
                     "discovery_format": "openai",
@@ -776,25 +759,27 @@ _PROVIDER_PAYLOAD = {
 class TestDeleteProviderCleansGlobalSettings:
     """回归: 删除 provider 时应清理全局 DB 中引用该 provider 的 default_*_backend。"""
 
-    async def test_global_settings_cleaned_on_delete(self, client: TestClient, session: AsyncSession):
+    async def test_global_settings_cleaned_on_delete(
+        self, custom_providers_client: TestClient, db_session: AsyncSession
+    ):
         # 创建供应商
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
 
         # 模拟全局配置引用该供应商
-        svc = ConfigService(session)
+        svc = ConfigService(db_session)
         await svc.set_setting("default_text_backend", f"custom-{pid}/gpt-4o")
         await svc.set_setting("default_image_backend", f"custom-{pid}/dall-e-3")
         await svc.set_setting("default_audio_backend", f"custom-{pid}/tts-1")
         await svc.set_setting("default_video_backend", "gemini-aistudio/veo-3")  # 不应被清理
-        await session.commit()
+        await db_session.commit()
 
         # 删除供应商（mock 掉项目清理和缓存失效）
         with (
             patch("server.routers.custom_providers._cleanup_project_refs"),
             patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock),
         ):
-            del_resp = client.delete(f"/api/v1/custom-providers/{pid}")
+            del_resp = custom_providers_client.delete(f"/api/v1/custom-providers/{pid}")
         assert del_resp.status_code == 204
 
         # 验证引用被清理
@@ -808,8 +793,8 @@ class TestDeleteProviderCleansGlobalSettings:
 class TestDeleteProviderCleansProjectRefs:
     """回归: 删除 provider 时应清理项目级 project.json 中的悬空引用。"""
 
-    def test_project_refs_cleaned_on_delete(self, client: TestClient):
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    def test_project_refs_cleaned_on_delete(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
         prefix = f"custom-{pid}/"
 
@@ -823,7 +808,7 @@ class TestDeleteProviderCleansProjectRefs:
             patch("lib.config.resolver.get_project_manager", return_value=mock_pm),
             patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock),
         ):
-            del_resp = client.delete(f"/api/v1/custom-providers/{pid}")
+            del_resp = custom_providers_client.delete(f"/api/v1/custom-providers/{pid}")
         assert del_resp.status_code == 204
 
         # 验证 update_project 被调用来清理引用
@@ -852,18 +837,18 @@ class TestDeleteProviderCleansProjectRefs:
 class TestReplaceModelsCleansStaleRefs:
     """回归: 替换 models 时应清理引用已删除 model 的全局配置。"""
 
-    async def test_stale_model_refs_cleaned(self, client: TestClient, session: AsyncSession):
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    async def test_stale_model_refs_cleaned(self, custom_providers_client: TestClient, db_session: AsyncSession):
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
 
         # 模拟全局配置引用 gpt-4o
-        svc = ConfigService(session)
+        svc = ConfigService(db_session)
         await svc.set_setting("default_text_backend", f"custom-{pid}/gpt-4o")
-        await session.commit()
+        await db_session.commit()
 
         # 替换 models — 移除 gpt-4o，保留 dall-e-3
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            replace_resp = client.put(
+            replace_resp = custom_providers_client.put(
                 f"/api/v1/custom-providers/{pid}/models",
                 json={
                     "models": [
@@ -886,41 +871,45 @@ class TestReplaceModelsCleansStaleRefs:
 class TestGlobalBucketRefsHint:
     """回归: 能力编辑响应应非阻塞地提示模型正被哪些全局桶键引用。"""
 
-    async def test_referenced_model_lists_global_keys(self, client: TestClient, session: AsyncSession):
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    async def test_referenced_model_lists_global_keys(
+        self, custom_providers_client: TestClient, db_session: AsyncSession
+    ):
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
 
-        svc = ConfigService(session)
+        svc = ConfigService(db_session)
         await svc.set_setting("default_text_backend", f"custom-{pid}/gpt-4o")
         await svc.set_setting("default_video_backend_i2v", f"custom-{pid}/gpt-4o")
-        await session.commit()
+        await db_session.commit()
 
-        get_resp = client.get(f"/api/v1/custom-providers/{pid}")
+        get_resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert get_resp.status_code == 200
         models = {m["model_id"]: m for m in get_resp.json()["models"]}
         assert set(models["gpt-4o"]["global_bucket_refs"]) == {"default_text_backend", "default_video_backend_i2v"}
         # 未被引用的模型不带提示
         assert models["dall-e-3"]["global_bucket_refs"] is None
 
-    async def test_unreferenced_models_have_no_hint(self, client: TestClient):
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    async def test_unreferenced_models_have_no_hint(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
 
-        get_resp = client.get(f"/api/v1/custom-providers/{pid}")
+        get_resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         for m in get_resp.json()["models"]:
             assert m["global_bucket_refs"] is None
 
-    async def test_save_not_blocked_when_referenced(self, client: TestClient, session: AsyncSession):
+    async def test_save_not_blocked_when_referenced(
+        self, custom_providers_client: TestClient, db_session: AsyncSession
+    ):
         """提示不阻塞保存：被全局桶引用的模型仍可正常被替换/删除。"""
-        resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+        resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = resp.json()["id"]
 
-        svc = ConfigService(session)
+        svc = ConfigService(db_session)
         await svc.set_setting("default_video_backend_i2v", f"custom-{pid}/gpt-4o")
-        await session.commit()
+        await db_session.commit()
 
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            replace_resp = client.put(
+            replace_resp = custom_providers_client.put(
                 f"/api/v1/custom-providers/{pid}/models",
                 json={
                     "models": [
@@ -950,8 +939,8 @@ class TestGlobalBucketRefsHint:
 class TestEmptyModelIdRejected:
     """回归: 启用模型必须有非空 model_id。"""
 
-    def test_create_with_empty_model_id(self, client: TestClient):
-        resp = client.post(
+    def test_create_with_empty_model_id(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Bad Provider",
@@ -965,11 +954,11 @@ class TestEmptyModelIdRejected:
         )
         assert resp.status_code == 422
 
-    def test_replace_models_with_empty_model_id(self, client: TestClient):
-        create_resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    def test_replace_models_with_empty_model_id(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = create_resp.json()["id"]
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = client.put(
+            resp = custom_providers_client.put(
                 f"/api/v1/custom-providers/{pid}/models",
                 json={
                     "models": [
@@ -983,8 +972,8 @@ class TestEmptyModelIdRejected:
 class TestUnknownEndpointRejected:
     """回归：写入路径用未注册 endpoint key 应被 AfterValidator 拦下，返回 422。"""
 
-    def test_create_with_unknown_endpoint(self, client: TestClient):
-        resp = client.post(
+    def test_create_with_unknown_endpoint(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Unknown Endpoint",
@@ -1008,8 +997,8 @@ class TestUnknownEndpointRejected:
 class TestDuplicateModelIdRejected:
     """回归: 同一供应商下不允许重复 model_id。"""
 
-    def test_create_with_duplicate(self, client: TestClient):
-        resp = client.post(
+    def test_create_with_duplicate(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Dup Provider",
@@ -1029,11 +1018,11 @@ class TestDuplicateModelIdRejected:
 class TestFullUpdateProvider:
     """回归: PUT 全量更新端点应原子更新 provider + models。"""
 
-    def test_full_update(self, client: TestClient):
-        create_resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    def test_full_update(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = create_resp.json()["id"]
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = client.put(
+            resp = custom_providers_client.put(
                 f"/api/v1/custom-providers/{pid}",
                 json={
                     "display_name": "Updated Name",
@@ -1056,10 +1045,10 @@ class TestFullUpdateProvider:
         assert len(body["models"]) == 1
         assert body["models"][0]["model_id"] == "new-model"
 
-    def test_full_update_rejects_empty_model_id(self, client: TestClient):
-        create_resp = client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
+    def test_full_update_rejects_empty_model_id(self, custom_providers_client: TestClient):
+        create_resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = create_resp.json()["id"]
-        resp = client.put(
+        resp = custom_providers_client.put(
             f"/api/v1/custom-providers/{pid}",
             json={
                 "display_name": "X",
@@ -1071,8 +1060,8 @@ class TestFullUpdateProvider:
         )
         assert resp.status_code == 422
 
-    def test_full_update_404_for_nonexistent(self, client: TestClient):
-        resp = client.put(
+    def test_full_update_404_for_nonexistent(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.put(
             "/api/v1/custom-providers/9999",
             json={
                 "display_name": "X",
@@ -1086,9 +1075,9 @@ class TestFullUpdateProvider:
 class TestConcurrencyFields:
     """image/video/audio_max_workers 经 POST / PUT 保存后回显，留空 → null，0/负值 → 422。"""
 
-    def test_create_echoes_workers(self, client: TestClient):
+    def test_create_echoes_workers(self, custom_providers_client: TestClient):
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers",
                 json={
                     "display_name": "P",
@@ -1107,9 +1096,9 @@ class TestConcurrencyFields:
         assert body["video_max_workers"] == 7
         assert body["audio_max_workers"] == 1
 
-    def test_create_defaults_to_null_when_omitted(self, client: TestClient):
+    def test_create_defaults_to_null_when_omitted(self, custom_providers_client: TestClient):
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers",
                 json={
                     "display_name": "P",
@@ -1126,8 +1115,8 @@ class TestConcurrencyFields:
         assert body["audio_max_workers"] is None
 
     @pytest.mark.parametrize("bad_value", [-1, 0])
-    def test_create_rejects_below_one(self, client: TestClient, bad_value: int):
-        resp = client.post(
+    def test_create_rejects_below_one(self, custom_providers_client: TestClient, bad_value: int):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "P",
@@ -1140,9 +1129,9 @@ class TestConcurrencyFields:
         )
         assert resp.status_code == 422
 
-    def test_full_update_overwrites_and_clears(self, client: TestClient):
+    def test_full_update_overwrites_and_clears(self, custom_providers_client: TestClient):
         with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            create_resp = client.post(
+            create_resp = custom_providers_client.post(
                 "/api/v1/custom-providers",
                 json={
                     "display_name": "P",
@@ -1156,7 +1145,7 @@ class TestConcurrencyFields:
             )
             pid = create_resp.json()["id"]
             # PUT 不带 image_max_workers → 视为 null（权威清除）；video 覆盖为 9
-            resp = client.put(
+            resp = custom_providers_client.put(
                 f"/api/v1/custom-providers/{pid}",
                 json={
                     "display_name": "P",
@@ -1195,9 +1184,9 @@ class TestValidateBackendValueCustomPrefix:
 class TestDuplicateDefaultRejected:
     """回归: 同一 media_type 下最多只能有一个 is_default=True 的模型。"""
 
-    def test_create_with_duplicate_defaults(self, client: TestClient):
+    def test_create_with_duplicate_defaults(self, custom_providers_client: TestClient):
         """创建供应商时同一 media_type 有两个 is_default=true 的模型，期望 422。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Dup Default Provider",
@@ -1225,9 +1214,9 @@ class TestDuplicateDefaultRejected:
         assert resp.status_code == 422
         assert "默认模型" in resp.json()["detail"]
 
-    def test_single_default_per_type_allowed(self, client: TestClient):
+    def test_single_default_per_type_allowed(self, custom_providers_client: TestClient):
         """不同 media_type 各一个 default，期望 201 成功。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Multi Default Provider",
@@ -1265,8 +1254,8 @@ class TestDuplicateDefaultRejected:
 class TestPriceFieldConsistency:
     """回归: price_output 不能脱离 price_input 单独存在；currency 可独立存在。"""
 
-    def test_output_without_input_rejected(self, client: TestClient):
-        resp = client.post(
+    def test_output_without_input_rejected(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Bad Price",
@@ -1286,9 +1275,9 @@ class TestPriceFieldConsistency:
         )
         assert resp.status_code == 422
 
-    def test_currency_without_input_accepted(self, client: TestClient):
+    def test_currency_without_input_accepted(self, custom_providers_client: TestClient):
         """currency 可独立存在（用户先选币种，稍后填价格）。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Currency Only",
@@ -1308,8 +1297,8 @@ class TestPriceFieldConsistency:
         )
         assert resp.status_code == 201
 
-    def test_valid_price_fields_accepted(self, client: TestClient):
-        resp = client.post(
+    def test_valid_price_fields_accepted(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Good Price",
@@ -1335,8 +1324,8 @@ class TestPriceFieldConsistency:
 class TestResolutionField:
     """验证 ModelInput / ModelResponse 的 resolution 字段贯通读写。"""
 
-    def test_create_with_resolution_and_read_back(self, client: TestClient):
-        resp = client.post(
+    def test_create_with_resolution_and_read_back(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "X",
@@ -1359,15 +1348,15 @@ class TestResolutionField:
         pid = resp.json()["id"]
 
         # 读取，确认 resolution 返回
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         models = resp.json()["models"]
         assert len(models) == 1
         assert models[0]["resolution"] == "720p"
 
-    def test_resolution_defaults_to_null_when_omitted(self, client: TestClient):
+    def test_resolution_defaults_to_null_when_omitted(self, custom_providers_client: TestClient):
         """未指定 resolution 时应返回 None。"""
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Y",
@@ -1387,14 +1376,14 @@ class TestResolutionField:
         assert resp.status_code == 201
         pid = resp.json()["id"]
 
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         assert resp.json()["models"][0]["resolution"] is None
 
-    def test_replace_models_updates_resolution_to_null(self, client: TestClient):
+    def test_replace_models_updates_resolution_to_null(self, custom_providers_client: TestClient):
         """通过 PUT /models 更新 resolution 为 null。"""
         # 先创建带 resolution 的 provider
-        resp = client.post(
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "Z",
@@ -1416,7 +1405,7 @@ class TestResolutionField:
         pid = resp.json()["id"]
 
         # 替换模型列表，resolution 省略即为 null
-        resp = client.put(
+        resp = custom_providers_client.put(
             f"/api/v1/custom-providers/{pid}/models",
             json={
                 "models": [
@@ -1432,7 +1421,7 @@ class TestResolutionField:
         assert resp.status_code == 200
 
         # 读取验证为 null
-        resp = client.get(f"/api/v1/custom-providers/{pid}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{pid}")
         assert resp.status_code == 200
         assert resp.json()["models"][0]["resolution"] is None
 
@@ -1443,7 +1432,7 @@ class TestResolutionField:
 
 
 @pytest.mark.asyncio
-async def test_create_provider_with_unknown_endpoint_returns_422(client):
+async def test_create_provider_with_unknown_endpoint_returns_422(custom_providers_client):
     payload = {
         "display_name": "X",
         "discovery_format": "openai",
@@ -1459,13 +1448,13 @@ async def test_create_provider_with_unknown_endpoint_returns_422(client):
             }
         ],
     }
-    resp = client.post("/api/v1/custom-providers", json=payload)
+    resp = custom_providers_client.post("/api/v1/custom-providers", json=payload)
     assert resp.status_code == 422
     assert "unknown_endpoint" in resp.text or "anthropic-messages" in resp.text
 
 
 @pytest.mark.asyncio
-async def test_create_provider_unknown_discovery_format_returns_422(client):
+async def test_create_provider_unknown_discovery_format_returns_422(custom_providers_client):
     payload = {
         "display_name": "X",
         "discovery_format": "newapi",  # 已被剔除
@@ -1473,12 +1462,12 @@ async def test_create_provider_unknown_discovery_format_returns_422(client):
         "api_key": "k",
         "models": [],
     }
-    resp = client.post("/api/v1/custom-providers", json=payload)
+    resp = custom_providers_client.post("/api/v1/custom-providers", json=payload)
     assert resp.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_default_conflict_grouped_by_endpoint_media(client):
+async def test_default_conflict_grouped_by_endpoint_media(custom_providers_client):
     """两条 endpoint 不同但推算 media_type 相同的模型不能同时 is_default。"""
     payload = {
         "display_name": "X",
@@ -1502,7 +1491,7 @@ async def test_default_conflict_grouped_by_endpoint_media(client):
             },  # 都是 text → 冲突
         ],
     }
-    resp = client.post("/api/v1/custom-providers", json=payload)
+    resp = custom_providers_client.post("/api/v1/custom-providers", json=payload)
     assert resp.status_code == 422
 
 
@@ -1586,7 +1575,7 @@ def test_check_unique_defaults_text_still_media_type_exclusive():
 
 
 class TestDiscoverAnthropic:
-    def test_explicit_credentials(self, client: TestClient):
+    def test_explicit_credentials(self, custom_providers_client: TestClient):
         """显式传入 base_url + api_key，调用 _run_discover('anthropic', ...)。"""
         mock_models = [
             {"model_id": "claude-x", "display_name": "X", "endpoint": "", "is_default": False, "is_enabled": True}
@@ -1596,7 +1585,7 @@ class TestDiscoverAnthropic:
 
             mock_run.return_value = DiscoverResponse(models=mock_models)
 
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover-anthropic",
                 json={"base_url": "https://example.com", "api_key": "sk-ant"},
             )
@@ -1609,11 +1598,11 @@ class TestDiscoverAnthropic:
         assert args[1] == "https://example.com"
         assert args[2] == "sk-ant"
 
-    async def test_falls_back_to_stored_api_key(self, client: TestClient, session: AsyncSession):
+    async def test_falls_back_to_stored_api_key(self, custom_providers_client: TestClient, db_session: AsyncSession):
         """请求未带 api_key 时，从 active AgentAnthropicCredential fallback。"""
         from lib.db.repositories.agent_credential_repo import AgentCredentialRepository
 
-        repo = AgentCredentialRepository(session)
+        repo = AgentCredentialRepository(db_session)
         cred = await repo.create(
             preset_id="__custom__",
             display_name="stored",
@@ -1621,32 +1610,34 @@ class TestDiscoverAnthropic:
             api_key="sk-stored",
         )
         await repo.set_active(cred.id)
-        await session.commit()
+        await db_session.commit()
 
         with patch("server.routers.custom_providers._run_discover", new=AsyncMock()) as mock_run:
             from server.routers.custom_providers import DiscoverResponse
 
             mock_run.return_value = DiscoverResponse(models=[])
 
-            resp = client.post("/api/v1/custom-providers/discover-anthropic", json={})
+            resp = custom_providers_client.post("/api/v1/custom-providers/discover-anthropic", json={})
 
         assert resp.status_code == 200
         args = mock_run.call_args.args
         assert args[1] == "https://stored.example"
         assert args[2] == "sk-stored"
 
-    def test_returns_400_when_no_key_anywhere(self, client: TestClient):
+    def test_returns_400_when_no_key_anywhere(self, custom_providers_client: TestClient):
         """请求未带 api_key 且 DB 也没有 → 400。"""
-        resp = client.post("/api/v1/custom-providers/discover-anthropic", json={})
+        resp = custom_providers_client.post("/api/v1/custom-providers/discover-anthropic", json={})
         assert resp.status_code == 400
         # i18n 默认 zh
         assert "API Key" in resp.json()["detail"]
 
-    async def test_whitespace_only_api_key_falls_back_to_stored(self, client: TestClient, session: AsyncSession):
+    async def test_whitespace_only_api_key_falls_back_to_stored(
+        self, custom_providers_client: TestClient, db_session: AsyncSession
+    ):
         """body.api_key 仅含空白时按缺失处理，回退至 active credential 而非送上游空白 key。"""
         from lib.db.repositories.agent_credential_repo import AgentCredentialRepository
 
-        repo = AgentCredentialRepository(session)
+        repo = AgentCredentialRepository(db_session)
         cred = await repo.create(
             preset_id="__custom__",
             display_name="stored",
@@ -1654,14 +1645,14 @@ class TestDiscoverAnthropic:
             api_key="sk-stored",
         )
         await repo.set_active(cred.id)
-        await session.commit()
+        await db_session.commit()
 
         with patch("server.routers.custom_providers._run_discover", new=AsyncMock()) as mock_run:
             from server.routers.custom_providers import DiscoverResponse
 
             mock_run.return_value = DiscoverResponse(models=[])
 
-            resp = client.post(
+            resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover-anthropic",
                 json={"api_key": "   "},
             )
@@ -1673,10 +1664,10 @@ class TestDiscoverAnthropic:
 
 
 class TestGetProviderCredentials:
-    def test_returns_plaintext(self, client: TestClient):
+    def test_returns_plaintext(self, custom_providers_client: TestClient):
         """正常路径返回明文 base_url + api_key。"""
         # 先创建 provider
-        create_resp = client.post(
+        create_resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "OneAPI",
@@ -1689,22 +1680,22 @@ class TestGetProviderCredentials:
         assert create_resp.status_code == 201
         provider_id = create_resp.json()["id"]
 
-        resp = client.get(f"/api/v1/custom-providers/{provider_id}/credentials")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{provider_id}/credentials")
         assert resp.status_code == 200
         body = resp.json()
         assert body["base_url"] == "https://oneapi.example.com"
         assert body["api_key"] == "sk-secret"
 
-    def test_returns_404_for_unknown_provider(self, client: TestClient):
-        resp = client.get("/api/v1/custom-providers/99999/credentials")
+    def test_returns_404_for_unknown_provider(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.get("/api/v1/custom-providers/99999/credentials")
         assert resp.status_code == 404
 
 
 class TestSupportedDurationsAutoFill:
     """video endpoint 模型创建时若未传 supported_durations，应由预设表自动填充。"""
 
-    def test_create_video_model_without_durations_autofills(self, client: TestClient):
-        resp = client.post(
+    def test_create_video_model_without_durations_autofills(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "test-cp",
@@ -1726,13 +1717,13 @@ class TestSupportedDurationsAutoFill:
         assert resp.status_code == 201, resp.text
         provider_id = resp.json()["id"]
 
-        resp = client.get(f"/api/v1/custom-providers/{provider_id}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{provider_id}")
         assert resp.status_code == 200
         model = resp.json()["models"][0]
         assert model["supported_durations"] == [4, 8, 12]
 
-    def test_create_video_model_user_provided_durations_kept(self, client: TestClient):
-        resp = client.post(
+    def test_create_video_model_user_provided_durations_kept(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "test-cp-2",
@@ -1754,12 +1745,12 @@ class TestSupportedDurationsAutoFill:
         assert resp.status_code == 201, resp.text
         provider_id = resp.json()["id"]
 
-        resp = client.get(f"/api/v1/custom-providers/{provider_id}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{provider_id}")
         model = resp.json()["models"][0]
         assert model["supported_durations"] == [6, 10, 12, 16, 20]
 
-    def test_text_endpoint_does_not_get_durations(self, client: TestClient):
-        resp = client.post(
+    def test_text_endpoint_does_not_get_durations(self, custom_providers_client: TestClient):
+        resp = custom_providers_client.post(
             "/api/v1/custom-providers",
             json={
                 "display_name": "test-cp-3",
@@ -1779,6 +1770,6 @@ class TestSupportedDurationsAutoFill:
         )
         assert resp.status_code == 201
         provider_id = resp.json()["id"]
-        resp = client.get(f"/api/v1/custom-providers/{provider_id}")
+        resp = custom_providers_client.get(f"/api/v1/custom-providers/{provider_id}")
         model = resp.json()["models"][0]
         assert model["supported_durations"] is None

--- a/tests/unit/server/routers/test_discover_anthropic_fallback.py
+++ b/tests/unit/server/routers/test_discover_anthropic_fallback.py
@@ -6,10 +6,9 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from lib.db import get_async_session
-from lib.db.base import Base
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import agent_config, custom_providers
 from tests.auth_deps import AUTH_DEPENDENCIES
@@ -31,17 +30,8 @@ def _make_app(session_factory) -> FastAPI:
 
 
 @pytest_asyncio.fixture
-async def _engine():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest_asyncio.fixture
-async def authed_client(_engine):
-    factory = async_sessionmaker(_engine, expire_on_commit=False)
+async def discover_client(db_engine):
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
     app = _make_app(factory)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -49,7 +39,7 @@ async def authed_client(_engine):
 
 
 @pytest.mark.asyncio
-async def test_discover_falls_back_to_active_credential(authed_client, monkeypatch) -> None:
+async def test_discover_falls_back_to_active_credential(discover_client, monkeypatch) -> None:
     captured: dict = {}
 
     async def fake_discover(discovery_format, base_url, api_key, _t):
@@ -60,14 +50,14 @@ async def test_discover_falls_back_to_active_credential(authed_client, monkeypat
     monkeypatch.setattr("server.routers.custom_providers._run_discover", fake_discover)
 
     # Create an active credential first
-    create_resp = await authed_client.post(
+    create_resp = await discover_client.post(
         "/api/v1/agent/credentials",
         json={"preset_id": "deepseek", "api_key": "stored-sk"},
     )
     assert create_resp.status_code == 201, create_resp.text
 
     # /discover-anthropic with empty body → should pick up the active credential
-    resp = await authed_client.post(
+    resp = await discover_client.post(
         "/api/v1/custom-providers/discover-anthropic",
         json={},
     )
@@ -77,8 +67,8 @@ async def test_discover_falls_back_to_active_credential(authed_client, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_discover_no_active_no_body_returns_400(authed_client) -> None:
-    resp = await authed_client.post(
+async def test_discover_no_active_no_body_returns_400(discover_client) -> None:
+    resp = await discover_client.post(
         "/api/v1/custom-providers/discover-anthropic",
         json={},
     )

--- a/tests/unit/server/routers/test_openai_connection.py
+++ b/tests/unit/server/routers/test_openai_connection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from server.routers.providers import _test_openai
-from tests.conftest import make_translator
+from tests.factories import make_translator
 
 _t = make_translator()
 

--- a/tests/unit/server/routers/test_providers_api.py
+++ b/tests/unit/server/routers/test_providers_api.py
@@ -22,7 +22,7 @@ from lib.i18n import get_translator
 from server.dependencies import get_config_service
 from server.routers import providers
 from tests.auth_deps import AUTH_DEPENDENCIES, override_auth
-from tests.conftest import make_translator
+from tests.factories import make_translator
 
 # ---------------------------------------------------------------------------
 # 测试应用工厂

--- a/tests/unit/server/routers/test_system_config_options.py
+++ b/tests/unit/server/routers/test_system_config_options.py
@@ -23,7 +23,7 @@ from server.routers.system_config import _build_options
 
 
 @pytest.fixture
-async def session():
+async def session_with_factory():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
@@ -66,8 +66,8 @@ def _make_mock_svc(ready_providers: list[str] | None = None) -> ConfigService:
 
 
 class TestBuildOptionsCustomModels:
-    async def test_includes_enabled_text_model(self, session):
-        db_session, factory = session
+    async def test_includes_enabled_text_model(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="My LLM",
@@ -94,8 +94,8 @@ class TestBuildOptionsCustomModels:
         assert expected not in options["image_backends"]
         assert expected not in options["video_backends"]
 
-    async def test_includes_enabled_image_model(self, session):
-        db_session, factory = session
+    async def test_includes_enabled_image_model(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="My Image Provider",
@@ -120,8 +120,8 @@ class TestBuildOptionsCustomModels:
         expected = f"custom-{provider.id}/dall-e-3"
         assert expected in options["image_backends"]
 
-    async def test_includes_enabled_video_model(self, session):
-        db_session, factory = session
+    async def test_includes_enabled_video_model(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="My Video Provider",
@@ -146,8 +146,8 @@ class TestBuildOptionsCustomModels:
         expected = f"custom-{provider.id}/sora-preview"
         assert expected in options["video_backends"]
 
-    async def test_excludes_disabled_model(self, session):
-        db_session, factory = session
+    async def test_excludes_disabled_model(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="My Provider",
@@ -172,8 +172,8 @@ class TestBuildOptionsCustomModels:
         excluded = f"custom-{provider.id}/disabled-model"
         assert excluded not in options["text_backends"]
 
-    async def test_multiple_providers_and_models(self, session):
-        db_session, factory = session
+    async def test_multiple_providers_and_models(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         p1 = await repo.create_provider(
             display_name="Provider A",
@@ -221,9 +221,9 @@ class TestBuildOptionsCustomModels:
         assert f"custom-{p2.id}/model-image" in options["image_backends"]
         assert f"custom-{p2.id}/model-disabled" not in options["image_backends"]
 
-    async def test_no_custom_providers_returns_empty_custom_section(self, session):
+    async def test_no_custom_providers_returns_empty_custom_section(self, session_with_factory):
         """When no custom providers exist, only preset backends are included."""
-        db_session, _factory = session
+        db_session, _factory = session_with_factory
 
         mock_svc = _make_mock_svc(ready_providers=[])
         options = await _build_options(mock_svc, db_session)
@@ -247,9 +247,9 @@ class TestBuildOptionsCustomModels:
         assert "image_backends" in options
         assert "text_backends" in options
 
-    async def test_preset_providers_still_included_alongside_custom(self, session):
+    async def test_preset_providers_still_included_alongside_custom(self, session_with_factory):
         """Preset ready providers + custom models both appear in options."""
-        db_session, factory = session
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="Custom Text",
@@ -284,9 +284,9 @@ class TestBuildOptionsCustomModels:
 
 
 class TestBuildOptionsProviderNames:
-    async def test_returns_provider_names_for_custom_providers(self, session):
+    async def test_returns_provider_names_for_custom_providers(self, session_with_factory):
         """provider_names 应包含自定义供应商的 ID→display_name 映射。"""
-        db_session, factory = session
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         provider = await repo.create_provider(
             display_name="我的 LLM 服务",
@@ -311,8 +311,8 @@ class TestBuildOptionsProviderNames:
         assert "provider_names" in options
         assert options["provider_names"][f"custom-{provider.id}"] == "我的 LLM 服务"
 
-    async def test_multiple_providers_all_have_names(self, session):
-        db_session, factory = session
+    async def test_multiple_providers_all_have_names(self, session_with_factory):
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         p1 = await repo.create_provider(
             display_name="Provider A",
@@ -352,16 +352,16 @@ class TestBuildOptionsProviderNames:
         assert options["provider_names"][f"custom-{p1.id}"] == "Provider A"
         assert options["provider_names"][f"custom-{p2.id}"] == "Provider B"
 
-    async def test_empty_provider_names_when_no_custom_providers(self, session):
-        db_session, _factory = session
+    async def test_empty_provider_names_when_no_custom_providers(self, session_with_factory):
+        db_session, _factory = session_with_factory
         mock_svc = _make_mock_svc()
         options = await _build_options(mock_svc, db_session)
 
         assert options["provider_names"] == {}
 
-    async def test_disabled_models_provider_not_in_names(self, session):
+    async def test_disabled_models_provider_not_in_names(self, session_with_factory):
         """如果供应商所有模型都被禁用，则不出现在 provider_names 中。"""
-        db_session, factory = session
+        db_session, factory = session_with_factory
         repo = CustomProviderRepository(db_session)
         await repo.create_provider(
             display_name="All Disabled",

--- a/tests/unit/server/routers/test_system_config_options.py
+++ b/tests/unit/server/routers/test_system_config_options.py
@@ -10,10 +10,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lib.config.service import ConfigService, ProviderStatus
-from lib.db.base import Base
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from server.routers.system_config import _build_options
 
@@ -23,14 +22,9 @@ from server.routers.system_config import _build_options
 
 
 @pytest.fixture
-async def session_with_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s, factory
-    await engine.dispose()
+async def session_with_factory(db_factory):
+    async with db_factory() as s:
+        yield s, db_factory
 
 
 def _make_mock_svc(ready_providers: list[str] | None = None) -> ConfigService:

--- a/tests/unit/server/routers/test_system_config_router.py
+++ b/tests/unit/server/routers/test_system_config_router.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -26,17 +25,6 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-async def db_session():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    sm = async_sessionmaker(engine, expire_on_commit=False)
-    async with sm() as session:
-        yield session
-    await engine.dispose()
 
 
 def _make_app_with_mock(mock_svc: ConfigService) -> FastAPI:
@@ -57,8 +45,8 @@ def _make_app_with_mock(mock_svc: ConfigService) -> FastAPI:
     app.dependency_overrides[get_config_service] = lambda: mock_svc
 
     async def _override_session():
-        async with mem_factory() as session:
-            yield session
+        async with mem_factory() as db_session:
+            yield db_session
 
     app.dependency_overrides[get_async_session] = _override_session
     app.include_router(system_config_router.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)

--- a/tests/unit/server/routers/test_system_version_api.py
+++ b/tests/unit/server/routers/test_system_version_api.py
@@ -13,7 +13,7 @@ from server.dependencies import get_config_service
 from server.routers import system_config
 from server.routers.system_config import _parse_version
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.conftest import make_translator
+from tests.factories import make_translator
 
 _FIXED_FETCHED_AT = datetime(2026, 4, 21, 8, 5, 0, tzinfo=UTC)
 

--- a/tests/unit/server/routers/test_usage_router.py
+++ b/tests/unit/server/routers/test_usage_router.py
@@ -1,9 +1,7 @@
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from server.auth import CurrentUserInfo, get_current_user
 from server.routers import usage
@@ -11,13 +9,8 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 
 
 @pytest.fixture
-async def _usage_env(monkeypatch):
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-
-    async with factory() as session:
+async def _usage_env(db_factory, monkeypatch):
+    async with db_factory() as session:
         repo = UsageRepository(session)
         cid1 = await repo.start_call(project_name="demo", call_type="image", model="gemini-3.1-flash-image-preview")
         await repo.finish_call(cid1, status="success", settlement=SettlementInput())
@@ -28,14 +21,13 @@ async def _usage_env(monkeypatch):
         cid4 = await repo.start_call(project_name="demo2", call_type="image", model="gemini-3.1-flash-image-preview")
         await repo.finish_call(cid4, status="success", settlement=SettlementInput())
 
-    monkeypatch.setattr(usage, "async_session_factory", factory)
+    monkeypatch.setattr(usage, "async_session_factory", db_factory)
 
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(usage.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
 
-    yield TestClient(app)
-    await engine.dispose()
+    return TestClient(app)
 
 
 class TestUsageRouter:

--- a/tests/unit/server/services/test_image_edit_executor.py
+++ b/tests/unit/server/services/test_image_edit_executor.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from lib.artifact_activation import register_current_artifact_if_provable
 from lib.artifact_manifest import (
@@ -22,7 +21,6 @@ from lib.artifact_manifest import (
     ProjectArtifactManifestAdapter,
 )
 from lib.config.resolver import ConfigResolver, ProviderModel
-from lib.db.base import Base
 from lib.project_manager import ProjectManager
 from lib.project_migration_failure import ProjectMigrationError
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
@@ -43,19 +41,14 @@ from server.services.image_edit_tasks import (
 
 
 @pytest.fixture
-async def patched_session_factory(monkeypatch):
+async def patched_session_factory(db_factory, monkeypatch):
     """真实内存 DB：建全部 ORM 表，把 lib.db.async_session_factory 指向它。
 
     供 image_size 解析等价用例的真实 ConfigResolver 使用（预置供应商无 DB 行，自定义供应商
     默认 resolution 才落 DB）。
     """
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    monkeypatch.setattr("lib.db.async_session_factory", factory)
-    yield factory
-    await engine.dispose()
+    monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+    return db_factory
 
 
 class _FakeGenerator:

--- a/tests/unit/server/services/test_image_edit_executor.py
+++ b/tests/unit/server/services/test_image_edit_executor.py
@@ -43,7 +43,7 @@ from server.services.image_edit_tasks import (
 
 
 @pytest.fixture
-async def session_factory(monkeypatch):
+async def patched_session_factory(monkeypatch):
     """真实内存 DB：建全部 ORM 表，把 lib.db.async_session_factory 指向它。
 
     供 image_size 解析等价用例的真实 ConfigResolver 使用（预置供应商无 DB 行，自定义供应商
@@ -902,26 +902,26 @@ class TestImageSizeResolutionEquivalence:
         generation_context.invalidate_backend_cache()
 
     @staticmethod
-    async def _old_image_size(session_factory, project, payload):
+    async def _old_image_size(patched_session_factory, project, payload):
         """旧执行层口径：resolve_image_backend(i2i) 得 provider/model，再按 model_id 查 resolution。"""
-        resolver = ConfigResolver(session_factory)
+        resolver = ConfigResolver(patched_session_factory)
         async with resolver.session() as r:
             resolved = await r.resolve_image_backend(project, payload, capability="i2i")
             return await r.resolve_resolution(project, resolved.provider_id, resolved.model_id)
 
-    async def test_model_settings_override(self, session_factory, _ctx_env):
+    async def test_model_settings_override(self, patched_session_factory, _ctx_env):
         project = {
             "image_provider_i2i": "gemini-aistudio/gemini-image",
             "model_settings": {"gemini-aistudio/gemini-image": {"resolution": "2048x2048"}},
         }
-        old = await self._old_image_size(session_factory, project, None)
+        old = await self._old_image_size(patched_session_factory, project, None)
         ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
         assert old == "2048x2048"
         assert ctx.image.resolution == old
 
-    async def test_default_falls_back_to_none(self, session_factory, _ctx_env):
+    async def test_default_falls_back_to_none(self, patched_session_factory, _ctx_env):
         project = {"image_provider_i2i": "gemini-aistudio/gemini-image"}
-        old = await self._old_image_size(session_factory, project, None)
+        old = await self._old_image_size(patched_session_factory, project, None)
         ctx = await resolve_generation_context("demo", None, project=project, image=ImageLaneRequest(capability="i2i"))
         assert old is None
         assert ctx.image.resolution == old

--- a/tests/unit/server/test_auth_middleware.py
+++ b/tests/unit/server/test_auth_middleware.py
@@ -32,7 +32,7 @@ def _auth_env():
 
 
 @pytest.fixture()
-def client():
+def middleware_client():
     """创建使用真实 app 的测试客户端。"""
     from server.app import app
 
@@ -40,9 +40,9 @@ def client():
         yield c
 
 
-def _login(client: TestClient) -> str:
+def _login(middleware_client: TestClient) -> str:
     """辅助函数：登录并返回 access_token。"""
-    resp = client.post(
+    resp = middleware_client.post(
         "/api/v1/auth/token",
         data={"username": "testuser", "password": "testpass"},
     )
@@ -51,49 +51,49 @@ def _login(client: TestClient) -> str:
 
 
 class TestAuthIntegration:
-    def test_health_no_auth(self, client):
+    def test_health_no_auth(self, middleware_client):
         """GET /health 不需要认证，返回 200"""
-        resp = client.get("/health")
+        resp = middleware_client.get("/health")
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
 
-    def test_login_no_auth(self, client):
+    def test_login_no_auth(self, middleware_client):
         """POST /api/v1/auth/token 不需要认证"""
-        resp = client.post(
+        resp = middleware_client.post(
             "/api/v1/auth/token",
             data={"username": "testuser", "password": "testpass"},
         )
         assert resp.status_code == 200
         assert "access_token" in resp.json()
 
-    def test_api_without_token(self, client):
+    def test_api_without_token(self, middleware_client):
         """GET /api/v1/projects 缺少 token 返回 401"""
-        resp = client.get("/api/v1/projects")
+        resp = middleware_client.get("/api/v1/projects")
         assert resp.status_code == 401
 
-    def test_api_with_valid_token(self, client):
+    def test_api_with_valid_token(self, middleware_client):
         """先登录获取 token，再带 token 访问 API，不应返回 401"""
-        token = _login(client)
-        resp = client.get(
+        token = _login(middleware_client)
+        resp = middleware_client.get(
             "/api/v1/projects",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code != 401
 
-    def test_api_with_invalid_token(self, client):
+    def test_api_with_invalid_token(self, middleware_client):
         """带无效 token 访问返回 401"""
-        resp = client.get(
+        resp = middleware_client.get(
             "/api/v1/projects",
             headers={"Authorization": "Bearer invalid-token-value"},
         )
         assert resp.status_code == 401
 
-    def test_docs_page_accessible(self, client):
+    def test_docs_page_accessible(self, middleware_client):
         """/docs Swagger UI 应可访问"""
-        resp = client.get("/docs")
+        resp = middleware_client.get("/docs")
         assert resp.status_code == 200
 
-    def test_frontend_path_no_auth(self, client):
+    def test_frontend_path_no_auth(self, middleware_client):
         """前端路径（非 /api/ 开头）不需要认证"""
-        resp = client.get("/app/projects")
+        resp = middleware_client.get("/app/projects")
         assert resp.status_code != 401

--- a/tests/unit/server/test_auth_router.py
+++ b/tests/unit/server/test_auth_router.py
@@ -17,7 +17,7 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 
 
 @pytest.fixture()
-def client():
+def auth_router_client():
     """创建测试客户端，设置固定的认证环境变量"""
     auth_module._cached_token_secret = None
     auth_module._cached_password_hash = None
@@ -37,9 +37,9 @@ def client():
 
 
 class TestLoginRoute:
-    def test_login_success(self, client):
+    def test_login_success(self, auth_router_client):
         """正确凭据返回 200 + access_token"""
-        resp = client.post(
+        resp = auth_router_client.post(
             "/api/v1/auth/token",
             data={"username": "testuser", "password": "testpass"},
         )
@@ -49,17 +49,17 @@ class TestLoginRoute:
         assert data["token_type"] == "bearer"
         assert len(data["access_token"]) > 0
 
-    def test_login_wrong_password(self, client):
+    def test_login_wrong_password(self, auth_router_client):
         """错误密码返回 401"""
-        resp = client.post(
+        resp = auth_router_client.post(
             "/api/v1/auth/token",
             data={"username": "testuser", "password": "wrongpass"},
         )
         assert resp.status_code == 401
 
-    def test_login_wrong_username(self, client):
+    def test_login_wrong_username(self, auth_router_client):
         """错误用户名返回 401"""
-        resp = client.post(
+        resp = auth_router_client.post(
             "/api/v1/auth/token",
             data={"username": "wronguser", "password": "testpass"},
         )
@@ -67,15 +67,15 @@ class TestLoginRoute:
 
 
 class TestVerifyRoute:
-    def test_verify_valid_token(self, client):
+    def test_verify_valid_token(self, auth_router_client):
         """有效 token 验证通过"""
-        login_resp = client.post(
+        login_resp = auth_router_client.post(
             "/api/v1/auth/token",
             data={"username": "testuser", "password": "testpass"},
         )
         token = login_resp.json()["access_token"]
 
-        resp = client.get(
+        resp = auth_router_client.get(
             "/api/v1/auth/verify",
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -84,14 +84,14 @@ class TestVerifyRoute:
         assert data["valid"] is True
         assert data["username"] == "testuser"
 
-    def test_verify_no_token(self, client):
+    def test_verify_no_token(self, auth_router_client):
         """缺少 token 返回 401"""
-        resp = client.get("/api/v1/auth/verify")
+        resp = auth_router_client.get("/api/v1/auth/verify")
         assert resp.status_code == 401
 
-    def test_verify_invalid_token(self, client):
+    def test_verify_invalid_token(self, auth_router_client):
         """无效 token 返回 401"""
-        resp = client.get(
+        resp = auth_router_client.get(
             "/api/v1/auth/verify",
             headers={"Authorization": "Bearer invalid-token"},
         )

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-docx" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -282,6 +283,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-docx", specifier = ">=1.2.0" },
+    { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.16.0" },
 ]
 
@@ -2621,6 +2623,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1996

Spec #1989 的 B5c：测试侧共享设施收编。

## 改动

- **审计脚本进 main**：`scripts/audit_tests.py` 从 research 分支收编，新增「类 3：共享设施结构」段，四条机械判据 `CONFTEST-IMPORT` / `FIXTURE-OVERRIDE` / `CONFTEST-SHADOW` / `FIXTURE-DUP`，各带处置指引。不带 `--check`、不含前端段——闸门形态是 B7 的边界。
- **`bounded_poll_clock` 定为轮询/重试替身入口**：13 处 `patch("lib.retry._compute_wait", ...)` 全部迁入；`lib/retry.py` 里为容纳「只接 (attempt, backoff) 的替身」而存在的两分支调用随之收敛回单一 `_compute_wait(attempt, backoff_seconds, jitter=jitter)`。
- **respx 共享 helper**：新增 `tests/http_capture.py`（`capture_http()` / `request_json()` / `only_request()`），dashscope 与 agnes 两个图像后端测试改写为 transport 层拦截作为接入示范（共 56 用例）。
- **conftest 三角色归位**：13 处 `from tests.conftest import ...` 清零，helper 落到 `tests/factories.py`。
- **DB fixture 收敛到唯一 engine 构造点**：`tests/conftest.py` 新增 `test_engine(*, dialect_aware=True, file_path=None)`，全部 DB fixture 由它派生；新增 `db_engine` / `db_session` / `db_factory` / `file_db_factory` 共享 fixture。18 个测试文件的本地 engine / session 定义删除后，又把余下 17 处 fixture 内的 `create_async_engine` 一并改为消费根 conftest 的 `db_engine` / `db_factory`，两处「文件库 + NullPool + WAL」并发 fixture 改消费 `file_db_factory`（等同 `file_session_factory`，但不带 `uses_db`，不把 unit 档用例拉进 PG 选集）。至此 `tests/` 下 **fixture 层的 engine 构造已全部收敛**，唯一登记的例外是 `async_session` 的 PG 分支。
- **同名 fixture 按实体收编**：同一实体的删本地定义改消费根 conftest 版本；恰好重名的不同实体（`client` 7 文件、`backend` 3、`pm` 4、`output_path` 3 等）改区分性名字。`CONTRIBUTING.md` 的 fixture 与 DB fixture 两条口径同步改成「同一实体」「唯一构造点 `test_engine`」的表述。

## 取舍

`uses_db` 单一来源落在构造函数 `test_engine` 而非 fixture 层：issue 原文的「所有 DB fixture 派生自唯一方言感知 engine 并进 `uses_db`」直译会让 `tests/unit/lib/db/**` 下约 20 个消费方被注入 `uses_db`，撞上收集期的 `uses_db ∧ unit` 断言而全部炸在收集期。改为两族 fixture 都只经 `test_engine` 建 engine，但 `session_factory` / `async_session` / `file_session_factory` 带 `uses_db` 进 PostgreSQL 兼容选集，`db_engine` / `db_session` / `db_factory` / `file_db_factory` 不进。唯一登记的例外是 `async_session` 的 PG 分支——它绑定 CI job 已 alembic 建好的 public schema，隔离原语与 `test_engine` 的 per-test schema + `create_all` 不同，该例外已写进 `CONTRIBUTING.md` 与代码注释。

同名 fixture 取「改名」而非「闸门豁免」：改名不改变任何用例的 PG 归属，豁免会让闸门失去意义。

## 本地审查修复

- `CONTRIBUTING.md` 的 DB fixture 一条按代码现状重写：原文遗漏 `file_session_factory` 恒为文件 SQLite 却带 `uses_db` 这一事实，也未提 `file_db_factory`，并且没登记 `async_session` PG 分支这个唯一不经 `test_engine` 的例外。
- 过渡期说明收窄为「`scripts/audit_tests.py` 的 `--check` 形态尚不存在」——脚本本体本票已进 main，原措辞会与现状矛盾。
- 删 `tests/http_capture.py` 的 `sent_json`（0 消费方）、`make_test_audio` 从 `tests/factories.py` 移回唯一消费方文件：两者都撞 CONTRIBUTING 的「共享设施公开符号须被 ≥2 个测试文件使用」闸门。
- `audit_tests.py` 的 `CONFTEST-IMPORT` 扫描此前跳过 conftest 自身，使 CONTRIBUTING 已声明的「conftest 之间不互相 import」闸门检不出来；改为先收集 import 再跳过，当前 0 命中。
- `.github/dependabot.yml` 的 uv `dev-dependencies` 分组补 `respx`（本票新增依赖）。
- 清理触及文件里带 issue 编号与时间性措辞的注释（`fix #647 #N：`、「实测」）。

## 验证

- `ruff check .` / `ruff format --check .` / `basedpyright`（0 errors）/ `lint-imports`（2 kept, 0 broken）全绿
- `pytest` 全量 10282 passed, 2 skipped，与 main 基线一致
- **守恒判据**：`-m uses_db` 收集在本分支与 main 均为 93 条，nodeid 集合逐条相等——fixture 改名与收编没有改变任何用例的 PostgreSQL 兼容选集归属
- `uv run python scripts/audit_tests.py` 的「类 3：共享设施结构」段无命中（迁移前 CONFTEST-IMPORT 13、FIXTURE-OVERRIDE 9、FIXTURE-DUP 54）
- 已 rebase 到含 #1993 测试文件拆分的 main，两侧改动文件无交集，rebase 后守恒判据与全量门重跑通过

## 已知边界（归后续票）

- 约 27 处 `patch("lib.retry.asyncio.sleep")` 与约 15 处 `patch("lib.video_backends.base.asyncio.sleep")` 未迁到 `bounded_poll_clock`；约 127 处 `patch("httpx.AsyncClient")` 未迁到 `capture_http`。本票只交付入口与示范，逐域迁移归 B6。
- fixture 层已全部收敛，但**用例体与私有 helper 内仍有 29 处 `create_async_engine`**（分布在 15 个文件，手搓 `create_all` + `dispose`）。AC3 的「DB fixture 单一来源」已达成，这批体内 engine 归 B6。
- 审计脚本的 `--check` 形态与前端段归 B7。

https://claude.ai/code/session_017dYPL4DmXdDbzyifcC6G3F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增测试质量审计工具，用于识别薄弱断言、过度模拟及测试结构问题。
  - 增强 HTTP 请求捕获与媒体测试数据生成功能。

- **文档**
  - 更新贡献指南，补充测试替身、数据库夹具及审计规范。

- **测试改进**
  - 统一数据库测试环境与重试时钟，提升测试稳定性、可维护性及行为验证准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->