### PR TITLE
test(agent_runtime): 以 config_resolver 注入缝替换私有 patch，域内测试卫生清零（#1998）

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -408,6 +408,118 @@ def fake_reference_caps_fetcher(
     return _fetch
 
 
+class FakeConfigResolver:
+    """能力解析器 seam 的手写替身：按桶回答视频能力，不触碰配置库。
+
+    生产侧凡接 ``config_resolver`` 关键字的入口（``ToolContext``、``resolve_video_caps`` /
+    ``fetch_video_caps`` 及 ``text_generation`` 的几个取值器）都可注入本类，替代对这些取值器
+    本身的整体替换——被替换掉的取值器里有软回退、联动约束收窄与声音档派生，那些才是用例要
+    保护的行为。
+
+    ``by_capability`` 给按桶分叉的路径用（参考生视频的无引用 unit 走 i2v 桶）：键是
+    ``VideoCapability`` 字面量，值是覆盖在基础能力上的字段。``error`` / ``generate_audio_error``
+    让软回退分支不必再 patch 就能触发。
+    """
+
+    def __init__(
+        self,
+        *,
+        supported_durations: tuple[int, ...] | list[int] = (4, 6, 8),
+        default_duration: int | None = 4,
+        provider_id: str = "fake",
+        model: str = "fake-video",
+        max_reference_images: int | None = 3,
+        max_reference_audio_count: int = 0,
+        reference_audio_per_image: bool = False,
+        generate_audio: bool = True,
+        requested_generate_audio: bool = True,
+        voice_consistency: str = "soft",
+        by_capability: Mapping[str, Mapping[str, Any]] | None = None,
+        capability_errors: Mapping[str, BaseException] | None = None,
+        error: BaseException | None = None,
+        generate_audio_error: BaseException | None = None,
+        image_backend: tuple[str, str] = ("fake", "fake-image"),
+        image_backend_error: BaseException | None = None,
+        **extra: Any,
+    ) -> None:
+        self._base: dict[str, Any] = {
+            "provider_id": provider_id,
+            "model": model,
+            "supported_durations": list(supported_durations),
+            "max_duration": max(supported_durations) if supported_durations else 0,
+            "max_reference_images": max_reference_images,
+            "max_reference_audio_count": max_reference_audio_count,
+            "reference_audio_per_image": reference_audio_per_image,
+            "generate_audio": generate_audio,
+            "requested_generate_audio": requested_generate_audio,
+            "voice_consistency": voice_consistency,
+            "source": "registry",
+            "default_duration": default_duration,
+            **extra,
+        }
+        self._by_capability = {key: dict(value) for key, value in (by_capability or {}).items()}
+        self._capability_errors = dict(capability_errors or {})
+        self._error = error
+        self._generate_audio_error = generate_audio_error
+        self._image_backend = image_backend
+        self._image_backend_error = image_backend_error
+        self.capability_calls: list[str | None] = []
+        self.project_names: list[str | None] = []
+        self.image_capability_calls: list[str | None] = []
+
+    def caps_for(self, capability: str | None = None) -> dict[str, Any]:
+        """该桶的能力 dict（与生产返回同形），供用例直接对照期望。"""
+        caps = dict(self._base)
+        caps.update(self._by_capability.get(capability or "", {}))
+        durations = caps.get("supported_durations") or []
+        caps["max_duration"] = max(durations) if durations else 0
+        return caps
+
+    async def video_capabilities(self, project_name: str | None = None) -> dict[str, Any]:
+        self.project_names.append(project_name)
+        return self._resolve(None)
+
+    async def video_capabilities_for_project(
+        self,
+        project: dict[str, Any],
+        *,
+        capability: str | None = None,
+    ) -> dict[str, Any]:
+        del project
+        return self._resolve(capability)
+
+    async def resolve_image_backend(
+        self,
+        project: dict[str, Any] | None,
+        payload: dict[str, Any] | None = None,
+        *,
+        capability: str | None = None,
+    ) -> Any:
+        """解析图像供应商；``image_backend_error`` 给「项目槽位解析不出可用供应商」那条路径。"""
+        from lib.config.resolver import ProviderModel
+
+        del project, payload
+        self.image_capability_calls.append(capability)
+        if self._image_backend_error is not None:
+            raise self._image_backend_error
+        return ProviderModel(*self._image_backend)
+
+    async def video_generate_audio_for_project(self, project: dict[str, Any] | None) -> bool:
+        del project
+        if self._generate_audio_error is not None:
+            raise self._generate_audio_error
+        return bool(self._base["requested_generate_audio"])
+
+    def _resolve(self, capability: str | None) -> dict[str, Any]:
+        self.capability_calls.append(capability)
+        if self._error is not None:
+            raise self._error
+        bucket_error = self._capability_errors.get(capability or "")
+        if bucket_error is not None:
+            raise bucket_error
+        return self.caps_for(capability)
+
+
 def instructor_api_call_exhausted(cause: Exception) -> InstructorRetryException:
     """构造「API 调用失败」形态的 Instructor 异常，供结构化输出降级链的判据测试使用。
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -466,6 +466,7 @@ class FakeConfigResolver:
         self.capability_calls: list[str | None] = []
         self.project_names: list[str | None] = []
         self.image_capability_calls: list[str | None] = []
+        self.generate_audio_calls: list[dict[str, Any] | None] = []
 
     def caps_for(self, capability: str | None = None) -> dict[str, Any]:
         """该桶的能力 dict（与生产返回同形），供用例直接对照期望。"""
@@ -505,7 +506,7 @@ class FakeConfigResolver:
         return ProviderModel(*self._image_backend)
 
     async def video_generate_audio_for_project(self, project: dict[str, Any] | None) -> bool:
-        del project
+        self.generate_audio_calls.append(project)
         if self._generate_audio_error is not None:
             raise self._generate_audio_error
         return bool(self._base["requested_generate_audio"])

--- a/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
@@ -24,7 +24,7 @@ from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
     validate_and_promote_draft_tool,
 )
-from tests.fakes import fake_reference_caps_fetcher
+from tests.fakes import FakeConfigResolver
 
 # ---------------------------------------------------------------------------
 # Generation result contract helpers
@@ -291,6 +291,27 @@ def _fake_reference_projection(
     return _project
 
 
+def _fake_caps_resolver(**kwargs: Any) -> Any:
+    """构造假能力解析器（见 ``tests.fakes.FakeConfigResolver``）。
+
+    返回值按 ``Any`` 交出：注入点标注的是生产的 ``ConfigResolver``，替身只实现被调到的那几个
+    方法，逐个调用点写类型豁免不如在这唯一的构造点交出去。
+    """
+    return FakeConfigResolver(**kwargs)
+
+
+def _use_fake_caps(fake_ctx: ToolContext, **kwargs: Any) -> Any:
+    """给这个会话装上假能力解析器并返回它。
+
+    工具经 ``ToolContext.config_resolver`` 把解析器透传给能力取值器，注入后取值器里的软回退、
+    时长联动约束收窄与声音档派生照常执行——那些正是用例要保护的行为，整体替换取值器会把它们
+    一并旁路掉。
+    """
+    resolver = _fake_caps_resolver(**kwargs)
+    fake_ctx.config_resolver = resolver
+    return resolver
+
+
 async def _call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
     """调工具处理器；工具声明为必填的交付方式在未点名时补成后期配音。
 
@@ -406,7 +427,7 @@ def _rv_step1_path(fake_ctx: ToolContext):
 async def _run_rv_split(fake_ctx: ToolContext, monkeypatch, units: list[dict], **caps_kwargs) -> dict:
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(**caps_kwargs))
+    _use_fake_caps(fake_ctx, **caps_kwargs)
     monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units))
     return await _call(split_reference_video_units_tool(fake_ctx), {"episode": 1})
 
@@ -419,12 +440,10 @@ def _read_rv_quarantine(fake_ctx: ToolContext) -> dict:
     return json.loads(_rv_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
 
 
-async def _promote(fake_ctx: ToolContext, monkeypatch, **caps_kwargs) -> dict:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
+async def _promote(fake_ctx: ToolContext, **caps_kwargs) -> dict:
     if not (fake_ctx.project_path / "project.json").exists():
         _rv_project(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(**caps_kwargs))
+    _use_fake_caps(fake_ctx, **caps_kwargs)
     return await _call(validate_and_promote_draft_tool(fake_ctx), {"episode": 1})
 
 
@@ -559,13 +578,8 @@ async def _open_drama_for_edit(fake_ctx: ToolContext, **args) -> dict:
     return await _call(open_step1_for_edit_tool(fake_ctx), {"episode": 1, **args})
 
 
-async def _promote_drama(fake_ctx: ToolContext, monkeypatch, durations=(4, 6, 8)) -> dict:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    async def fake_caps(_project, _episode=None):
-        return durations[0], list(durations)
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+async def _promote_drama(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
+    _use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
     return await _call(validate_and_promote_draft_tool(fake_ctx), {"episode": 1})
 
 
@@ -591,8 +605,6 @@ async def _open_nr_for_edit(fake_ctx: ToolContext, **args) -> dict:
     return await _call(open_step1_for_edit_tool(fake_ctx), {"episode": 1, **args})
 
 
-async def _promote_nr(fake_ctx: ToolContext, monkeypatch, durations=(4, 6, 8)) -> dict:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps(durations[0], durations))
+async def _promote_nr(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
+    _use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
     return await _call(validate_and_promote_draft_tool(fake_ctx), {"episode": 1})

--- a/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
@@ -470,13 +470,6 @@ async def _open_for_edit(fake_ctx: ToolContext, **args) -> dict:
     return await _call(open_step1_for_edit_tool(fake_ctx), {"episode": 1, **args})
 
 
-def _nr_caps(default=4, durations=(4, 6, 8)):
-    async def fake_caps(_p, _episode=None):
-        return default, list(durations)
-
-    return fake_caps
-
-
 def _nr_project(fake_ctx: ToolContext) -> None:
     _rv_project(fake_ctx, generation_mode="storyboard")
 

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
@@ -230,7 +230,6 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
 
 
 async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
     _use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
@@ -275,7 +274,6 @@ async def test_edit_images_rejects_unknown_resource_type(fake_ctx: ToolContext) 
 
 async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext, monkeypatch) -> None:
     """资产没有可编辑的当前图（sheet 字段未设置）时跳过并告警，不入队。"""
-    from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
     _use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
@@ -229,8 +229,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
     assert blocked_item.problem.code == "generation_artifact_state_unavailable"
 
 
-async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext, monkeypatch) -> None:
-
+async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext) -> None:
     _use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "storyboard", "edits": [{"id": "E1S01", "instruction": "去杂物"}]})
@@ -272,7 +271,7 @@ async def test_edit_images_rejects_unknown_resource_type(fake_ctx: ToolContext) 
     assert out.get("is_error") is True
 
 
-async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext) -> None:
     """资产没有可编辑的当前图（sheet 字段未设置）时跳过并告警，不入队。"""
 
     _use_fake_caps(fake_ctx)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_image_edits.py
@@ -13,7 +13,9 @@ from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.enqueue_image_edits import edit_images_tool
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _call,
+    _fake_caps_resolver,
     _generation_result,
+    _use_fake_caps,
 )
 
 pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_reference_request_projection")
@@ -38,9 +40,6 @@ async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
     fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -55,7 +54,7 @@ async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
         ]
         return succ, []
 
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(
@@ -77,9 +76,6 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
     fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -89,7 +85,7 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
         ]
         return [], fail
 
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(
@@ -103,14 +99,9 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
     assert item.artifact_path == "characters/zhangsan.png"
 
 
-async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext) -> None:
     """i2i 不可用时直接报错，不创建任何任务（复用服务端 fail-fast 判断点）。"""
-    from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
-
-    async def fake_i2i(_project):
-        return False
-
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx, image_backend_error=ValueError("未找到可用的 image 供应商"))
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(
         tool_obj,
@@ -151,12 +142,9 @@ async def test_edit_images_active_asset_without_a_manifest_claim_is_not_enqueued
             self.compare(key, artifact_path=artifact_path)
             return None
 
-    async def fake_i2i(_project):
-        return True
-
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _Currency())
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(
@@ -192,9 +180,6 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
     fake_ctx.pm.project_payload["characters"]["李四"]["character_sheet"] = "characters/lisi.png"  # type: ignore[attr-defined]
     fake_ctx.pm.project_payload["characters"]["李四"]["description"] = "配角"  # type: ignore[attr-defined]
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -214,7 +199,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
             raise ArtifactManifestError("manifest sidecar unreadable")
         return _ImageEditSource(resource_id=resource_id, artifact_path="characters/lisi.png", formal_claims=())
 
-    monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_image_edits._i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr("server.agent_runtime.sdk_tools.enqueue_image_edits.batch_enqueue_and_wait", fake_batch)
     monkeypatch.setattr(
         "server.agent_runtime.sdk_tools.enqueue_image_edits.active_artifact_currency_resolver",
@@ -247,10 +232,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
 async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
-    async def fake_i2i(_project):
-        return True
-
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "storyboard", "edits": [{"id": "E1S01", "instruction": "去杂物"}]})
     assert out.get("is_error") is True
@@ -265,9 +247,8 @@ async def test_edit_images_storyboard_rejects_an_unbound_script_before_provider(
 
     fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
     fake_ctx.pm.project_payload["episodes"] = []  # type: ignore[attr-defined]
-    provider_gate = AsyncMock(return_value=True)
+    resolver = _use_fake_caps(fake_ctx)
     enqueue = AsyncMock(return_value=([], []))
-    monkeypatch.setattr(mod, "_i2i_provider_available", provider_gate)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(
@@ -281,7 +262,8 @@ async def test_edit_images_storyboard_rejects_an_unbound_script_before_provider(
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
-    provider_gate.assert_not_awaited()
+    # 剧本未绑定在供应商判定之前就拒：解析器一次都没被问过
+    assert resolver.image_capability_calls == []
     enqueue.assert_not_awaited()
 
 
@@ -295,10 +277,7 @@ async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext, mo
     """资产没有可编辑的当前图（sheet 字段未设置）时跳过并告警，不入队。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
-    async def fake_i2i(_project):
-        return True
-
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
     # 李四 没有 character_sheet
     out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "李四", "instruction": "换发色"}]})
@@ -324,9 +303,6 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
     fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -341,7 +317,7 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
         ]
         return succ, []
 
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(
@@ -378,9 +354,6 @@ async def test_edit_images_storyboard_happy(fake_ctx: ToolContext, monkeypatch) 
     """storyboard 分支带合法 script_file 时应正常解析剧本并入队（覆盖 validate_script_filename + load_script 调用）。"""
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -395,7 +368,7 @@ async def test_edit_images_storyboard_happy(fake_ctx: ToolContext, monkeypatch) 
         ]
         return succ, []
 
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(
@@ -419,9 +392,6 @@ async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) 
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
     fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
 
-    async def fake_i2i(_project):
-        return True
-
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
 
@@ -431,7 +401,7 @@ async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) 
         ]
         return [], fail
 
-    monkeypatch.setattr(mod, "_i2i_provider_available", fake_i2i)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "改发型"}]})
@@ -454,24 +424,17 @@ async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
     assert "edit_images 失败" in out["content"][0]["text"]
 
 
-async def test_i2i_provider_available_true(monkeypatch) -> None:
-    from lib.config.resolver import ConfigResolver
+async def test_i2i_provider_available_true() -> None:
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
-    async def fake_resolve(self, project, payload, *, capability):
-        assert capability == "i2i"
-        return object()
-
-    monkeypatch.setattr(ConfigResolver, "resolve_image_backend", fake_resolve)
-    assert await mod._i2i_provider_available({}) is True
+    resolver = _fake_caps_resolver()
+    assert await mod._i2i_provider_available({}, config_resolver=resolver) is True
+    # 判的是 i2i 槽位，不是项目默认图像槽
+    assert resolver.image_capability_calls == ["i2i"]
 
 
-async def test_i2i_provider_available_false_on_value_error(monkeypatch) -> None:
-    from lib.config.resolver import ConfigResolver
+async def test_i2i_provider_available_false_on_value_error() -> None:
     from server.agent_runtime.sdk_tools import enqueue_image_edits as mod
 
-    async def fake_resolve(self, project, payload, *, capability):
-        raise ValueError("未找到可用的 image 供应商")
-
-    monkeypatch.setattr(ConfigResolver, "resolve_image_backend", fake_resolve)
-    assert await mod._i2i_provider_available({}) is False
+    resolver = _fake_caps_resolver(image_backend_error=ValueError("未找到可用的 image 供应商"))
+    assert await mod._i2i_provider_available({}, config_resolver=resolver) is False

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_narration_audio.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_narration_audio.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lib.artifact_manifest import ArtifactStatus
+from lib.artifact_manifest import ArtifactKey, ArtifactStatus
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.agent_runtime.sdk_tools._context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
@@ -231,25 +231,23 @@ async def test_generate_narration_audio_uses_canonical_filename_when_episode_fie
         encoding="utf-8",
     )
     captured: list[Any] = []
-    selected_episodes: list[int] = []
-    build_candidates = mod._candidates
-
-    def _capture_episode(*args, **kwargs):
-        selected_episodes.append(kwargs["episode"])
-        return build_candidates(*args, **kwargs)
 
     async def _batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
-        captured.extend(specs)
-        return [], []
+        from lib.generation_queue_client import BatchTaskResult
 
-    monkeypatch.setattr(mod, "_candidates", _capture_episode)
+        captured.extend(specs)
+        return [
+            BatchTaskResult(resource_id=s.resource_id, task_id="t1", status="succeeded", result={}) for s in specs
+        ], []
+
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
 
     out = await _call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_2.json"})
 
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1S01"]
-    assert selected_episodes == [2]
+    # 集号取自项目绑定而非剧本自述：产物身份随之落在第 2 集
+    assert _generation_result(out).items[0].artifact_key == ArtifactKey.episode_audio(2, "E1S01").encode()
 
 
 async def test_generate_narration_audio_selects_item_with_corrupt_generated_assets(

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_videos.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_videos.py
@@ -393,7 +393,6 @@ async def test_generate_video_episode_rejects_unbound_active_script_before_enque
     from server.agent_runtime.sdk_tools import enqueue_videos as mod
 
     _activate_unbound_project(fake_ctx)
-    submitted = False
     spec = TaskSpec.from_request(
         task_type="video",
         media_type="video",
@@ -405,19 +404,15 @@ async def test_generate_video_episode_rejects_unbound_active_script_before_enque
     def fake_build_specs(**_kwargs):
         return [spec], {"E1S01": 0}, []
 
-    async def fake_submit(**_kwargs):
-        nonlocal submitted
-        submitted = True
-        return []
-
+    enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "build_storyboard_video_specs", fake_build_specs)
-    monkeypatch.setattr(mod, "_submit_with_checkpoint", fake_submit)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(mod.generate_video_episode_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
-    assert submitted is False
+    enqueue.assert_not_awaited()
 
 
 async def test_generate_video_episode_resolves_episode_from_canonical_filename(
@@ -532,20 +527,14 @@ async def test_generate_reference_video_rejects_unbound_active_script_before_gen
 
     _activate_unbound_project(fake_ctx, generation_mode="reference_video")
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
-    generated = False
-
-    async def fake_generate(**_kwargs):
-        nonlocal generated
-        generated = True
-        return mod.ReferenceGenerationComplete(paths=[], projections=[])
-
-    monkeypatch.setattr(mod, "_generate_reference_units", fake_generate)
+    enqueue = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(mod.generate_video_episode_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
-    assert generated is False
+    enqueue.assert_not_awaited()
 
 
 async def test_generate_reference_video_legacy_unresolvable_episode_fails_before_generation(
@@ -557,14 +546,14 @@ async def test_generate_reference_video_legacy_unresolvable_episode_fails_before
     _use_reference_route(fake_ctx)
     fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
     fake_ctx.pm.script_payload.pop("episode")  # type: ignore[attr-defined]
-    generate = AsyncMock(return_value=mod.ReferenceGenerationComplete(paths=[], projections=[]))
-    monkeypatch.setattr(mod, "_generate_reference_units", generate)
+    enqueue = AsyncMock(return_value=([], []))
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
     out = await _call(mod.generate_video_episode_tool(fake_ctx), {"script": "draft.json"})
 
     assert out.get("is_error") is True
     assert "无法确定集号" in out["content"][0]["text"]
-    generate.assert_not_awaited()
+    enqueue.assert_not_awaited()
 
 
 async def test_generate_video_episode_reference_rejects_malformed_unit_container(fake_ctx: ToolContext) -> None:

--- a/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_videos_audio_switch.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_enqueue_videos_audio_switch.py
@@ -13,10 +13,10 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from lib.config.resolver import ConfigResolver
 from lib.config.service import ConfigService
-from lib.db.base import Base
 from lib.generation_queue_client import TaskSpec
 from lib.generation_result import GenerationAction, GenerationSelectionMode
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
@@ -32,18 +32,13 @@ _ALWAYS_AUDIBLE = "dashscope/wan2.7-i2v"
 _CONTROLLABLE = "ark/doubao-seedance-2-0-260128"
 
 
-async def _make_factory(**settings: str):
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    if settings:
-        async with factory() as session:
-            svc = ConfigService(session)
-            for key, value in settings.items():
-                await svc.set_setting(key, value)
-            await session.commit()
-    return factory, engine
+async def _seed_settings(factory: async_sessionmaker[AsyncSession], **settings: str) -> None:
+    """把系统设置写进共享 DB fixture 的库里。"""
+    async with factory() as session:
+        svc = ConfigService(session)
+        for key, value in settings.items():
+            await svc.set_setting(key, value)
+        await session.commit()
 
 
 class _FakePM:
@@ -74,23 +69,23 @@ def _unit_spec(unit: dict[str, Any]) -> TaskSpec:
 
 
 class TestAssertAudioSwitchSupported:
-    async def test_always_audible_model_with_audio_off_names_provider_and_model(self, monkeypatch):
-        factory, engine = await _make_factory(default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="false")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            with pytest.raises(ValueError) as exc_info:
-                await assert_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+    async def test_always_audible_model_with_audio_off_names_provider_and_model(self, db_factory, monkeypatch):
+        await _seed_settings(db_factory, default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="false")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        with pytest.raises(ValueError) as exc_info:
+            await assert_audio_switch_supported({}, "i2v")
+
         assert "dashscope/wan2.7-i2v" in str(exc_info.value)
 
-    async def test_controllable_model_keeps_the_off_setting(self, monkeypatch):
-        factory, engine = await _make_factory(default_video_backend=_CONTROLLABLE, video_generate_audio="false")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await assert_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+    async def test_controllable_model_keeps_the_off_setting(self, db_factory, monkeypatch):
+        await _seed_settings(db_factory, default_video_backend=_CONTROLLABLE, video_generate_audio="false")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        await assert_audio_switch_supported({}, "i2v")
+
+        # 闸门放行后关音设置原样生效，没有被改写成有声
+        assert await ConfigResolver(db_factory).video_generate_audio_for_project({}) is False
 
 
 class TestStoryboardRouteGate:

--- a/tests/integration/server/agent_runtime/sdk_tools/test_open_step1_for_edit.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_open_step1_for_edit.py
@@ -94,7 +94,7 @@ async def test_open_step1_for_edit_round_trips_through_promote(fake_ctx: ToolCon
     envelope["content"]["units"][0]["text"] = "@[张三] 在 @[村口] 出场"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert not _rv_quarantine_path(fake_ctx).exists()
@@ -233,7 +233,7 @@ async def test_open_step1_for_edit_drama_round_trips_through_promote(fake_ctx: T
     envelope["content"]["scenes"][0]["scene_description"] = "阿离推开山门。"
     _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx, monkeypatch)
+    out = await _promote_drama(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert not _drama_quarantine_path(fake_ctx).exists()
@@ -300,7 +300,7 @@ async def test_open_step1_for_edit_narration_round_trips_through_promote(fake_ct
     envelope["content"]["segments"][0]["duration_seconds"] = 8
     _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx, monkeypatch)
+    out = await _promote_nr(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert not _nr_quarantine_path(fake_ctx).exists()

--- a/tests/integration/server/agent_runtime/sdk_tools/test_open_step1_for_edit.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_open_step1_for_edit.py
@@ -84,7 +84,7 @@ async def test_open_step1_for_edit_leaves_official_file_untouched(fake_ctx: Tool
     assert _rv_step1_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
-async def test_open_step1_for_edit_round_trips_through_promote(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_open_step1_for_edit_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """情况 B 的完整闭环：取回 → 改草稿 → 晋升。改动经晋升侧的持锁写盘落回正式文件。"""
     _rv_source(fake_ctx)
     _write_rv_step1(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
@@ -223,7 +223,7 @@ async def test_open_step1_for_edit_returns_drama_scenes(fake_ctx: ToolContext) -
     assert _drama_step1_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
-async def test_open_step1_for_edit_drama_round_trips_through_promote(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_open_step1_for_edit_drama_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """完整闭环：取回 → 改草稿 → 晋升。改动经持锁写盘落回正式文件，派生字段按新内容重算。"""
     _drama_project(fake_ctx)
     _write_drama_step1(fake_ctx, [_drama_scene()])
@@ -290,7 +290,7 @@ async def test_open_step1_for_edit_returns_narration_segments(fake_ctx: ToolCont
     assert _nr_step1_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
-async def test_open_step1_for_edit_narration_round_trips_through_promote(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_open_step1_for_edit_narration_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """取回 → 改草稿 → 晋升写回正式文件、草稿清除：与 drama / 参考生视频同一条晋升通道。"""
     _nr_source(fake_ctx)
     _write_nr_step1(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])

--- a/tests/integration/server/agent_runtime/sdk_tools/test_patch_tools.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_patch_tools.py
@@ -1398,12 +1398,9 @@ class TestPatchProjectNarrationSettings:
         assert "narration_voice" not in project
         assert "narration_speed" not in project
 
-    async def test_resolver_uses_values_written_by_tool(self, ctx: ToolContext) -> None:
+    async def test_resolver_uses_values_written_by_tool(self, ctx: ToolContext, db_factory) -> None:
         """工具写入与生成端解析读的是同一份顶层字段:写入后 resolver 实际解析出覆盖值。"""
-        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
         from lib.config.resolver import ConfigResolver
-        from lib.db.base import Base
 
         out = await _call(
             patch_project_tool(ctx),
@@ -1412,15 +1409,9 @@ class TestPatchProjectNarrationSettings:
         assert out.get("is_error") is not True
         project = ctx.pm.load_project("demo")
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        try:
-            resolver = ConfigResolver(async_sessionmaker(engine, expire_on_commit=False))
-            assert await resolver.resolve_narration_voice(project) == "Ethan"
-            assert await resolver.resolve_narration_speed(project) == 1.2
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_voice(project) == "Ethan"
+        assert await resolver.resolve_narration_speed(project) == 1.2
 
 
 class TestPatchProjectOverview:

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
@@ -15,11 +15,11 @@ from server.agent_runtime.sdk_tools.text_generation import (
 )
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _call,
-    _nr_caps,
     _nr_generator_returning,
     _nr_project,
     _nr_segment,
     _nr_source,
+    _use_fake_caps,
 )
 
 pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_reference_request_projection")
@@ -33,7 +33,7 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypat
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
 
     tool_obj = split_narration_segments_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
@@ -53,7 +53,7 @@ async def test_split_narration_segments_injects_instructions(fake_ctx: ToolConte
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
 
     tool_obj = split_narration_segments_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单个分镜出场人物尽量不超过两人"})
@@ -69,7 +69,7 @@ async def test_split_narration_segments_rejects_bad_instructions(fake_ctx: ToolC
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     tool_obj = split_narration_segments_tool(fake_ctx)
 
     out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "长" * 4001})
@@ -97,7 +97,7 @@ async def test_split_narration_segments_happy(fake_ctx: ToolContext, monkeypatch
         _nr_segment("E1S01", 4, "张三走向村口。", characters_in_segment=["张三"], scenes=["村口"]),
         _nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
     ]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments, captured))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -142,9 +142,6 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
     frozen_source = "第一段原文。\n\n第二段原文。"
     expected = build_step1_basis(frozen_source, episode=1, project=project)
 
-    async def fake_caps(_project, _episode=None):
-        return 4, [4, 6, 8]
-
     class _Generator:
         async def generate(self, _request, project_name=None):
             second_source.write_text("等待供应商期间改过的第二段。", encoding="utf-8")
@@ -164,7 +161,7 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     result = await _call(split_narration_segments_tool(fake_ctx), {"episode": 1})
@@ -181,7 +178,7 @@ async def test_split_narration_segments_rejects_out_of_enum_duration(fake_ctx: T
 
     _nr_source(fake_ctx)
     segments = [_nr_segment("E1S01", 5)]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -196,7 +193,7 @@ async def test_split_narration_segments_rejects_duplicate_segment_ids(fake_ctx: 
 
     _nr_source(fake_ctx)
     segments = [_nr_segment("E1S01", 4), _nr_segment("E1S01", 6)]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -212,7 +209,7 @@ async def test_split_narration_segments_rejects_blank_novel_text(fake_ctx: ToolC
 
     _nr_source(fake_ctx)
     segments = [_nr_segment("E1S01", 4, "张三在村口等人"), _nr_segment("E1S02", 4, novel_text=" ")]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -227,7 +224,7 @@ async def test_split_narration_segments_rejects_empty_segments(fake_ctx: ToolCon
     from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([]))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -242,7 +239,7 @@ async def test_split_narration_segments_rejects_missing_field(fake_ctx: ToolCont
 
     _nr_source(fake_ctx)
     bad = {"segment_id": "E1S01", "novel_text": "缺字段", "duration_seconds": 4, "segment_break": False}
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([bad]))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -260,7 +257,7 @@ async def test_split_narration_segments_rejects_unregistered_asset_reference(
 
     _nr_source(fake_ctx)
     segments = [_nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=["王五"])]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     tool_obj = split_narration_segments_tool(fake_ctx)
@@ -287,7 +284,7 @@ async def test_split_narration_segments_accepts_asset_name_in_other_unicode_form
     segments = [
         _nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=[unicodedata.normalize("NFD", nfc_name)])
     ]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     out = await _call(split_narration_segments_tool(fake_ctx), {"episode": 1})
@@ -303,7 +300,7 @@ async def _nr_source_and_call(fake_ctx: ToolContext, monkeypatch, source_text: s
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
     (src / "episode_1.txt").write_text(source_text, encoding="utf-8")
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     tool_obj = split_narration_segments_tool(fake_ctx)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
@@ -29,8 +29,7 @@ pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_referenc
 # ---------------------------------------------------------------------------
 
 
-async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
-
+async def test_split_narration_segments_dry_run(fake_ctx: ToolContext) -> None:
     _nr_source(fake_ctx)
     _use_fake_caps(fake_ctx)
 
@@ -47,7 +46,7 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypat
     assert "# 用户意见" not in prompt_text
 
 
-async def test_split_narration_segments_injects_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_split_narration_segments_injects_instructions(fake_ctx: ToolContext) -> None:
     """instructions 原样进 prompt 末尾的中性「用户意见」分节，不附加强度措辞。"""
 
     _nr_source(fake_ctx)
@@ -62,7 +61,7 @@ async def test_split_narration_segments_injects_instructions(fake_ctx: ToolConte
     assert "必须全部落实" not in prompt_text
 
 
-async def test_split_narration_segments_rejects_bad_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_split_narration_segments_rejects_bad_instructions(fake_ctx: ToolContext) -> None:
     """instructions 超长 / 非字符串按参数错误拒绝；空白 strip 后视同未传（校验为四个生成工具共享）。"""
 
     _nr_source(fake_ctx)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
@@ -30,7 +30,6 @@ pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_referenc
 
 
 async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
     _use_fake_caps(fake_ctx)
@@ -50,7 +49,6 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext, monkeypat
 
 async def test_split_narration_segments_injects_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """instructions 原样进 prompt 末尾的中性「用户意见」分节，不附加强度措辞。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
     _use_fake_caps(fake_ctx)
@@ -66,7 +64,6 @@ async def test_split_narration_segments_injects_instructions(fake_ctx: ToolConte
 
 async def test_split_narration_segments_rejects_bad_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
     """instructions 超长 / 非字符串按参数错误拒绝；空白 strip 后视同未传（校验为四个生成工具共享）。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     _nr_source(fake_ctx)
     _use_fake_caps(fake_ctx)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -7,47 +7,61 @@ from typing import Any
 
 import pytest
 
-from lib.reference_video.voice_settings import VoiceRenderSettings
 from server.agent_runtime.sdk_tools._context import ToolContext
 from server.agent_runtime.sdk_tools.text_generation import (
     split_reference_video_units_tool,
 )
-from tests.fakes import fake_reference_caps_fetcher
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _RV_NOVEL,
     _call,
     _derived_reference_names,
+    _fake_caps_resolver,
     _read_rv_quarantine,
     _run_rv_split,
     _rv_generator_returning,
     _rv_source,
     _rv_step1_path,
     _rv_unit,
+    _use_fake_caps,
 )
 
 pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_reference_request_projection")
+
+# i2v 桶不可解析：不带图档位随之回退按 r2v 桶求值（``reference_unit_duration_tiers``）。
+_NO_I2V = {"i2v": ValueError("i2v bucket unresolvable in this test")}
+
+# Veo 在 720p 下声明「带参考图仅 8 秒」，是两套逐 unit 档位分叉的现成型号。
+_VEO_CAPS = {
+    "provider_id": "gemini-aistudio",
+    "model": "veo-3.1-generate-preview",
+    "supported_durations": (4, 6, 8),
+    "capability_errors": _NO_I2V,
+}
+
+
+def _veo_720p(fake_ctx: ToolContext) -> None:
+    """把项目的生效分辨率钉在 720p——联动约束按已保存的档位求值。"""
+    fake_ctx.pm.project_payload["model_settings"] = {  # pyright: ignore[reportAttributeAccessIssue]
+        "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
+    }
 
 # ---------------------------------------------------------------------------
 # split_reference_video_units
 # ---------------------------------------------------------------------------
 
 
-async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_returns_declared_slots() -> None:
     """unit 时长就是发给供应商的那个值，档位原样取自模型声明（不与任何静态区间求交）。"""
-    from server.agent_runtime.sdk_tools import _context
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project, _episode=None):
-        return {"supported_durations": [1, 8, 16, 18], "max_duration": 18, "default_duration": 16}
+    resolver = _fake_caps_resolver(
+        supported_durations=[1, 8, 16, 18],
+        default_duration=16,
+        max_reference_images=None,
+        capability_errors=_NO_I2V,
+    )
 
-    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
-
-    caps = await mod._fetch_reference_caps_with_fallback({}, 1)
+    caps = await mod._fetch_reference_caps_with_fallback({}, 1, config_resolver=resolver)
 
     assert caps.durations == [1, 8, 16, 18]
     assert caps.reference_durations == [1, 8, 16, 18]
@@ -57,59 +71,41 @@ async def test_fetch_reference_caps_with_fallback_returns_declared_slots(monkeyp
     assert caps.max_refs is None
 
 
-async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap() -> None:
     """档位随联动约束收窄：海螺在 1080p 下只接受 6 秒，全集是 [6, 10]。
 
     不收窄的话 step1 会按 10 秒拆出 unit，step2 的枚举 schema 再把它判非法。
     """
-    from server.agent_runtime.sdk_tools import _context
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project, _episode=None):
-        return {
-            "provider_id": "minimax",
-            "model": "MiniMax-Hailuo-2.3",
-            "supported_durations": [6, 10],
-            "max_duration": 10,
-            "default_duration": None,
-        }
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
+    resolver = _fake_caps_resolver(
+        provider_id="minimax",
+        model="MiniMax-Hailuo-2.3",
+        supported_durations=[6, 10],
+        default_duration=None,
+        capability_errors=_NO_I2V,
+    )
 
     project = {"model_settings": {"minimax/MiniMax-Hailuo-2.3": {"resolution": "1080p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1, config_resolver=resolver)
     assert caps.durations == [6]
     assert caps.max_duration == 6
 
 
-async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution() -> None:
     """分辨率联动约束同样收窄 unit 档位：Veo 1080p 下只接受 8 秒。"""
-    from server.agent_runtime.sdk_tools import _context
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project, _episode=None):
-        return {
-            "provider_id": "gemini-aistudio",
-            "model": "veo-3.1-generate-preview",
-            "supported_durations": [4, 6, 8],
-            "max_duration": 8,
-            "default_duration": None,
-        }
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
+    resolver = _fake_caps_resolver(
+        provider_id="gemini-aistudio",
+        model="veo-3.1-generate-preview",
+        supported_durations=[4, 6, 8],
+        default_duration=None,
+        capability_errors=_NO_I2V,
+    )
 
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1, config_resolver=resolver)
     assert caps.durations == [8]
     assert caps.max_duration == 8
 
@@ -135,14 +131,12 @@ async def test_reference_unit_duration_tiers_does_not_assume_containment(monkeyp
     )
     monkeypatch.setattr(resolver_mod, "model_info_for", lambda *_args: contradictory)
 
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
-
     project = {"model_settings": {"p/m": {"resolution": "1080p"}}}
     with_refs, without_refs = await _context.reference_unit_duration_tiers(
-        project, {"provider_id": "p", "model": "m"}, [4, 6, 8]
+        project,
+        {"provider_id": "p", "model": "m"},
+        [4, 6, 8],
+        config_resolver=_fake_caps_resolver(capability_errors=_NO_I2V),
     )
 
     assert with_refs == [4, 6, 8]
@@ -150,51 +144,48 @@ async def test_reference_unit_duration_tiers_does_not_assume_containment(monkeyp
     assert not set(with_refs) <= set(without_refs)
 
 
-async def test_reference_unit_duration_tiers_without_refs_follow_i2v_bucket(monkeypatch) -> None:
+async def test_reference_unit_duration_tiers_without_refs_follow_i2v_bucket() -> None:
     """不带图档位按 i2v 桶模型求值：无引用 unit 执行期降级到 i2v 桶执行，创作侧放行的秒数
     须与该桶模型的声明一致，否则会放行 r2v 独有档位、漏掉 i2v 独有档位。"""
     from server.agent_runtime.sdk_tools import _context
 
-    async def _i2v_caps(_project, *, capability=None):
-        assert capability == "i2v"
-        return {"provider_id": "ark", "model": "doubao-seedance-1-5-pro-251215", "supported_durations": [5, 10]}
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _i2v_caps)
+    resolver = _fake_caps_resolver(
+        by_capability={
+            "i2v": {
+                "provider_id": "ark",
+                "model": "doubao-seedance-1-5-pro-251215",
+                "supported_durations": [5, 10],
+            }
+        },
+    )
 
     with_refs, without_refs = await _context.reference_unit_duration_tiers(
-        {}, {"provider_id": "minimax", "model": "S2V-01"}, [6, 10]
+        {}, {"provider_id": "minimax", "model": "S2V-01"}, [6, 10], config_resolver=resolver
     )
 
     assert with_refs == [6, 10]
     assert without_refs == [5, 10]
+    # 不带图那套只按 i2v 桶解析一次，r2v 的档位由调用方传入、不再回查
+    assert resolver.capability_calls == ["i2v"]
 
 
-async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_state(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_state() -> None:
     """「参考图↔时长」约束逐 unit 生效：Veo 720p 下带引用只剩 8 秒，无引用仍有 4/6/8。
 
     枚举与 prompt 候选取并集——一律按带图收窄会把无引用 unit 本可申请的短档也收掉。
     """
-    from server.agent_runtime.sdk_tools import _context
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _fake_caps(_project, _episode=None):
-        return {
-            "provider_id": "gemini-aistudio",
-            "model": "veo-3.1-generate-preview",
-            "supported_durations": [4, 6, 8],
-            "max_duration": 8,
-            "default_duration": None,
-        }
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
+    resolver = _fake_caps_resolver(
+        provider_id="gemini-aistudio",
+        model="veo-3.1-generate-preview",
+        supported_durations=[4, 6, 8],
+        default_duration=None,
+        capability_errors=_NO_I2V,
+    )
 
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
-    caps = await mod._fetch_reference_caps_with_fallback(project, 1)
+    caps = await mod._fetch_reference_caps_with_fallback(project, 1, config_resolver=resolver)
     assert caps.reference_durations == [8]
     assert caps.text_durations == [4, 6, 8]
     assert caps.durations == [4, 6, 8]
@@ -203,77 +194,58 @@ async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_stat
     assert caps.tiers_for(has_references=False) == [4, 6, 8]
 
 
-async def test_fetch_reference_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_uses_write_layer_default() -> None:
     """rv 路径的软回退与 _fetch_caps_with_fallback 同口径，取 duration_presets.DEFAULT_FALLBACK。"""
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
-    from server.agent_runtime.sdk_tools import _context
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _raising_caps(_project, _episode=None):
-        raise ValueError("no provider configured")
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
-    caps = await mod._fetch_reference_caps_with_fallback({}, 1)
+    resolver = _fake_caps_resolver(error=ValueError("no provider configured"))
+    caps = await mod._fetch_reference_caps_with_fallback({}, 1, config_resolver=resolver)
     assert caps.default_duration is None
     assert caps.durations == DEFAULT_FALLBACK
     assert caps.max_duration == max(DEFAULT_FALLBACK)
     assert caps.max_refs is None
 
 
-async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_failure(monkeypatch) -> None:
-    """能力查询失败时，`raw["requested_generate_audio"]` 仍随项目覆盖走，不回退成 True。
+async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_failure() -> None:
+    """能力查询失败时，`raw["requested_generate_audio"]` 仍随项目的无声意图走，不回退成 True。
 
     它不依赖能力接口独立解析（同 generation_context.py），否则声音提示层会漏发
-    WARN_SILENT_EPISODE，误导用户以为本集仍会尝试组装参考音频。独立解析本身照原样
-    mock 掉（不经 async_session_factory 打真实 DB）：这条测不验证 DB 读取，只验证
-    能力查询失败下 caps 字典的组装口径，打真 DB 只会让结果依赖本机是否已初始化好应用库。
+    WARN_SILENT_EPISODE，误导用户以为本集仍会尝试组装参考音频。
     """
-    from lib.config.resolver import ConfigResolver
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _raising_caps(_project, _episode=None):
-        raise ValueError("no provider configured")
-
-    async def _fake_project_audio(self, project):
-        return bool(project.get("video_generate_audio", True))
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
-    monkeypatch.setattr(ConfigResolver, "video_generate_audio_for_project", _fake_project_audio)
-    caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1)
+    resolver = _fake_caps_resolver(
+        error=ValueError("no provider configured"),
+        requested_generate_audio=False,
+    )
+    caps = await mod._fetch_reference_caps_with_fallback(
+        {"video_generate_audio": False}, 1, config_resolver=resolver
+    )
     assert caps.voice.requested_generate_audio is False
 
 
-async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_failure(monkeypatch) -> None:
+async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_failure() -> None:
     """独立解析也失败（双重故障）时收紧到 False，不得落回 True。
 
     与其余能力字段「不明时不额外收紧」相反：这里不明时假定无声，代价只是少发一条声音
     提示；假定有声则会让 `derive_voice_bindings` 在派生阶段继续算参考音频，误导排查方向。
     """
-    from lib.config.resolver import ConfigResolver
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _raising_caps(_project, _episode=None):
-        raise ValueError("no provider configured")
-
-    async def _raising_project_audio(self, _project):
-        raise RuntimeError("db unavailable")
-
-    monkeypatch.setattr(mod, "resolve_video_caps", _raising_caps)
-    monkeypatch.setattr(ConfigResolver, "video_generate_audio_for_project", _raising_project_audio)
-    caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1)
+    resolver = _fake_caps_resolver(
+        error=ValueError("no provider configured"),
+        generate_audio_error=RuntimeError("db unavailable"),
+    )
+    caps = await mod._fetch_reference_caps_with_fallback(
+        {"video_generate_audio": False}, 1, config_resolver=resolver
+    )
     assert caps.voice.requested_generate_audio is False
 
 
-async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
+async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext) -> None:
     _rv_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher())
+    _use_fake_caps(fake_ctx)
 
     tool_obj = split_reference_video_units_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
@@ -283,7 +255,8 @@ async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext, monkey
     # 集号、资产候选与能力约束进 prompt；引用语法规范随之注入
     assert "第 1 集" in prompt_text
     assert "张三" in prompt_text
-    assert "12 秒" in prompt_text
+    # 上限是两套逐 unit 档位并集的最大值，随能力解析派生
+    assert "8 秒" in prompt_text
     assert "分段前缀" in prompt_text
 
 
@@ -295,7 +268,7 @@ async def test_split_reference_video_units_happy_derives_structure(fake_ctx: Too
     captured: dict[str, Any] = {}
     text = "@[张三] 走向 @[村口]\n@[张三] 停下脚步"
     units = [_rv_unit(text)]
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units, captured))
 
     out = await _call(split_reference_video_units_tool(fake_ctx), {"episode": 1})
@@ -356,7 +329,9 @@ async def test_split_reference_video_units_rejects_unregistered_speaker(fake_ctx
 
 async def test_split_reference_video_units_rejects_over_max_refs(fake_ctx: ToolContext, monkeypatch) -> None:
     _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 与 @[李四] 在 @[村口]")], max_refs=2)
+    out = await _run_rv_split(
+        fake_ctx, monkeypatch, [_rv_unit("@[张三] 与 @[李四] 在 @[村口]")], max_reference_images=2
+    )
     assert out.get("is_error") is True
     assert "参考图数" in out["content"][0]["text"]
     assert not _rv_step1_path(fake_ctx).exists()
@@ -370,12 +345,8 @@ async def test_split_reference_video_units_rejects_duration_off_reference_tier(
     枚举卡的是两套档位的并集，这类越界过得了 schema；不在此拦，执行期才会申请不到。
     """
     _rv_source(fake_ctx)
-    out = await _run_rv_split(
-        fake_ctx,
-        monkeypatch,
-        [_rv_unit("@[张三] 起身", duration=4)],
-        reference_durations=(8,),
-    )
+    _veo_720p(fake_ctx)
+    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身", duration=4)], **_VEO_CAPS)
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "生效档位" in text and "[8]" in text
@@ -389,12 +360,8 @@ async def test_split_reference_video_units_accepts_wide_tier_without_references(
 ) -> None:
     """无 `@` 引用的 unit 不受「参考图↔时长」约束，仍可取更短的档位。"""
     _rv_source(fake_ctx)
-    out = await _run_rv_split(
-        fake_ctx,
-        monkeypatch,
-        [_rv_unit("门被风吹开", duration=4)],
-        reference_durations=(8,),
-    )
+    _veo_720p(fake_ctx)
+    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("门被风吹开", duration=4)], **_VEO_CAPS)
     assert out.get("is_error") is not True, out
     saved = json.loads(_rv_step1_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["units"][0]["duration_seconds"] == 4
@@ -461,11 +428,9 @@ async def test_split_reference_video_units_no_source(fake_ctx: ToolContext) -> N
     assert out.get("is_error") is True
 
 
-async def test_split_reference_video_units_injects_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
+async def test_split_reference_video_units_injects_instructions(fake_ctx: ToolContext) -> None:
     _rv_source(fake_ctx)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher())
+    _use_fake_caps(fake_ctx)
 
     tool_obj = split_reference_video_units_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单 unit 出场人物尽量不超过两人"})
@@ -484,7 +449,9 @@ async def test_split_reference_video_units_surfaces_tolerated_voice_warnings(
         fake_ctx,
         monkeypatch,
         [_rv_unit("@[张三] 起身\n@[张三]：{我来了。}")],
-        voice=VoiceRenderSettings(voice_consistency="native", max_reference_audio=2, model_id="m"),
+        voice_consistency="native",
+        max_reference_audio_count=2,
+        model="m",
     )
 
     assert out.get("is_error") is not True, out
@@ -511,9 +478,10 @@ async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_bac
         fake_ctx,
         monkeypatch,
         [_rv_unit("@[张三] 起身\n@[张三]：{我来了。}\n@[李四]：{你终于来了。}")],
-        voice=VoiceRenderSettings(
-            voice_consistency="native", max_reference_audio=1, model_id="m", requires_reference_image=True
-        ),
+        voice_consistency="native",
+        max_reference_audio_count=1,
+        model="m",
+        reference_audio_per_image=True,
     )
 
     assert out.get("is_error") is not True, out

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -45,6 +45,7 @@ def _veo_720p(fake_ctx: ToolContext) -> None:
         "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
     }
 
+
 # ---------------------------------------------------------------------------
 # split_reference_video_units
 # ---------------------------------------------------------------------------
@@ -219,9 +220,7 @@ async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_fai
         error=ValueError("no provider configured"),
         requested_generate_audio=False,
     )
-    caps = await mod._fetch_reference_caps_with_fallback(
-        {"video_generate_audio": False}, 1, config_resolver=resolver
-    )
+    caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1, config_resolver=resolver)
     assert caps.voice.requested_generate_audio is False
 
 
@@ -237,9 +236,7 @@ async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_fail
         error=ValueError("no provider configured"),
         generate_audio_error=RuntimeError("db unavailable"),
     )
-    caps = await mod._fetch_reference_caps_with_fallback(
-        {"video_generate_audio": False}, 1, config_resolver=resolver
-    )
+    caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1, config_resolver=resolver)
     assert caps.voice.requested_generate_audio is False
 
 

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -222,6 +222,7 @@ async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_fai
     )
     caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1, config_resolver=resolver)
     assert caps.voice.requested_generate_audio is False
+    assert resolver.generate_audio_calls == [{"video_generate_audio": False}]
 
 
 async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_failure() -> None:
@@ -238,6 +239,7 @@ async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_fail
     )
     caps = await mod._fetch_reference_caps_with_fallback({"video_generate_audio": False}, 1, config_resolver=resolver)
     assert caps.voice.requested_generate_audio is False
+    assert resolver.generate_audio_calls == [{"video_generate_audio": False}]
 
 
 async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext) -> None:

--- a/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
@@ -311,8 +311,7 @@ async def test_fetch_video_caps_narrows_durations_by_constraints() -> None:
     assert durations == [8]
 
 
-async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
-
+async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext) -> None:
     project_path = fake_ctx.project_path
     src = project_path / "source"
     src.mkdir(parents=True)
@@ -336,12 +335,10 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
 )
 async def test_step1_tools_reject_incompatible_project_axes_before_capability_lookup(
     fake_ctx: ToolContext,
-    monkeypatch,
     tool_factory,
     content_mode: str,
     generation_mode: str,
 ) -> None:
-
     fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
         content_mode=content_mode,
         generation_mode=generation_mode,
@@ -385,7 +382,7 @@ async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: Too
     assert calls == 1
 
 
-async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContext) -> None:
     """normalize 把项目 source_language 透传为 build_normalize_prompt 的 target_language——
     非中文项目的 step1 输出语言据此切换，而非恒退默认中文。"""
 
@@ -432,7 +429,7 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     assert not (project_path / "drafts" / "episode_1" / "step1_normalized_script.json").exists()
 
 
-async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: ToolContext) -> None:
     """工具必须把 episode 注入 build_normalize_prompt，避免 LLM 写错 E\\d+ 前缀。"""
 
     project_path = fake_ctx.project_path
@@ -450,7 +447,7 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
     assert "E1S01" not in prompt_text
 
 
-async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolContext) -> None:
     """内容抽取前移后，分集大纲（故事节点 / 钩子）随 step1 注入 normalize prompt（见 ADR 0041）。"""
 
     project_path = fake_ctx.project_path
@@ -787,8 +784,7 @@ class TestBuildPrompt:
         assert out.endswith("画面避免：水印、多余文字、Logo。")
 
 
-async def test_normalize_drama_script_injects_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
-
+async def test_normalize_drama_script_injects_instructions(fake_ctx: ToolContext) -> None:
     project_path = fake_ctx.project_path
     src = project_path / "source"
     src.mkdir(parents=True)

--- a/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
@@ -312,7 +312,6 @@ async def test_fetch_video_caps_narrows_durations_by_constraints() -> None:
 
 
 async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
     src = project_path / "source"
@@ -342,7 +341,6 @@ async def test_step1_tools_reject_incompatible_project_axes_before_capability_lo
     content_mode: str,
     generation_mode: str,
 ) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
         content_mode=content_mode,
@@ -366,7 +364,6 @@ async def test_step1_tools_reject_incompatible_project_axes_before_capability_lo
 
 async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: ToolContext, monkeypatch) -> None:
     from lib import artifact_provenance
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     source_dir = fake_ctx.project_path / "source"
     source_dir.mkdir(parents=True)
@@ -391,7 +388,6 @@ async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: Too
 async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContext, monkeypatch) -> None:
     """normalize 把项目 source_language 透传为 build_normalize_prompt 的 target_language——
     非中文项目的 step1 输出语言据此切换，而非恒退默认中文。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     # 工具经 ctx.pm.load_project 取项目；source_language 是输出语言的唯一真相源
     fake_ctx.pm.project_payload["source_language"] = "English"  # type: ignore[attr-defined]
@@ -438,7 +434,6 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
 
 async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: ToolContext, monkeypatch) -> None:
     """工具必须把 episode 注入 build_normalize_prompt，避免 LLM 写错 E\\d+ 前缀。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
     src = project_path / "source"
@@ -457,7 +452,6 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
 
 async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolContext, monkeypatch) -> None:
     """内容抽取前移后，分集大纲（故事节点 / 钩子）随 step1 注入 normalize prompt（见 ADR 0041）。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
     src = project_path / "source"
@@ -794,7 +788,6 @@ class TestBuildPrompt:
 
 
 async def test_normalize_drama_script_injects_instructions(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
 
     project_path = fake_ctx.project_path
     src = project_path / "source"

--- a/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
@@ -21,67 +21,50 @@ from server.agent_runtime.sdk_tools.text_generation import (
 )
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _call,
+    _fake_caps_resolver,
+    _use_fake_caps,
 )
 
 pytestmark = pytest.mark.usefixtures("_stub_audio_switch_guard", "_stub_reference_request_projection")
+
+# i2v 桶不可解析：不带图档位随之回退按 r2v 桶求值（``reference_unit_duration_tiers``）。
+_NO_I2V = {"i2v": ValueError("i2v bucket unresolvable in this test")}
 
 # ---------------------------------------------------------------------------
 # text_generation
 # ---------------------------------------------------------------------------
 
 
-async def test_get_video_capabilities_happy(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    async def fake_resolve(_project, _episode=None):
-        return {"provider_id": "fake", "supported_durations": [4, 6, 8]}
-
-    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+async def test_get_video_capabilities_happy(fake_ctx: ToolContext) -> None:
+    _use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
     tool_obj = get_video_capabilities_tool(fake_ctx)
     out = await _call(tool_obj, {})
     assert out.get("is_error") is not True
     assert json.loads(out["content"][0]["text"])["provider_id"] == "fake"
 
 
-async def test_get_video_capabilities_resolves_by_project(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_get_video_capabilities_resolves_by_project(fake_ctx: ToolContext) -> None:
     """能力按项目生成模式解析：工具不收集号，多余的集号入参被忽略、不改变解析口径。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    seen: list[str] = []
-
-    async def fake_resolve(project_name):
-        seen.append(project_name)
-        return {"provider_id": "fake", "supported_durations": [4, 6, 8]}
-
-    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+    resolver = _use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
     tool_obj = get_video_capabilities_tool(fake_ctx)
     assert (await _call(tool_obj, {})).get("is_error") is not True
     assert (await _call(tool_obj, {"episode": 3})).get("is_error") is not True
-    assert seen == [fake_ctx.project_name, fake_ctx.project_name]
+    assert resolver.project_names == [fake_ctx.project_name, fake_ctx.project_name]
 
 
-async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext) -> None:
     """参考路径项目另返回两套逐 unit 生效档位，供手工改 step1 时与生成侧对同一份数字。"""
-    from server.agent_runtime.sdk_tools import _context
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    async def fake_resolve(_project):
-        return {
-            "provider_id": "gemini-aistudio",
-            "model": "veo-3.1-generate-preview",
-            "supported_durations": [4, 6, 8],
-            "generation_mode": "reference_video",
-        }
-
     fake_ctx.pm.project_payload["model_settings"] = {  # type: ignore[attr-defined]
         "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
     }
-    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
-
-    async def _no_i2v(_project, *, capability=None):
-        raise ValueError("i2v bucket unresolvable in this test")
-
-    monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
+    _use_fake_caps(
+        fake_ctx,
+        provider_id="gemini-aistudio",
+        model="veo-3.1-generate-preview",
+        supported_durations=[4, 6, 8],
+        generation_mode="reference_video",
+        capability_errors=_NO_I2V,
+    )
     out = await _call(get_video_capabilities_tool(fake_ctx), {})
     assert out.get("is_error") is not True, out
     payload = json.loads(out["content"][0]["text"])
@@ -95,21 +78,17 @@ async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: T
     [("storyboard", "drama"), ("reference_video", "ad")],
 )
 async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
-    fake_ctx: ToolContext, monkeypatch, generation_mode: str, content_mode: str
+    fake_ctx: ToolContext, generation_mode: str, content_mode: str
 ) -> None:
     """非剧集参考路径不补该字段：其它路径没有逐 unit 引用状态，ad 分镜时长也不受档位枚举管辖。"""
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    async def fake_resolve(_project):
-        return {
-            "provider_id": "gemini-aistudio",
-            "model": "veo-3.1-generate-preview",
-            "supported_durations": [4, 6, 8],
-            "generation_mode": generation_mode,
-            "content_mode": content_mode,
-        }
-
-    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+    _use_fake_caps(
+        fake_ctx,
+        provider_id="gemini-aistudio",
+        model="veo-3.1-generate-preview",
+        supported_durations=[4, 6, 8],
+        generation_mode=generation_mode,
+        content_mode=content_mode,
+    )
     out = await _call(get_video_capabilities_tool(fake_ctx), {})
     assert "reference_unit_durations" not in json.loads(out["content"][0]["text"])
 
@@ -134,13 +113,8 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
     assert seen == [fake_ctx.project_name]
 
 
-async def test_get_video_capabilities_error(fake_ctx: ToolContext, monkeypatch) -> None:
-    from server.agent_runtime.sdk_tools import text_generation as mod
-
-    async def fake_resolve(_project, _episode=None):
-        raise FileNotFoundError("missing project.json")
-
-    monkeypatch.setattr(mod, "_resolve_video_capabilities", fake_resolve)
+async def test_get_video_capabilities_error(fake_ctx: ToolContext) -> None:
+    _use_fake_caps(fake_ctx, error=FileNotFoundError("missing project.json"))
     tool_obj = get_video_capabilities_tool(fake_ctx)
     out = await _call(tool_obj, {})
     assert out.get("is_error") is True
@@ -265,22 +239,19 @@ def test_parse_normalized_content_uses_dynamic_duration_schema() -> None:
         _parse_normalized_content(json.dumps({"title": "t", "scenes": [bad]}), model)
 
 
-async def test_fetch_caps_with_fallback_uses_write_layer_default(monkeypatch) -> None:
+async def test_fetch_caps_with_fallback_uses_write_layer_default() -> None:
     """resolver 失败时软回退须与自定义供应商写入层的保守默认（duration_presets.DEFAULT_FALLBACK）
     同一真相源——独立维护第二套回退集会让 LLM 拿到供应商未必支持的时长。"""
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def raising_caps(_p, *, episode=None, generation_mode=None):
-        raise ValueError("no provider configured")
-
-    monkeypatch.setattr(mod, "fetch_video_caps", raising_caps)
-    default, durations = await mod._fetch_caps_with_fallback({}, 1)
+    resolver = _fake_caps_resolver(error=ValueError("no provider configured"))
+    default, durations = await mod._fetch_caps_with_fallback({}, 1, config_resolver=resolver)
     assert default is None
     assert durations == DEFAULT_FALLBACK
 
 
-async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) -> None:
+async def test_fetch_caps_with_fallback_drops_out_of_range_default() -> None:
     """收窄后落在集合外的已保存 default_duration 归 None（回到 auto 档），不拖垮整个工具。
 
     ``build_normalize_prompt`` 对非成员 default 是 fail-loud 的：用户在 720p 下存过 4 秒、
@@ -288,24 +259,21 @@ async def test_fetch_caps_with_fallback_drops_out_of_range_default(monkeypatch) 
     """
     from server.agent_runtime.sdk_tools import text_generation as mod
 
-    async def _narrowed_caps(_p, *, episode=None, generation_mode=None):
-        return 4, [8]
+    veo = {"provider_id": "gemini-aistudio", "model": "veo-3.1-generate-preview"}
+    project_1080p = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
 
-    monkeypatch.setattr(mod, "fetch_video_caps", _narrowed_caps)
-    default, durations = await mod._fetch_caps_with_fallback({}, 1)
+    narrowed = _fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=4, **veo)
+    default, durations = await mod._fetch_caps_with_fallback(project_1080p, 1, config_resolver=narrowed)
     assert default is None
     assert durations == [8]
 
-    async def _in_range_caps(_p, *, episode=None, generation_mode=None):
-        return 8, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "fetch_video_caps", _in_range_caps)
-    default, durations = await mod._fetch_caps_with_fallback({}, 1)
+    in_range = _fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=8, **veo)
+    default, durations = await mod._fetch_caps_with_fallback({}, 1, config_resolver=in_range)
     assert default == 8
     assert durations == [4, 6, 8]
 
 
-async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) -> None:
+async def test_fetch_video_caps_narrows_durations_by_constraints() -> None:
     """交给 LLM 的时长集合已按项目分辨率经联动约束收窄。
 
     Veo 项目保存 1080p 时只接受 8 秒；不收窄的话 drama / narration 拆分会产出 4/6 秒镜头，
@@ -313,34 +281,33 @@ async def test_fetch_video_caps_narrows_durations_by_constraints(monkeypatch) ->
     """
     from server.agent_runtime.sdk_tools import _context as ctx_mod
 
-    async def _fake_caps(_project, _episode=None):
-        return {
-            "provider_id": "gemini-aistudio",
-            "model": "veo-3.1-generate-preview",
-            "supported_durations": [4, 6, 8],
-            "default_duration": 4,
-        }
-
-    monkeypatch.setattr(ctx_mod, "resolve_video_caps", _fake_caps)
+    resolver = _fake_caps_resolver(
+        provider_id="gemini-aistudio",
+        model="veo-3.1-generate-preview",
+        supported_durations=[4, 6, 8],
+        default_duration=4,
+    )
 
     project_1080p = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
-    default, durations = await ctx_mod.fetch_video_caps(project_1080p)
+    default, durations = await ctx_mod.fetch_video_caps(project_1080p, config_resolver=resolver)
     assert durations == [8]
     # default_duration 原样返回（用户配置值），成员性由调用方按各自口径判定
     assert default == 4
 
     # 未配置分辨率：普通路径省略 resolution 参数，供应商按自己的默认档位（Veo 720p）接受 4/6/8，
     # 故不施加分辨率约束——按 provider 兜底档位收窄会凭空把剧本节奏锁死 8 秒。
-    _default, durations = await ctx_mod.fetch_video_caps({})
+    _default, durations = await ctx_mod.fetch_video_caps({}, config_resolver=resolver)
     assert durations == [4, 6, 8]
 
     # 项目显式选了无声明的分辨率时不收窄。
     project = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}}
-    _default, durations = await ctx_mod.fetch_video_caps(project)
+    _default, durations = await ctx_mod.fetch_video_caps(project, config_resolver=resolver)
     assert durations == [4, 6, 8]
 
     # 参考图路径：即便分辨率无声明也收窄
-    _default, durations = await ctx_mod.fetch_video_caps(project, generation_mode="reference_video")
+    _default, durations = await ctx_mod.fetch_video_caps(
+        project, generation_mode="reference_video", config_resolver=resolver
+    )
     assert durations == [8]
 
 
@@ -352,10 +319,7 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext, monkeypatch
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True
@@ -388,11 +352,7 @@ async def test_step1_tools_reject_incompatible_project_axes_before_capability_lo
     source_dir.mkdir(parents=True)
     (source_dir / "episode_1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def unexpected_caps(*_args, **_kwargs):
-        pytest.fail("incompatible step1 tool must reject before capability lookup")
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", unexpected_caps)
-    monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", unexpected_caps)
+    resolver = _use_fake_caps(fake_ctx)
 
     result = await _call(tool_factory(fake_ctx), {"episode": 1, "dry_run": True})
 
@@ -400,6 +360,8 @@ async def test_step1_tools_reject_incompatible_project_axes_before_capability_lo
     message = result["content"][0]["text"]
     assert content_mode in message
     assert generation_mode in message
+    # 轴不兼容在能力查询之前就判定：解析器一次都没被问过
+    assert resolver.capability_calls == []
 
 
 async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: ToolContext, monkeypatch) -> None:
@@ -417,11 +379,8 @@ async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: Too
         calls += 1
         return original(*args, **kwargs)
 
-    async def fake_caps(_project, _episode=None):
-        return 4, [4, 6, 8]
-
     monkeypatch.setattr(artifact_provenance, "project_step1_prompt_inputs", counted_projection)
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
 
     result = await _call(normalize_drama_script_tool(fake_ctx), {"episode": 1, "dry_run": True})
 
@@ -441,10 +400,7 @@ async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContex
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("once upon a time", encoding="utf-8")
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True
@@ -460,9 +416,6 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
     class _EmptyGenerator:
         async def generate(self, _request, project_name=None):
             class _R:
@@ -473,7 +426,7 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     async def fake_create(task_type, project_name=None):
         return _EmptyGenerator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = normalize_drama_script_tool(fake_ctx)
@@ -492,10 +445,7 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
     src.mkdir(parents=True)
     (src / "chapter2.txt").write_text("第二集开场", encoding="utf-8")
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 2, "dry_run": True, "source": "source/chapter2.txt"})
     assert out.get("is_error") is not True, out
@@ -522,10 +472,7 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
         }
     ]
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True, out
@@ -543,9 +490,6 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
     src = project_path / "source"
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
-
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
 
     captured: dict[str, Any] = {}
 
@@ -582,7 +526,7 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
         captured["create_project_name"] = project_name
         return _FakeGenerator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = normalize_drama_script_tool(fake_ctx)
@@ -624,9 +568,6 @@ async def test_normalize_drama_script_registers_the_frozen_explicit_source_basis
     source_path.write_text(frozen_source, encoding="utf-8")
     expected = build_step1_basis(frozen_source, episode=1, project=project)
 
-    async def fake_caps(_project, _episode=None):
-        return 4, [4, 6, 8]
-
     class _Generator:
         async def generate(self, _request, project_name=None):
             source_path.write_text("等待供应商期间改过的原文", encoding="utf-8")
@@ -662,7 +603,7 @@ async def test_normalize_drama_script_registers_the_frozen_explicit_source_basis
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     result = await _call(
@@ -704,9 +645,6 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
     (source_dir / "episode_1.txt").write_text("激活器可重建的另一份原文", encoding="utf-8")
     expected = build_step1_basis("实际发送给供应商的原文", episode=1, project=project)
 
-    async def fake_caps(_project, _episode=None):
-        return 4, [4, 6, 8]
-
     class _Generator:
         async def generate(self, _request, project_name=None):
             activated = {**project, "schema_version": 8}
@@ -741,7 +679,7 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     result = await _call(
@@ -764,9 +702,6 @@ async def test_normalize_drama_script_marks_mixed_machine_candidate_before_revie
     source_dir = project_path / "source"
     source_dir.mkdir(parents=True)
     (source_dir / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
-
-    async def fake_caps(_project, _episode=None):
-        return 4, [4, 6, 8]
 
     class _FakeGenerator:
         async def generate(self, _request, project_name=None):
@@ -799,7 +734,7 @@ async def test_normalize_drama_script_marks_mixed_machine_candidate_before_revie
     async def fake_create(_task_type, project_name=None):
         return _FakeGenerator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     result = await _call(normalize_drama_script_tool(fake_ctx), {"episode": 1})
@@ -866,10 +801,7 @@ async def test_normalize_drama_script_injects_instructions(fake_ctx: ToolContext
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     tool_obj = normalize_drama_script_tool(fake_ctx)
     out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "打斗场面多拆几个短镜头"})
     assert out.get("is_error") is not True, out

--- a/tests/integration/server/agent_runtime/sdk_tools/test_validate_and_promote_draft.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_validate_and_promote_draft.py
@@ -169,7 +169,7 @@ async def test_validate_and_promote_draft_reports_again_without_round_limit(fake
 # ---------------------------------------------------------------------------
 
 
-async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: ToolContext) -> None:
     """「用户在内容确认界面编辑 + Agent 改草稿并晋升」的双端并发：取回后正式文件被另一写入方
     改过时，晋升中止并返回冲突报告（含最新内容与合并指引），不静默覆盖对方的修改；草稿
     留在原地。按报告把 meta.base_fingerprint 更新为现值（显式确认已合并）后方可重新晋升。"""
@@ -202,9 +202,7 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
-async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
-    fake_ctx: ToolContext, monkeypatch
-) -> None:
+async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(fake_ctx: ToolContext) -> None:
     """取回后正式文件被删除：现值指纹是 null，报告须按 JSON 字面量给出而非字符串 "None"。
     照报告把 meta.base_fingerprint 设为 null 后重晋升即放行——写成字符串则永远比对不上、冲突解不掉。"""
     _rv_source(fake_ctx)
@@ -227,7 +225,7 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     assert not _rv_quarantine_path(fake_ctx).exists()
 
 
-async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext) -> None:
     """基线机制引入前产出的存量草稿缺 meta.base_fingerprint 键：按无基线晋升，不被新校验卡死。"""
     _rv_source(fake_ctx)
     _write_rv_step1(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
@@ -387,9 +385,7 @@ async def test_writing_reference_step1_clears_stale_step2_quarantine(fake_ctx: T
     assert not step2_path.exists()
 
 
-async def test_promote_reference_step1_preserves_step2_draft_when_content_unchanged(
-    fake_ctx: ToolContext, monkeypatch
-) -> None:
+async def test_promote_reference_step1_preserves_step2_draft_when_content_unchanged(fake_ctx: ToolContext) -> None:
     """情况 B 中途放弃、原样晋升：取回草稿未改动即晋升，写回的 step1 与盘上原值逐字相同，
     此时不该清在场的 step2 草稿——它的保结构 diff 仍然对得上这份没变的基底，Agent
     放弃 step1 修改不该连带销毁一份仍然有效的 step2 修复草稿。"""
@@ -444,7 +440,7 @@ async def test_validate_and_promote_draft_step2_uses_async_factory(fake_ctx: Too
     assert "episode_1.json" in out["content"][0]["text"]
 
 
-async def test_validate_and_promote_draft_refuses_after_mode_switch(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_validate_and_promote_draft_refuses_after_mode_switch(fake_ctx: ToolContext) -> None:
     """切走参考路径后不再晋升残留草稿：晋升会按参考路径的形状覆盖该集正式剧本。"""
     _rv_project(fake_ctx, generation_mode="storyboard")
     write_quarantine(
@@ -491,7 +487,7 @@ async def test_validate_and_promote_draft_step2_blocked_by_review_gate(fake_ctx:
     assert "尚未完成内容确认" in out["content"][0]["text"]
 
 
-async def test_validate_and_promote_draft_without_draft(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_validate_and_promote_draft_without_draft(fake_ctx: ToolContext) -> None:
     out = await _promote(fake_ctx)
     assert out.get("is_error") is True
     assert "没有待处置的草稿" in out["content"][0]["text"]
@@ -577,7 +573,7 @@ async def test_generate_episode_script_ignores_quarantine_after_mode_switch(fake
 # ---------------------------------------------------------------------------
 
 
-async def test_promote_drama_step1_rederives_needs_replan(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_drama_step1_rederives_needs_replan(fake_ctx: ToolContext) -> None:
     """needs_replan 由晋升侧按台词准入重新派生，不取草稿里的值——它是机器判据，
     手写值一旦被采信，后续重规划会漏掉真正需要重排的场景。"""
     _drama_project(fake_ctx)
@@ -600,7 +596,7 @@ async def test_promote_drama_step1_rederives_needs_replan(fake_ctx: ToolContext,
     assert saved["scenes"][0]["needs_replan"] is True
 
 
-async def test_promote_drama_step1_reports_schema_breach_without_writing(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_drama_step1_reports_schema_breach_without_writing(fake_ctx: ToolContext) -> None:
     """草稿被改坏时正式文件不写：草稿留在场、按 violations 继续改再晋升，不丢内容也不污染正式文件。"""
     _drama_project(fake_ctx)
     _write_drama_step1(fake_ctx, [_drama_scene()])
@@ -619,7 +615,7 @@ async def test_promote_drama_step1_reports_schema_breach_without_writing(fake_ct
     assert "content.scenes[i]" in out["content"][0]["text"]
 
 
-async def test_promote_drama_step1_aborts_on_concurrent_write(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_drama_step1_aborts_on_concurrent_write(fake_ctx: ToolContext) -> None:
     """取回与晋升之间正式文件被别的写入方改过 → 中止并报冲突，不静默覆盖对方的保存。"""
     _drama_project(fake_ctx)
     _write_drama_step1(fake_ctx, [_drama_scene()])
@@ -742,9 +738,7 @@ async def test_split_narration_segments_clears_quarantine_on_regeneration(fake_c
     assert json.loads(_nr_step1_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 4
 
 
-async def test_promote_narration_step1_reports_schema_breach_without_writing(
-    fake_ctx: ToolContext, monkeypatch
-) -> None:
+async def test_promote_narration_step1_reports_schema_breach_without_writing(fake_ctx: ToolContext) -> None:
     """草稿被改到过不了产出时那份 schema：报告刷新、正式文件不写，草稿保留 Agent 手里那份原样内容。"""
     _nr_source(fake_ctx)
     _write_nr_step1(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
@@ -763,7 +757,7 @@ async def test_promote_narration_step1_reports_schema_breach_without_writing(
     assert "novel_text" not in _read_nr_quarantine(fake_ctx)["content"]["segments"][0]
 
 
-async def test_promote_narration_step1_aborts_on_concurrent_write(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_narration_step1_aborts_on_concurrent_write(fake_ctx: ToolContext) -> None:
     """取回后正式文件被别的写入方改过：晋升中止、报冲突让 Agent 合并，不静默覆盖。"""
     _nr_source(fake_ctx)
     _write_nr_step1(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
@@ -779,7 +773,7 @@ async def test_promote_narration_step1_aborts_on_concurrent_write(fake_ctx: Tool
     assert json.loads(_nr_step1_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 6
 
 
-async def test_promote_narration_step1_revalidates_against_current_source(fake_ctx: ToolContext, monkeypatch) -> None:
+async def test_promote_narration_step1_revalidates_against_current_source(fake_ctx: ToolContext) -> None:
     """晋升按现值重判原文覆盖：草稿里改写过的正文即便结构合法也拒，正式文件不被污染。"""
     _nr_source(fake_ctx)
     _write_nr_step1(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
@@ -797,9 +791,7 @@ async def test_promote_narration_step1_revalidates_against_current_source(fake_c
     assert _nr_step1_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
-async def test_promote_narration_step1_names_source_scope_on_coverage_violation(
-    fake_ctx: ToolContext, monkeypatch
-) -> None:
+async def test_promote_narration_step1_names_source_scope_on_coverage_violation(fake_ctx: ToolContext) -> None:
     """取回时未指定 source、而 source/ 下不止一集：一字未改的草稿也判不过，报告须指名范围与出路。
 
     草稿在场时不能重新取回，改 meta.source 是 Agent 唯一的出路；报告只说「分镜正文须原样复制

--- a/tests/integration/server/agent_runtime/sdk_tools/test_validate_and_promote_draft.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_validate_and_promote_draft.py
@@ -29,7 +29,6 @@ from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _drama_quarantine_path,
     _drama_scene,
     _drama_step1_path,
-    _nr_caps,
     _nr_generator_returning,
     _nr_quarantine_path,
     _nr_segment,
@@ -51,6 +50,7 @@ from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _rv_source,
     _rv_step1_path,
     _rv_unit,
+    _use_fake_caps,
     _write_drama_step1,
     _write_nr_step1,
     _write_rv_step1,
@@ -135,7 +135,7 @@ async def test_validate_and_promote_draft_promotes_after_repair(fake_ctx: ToolCo
     envelope["content"]["units"][0]["text"] = "@[张三] 在 @[村口] 出场"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert not _rv_quarantine_path(fake_ctx).exists()
@@ -150,7 +150,7 @@ async def test_validate_and_promote_draft_reports_again_without_round_limit(fake
     await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
 
     for _round in range(3):
-        out = await _promote(fake_ctx, monkeypatch)
+        out = await _promote(fake_ctx)
         assert out.get("is_error") is True
         assert "unregistered_asset" in out["content"][0]["text"]
         assert _rv_quarantine_path(fake_ctx).exists()
@@ -160,7 +160,7 @@ async def test_validate_and_promote_draft_reports_again_without_round_limit(fake
     envelope = _read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 推门，音量 {}"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
-    await _promote(fake_ctx, monkeypatch)
+    await _promote(fake_ctx)
     assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["braces_in_description"]
 
 
@@ -181,7 +181,7 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     _write_rv_step1(fake_ctx, [_rv_saved_unit("@[张三] 在 @[村口] 等候")])
     web_version = _rv_step1_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is True
     report = out["content"][0]["text"]
@@ -197,7 +197,7 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     envelope = _read_rv_quarantine(fake_ctx)
     envelope["meta"]["base_fingerprint"] = script_review.content_fingerprint(_rv_step1_path(fake_ctx))
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is not True, out
     assert not _rv_quarantine_path(fake_ctx).exists()
 
@@ -212,7 +212,7 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     await _open_for_edit(fake_ctx, source="source/episode_1.txt")
     _rv_step1_path(fake_ctx).unlink()
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is True
     report = out["content"][0]["text"]
@@ -222,7 +222,7 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     envelope = _read_rv_quarantine(fake_ctx)
     envelope["meta"]["base_fingerprint"] = None
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is not True, out
     assert not _rv_quarantine_path(fake_ctx).exists()
 
@@ -238,7 +238,7 @@ async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx
     # 取回后正式文件又被改过——存量草稿无基线可比，照旧覆盖（维持引入前语义）
     _write_rv_step1(fake_ctx, [_rv_saved_unit("@[张三] 在 @[村口] 等候")])
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert not _rv_quarantine_path(fake_ctx).exists()
@@ -260,7 +260,7 @@ async def test_split_violation_quarantine_records_base_fingerprint(fake_ctx: Too
     envelope["content"]["units"][0]["text"] = "@[张三] 出场"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is True
     assert "并发冲突" in out["content"][0]["text"]
@@ -291,7 +291,7 @@ async def test_validate_and_promote_draft_rejects_schema_breach(
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is True
     assert hint in out["content"][0]["text"]
@@ -324,7 +324,7 @@ async def test_validate_and_promote_draft_reports_broken_outer_shape(
     edited_content = copy.deepcopy(envelope["content"])
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is True
     assert "content.units" in out["content"][0]["text"]
@@ -348,7 +348,7 @@ async def test_validate_and_promote_draft_requires_source_provenance(fake_ctx: T
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is True
     assert "meta.source 缺失" in out["content"][0]["text"]
     assert not _rv_step1_path(fake_ctx).exists()
@@ -362,7 +362,7 @@ async def test_validate_and_promote_draft_reports_promotion_not_split(fake_ctx: 
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
     _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert "晋升" in out["content"][0]["text"]
@@ -406,7 +406,7 @@ async def test_promote_reference_step1_preserves_step2_draft_when_content_unchan
     assert step2_path.exists()
 
     await _open_for_edit(fake_ctx, source="source/episode_1.txt")
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert step2_path.exists()
@@ -430,7 +430,7 @@ async def test_validate_and_promote_draft_step2_uses_async_factory(fake_ctx: Too
             raise AssertionError("晋升不得裸构造 ScriptGenerator")
 
         @classmethod
-        async def create(cls, project_path):
+        async def create(cls, project_path, **_kwargs):
             obj = cls.__new__(cls)
             obj.project_path = project_path
             return obj
@@ -439,7 +439,7 @@ async def test_validate_and_promote_draft_step2_uses_async_factory(fake_ctx: Too
             return self.project_path / "scripts" / f"episode_{episode}.json"
 
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is not True, out
     assert "episode_1.json" in out["content"][0]["text"]
 
@@ -455,7 +455,7 @@ async def test_validate_and_promote_draft_refuses_after_mode_switch(fake_ctx: To
         violations=[],
     )
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is True
     # 项目已是 narration + storyboard，晋升按该变体的草稿位分派：残留的参考路径 step2 草稿不在
     # 它的视野内，故报「本集没有待处置的草稿」而不是去晋升它。
@@ -486,13 +486,13 @@ async def test_validate_and_promote_draft_step2_blocked_by_review_gate(fake_ctx:
     )
     monkeypatch.setattr(mod.script_review, "gate_blocks_step2", lambda *_args, **_kw: True)
 
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is True
     assert "尚未完成内容确认" in out["content"][0]["text"]
 
 
 async def test_validate_and_promote_draft_without_draft(fake_ctx: ToolContext, monkeypatch) -> None:
-    out = await _promote(fake_ctx, monkeypatch)
+    out = await _promote(fake_ctx)
     assert out.get("is_error") is True
     assert "没有待处置的草稿" in out["content"][0]["text"]
 
@@ -593,7 +593,7 @@ async def test_promote_drama_step1_rederives_needs_replan(fake_ctx: ToolContext,
     scene["needs_replan"] = False
     _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx, monkeypatch)
+    out = await _promote_drama(fake_ctx)
 
     assert out.get("is_error") is not True, out
     saved = json.loads(_drama_step1_path(fake_ctx).read_text(encoding="utf-8"))
@@ -611,7 +611,7 @@ async def test_promote_drama_step1_reports_schema_breach_without_writing(fake_ct
     envelope["content"]["scenes"][0]["duration_seconds"] = 7  # 不在档位内
     _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx, monkeypatch)
+    out = await _promote_drama(fake_ctx)
 
     assert out.get("is_error") is True
     assert _drama_step1_path(fake_ctx).read_text(encoding="utf-8") == before
@@ -628,7 +628,7 @@ async def test_promote_drama_step1_aborts_on_concurrent_write(fake_ctx: ToolCont
     _write_drama_step1(fake_ctx, [_drama_scene(scene_description="别处改过的描述。")])
     concurrent = _drama_step1_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx, monkeypatch)
+    out = await _promote_drama(fake_ctx)
 
     assert out.get("is_error") is True
     assert _drama_step1_path(fake_ctx).read_text(encoding="utf-8") == concurrent
@@ -668,13 +668,10 @@ async def test_normalize_drama_script_clears_quarantine_on_regeneration(fake_ctx
 
             return _R()
 
-    async def fake_caps(_p, _episode=None):
-        return 4, [4, 6, 8]
-
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     out = await _call(normalize_drama_script_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
@@ -702,7 +699,7 @@ async def test_split_narration_segments_quarantines_violation_instead_of_discard
 
     _nr_source(fake_ctx)
     segments = [_nr_segment("E1S01", 5, _RV_NOVEL, characters_in_segment=["王五"])]
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
 
     out = await _call(split_narration_segments_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
@@ -735,7 +732,7 @@ async def test_split_narration_segments_clears_quarantine_on_regeneration(fake_c
         content={"segments": [_nr_segment("E1S01", 5)]},
         violations=[],
     )
-    monkeypatch.setattr(mod, "_fetch_caps_with_fallback", _nr_caps())
+    _use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([_nr_segment("E1S01", 4, _RV_NOVEL)]))
 
     out = await _call(split_narration_segments_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
@@ -758,7 +755,7 @@ async def test_promote_narration_step1_reports_schema_breach_without_writing(
     del envelope["content"]["segments"][0]["novel_text"]
     _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx, monkeypatch)
+    out = await _promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "[schema_invalid]" in out["content"][0]["text"]
@@ -773,7 +770,7 @@ async def test_promote_narration_step1_aborts_on_concurrent_write(fake_ctx: Tool
     await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
     _write_nr_step1(fake_ctx, [_nr_segment("E1S01", 6, _RV_NOVEL)])
 
-    out = await _promote_nr(fake_ctx, monkeypatch)
+    out = await _promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "并发冲突" in out["content"][0]["text"]
@@ -793,7 +790,7 @@ async def test_promote_narration_step1_revalidates_against_current_source(fake_c
     envelope["content"]["segments"][0]["novel_text"] = "张三在村口等候"
     _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx, monkeypatch)
+    out = await _promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "[novel_text_coverage]" in out["content"][0]["text"]
@@ -814,7 +811,7 @@ async def test_promote_narration_step1_names_source_scope_on_coverage_violation(
     await _open_nr_for_edit(fake_ctx)
     assert _read_nr_quarantine(fake_ctx)["meta"]["source"] is None
 
-    out = await _promote_nr(fake_ctx, monkeypatch)
+    out = await _promote_nr(fake_ctx)
 
     text = out["content"][0]["text"]
     assert out.get("is_error") is True

--- a/tests/unit/server/agent_runtime/test_agent_startup_error.py
+++ b/tests/unit/server/agent_runtime/test_agent_startup_error.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -23,6 +24,17 @@ from server.agent_runtime.session_manager import (
     SessionManager,
 )
 from server.agent_runtime.session_store import SessionMetaStore
+
+
+class _RecordingClient:
+    """假 SDK 客户端：只记住这轮装配好的 options。
+
+    actor 收到的是闭包着 options 的 ``client_factory``，调用一次即可取出其中的
+    stderr 回调——被测的正是「装配器把回调挂进 options」这一步，不能替换掉它。
+    """
+
+    def __init__(self, options: Any) -> None:
+        self.options = options
 
 
 def test_agent_startup_error_str_includes_stderr() -> None:
@@ -100,8 +112,7 @@ async def test_send_new_session_wraps_actor_failure_with_stderr(
         def __init__(self, *_, on_message=None, client_factory=None):
             self.task = None
             self._on_message = on_message
-            # client_factory 是个 lambda，里面闭包了 options；从 client_factory
-            # 反推 options 比较麻烦，改由 monkeypatch 直接捕获 _build_options。
+            captured_stderr_cb.append(client_factory().options.stderr)
 
         async def start(self):
             # 模拟 SDK 在 connect 阶段先喷 stderr 再退出
@@ -114,19 +125,8 @@ async def test_send_new_session_wraps_actor_failure_with_stderr(
         def add_done_callback(self, _cb):
             pass
 
-    # 包装 _build_options，把 stderr 回调暴露给假 actor
-    real_build_options = SessionManager._build_options
-
-    async def wrapped_build_options(self, *args, **kwargs):
-        opts = await real_build_options(self, *args, **kwargs)
-        captured_stderr_cb.append(opts.stderr)
-        return opts
-
-    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.ClaudeSDKClient", _RecordingClient)
     monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
-
-    # _ensure_capacity 内部访问 DB，跳过
-    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
     caplog.set_level("ERROR", logger="server.agent_runtime.session_manager")
 
     with pytest.raises(AgentStartupError) as exc_info:
@@ -174,7 +174,6 @@ async def test_send_new_session_no_stderr_still_wraps(
             pass
 
     monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
-    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
 
     with pytest.raises(AgentStartupError) as exc_info:
         await seeded_session_manager.send_new_session("demo", "你好")
@@ -189,8 +188,11 @@ async def test_send_new_session_no_stderr_still_wraps(
 async def test_send_new_session_wraps_option_assembly_failure(
     seeded_session_manager: SessionManager, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
-    monkeypatch.setattr(SessionManager, "_build_options", AsyncMock(side_effect=LookupError("credential missing")))
+    # 凭证注入失败是 options 装配失败的真实来源，异常须原样浮到 send_new_session
+    monkeypatch.setattr(
+        "server.agent_runtime.options_assembler.load_provider_env_overrides",
+        AsyncMock(side_effect=LookupError("credential missing")),
+    )
 
     with pytest.raises(AgentStartupError) as exc_info:
         await seeded_session_manager.send_new_session("demo", "你好")
@@ -224,6 +226,7 @@ async def test_get_or_connect_wraps_actor_failure_with_stderr(
     class _FakeActor:
         def __init__(self, *_, on_message=None, client_factory=None):
             self.task = None
+            captured_stderr_cb.append(client_factory().options.stderr)
 
         async def start(self):
             cb = captured_stderr_cb[0]
@@ -233,16 +236,8 @@ async def test_get_or_connect_wraps_actor_failure_with_stderr(
         def add_done_callback(self, _cb):
             pass
 
-    real_build_options = SessionManager._build_options
-
-    async def wrapped_build_options(self, *args, **kwargs):
-        opts = await real_build_options(self, *args, **kwargs)
-        captured_stderr_cb.append(opts.stderr)
-        return opts
-
-    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.ClaudeSDKClient", _RecordingClient)
     monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
-    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
 
     meta = make_session_meta(id="resumed-session", project_name="demo", status="idle")
 
@@ -273,6 +268,7 @@ async def test_startup_stderr_is_not_truncated(
     class _FakeActor:
         def __init__(self, *_, on_message=None, client_factory=None):
             self.task = None
+            captured_stderr_cb.append(client_factory().options.stderr)
 
         async def start(self):
             cb = captured_stderr_cb[0]
@@ -283,16 +279,8 @@ async def test_startup_stderr_is_not_truncated(
         def add_done_callback(self, _cb):
             pass
 
-    real_build_options = SessionManager._build_options
-
-    async def wrapped_build_options(self, *args, **kwargs):
-        opts = await real_build_options(self, *args, **kwargs)
-        captured_stderr_cb.append(opts.stderr)
-        return opts
-
-    monkeypatch.setattr(SessionManager, "_build_options", wrapped_build_options)
+    monkeypatch.setattr("server.agent_runtime.session_manager.ClaudeSDKClient", _RecordingClient)
     monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
-    monkeypatch.setattr(SessionManager, "_ensure_capacity", AsyncMock(return_value=None))
 
     with pytest.raises(AgentStartupError) as exc_info:
         await seeded_session_manager.send_new_session("demo", "你好")

--- a/tests/unit/server/agent_runtime/test_assistant_service_more.py
+++ b/tests/unit/server/agent_runtime/test_assistant_service_more.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime.service import AssistantService
 from server.agent_runtime.session_store import SessionMetaStore
 from tests.factories import make_session_meta
@@ -106,13 +104,9 @@ class _FakeSessionManager:
 
 class TestAssistantServiceMore:
     @pytest.mark.asyncio
-    async def test_service_init_interrupts_stale_running_sessions(self, tmp_path):
+    async def test_service_init_interrupts_stale_running_sessions(self, tmp_path, db_factory):
         # Create an in-memory async store and seed data
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = SessionMetaStore(session_factory=factory)
+        store = SessionMetaStore(session_factory=db_factory)
 
         running = await store.create("demo", "sdk-running-1")
         completed = await store.create("demo", "sdk-completed-1")
@@ -133,8 +127,6 @@ class TestAssistantServiceMore:
         assert refreshed_running.status == "interrupted"
         assert refreshed_completed is not None
         assert refreshed_completed.status == "completed"
-
-        await engine.dispose()
 
     @pytest.mark.asyncio
     async def test_startup_waits_cleanup_and_is_idempotent(self, tmp_path, monkeypatch):
@@ -296,16 +288,12 @@ class TestAssistantServiceMore:
         assert result1["session_id"] == result2["session_id"] == "sdk-new-id"
 
     @pytest.mark.asyncio
-    async def test_send_or_create_recovers_client_key_mapping_from_db_after_restart(self, tmp_path):
+    async def test_send_or_create_recovers_client_key_mapping_from_db_after_restart(self, tmp_path, db_factory):
         """进程内幂等映射重启丢失后，受理已落库（新会话首条条目 seq 0 携带
         client_key）的重试应经 DB 兜底命中既有会话，不再重复建会话。"""
         from server.agent_runtime.event_log import EventLogStore, build_user_entry
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         # 首次受理（重启前）：新会话首条用户条目已随 client_key 落库
         accepted_entry = build_user_entry([{"type": "text", "text": "hello"}])
@@ -329,18 +317,12 @@ class TestAssistantServiceMore:
         # 命中后回填进程内映射，后续重试走快路径
         assert service._new_session_client_keys["ck-restart"] == "sdk-prev"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_send_or_create_recovers_client_key_after_lru_eviction(self, tmp_path):
+    async def test_send_or_create_recovers_client_key_after_lru_eviction(self, tmp_path, db_factory):
         """进程内 LRU 淘汰旧键后，同键重试经 DB 兜底命中原会话。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         service = AssistantService(project_root=tmp_path)
         sm = _FakeSessionManager()
@@ -370,8 +352,6 @@ class TestAssistantServiceMore:
         assert len(sm.new_sessions) == 2  # 重试未新建第三个会话
         assert retry["session_id"] == first["session_id"] == "sdk-0"
 
-        await engine.dispose()
-
     @staticmethod
     def _make_project_scoped_service(tmp_path, store, sm, meta_store):
         """装配一个跨项目 send_new_session 会落地 meta + 事件日志的 service。"""
@@ -394,17 +374,13 @@ class TestAssistantServiceMore:
         return service
 
     @pytest.mark.asyncio
-    async def test_new_session_client_key_project_scoped_via_map_hit(self, tmp_path):
+    async def test_new_session_client_key_project_scoped_via_map_hit(self, tmp_path, db_factory):
         """项目 A 已受理的新会话 client_key，用相同 client_key 对项目 B 调
         send_or_create（无 session_id）→ 返回项目 B 下新建的会话，而非静默接回 A
         的会话。覆盖进程内映射命中的快路径。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         sm = _FakeSessionManager()
         meta_store = _FakeMetaStore([])
@@ -423,19 +399,13 @@ class TestAssistantServiceMore:
         # 映射被本项目会话覆盖，后续同项目重试命中 B
         assert service._new_session_client_keys["ck-shared"] == "sdk-1"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_new_session_client_key_project_scoped_via_db_fallback(self, tmp_path):
+    async def test_new_session_client_key_project_scoped_via_db_fallback(self, tmp_path, db_factory):
         """清空进程内映射（模拟重启）后，DB 兜底恢复路径同样按项目隔离：
         项目 A 的 client_key 对项目 B 恢复时视为未命中，在 B 下新建会话。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         sm = _FakeSessionManager()
         meta_store = _FakeMetaStore([])
@@ -451,19 +421,13 @@ class TestAssistantServiceMore:
         assert meta_store.metas["sdk-1"].project_name == "proj_b"
         assert sm.new_sessions == [("proj_a", "hello"), ("proj_b", "hello")]
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_new_session_client_key_same_project_retry_still_idempotent(self, tmp_path):
+    async def test_new_session_client_key_same_project_retry_still_idempotent(self, tmp_path, db_factory):
         """同项目内幂等语义不回归：相同 client_key 在同一项目重发，仍命中原会话、
         不重复建会话（分别经映射快路径与 DB 兜底路径）。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         sm = _FakeSessionManager()
         meta_store = _FakeMetaStore([])
@@ -483,19 +447,13 @@ class TestAssistantServiceMore:
         assert recovered["session_id"] == "sdk-0"
         assert len(sm.new_sessions) == 1  # 全程未重复建会话
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_send_or_create_hit_refreshes_lru_position(self, tmp_path):
+    async def test_send_or_create_hit_refreshes_lru_position(self, tmp_path, db_factory):
         """命中进程内映射时刷新 LRU 位置：被频繁重试命中的 key 不因插入顺序
         在先，被之后新到达但只访问一次的 key 挤出缓存（退化为 FIFO）。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         service = AssistantService(project_root=tmp_path)
         sm = _FakeSessionManager()
@@ -531,20 +489,16 @@ class TestAssistantServiceMore:
         assert "ck-b" not in service._new_session_client_keys
         assert len(sm.new_sessions) == 3  # a/b/c 三次真正新建，命中未重复建会话
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_send_or_create_hit_survives_concurrent_eviction_during_db_lookup(self, tmp_path, monkeypatch):
+    async def test_send_or_create_hit_survives_concurrent_eviction_during_db_lookup(
+        self, tmp_path, monkeypatch, db_factory
+    ):
         """命中路径在 `await find_by_client_key(...)` 期间，该 key 被其他并发
         请求的淘汰逻辑移除：刷新 LRU 位置的收尾步骤须安全处理键已不存在的
         情形（不能直接 move_to_end 抛 KeyError 把幂等命中打成未处理异常）。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         service = AssistantService(project_root=tmp_path)
         sm = _FakeSessionManager()
@@ -581,20 +535,14 @@ class TestAssistantServiceMore:
         assert len(sm.new_sessions) == 1  # 未因异常或键缺失而重复建会话
         assert service._new_session_client_keys["ck-a"] == "sdk-0"  # 命中后已安全重新记入
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_send_or_create_falls_back_when_cached_mapping_points_to_deleted_session(self, tmp_path):
+    async def test_send_or_create_falls_back_when_cached_mapping_points_to_deleted_session(self, tmp_path, db_factory):
         """进程内映射指向的会话条目已不存在（如会话被删除后映射未清）时，
         不应把幽灵 "accepted" 响应（entry=None）返回给调用方——应清掉失效
         映射并按正常路径新建会话，而不是让调用方连接一个不存在的会话。"""
         from server.agent_runtime.event_log import EventLogStore
 
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        store = EventLogStore(session_factory=factory)
+        store = EventLogStore(session_factory=db_factory)
 
         service = AssistantService(project_root=tmp_path)
         sm = _FakeSessionManager()
@@ -613,8 +561,6 @@ class TestAssistantServiceMore:
         assert result["session_id"] != "sdk-deleted"
         # 映射已刷新为新会话，不再指向已删除的会话
         assert service._new_session_client_keys["ck-stale"] == "sdk-new-id"
-
-        await engine.dispose()
 
     @pytest.mark.asyncio
     async def test_ghost_mapping_cleanup_does_not_clobber_concurrent_fresh_mapping(self, tmp_path):

--- a/tests/unit/server/agent_runtime/test_event_log.py
+++ b/tests/unit/server/agent_runtime/test_event_log.py
@@ -801,27 +801,24 @@ class TestEventLogStore:
     async def test_append_seq_race_retries_when_client_key_absent_despite_false_positive_violation_check(
         self, log_store: EventLogStore, monkeypatch
     ):
-        """本次调用未传 client_key 时，即便 ``_is_client_key_violation``
-        误判为 True（无论因何种原因），也应结构性排除 client_key 冲突分类
-        ——未传 client_key 的写入根本不可能撞上 client_key 唯一约束，不能
-        让误判把普通 seq 竞争的重试关掉。"""
+        """本次调用未传 client_key 时，即便冲突文案把 client_key 判成命中，
+        也应结构性排除 client_key 冲突分类——未传 client_key 的写入根本不可能
+        撞上 client_key 唯一约束，不能让误判把普通 seq 竞争的重试关掉。"""
         from sqlalchemy.exc import IntegrityError
-
-        from server.agent_runtime import event_log as event_log_module
-
-        monkeypatch.setattr(event_log_module, "_is_client_key_violation", lambda exc: True)
 
         calls = {"n": 0}
         original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+        # 驱动只给出含 client_key 字样的文案：真实分类器据此判为 True，正是要被
+        # 结构性排除的那种误判。
+        misleading = _FakeDriverError(
+            "UNIQUE constraint failed: agent_session_event_log.client_key",
+            sqlite_errorname="SQLITE_CONSTRAINT_PRIMARYKEY",
+        )
 
         async def _flaky_append_once(session_id, entries, client_key):
             calls["n"] += 1
             if calls["n"] == 1:
-                raise IntegrityError(
-                    "INSERT INTO agent_session_event_log ...",
-                    {},
-                    _FakeDriverError("constraint failed", sqlite_errorname="SQLITE_CONSTRAINT_PRIMARYKEY"),
-                )
+                raise IntegrityError("INSERT INTO agent_session_event_log ...", {}, misleading)
             return await original_append_once(session_id, entries, client_key)
 
         monkeypatch.setattr(log_store, "_append_once", _flaky_append_once)

--- a/tests/unit/server/agent_runtime/test_session_lifecycle.py
+++ b/tests/unit/server/agent_runtime/test_session_lifecycle.py
@@ -88,8 +88,19 @@ class TestCloseSession:
         assert managed._process_task.done()
 
     async def test_close_noop_for_missing_session(self, tmp_path):
+        """关闭未登记的会话是空操作：不抛错，也不动别的会话。"""
         mgr = _make_manager(tmp_path)
-        await mgr.close_session("nonexistent")  # should not raise
+        managed, client = _make_managed("s1")
+        await _start(managed)
+        mgr.sessions["s1"] = managed
+
+        try:
+            await mgr.close_session("nonexistent")
+
+            assert "s1" in mgr.sessions
+            assert client.disconnected is False
+        finally:
+            await mgr.close_session("s1")
 
 
 class TestConfigReading:
@@ -232,42 +243,50 @@ class TestEnsureCapacity:
     async def test_evicts_oldest_non_running(self, tmp_path):
         """超限时淘汰最久未活跃的非 running 会话。"""
         mgr = _make_manager(tmp_path)
-        old, _ = _make_managed("s_old", status="idle")
+        old, old_client = _make_managed("s_old", status="idle")
         await _start(old)
         old.last_activity = time.monotonic() - 100
-        new, _ = _make_managed("s_new", status="idle")
+        new, new_client = _make_managed("s_new", status="idle")
         await _start(new)
         new.last_activity = time.monotonic()
         mgr.sessions["s_old"] = old
         mgr.sessions["s_new"] = new
 
-        with patch.object(mgr, "_get_max_concurrent", new_callable=AsyncMock, return_value=2):
-            with patch.object(mgr, "_evict_one", new_callable=AsyncMock) as mock_evict:
+        try:
+            with patch.object(mgr, "_get_max_concurrent", new_callable=AsyncMock, return_value=2):
                 await mgr._ensure_capacity()
-                mock_evict.assert_called_once_with(old)
 
-        await mgr.close_session("s_old")
-        await mgr.close_session("s_new")
+            assert "s_old" not in mgr.sessions
+            assert old_client.disconnected is True
+            assert "s_new" in mgr.sessions
+            assert new_client.disconnected is False
+        finally:
+            await mgr.close_session("s_old")
+            await mgr.close_session("s_new")
 
     async def test_evicts_completed_session_when_no_idle(self, tmp_path):
         """无 idle 会话时，应淘汰 completed/error/interrupted 状态的会话。"""
         mgr = _make_manager(tmp_path)
-        completed, _ = _make_managed("s_completed", status="completed")
+        completed, completed_client = _make_managed("s_completed", status="completed")
         await _start(completed)
         completed.last_activity = time.monotonic() - 50
-        running, _ = _make_managed("s_running", status="running")
+        running, running_client = _make_managed("s_running", status="running")
         await _start(running)
         running.last_activity = time.monotonic()
         mgr.sessions["s_completed"] = completed
         mgr.sessions["s_running"] = running
 
-        with patch.object(mgr, "_get_max_concurrent", new_callable=AsyncMock, return_value=2):
-            with patch.object(mgr, "_evict_one", new_callable=AsyncMock) as mock_evict:
+        try:
+            with patch.object(mgr, "_get_max_concurrent", new_callable=AsyncMock, return_value=2):
                 await mgr._ensure_capacity()
-                mock_evict.assert_called_once_with(completed)
 
-        await mgr.close_session("s_completed")
-        await mgr.close_session("s_running")
+            assert "s_completed" not in mgr.sessions
+            assert completed_client.disconnected is True
+            assert "s_running" in mgr.sessions
+            assert running_client.disconnected is False
+        finally:
+            await mgr.close_session("s_completed")
+            await mgr.close_session("s_running")
 
     async def test_all_running_raises_capacity_error(self, tmp_path):
         """所有会话都在 running 时应抛出 SessionCapacityError。"""
@@ -308,45 +327,49 @@ class TestPatrolLoop:
     async def test_patrol_cleans_stale_session(self, tmp_path):
         """巡检应清理超时的非 running 会话。"""
         mgr = _make_manager(tmp_path)
-        managed, _ = _make_managed("s1", status="completed")
+        managed, client = _make_managed("s1", status="completed")
         await _start(managed)
         managed.last_activity = time.monotonic() - 1000
         mgr.sessions["s1"] = managed
 
-        with patch.object(mgr, "_get_cleanup_delay", new_callable=AsyncMock, return_value=60):
-            with patch.object(mgr, "_evict_one", new_callable=AsyncMock) as mock_evict:
+        try:
+            with patch.object(mgr, "_get_cleanup_delay", new_callable=AsyncMock, return_value=60):
                 await mgr._patrol_once()
-                mock_evict.assert_called_once_with(managed)
 
-        await mgr.close_session("s1")
+            assert "s1" not in mgr.sessions
+            assert client.disconnected is True
+        finally:
+            await mgr.close_session("s1")
 
     async def test_patrol_skips_running(self, tmp_path):
         """巡检不应清理 running 会话。"""
         mgr = _make_manager(tmp_path)
-        managed, _ = _make_managed("s1", status="running")
+        managed, client = _make_managed("s1", status="running")
         await _start(managed)
         mgr.sessions["s1"] = managed
 
         try:
             with patch.object(mgr, "_get_cleanup_delay", new_callable=AsyncMock, return_value=60):
-                with patch.object(mgr, "_evict_one", new_callable=AsyncMock) as mock_evict:
-                    await mgr._patrol_once()
-                    mock_evict.assert_not_called()
+                await mgr._patrol_once()
+
+            assert "s1" in mgr.sessions
+            assert client.disconnected is False
         finally:
             await mgr.close_session("s1")
 
     async def test_patrol_skips_recent_session(self, tmp_path):
         """巡检不应清理近期活跃的会话。"""
         mgr = _make_manager(tmp_path)
-        managed, _ = _make_managed("s1", status="completed")
+        managed, client = _make_managed("s1", status="completed")
         await _start(managed)
         managed.last_activity = time.monotonic()  # 刚刚活跃
         mgr.sessions["s1"] = managed
 
         try:
             with patch.object(mgr, "_get_cleanup_delay", new_callable=AsyncMock, return_value=600):
-                with patch.object(mgr, "_evict_one", new_callable=AsyncMock) as mock_evict:
-                    await mgr._patrol_once()
-                    mock_evict.assert_not_called()
+                await mgr._patrol_once()
+
+            assert "s1" in mgr.sessions
+            assert client.disconnected is False
         finally:
             await mgr.close_session("s1")

--- a/tests/unit/server/agent_runtime/test_session_manager_more.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_more.py
@@ -4,9 +4,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime import session_manager as sm_mod
 from server.agent_runtime.agent_access_policy import AgentAccessPolicy
 from server.agent_runtime.message_utils import extract_plain_user_content
@@ -441,7 +439,7 @@ class TestSessionManagerMore:
         assert not managed.channel.has_subscribers
 
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_read_within_project_root(self, tmp_path):
+    async def test_file_access_hook_allows_read_within_project_root(self, tmp_path, meta_store):
         """Hook allows Read within cwd and cwd-external (non-projects) paths;
         cross-project read is denied per new sandbox policy."""
         own_project = tmp_path / "projects" / "alpha"
@@ -450,12 +448,6 @@ class TestSessionManagerMore:
         other_project.mkdir(parents=True)
         docs_dir = tmp_path / "docs"
         docs_dir.mkdir(parents=True)
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
@@ -488,21 +480,13 @@ class TestSessionManagerMore:
         )
         assert result.get("continue_") is True
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_blocks_write_to_readonly_dir(self, tmp_path):
+    async def test_file_access_hook_blocks_write_to_readonly_dir(self, tmp_path, meta_store):
         """Hook denies Write to lib/, allows own project."""
         own_project = tmp_path / "projects" / "alpha"
         own_project.mkdir(parents=True)
         lib_dir = tmp_path / "lib"
         lib_dir.mkdir(parents=True)
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
@@ -527,19 +511,11 @@ class TestSessionManagerMore:
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_bash_without_path_check(self, tmp_path):
+    async def test_file_access_hook_allows_bash_without_path_check(self, tmp_path, meta_store):
         """Hook skips Bash (not in PATH_TOOLS)."""
         own_project = tmp_path / "projects" / "alpha"
         own_project.mkdir(parents=True)
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
@@ -556,10 +532,8 @@ class TestSessionManagerMore:
         )
         assert result.get("continue_") is True
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_blocks_write_non_whitelisted_ext(self, tmp_path):
+    async def test_file_access_hook_blocks_write_non_whitelisted_ext(self, tmp_path, meta_store):
         """Hook denies Write/Edit for forbidden code extensions in project dir.
 
         New policy: blacklist of code extensions (.py/.js/.ts/.tsx/.sh/.yaml/.yml/.toml)
@@ -567,12 +541,6 @@ class TestSessionManagerMore:
         """
         own_project = tmp_path / "projects" / "alpha"
         own_project.mkdir(parents=True)
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
@@ -646,10 +614,8 @@ class TestSessionManagerMore:
         )
         assert result.get("continue_") is True
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_read_agent_profile(self, tmp_path):
+    async def test_file_access_hook_allows_read_agent_profile(self, tmp_path, meta_store):
         """Hook allows Read for agent_runtime_profile/ files."""
         own_project = tmp_path / "projects" / "alpha"
         own_project.mkdir(parents=True)
@@ -658,12 +624,6 @@ class TestSessionManagerMore:
         # 这里用 exist_ok=True 容忍。CLAUDE.md 内容会被本测试覆写为有意义文本。
         profile_md.parent.mkdir(parents=True, exist_ok=True)
         profile_md.write_text("# Agent instructions")
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=tmp_path,
@@ -680,9 +640,7 @@ class TestSessionManagerMore:
         )
         assert result.get("continue_") is True
 
-        await engine.dispose()
-
-    async def _make_sdk_hook_env(self, tmp_path):
+    async def _make_sdk_hook_env(self, tmp_path, meta_store):
         """Create a SessionManager + hook with SDK dir outside project_root."""
         app_root = tmp_path / "app"
         own_project = app_root / "projects" / "alpha"
@@ -690,12 +648,6 @@ class TestSessionManagerMore:
 
         claude_home = tmp_path / "claude_home" / "projects"
         claude_home.mkdir(parents=True)
-
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
-        meta_store = SessionMetaStore(session_factory=factory)
 
         mgr = sm_mod.SessionManager(
             project_root=app_root,
@@ -705,16 +657,16 @@ class TestSessionManagerMore:
         mgr.access_policy = replace(mgr.access_policy, claude_projects_dir=claude_home)
 
         hook = mgr._options_assembler._build_file_access_hook(own_project)
-        return hook, own_project, claude_home, engine
+        return hook, own_project, claude_home
 
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_read_sdk_tool_results(self, tmp_path):
+    async def test_file_access_hook_allows_read_sdk_tool_results(self, tmp_path, meta_store):
         """Hook allows Read for SDK tool-results of the CURRENT project.
 
         New policy: cwd-external non-projects paths (含 SDK 目录) 默认放行；
         Write 仍受 cwd 内限制约束。
         """
-        hook, own_project, claude_home, engine = await self._make_sdk_hook_env(tmp_path)
+        hook, own_project, claude_home = await self._make_sdk_hook_env(tmp_path, meta_store)
 
         encoded = AgentAccessPolicy.encode_sdk_project_path(own_project)
         tool_results_dir = claude_home / encoded / "abc-session" / "tool-results"
@@ -738,16 +690,14 @@ class TestSessionManagerMore:
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_denies_read_other_project_dir(self, tmp_path):
+    async def test_file_access_hook_denies_read_other_project_dir(self, tmp_path, meta_store):
         """Hook denies Read for ANOTHER project's directory under projects/.
 
         New policy: 跨项目隔离基于 project_root/projects/<other>/ 的物理位置，
         而非 SDK 编码路径。
         """
-        hook, _, _, engine = await self._make_sdk_hook_env(tmp_path)
+        hook, _, _ = await self._make_sdk_hook_env(tmp_path, meta_store)
 
         other_project = tmp_path / "app" / "projects" / "beta"
         other_project.mkdir(parents=True)
@@ -762,15 +712,13 @@ class TestSessionManagerMore:
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_denies_write_outside_cwd(self, tmp_path):
+    async def test_file_access_hook_denies_write_outside_cwd(self, tmp_path, meta_store):
         """Hook denies Write to any path outside project_cwd.
 
         New policy: 写工具一律拒绝 cwd 外路径；Read 已放宽至 cwd 外非 projects/ 路径。
         """
-        hook, _, _, engine = await self._make_sdk_hook_env(tmp_path)
+        hook, _, _ = await self._make_sdk_hook_env(tmp_path, meta_store)
 
         # Write outside cwd — denied
         result = await hook(
@@ -780,16 +728,14 @@ class TestSessionManagerMore:
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_read_sdk_task_output(self, tmp_path):
+    async def test_file_access_hook_allows_read_sdk_task_output(self, tmp_path, meta_store):
         """Hook allows Read for SDK task output files under /tmp/claude-*.
 
         New policy: cwd-external non-projects 路径默认放行（含 SDK 后台任务输出），
         写工具仍受 cwd 内限制约束。
         """
-        hook, _, _, engine = await self._make_sdk_hook_env(tmp_path)
+        hook, _, _ = await self._make_sdk_hook_env(tmp_path, meta_store)
 
         # SDK task output path pattern: /tmp/claude-{N}/{encoded}/tasks/{id}.output
         task_output = "/tmp/claude-0/-app-projects-alpha-abc123/tasks/bdgaof0ba.output"
@@ -808,8 +754,6 @@ class TestSessionManagerMore:
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        await engine.dispose()
-
 
 class TestJsonValidationHook:
     """Tests for the PreToolUse JSON validation hook."""
@@ -817,7 +761,6 @@ class TestJsonValidationHook:
     def _make_manager(self, tmp_path):
         """Build a SessionManager with minimal fakes (SDK not required)."""
         from server.agent_runtime.session_manager import SessionManager
-        from server.agent_runtime.session_store import SessionMetaStore
 
         return SessionManager(
             project_root=tmp_path,
@@ -1036,7 +979,7 @@ class TestJsonValidationHook:
         # old_string not in file → hook skips → allowed
         assert result == {}
 
-    async def test_edit_curly_quotes_in_new_string_straight_old_denies(self, tmp_path):
+    async def test_edit_curly_quotes_in_new_string_straight_old_denies(self, tmp_path, meta_store):
         """Edit with straight-quote old_string that matches file but
         curly-quote new_string is denied via the early curly-quote check."""
         json_file = tmp_path / "ep.json"
@@ -1060,7 +1003,6 @@ class TestJsonPostValidationHook:
 
     def _make_manager(self, tmp_path):
         from server.agent_runtime.session_manager import SessionManager
-        from server.agent_runtime.session_store import SessionMetaStore
 
         return SessionManager(
             project_root=tmp_path,

--- a/tests/unit/server/agent_runtime/test_session_manager_more.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_more.py
@@ -979,7 +979,7 @@ class TestJsonValidationHook:
         # old_string not in file → hook skips → allowed
         assert result == {}
 
-    async def test_edit_curly_quotes_in_new_string_straight_old_denies(self, tmp_path, meta_store):
+    async def test_edit_curly_quotes_in_new_string_straight_old_denies(self, tmp_path):
         """Edit with straight-quote old_string that matches file but
         curly-quote new_string is denied via the early curly-quote check."""
         json_file = tmp_path / "ep.json"

--- a/tests/unit/server/agent_runtime/test_session_manager_project_scope.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_project_scope.py
@@ -4,11 +4,8 @@ import json
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from server.agent_runtime.session_manager import SessionManager
-from server.agent_runtime.session_store import SessionMetaStore
 
 
 class _FakeOptions:
@@ -22,16 +19,6 @@ class _FakeHookMatcher:
         self.hooks = hooks or []
 
 
-async def _make_store():
-    """Create an async SessionMetaStore backed by in-memory SQLite."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    store = SessionMetaStore(session_factory=factory)
-    return store, engine
-
-
 async def _fake_provider_env():
     """Stub for OptionsAssembler 凭证注入 — 跳过 DB 访问。"""
     return {}
@@ -39,10 +26,10 @@ async def _fake_provider_env():
 
 class TestSessionManagerProjectScope:
     @pytest.mark.asyncio
-    async def test_build_options_uses_project_directory_as_cwd(self, tmp_path, monkeypatch):
+    async def test_build_options_uses_project_directory_as_cwd(self, tmp_path, monkeypatch, meta_store):
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -57,12 +44,11 @@ class TestSessionManagerProjectScope:
                 options = await manager._build_options("demo")
 
         assert options.kwargs["cwd"] == str(project_dir.resolve())
-        await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_build_options_raises_when_project_missing(self, tmp_path, monkeypatch):
+    async def test_build_options_raises_when_project_missing(self, tmp_path, monkeypatch, meta_store):
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -77,14 +63,12 @@ class TestSessionManagerProjectScope:
                 with pytest.raises(FileNotFoundError):
                     await manager._build_options("missing-project")
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_build_options_always_adds_file_access_hook(self, tmp_path, monkeypatch):
+    async def test_build_options_always_adds_file_access_hook(self, tmp_path, monkeypatch, meta_store):
         """File access hook is always registered, even without can_use_tool."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -110,14 +94,12 @@ class TestSessionManagerProjectScope:
         assert len(matcher.hooks) == 1
         assert matcher.hooks[0] is not manager._options_assembler._keep_stream_open_hook
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_build_options_with_can_use_tool_adds_keep_alive_hook(self, tmp_path, monkeypatch):
+    async def test_build_options_with_can_use_tool_adds_keep_alive_hook(self, tmp_path, monkeypatch, meta_store):
         """With can_use_tool: keep_stream_open + file_access hooks."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -148,10 +130,8 @@ class TestSessionManagerProjectScope:
         assert len(matcher.hooks) == 2
         assert matcher.hooks[0] is manager._options_assembler._keep_stream_open_hook
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_build_project_context_excludes_mutable_metadata(self, tmp_path):
+    async def test_build_project_context_excludes_mutable_metadata(self, tmp_path, meta_store):
         """Mutable metadata must NOT leak into the session-fixed system prompt."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
@@ -175,7 +155,7 @@ class TestSessionManagerProjectScope:
             encoding="utf-8",
         )
 
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -215,16 +195,14 @@ class TestSessionManagerProjectScope:
         assert "必须使用绝对路径" not in body
         assert "必须使用相对路径" not in body
 
-        await engine.dispose()
-
     @pytest.mark.asyncio
-    async def test_build_project_context_emits_block_without_project_json(self, tmp_path):
+    async def test_build_project_context_emits_block_without_project_json(self, tmp_path, meta_store):
         """Output is independent of project.json: the stable block is emitted even when it is absent."""
         project_dir = tmp_path / "projects" / "empty"
         project_dir.mkdir(parents=True)
         # No project.json created
 
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -236,14 +214,12 @@ class TestSessionManagerProjectScope:
         assert f"项目目录（即当前工作目录 cwd）：{project_dir.resolve().as_posix()}" in prompt
         assert "项目元数据（标题、风格、概述等）存于 project.json，需要时读取。" in prompt
 
-        await engine.dispose()
-
 
 class TestAllowedToolsAndConstants:
     @pytest.mark.asyncio
-    async def test_default_allowed_tools_matches_sdk(self, tmp_path):
+    async def test_default_allowed_tools_matches_sdk(self, tmp_path, meta_store):
         """Verify allowed tools align with SDK documentation."""
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -260,28 +236,26 @@ class TestAllowedToolsAndConstants:
         assert "Bash" in tools
         assert "BashOutput" in tools
         assert "KillBash" in tools
-        await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_path_tools_no_ls(self, tmp_path):
+    async def test_path_tools_no_ls(self, tmp_path, meta_store):
         """LS should not be in PATH_TOOLS."""
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
         )
         assert "LS" not in manager.access_policy.PATH_TOOLS
         assert "MultiEdit" not in manager.access_policy.PATH_TOOLS
-        await engine.dispose()
 
 
 class TestSystemPromptProjectContext:
     @pytest.mark.asyncio
-    async def test_build_project_context_returns_empty_when_project_dir_missing(self, tmp_path):
+    async def test_build_project_context_returns_empty_when_project_dir_missing(self, tmp_path, meta_store):
         """The only empty case left: no project directory at all (cwd cannot resolve)."""
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
 
-        store, engine = await _make_store()
+        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
             meta_store=store,
@@ -289,4 +263,3 @@ class TestSystemPromptProjectContext:
 
         prompt = manager._options_assembler._build_project_context("does-not-exist")
         assert prompt == ""
-        await engine.dispose()

--- a/tests/unit/server/agent_runtime/test_session_manager_project_scope.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_project_scope.py
@@ -29,10 +29,9 @@ class TestSessionManagerProjectScope:
     async def test_build_options_uses_project_directory_as_cwd(self, tmp_path, monkeypatch, meta_store):
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
@@ -48,10 +47,9 @@ class TestSessionManagerProjectScope:
     @pytest.mark.asyncio
     async def test_build_options_raises_when_project_missing(self, tmp_path, monkeypatch, meta_store):
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
@@ -68,10 +66,9 @@ class TestSessionManagerProjectScope:
         """File access hook is always registered, even without can_use_tool."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
@@ -99,10 +96,9 @@ class TestSessionManagerProjectScope:
         """With can_use_tool: keep_stream_open + file_access hooks."""
         project_dir = tmp_path / "projects" / "demo"
         project_dir.mkdir(parents=True)
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", _fake_provider_env)
 
@@ -155,10 +151,9 @@ class TestSessionManagerProjectScope:
             encoding="utf-8",
         )
 
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
 
         prompt = manager._options_assembler._build_project_context("demo")
@@ -202,10 +197,9 @@ class TestSessionManagerProjectScope:
         project_dir.mkdir(parents=True)
         # No project.json created
 
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
 
         prompt = manager._options_assembler._build_project_context("empty")
@@ -219,10 +213,9 @@ class TestAllowedToolsAndConstants:
     @pytest.mark.asyncio
     async def test_default_allowed_tools_matches_sdk(self, tmp_path, meta_store):
         """Verify allowed tools align with SDK documentation."""
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         tools = manager.DEFAULT_ALLOWED_TOOLS
         assert "Task" in tools
@@ -240,10 +233,9 @@ class TestAllowedToolsAndConstants:
     @pytest.mark.asyncio
     async def test_path_tools_no_ls(self, tmp_path, meta_store):
         """LS should not be in PATH_TOOLS."""
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
         assert "LS" not in manager.access_policy.PATH_TOOLS
         assert "MultiEdit" not in manager.access_policy.PATH_TOOLS
@@ -255,10 +247,9 @@ class TestSystemPromptProjectContext:
         """The only empty case left: no project directory at all (cwd cannot resolve)."""
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
 
-        store = meta_store
         manager = SessionManager(
             project_root=tmp_path,
-            meta_store=store,
+            meta_store=meta_store,
         )
 
         prompt = manager._options_assembler._build_project_context("does-not-exist")


### PR DESCRIPTION
Closes #1998

Spec #1989 的 B6 域（`server/agent_runtime`）测试卫生整改。

## 改动要点

- sdk_tools 族约 75 处私有 patch（`_context.resolve_video_caps` / `fetch_video_caps`、`text_generation._resolve_video_capabilities` / `_fetch_caps_with_fallback` / `_fetch_reference_caps_with_fallback`、`enqueue_image_edits._i2i_provider_available`）全部改走 B5b 已有的 `config_resolver=` 注入缝，`tests/fakes.py` 追加 `FakeConfigResolver`（纯新增，未改动既有符号）。被替换掉的取值器里装着软回退、时长联动约束收窄与声音档派生，正是用例要保护的行为。
- 换成真实取值器后两处旧期望被证伪，按真实产物改正：`test_split_reference_video_units_dry_run` 的 `"12 秒"` 实际派生为 8 秒（`_fetch_reference_caps_with_fallback` 取 `max(sorted(set(with_refs) | set(without_refs)))`）；`_FakeGenerator.create` 签名收不下透传的 `config_resolver`。
- `test_agent_startup_error.py` 4 处包装 `SessionManager._build_options` 改为替换 `session_manager.ClaudeSDKClient` 为记录用假客户端；5 处 `_ensure_capacity` patch 直接删除；`_build_options` 抛 LookupError 一处改为让 `options_assembler.load_provider_env_overrides` 抛。
- `test_event_log.py` 的假分类器改为让真实分类器判定含 `client_key` 的 `IntegrityError`。
- `test_session_lifecycle.py` 5 处 `mock_evict.assert_called_once_with` 换成 `_evict_one` 跑完后的后置状态断言。
- 域内 18 处测试体内 `create_async_engine` 收到 B5c 的 `db_factory` / `meta_store` 共享 fixture。
- 本地审查修复：删除改造后残留的 27 处未用 `monkeypatch` 形参、1 处未用 `meta_store` 形参、5 处 `def` 行后空行、9 处 `store = meta_store` 纯别名。

## 验证

- `ruff check` / `ruff format --check`（1370 files already formatted）/ `lint-imports`（Contracts: 2 kept, 0 broken）/ `basedpyright`（0 errors）全绿。
- 全量 `pytest`：10282 passed, 2 skipped。
- `scripts/audit_tests.py` 对账：test_files 478、test_functions 8191（未变）、private_patch_sites 233、double_only_tests 110、no_assertion_tests 45、shared_facility_findings 0、conftest 违规 0；按 `agent_runtime` 域过滤后 private_patch_sites / integration_self_patch_sites / double_only 均为 0。

## 已知遗留（见 handoff follow-up）

- `tests/fakes.py` 的 `FakeConfigResolver` 与 `fake_reference_caps_fetcher` 目前各只有 1 个消费文件，未满足「公开符号 ≥2 文件」闸门。其余消费方（`tests/integration/lib/test_script_review_router.py`、`tests/integration/server/services/test_script_review.py` 共 7 处）归属并行的其他 B6 域，按本批「共享设施文件只增不改、不跨域改」预裁保留原位，随那些迁移自然满足。
- `test_session_lifecycle.py` 仍对实例 patch `_get_max_concurrent` / `_get_cleanup_delay`（真修法是 `SessionManager` 构造参数，属生产改动）；`test_event_log.py` 仍对实例 `_append_once` 做故障注入（无等价外部触发）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 新增统一能力配置测试替身，覆盖视频、图像和音频能力解析、动态时长限制及错误回退。
  * 扩展视频生成、图像编辑、旁白、草稿晋升和会话管理测试，验证音频开关、资源清理与异常处理。
  * 统一使用共享配置、数据库和存储测试夹具，减少重复初始化并提升测试稳定性。
  * 增加启动失败、并发冲突、会话淘汰及事件日志重试等回归验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->