### PR TITLE
test(backends): B6 供应商后端与装配测试处置——出站 HTTP 迁 respx，替身改记录型

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,3 +461,21 @@ async def generation_queue(db_factory: async_sessionmaker[AsyncSession]):
     generation_queue_module._QUEUE_INSTANCE = queue
     yield queue
     generation_queue_module._QUEUE_INSTANCE = None
+
+
+# ---------------------------------------------------------------------------
+# Polling / retry clock (used by 2+ test files)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def poll_clock():
+    """``bounded_poll_clock`` 的 fixture 形态：整条用例的轮询与退避等待都走假表。
+
+    供原先以 ``monkeypatch.setattr`` 压缩等待的用例改用共享入口，压缩语义与超时兜底
+    与上下文管理器形态完全一致。
+    """
+    from tests.fakes import bounded_poll_clock
+
+    with bounded_poll_clock():
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -472,8 +472,7 @@ async def generation_queue(db_factory: async_sessionmaker[AsyncSession]):
 def poll_clock():
     """``bounded_poll_clock`` 的 fixture 形态：整条用例的轮询与退避等待都走假表。
 
-    供原先以 ``monkeypatch.setattr`` 压缩等待的用例改用共享入口，压缩语义与超时兜底
-    与上下文管理器形态完全一致。
+    压缩语义与超时兜底与上下文管理器形态完全一致，适用于整条用例都需要假表的场景。
     """
     from tests.fakes import bounded_poll_clock
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -500,6 +500,27 @@ def captured_ark_clients(module: str, client: Any = None) -> Iterator[list[dict[
 
 
 @contextmanager
+def captured_openai_clients(client: Any = None) -> Iterator[list[dict[str, Any]]]:
+    """AsyncOpenAI 构造的记录器：收下建客户端的参数，回给定（或空）客户端替身。
+
+    OpenAI 兼容族（openai / agnes 文本、openai 图像与视频、openai TTS、dashscope 与 minimax
+    视频）都经 ``lib.openai_shared`` 取这个 SDK 入口，构造参数就是该边界上的契约：鉴权、
+    base_url 归一化、超时。断言落在记录的构造参数上，而不是替身的调用对象。
+    """
+    from unittest.mock import AsyncMock
+
+    created: list[dict[str, Any]] = []
+    instance = AsyncMock() if client is None else client
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return instance
+
+    with patch("lib.openai_shared.AsyncOpenAI", _create):
+        yield created
+
+
+@contextmanager
 def captured_backend_construction() -> Iterator[list[dict[str, Any]]]:
     """四个后端 registry 的构造记录器：工厂换成只记参数的哑后端，不建 SDK 客户端。
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -445,3 +445,35 @@ def bounded_poll_clock(step: float = 30.0):
         patch("lib.retry.time.monotonic", side_effect=lambda: next(clock)),
     ):
         yield
+
+
+@contextmanager
+def captured_provider_job_ids() -> Iterator[list[dict[str, Any]]]:
+    """provider_job_id 写回的手写替身：收下写回参数，不落 DB。
+
+    ``persist_provider_job_id`` 是 backend 的 DB 边界，各提交-轮询型 backend 的测试只关心
+    「写回了什么」。产出按参数名归档的记录列表，断言落在记录内容上而不是替身的调用对象上；
+    非 worker 路径（``task_id=None``）跳过写回时列表保持为空。
+    """
+    records: list[dict[str, Any]] = []
+
+    async def _record(
+        task_id: str,
+        job_id: str,
+        *,
+        provider: str,
+        endpoint: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        records.append(
+            {
+                "task_id": task_id,
+                "job_id": job_id,
+                "provider": provider,
+                "endpoint": endpoint,
+                "base_url": base_url,
+            }
+        )
+
+    with patch("lib.video_backends.base.persist_provider_job_id", _record):
+        yield records

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -477,3 +477,44 @@ def captured_provider_job_ids() -> Iterator[list[dict[str, Any]]]:
 
     with patch("lib.video_backends.base.persist_provider_job_id", _record):
         yield records
+
+
+@contextmanager
+def captured_backend_construction() -> Iterator[list[dict[str, Any]]]:
+    """四个后端 registry 的构造记录器：工厂换成只记参数的哑后端，不建 SDK 客户端。
+
+    装配层（``ProviderSpec.build_backend``、``lib.text_backends.factory``）的产出就是
+    「往哪个 media registry、用什么后端名、什么构造参数建后端」，真实后端要凭证要网络。
+    按名逐个换工厂（保留键集合，``get_registered_backends`` 的读者不受影响），记录列表让
+    断言落在构造参数本身；未注册名照旧由 ``create_backend`` fail-loud。
+    """
+    from lib.audio_backends import registry as audio_registry
+    from lib.image_backends import registry as image_registry
+    from lib.text_backends import registry as text_registry
+    from lib.video_backends import registry as video_registry
+
+    records: list[dict[str, Any]] = []
+    factories: dict[str, dict[str, Any]] = {
+        "text": text_registry._BACKEND_FACTORIES,
+        "image": image_registry._BACKEND_FACTORIES,
+        "video": video_registry._BACKEND_FACTORIES,
+        "audio": audio_registry._BACKEND_FACTORIES,
+    }
+
+    def _recorder(media: str, name: str) -> Callable[..., Any]:
+        def _build(**kwargs: Any) -> Any:
+            records.append({"media": media, "backend": name, "kwargs": kwargs})
+            return object()
+
+        return _build
+
+    saved = {media: dict(table) for media, table in factories.items()}
+    for media, table in factories.items():
+        for name in list(table):
+            table[name] = _recorder(media, name)
+    try:
+        yield records
+    finally:
+        for media, table in factories.items():
+            table.clear()
+            table.update(saved[media])

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -480,6 +480,26 @@ def captured_provider_job_ids() -> Iterator[list[dict[str, Any]]]:
 
 
 @contextmanager
+def captured_ark_clients(module: str, client: Any = None) -> Iterator[list[dict[str, Any]]]:
+    """create_ark_client 的记录器：收下建客户端的参数，回给定（或空）客户端替身。
+
+    Ark 系三个后端（文本 / 图像 / 视频）各自从自己的模块引用这个工厂，模块路径由调用方给出。
+    base_url 归一化、鉴权透传的断言落在记录的构造参数上，而不是替身的调用对象。
+    """
+    from unittest.mock import MagicMock
+
+    created: list[dict[str, Any]] = []
+    instance = MagicMock() if client is None else client
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return instance
+
+    with patch(f"{module}.create_ark_client", _create):
+        yield created
+
+
+@contextmanager
 def captured_backend_construction() -> Iterator[list[dict[str, Any]]]:
     """四个后端 registry 的构造记录器：工厂换成只记参数的哑后端，不建 SDK 客户端。
 

--- a/tests/integration/lib/video_backends/test_kling_video_backend.py
+++ b/tests/integration/lib/video_backends/test_kling_video_backend.py
@@ -1,4 +1,4 @@
-"""KlingVideoBackend 单元测试（mock httpx，异步轮询，不打真实 HTTP）。
+"""KlingVideoBackend 测试（respx 在 transport 层拦截，不打真实 HTTP）。
 
 覆盖：JWT / Bearer 双模式鉴权注入、子路径选择（text2video / image2video）、请求体构建、
 脱敏日志视图、submit→轮询→下载端到端、provider_job_id 持久化、失败终态、resume 不重提交。
@@ -6,26 +6,50 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import NamedTuple
 
+import httpx
 import jwt
 import pytest
+import respx
 
 from lib.providers import PROVIDER_KLING
 from lib.video_backends.base import VideoAudioMode, VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.registry import effective_generate_audio_for_model
+from tests.fakes import bounded_poll_clock, captured_provider_job_ids
+from tests.http_capture import capture_http, only_request
 
 _SECRET = "s" * 40
+_BASE_URL = "https://api-beijing.klingai.com/v1"
+_DOWNLOAD_URL = "https://x/final.mp4"
 
 
-def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    resp.raise_for_status = MagicMock()
-    return resp
+class _KlingRoutes(NamedTuple):
+    """Kling 的三条出站流量：建任务（子路径可变）、任务轮询、成片下载。"""
+
+    submit: respx.Route
+    poll: respx.Route
+    download: respx.Route
+
+
+@contextmanager
+def _kling_api() -> Iterator[_KlingRoutes]:
+    videos = re.escape(f"{_BASE_URL}/videos")
+    with capture_http() as router:
+        yield _KlingRoutes(
+            submit=router.post(url__regex=rf"^{videos}/[^/]+$"),
+            poll=router.get(url__regex=rf"^{videos}/[^/]+/[^/]+$"),
+            download=router.get(url__regex=r"^https://x/"),
+        )
+
+
+def _resp(json_body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=json_body)
 
 
 def _submit(task_id: str = "t-1") -> dict:
@@ -37,17 +61,6 @@ def _query(status: str, url: str = "", status_msg: str = "") -> dict:
     if url:
         data["task_result"] = {"videos": [{"id": "v1", "url": url}]}
     return {"code": 0, "message": "SUCCEED", "data": data}
-
-
-def _client(*, post=None, get=None) -> AsyncMock:
-    c = AsyncMock()
-    if post is not None:
-        c.post = post
-    if get is not None:
-        c.get = get
-    c.__aenter__ = AsyncMock(return_value=c)
-    c.__aexit__ = AsyncMock(return_value=None)
-    return c
 
 
 def _jwt_backend(model: str | None = None) -> KlingVideoBackend:
@@ -473,236 +486,185 @@ class TestSafeLogView:
 
 class TestGenerateHappyPath:
     async def test_submit_poll_download(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit("task-9")))
-        get = AsyncMock(
-            side_effect=[
-                _resp(_query("processing")),
-                _resp(_query("succeed", url="https://x/final.mp4")),
-            ]
-        )
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()) as dl,
-        ):
+        with _kling_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_resp(_submit("task-9")))
+            routes.poll.mock(
+                side_effect=[
+                    _resp(_query("processing")),
+                    _resp(_query("succeed", url=_DOWNLOAD_URL)),
+                ]
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4-bytes"))
+
             result = await _jwt_backend().generate(_request(tmp_path))
+
+            # text2video 提交端点
+            assert only_request(routes.submit).url.path == "/v1/videos/text2video"
+            assert str(only_request(routes.download).url) == _DOWNLOAD_URL
 
         assert result.provider == PROVIDER_KLING
         assert result.task_id == "task-9"
-        assert result.video_uri == "https://x/final.mp4"
+        assert result.video_uri == _DOWNLOAD_URL
         assert result.generate_audio is False  # turbo 无音频
-        dl.assert_awaited_once()
-        # text2video 提交端点
-        assert post.await_args.args[0].endswith("/videos/text2video")
+        assert result.video_path.read_bytes() == b"mp4-bytes"
 
     async def test_jwt_injected_on_submit(self, tmp_path):
-        captured: dict = {}
+        with _kling_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("succeed", url=_DOWNLOAD_URL)))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
 
-        async def _post(url, json, headers):
-            captured["headers"] = headers
-            return _resp(_submit())
-
-        post = AsyncMock(side_effect=_post)
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
             await _jwt_backend().generate(_request(tmp_path))
 
-        token = captured["headers"]["Authorization"].removeprefix("Bearer ")
+            token = only_request(routes.submit).headers["Authorization"].removeprefix("Bearer ")
+
         claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
         assert claims["iss"] == "ak-1"
 
     async def test_bearer_static_key_on_submit(self, tmp_path):
-        captured: dict = {}
+        with _kling_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("succeed", url=_DOWNLOAD_URL)))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
 
-        async def _post(url, json, headers):
-            captured["headers"] = headers
-            return _resp(_submit())
-
-        post = AsyncMock(side_effect=_post)
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
             await _bearer_backend().generate(_request(tmp_path))
-        assert captured["headers"]["Authorization"] == "Bearer static-key"
+
+            assert only_request(routes.submit).headers["Authorization"] == "Bearer static-key"
 
     async def test_failed_status_raises(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit()))
-        get = AsyncMock(return_value=_resp(_query("failed", status_msg="content rejected")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("failed", status_msg="content rejected")))
+
             with pytest.raises(RuntimeError, match="content rejected"):
                 await _jwt_backend().generate(_request(tmp_path))
 
+            assert routes.download.call_count == 0
+
     async def test_persists_provider_job_id_when_task_id_present(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit("task-x")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
-        ):
+        with _kling_api() as routes, captured_provider_job_ids() as persisted:
+            routes.submit.mock(return_value=_resp(_submit("task-x")))
+            routes.poll.mock(return_value=_resp(_query("succeed", url=_DOWNLOAD_URL)))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-1"))
-        persist.assert_awaited_once()
-        assert persist.await_args is not None
+
         # 持久化的是「子路径:task_id:有声标志」，resume 据此复原查询端点（text2video 因无首帧）+ 有声决策（turbo 恒 0）
-        assert persist.await_args.args[1] == "text2video:task-x:0"
+        assert [(r["task_id"], r["job_id"]) for r in persisted] == [("local-task-1", "text2video:task-x:0")]
 
     async def test_persists_image2video_subpath_in_job_id(self, tmp_path):
         img = tmp_path / "first.png"
         img.write_bytes(b"\x89PNG\r\n")
-        post = AsyncMock(return_value=_resp(_submit("task-i")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
-        ):
+        with _kling_api() as routes, captured_provider_job_ids() as persisted:
+            routes.submit.mock(return_value=_resp(_submit("task-i")))
+            routes.poll.mock(return_value=_resp(_query("succeed", url=_DOWNLOAD_URL)))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             await _jwt_backend().generate(_request(tmp_path, task_id="local-task-2", start_image=img))
+
         # 有首帧 → image2video 前缀编入 job_id，resume 才能查对端点
-        assert persist.await_args is not None
-        assert persist.await_args.args[1] == "image2video:task-i:0"
+        assert [r["job_id"] for r in persisted] == ["image2video:task-i:0"]
 
 
 class TestResume:
     async def test_resume_polls_without_resubmit(self, tmp_path):
-        post = AsyncMock()  # must NOT be called
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()) as dl,
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b"resumed"))
+
             # 持久化 job_id 带 text2video 前缀 → 复原查询端点 + 还原裸 task_id
             result = await _jwt_backend().resume_video("text2video:task-resume", _request(tmp_path))
 
-        post.assert_not_called()
+            assert routes.submit.call_count == 0
+            assert only_request(routes.poll).url.path == "/v1/videos/text2video/task-resume"
+
         assert result.task_id == "task-resume"
         assert result.video_uri == "https://x/r.mp4"
-        assert get.await_args.args[0].endswith("/videos/text2video/task-resume")
-        dl.assert_awaited_once()
+        assert result.video_path.read_bytes() == b"resumed"
 
     async def test_resume_image2video_subpath_from_encoded_job_id(self, tmp_path):
         # resume 请求不带 start_image（真实重启路径如此）：子路径必须来自持久化 job_id 前缀，
         # 否则 image2video 任务会误查 text2video 端点取不到。
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend().resume_video("image2video:task-r2", _request(tmp_path))
-        post.assert_not_called()
+
+            assert routes.submit.call_count == 0
+            assert only_request(routes.poll).url.path == "/v1/videos/image2video/task-r2"
+
         assert result.task_id == "task-r2"
-        assert get.await_args.args[0].endswith("/videos/image2video/task-r2")
 
     async def test_resume_bare_job_id_falls_back_to_text2video(self, tmp_path):
         # 无已知前缀（异常/旧数据）回落 text2video，整串作 task_id。
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend().resume_video("legacy-bare-id", _request(tmp_path))
+
+            assert only_request(routes.poll).url.path == "/v1/videos/text2video/legacy-bare-id"
+
         assert result.task_id == "legacy-bare-id"
-        assert get.await_args.args[0].endswith("/videos/text2video/legacy-bare-id")
 
     async def test_resume_multi_image2video_subpath_from_encoded_job_id(self, tmp_path):
         # 多图主体任务 resume：子路径从持久化 job_id 前缀复原，查 multi-image2video 端点。
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend("kling-v3-omni").resume_video("multi-image2video:task-m", _request(tmp_path))
-        post.assert_not_called()
+
+            assert routes.submit.call_count == 0
+            assert only_request(routes.poll).url.path == "/v1/videos/multi-image2video/task-m"
+
         assert result.task_id == "task-m"
-        assert get.await_args.args[0].endswith("/videos/multi-image2video/task-m")
 
 
 class TestAudioGatingResult:
+    @staticmethod
+    @contextmanager
+    def _succeeding(task_id: str) -> Iterator[_KlingRoutes]:
+        """submit 成功 → 一次轮询直接终态 → 下载空片，只留有声决策作观察点。"""
+        with _kling_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit(task_id)))
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+            yield routes
+
     async def test_v2_6_pro_audio_result_true(self, tmp_path):
         # v2-6 pro（即 1080P 档）+ 请求有声 → result.generate_audio=True（下游计费取有声价）
-        post = AsyncMock(return_value=_resp(_submit("task-a")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with self._succeeding("task-a") as routes:
             result = await _jwt_backend("kling-v2-6").generate(
                 _request(tmp_path, resolution="1080p", service_tier="pro", generate_audio=True)
             )
+            assert only_request(routes.submit).url.path == "/v1/videos/text2video"
+
         assert result.generate_audio is True
-        assert post.await_args.args[0].endswith("/videos/text2video")
 
     async def test_v2_6_std_audio_result_false(self, tmp_path):
         # std 档拿不到 1080P：即使 request.resolution 写 1080p，结果也必须记为无声，
         # 否则拿到无声片却按有声价（¥1.0/s vs ¥0.8/s）出账
-        post = AsyncMock(return_value=_resp(_submit("task-a2")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with self._succeeding("task-a2"):
             result = await _jwt_backend("kling-v2-6").generate(
                 _request(tmp_path, resolution="1080p", service_tier="std", generate_audio=True)
             )
+
         assert result.generate_audio is False
 
     async def test_v3_audio_result_true(self, tmp_path):
         # v3 支持音画同出且无分辨率约束：请求有声 → result.generate_audio=True
-        post = AsyncMock(return_value=_resp(_submit("task-b")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with self._succeeding("task-b"):
             result = await _jwt_backend("kling-v3").generate(_request(tmp_path, generate_audio=True))
+
         assert result.generate_audio is True
 
     async def test_turbo_audio_gated_result_false(self, tmp_path):
         # turbo 无音频能力：即使请求有声，result.generate_audio=False（计费取无声价）
-        post = AsyncMock(return_value=_resp(_submit("task-b2")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with self._succeeding("task-b2"):
             result = await _jwt_backend().generate(_request(tmp_path, resolution="1080p", generate_audio=True))
+
         assert result.generate_audio is False
 
     async def test_v3_omni_multi_image_audio_result_false(self, tmp_path):
@@ -710,89 +672,69 @@ class TestAudioGatingResult:
         # result.generate_audio 必须同步为 False，否则按有声价出账却拿到无声片
         ref = tmp_path / "ref0.png"
         ref.write_bytes(b"\x89PNG\r\n")
-        post = AsyncMock(return_value=_resp(_submit("task-b3")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with self._succeeding("task-b3") as routes:
             result = await _jwt_backend("kling-v3-omni").generate(
                 _request(tmp_path, reference_images=[ref], resolution="1080p", generate_audio=True)
             )
-        assert post.await_args.args[0].endswith("/videos/multi-image2video")
+            assert only_request(routes.submit).url.path == "/v1/videos/multi-image2video"
+
         assert result.generate_audio is False
 
     async def test_v2_6_persists_audio_bit_in_job_id(self, tmp_path):
         # submit 时算定的有声决策编入 job_id（v2-6 pro 有声 → 末段 :1），resume 据此直连计费
-        post = AsyncMock(return_value=_resp(_submit("task-c")))
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/v.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
-        ):
+        with self._succeeding("task-c"), captured_provider_job_ids() as persisted:
             await _jwt_backend("kling-v2-6").generate(
                 _request(tmp_path, task_id="local-a", service_tier="pro", generate_audio=True)
             )
-        assert persist.await_args is not None
-        assert persist.await_args.args[1] == "text2video:task-c:1"
+
+        assert [r["job_id"] for r in persisted] == ["text2video:task-c:1"]
 
     async def test_resume_reuses_persisted_audio_over_recompute(self, tmp_path):
         # 持久化有声标志（:1）优先于 resume 时按请求重算：即使请求 generate_audio=False，
         # 结果仍取 submit 时算定的有声（避免计费漂移）
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend("kling-v2-6").resume_video(
                 "text2video:task-c:1", _request(tmp_path, service_tier="pro", generate_audio=False)
             )
-        post.assert_not_called()
+
+            assert routes.submit.call_count == 0
+            # 锁定解析契约：3 段 job_id 的有声末段不得漏进 task_id，子路径/任务号须正确复原
+            assert only_request(routes.poll).url.path == "/v1/videos/text2video/task-c"
+
         assert result.generate_audio is True
-        # 锁定解析契约：3 段 job_id 的有声末段不得漏进 task_id，子路径/任务号须正确复原
         assert result.task_id == "task-c"
-        assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
     async def test_resume_legacy_job_id_stays_silent(self, tmp_path):
         # 不含有声标志的 2 段 job_id 一律判无声：这类任务的成片必然无声，不得按当前能力表重算为有声
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend("kling-v2-6").resume_video(
                 "text2video:task-c", _request(tmp_path, service_tier="pro", generate_audio=True)
             )
-        post.assert_not_called()
+
+            assert routes.submit.call_count == 0
+            # 2 段旧 job_id 同样须正确复原子路径/任务号（不误把整串当 task_id）
+            assert only_request(routes.poll).url.path == "/v1/videos/text2video/task-c"
+
         assert result.generate_audio is False
-        # 2 段旧 job_id 同样须正确复原子路径/任务号（不误把整串当 task_id）
         assert result.task_id == "task-c"
-        assert get.await_args.args[0].endswith("/videos/text2video/task-c")
 
     async def test_resume_legacy_multi_image_job_id_stays_silent(self, tmp_path):
         # 多图主体子路径的成片必然无声：接续请求不带参考图字段，判据只能取自解码出的子路径
-        post = AsyncMock()
-        get = AsyncMock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.kling._KLING_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.kling.download_video", new=AsyncMock()),
-        ):
+        with _kling_api() as routes:
+            routes.poll.mock(return_value=_resp(_query("succeed", url="https://x/r.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend("kling-v3-omni").resume_video(
                 "multi-image2video:task-d", _request(tmp_path, generate_audio=True)
             )
-        post.assert_not_called()
+
+            assert routes.submit.call_count == 0
+            assert only_request(routes.poll).url.path == "/v1/videos/multi-image2video/task-d"
+
         assert result.generate_audio is False
-        assert get.await_args.args[0].endswith("/videos/multi-image2video/task-d")

--- a/tests/unit/lib/audio_backends/test_audio_backends.py
+++ b/tests/unit/lib/audio_backends/test_audio_backends.py
@@ -3,13 +3,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any, NamedTuple
+from unittest.mock import patch
 
 import httpx
 import pytest
+import respx
 
 from lib.audio_backends import (
     AudioCapability,
@@ -20,6 +23,7 @@ from lib.audio_backends import (
 )
 from lib.dashscope_shared import extract_audio_url
 from lib.providers import PROVIDER_DASHSCOPE
+from tests.http_capture import capture_http, only_request, request_json
 
 
 class TestRegistry:
@@ -62,27 +66,37 @@ class TestExtractAudioUrl:
             extract_audio_url({"code": "InvalidApiKey", "message": "bad key"})
 
 
-def _synth_response(url: str = "https://x/out.wav") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"output": {"audio": {"url": url}}}
-    return resp
+_SYNTH_URL = "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
+_AUDIO_URL = "https://x/out.wav"
 
 
-def _download_response(content: bytes = b"RIFFfakewav") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.content = content
-    return resp
+class _DashScopeRoutes(NamedTuple):
+    synthesize: respx.Route
+    download: respx.Route
 
 
-def _mock_client(post_resp: httpx.Response | MagicMock, get_resp: httpx.Response | MagicMock) -> AsyncMock:
-    client = AsyncMock()
-    client.post = AsyncMock(return_value=post_resp)
-    client.get = AsyncMock(return_value=get_resp)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+@contextmanager
+def _dashscope_audio_routes(
+    *,
+    synth: httpx.Response | None = None,
+    download: httpx.Response | list[httpx.Response | Exception] | None = None,
+    audio_url: str = _AUDIO_URL,
+    synth_url: str = _SYNTH_URL,
+) -> Iterator[_DashScopeRoutes]:
+    """DashScope TTS 的两条出站流：合成 POST 与音频 GET。
+
+    走 respx 在 transport 层拦截，断言对象是真实序列化后的请求（URL 拼接、鉴权头、body 编码
+    都在断言范围内），而不是客户端替身记录的调用参数。
+    """
+    with capture_http() as router:
+        synth_route = router.post(synth_url)
+        synth_route.mock(return_value=synth or httpx.Response(200, json={"output": {"audio": {"url": audio_url}}}))
+        download_route = router.get(audio_url)
+        if isinstance(download, list):
+            download_route.mock(side_effect=download)
+        else:
+            download_route.mock(return_value=download or httpx.Response(200, content=b"RIFFfakewav"))
+        yield _DashScopeRoutes(synthesize=synth_route, download=download_route)
 
 
 class TestDashScopeAudioBackend:
@@ -113,27 +127,26 @@ class TestDashScopeAudioBackend:
         assert voices is not b.list_voices()
 
     async def test_synthesize_request_and_download(self, tmp_path: Path):
-        client = _mock_client(_synth_response(), _download_response(b"RIFFwavbytes"))
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        with _dashscope_audio_routes(download=httpx.Response(200, content=b"RIFFwavbytes")) as routes:
             b = DashScopeAudioBackend(api_key="sk", model="qwen3-tts-flash", base_url="https://dashscope.aliyuncs.com")
             out = tmp_path / "o.wav"
             result = await b.synthesize(
                 AudioSynthesisRequest(text="你好世界", output_path=out, voice="Cherry", language_type="Chinese")
             )
 
-        body = client.post.call_args.kwargs["json"]
+        submitted = only_request(routes.synthesize)
+        body = request_json(submitted)
         assert body["model"] == "qwen3-tts-flash"
         assert body["input"] == {"text": "你好世界", "voice": "Cherry", "language_type": "Chinese"}
         # 同步 TTS 不带 async 头
-        headers = client.post.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer sk"
-        assert "X-DashScope-Async" not in headers
+        assert submitted.headers["Authorization"] == "Bearer sk"
+        assert "X-DashScope-Async" not in submitted.headers
         # 端点：host 派生 /api/v1 + 多模态生成路径
-        assert client.post.call_args.args[0].endswith("/api/v1/services/aigc/multimodal-generation/generation")
+        assert submitted.url.path == "/api/v1/services/aigc/multimodal-generation/generation"
         # 下载 URL 命中响应里的 audio.url
-        assert client.get.call_args.args[0] == "https://x/out.wav"
+        assert str(only_request(routes.download).url) == _AUDIO_URL
         # 字节落盘 + 结果字段
         assert out.read_bytes() == b"RIFFwavbytes"
         assert result.provider == PROVIDER_DASHSCOPE
@@ -143,118 +156,105 @@ class TestDashScopeAudioBackend:
 
     async def test_speed_param_ignored(self, tmp_path: Path):
         # speed 仅 realtime 支持，同步模型忽略（不报错、请求体不带 speed）
-        client = _mock_client(_synth_response(), _download_response())
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        with _dashscope_audio_routes() as routes:
             b = DashScopeAudioBackend(api_key="sk")
             await b.synthesize(
                 AudioSynthesisRequest(text="hi", output_path=tmp_path / "s.wav", voice="Ethan", speed=1.5)
             )
-        body = client.post.call_args.kwargs["json"]
+
+        body = request_json(only_request(routes.synthesize))
         assert "speed" not in body["input"]
         assert "speech_rate" not in body["input"]
 
     async def test_http_error_raises(self, tmp_path: Path):
         # 4xx 透出 httpx.HTTPStatusError（与其余 backend 一致），不嵌响应体进异常消息；提交按状态码不可重试
-        err_resp = httpx.Response(400, text="bad request", request=httpx.Request("POST", "https://x"))
-        client = _mock_client(err_resp, _download_response())
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        with _dashscope_audio_routes(synth=httpx.Response(400, text="bad request")) as routes:
             b = DashScopeAudioBackend(api_key="sk")
             with pytest.raises(httpx.HTTPStatusError):
                 await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="Cherry"))
+
         # 4xx 按 status_code fail-fast：计费的合成 POST 只发一次、不连带触发下载
-        assert client.post.call_count == 1
-        client.get.assert_not_called()
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == 0
 
     async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, poll_clock):
         # 4xx 错误消息带 "503" 子串（请求 URL/task_id）：旧字符串兜底会据此误判重试到超时，
         # 新状态码谓词只读 response.status_code，按 400 fail-fast——计费的合成 POST 只发一次、不连带下载。
-        err_resp = httpx.Response(
-            400, text="bad request", request=httpx.Request("POST", "https://x/api/v1/tasks/job-503")
-        )
-        client = _mock_client(err_resp, _download_response())
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
-            b = DashScopeAudioBackend(api_key="sk")
+        # host 里带 503 让异常文本命中瞬态子串——真实形态是请求 URL / task_id 里出现的数字
+        host = "https://dashscope-503.example.com"
+        with _dashscope_audio_routes(
+            synth=httpx.Response(400, text="bad request"),
+            synth_url=f"{host}/api/v1/services/aigc/multimodal-generation/generation",
+        ) as routes:
+            b = DashScopeAudioBackend(api_key="sk", base_url=host)
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.synthesize(AudioSynthesisRequest(text="x", output_path=tmp_path / "e.wav", voice="Cherry"))
+
         # 异常字符串确实带瞬态子串（旧兜底据此误判重试的前提）；新谓词按状态码单次 fail-fast
         assert "503" in str(ei.value)
         assert ei.value.response.status_code == 400
-        assert client.post.call_count == 1
-        client.get.assert_not_called()
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == 0
 
     async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, poll_clock):
         # 下载瞬时失败只重试 GET，绝不回头重跑会再次计费的合成 POST。
-        client = AsyncMock()
-        client.post = AsyncMock(return_value=_synth_response())
-        client.get = AsyncMock(side_effect=[httpx.ConnectError("transient"), _download_response(b"ok")])
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        with _dashscope_audio_routes(
+            download=[httpx.ConnectError("transient"), httpx.Response(200, content=b"ok")]
+        ) as routes:
             b = DashScopeAudioBackend(api_key="sk")
             out = tmp_path / "d.wav"
             await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="Cherry"))
 
         # 合成 POST 只发一次（未被下载重试连带重跑 → 不重复计费），下载 GET 重试到第 2 次成功
-        assert client.post.call_count == 1
-        assert client.get.call_count == 2
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == 2
         assert out.read_bytes() == b"ok"
 
     async def test_empty_download_retried_then_rejected_no_file(self, tmp_path: Path, poll_clock):
         # 200 但空体视为瞬态：重试到下载上限后失败，不写 0 字节 wav，合成 POST 不被重跑。
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
         from lib.retry import DOWNLOAD_MAX_ATTEMPTS
 
-        client = AsyncMock()
-        client.post = AsyncMock(return_value=_synth_response())
-        client.get = AsyncMock(return_value=_download_response(b""))
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
-
+        with _dashscope_audio_routes(download=httpx.Response(200, content=b"")) as routes:
             b = DashScopeAudioBackend(api_key="sk")
             out = tmp_path / "empty.wav"
             with pytest.raises(RuntimeError, match="空内容"):
                 await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="Cherry"))
 
-        assert client.post.call_count == 1
-        assert client.get.call_count == DOWNLOAD_MAX_ATTEMPTS
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == DOWNLOAD_MAX_ATTEMPTS
         assert not out.exists()
 
     async def test_empty_download_transient_recovers(self, tmp_path: Path, poll_clock):
         # 空体一次后恢复：重试拿到字节落盘，合成 POST 不被重跑
-        client = AsyncMock()
-        client.post = AsyncMock(return_value=_synth_response())
-        client.get = AsyncMock(side_effect=[_download_response(b""), _download_response(b"ok")])
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        with _dashscope_audio_routes(
+            download=[httpx.Response(200, content=b""), httpx.Response(200, content=b"ok")]
+        ) as routes:
             b = DashScopeAudioBackend(api_key="sk")
             out = tmp_path / "recover.wav"
             await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="Cherry"))
 
-        assert client.post.call_count == 1
-        assert client.get.call_count == 2
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == 2
         assert out.read_bytes() == b"ok"
 
     async def test_download_http_error_raises(self, tmp_path: Path, poll_clock):
         # 下载 4xx：透出 httpx.HTTPStatusError 且不写文件、不被误判可重试、合成 POST 不被重跑；
         # 异常文本不携带预签名 query（有效期内等同下载凭证）
-        signed_url = "https://x/out.wav?Expires=1&Signature=topsecret"
-        err_resp = httpx.Response(404, request=httpx.Request("GET", signed_url))
-        client = _mock_client(_synth_response(signed_url), err_resp)
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.audio_backends.dashscope import DashScopeAudioBackend
+        from lib.audio_backends.dashscope import DashScopeAudioBackend
 
+        signed_url = "https://x/out.wav?Expires=1&Signature=topsecret"
+        with _dashscope_audio_routes(audio_url=signed_url, download=httpx.Response(404)) as routes:
             b = DashScopeAudioBackend(api_key="sk")
             out = tmp_path / "err.wav"
             with pytest.raises(httpx.HTTPStatusError) as excinfo:
@@ -263,8 +263,8 @@ class TestDashScopeAudioBackend:
         assert "Signature" not in str(excinfo.value)
         assert "https://x/out.wav" in str(excinfo.value)
         assert excinfo.value.response.status_code == 404
-        assert client.post.call_count == 1
-        assert client.get.call_count == 1, "4xx 不可重试，下载 GET 不应被重试"
+        assert routes.synthesize.call_count == 1
+        assert routes.download.call_count == 1, "4xx 不可重试，下载 GET 不应被重试"
         assert not out.exists()
 
 

--- a/tests/unit/lib/audio_backends/test_audio_backends.py
+++ b/tests/unit/lib/audio_backends/test_audio_backends.py
@@ -23,6 +23,7 @@ from lib.audio_backends import (
 )
 from lib.dashscope_shared import extract_audio_url
 from lib.providers import PROVIDER_DASHSCOPE
+from tests.fakes import captured_openai_clients
 from tests.http_capture import capture_http, only_request, request_json
 
 
@@ -292,7 +293,7 @@ def _mock_speech_client(content: bytes = b"RIFFwavbytes") -> _RecordingSpeechCli
 class TestOpenAIAudioBackend:
     async def test_synthesize_request_and_bytes(self, tmp_path: Path):
         mock_client = _mock_speech_client()
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", base_url="https://relay.example.com/v1", model="tts-1")
@@ -312,7 +313,7 @@ class TestOpenAIAudioBackend:
         assert result.output_path == out
 
     def test_metadata(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
             from lib.providers import PROVIDER_OPENAI
 
@@ -323,14 +324,14 @@ class TestOpenAIAudioBackend:
 
     def test_provider_name_override(self):
         # 包装层（自定义供应商）可用真实 provider 记账
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1", provider_name="custom-7")
             assert b.name == "custom-7"
 
     def test_list_voices_returns_official_catalog(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="gpt-4o-mini-tts")
@@ -340,7 +341,7 @@ class TestOpenAIAudioBackend:
             assert len(ids) == len(voices)
 
     def test_list_voices_excludes_unsupported_ids_for_legacy_models(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             for legacy_model in ("tts-1", "tts-1-hd"):
@@ -351,7 +352,7 @@ class TestOpenAIAudioBackend:
 
     def test_list_voices_returns_full_catalog_for_custom_openai_tts_endpoint(self):
         """自定义 openai-tts endpoint 未落入官方 legacy 集合时不额外收窄，保持既有兼容口径。"""
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="fish-audio-v1", provider_name="custom-7")
@@ -362,7 +363,7 @@ class TestOpenAIAudioBackend:
         """自定义供应商即使模型名恰好也叫 tts-1/tts-1-hd，也无法确定其继承官方同名模型的
         音色限制——legacy 收窄只对 provider_name 为官方 openai 时生效，避免对无法验证的
         第三方 endpoint 误收窄。"""
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             for legacy_model in ("tts-1", "tts-1-hd"):
@@ -372,7 +373,7 @@ class TestOpenAIAudioBackend:
 
     async def test_speed_passthrough_and_omitted_when_none(self, tmp_path: Path):
         mock_client = _mock_speech_client()
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
@@ -387,7 +388,7 @@ class TestOpenAIAudioBackend:
     async def test_language_type_not_sent(self, tmp_path: Path):
         # /v1/audio/speech 无语种字段（DashScope 特有），不应混入请求
         mock_client = _mock_speech_client()
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
@@ -400,7 +401,7 @@ class TestOpenAIAudioBackend:
 
     async def test_unknown_suffix_falls_back_to_wav(self, tmp_path: Path):
         mock_client = _mock_speech_client()
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
@@ -410,7 +411,7 @@ class TestOpenAIAudioBackend:
     async def test_empty_body_rejected_no_file_no_rebill(self, tmp_path: Path):
         # 200 + 空体：不落 0 字节文件、不重试（重试 = 再次计费）
         mock_client = _mock_speech_client(content=b"")
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
@@ -424,7 +425,7 @@ class TestOpenAIAudioBackend:
     async def test_write_failure_does_not_rebill_synthesis(self, tmp_path: Path, poll_clock):
         # 写盘瞬态失败（消息含可重试模式）不应回头重跑会再次计费的合成调用
         mock_client = _mock_speech_client()
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")

--- a/tests/unit/lib/audio_backends/test_audio_backends.py
+++ b/tests/unit/lib/audio_backends/test_audio_backends.py
@@ -169,10 +169,9 @@ class TestDashScopeAudioBackend:
         assert client.post.call_count == 1
         client.get.assert_not_called()
 
-    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, monkeypatch):
+    async def test_submit_4xx_with_transient_substring_no_retry(self, tmp_path: Path, poll_clock):
         # 4xx 错误消息带 "503" 子串（请求 URL/task_id）：旧字符串兜底会据此误判重试到超时，
         # 新状态码谓词只读 response.status_code，按 400 fail-fast——计费的合成 POST 只发一次、不连带下载。
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         err_resp = httpx.Response(
             400, text="bad request", request=httpx.Request("POST", "https://x/api/v1/tasks/job-503")
         )
@@ -189,9 +188,8 @@ class TestDashScopeAudioBackend:
         assert client.post.call_count == 1
         client.get.assert_not_called()
 
-    async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
+    async def test_download_failure_does_not_rebill_synthesis(self, tmp_path: Path, poll_clock):
         # 下载瞬时失败只重试 GET，绝不回头重跑会再次计费的合成 POST。
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         client = AsyncMock()
         client.post = AsyncMock(return_value=_synth_response())
         client.get = AsyncMock(side_effect=[httpx.ConnectError("transient"), _download_response(b"ok")])
@@ -209,11 +207,10 @@ class TestDashScopeAudioBackend:
         assert client.get.call_count == 2
         assert out.read_bytes() == b"ok"
 
-    async def test_empty_download_retried_then_rejected_no_file(self, tmp_path: Path, monkeypatch):
+    async def test_empty_download_retried_then_rejected_no_file(self, tmp_path: Path, poll_clock):
         # 200 但空体视为瞬态：重试到下载上限后失败，不写 0 字节 wav，合成 POST 不被重跑。
         from lib.retry import DOWNLOAD_MAX_ATTEMPTS
 
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         client = AsyncMock()
         client.post = AsyncMock(return_value=_synth_response())
         client.get = AsyncMock(return_value=_download_response(b""))
@@ -231,9 +228,8 @@ class TestDashScopeAudioBackend:
         assert client.get.call_count == DOWNLOAD_MAX_ATTEMPTS
         assert not out.exists()
 
-    async def test_empty_download_transient_recovers(self, tmp_path: Path, monkeypatch):
+    async def test_empty_download_transient_recovers(self, tmp_path: Path, poll_clock):
         # 空体一次后恢复：重试拿到字节落盘，合成 POST 不被重跑
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         client = AsyncMock()
         client.post = AsyncMock(return_value=_synth_response())
         client.get = AsyncMock(side_effect=[_download_response(b""), _download_response(b"ok")])
@@ -250,10 +246,9 @@ class TestDashScopeAudioBackend:
         assert client.get.call_count == 2
         assert out.read_bytes() == b"ok"
 
-    async def test_download_http_error_raises(self, tmp_path: Path, monkeypatch):
+    async def test_download_http_error_raises(self, tmp_path: Path, poll_clock):
         # 下载 4xx：透出 httpx.HTTPStatusError 且不写文件、不被误判可重试、合成 POST 不被重跑；
         # 异常文本不携带预签名 query（有效期内等同下载凭证）
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         signed_url = "https://x/out.wav?Expires=1&Signature=topsecret"
         err_resp = httpx.Response(404, request=httpx.Request("GET", signed_url))
         client = _mock_client(_synth_response(signed_url), err_resp)
@@ -426,9 +421,8 @@ class TestOpenAIAudioBackend:
         assert len(mock_client.requests) == 1
         assert not out.exists()
 
-    async def test_write_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
+    async def test_write_failure_does_not_rebill_synthesis(self, tmp_path: Path, poll_clock):
         # 写盘瞬态失败（消息含可重试模式）不应回头重跑会再次计费的合成调用
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         mock_client = _mock_speech_client()
         with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
             from lib.audio_backends.openai import OpenAIAudioBackend

--- a/tests/unit/lib/audio_backends/test_audio_backends.py
+++ b/tests/unit/lib/audio_backends/test_audio_backends.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -271,12 +273,25 @@ class TestDashScopeAudioBackend:
         assert not out.exists()
 
 
-def _mock_speech_client(content: bytes = b"RIFFwavbytes") -> AsyncMock:
-    speech_resp = MagicMock()
-    speech_resp.content = content
-    client = AsyncMock()
-    client.audio.speech.create = AsyncMock(return_value=speech_resp)
-    return client
+class _RecordingSpeechClient:
+    """OpenAI 兼容 TTS 客户端替身：记录每次 speech.create 的请求参数，回固定字节。
+
+    上线参数、落盘格式这些契约都是「发出去的请求长什么样」，断言落在 ``requests`` 里的
+    请求内容上，而不是替身的调用对象。
+    """
+
+    def __init__(self, content: bytes = b"RIFFwavbytes") -> None:
+        self.requests: list[dict[str, Any]] = []
+        self._response = SimpleNamespace(content=content)
+        self.audio = SimpleNamespace(speech=SimpleNamespace(create=self._create))
+
+    async def _create(self, **kwargs: Any) -> SimpleNamespace:
+        self.requests.append(kwargs)
+        return self._response
+
+
+def _mock_speech_client(content: bytes = b"RIFFwavbytes") -> _RecordingSpeechClient:
+    return _RecordingSpeechClient(content)
 
 
 class TestOpenAIAudioBackend:
@@ -289,7 +304,7 @@ class TestOpenAIAudioBackend:
             out = tmp_path / "o.wav"
             result = await b.synthesize(AudioSynthesisRequest(text="你好世界", output_path=out, voice="alloy"))
 
-        kwargs = mock_client.audio.speech.create.call_args.kwargs
+        kwargs = mock_client.requests[-1]
         assert kwargs["model"] == "tts-1"
         assert kwargs["input"] == "你好世界"
         assert kwargs["voice"] == "alloy"
@@ -367,12 +382,12 @@ class TestOpenAIAudioBackend:
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
             await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "a.wav", voice="alloy"))
-            assert "speed" not in mock_client.audio.speech.create.call_args.kwargs
+            assert "speed" not in mock_client.requests[-1]
 
             await b.synthesize(
                 AudioSynthesisRequest(text="hi", output_path=tmp_path / "b.wav", voice="alloy", speed=1.5)
             )
-            assert mock_client.audio.speech.create.call_args.kwargs["speed"] == 1.5
+            assert mock_client.requests[-1]["speed"] == 1.5
 
     async def test_language_type_not_sent(self, tmp_path: Path):
         # /v1/audio/speech 无语种字段（DashScope 特有），不应混入请求
@@ -384,7 +399,7 @@ class TestOpenAIAudioBackend:
             await b.synthesize(
                 AudioSynthesisRequest(text="hi", output_path=tmp_path / "c.wav", voice="alloy", language_type="Chinese")
             )
-        kwargs = mock_client.audio.speech.create.call_args.kwargs
+        kwargs = mock_client.requests[-1]
         assert "language_type" not in kwargs
         assert "language" not in kwargs
 
@@ -395,7 +410,7 @@ class TestOpenAIAudioBackend:
 
             b = OpenAIAudioBackend(api_key="sk", model="tts-1")
             await b.synthesize(AudioSynthesisRequest(text="hi", output_path=tmp_path / "x.bin", voice="alloy"))
-        assert mock_client.audio.speech.create.call_args.kwargs["response_format"] == "wav"
+        assert mock_client.requests[-1]["response_format"] == "wav"
 
     async def test_empty_body_rejected_no_file_no_rebill(self, tmp_path: Path):
         # 200 + 空体：不落 0 字节文件、不重试（重试 = 再次计费）
@@ -408,7 +423,7 @@ class TestOpenAIAudioBackend:
             with pytest.raises(RuntimeError, match="空响应体"):
                 await b.synthesize(AudioSynthesisRequest(text="hi", output_path=out, voice="alloy"))
 
-        assert mock_client.audio.speech.create.call_count == 1
+        assert len(mock_client.requests) == 1
         assert not out.exists()
 
     async def test_write_failure_does_not_rebill_synthesis(self, tmp_path: Path, monkeypatch):
@@ -426,4 +441,4 @@ class TestOpenAIAudioBackend:
                 with patch.object(type(req.output_path), "write_bytes", side_effect=OSError("Connection timed out")):
                     await b.synthesize(req)
 
-        assert mock_client.audio.speech.create.call_count == 1, "写盘失败不得重跑计费的合成调用"
+        assert len(mock_client.requests) == 1, "写盘失败不得重跑计费的合成调用"

--- a/tests/unit/lib/backend_assembly/test_backend_assembly_loader.py
+++ b/tests/unit/lib/backend_assembly/test_backend_assembly_loader.py
@@ -14,6 +14,7 @@ from lib.backend_assembly import assemble_backend
 from lib.backend_assembly.assembler import _load_builtin_config
 from lib.config.resolver import ConfigResolver
 from lib.config.service import ConfigService
+from tests.fakes import captured_backend_construction
 
 
 async def _seed_provider_config(factory, provider: str, **kv: str) -> None:
@@ -43,84 +44,115 @@ class TestLoadBuiltinConfig:
 
 
 class TestAssembleBuiltinEndToEnd:
-    @patch("lib.image_backends.registry.create_backend")
-    async def test_simple_image_end_to_end(self, mock_create, db_factory):
+    async def test_simple_image_end_to_end(self, db_factory):
         await _seed_provider_config(db_factory, "ark", api_key="ark-secret")
         resolver = ConfigResolver(db_factory)
-        await assemble_backend(provider_id="ark", media_type="image", model_id="doubao-x", resolver=resolver)
+        with captured_backend_construction() as built:
+            await assemble_backend(provider_id="ark", media_type="image", model_id="doubao-x", resolver=resolver)
         # 用户未配 base_url → 回落 registry default；凭证 overlay 经装载真进构造参数
-        mock_create.assert_called_once_with(
-            "ark", api_key="ark-secret", model="doubao-x", base_url="https://ark.cn-beijing.volces.com/api/v3"
-        )
+        assert built == [
+            {
+                "media": "image",
+                "backend": "ark",
+                "kwargs": {
+                    "api_key": "ark-secret",
+                    "model": "doubao-x",
+                    "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+                },
+            }
+        ]
 
     async def test_unknown_provider_media_fails_loud(self, db_factory):
         resolver = ConfigResolver(db_factory)
         with pytest.raises(ValueError, match="no builtin ProviderSpec"):
             await assemble_backend(provider_id="ark", media_type="audio", model_id="x", resolver=resolver)
 
-    @patch("lib.image_backends.registry.create_backend")
-    async def test_gemini_aistudio_image_end_to_end(self, mock_create, db_factory):
+    async def test_gemini_aistudio_image_end_to_end(self, db_factory):
         # gemini 特例族：provider_id 直接决定 backend_type，凭证 overlay + 共享 rate_limiter 经装载进闭包
         await _seed_provider_config(db_factory, "gemini-aistudio", api_key="g-secret", base_url="https://g.relay.test")
         sentinel = object()
         resolver = ConfigResolver(db_factory)
-        await assemble_backend(
-            provider_id="gemini-aistudio",
-            media_type="image",
-            model_id="gemini-3.1-flash-image-preview",
-            resolver=resolver,
-            rate_limiter=sentinel,
-        )
-        mock_create.assert_called_once_with(
-            "gemini",
-            backend_type="aistudio",
-            api_key="g-secret",
-            base_url="https://g.relay.test",
-            rate_limiter=sentinel,
-            image_model="gemini-3.1-flash-image-preview",
-        )
+        with captured_backend_construction() as built:
+            await assemble_backend(
+                provider_id="gemini-aistudio",
+                media_type="image",
+                model_id="gemini-3.1-flash-image-preview",
+                resolver=resolver,
+                rate_limiter=sentinel,
+            )
+        assert built == [
+            {
+                "media": "image",
+                "backend": "gemini",
+                "kwargs": {
+                    "backend_type": "aistudio",
+                    "api_key": "g-secret",
+                    "base_url": "https://g.relay.test",
+                    "rate_limiter": sentinel,
+                    "image_model": "gemini-3.1-flash-image-preview",
+                },
+            }
+        ]
 
-    @patch("lib.text_backends.registry.create_backend")
-    async def test_text_simple_end_to_end(self, mock_create, db_factory):
+    async def test_text_simple_end_to_end(self, db_factory):
         # 文本简单族：凭证 overlay 经装载真进构造参数，base_url 回落 registry default
         await _seed_provider_config(db_factory, "ark", api_key="ark-secret")
         resolver = ConfigResolver(db_factory)
-        await assemble_backend(provider_id="ark", media_type="text", model_id="doubao-x", resolver=resolver)
-        mock_create.assert_called_once_with(
-            "ark", model="doubao-x", api_key="ark-secret", base_url="https://ark.cn-beijing.volces.com/api/v3"
-        )
+        with captured_backend_construction() as built:
+            await assemble_backend(provider_id="ark", media_type="text", model_id="doubao-x", resolver=resolver)
+        assert built == [
+            {
+                "media": "text",
+                "backend": "ark",
+                "kwargs": {
+                    "model": "doubao-x",
+                    "api_key": "ark-secret",
+                    "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+                },
+            }
+        ]
 
-    @patch("lib.text_backends.registry.create_backend")
-    async def test_text_dashscope_compat_end_to_end(self, mock_create, db_factory):
+    async def test_text_dashscope_compat_end_to_end(self, db_factory):
         # dashscope 文本 OpenAI-compat：base_url 经 helper 派生、透传 provider_name 计费归因，端到端经缝
         await _seed_provider_config(db_factory, "dashscope", api_key="ds-secret")
         resolver = ConfigResolver(db_factory)
-        await assemble_backend(provider_id="dashscope", media_type="text", model_id="qwen-max", resolver=resolver)
-        mock_create.assert_called_once_with(
-            "openai",
-            model="qwen-max",
-            api_key="ds-secret",
-            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            provider_name="dashscope",
-        )
+        with captured_backend_construction() as built:
+            await assemble_backend(provider_id="dashscope", media_type="text", model_id="qwen-max", resolver=resolver)
+        assert built == [
+            {
+                "media": "text",
+                "backend": "openai",
+                "kwargs": {
+                    "model": "qwen-max",
+                    "api_key": "ds-secret",
+                    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                    "provider_name": "dashscope",
+                },
+            }
+        ]
 
-    @patch("lib.image_backends.registry.create_backend")
-    async def test_kling_image_api_model_name_decoupled_end_to_end(self, mock_create, db_factory):
+    async def test_kling_image_api_model_name_decoupled_end_to_end(self, db_factory):
         # kling 特例族：双 secret overlay 真进闭包；api_model_name 解耦从 registry models 读到（别名键）
         await _seed_provider_config(db_factory, "kling", access_key="ak-1", secret_key="sk-1")
         resolver = ConfigResolver(db_factory)
-        await assemble_backend(
-            provider_id="kling", media_type="image", model_id="kling-v3-omni-image", resolver=resolver
-        )
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="jwt",
-            access_key="ak-1",
-            secret_key="sk-1",
-            model="kling-v3-omni-image",
-            api_model_name="kling-v3-omni",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        with captured_backend_construction() as built:
+            await assemble_backend(
+                provider_id="kling", media_type="image", model_id="kling-v3-omni-image", resolver=resolver
+            )
+        assert built == [
+            {
+                "media": "image",
+                "backend": "kling",
+                "kwargs": {
+                    "auth_mode": "jwt",
+                    "access_key": "ak-1",
+                    "secret_key": "sk-1",
+                    "model": "kling-v3-omni-image",
+                    "api_model_name": "kling-v3-omni",
+                    "base_url": "https://api-beijing.klingai.com/v1",
+                },
+            }
+        ]
 
 
 class TestAssembleCustomEndToEnd:

--- a/tests/unit/lib/backend_assembly/test_backend_assembly_specs.py
+++ b/tests/unit/lib/backend_assembly/test_backend_assembly_specs.py
@@ -67,7 +67,7 @@ class TestBuildSimpleBaseUrlPriority:
 
     def test_ark_agent_plan_uses_own_plan_base_url(self):
         # ark-agent-plan 媒体侧复用 Ark backend，但 registry default 是独立的 /api/plan/v3
-        # （非 ark 的 /api/v3）——回归保护：迁移前经简单族构造即取此值，新缝须一致。
+        # （非 ark 的 /api/v3）。
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="ark-agent-plan")
         assert _built(get_provider_spec("ark-agent-plan", "video"), config, "doubao-seedance-2.0") == {
             "media": "video",
@@ -278,7 +278,7 @@ class TestKlingSpec:
         spec = get_provider_spec("kling", "video")
         assert spec.registry_backend == "kling"
         config = self._kling_config(access_key="ak-1", secret_key="sk-1")
-        # video backend 不接受 api_model_name：即使 model 是别名也不传该参数（迁移前 video 分支即不设）
+        # video backend 不接受 api_model_name：即使 model 是别名也不传该参数
         assert _built(spec, config, "kling-v3") == {
             "media": "video",
             "backend": "kling",
@@ -376,8 +376,7 @@ class TestTextSimpleSpec:
         }
 
     def test_api_key_passed_unconditionally_even_when_missing(self):
-        # 文本简单族 api_key 无条件透传（含 None）：保留迁移前命令式分支语义，
-        # 与媒体简单族「缺省省略」非对称。
+        # 文本简单族 api_key 无条件透传（含 None），与媒体简单族「缺省省略」非对称。
         config = _loaded(credentials={}, provider_id="grok")
         assert _built(get_provider_spec("grok", "text"), config, "grok-4")["kwargs"] == {
             "model": "grok-4",

--- a/tests/unit/lib/backend_assembly/test_backend_assembly_specs.py
+++ b/tests/unit/lib/backend_assembly/test_backend_assembly_specs.py
@@ -1,23 +1,26 @@
 """内置 ProviderSpec 表 + _build_simple 闭包的 sync 构造单测。
 
-镜像 test_custom_provider_factory.py：patch 各 backend 类、手搓 LoadedConfig 信封、
-断言 backend 类被以正确构造参数调用。逐 (provider, media) 覆盖简单族 base_url 优先级特例。
+装配层的产出是「往哪个 media registry、用什么后端名、什么构造参数建后端」：用记录型工厂
+替下四个 registry 的真实后端，逐 (provider, media) 断言整条构造记录，覆盖简单族 base_url
+优先级、gemini/kling 特例族的分叉与参数解耦。
 """
 
 from __future__ import annotations
 
 import dataclasses
-from unittest.mock import patch
+from typing import Any
 
 import pytest
 
 from lib.backend_assembly.loaded_config import LoadedConfig
 from lib.backend_assembly.specs import (
     PROVIDER_SPEC_REGISTRY,
+    ProviderSpec,
     _validate_provider_specs,
     get_provider_spec,
 )
 from lib.config.registry import PROVIDER_REGISTRY
+from tests.fakes import captured_backend_construction
 
 
 def _loaded(*, credentials: dict, provider_id: str) -> LoadedConfig:
@@ -28,103 +31,109 @@ def _loaded(*, credentials: dict, provider_id: str) -> LoadedConfig:
     )
 
 
+def _built(spec: ProviderSpec, config: LoadedConfig, model: str | None) -> dict[str, Any]:
+    """跑一次装配，返回唯一一条构造记录（media / backend 名 / 构造参数）。"""
+    with captured_backend_construction() as records:
+        spec.build_backend(config, model)
+    assert len(records) == 1
+    return records[0]
+
+
 class TestBuildSimpleBaseUrlPriority:
     """简单族 base_url 优先级：用户显式 > registry default > 不传。"""
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_ark_image_falls_back_to_registry_default(self, mock_create):
-        spec = get_provider_spec("ark", "image")
+    def test_ark_image_falls_back_to_registry_default(self):
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="ark")
-        spec.build_backend(config, "doubao-seed-2-0-pro-260215")
-        mock_create.assert_called_once_with(
-            "ark",
-            api_key="sk-test",
-            model="doubao-seed-2-0-pro-260215",
-            base_url="https://ark.cn-beijing.volces.com/api/v3",
-        )
+        assert _built(get_provider_spec("ark", "image"), config, "doubao-seed-2-0-pro-260215") == {
+            "media": "image",
+            "backend": "ark",
+            "kwargs": {
+                "api_key": "sk-test",
+                "model": "doubao-seed-2-0-pro-260215",
+                "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            },
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_user_base_url_wins_over_registry_default(self, mock_create):
-        spec = get_provider_spec("ark", "image")
+    def test_user_base_url_wins_over_registry_default(self):
         config = _loaded(
             credentials={"api_key": "sk-test", "base_url": "https://custom.example.com/v3"},
             provider_id="ark",
         )
-        spec.build_backend(config, "model-x")
-        mock_create.assert_called_once_with(
-            "ark", api_key="sk-test", model="model-x", base_url="https://custom.example.com/v3"
-        )
+        assert _built(get_provider_spec("ark", "image"), config, "model-x")["kwargs"] == {
+            "api_key": "sk-test",
+            "model": "model-x",
+            "base_url": "https://custom.example.com/v3",
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_ark_agent_plan_uses_own_plan_base_url(self, mock_create):
+    def test_ark_agent_plan_uses_own_plan_base_url(self):
         # ark-agent-plan 媒体侧复用 Ark backend，但 registry default 是独立的 /api/plan/v3
         # （非 ark 的 /api/v3）——回归保护：迁移前经简单族构造即取此值，新缝须一致。
-        spec = get_provider_spec("ark-agent-plan", "video")
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="ark-agent-plan")
-        spec.build_backend(config, "doubao-seedance-2.0")
-        mock_create.assert_called_once_with(
-            "ark-agent-plan",
-            api_key="sk-test",
-            model="doubao-seedance-2.0",
-            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-        )
+        assert _built(get_provider_spec("ark-agent-plan", "video"), config, "doubao-seedance-2.0") == {
+            "media": "video",
+            "backend": "ark-agent-plan",
+            "kwargs": {
+                "api_key": "sk-test",
+                "model": "doubao-seedance-2.0",
+                "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
+            },
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_grok_image_no_default_no_user_omits_base_url(self, mock_create):
+    def test_grok_image_no_default_no_user_omits_base_url(self):
         # grok 无 registry default 且用户未配 → 不传 base_url（grok backend 不接受该参数）
-        spec = get_provider_spec("grok", "image")
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="grok")
-        spec.build_backend(config, "grok-2-image")
-        mock_create.assert_called_once_with("grok", api_key="sk-test", model="grok-2-image")
+        assert _built(get_provider_spec("grok", "image"), config, "grok-2-image")["kwargs"] == {
+            "api_key": "sk-test",
+            "model": "grok-2-image",
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_missing_api_key_omitted_so_sdk_env_fallback_survives(self, mock_create):
+    def test_missing_api_key_omitted_so_sdk_env_fallback_survives(self):
         # 用户未配 api_key → 不传 api_key（而非传 None）：让 backend 各自决定环境变量兜底
         # （OpenAI SDK 读 OPENAI_API_KEY）或 fail-loud；显式 None 会覆盖兜底。
-        spec = get_provider_spec("openai", "image")
         config = _loaded(credentials={}, provider_id="openai")
-        spec.build_backend(config, "gpt-image-1")
-        mock_create.assert_called_once_with("openai", model="gpt-image-1")
+        assert _built(get_provider_spec("openai", "image"), config, "gpt-image-1")["kwargs"] == {"model": "gpt-image-1"}
 
 
 class TestMediaRegistryRouting:
     """_build_simple 按 media_type 选对应 registry 的 create_backend（唯一分支逻辑）。"""
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_dashscope_video_uses_video_registry_and_default(self, mock_create):
-        spec = get_provider_spec("dashscope", "video")
+    def test_dashscope_video_uses_video_registry_and_default(self):
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="dashscope")
-        spec.build_backend(config, "wan2.7-r2v")
-        mock_create.assert_called_once_with(
-            "dashscope", api_key="sk-test", model="wan2.7-r2v", base_url="https://dashscope.aliyuncs.com"
-        )
+        assert _built(get_provider_spec("dashscope", "video"), config, "wan2.7-r2v") == {
+            "media": "video",
+            "backend": "dashscope",
+            "kwargs": {
+                "api_key": "sk-test",
+                "model": "wan2.7-r2v",
+                "base_url": "https://dashscope.aliyuncs.com",
+            },
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_dashscope_video_passes_wan3_base_url(self, mock_create):
+    def test_dashscope_video_passes_wan3_base_url(self):
         # wan3 专用 maas 域名单列一键，仅 video lane 消费；未填时不写入 kwargs
-        spec = get_provider_spec("dashscope", "video")
         config = _loaded(
             credentials={"api_key": "sk-test", "wan3_base_url": "https://maas.example.com/ws-1/api/v1"},
             provider_id="dashscope",
         )
-        spec.build_backend(config, "wan3.0-video")
-        assert mock_create.call_args.kwargs["wan3_base_url"] == "https://maas.example.com/ws-1/api/v1"
+        built = _built(get_provider_spec("dashscope", "video"), config, "wan3.0-video")
+        assert built["kwargs"]["wan3_base_url"] == "https://maas.example.com/ws-1/api/v1"
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_dashscope_video_omits_unset_wan3_base_url(self, mock_create):
-        spec = get_provider_spec("dashscope", "video")
+    def test_dashscope_video_omits_unset_wan3_base_url(self):
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="dashscope")
-        spec.build_backend(config, "wan3.0-video")
-        assert "wan3_base_url" not in mock_create.call_args.kwargs
+        built = _built(get_provider_spec("dashscope", "video"), config, "wan3.0-video")
+        assert "wan3_base_url" not in built["kwargs"]
 
-    @patch("lib.audio_backends.registry.create_backend")
-    def test_dashscope_audio_uses_audio_registry(self, mock_create):
-        spec = get_provider_spec("dashscope", "audio")
+    def test_dashscope_audio_uses_audio_registry(self):
         config = _loaded(credentials={"api_key": "sk-test"}, provider_id="dashscope")
-        spec.build_backend(config, "qwen3-tts-flash")
-        mock_create.assert_called_once_with(
-            "dashscope", api_key="sk-test", model="qwen3-tts-flash", base_url="https://dashscope.aliyuncs.com"
-        )
+        assert _built(get_provider_spec("dashscope", "audio"), config, "qwen3-tts-flash") == {
+            "media": "audio",
+            "backend": "dashscope",
+            "kwargs": {
+                "api_key": "sk-test",
+                "model": "qwen3-tts-flash",
+                "base_url": "https://dashscope.aliyuncs.com",
+            },
+        }
 
 
 class TestGeminiSpec:
@@ -133,8 +142,7 @@ class TestGeminiSpec:
     （含 None）：由 backend 内 resolve_gemini_api_key / normalize_base_url 处理 None（读环境变量 / 省略），
     vertex 分支结构性忽略 base_url（vertexai=True + 服务账号凭证，无注入点）。"""
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_aistudio_image_sets_base_url_and_image_model(self, mock_create):
+    def test_aistudio_image_sets_base_url_and_image_model(self):
         spec = get_provider_spec("gemini-aistudio", "image")
         assert spec.registry_backend == "gemini"
         limiter = object()
@@ -143,37 +151,34 @@ class TestGeminiSpec:
             provider_meta=PROVIDER_REGISTRY.get("gemini-aistudio"),
             rate_limiter=limiter,
         )
-        spec.build_backend(config, "gemini-3.1-flash-image-preview")
-        mock_create.assert_called_once_with(
-            "gemini",
-            backend_type="aistudio",
-            api_key="sk-aistudio",
-            base_url="https://custom.example.com",
-            rate_limiter=limiter,
-            image_model="gemini-3.1-flash-image-preview",
-        )
+        assert _built(spec, config, "gemini-3.1-flash-image-preview") == {
+            "media": "image",
+            "backend": "gemini",
+            "kwargs": {
+                "backend_type": "aistudio",
+                "api_key": "sk-aistudio",
+                "base_url": "https://custom.example.com",
+                "rate_limiter": limiter,
+                "image_model": "gemini-3.1-flash-image-preview",
+            },
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_vertex_image_backend_type_vertex(self, mock_create):
-        spec = get_provider_spec("gemini-vertex", "image")
+    def test_vertex_image_backend_type_vertex(self):
         config = LoadedConfig(
             credentials={"api_key": None, "base_url": None},
             provider_meta=PROVIDER_REGISTRY.get("gemini-vertex"),
             rate_limiter=None,
         )
-        spec.build_backend(config, None)
         # vertex 无 api_key/base_url：仍无条件透传 None（backend 内回落凭证文件 / 省略 base_url）
-        mock_create.assert_called_once_with(
-            "gemini",
-            backend_type="vertex",
-            api_key=None,
-            base_url=None,
-            rate_limiter=None,
-            image_model=None,
-        )
+        assert _built(get_provider_spec("gemini-vertex", "image"), config, None)["kwargs"] == {
+            "backend_type": "vertex",
+            "api_key": None,
+            "base_url": None,
+            "rate_limiter": None,
+            "image_model": None,
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_aistudio_video_sets_base_url_uses_video_model(self, mock_create):
+    def test_aistudio_video_sets_base_url_uses_video_model(self):
         spec = get_provider_spec("gemini-aistudio", "video")
         assert spec.registry_backend == "gemini"
         limiter = object()
@@ -182,35 +187,33 @@ class TestGeminiSpec:
             provider_meta=PROVIDER_REGISTRY.get("gemini-aistudio"),
             rate_limiter=limiter,
         )
-        spec.build_backend(config, "veo-3.1-lite-generate-preview")
         # video 与 image 对等：aistudio 透传用户 base_url，命名参数是 video_model 不是 image_model
-        mock_create.assert_called_once_with(
-            "gemini",
-            backend_type="aistudio",
-            api_key="sk-aistudio",
-            base_url="https://custom.example.com",
-            rate_limiter=limiter,
-            video_model="veo-3.1-lite-generate-preview",
-        )
+        assert _built(spec, config, "veo-3.1-lite-generate-preview") == {
+            "media": "video",
+            "backend": "gemini",
+            "kwargs": {
+                "backend_type": "aistudio",
+                "api_key": "sk-aistudio",
+                "base_url": "https://custom.example.com",
+                "rate_limiter": limiter,
+                "video_model": "veo-3.1-lite-generate-preview",
+            },
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_vertex_video_backend_type_vertex(self, mock_create):
-        spec = get_provider_spec("gemini-vertex", "video")
+    def test_vertex_video_backend_type_vertex(self):
         config = LoadedConfig(
             credentials={"api_key": None, "base_url": None},
             provider_meta=PROVIDER_REGISTRY.get("gemini-vertex"),
             rate_limiter=None,
         )
-        spec.build_backend(config, "veo-3.1-generate-preview")
         # vertex 无 api_key/base_url：仍无条件透传 None（与 vertex image 对称，backend 内结构性忽略）
-        mock_create.assert_called_once_with(
-            "gemini",
-            backend_type="vertex",
-            api_key=None,
-            base_url=None,
-            rate_limiter=None,
-            video_model="veo-3.1-generate-preview",
-        )
+        assert _built(get_provider_spec("gemini-vertex", "video"), config, "veo-3.1-generate-preview")["kwargs"] == {
+            "backend_type": "vertex",
+            "api_key": None,
+            "base_url": None,
+            "rate_limiter": None,
+            "video_model": "veo-3.1-generate-preview",
+        }
 
     def test_bare_gemini_not_registered(self):
         # 裸 "gemini"（无 aistudio/vertex 后缀）是死路径：resolver 只产出带后缀 id。
@@ -225,137 +228,99 @@ class TestKlingSpec:
     base_url 兜底（db > registry default，国内域名已迁移至 api-beijing）。
     video backend 不接受 api_model_name —— 非对称，video 闭包不传。"""
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_image_dual_secret_and_jwt(self, mock_create):
-        spec = get_provider_spec("kling", "image")
-        assert spec.registry_backend == "kling"
-        config = LoadedConfig(
-            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
+    @staticmethod
+    def _kling_config(**credentials) -> LoadedConfig:
+        return LoadedConfig(
+            credentials=credentials,
             provider_meta=PROVIDER_REGISTRY.get("kling"),
             rate_limiter=None,
         )
-        spec.build_backend(config, "kling-image-o1")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="jwt",
-            access_key="ak-1",
-            secret_key="sk-1",
-            model="kling-image-o1",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_image_api_model_name_decoupled_for_amphibious_alias(self, mock_create):
+    def test_image_dual_secret_and_jwt(self):
+        spec = get_provider_spec("kling", "image")
+        assert spec.registry_backend == "kling"
+        config = self._kling_config(access_key="ak-1", secret_key="sk-1")
+        assert _built(spec, config, "kling-image-o1") == {
+            "media": "image",
+            "backend": "kling",
+            "kwargs": {
+                "auth_mode": "jwt",
+                "access_key": "ak-1",
+                "secret_key": "sk-1",
+                "model": "kling-image-o1",
+                "base_url": "https://api-beijing.klingai.com/v1",
+            },
+        }
+
+    def test_image_api_model_name_decoupled_for_amphibious_alias(self):
         # 两栖别名键 kling-v3-omni-image 的 registry api_model_name 是 kling-v3-omni（发真实 API 名）。
-        spec = get_provider_spec("kling", "image")
-        config = LoadedConfig(
-            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-v3-omni-image")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="jwt",
-            access_key="ak-1",
-            secret_key="sk-1",
-            model="kling-v3-omni-image",
-            api_model_name="kling-v3-omni",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        config = self._kling_config(access_key="ak-1", secret_key="sk-1")
+        assert _built(get_provider_spec("kling", "image"), config, "kling-v3-omni-image")["kwargs"] == {
+            "auth_mode": "jwt",
+            "access_key": "ak-1",
+            "secret_key": "sk-1",
+            "model": "kling-v3-omni-image",
+            "api_model_name": "kling-v3-omni",
+            "base_url": "https://api-beijing.klingai.com/v1",
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_image_user_base_url_wins_over_registry_default(self, mock_create):
-        spec = get_provider_spec("kling", "image")
-        config = LoadedConfig(
-            credentials={"access_key": "ak-1", "secret_key": "sk-1", "base_url": "https://relay.example.com"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-image-o1")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="jwt",
-            access_key="ak-1",
-            secret_key="sk-1",
-            model="kling-image-o1",
-            base_url="https://relay.example.com",
-        )
+    def test_image_user_base_url_wins_over_registry_default(self):
+        config = self._kling_config(access_key="ak-1", secret_key="sk-1", base_url="https://relay.example.com")
+        assert _built(get_provider_spec("kling", "image"), config, "kling-image-o1")["kwargs"] == {
+            "auth_mode": "jwt",
+            "access_key": "ak-1",
+            "secret_key": "sk-1",
+            "model": "kling-image-o1",
+            "base_url": "https://relay.example.com",
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_video_dual_secret_no_api_model_name(self, mock_create):
+    def test_video_dual_secret_no_api_model_name(self):
         spec = get_provider_spec("kling", "video")
         assert spec.registry_backend == "kling"
-        config = LoadedConfig(
-            credentials={"access_key": "ak-1", "secret_key": "sk-1"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-v3")
+        config = self._kling_config(access_key="ak-1", secret_key="sk-1")
         # video backend 不接受 api_model_name：即使 model 是别名也不传该参数（迁移前 video 分支即不设）
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="jwt",
-            access_key="ak-1",
-            secret_key="sk-1",
-            model="kling-v3",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        assert _built(spec, config, "kling-v3") == {
+            "media": "video",
+            "backend": "kling",
+            "kwargs": {
+                "auth_mode": "jwt",
+                "access_key": "ak-1",
+                "secret_key": "sk-1",
+                "model": "kling-v3",
+                "base_url": "https://api-beijing.klingai.com/v1",
+            },
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_video_api_key_dispatches_bearer_mode(self, mock_create):
+    def test_video_api_key_dispatches_bearer_mode(self):
         """单填 api_key（无 access_key/secret_key）→ auth_mode=bearer，不透传 access_key/secret_key。"""
-        spec = get_provider_spec("kling", "video")
-        config = LoadedConfig(
-            credentials={"api_key": "sk-api-1"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-v3")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="bearer",
-            api_key="sk-api-1",
-            model="kling-v3",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        config = self._kling_config(api_key="sk-api-1")
+        assert _built(get_provider_spec("kling", "video"), config, "kling-v3")["kwargs"] == {
+            "auth_mode": "bearer",
+            "api_key": "sk-api-1",
+            "model": "kling-v3",
+            "base_url": "https://api-beijing.klingai.com/v1",
+        }
 
-    @patch("lib.image_backends.registry.create_backend")
-    def test_image_api_key_dispatches_bearer_mode_with_api_model_name(self, mock_create):
+    def test_image_api_key_dispatches_bearer_mode_with_api_model_name(self):
         """image 侧 bearer 模式同样叠加 api_model_name 解耦（两栖别名键）。"""
-        spec = get_provider_spec("kling", "image")
-        config = LoadedConfig(
-            credentials={"api_key": "sk-api-1"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-v3-omni-image")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="bearer",
-            api_key="sk-api-1",
-            model="kling-v3-omni-image",
-            api_model_name="kling-v3-omni",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        config = self._kling_config(api_key="sk-api-1")
+        assert _built(get_provider_spec("kling", "image"), config, "kling-v3-omni-image")["kwargs"] == {
+            "auth_mode": "bearer",
+            "api_key": "sk-api-1",
+            "model": "kling-v3-omni-image",
+            "api_model_name": "kling-v3-omni",
+            "base_url": "https://api-beijing.klingai.com/v1",
+        }
 
-    @patch("lib.video_backends.registry.create_backend")
-    def test_api_key_takes_priority_over_dual_secret_when_both_set(self, mock_create):
+    def test_api_key_takes_priority_over_dual_secret_when_both_set(self):
         """两者都填时 api_key 优先（不透传 access_key/secret_key）。"""
-        spec = get_provider_spec("kling", "video")
-        config = LoadedConfig(
-            credentials={"api_key": "sk-api-1", "access_key": "ak-1", "secret_key": "sk-1"},
-            provider_meta=PROVIDER_REGISTRY.get("kling"),
-            rate_limiter=None,
-        )
-        spec.build_backend(config, "kling-v3")
-        mock_create.assert_called_once_with(
-            "kling",
-            auth_mode="bearer",
-            api_key="sk-api-1",
-            model="kling-v3",
-            base_url="https://api-beijing.klingai.com/v1",
-        )
+        config = self._kling_config(api_key="sk-api-1", access_key="ak-1", secret_key="sk-1")
+        assert _built(get_provider_spec("kling", "video"), config, "kling-v3")["kwargs"] == {
+            "auth_mode": "bearer",
+            "api_key": "sk-api-1",
+            "model": "kling-v3",
+            "base_url": "https://api-beijing.klingai.com/v1",
+        }
 
 
 class TestTextSimpleSpec:
@@ -363,100 +328,87 @@ class TestTextSimpleSpec:
     （user > registry default，仅非空才传）。映射到文本 registry 的 create_backend，registry_backend
     即 provider_id 自身。"""
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_ark_falls_back_to_registry_default(self, mock_create):
+    def test_ark_falls_back_to_registry_default(self):
         spec = get_provider_spec("ark", "text")
         assert spec.registry_backend == "ark"
         config = _loaded(credentials={"api_key": "ark-key"}, provider_id="ark")
-        spec.build_backend(config, "doubao-seed-2-0-lite-260215")
-        mock_create.assert_called_once_with(
-            "ark",
-            model="doubao-seed-2-0-lite-260215",
-            api_key="ark-key",
-            base_url="https://ark.cn-beijing.volces.com/api/v3",
-        )
+        assert _built(spec, config, "doubao-seed-2-0-lite-260215") == {
+            "media": "text",
+            "backend": "ark",
+            "kwargs": {
+                "model": "doubao-seed-2-0-lite-260215",
+                "api_key": "ark-key",
+                "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            },
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_ark_agent_plan_uses_plan_base_url(self, mock_create):
+    def test_ark_agent_plan_uses_plan_base_url(self):
         spec = get_provider_spec("ark-agent-plan", "text")
         assert spec.registry_backend == "ark-agent-plan"
         config = _loaded(credentials={"api_key": "k"}, provider_id="ark-agent-plan")
-        spec.build_backend(config, "doubao-seed-2.0-lite")
-        mock_create.assert_called_once_with(
-            "ark-agent-plan",
-            model="doubao-seed-2.0-lite",
-            api_key="k",
-            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-        )
+        assert _built(spec, config, "doubao-seed-2.0-lite")["kwargs"] == {
+            "model": "doubao-seed-2.0-lite",
+            "api_key": "k",
+            "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_user_base_url_wins(self, mock_create):
-        spec = get_provider_spec("ark", "text")
+    def test_user_base_url_wins(self):
         config = _loaded(credentials={"api_key": "k", "base_url": "https://relay.test/v3"}, provider_id="ark")
-        spec.build_backend(config, "m")
-        assert mock_create.call_args.kwargs["base_url"] == "https://relay.test/v3"
+        built = _built(get_provider_spec("ark", "text"), config, "m")
+        assert built["kwargs"]["base_url"] == "https://relay.test/v3"
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_grok_no_default_no_user_omits_base_url(self, mock_create):
-        spec = get_provider_spec("grok", "text")
+    def test_grok_no_default_no_user_omits_base_url(self):
         config = _loaded(credentials={"api_key": "grok-key"}, provider_id="grok")
-        spec.build_backend(config, "grok-4")
-        mock_create.assert_called_once_with("grok", model="grok-4", api_key="grok-key")
+        assert _built(get_provider_spec("grok", "text"), config, "grok-4")["kwargs"] == {
+            "model": "grok-4",
+            "api_key": "grok-key",
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_agnes_falls_back_to_registry_default_base_url(self, mock_create):
+    def test_agnes_falls_back_to_registry_default_base_url(self):
         # agnes 走简单文本族（registry_backend = provider_id），无用户 base_url 时回落 registry default。
         spec = get_provider_spec("agnes", "text")
         assert spec.registry_backend == "agnes"
         config = _loaded(credentials={"api_key": "ag-key"}, provider_id="agnes")
-        spec.build_backend(config, "agnes-2.0-flash")
-        mock_create.assert_called_once_with(
-            "agnes",
-            model="agnes-2.0-flash",
-            api_key="ag-key",
-            base_url="https://apihub.agnes-ai.com/v1",
-        )
+        assert _built(spec, config, "agnes-2.0-flash")["kwargs"] == {
+            "model": "agnes-2.0-flash",
+            "api_key": "ag-key",
+            "base_url": "https://apihub.agnes-ai.com/v1",
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_api_key_passed_unconditionally_even_when_missing(self, mock_create):
+    def test_api_key_passed_unconditionally_even_when_missing(self):
         # 文本简单族 api_key 无条件透传（含 None）：保留迁移前命令式分支语义，
         # 与媒体简单族「缺省省略」非对称。
-        spec = get_provider_spec("grok", "text")
         config = _loaded(credentials={}, provider_id="grok")
-        spec.build_backend(config, "grok-4")
-        mock_create.assert_called_once_with("grok", model="grok-4", api_key=None)
+        assert _built(get_provider_spec("grok", "text"), config, "grok-4")["kwargs"] == {
+            "model": "grok-4",
+            "api_key": None,
+        }
 
 
 class TestTextGeminiSpec:
     """gemini 文本：aistudio（base_url 无条件透传用户值）/ vertex（backend=vertex + gcs_bucket）
     按 provider_id 分两行，registry_backend 同为 "gemini"。文本 gemini 不接受 rate_limiter。"""
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_aistudio_passes_user_base_url_unconditionally(self, mock_create):
+    def test_aistudio_passes_user_base_url_unconditionally(self):
         spec = get_provider_spec("gemini-aistudio", "text")
         assert spec.registry_backend == "gemini"
         config = _loaded(credentials={"api_key": "g-key", "base_url": ""}, provider_id="gemini-aistudio")
-        spec.build_backend(config, "gemini-3-flash-preview")
         # base_url 无条件透传（含空串），不回落 registry default
-        mock_create.assert_called_once_with(
-            "gemini",
-            model="gemini-3-flash-preview",
-            api_key="g-key",
-            base_url="",
-        )
+        assert _built(spec, config, "gemini-3-flash-preview") == {
+            "media": "text",
+            "backend": "gemini",
+            "kwargs": {"model": "gemini-3-flash-preview", "api_key": "g-key", "base_url": ""},
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_vertex_uses_gcs_bucket_no_api_key(self, mock_create):
+    def test_vertex_uses_gcs_bucket_no_api_key(self):
         spec = get_provider_spec("gemini-vertex", "text")
         assert spec.registry_backend == "gemini"
         config = _loaded(credentials={"gcs_bucket": "my-bucket"}, provider_id="gemini-vertex")
-        spec.build_backend(config, "gemini-3-flash-preview")
-        mock_create.assert_called_once_with(
-            "gemini",
-            model="gemini-3-flash-preview",
-            backend="vertex",
-            gcs_bucket="my-bucket",
-        )
+        assert _built(spec, config, "gemini-3-flash-preview")["kwargs"] == {
+            "model": "gemini-3-flash-preview",
+            "backend": "vertex",
+            "gcs_bucket": "my-bucket",
+        }
 
 
 class TestTextOpenAICompatSpec:
@@ -464,57 +416,46 @@ class TestTextOpenAICompatSpec:
     openai 直传用户 base_url；dashscope/minimax 经 helper 从 host 派生 base_url 并透传 provider_name
     计费归因（保证 usage 记账命中自身 CNY 费率，非 OpenAI USD）。"""
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_openai_passes_user_base_url_no_provider_name(self, mock_create):
+    def test_openai_passes_user_base_url_no_provider_name(self):
         spec = get_provider_spec("openai", "text")
         assert spec.registry_backend == "openai"
         config = _loaded(credentials={"api_key": "oa", "base_url": "https://relay.test/v1"}, provider_id="openai")
-        spec.build_backend(config, "gpt-5")
-        mock_create.assert_called_once_with(
-            "openai",
-            model="gpt-5",
-            api_key="oa",
-            base_url="https://relay.test/v1",
-        )
+        assert _built(spec, config, "gpt-5") == {
+            "media": "text",
+            "backend": "openai",
+            "kwargs": {"model": "gpt-5", "api_key": "oa", "base_url": "https://relay.test/v1"},
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_dashscope_derives_base_url_and_passes_provider_name(self, mock_create):
+    def test_dashscope_derives_base_url_and_passes_provider_name(self):
         spec = get_provider_spec("dashscope", "text")
         assert spec.registry_backend == "openai"
         config = _loaded(credentials={"api_key": "ds"}, provider_id="dashscope")
-        spec.build_backend(config, "qwen-max")
-        mock_create.assert_called_once_with(
-            "openai",
-            model="qwen-max",
-            api_key="ds",
-            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            provider_name="dashscope",
-        )
+        assert _built(spec, config, "qwen-max")["kwargs"] == {
+            "model": "qwen-max",
+            "api_key": "ds",
+            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "provider_name": "dashscope",
+        }
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_dashscope_user_host_derives_compatible_mode_path(self, mock_create):
+    def test_dashscope_user_host_derives_compatible_mode_path(self):
         # 用户填自定义 host → helper 仍派生 /compatible-mode/v1 后缀
-        spec = get_provider_spec("dashscope", "text")
         config = _loaded(
             credentials={"api_key": "ds", "base_url": "https://dashscope-intl.aliyuncs.com"},
             provider_id="dashscope",
         )
-        spec.build_backend(config, "qwen-max")
-        assert mock_create.call_args.kwargs["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        built = _built(get_provider_spec("dashscope", "text"), config, "qwen-max")
+        assert built["kwargs"]["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
-    @patch("lib.text_backends.registry.create_backend")
-    def test_minimax_derives_base_url_and_passes_provider_name(self, mock_create):
+    def test_minimax_derives_base_url_and_passes_provider_name(self):
         spec = get_provider_spec("minimax", "text")
         assert spec.registry_backend == "openai"
         config = _loaded(credentials={"api_key": "mm"}, provider_id="minimax")
-        spec.build_backend(config, "minimax-text-01")
-        mock_create.assert_called_once_with(
-            "openai",
-            model="minimax-text-01",
-            api_key="mm",
-            base_url="https://api.minimaxi.com/v1",
-            provider_name="minimax",
-        )
+        assert _built(spec, config, "minimax-text-01")["kwargs"] == {
+            "model": "minimax-text-01",
+            "api_key": "mm",
+            "base_url": "https://api.minimaxi.com/v1",
+            "provider_name": "minimax",
+        }
 
 
 class TestRegistryShape:
@@ -556,6 +497,7 @@ class TestValidateProviderSpecs:
 
     def test_passes_on_real_registry(self):
         _validate_provider_specs()  # 真表不抛
+        assert PROVIDER_SPEC_REGISTRY  # 空表也不抛，校验须建立在真表非空之上
 
     def test_non_callable_build_rejected(self, monkeypatch: pytest.MonkeyPatch):
         bad = dataclasses.replace(PROVIDER_SPEC_REGISTRY[("ark", "image")], build_backend="not-callable")

--- a/tests/unit/lib/custom_provider/test_custom_provider_factory.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_factory.py
@@ -78,7 +78,9 @@ def _built(provider: MagicMock, model_id: str, endpoint: str, **kwargs: Any) -> 
 
 class TestEndpointDispatch:
     def test_openai_chat(self):
-        result, built = _built(_make_provider(), "gpt-4o", "openai-chat")
+        # host-only base_url：openai 端点补 /v1 的接线在此覆盖
+        provider = _make_provider(base_url="https://api.example.com")
+        result, built = _built(provider, "gpt-4o", "openai-chat")
         assert isinstance(result, CustomTextBackend)
         assert result.model == "gpt-4o"
         assert built == {

--- a/tests/unit/lib/custom_provider/test_custom_provider_factory.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_factory.py
@@ -1,7 +1,14 @@
-"""create_custom_backend(provider, model_id, endpoint) 单元测试。"""
+"""create_custom_backend(provider, model_id, endpoint) 单元测试。
+
+endpoints 模块内的真实后端类换成记录型工厂：工厂的产出就是「用哪个后端类、什么构造参数」，
+断言落在整条构造记录上（能抓多传/漏传参数），delegate 仍是可用对象供包装层继续构造。
+"""
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +21,44 @@ from lib.custom_provider.backends import (
 )
 from lib.custom_provider.factory import create_custom_backend
 
+# endpoints 模块里被 build_backend 闭包直接构造的全部后端类。
+_ENDPOINT_BACKEND_CLASSES = (
+    "ArkVideoBackend",
+    "DashScopeImageBackend",
+    "DashScopeVideoBackend",
+    "GeminiImageBackend",
+    "GeminiTextBackend",
+    "KlingImageBackend",
+    "KlingVideoBackend",
+    "MiniMaxImageBackend",
+    "MiniMaxVideoBackend",
+    "NewAPIVideoBackend",
+    "OpenAIAudioBackend",
+    "OpenAIImageBackend",
+    "OpenAITextBackend",
+    "OpenAIVideoBackend",
+    "V2VideoGenerationsBackend",
+    "ViduVideoBackend",
+)
+
+
+@contextmanager
+def _endpoint_backends() -> Iterator[list[dict[str, Any]]]:
+    """endpoints 模块各后端类的构造记录器：记类名与构造参数，不建 SDK 客户端。"""
+    records: list[dict[str, Any]] = []
+
+    def _recorder(cls_name: str):
+        def _build(**kwargs: Any) -> Any:
+            records.append({"backend": cls_name, "kwargs": kwargs})
+            return MagicMock()
+
+        return _build
+
+    with ExitStack() as stack:
+        for cls_name in _ENDPOINT_BACKEND_CLASSES:
+            stack.enter_context(patch(f"lib.custom_provider.endpoints.{cls_name}", _recorder(cls_name)))
+        yield records
+
 
 def _make_provider(*, base_url: str = "https://api.example.com/v1", api_key: str = "sk-test") -> MagicMock:
     p = MagicMock()
@@ -23,283 +68,262 @@ def _make_provider(*, base_url: str = "https://api.example.com/v1", api_key: str
     return p
 
 
+def _built(provider: MagicMock, model_id: str, endpoint: str, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    """跑一次工厂，返回 (包装层结果, 唯一一条 delegate 构造记录)。"""
+    with _endpoint_backends() as records:
+        result = create_custom_backend(provider=provider, model_id=model_id, endpoint=endpoint, **kwargs)
+    assert len(records) == 1
+    return result, records[0]
+
+
 class TestEndpointDispatch:
-    @patch("lib.custom_provider.endpoints.OpenAITextBackend")
-    def test_openai_chat(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="gpt-4o", endpoint="openai-chat")
+    def test_openai_chat(self):
+        result, built = _built(_make_provider(), "gpt-4o", "openai-chat")
         assert isinstance(result, CustomTextBackend)
         assert result.model == "gpt-4o"
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="gpt-4o")
+        assert built == {
+            "backend": "OpenAITextBackend",
+            "kwargs": {"api_key": "sk-test", "base_url": "https://api.example.com/v1", "model": "gpt-4o"},
+        }
 
-    @patch("lib.custom_provider.endpoints.GeminiTextBackend")
-    def test_gemini_generate(self, mock_cls):
+    def test_gemini_generate(self):
         provider = _make_provider(base_url="https://generativelanguage.googleapis.com")
-        create_custom_backend(provider=provider, model_id="gemini-2.5-flash", endpoint="gemini-generate")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://generativelanguage.googleapis.com/",
-            model="gemini-2.5-flash",
-        )
+        _result, built = _built(provider, "gemini-2.5-flash", "gemini-generate")
+        assert built == {
+            "backend": "GeminiTextBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://generativelanguage.googleapis.com/",
+                "model": "gemini-2.5-flash",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    def test_openai_images(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="dall-e-3", endpoint="openai-images")
+    def test_openai_images(self):
+        result, built = _built(_make_provider(), "dall-e-3", "openai-images")
         assert isinstance(result, CustomImageBackend)
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="dall-e-3")
+        assert built == {
+            "backend": "OpenAIImageBackend",
+            "kwargs": {"api_key": "sk-test", "base_url": "https://api.example.com/v1", "model": "dall-e-3"},
+        }
 
-    @patch("lib.custom_provider.endpoints.GeminiImageBackend")
-    def test_gemini_image(self, mock_cls):
+    def test_gemini_image(self):
         provider = _make_provider(base_url="https://generativelanguage.googleapis.com")
-        create_custom_backend(provider=provider, model_id="imagen-4", endpoint="gemini-image")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://generativelanguage.googleapis.com/",
-            image_model="imagen-4",
-        )
+        _result, built = _built(provider, "imagen-4", "gemini-image")
+        assert built == {
+            "backend": "GeminiImageBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://generativelanguage.googleapis.com/",
+                "image_model": "imagen-4",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
-    def test_openai_video(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="sora-2", endpoint="openai-video")
+    def test_openai_video(self):
+        result, built = _built(_make_provider(), "sora-2", "openai-video")
         assert isinstance(result, CustomVideoBackend)
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="sora-2")
+        assert built == {
+            "backend": "OpenAIVideoBackend",
+            "kwargs": {"api_key": "sk-test", "base_url": "https://api.example.com/v1", "model": "sora-2"},
+        }
 
-    @patch("lib.custom_provider.endpoints.NewAPIVideoBackend")
-    def test_newapi_video(self, mock_cls):
-        provider = _make_provider()
-        create_custom_backend(provider=provider, model_id="kling-v2", endpoint="newapi-video")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="kling-v2")
+    def test_newapi_video(self):
+        _result, built = _built(_make_provider(), "kling-v2", "newapi-video")
+        assert built == {
+            "backend": "NewAPIVideoBackend",
+            "kwargs": {"api_key": "sk-test", "base_url": "https://api.example.com/v1", "model": "kling-v2"},
+        }
 
-    @patch("lib.custom_provider.endpoints.V2VideoGenerationsBackend")
-    def test_v2_video_generations(self, mock_cls):
+    def test_v2_video_generations(self):
         provider = _make_provider(base_url="https://api.aimlapi.com")
-        result = create_custom_backend(
-            provider=provider, model_id="bytedance/seedance-1-0-lite-i2v", endpoint="v2-video-generations"
-        )
+        result, built = _built(provider, "bytedance/seedance-1-0-lite-i2v", "v2-video-generations")
         assert isinstance(result, CustomVideoBackend)
         # base_url 原样下传，归一化由 V2VideoGenerationsBackend 内部处理
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://api.aimlapi.com", model="bytedance/seedance-1-0-lite-i2v"
-        )
+        assert built == {
+            "backend": "V2VideoGenerationsBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://api.aimlapi.com",
+                "model": "bytedance/seedance-1-0-lite-i2v",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    def test_ark_seedance(self, mock_cls):
+    def test_ark_seedance(self):
         provider = _make_provider(base_url="https://relay.example.com")
-        result = create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
+        result, built = _built(provider, "doubao-seedance-2-0", "ark-seedance")
         assert isinstance(result, CustomVideoBackend)
         # 仅 host → 补全 ark 协议挂载路径 /api/v3
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
-        )
+        assert built == {
+            "backend": "ArkVideoBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://relay.example.com/api/v3",
+                "model": "doubao-seedance-2-0",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
-    def test_vidu_video(self, mock_cls):
+    def test_vidu_video(self):
         provider = _make_provider(base_url="https://relay.example.com")
-        result = create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
+        result, built = _built(provider, "viduq3-turbo", "vidu-video")
         assert isinstance(result, CustomVideoBackend)
         # 仅 host → 补全 vidu 协议挂载路径 /ent/v2
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/ent/v2", model="viduq3-turbo"
-        )
+        assert built == {
+            "backend": "ViduVideoBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://relay.example.com/ent/v2",
+                "model": "viduq3-turbo",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.OpenAIAudioBackend")
-    def test_openai_tts(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="tts-1", endpoint="openai-tts")
+    def test_openai_tts(self):
+        result, built = _built(_make_provider(), "tts-1", "openai-tts")
         assert isinstance(result, CustomAudioBackend)
         assert result.name == "custom-42"
         assert result.model == "tts-1"
         # provider_name 让 delegate 记账/日志归因到真实 provider 而非内置 openai
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://api.example.com/v1",
-            model="tts-1",
-            provider_name="custom-42",
-        )
+        assert built == {
+            "backend": "OpenAIAudioBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com/v1",
+                "model": "tts-1",
+                "provider_name": "custom-42",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.OpenAIAudioBackend")
-    def test_openai_tts_appends_v1(self, mock_cls):
+    def test_openai_tts_appends_v1(self):
         provider = _make_provider(base_url="https://relay.example.com")
-        create_custom_backend(provider=provider, model_id="speech-1.5", endpoint="openai-tts")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://relay.example.com/v1",
-            model="speech-1.5",
-            provider_name="custom-42",
-        )
+        _result, built = _built(provider, "speech-1.5", "openai-tts")
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/v1"
 
-    @patch("lib.custom_provider.endpoints.MiniMaxImageBackend")
-    def test_minimax_image(self, mock_cls):
+    def test_minimax_image(self):
         provider = _make_provider(base_url="https://api.minimaxi.com/v1")
-        result = create_custom_backend(provider=provider, model_id="image-01", endpoint="minimax-image")
+        result, built = _built(provider, "image-01", "minimax-image")
         assert isinstance(result, CustomImageBackend)
         assert result.model == "image-01"
         # base_url 原样下传，归一化（host→{host}/v1）由 MiniMaxImageBackend 内部处理
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.minimaxi.com/v1", model="image-01")
+        assert built == {
+            "backend": "MiniMaxImageBackend",
+            "kwargs": {"api_key": "sk-test", "base_url": "https://api.minimaxi.com/v1", "model": "image-01"},
+        }
 
-    @patch("lib.custom_provider.endpoints.MiniMaxVideoBackend")
-    def test_minimax_video(self, mock_cls):
+    def test_minimax_video(self):
         provider = _make_provider(base_url="https://api.minimaxi.com/v1")
-        result = create_custom_backend(provider=provider, model_id="MiniMax-Hailuo-2.3", endpoint="minimax-video")
+        result, built = _built(provider, "MiniMax-Hailuo-2.3", "minimax-video")
         assert isinstance(result, CustomVideoBackend)
         assert result.model == "MiniMax-Hailuo-2.3"
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://api.minimaxi.com/v1", model="MiniMax-Hailuo-2.3"
-        )
+        assert built == {
+            "backend": "MiniMaxVideoBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://api.minimaxi.com/v1",
+                "model": "MiniMax-Hailuo-2.3",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.KlingImageBackend")
-    def test_kling_image(self, mock_cls):
+    def test_kling_image(self):
         provider = _make_provider(base_url="https://relay.example.com/v1")
-        result = create_custom_backend(provider=provider, model_id="kling-image-o1", endpoint="kling-image")
+        result, built = _built(provider, "kling-image-o1", "kling-image")
         assert isinstance(result, CustomImageBackend)
         assert result.model == "kling-image-o1"
         # bearer 模式：静态 api_key 旁路 JWT；显式 /v1 路径原样信任；原生 model_name 透传
-        mock_cls.assert_called_once_with(
-            auth_mode="bearer",
-            api_key="sk-test",
-            base_url="https://relay.example.com/v1",
-            model="kling-image-o1",
-        )
+        assert built == {
+            "backend": "KlingImageBackend",
+            "kwargs": {
+                "auth_mode": "bearer",
+                "api_key": "sk-test",
+                "base_url": "https://relay.example.com/v1",
+                "model": "kling-image-o1",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.KlingImageBackend")
-    def test_kling_image_host_only_mounts_v1(self, mock_cls):
+    def test_kling_image_host_only_mounts_v1(self):
         provider = _make_provider(base_url="https://relay.example.com")
-        create_custom_backend(provider=provider, model_id="kling-image-o1", endpoint="kling-image")
+        _result, built = _built(provider, "kling-image-o1", "kling-image")
         # 仅 host → 补全可灵协议挂载路径 /v1
-        mock_cls.assert_called_once_with(
-            auth_mode="bearer",
-            api_key="sk-test",
-            base_url="https://relay.example.com/v1",
-            model="kling-image-o1",
-        )
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/v1"
 
-    @patch("lib.custom_provider.endpoints.KlingVideoBackend")
-    def test_kling_video(self, mock_cls):
+    def test_kling_video(self):
         provider = _make_provider(base_url="https://relay.example.com/v1")
-        result = create_custom_backend(provider=provider, model_id="kling-v2-5-turbo", endpoint="kling-video")
+        result, built = _built(provider, "kling-v2-5-turbo", "kling-video")
         assert isinstance(result, CustomVideoBackend)
         assert result.model == "kling-v2-5-turbo"
-        mock_cls.assert_called_once_with(
-            auth_mode="bearer",
-            api_key="sk-test",
-            base_url="https://relay.example.com/v1",
-            model="kling-v2-5-turbo",
-        )
+        assert built == {
+            "backend": "KlingVideoBackend",
+            "kwargs": {
+                "auth_mode": "bearer",
+                "api_key": "sk-test",
+                "base_url": "https://relay.example.com/v1",
+                "model": "kling-v2-5-turbo",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.KlingVideoBackend")
-    def test_kling_video_host_only_mounts_v1(self, mock_cls):
+    def test_kling_video_host_only_mounts_v1(self):
         provider = _make_provider(base_url="relay.example.com")
-        create_custom_backend(provider=provider, model_id="kling-v3", endpoint="kling-video")
+        _result, built = _built(provider, "kling-v3", "kling-video")
         # 纯域名（无 scheme）→ 补 https:// 再挂载 /v1
-        mock_cls.assert_called_once_with(
-            auth_mode="bearer",
-            api_key="sk-test",
-            base_url="https://relay.example.com/v1",
-            model="kling-v3",
-        )
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/v1"
 
-    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    def test_openai_images_generations(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="dall-e-3", endpoint="openai-images-generations")
+    def test_openai_images_generations(self):
+        result, built = _built(_make_provider(), "dall-e-3", "openai-images-generations")
         assert isinstance(result, CustomImageBackend)
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://api.example.com/v1",
-            model="dall-e-3",
-            mode="generations_only",
-        )
+        assert built == {
+            "backend": "OpenAIImageBackend",
+            "kwargs": {
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com/v1",
+                "model": "dall-e-3",
+                "mode": "generations_only",
+            },
+        }
 
-    @patch("lib.custom_provider.endpoints.OpenAIImageBackend")
-    def test_openai_images_edits(self, mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="dall-e-3", endpoint="openai-images-edits")
+    def test_openai_images_edits(self):
+        result, built = _built(_make_provider(), "dall-e-3", "openai-images-edits")
         assert isinstance(result, CustomImageBackend)
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://api.example.com/v1",
-            model="dall-e-3",
-            mode="edits_only",
-        )
+        assert built["kwargs"]["mode"] == "edits_only"
 
 
 class TestUrlNormalization:
-    @patch("lib.custom_provider.endpoints.OpenAITextBackend")
-    def test_openai_appends_v1(self, mock_cls):
-        provider = _make_provider(base_url="https://api.example.com")
-        create_custom_backend(provider=provider, model_id="gpt-4o", endpoint="openai-chat")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.example.com/v1", model="gpt-4o")
+    """挂载路径补全（_ensure_url_path_suffix）：仅此处覆盖。openai 补 /v1、google 剥版本段的
+    纯归一化行为由 tests/unit/lib/config/test_normalize_base_url.py 覆盖，不在此重复。"""
 
-    @patch("lib.custom_provider.endpoints.GeminiTextBackend")
-    def test_google_strips_v1beta(self, mock_cls):
-        provider = _make_provider(base_url="https://generativelanguage.googleapis.com/v1beta")
-        create_custom_backend(provider=provider, model_id="gemini-2.5", endpoint="gemini-generate")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://generativelanguage.googleapis.com/",
-            model="gemini-2.5",
-        )
-
-    @patch("lib.custom_provider.endpoints.GeminiTextBackend")
-    def test_google_empty_base_url(self, mock_cls):
-        provider = _make_provider(base_url="")
-        create_custom_backend(provider=provider, model_id="gemini-2.5", endpoint="gemini-generate")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="gemini-2.5")
-
-    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    def test_ark_explicit_path_passthrough(self, mock_cls):
+    def test_ark_explicit_path_passthrough(self):
         """已带显式路径（/api/v3）→ 原样信任，不重复叠加。"""
         provider = _make_provider(base_url="https://relay.example.com/api/v3")
-        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
-        )
+        _result, built = _built(provider, "doubao-seedance-2-0", "ark-seedance")
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/api/v3"
 
-    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    def test_ark_mounted_base_url_appends_api_v3(self, mock_cls):
+    def test_ark_mounted_base_url_appends_api_v3(self):
         provider = _make_provider(base_url="https://relay.example.com/seedance")
-        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/seedance/api/v3", model="doubao-seedance-2-0"
-        )
+        _result, built = _built(provider, "doubao-seedance-2-0", "ark-seedance")
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/seedance/api/v3"
 
-    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
-    def test_vidu_explicit_path_passthrough(self, mock_cls):
+    def test_vidu_explicit_path_passthrough(self):
         provider = _make_provider(base_url="https://api.vidu.cn/ent/v2")
-        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url="https://api.vidu.cn/ent/v2", model="viduq3-turbo")
+        _result, built = _built(provider, "viduq3-turbo", "vidu-video")
+        assert built["kwargs"]["base_url"] == "https://api.vidu.cn/ent/v2"
 
-    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    def test_ark_host_only_no_scheme(self, mock_cls):
+    def test_ark_host_only_no_scheme(self):
         """纯域名（无 scheme）→ 补 https:// 再挂载 /api/v3。"""
         provider = _make_provider(base_url="relay.example.com")
-        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/api/v3", model="doubao-seedance-2-0"
-        )
+        _result, built = _built(provider, "doubao-seedance-2-0", "ark-seedance")
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/api/v3"
 
-    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
-    def test_vidu_host_only_no_scheme(self, mock_cls):
+    def test_vidu_host_only_no_scheme(self):
         provider = _make_provider(base_url="relay.example.com")
-        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
-        mock_cls.assert_called_once_with(
-            api_key="sk-test", base_url="https://relay.example.com/ent/v2", model="viduq3-turbo"
-        )
+        _result, built = _built(provider, "viduq3-turbo", "vidu-video")
+        assert built["kwargs"]["base_url"] == "https://relay.example.com/ent/v2"
 
-    @patch("lib.custom_provider.endpoints.ArkVideoBackend")
-    def test_ark_empty_base_url_normalizes_to_none(self, mock_cls):
+    def test_ark_empty_base_url_normalizes_to_none(self):
         """空 base_url → _ensure_url_path_suffix 归一化为 None 下传（不强行补挂载路径）。"""
         provider = _make_provider(base_url="")
-        create_custom_backend(provider=provider, model_id="doubao-seedance-2-0", endpoint="ark-seedance")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="doubao-seedance-2-0")
+        _result, built = _built(provider, "doubao-seedance-2-0", "ark-seedance")
+        assert built["kwargs"]["base_url"] is None
 
-    @patch("lib.custom_provider.endpoints.ViduVideoBackend")
-    def test_vidu_empty_base_url_normalizes_to_none(self, mock_cls):
+    def test_vidu_empty_base_url_normalizes_to_none(self):
         provider = _make_provider(base_url="")
-        create_custom_backend(provider=provider, model_id="viduq3-turbo", endpoint="vidu-video")
-        mock_cls.assert_called_once_with(api_key="sk-test", base_url=None, model="viduq3-turbo")
+        _result, built = _built(provider, "viduq3-turbo", "vidu-video")
+        assert built["kwargs"]["base_url"] is None
 
 
 class TestErrors:
@@ -318,21 +342,17 @@ class TestErrors:
 class TestVideoEndpointRecorded:
     """工厂把构造 endpoint 记进 video 包装层，续跑据此比对协议（`docs/adr/0054`）。"""
 
-    @patch("lib.custom_provider.endpoints.OpenAIVideoBackend")
-    def test_video_backend_records_endpoint(self, _mock_cls):
-        provider = _make_provider()
-        result = create_custom_backend(provider=provider, model_id="sora-2", endpoint="openai-video")
+    def test_video_backend_records_endpoint(self):
+        result, _built_record = _built(_make_provider(), "sora-2", "openai-video")
         assert isinstance(result, CustomVideoBackend)
         assert result.endpoint == "openai-video"
 
-    @patch("lib.custom_provider.endpoints.MiniMaxVideoBackend")
-    def test_endpoint_survives_capability_injection(self, _mock_cls):
+    def test_endpoint_survives_capability_injection(self):
         """能力注入返回新实例，endpoint 不能在链式构造中丢失。"""
-        provider = _make_provider()
-        result = create_custom_backend(
-            provider=provider,
-            model_id="MiniMax-Hailuo-02",
-            endpoint="minimax-video",
+        result, _built_record = _built(
+            _make_provider(),
+            "MiniMax-Hailuo-02",
+            "minimax-video",
             capability_overrides={"last_frame": True},
         )
         assert isinstance(result, CustomVideoBackend)

--- a/tests/unit/lib/custom_provider/test_model_discovery.py
+++ b/tests/unit/lib/custom_provider/test_model_discovery.py
@@ -3,9 +3,32 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+@contextmanager
+def _recorded_genai_clients(models: list[Any] | None = None) -> Iterator[list[dict[str, Any]]]:
+    """genai 客户端构造的记录器：收下建客户端的参数，回一个列出给定模型的替身。
+
+    鉴权与 base_url 透传的契约就是构造参数本身，断言落在记录的参数上，而不是替身的调用对象。
+    """
+    created: list[dict[str, Any]] = []
+    listed = list(models or [])
+    client = SimpleNamespace(models=SimpleNamespace(list=lambda: listed))
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return client
+
+    with patch("lib.custom_provider.discovery.genai.Client", _create):
+        yield created
+
 
 # ---------------------------------------------------------------------------
 # infer_endpoint smoke check（主体已在 test_custom_provider_endpoints.py 覆盖）
@@ -318,42 +341,31 @@ class TestDiscoverModelsGoogle:
         assert result[0]["model_id"] == "gemini-3-flash"
         assert result[0]["display_name"] == "gemini-3-flash"
 
-    @patch("lib.custom_provider.discovery.genai")
-    async def test_no_base_url(self, mock_genai):
+    async def test_no_base_url(self):
         """base_url 为 None 时不传 http_options。"""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_client.models.list.return_value = []
-
         from lib.custom_provider.discovery import discover_models
 
-        await discover_models(
-            discovery_format="google",
-            base_url=None,
-            api_key="test-key",
-        )
+        with _recorded_genai_clients() as created:
+            await discover_models(
+                discovery_format="google",
+                base_url=None,
+                api_key="test-key",
+            )
 
-        mock_genai.Client.assert_called_once_with(api_key="test-key")
+        assert created == [{"api_key": "test-key"}]
 
-    @patch("lib.custom_provider.discovery.genai")
-    async def test_with_base_url(self, mock_genai):
+    async def test_with_base_url(self):
         """base_url 不为空时传 http_options。"""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_client.models.list.return_value = []
-
         from lib.custom_provider.discovery import discover_models
 
-        await discover_models(
-            discovery_format="google",
-            base_url="https://custom-endpoint.com/",
-            api_key="test-key",
-        )
+        with _recorded_genai_clients() as created:
+            await discover_models(
+                discovery_format="google",
+                base_url="https://custom-endpoint.com/",
+                api_key="test-key",
+            )
 
-        mock_genai.Client.assert_called_once_with(
-            api_key="test-key",
-            http_options={"base_url": "https://custom-endpoint.com/"},
-        )
+        assert created == [{"api_key": "test-key", "http_options": {"base_url": "https://custom-endpoint.com/"}}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/image_backends/test_ark.py
+++ b/tests/unit/lib/image_backends/test_ark.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from unittest.mock import patch
 
+import httpx
 import pytest
 
 from lib.image_backends.base import (
@@ -16,6 +20,7 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_ARK
+from tests.http_capture import capture_http, only_request
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,11 +40,45 @@ class _FakeImagesResponse:
     data: list[_FakeImageData]
 
 
-def _make_client_mock() -> MagicMock:
-    """Return a mock Ark client whose images.generate returns a valid response."""
-    client = MagicMock()
-    client.images.generate.return_value = _FakeImagesResponse(data=[_FakeImageData()])
-    return client
+class _RecordingImages:
+    def __init__(self, response: _FakeImagesResponse) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.response = response
+
+    def generate(self, **kwargs: Any) -> _FakeImagesResponse:
+        self.requests.append(kwargs)
+        return self.response
+
+
+class _RecordingArkClient:
+    """Ark SDK 客户端替身：记录 images.generate 的请求参数，回固定响应。
+
+    尺寸映射、参考图编码这些契约都是「发出去的请求长什么样」，断言落在 ``requests``
+    里的请求内容上，而不是替身的调用对象。
+    """
+
+    def __init__(self, response: _FakeImagesResponse | None = None) -> None:
+        self.images = _RecordingImages(response or _FakeImagesResponse(data=[_FakeImageData()]))
+
+    @property
+    def requests(self) -> list[dict[str, Any]]:
+        return self.images.requests
+
+
+@contextmanager
+def _recorded_ark_client(
+    response: _FakeImagesResponse | None = None,
+) -> Iterator[tuple[list[dict[str, Any]], _RecordingArkClient]]:
+    """create_ark_client 的记录器：收下建客户端的参数，回一个记录型客户端。"""
+    created: list[dict[str, Any]] = []
+    client = _RecordingArkClient(response)
+
+    def _create(**kwargs: Any) -> _RecordingArkClient:
+        created.append(kwargs)
+        return client
+
+    with patch("lib.image_backends.ark.create_ark_client", _create):
+        yield created, client
 
 
 # ---------------------------------------------------------------------------
@@ -67,22 +106,19 @@ class TestArkImageBackendInit:
 
     def test_api_key_from_param(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        with patch("lib.image_backends.ark.create_ark_client") as mock_create:
+        with _recorded_ark_client() as (created, _client):
             from lib.image_backends.ark import ArkImageBackend
 
             ArkImageBackend(api_key="my-key")
-            mock_create.assert_called_once_with(api_key="my-key", base_url=None)
+        assert created == [{"api_key": "my-key", "base_url": None}]
 
     def test_custom_base_url_passed_through(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        with patch("lib.image_backends.ark.create_ark_client") as mock_create:
+        with _recorded_ark_client() as (created, _client):
             from lib.image_backends.ark import ArkImageBackend
 
             ArkImageBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
-            mock_create.assert_called_once_with(
-                api_key="k",
-                base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-            )
+        assert created == [{"api_key": "k", "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"}]
 
 
 class TestArkImageBackendProperties:
@@ -123,12 +159,11 @@ class TestArkImageBackendGenerate:
     @pytest.fixture()
     def backend_and_client(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        mock_client = _make_client_mock()
-        with patch("lib.image_backends.ark.create_ark_client", return_value=mock_client):
+        with _recorded_ark_client() as (_created, client):
             from lib.image_backends.ark import ArkImageBackend
 
             backend = ArkImageBackend(api_key="test-key")
-        return backend, mock_client
+        return backend, client
 
     async def test_t2i_generate(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client
@@ -138,12 +173,12 @@ class TestArkImageBackendGenerate:
         result = await backend.generate(request)
 
         # SDK called correctly
-        call_kwargs = client.images.generate.call_args
-        assert call_kwargs.kwargs["model"] == "doubao-seedream-5-0-lite-260128"
-        assert call_kwargs.kwargs["prompt"] == "a cat"
+        call_kwargs = client.requests[-1]
+        assert call_kwargs["model"] == "doubao-seedream-5-0-lite-260128"
+        assert call_kwargs["prompt"] == "a cat"
         # 部分兼容网关即便吃 response_format 仍返回 url，所以请求端不再传该参数
-        assert "response_format" not in call_kwargs.kwargs
-        assert "image" not in call_kwargs.kwargs
+        assert "response_format" not in call_kwargs
+        assert "image" not in call_kwargs
 
         # Result
         assert isinstance(result, ImageGenerationResult)
@@ -159,7 +194,7 @@ class TestArkImageBackendGenerate:
 
         await backend.generate(request)
 
-        call_kwargs = client.images.generate.call_args.kwargs
+        call_kwargs = client.requests[-1]
         assert call_kwargs["seed"] == 42
 
     async def test_size_from_aspect_ratio(self, backend_and_client, tmp_path: Path):
@@ -177,7 +212,7 @@ class TestArkImageBackendGenerate:
         for i, (ar, expected) in enumerate(cases):
             request = ImageGenerationRequest(prompt="x", output_path=tmp_path / f"{i}.png", aspect_ratio=ar)
             await backend.generate(request)
-            assert client.images.generate.call_args.kwargs["size"] == expected, f"aspect_ratio={ar} 应映射到 {expected}"
+            assert client.requests[-1]["size"] == expected, f"aspect_ratio={ar} 应映射到 {expected}"
 
     async def test_size_fallback_unknown_aspect_ratio(self, backend_and_client, tmp_path: Path):
         """未识别比例回退到 '2K' keyword（方式 1），由模型按 prompt 自适应，
@@ -185,33 +220,31 @@ class TestArkImageBackendGenerate:
         backend, client = backend_and_client
         request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "u.png", aspect_ratio="weird")
         await backend.generate(request)
-        assert client.images.generate.call_args.kwargs["size"] == "2K"
+        assert client.requests[-1]["size"] == "2K"
 
     async def test_size_for_seedream_3_uses_1k_table(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """3.0-t2i 模型族单边像素 ∈ [512, 2048]，必须用 1K 表而非 2K 表。"""
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        mock_client = _make_client_mock()
-        with patch("lib.image_backends.ark.create_ark_client", return_value=mock_client):
+        with _recorded_ark_client() as (_created, client):
             from lib.image_backends.ark import ArkImageBackend
 
             backend = ArkImageBackend(api_key="test-key", model="doubao-seedream-3-0-t2i-250415")
 
         request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "v.png", aspect_ratio="9:16")
         await backend.generate(request)
-        assert mock_client.images.generate.call_args.kwargs["size"] == "720x1280"
+        assert client.requests[-1]["size"] == "720x1280"
 
     async def test_size_fallback_unknown_aspect_ratio_seedream_3(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """3.0-t2i 未识别比例必须回退到 '1K' 而非 '2K'（单边像素上限 2048）。"""
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        mock_client = _make_client_mock()
-        with patch("lib.image_backends.ark.create_ark_client", return_value=mock_client):
+        with _recorded_ark_client() as (_created, client):
             from lib.image_backends.ark import ArkImageBackend
 
             backend = ArkImageBackend(api_key="test-key", model="doubao-seedream-3-0-t2i-250415")
 
         request = ImageGenerationRequest(prompt="x", output_path=tmp_path / "u3.png", aspect_ratio="weird")
         await backend.generate(request)
-        assert mock_client.images.generate.call_args.kwargs["size"] == "1K"
+        assert client.requests[-1]["size"] == "1K"
 
     async def test_explicit_image_size_overrides_aspect_ratio(self, backend_and_client, tmp_path: Path):
         """caller 显式传入 image_size（如 grid 路径的 '2K'）必须保留，不被 aspect_ratio 推导覆盖。"""
@@ -220,7 +253,7 @@ class TestArkImageBackendGenerate:
             prompt="x", output_path=tmp_path / "g.png", aspect_ratio="9:16", image_size="2K"
         )
         await backend.generate(request)
-        assert client.images.generate.call_args.kwargs["size"] == "2K"
+        assert client.requests[-1]["size"] == "2K"
 
     async def test_i2i_single_ref(self, backend_and_client, tmp_path: Path):
         backend, client = backend_and_client
@@ -239,7 +272,7 @@ class TestArkImageBackendGenerate:
 
         await backend.generate(request)
 
-        call_kwargs = client.images.generate.call_args.kwargs
+        call_kwargs = client.requests[-1]
         assert call_kwargs["image"] == expected_data_uri
 
     async def test_i2i_multiple_refs(self, backend_and_client, tmp_path: Path):
@@ -262,7 +295,7 @@ class TestArkImageBackendGenerate:
 
         await backend.generate(request)
 
-        call_kwargs = client.images.generate.call_args.kwargs
+        call_kwargs = client.requests[-1]
         assert call_kwargs["image"] == [
             "data:image/png;base64," + base64.b64encode(b"img-a").decode(),
             "data:image/png;base64," + base64.b64encode(b"img-b").decode(),
@@ -280,10 +313,7 @@ class TestArkImageBackendGenerate:
     async def test_empty_data_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """Ark 返回空 data 数组时，应抛出清晰的 RuntimeError 而非 IndexError。"""
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        client = MagicMock()
-        client.images.generate.return_value = _FakeImagesResponse(data=[])
-
-        with patch("lib.image_backends.ark.create_ark_client", return_value=client):
+        with _recorded_ark_client(_FakeImagesResponse(data=[])) as (_created, _client):
             from lib.image_backends.ark import ArkImageBackend
 
             backend = ArkImageBackend(api_key="test-key")
@@ -296,31 +326,23 @@ class TestArkImageBackendGenerate:
     async def test_t2i_url_fallback(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         """网关只返回 url 时，应走 httpx 下载分支。"""
         monkeypatch.delenv("ARK_API_KEY", raising=False)
-        client = MagicMock()
-        client.images.generate.return_value = _FakeImagesResponse(
-            data=[_FakeImageData(b64_json=None, url="https://gateway/img.png")]
-        )
+        response = _FakeImagesResponse(data=[_FakeImageData(b64_json=None, url="https://gateway/img.png")])
         downloaded = b"downloaded-from-gateway"
 
-        with patch("lib.image_backends.ark.create_ark_client", return_value=client):
+        with _recorded_ark_client(response) as (_created, _client):
             from lib.image_backends.ark import ArkImageBackend
 
             backend = ArkImageBackend(api_key="test-key")
             output = tmp_path / "out.png"
             request = ImageGenerationRequest(prompt="a cat", output_path=output)
 
-            with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-                mock_http = AsyncMock()
-                MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-                mock_resp = MagicMock()
-                mock_resp.content = downloaded
-                mock_resp.raise_for_status = MagicMock()
-                mock_http.get = AsyncMock(return_value=mock_resp)
-
+            with capture_http() as router:
+                download = router.get("https://gateway/img.png").mock(
+                    return_value=httpx.Response(200, content=downloaded)
+                )
                 result = await backend.generate(request)
 
-            mock_http.get.assert_awaited_once_with("https://gateway/img.png", timeout=60)
+            assert only_request(download).url.host == "gateway"
 
         assert result.image_path == output
         assert output.read_bytes() == downloaded

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ReferenceImage
+from tests.http_capture import capture_http
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _image_download(url: str, content: bytes) -> Iterator[respx.Route]:
+    """成图下载的出站流：base 层用真实 httpx 取字节，走 respx 在 transport 层拦截。"""
+    with capture_http() as router:
+        yield router.get(url).mock(return_value=httpx.Response(200, content=content))
 
 
 @pytest.fixture()
@@ -94,14 +106,7 @@ class TestGenerateT2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 
-        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-            mock_http = AsyncMock()
-            MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_resp = MagicMock()
-            mock_resp.content = fake_image_bytes
-            mock_resp.raise_for_status = MagicMock()
-            mock_http.get = AsyncMock(return_value=mock_resp)
+        with _image_download(mock_response.url, fake_image_bytes):
 
             request = ImageGenerationRequest(
                 prompt="A beautiful sunset",
@@ -145,14 +150,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
-        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-            mock_http = AsyncMock()
-            MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_resp = MagicMock()
-            mock_resp.content = fake_image_bytes
-            mock_resp.raise_for_status = MagicMock()
-            mock_http.get = AsyncMock(return_value=mock_resp)
+        with _image_download(mock_response.url, fake_image_bytes):
 
             request = ImageGenerationRequest(
                 prompt="Make it darker",
@@ -183,14 +181,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
-        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-            mock_http = AsyncMock()
-            MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_resp = MagicMock()
-            mock_resp.content = fake_image_bytes
-            mock_resp.raise_for_status = MagicMock()
-            mock_http.get = AsyncMock(return_value=mock_resp)
+        with _image_download(mock_response.url, fake_image_bytes):
 
             request = ImageGenerationRequest(
                 prompt="Merge subjects",
@@ -215,14 +206,7 @@ class TestGenerateI2I:
 
         fake_image_bytes = b"\x89PNG\r\n\x1a\n"
 
-        with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-            mock_http = AsyncMock()
-            MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_resp = MagicMock()
-            mock_resp.content = fake_image_bytes
-            mock_resp.raise_for_status = MagicMock()
-            mock_http.get = AsyncMock(return_value=mock_resp)
+        with _image_download(mock_response.url, fake_image_bytes):
 
             request = ImageGenerationRequest(
                 prompt="A cat",

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -107,7 +107,6 @@ class TestGenerateT2I:
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 
         with _image_download(mock_response.url, fake_image_bytes):
-
             request = ImageGenerationRequest(
                 prompt="A beautiful sunset",
                 output_path=output,
@@ -151,7 +150,6 @@ class TestGenerateI2I:
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
         with _image_download(mock_response.url, fake_image_bytes):
-
             request = ImageGenerationRequest(
                 prompt="Make it darker",
                 output_path=output,
@@ -182,7 +180,6 @@ class TestGenerateI2I:
         fake_image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
 
         with _image_download(mock_response.url, fake_image_bytes):
-
             request = ImageGenerationRequest(
                 prompt="Merge subjects",
                 output_path=output,
@@ -207,7 +204,6 @@ class TestGenerateI2I:
         fake_image_bytes = b"\x89PNG\r\n\x1a\n"
 
         with _image_download(mock_response.url, fake_image_bytes):
-
             request = ImageGenerationRequest(
                 prompt="A cat",
                 output_path=output,

--- a/tests/unit/lib/image_backends/test_kling_image_backend.py
+++ b/tests/unit/lib/image_backends/test_kling_image_backend.py
@@ -1,4 +1,4 @@
-"""KlingImageBackend 单元测试（mock httpx，异步轮询，不打真实 HTTP）。
+"""KlingImageBackend 单元测试（respx 在 transport 层拦截，不打真实 HTTP）。
 
 覆盖：JWT / Bearer 双模式鉴权注入、请求体构建（文生图 / 图生图 image 数组）、参考图上限截断、
 缺失参考图 fail-loud、脱敏日志视图、submit→轮询→取 image_url→下载端到端、失败终态、多图取首张。
@@ -6,12 +6,16 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import NamedTuple
 
 import httpx
 import jwt
 import pytest
+import respx
 
 from lib.image_backends.base import (
     ImageCapability,
@@ -21,16 +25,33 @@ from lib.image_backends.base import (
 )
 from lib.image_backends.kling import KlingImageBackend
 from lib.providers import PROVIDER_KLING
+from tests.fakes import bounded_poll_clock
+from tests.http_capture import capture_http, only_request
 
 _SECRET = "s" * 40
+_GENERATIONS_URL = "https://api-beijing.klingai.com/v1/images/generations"
 
 
-def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    resp.raise_for_status = MagicMock()
-    return resp
+class _KlingImageRoutes(NamedTuple):
+    """Kling 图像的三条出站流量：建任务、任务轮询、成图下载。"""
+
+    submit: respx.Route
+    poll: respx.Route
+    download: respx.Route
+
+
+@contextmanager
+def _kling_image_api() -> Iterator[_KlingImageRoutes]:
+    with capture_http() as router:
+        yield _KlingImageRoutes(
+            submit=router.post(_GENERATIONS_URL),
+            poll=router.get(url__regex=rf"^{re.escape(_GENERATIONS_URL)}/[^/]+$"),
+            download=router.get(url__regex=r"^https://x/"),
+        )
+
+
+def _resp(json_body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=json_body)
 
 
 def _submit(task_id: str = "t-1") -> dict:
@@ -42,17 +63,6 @@ def _query(status: str, urls: list[str] | None = None, status_msg: str = "") -> 
     if urls:
         data["task_result"] = {"images": [{"index": i, "url": u} for i, u in enumerate(urls)]}
     return {"code": 0, "message": "SUCCEED", "data": data}
-
-
-def _client(*, post=None, get=None) -> AsyncMock:
-    c = AsyncMock()
-    if post is not None:
-        c.post = post
-    if get is not None:
-        c.get = get
-    c.__aenter__ = AsyncMock(return_value=c)
-    c.__aexit__ = AsyncMock(return_value=None)
-    return c
 
 
 def _jwt_backend(model: str | None = None, api_model_name: str | None = None) -> KlingImageBackend:
@@ -192,104 +202,81 @@ class TestSafeLogView:
 
 class TestGenerateHappyPath:
     async def test_submit_poll_download(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit("task-9")))
-        get = AsyncMock(
-            side_effect=[
-                _resp(_query("processing")),
-                _resp(_query("succeed", urls=["https://x/final.png"])),
-            ]
-        )
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()) as dl,
-        ):
+        with _kling_image_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_resp(_submit("task-9")))
+            routes.poll.mock(
+                side_effect=[
+                    _resp(_query("processing")),
+                    _resp(_query("succeed", urls=["https://x/final.png"])),
+                ]
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"png-bytes"))
+
             result = await _jwt_backend().generate(_request(tmp_path))
+
+            # images/generations 提交端点
+            assert only_request(routes.submit).url.path == "/v1/images/generations"
+            assert routes.poll.calls.last.request.url.path == "/v1/images/generations/task-9"
 
         assert result.provider == PROVIDER_KLING
         assert result.image_uri == "https://x/final.png"
-        dl.assert_awaited_once()
-        # images/generations 提交端点
-        assert post.await_args.args[0].endswith("/images/generations")
+        assert result.image_path.read_bytes() == b"png-bytes"
 
     async def test_multiple_images_takes_first(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit()))
-        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/1.png", "https://x/2.png"])))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
-        ):
+        with _kling_image_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("succeed", urls=["https://x/1.png", "https://x/2.png"])))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
+
             result = await _jwt_backend().generate(_request(tmp_path))
+
+            assert str(only_request(routes.download).url) == "https://x/1.png"
+
         assert result.image_uri == "https://x/1.png"
 
     async def test_jwt_injected_on_submit(self, tmp_path):
-        captured: dict = {}
+        with _kling_image_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
 
-        async def _post(url, json, headers):
-            captured["headers"] = headers
-            return _resp(_submit())
-
-        post = AsyncMock(side_effect=_post)
-        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
-        ):
             await _jwt_backend().generate(_request(tmp_path))
 
-        token = captured["headers"]["Authorization"].removeprefix("Bearer ")
+            token = only_request(routes.submit).headers["Authorization"].removeprefix("Bearer ")
+
         claims = jwt.decode(token, _SECRET, algorithms=["HS256"], options={"verify_exp": False})
         assert claims["iss"] == "ak-1"
 
     async def test_bearer_static_key_on_submit(self, tmp_path):
-        captured: dict = {}
+        with _kling_image_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
+            routes.download.mock(return_value=httpx.Response(200, content=b""))
 
-        async def _post(url, json, headers):
-            captured["headers"] = headers
-            return _resp(_submit())
-
-        post = AsyncMock(side_effect=_post)
-        get = AsyncMock(return_value=_resp(_query("succeed", urls=["https://x/v.png"])))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
-        ):
             await _bearer_backend().generate(_request(tmp_path))
-        assert captured["headers"]["Authorization"] == "Bearer static-key"
+
+            assert only_request(routes.submit).headers["Authorization"] == "Bearer static-key"
 
     async def test_failed_status_raises(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit()))
-        get = AsyncMock(return_value=_resp(_query("failed", status_msg="content rejected")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-            patch("lib.image_backends.kling.download_image_to_path", new=AsyncMock()),
-        ):
+        with _kling_image_api() as routes:
+            routes.submit.mock(return_value=_resp(_submit()))
+            routes.poll.mock(return_value=_resp(_query("failed", status_msg="content rejected")))
+
             with pytest.raises(RuntimeError, match="content rejected"):
                 await _jwt_backend().generate(_request(tmp_path))
 
+            assert routes.download.call_count == 0
+
     async def test_http_error_raises_and_no_retry_on_4xx(self, tmp_path):
-        # 真实 httpx.Response：submit 阶段 4xx 经 raise_for_status 抛 HTTPStatusError；
-        # 确定性 4xx 不重试（非幂等建任务 POST），post 仅调用一次，不重复建任务 + 重复计费。
-        req = httpx.Request("POST", "https://api.klingai.com/v1/images/generations")
-        resp = httpx.Response(400, request=req, text="Bad Request")
-        post = AsyncMock(return_value=resp)
-        client = _client(post=post)
-        with (
-            patch("lib.image_backends.kling.httpx.AsyncClient", return_value=client),
-            patch("lib.image_backends.kling._POLL_INTERVAL_SECONDS", 0),
-        ):
+        # submit 阶段 4xx 经 raise_for_status 抛 HTTPStatusError；确定性 4xx 不重试
+        # （非幂等建任务 POST），提交仅发一次，不重复建任务 + 重复计费。
+        with _kling_image_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=httpx.Response(400, text="Bad Request"))
+
             with pytest.raises(httpx.HTTPStatusError):
                 await _jwt_backend().generate(_request(tmp_path))
-        assert post.call_count == 1
+
+            assert routes.submit.call_count == 1
 
 
 class TestRegistration:

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import respx
 
 from lib.image_backends.base import (
     ImageCapability,
@@ -17,61 +19,33 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_MINIMAX
+from tests.http_capture import capture_http, request_json
 
 
-def _img_response(url: str = "https://x/out.png") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {
-        "id": "trace-1",
-        "data": {"image_urls": [url]},
-        "base_resp": {"status_code": 0, "status_msg": "success"},
-    }
-    return resp
+def _img_response(url: str = "https://x/out.png") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "trace-1",
+            "data": {"image_urls": [url]},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
 
 
-def _b64_response(b64: str) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {
-        "id": "trace-1",
-        "data": {"image_base64": [b64]},
-        "base_resp": {"status_code": 0, "status_msg": "success"},
-    }
-    return resp
+def _b64_response(b64: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "trace-1",
+            "data": {"image_base64": [b64]},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
 
 
-def _biz_error_response(status_code: int = 1004, msg: str = "invalid api key") -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = {"base_resp": {"status_code": status_code, "status_msg": msg}}
-    return resp
-
-
-class _RecordingClient:
-    """httpx.AsyncClient 替身：记录每次 post 的 url 与参数，回固定响应。
-
-    端点派生、请求体字段、鉴权头都是「发出去的请求长什么样」的契约，断言落在 ``posts``
-    里的请求内容上，而不是替身的调用对象。
-    """
-
-    def __init__(self, resp: MagicMock) -> None:
-        self.posts: list[dict[str, Any]] = []
-        self._resp = resp
-
-    async def post(self, url: str, **kwargs: Any) -> MagicMock:
-        self.posts.append({"url": url, **kwargs})
-        return self._resp
-
-    async def __aenter__(self) -> _RecordingClient:
-        return self
-
-    async def __aexit__(self, *_exc: object) -> None:
-        return None
-
-
-def _mock_client(resp: MagicMock) -> _RecordingClient:
-    return _RecordingClient(resp)
+def _biz_error_response(status_code: int = 1004, msg: str = "invalid api key") -> httpx.Response:
+    return httpx.Response(200, json={"base_resp": {"status_code": status_code, "status_msg": msg}})
 
 
 def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
@@ -80,25 +54,26 @@ def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
     return ReferenceImage(path=str(p))
 
 
-def _http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://x/v1/image_generation")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"error {status_code}", request=request, response=response)
+def _error_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code, text="Request Entity Too Large")
 
 
-def _error_response(status_code: int) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.text = "Request Entity Too Large"
-    resp.raise_for_status = MagicMock(side_effect=_http_error(status_code, "Request Entity Too Large"))
-    return resp
+@contextmanager
+def _generation_route(
+    resp: httpx.Response, download: AsyncMock | None = None
+) -> Iterator[respx.Route]:
+    """成图端点的出站流：走 respx 在 transport 层拦截。
 
-
-def _patches(client: AsyncMock, download: AsyncMock):
-    return (
-        patch("httpx.AsyncClient", return_value=client),
-        patch("lib.image_backends.minimax.download_image_to_path", download),
-    )
+    端点派生、请求体字段、鉴权头都是「发出去的请求长什么样」的契约，断言落在路由捕获的
+    真实请求上；``download`` 给出时同时接管落盘（非 base64 分支的独立下载段）。
+    """
+    with capture_http() as router:
+        route = router.post(url__regex=r"https://[^/]+/v1/image_generation").mock(return_value=resp)
+        if download is None:
+            yield route
+        else:
+            with patch("lib.image_backends.minimax.download_image_to_path", download):
+                yield route
 
 
 class TestCapabilities:
@@ -125,16 +100,14 @@ class TestCapabilities:
 
 class TestTextToImage:
     async def test_t2i_request_build(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk", model="image-01", base_url="https://api.minimax.io")
             result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
 
-        body = client.posts[-1]["json"]
+        body = request_json(route.calls.last.request)
         assert body["model"] == "image-01"
         assert body["prompt"] == "a fox"
         assert body["response_format"] == "url"
@@ -144,61 +117,53 @@ class TestTextToImage:
         # 默认 aspect_ratio=9:16 精确算、受单边 2048 收口
         assert (body["width"], body["height"]) == (1152, 2048)
         # 端点：base host 派生 /v1 + /image_generation
-        assert client.posts[-1]["url"] == "https://api.minimax.io/v1/image_generation"
-        assert client.posts[-1]["headers"]["Authorization"] == "Bearer sk"
+        assert str(route.calls.last.request.url) == "https://api.minimax.io/v1/image_generation"
+        assert route.calls.last.request.headers["Authorization"] == "Bearer sk"
         assert result.provider == PROVIDER_MINIMAX
         assert result.model == "image-01"
         assert result.image_uri == "https://x/out.png"
         download.assert_called_once()
 
     async def test_default_endpoint_is_domestic(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert client.posts[-1]["url"] == "https://api.minimaxi.com/v1/image_generation"
+        assert str(route.calls.last.request.url) == "https://api.minimaxi.com/v1/image_generation"
 
     async def test_seed_passthrough(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", seed=42))
 
-        assert client.posts[-1]["json"]["seed"] == 42
+        assert request_json(route.calls.last.request)["seed"] == 42
 
     async def test_no_seed_field_when_unset(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert "seed" not in client.posts[-1]["json"]
+        assert "seed" not in request_json(route.calls.last.request)
 
 
 class TestDimensions:
     async def _dims(self, tmp_path: Path, **req_kwargs) -> tuple[int, int]:
-        client = _mock_client(_img_response())
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", **req_kwargs))
-        body = client.posts[-1]["json"]
+        body = request_json(route.calls.last.request)
         return body["width"], body["height"]
 
     async def test_landscape_picks_wide(self, tmp_path: Path):
@@ -237,11 +202,9 @@ class TestDimensions:
 
 class TestSubjectReference:
     async def test_i2i_single_subject_reference(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         ref = _make_ref(tmp_path, "face.png")
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -249,24 +212,22 @@ class TestSubjectReference:
                 ImageGenerationRequest(prompt="hero portrait", output_path=tmp_path / "o.png", reference_images=[ref])
             )
 
-        subject = client.posts[-1]["json"]["subject_reference"]
+        subject = request_json(route.calls.last.request)["subject_reference"]
         assert len(subject) == 1
         assert subject[0]["type"] == "character"
         assert subject[0]["image_file"].startswith("data:image/png;base64,")
 
     async def test_multiple_refs_truncated_to_first(self, tmp_path: Path):
-        client = _mock_client(_img_response())
         download = AsyncMock()
         refs = [_make_ref(tmp_path, f"r{i}.png") for i in range(3)]
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=refs))
 
         # image-01 单脸参考：仅取首张
-        subject = client.posts[-1]["json"]["subject_reference"]
+        subject = request_json(route.calls.last.request)["subject_reference"]
         assert len(subject) == 1
 
     async def test_missing_ref_raises_unreadable(self, tmp_path: Path):
@@ -315,11 +276,10 @@ class TestResponseHandling:
     async def test_base64_response_decoded_and_saved(self, tmp_path: Path):
         raw = b"\x89PNG\r\nhello-bytes"
         b64 = base64.b64encode(raw).decode("ascii")
-        client = _mock_client(_b64_response(b64))
         download = AsyncMock()
         out = tmp_path / "o.png"
-        # 不 patch download：base64 路径独立落盘
-        with patch("httpx.AsyncClient", return_value=client):
+        # 不接管 download：base64 路径独立落盘
+        with _generation_route(_b64_response(b64)):
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -333,9 +293,8 @@ class TestResponseHandling:
     async def test_base64_data_uri_prefix_stripped(self, tmp_path: Path):
         raw = b"PNGDATA"
         b64 = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
-        client = _mock_client(_b64_response(b64))
         out = tmp_path / "o.png"
-        with patch("httpx.AsyncClient", return_value=client):
+        with _generation_route(_b64_response(b64)):
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -344,10 +303,8 @@ class TestResponseHandling:
         assert out.read_bytes() == raw
 
     async def test_business_error_raises_runtime(self, tmp_path: Path):
-        client = _mock_client(_biz_error_response(1004, "invalid api key"))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_biz_error_response(1004, "invalid api key"), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -355,17 +312,13 @@ class TestResponseHandling:
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         assert "1004" in str(ei.value)
         # 业务错误不重试、不下载
-        assert len(client.posts) == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
     async def test_empty_data_raises_runtime(self, tmp_path: Path):
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = {"data": {}, "base_resp": {"status_code": 0}}
-        client = _mock_client(resp)
+        resp = httpx.Response(200, json={"data": {}, "base_resp": {"status_code": 0}})
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(resp, download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -375,24 +328,20 @@ class TestResponseHandling:
 
 class TestHttpErrors:
     async def test_400_surfaces_httpstatuserror_single_call(self, tmp_path: Path):
-        client = _mock_client(_error_response(400))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_error_response(400), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         assert ei.value.response.status_code == 400
-        assert len(client.posts) == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
     async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
-        client = _mock_client(_error_response(413))
         download = AsyncMock()
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_error_response(413), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
@@ -400,7 +349,7 @@ class TestHttpErrors:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # 保留 status_code 让咽喉层识别 413 走降档；单次 fail-fast
         assert ei.value.response.status_code == 413
-        assert len(client.posts) == 1
+        assert route.call_count == 1
         download.assert_not_called()
 
 
@@ -410,17 +359,15 @@ class TestRetryScope:
         # 退避 sleep 打桩跳过，避免下载层重试真的等 DOWNLOAD_BACKOFF 秒级时间。
         from lib.retry import DOWNLOAD_MAX_ATTEMPTS
 
-        client = _mock_client(_img_response())
         download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
-        p1, p2 = _patches(client, download)
-        with p1, p2:
+        with _generation_route(_img_response(), download) as route:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             with pytest.raises(httpx.ConnectError):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
-        assert len(client.posts) == 1
+        assert route.call_count == 1
         assert download.call_count == DOWNLOAD_MAX_ATTEMPTS
 
 

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -355,7 +355,7 @@ class TestResponseHandling:
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         assert "1004" in str(ei.value)
         # 业务错误不重试、不下载
-        assert client.post.call_count == 1
+        assert len(client.posts) == 1
         download.assert_not_called()
 
     async def test_empty_data_raises_runtime(self, tmp_path: Path):
@@ -385,7 +385,7 @@ class TestHttpErrors:
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         assert ei.value.response.status_code == 400
-        assert client.post.call_count == 1
+        assert len(client.posts) == 1
         download.assert_not_called()
 
     async def test_413_surfaces_httpstatuserror_no_retry(self, tmp_path: Path):
@@ -400,17 +400,16 @@ class TestHttpErrors:
                 await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png"))
         # 保留 status_code 让咽喉层识别 413 走降档；单次 fail-fast
         assert ei.value.response.status_code == 413
-        assert client.post.call_count == 1
+        assert len(client.posts) == 1
         download.assert_not_called()
 
 
 class TestRetryScope:
-    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, monkeypatch):
+    async def test_download_failure_does_not_retrigger_generation(self, tmp_path: Path, poll_clock):
         # 下载阶段瞬态失败只在下载层重试，绝不回退到重跑非幂等的生成 POST（防重复建图 + 重复计费）。
         # 退避 sleep 打桩跳过，避免下载层重试真的等 DOWNLOAD_BACKOFF 秒级时间。
         from lib.retry import DOWNLOAD_MAX_ATTEMPTS
 
-        monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())
         client = _mock_client(_img_response())
         download = AsyncMock(side_effect=httpx.ConnectError("conn reset"))
         p1, p2 = _patches(client, download)
@@ -421,7 +420,7 @@ class TestRetryScope:
             with pytest.raises(httpx.ConnectError):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         # 生成 POST 恰好一次（计费一次）；重试全部发生在下载层
-        assert client.post.call_count == 1
+        assert len(client.posts) == 1
         assert download.call_count == DOWNLOAD_MAX_ATTEMPTS
 
 

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -47,12 +48,30 @@ def _biz_error_response(status_code: int = 1004, msg: str = "invalid api key") -
     return resp
 
 
-def _mock_client(resp: MagicMock) -> AsyncMock:
-    client = AsyncMock()
-    client.post = AsyncMock(return_value=resp)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+class _RecordingClient:
+    """httpx.AsyncClient 替身：记录每次 post 的 url 与参数，回固定响应。
+
+    端点派生、请求体字段、鉴权头都是「发出去的请求长什么样」的契约，断言落在 ``posts``
+    里的请求内容上，而不是替身的调用对象。
+    """
+
+    def __init__(self, resp: MagicMock) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self._resp = resp
+
+    async def post(self, url: str, **kwargs: Any) -> MagicMock:
+        self.posts.append({"url": url, **kwargs})
+        return self._resp
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+def _mock_client(resp: MagicMock) -> _RecordingClient:
+    return _RecordingClient(resp)
 
 
 def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
@@ -115,7 +134,7 @@ class TestTextToImage:
             b = MiniMaxImageBackend(api_key="sk", model="image-01", base_url="https://api.minimax.io")
             result = await b.generate(ImageGenerationRequest(prompt="a fox", output_path=tmp_path / "o.png"))
 
-        body = client.post.call_args.kwargs["json"]
+        body = client.posts[-1]["json"]
         assert body["model"] == "image-01"
         assert body["prompt"] == "a fox"
         assert body["response_format"] == "url"
@@ -125,8 +144,8 @@ class TestTextToImage:
         # 默认 aspect_ratio=9:16 精确算、受单边 2048 收口
         assert (body["width"], body["height"]) == (1152, 2048)
         # 端点：base host 派生 /v1 + /image_generation
-        assert client.post.call_args.args[0] == "https://api.minimax.io/v1/image_generation"
-        assert client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk"
+        assert client.posts[-1]["url"] == "https://api.minimax.io/v1/image_generation"
+        assert client.posts[-1]["headers"]["Authorization"] == "Bearer sk"
         assert result.provider == PROVIDER_MINIMAX
         assert result.model == "image-01"
         assert result.image_uri == "https://x/out.png"
@@ -142,7 +161,7 @@ class TestTextToImage:
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert client.post.call_args.args[0] == "https://api.minimaxi.com/v1/image_generation"
+        assert client.posts[-1]["url"] == "https://api.minimaxi.com/v1/image_generation"
 
     async def test_seed_passthrough(self, tmp_path: Path):
         client = _mock_client(_img_response())
@@ -154,7 +173,7 @@ class TestTextToImage:
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", seed=42))
 
-        assert client.post.call_args.kwargs["json"]["seed"] == 42
+        assert client.posts[-1]["json"]["seed"] == 42
 
     async def test_no_seed_field_when_unset(self, tmp_path: Path):
         client = _mock_client(_img_response())
@@ -166,7 +185,7 @@ class TestTextToImage:
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
 
-        assert "seed" not in client.post.call_args.kwargs["json"]
+        assert "seed" not in client.posts[-1]["json"]
 
 
 class TestDimensions:
@@ -179,7 +198,7 @@ class TestDimensions:
 
             b = MiniMaxImageBackend(api_key="sk")
             await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png", **req_kwargs))
-        body = client.post.call_args.kwargs["json"]
+        body = client.posts[-1]["json"]
         return body["width"], body["height"]
 
     async def test_landscape_picks_wide(self, tmp_path: Path):
@@ -230,7 +249,7 @@ class TestSubjectReference:
                 ImageGenerationRequest(prompt="hero portrait", output_path=tmp_path / "o.png", reference_images=[ref])
             )
 
-        subject = client.post.call_args.kwargs["json"]["subject_reference"]
+        subject = client.posts[-1]["json"]["subject_reference"]
         assert len(subject) == 1
         assert subject[0]["type"] == "character"
         assert subject[0]["image_file"].startswith("data:image/png;base64,")
@@ -247,7 +266,7 @@ class TestSubjectReference:
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=refs))
 
         # image-01 单脸参考：仅取首张
-        subject = client.post.call_args.kwargs["json"]["subject_reference"]
+        subject = client.posts[-1]["json"]["subject_reference"]
         assert len(subject) == 1
 
     async def test_missing_ref_raises_unreadable(self, tmp_path: Path):

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -59,9 +59,7 @@ def _error_response(status_code: int) -> httpx.Response:
 
 
 @contextmanager
-def _generation_route(
-    resp: httpx.Response, download: AsyncMock | None = None
-) -> Iterator[respx.Route]:
+def _generation_route(resp: httpx.Response, download: AsyncMock | None = None) -> Iterator[respx.Route]:
     """成图端点的出站流：走 respx 在 transport 层拦截。
 
     端点派生、请求体字段、鉴权头都是「发出去的请求长什么样」的契约，断言落在路由捕获的
@@ -318,12 +316,13 @@ class TestResponseHandling:
     async def test_empty_data_raises_runtime(self, tmp_path: Path):
         resp = httpx.Response(200, json={"data": {}, "base_resp": {"status_code": 0}})
         download = AsyncMock()
-        with _generation_route(resp, download) as route:
+        with _generation_route(resp, download):
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
             with pytest.raises(RuntimeError):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
+        download.assert_not_called()
 
 
 class TestHttpErrors:

--- a/tests/unit/lib/image_backends/test_openai_image_backend.py
+++ b/tests/unit/lib/image_backends/test_openai_image_backend.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from lib.image_backends import ImageCapabilityError
@@ -15,6 +16,7 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_OPENAI
+from tests.http_capture import capture_http, only_request
 
 
 def _make_mock_image_response(
@@ -192,18 +194,13 @@ class TestOpenAIImageBackend:
                 image_size="1K",
             )
 
-            with patch("lib.image_backends.base.httpx.AsyncClient") as MockHttpClient:
-                mock_http = AsyncMock()
-                MockHttpClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-                MockHttpClient.return_value.__aexit__ = AsyncMock(return_value=False)
-                mock_resp = MagicMock()
-                mock_resp.content = downloaded
-                mock_resp.raise_for_status = MagicMock()
-                mock_http.get = AsyncMock(return_value=mock_resp)
-
+            with capture_http() as router:
+                download = router.get("https://gateway/img.png").mock(
+                    return_value=httpx.Response(200, content=downloaded)
+                )
                 result = await backend.generate(request)
 
-            mock_http.get.assert_awaited_once_with("https://gateway/img.png", timeout=60)
+            assert str(only_request(download).url) == "https://gateway/img.png"
 
         assert result.image_path == output_path
         assert output_path.read_bytes() == downloaded

--- a/tests/unit/lib/image_backends/test_openai_image_backend.py
+++ b/tests/unit/lib/image_backends/test_openai_image_backend.py
@@ -16,6 +16,7 @@ from lib.image_backends.base import (
     ReferenceImage,
 )
 from lib.providers import PROVIDER_OPENAI
+from tests.fakes import captured_openai_clients
 from tests.http_capture import capture_http, only_request
 
 
@@ -65,7 +66,7 @@ def _make_mock_image_response(
 
 class TestOpenAIImageBackend:
     def test_name_and_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -73,14 +74,14 @@ class TestOpenAIImageBackend:
             assert backend.model == "gpt-image-2"
 
     def test_custom_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key", model="custom-image-model")
             assert backend.model == "custom-image-model"
 
     def test_capabilities(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -93,7 +94,7 @@ class TestOpenAIImageBackend:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -128,7 +129,7 @@ class TestOpenAIImageBackend:
         ref_path = tmp_path / "ref.png"
         ref_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -159,7 +160,7 @@ class TestOpenAIImageBackend:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=empty_response)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -182,7 +183,7 @@ class TestOpenAIImageBackend:
 
         downloaded = b"downloaded-from-gateway"
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -211,7 +212,7 @@ class TestOpenAIImageBackend:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -235,7 +236,7 @@ class TestOpenAIImageBackend:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -269,7 +270,7 @@ class TestOpenAIImageBackend:
             )
         )
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -292,7 +293,7 @@ class TestOpenAIImageBackend:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -327,7 +328,7 @@ class TestOpenAIImageBackend:
             )
         )
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -359,7 +360,7 @@ class TestOpenAIImageBackend:
             )
         )
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -391,7 +392,7 @@ class TestOpenAIImageBackend:
             )
         )
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -427,7 +428,7 @@ class TestOpenAIImageBackend:
         ref_path = tmp_path / "ref.png"
         ref_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.openai import OpenAIImageBackend
 
             backend = OpenAIImageBackend(api_key="test-key")
@@ -501,7 +502,7 @@ class TestModeGating:
     @pytest.mark.asyncio
     async def test_all_refs_failed_to_open_raises(self, tmp_path):
         """所有 ref 图都打不开时，应抛 ImageCapabilityError 而非回退到 T2I。"""
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.image_backends.openai import OpenAIImageBackend
 
             b = OpenAIImageBackend(api_key="x", model="m")  # mode="both" 默认

--- a/tests/unit/lib/image_backends/test_quality_propagation.py
+++ b/tests/unit/lib/image_backends/test_quality_propagation.py
@@ -13,6 +13,8 @@ import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from tests.fakes import captured_openai_clients
+
 # ---------------------------------------------------------------------------
 # 1 & 2: ImageGenerationResult dataclass
 # ---------------------------------------------------------------------------
@@ -74,7 +76,7 @@ class TestOpenAIImageBackendQuality:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.base import ImageGenerationRequest
             from lib.image_backends.openai import OpenAIImageBackend
 
@@ -95,7 +97,7 @@ class TestOpenAIImageBackendQuality:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.base import ImageGenerationRequest
             from lib.image_backends.openai import OpenAIImageBackend
 
@@ -123,7 +125,7 @@ class TestOpenAIImageBackendQuality:
         mock_client = AsyncMock()
         mock_client.images.generate = AsyncMock(return_value=_make_mock_image_response(b64_data))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.image_backends.base import ImageGenerationRequest
             from lib.image_backends.openai import OpenAIImageBackend
 

--- a/tests/unit/lib/image_backends/test_registry.py
+++ b/tests/unit/lib/image_backends/test_registry.py
@@ -1,6 +1,13 @@
+"""图片后端注册表测试。"""
+
 import pytest
 
-from lib.image_backends.registry import create_backend, get_registered_backends, register_backend
+from lib.image_backends.registry import (
+    _BACKEND_FACTORIES,
+    create_backend,
+    get_registered_backends,
+    register_backend,
+)
 
 
 class _DummyBackend:
@@ -8,19 +15,23 @@ class _DummyBackend:
         self.kwargs = kwargs
 
 
-def test_register_and_create(monkeypatch):
-    from lib.image_backends import registry
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """注册表是模块级全局：清空后跑，跑完还原，避免测试用后端泄漏给其他用例。"""
+    saved = dict(_BACKEND_FACTORIES)
+    _BACKEND_FACTORIES.clear()
+    yield
+    _BACKEND_FACTORIES.clear()
+    _BACKEND_FACTORIES.update(saved)
 
-    monkeypatch.setattr(registry, "_BACKEND_FACTORIES", {})
+
+def test_register_and_create():
     register_backend("dummy", _DummyBackend)
-    assert "dummy" in get_registered_backends()
+    assert get_registered_backends() == ["dummy"]
     backend = create_backend("dummy", api_key="test")
     assert backend.kwargs == {"api_key": "test"}
 
 
-def test_create_unknown_raises(monkeypatch):
-    from lib.image_backends import registry
-
-    monkeypatch.setattr(registry, "_BACKEND_FACTORIES", {})
+def test_create_unknown_raises():
     with pytest.raises(ValueError, match="Unknown image backend"):
         create_backend("nonexistent")

--- a/tests/unit/lib/image_backends/test_registry.py
+++ b/tests/unit/lib/image_backends/test_registry.py
@@ -16,7 +16,7 @@ class _DummyBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_image_registry():
     """注册表是模块级全局：清空后跑，跑完还原，避免测试用后端泄漏给其他用例。"""
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()

--- a/tests/unit/lib/test_ark_shared.py
+++ b/tests/unit/lib/test_ark_shared.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -50,15 +53,26 @@ class TestApiKeyResolution:
             resolve_ark_api_key("   ")
 
 
+@contextmanager
+def _recorded_ark_sdk() -> Iterator[list[dict[str, Any]]]:
+    """Ark SDK 类构造的记录器：收下建客户端的参数，回一个空替身。"""
+    created: list[dict[str, Any]] = []
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return MagicMock()
+
+    with patch("volcenginesdkarkruntime.Ark", _create):
+        yield created
+
+
 class TestCreateArkClient:
     def test_trailing_slash_normalized_before_client_construction(self):
-        mock_ark_cls = MagicMock()
-        with patch("volcenginesdkarkruntime.Ark", mock_ark_cls):
+        with _recorded_ark_sdk() as created:
             create_ark_client(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/v3/")
-        mock_ark_cls.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")
+        assert created == [{"base_url": ARK_BASE_URL, "api_key": "k"}]
 
     def test_default_base_url_when_omitted(self):
-        mock_ark_cls = MagicMock()
-        with patch("volcenginesdkarkruntime.Ark", mock_ark_cls):
+        with _recorded_ark_sdk() as created:
             create_ark_client(api_key="k")
-        mock_ark_cls.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")
+        assert created == [{"base_url": ARK_BASE_URL, "api_key": "k"}]

--- a/tests/unit/lib/test_grok_shared.py
+++ b/tests/unit/lib/test_grok_shared.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import grpc
 import grpc.aio
@@ -10,6 +10,7 @@ import pytest
 
 from lib.grok_shared import grok_should_retry
 from lib.retry import with_retry_async
+from tests.fakes import bounded_poll_clock
 
 
 def _make_aio_rpc_error(code: grpc.StatusCode, details: str = "") -> grpc.aio.AioRpcError:
@@ -81,7 +82,7 @@ class TestGrokRetryIntegration:
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+        with bounded_poll_clock():
             result = await fn()
 
         assert result == "ok"

--- a/tests/unit/lib/test_vidu_shared.py
+++ b/tests/unit/lib/test_vidu_shared.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import httpx
 import pytest
+import respx
 
 from lib import vidu_shared
+from tests.http_capture import capture_http, only_request
 
 
 class TestResolveViduApiKey:
@@ -31,60 +37,48 @@ class TestViduConnectionTestKeyResolution:
     def test_missing_config_key_raises_before_http(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("VIDU_API_KEY", "from-env")
 
-        # resolve 阶段就该抛错，httpx.Client 不应被构造
-        def _should_not_be_called(*_args, **_kwargs):
-            raise AssertionError("connection test should fail before HTTP call")
+        # 未声明任何路由：真发出请求会被 respx 判红，凭证解析失败必须先于出站发生
+        with capture_http() as router:
+            with pytest.raises(ValueError, match="Vidu API Key"):
+                vidu_shared.test_vidu_connection({})
 
-        monkeypatch.setattr(vidu_shared.httpx, "Client", _should_not_be_called)
+            assert router.calls.call_count == 0
 
-        with pytest.raises(ValueError, match="Vidu API Key"):
-            vidu_shared.test_vidu_connection({})
+
+@contextmanager
+def _probe_route(*, status_code: int, body: str = "") -> Iterator[respx.Route]:
+    """连接测试探针的出站流：走 respx 在 transport 层拦截。
+
+    白名单判定的输入是真实响应的状态码，URL 拼接与 Authorization 头都在断言范围内。
+    """
+    with capture_http() as router:
+        yield router.get(url__regex=r".*/tasks/0/creations").mock(return_value=httpx.Response(status_code, text=body))
 
 
 class TestViduConnectionTestUrl:
     """验证连接测试用数字 task id（Vidu 服务端把 id 当 int 解析，非数字会 400 CODEC）。"""
 
-    @staticmethod
-    def _patched_client(monkeypatch: pytest.MonkeyPatch, *, status_code: int, body: str = ""):
-        captured: dict[str, str] = {}
-
-        class _FakeResp:
-            def __init__(self):
-                self.status_code = status_code
-                self.text = body
-
-        class _FakeClient:
-            def __init__(self, *_args, **_kwargs):
-                pass
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_exc):
-                return False
-
-            def get(self, url, **_kwargs):
-                captured["url"] = url
-                return _FakeResp()
-
-        monkeypatch.setattr(vidu_shared.httpx, "Client", _FakeClient)
-        return captured
-
-    def test_url_uses_numeric_bogus_id(self, monkeypatch: pytest.MonkeyPatch):
-        captured = self._patched_client(monkeypatch, status_code=404)
-        vidu_shared.test_vidu_connection({"api_key": "vda_test"})
-        assert captured["url"].endswith("/tasks/0/creations")
-
-    def test_404_is_success(self, monkeypatch: pytest.MonkeyPatch):
-        self._patched_client(monkeypatch, status_code=404)
-        vidu_shared.test_vidu_connection({"api_key": "vda_test"})  # 不抛错即成功
-
-    def test_401_is_invalid_credential(self, monkeypatch: pytest.MonkeyPatch):
-        self._patched_client(monkeypatch, status_code=401)
-        with pytest.raises(RuntimeError, match="凭证无效"):
+    def test_url_uses_numeric_bogus_id(self):
+        with _probe_route(status_code=404) as route:
             vidu_shared.test_vidu_connection({"api_key": "vda_test"})
 
-    def test_400_is_undecidable(self, monkeypatch: pytest.MonkeyPatch):
-        self._patched_client(monkeypatch, status_code=400, body="CODEC parse error")
-        with pytest.raises(RuntimeError, match="无法判定"):
-            vidu_shared.test_vidu_connection({"api_key": "vda_test"})
+        request = only_request(route)
+        assert request.url.path.endswith("/tasks/0/creations")
+        assert request.headers["authorization"] == "Token vda_test"
+
+    def test_404_is_success(self):
+        """404 = task 不存在但认证通过，白名单放行：不抛错，且探针请求确实发出去了。"""
+        with _probe_route(status_code=404) as route:
+            assert vidu_shared.test_vidu_connection({"api_key": "vda_test"}) is None
+
+        assert route.call_count == 1
+
+    def test_401_is_invalid_credential(self):
+        with _probe_route(status_code=401):
+            with pytest.raises(RuntimeError, match="凭证无效"):
+                vidu_shared.test_vidu_connection({"api_key": "vda_test"})
+
+    def test_400_is_undecidable(self):
+        with _probe_route(status_code=400, body="CODEC parse error"):
+            with pytest.raises(RuntimeError, match="无法判定"):
+                vidu_shared.test_vidu_connection({"api_key": "vda_test"})

--- a/tests/unit/lib/text_backends/test_agnes_text_backend.py
+++ b/tests/unit/lib/text_backends/test_agnes_text_backend.py
@@ -8,9 +8,6 @@ AgnesTextBackend 复用 OpenAITextBackend 的原生 + Instructor 降级流水线
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
-from contextlib import contextmanager
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,19 +15,7 @@ from pydantic import BaseModel
 
 from lib.providers import PROVIDER_AGNES
 from lib.text_backends.base import TextCapability, TextGenerationRequest
-
-
-@contextmanager
-def _recorded_openai_clients() -> Iterator[list[dict[str, Any]]]:
-    """AsyncOpenAI 构造的记录器：收下建客户端的参数，回一个空替身。"""
-    created: list[dict[str, Any]] = []
-
-    def _create(**kwargs: Any) -> Any:
-        created.append(kwargs)
-        return AsyncMock()
-
-    with patch("lib.openai_shared.AsyncOpenAI", _create):
-        yield created
+from tests.fakes import captured_openai_clients
 
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
@@ -59,7 +44,7 @@ class _PersonSchema(BaseModel):
 
 class TestConstruction:
     def test_name_and_default_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.agnes import AgnesTextBackend
 
             backend = AgnesTextBackend(api_key="sk")
@@ -67,14 +52,14 @@ class TestConstruction:
             assert backend.model == "agnes-2.0-flash"
 
     def test_custom_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.agnes import AgnesTextBackend
 
             backend = AgnesTextBackend(api_key="sk", model="agnes-2.0-pro")
             assert backend.model == "agnes-2.0-pro"
 
     def test_capabilities_text_and_structured_no_vision(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.agnes import AgnesTextBackend
 
             backend = AgnesTextBackend(api_key="sk")
@@ -84,7 +69,7 @@ class TestConstruction:
             assert TextCapability.VISION not in backend.capabilities
 
     def test_missing_api_key_raises(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.agnes import AgnesTextBackend
 
             with pytest.raises(ValueError, match="Agnes API Key"):
@@ -92,14 +77,14 @@ class TestConstruction:
 
     def test_base_url_normalized_to_v1(self):
         # 用户填 host（无 /v1 后缀）→ 归一化为 {host}/v1 后传给 SDK。
-        with _recorded_openai_clients() as created:
+        with captured_openai_clients() as created:
             from lib.text_backends.agnes import AgnesTextBackend
 
             AgnesTextBackend(api_key="sk", base_url="https://apihub.agnes-ai.com")
         assert [c["base_url"] for c in created] == ["https://apihub.agnes-ai.com/v1"]
 
     def test_default_base_url_when_unset(self):
-        with _recorded_openai_clients() as created:
+        with captured_openai_clients() as created:
             from lib.text_backends.agnes import AgnesTextBackend
 
             AgnesTextBackend(api_key="sk")
@@ -111,7 +96,7 @@ class TestGenerate:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("Test output", 15, 8))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.agnes import AgnesTextBackend
 
             backend = AgnesTextBackend(api_key="sk")
@@ -127,7 +112,7 @@ class TestGenerate:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.agnes import AgnesTextBackend
 
             backend = AgnesTextBackend(api_key="sk")
@@ -144,7 +129,7 @@ class TestGenerate:
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(schema_response))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.agnes import AgnesTextBackend
@@ -176,7 +161,7 @@ class TestGenerate:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.agnes import AgnesTextBackend

--- a/tests/unit/lib/text_backends/test_agnes_text_backend.py
+++ b/tests/unit/lib/text_backends/test_agnes_text_backend.py
@@ -8,6 +8,9 @@ AgnesTextBackend 复用 OpenAITextBackend 的原生 + Instructor 降级流水线
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,6 +18,19 @@ from pydantic import BaseModel
 
 from lib.providers import PROVIDER_AGNES
 from lib.text_backends.base import TextCapability, TextGenerationRequest
+
+
+@contextmanager
+def _recorded_openai_clients() -> Iterator[list[dict[str, Any]]]:
+    """AsyncOpenAI 构造的记录器：收下建客户端的参数，回一个空替身。"""
+    created: list[dict[str, Any]] = []
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return AsyncMock()
+
+    with patch("lib.openai_shared.AsyncOpenAI", _create):
+        yield created
 
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
@@ -76,18 +92,18 @@ class TestConstruction:
 
     def test_base_url_normalized_to_v1(self):
         # 用户填 host（无 /v1 后缀）→ 归一化为 {host}/v1 后传给 SDK。
-        with patch("lib.openai_shared.AsyncOpenAI") as mock_ctor:
+        with _recorded_openai_clients() as created:
             from lib.text_backends.agnes import AgnesTextBackend
 
             AgnesTextBackend(api_key="sk", base_url="https://apihub.agnes-ai.com")
-            assert mock_ctor.call_args.kwargs["base_url"] == "https://apihub.agnes-ai.com/v1"
+        assert [c["base_url"] for c in created] == ["https://apihub.agnes-ai.com/v1"]
 
     def test_default_base_url_when_unset(self):
-        with patch("lib.openai_shared.AsyncOpenAI") as mock_ctor:
+        with _recorded_openai_clients() as created:
             from lib.text_backends.agnes import AgnesTextBackend
 
             AgnesTextBackend(api_key="sk")
-            assert mock_ctor.call_args.kwargs["base_url"] == "https://apihub.agnes-ai.com/v1"
+        assert [c["base_url"] for c in created] == ["https://apihub.agnes-ai.com/v1"]
 
 
 class TestGenerate:

--- a/tests/unit/lib/text_backends/test_agnes_text_backend.py
+++ b/tests/unit/lib/text_backends/test_agnes_text_backend.py
@@ -129,7 +129,7 @@ class TestGenerate:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.text_backends.openai._instructor_fallback") as mock_fallback,
+            patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.agnes import AgnesTextBackend
 
@@ -139,8 +139,8 @@ class TestGenerate:
         assert result.text == schema_response
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["response_format"]["type"] == "json_schema"
-        # 原生成功，不触发降级
-        mock_fallback.assert_not_called()
+        # 原生成功，不触发降级（instructor 客户端未构造）
+        from_openai.assert_not_called()
 
     async def test_non_json_response_triggers_instructor_fallback(self):
         # 原生返回 200 但内容非 JSON（代理静默忽略 response_format）→ 选择性降级到 Instructor。

--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -1,12 +1,57 @@
 """ArkTextBackend tests."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lib.text_backends.ark import ArkTextBackend
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
+from tests.fakes import captured_ark_clients
+
+
+@contextmanager
+def _recorded_openai_clients() -> Iterator[list[dict[str, Any]]]:
+    """OpenAI 兼容客户端构造的记录器：收下建客户端的参数，回一个空替身。"""
+    created: list[dict[str, Any]] = []
+
+    def _create(**kwargs: Any) -> Any:
+        created.append(kwargs)
+        return MagicMock()
+
+    with patch("lib.text_backends.ark.OpenAI", _create):
+        yield created
+
+
+@contextmanager
+def _recorded_instructor_fallback(result: tuple[str, int, int]) -> Iterator[list[dict[str, Any]]]:
+    """instructor 降级入口的记录器：收下降级调用参数，回固定结果。"""
+    calls: list[dict[str, Any]] = []
+
+    def _call(**kwargs: Any) -> tuple[str, int, int]:
+        calls.append(kwargs)
+        return result
+
+    with patch("lib.text_backends.instructor_support.generate_structured_via_instructor", _call):
+        yield calls
+
+
+@contextmanager
+def _recorded_instructor_wire(result: tuple[Any, Any]) -> Iterator[list[dict[str, Any]]]:
+    """instructor patched client 的记录器：收下最终发往端点的参数。"""
+    calls: list[dict[str, Any]] = []
+
+    class _Completions:
+        def create_with_completion(self, **kwargs: Any) -> tuple[Any, Any]:
+            calls.append(kwargs)
+            return result
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+    with patch("instructor.from_openai", return_value=client):
+        yield calls
 
 
 @pytest.fixture
@@ -282,15 +327,11 @@ class TestCapabilityAwareStructured:
             k: str
 
         sample = M(k="v")
-        with patch(
-            "lib.text_backends.instructor_support.generate_structured_via_instructor",
-            return_value=(sample.model_dump_json(), 1, 1),
-        ) as mock_fn:
+        with _recorded_instructor_fallback((sample.model_dump_json(), 1, 1)) as calls:
             await backend_no_structured.generate(
                 TextGenerationRequest(prompt="g", response_schema=M, max_output_tokens=24000)
             )
-            assert mock_fn.call_args.kwargs["max_tokens"] == 24000
-            assert mock_fn.call_args.kwargs["token_param"] == "max_tokens"
+        assert [(c["max_tokens"], c["token_param"]) for c in calls] == [(24000, "max_tokens")]
 
     async def test_instructor_fallback_wire_param_is_max_tokens(self, backend_no_structured, sync_to_thread):
         """导线级守护：Ark 降级链路最终发给端点的参数名必须是 max_tokens。"""
@@ -301,17 +342,15 @@ class TestCapabilityAwareStructured:
 
         sample = M(k="v")
         completion = SimpleNamespace(usage=None)
-        mock_patched = MagicMock()
-        mock_patched.chat.completions.create_with_completion = MagicMock(return_value=(sample, completion))
 
-        with patch("instructor.from_openai", return_value=mock_patched):
+        with _recorded_instructor_wire((sample, completion)) as calls:
             await backend_no_structured.generate(
                 TextGenerationRequest(prompt="g", response_schema=M, max_output_tokens=24000)
             )
 
-        call_kwargs = mock_patched.chat.completions.create_with_completion.call_args.kwargs
-        assert call_kwargs["max_tokens"] == 24000
-        assert "max_completion_tokens" not in call_kwargs
+        assert len(calls) == 1
+        assert calls[0]["max_tokens"] == 24000
+        assert "max_completion_tokens" not in calls[0]
 
     async def test_native_failure_falls_back(self, backend_with_structured, sync_to_thread):
         """原生 json_schema 运行时失败后降级到 json_object。"""
@@ -585,23 +624,16 @@ class TestSuccessPathReverify:
 
 class TestBaseUrl:
     def test_custom_base_url_passes_to_both_clients(self):
-        with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:
-            with patch("lib.text_backends.ark.OpenAI") as mock_openai_ctor:
-                ArkTextBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
-                mock_ark_create.assert_called_once_with(
-                    api_key="k",
-                    base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-                )
-                mock_openai_ctor.assert_called_once_with(
-                    base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-                    api_key="k",
-                )
+        url = "https://ark.cn-beijing.volces.com/api/plan/v3"
+        with captured_ark_clients("lib.text_backends.ark") as ark_created, _recorded_openai_clients() as oa_created:
+            ArkTextBackend(api_key="k", base_url=url)
+        assert ark_created == [{"api_key": "k", "base_url": url}]
+        assert oa_created == [{"base_url": url, "api_key": "k"}]
 
     def test_default_base_url_keeps_ark_v3(self):
         from lib.ark_shared import ARK_BASE_URL
 
-        with patch("lib.text_backends.ark.create_ark_client") as mock_ark_create:
-            with patch("lib.text_backends.ark.OpenAI") as mock_openai_ctor:
-                ArkTextBackend(api_key="k")
-                mock_ark_create.assert_called_once_with(api_key="k", base_url=ARK_BASE_URL)
-                mock_openai_ctor.assert_called_once_with(base_url=ARK_BASE_URL, api_key="k")
+        with captured_ark_clients("lib.text_backends.ark") as ark_created, _recorded_openai_clients() as oa_created:
+            ArkTextBackend(api_key="k")
+        assert ark_created == [{"api_key": "k", "base_url": ARK_BASE_URL}]
+        assert oa_created == [{"base_url": ARK_BASE_URL, "api_key": "k"}]

--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -10,7 +10,7 @@ import pytest
 
 from lib.text_backends.ark import ArkTextBackend
 from lib.text_backends.base import TextCapability, TextGenerationRequest, TextGenerationResult
-from tests.fakes import captured_ark_clients
+from tests.fakes import bounded_poll_clock, captured_ark_clients
 
 
 @contextmanager
@@ -612,7 +612,7 @@ class TestSuccessPathReverify:
                 "lib.text_backends.instructor_support.instructor_fallback_sync",
                 side_effect=ConnectionError("503 service unavailable"),
             ) as mock_instructor,
-            patch("lib.retry.asyncio.sleep", new=AsyncMock()),
+            bounded_poll_clock(),
         ):
             with pytest.raises(ConnectionError):
                 await backend.generate(TextGenerationRequest(prompt="x", response_schema=Person))

--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/lib/text_backends/test_factory.py
+++ b/tests/unit/lib/text_backends/test_factory.py
@@ -1,15 +1,19 @@
 """Text backend factory tests.
 
-工厂构造已收口到 assemble_backend（media_type=text）：文本工厂只解析
-provider/model，构造经统一缝下沉到 ProviderSpec 表。这些测试 mock 文本 registry 的 create_backend
-（spec 闭包最终调它），断言各内置文本 provider 的构造参数与 provider_name 计费归因透传零变化。
+工厂构造已收口到 assemble_backend（media_type=text）：文本工厂只解析 provider/model，构造经统一缝
+下沉到 ProviderSpec 表。逐 provider 的构造参数表由 test_backend_assembly_specs.py 覆盖，这里只保工厂
+自身的两条契约：解析层给出的 provider/model/凭证真到达 spec 闭包；返回的 provider_id 取解析层 id
+（而非 backend 注册名），计费归因据此单一真相。
 """
 
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from lib.text_backends.base import TextTaskType
 from lib.text_backends.factory import create_text_backend_for_task
+from tests.fakes import captured_backend_construction
 
 
 def _make_mock_resolver(**async_methods):
@@ -26,34 +30,7 @@ def _make_mock_resolver(**async_methods):
     return mock
 
 
-async def test_creates_gemini_aistudio_backend():
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("gemini-aistudio", "gemini-3-flash-preview"),
-        provider_config={"api_key": "test-key", "base_url": ""},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        mock_backend = MagicMock()
-        mock_create.return_value = mock_backend
-
-        backend, provider_id = await create_text_backend_for_task(TextTaskType.SCRIPT)
-
-        # aistudio：base_url 无条件透传用户值（含空串），由 backend 内部处理
-        mock_create.assert_called_once_with(
-            "gemini",
-            model="gemini-3-flash-preview",
-            api_key="test-key",
-            base_url="",
-        )
-        assert backend is mock_backend
-        # 工厂随 backend 返回解析层 provider_id（记账单一真相源）
-        assert provider_id == "gemini-aistudio"
-
-
-async def test_creates_ark_backend():
+async def test_resolved_provider_model_and_credentials_reach_the_spec():
     mock_resolver = _make_mock_resolver(
         text_backend_for_task=("ark", "doubao-seed-2-0-lite-260215"),
         provider_config={"api_key": "ark-key"},
@@ -61,163 +38,46 @@ async def test_creates_ark_backend():
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        mock_backend = MagicMock()
-        mock_create.return_value = mock_backend
-
-        backend, provider_id = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
-
-        # ark：用户未配 base_url → 回落 registry default
-        mock_create.assert_called_once_with(
-            "ark",
-            model="doubao-seed-2-0-lite-260215",
-            api_key="ark-key",
-            base_url="https://ark.cn-beijing.volces.com/api/v3",
-        )
-        assert backend is mock_backend
-        assert provider_id == "ark"
-
-
-async def test_creates_ark_agent_plan_backend_uses_plan_endpoint():
-    """ark-agent-plan 必须把 default_base_url=/api/plan/v3 透传到 backend，
-    否则文本生成会被 ArkTextBackend 默认的 /api/v3 拉到错误的套餐网关。"""
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("ark-agent-plan", "doubao-seed-2.0-lite"),
-        provider_config={"api_key": "ark-plan-key"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        mock_backend = MagicMock()
-        mock_create.return_value = mock_backend
-
-        backend, provider_id = await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
-
-        mock_create.assert_called_once_with(
-            "ark-agent-plan",
-            model="doubao-seed-2.0-lite",
-            api_key="ark-plan-key",
-            base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-        )
-        assert backend is mock_backend
-        # ark-agent-plan 复用 ArkTextBackend（name 报 "ark"），记账须取解析层 id "ark-agent-plan"
-        assert provider_id == "ark-agent-plan"
-
-
-async def test_user_base_url_overrides_default_for_ark_agent_plan():
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("ark-agent-plan", "doubao-seed-2.0-lite"),
-        provider_config={"api_key": "k", "base_url": "https://custom.example.com/v9"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
+        captured_backend_construction() as built,
     ):
         await create_text_backend_for_task(TextTaskType.OVERVIEW, "my-project")
-        assert mock_create.call_args.kwargs["base_url"] == "https://custom.example.com/v9"
+
+    assert built == [
+        {
+            "media": "text",
+            "backend": "ark",
+            "kwargs": {
+                "model": "doubao-seed-2-0-lite-260215",
+                "api_key": "ark-key",
+                "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            },
+        }
+    ]
 
 
-async def test_creates_vertex_backend():
+@pytest.mark.parametrize(
+    ("provider_id", "model", "credentials", "registry_backend"),
+    [
+        # 解析层 id 与 backend 注册名不同的两族：gemini 双 id 共用 "gemini" 注册名；
+        # ark-agent-plan 复用 ArkTextBackend（name 报 "ark"）。记账须取解析层 id。
+        ("gemini-aistudio", "gemini-3-flash-preview", {"api_key": "test-key", "base_url": ""}, "gemini"),
+        ("gemini-vertex", "gemini-3-flash-preview", {"gcs_bucket": "my-bucket"}, "gemini"),
+        ("ark-agent-plan", "doubao-seed-2.0-lite", {"api_key": "ark-plan-key"}, "ark-agent-plan"),
+    ],
+)
+async def test_returns_resolver_provider_id_not_registry_backend_name(
+    provider_id: str, model: str, credentials: dict, registry_backend: str
+):
     mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("gemini-vertex", "gemini-3-flash-preview"),
-        provider_config={"gcs_bucket": "my-bucket"},
+        text_backend_for_task=(provider_id, model),
+        provider_config=credentials,
     )
 
     with (
         patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
+        captured_backend_construction() as built,
     ):
-        mock_backend = MagicMock()
-        mock_create.return_value = mock_backend
+        _backend, returned_id = await create_text_backend_for_task(TextTaskType.SCRIPT)
 
-        backend, provider_id = await create_text_backend_for_task(TextTaskType.STYLE_ANALYSIS)
-
-        mock_create.assert_called_once_with(
-            "gemini",
-            model="gemini-3-flash-preview",
-            backend="vertex",
-            gcs_bucket="my-bucket",
-        )
-        assert backend is mock_backend
-        assert provider_id == "gemini-vertex"
-
-
-async def test_creates_grok_backend_omits_base_url_when_unset():
-    """grok 无 registry default 且用户未配 → 不传 base_url（GrokTextBackend 不接受该参数）。"""
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("grok", "grok-4"),
-        provider_config={"api_key": "grok-key"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        await create_text_backend_for_task(TextTaskType.SCRIPT)
-        mock_create.assert_called_once_with("grok", model="grok-4", api_key="grok-key")
-
-
-async def test_creates_openai_backend_passes_user_base_url():
-    """openai：base_url 无条件透传用户值（无 registry default，允许自定义 endpoint）。"""
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("openai", "gpt-5"),
-        provider_config={"api_key": "oa-key", "base_url": "https://relay.example.com/v1"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        await create_text_backend_for_task(TextTaskType.SCRIPT)
-        mock_create.assert_called_once_with(
-            "openai",
-            model="gpt-5",
-            api_key="oa-key",
-            base_url="https://relay.example.com/v1",
-        )
-
-
-async def test_creates_dashscope_backend_derives_base_url_and_passes_provider_name():
-    """dashscope 文本走 OpenAI 兼容：从 host 派生 /compatible-mode/v1，并透传 provider_name 计费归因。"""
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("dashscope", "qwen-max"),
-        provider_config={"api_key": "ds-key"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        await create_text_backend_for_task(TextTaskType.SCRIPT)
-        mock_create.assert_called_once_with(
-            "openai",
-            model="qwen-max",
-            api_key="ds-key",
-            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            provider_name="dashscope",
-        )
-
-
-async def test_creates_minimax_backend_derives_base_url_and_passes_provider_name():
-    """minimax 文本走 OpenAI 兼容：单 /v1 base，并透传 provider_name 计费归因。"""
-    mock_resolver = _make_mock_resolver(
-        text_backend_for_task=("minimax", "minimax-text-01"),
-        provider_config={"api_key": "mm-key"},
-    )
-
-    with (
-        patch("lib.text_backends.factory.ConfigResolver", return_value=mock_resolver),
-        patch("lib.text_backends.registry.create_backend") as mock_create,
-    ):
-        await create_text_backend_for_task(TextTaskType.SCRIPT)
-        mock_create.assert_called_once_with(
-            "openai",
-            model="minimax-text-01",
-            api_key="mm-key",
-            base_url="https://api.minimaxi.com/v1",
-            provider_name="minimax",
-        )
+    assert returned_id == provider_id
+    assert [r["backend"] for r in built] == [registry_backend]

--- a/tests/unit/lib/text_backends/test_gemini.py
+++ b/tests/unit/lib/text_backends/test_gemini.py
@@ -233,10 +233,12 @@ class TestGenerate:
             # step2 的实际 response_schema（静态，无枚举收窄）同样过这条通道
             ReferenceStep2FlatScript,
         ]
+        assert schemas, "schema 清单为空时下面的循环形同虚设"
         for schema in schemas:
             config = backend._build_config(schema, None)
             # 不抛 = 转换后的 dict（字符串枚举、无 const）被 google-genai types.Schema 接受
-            gtypes.Schema.model_validate(config["response_schema"])
+            validated = gtypes.Schema.model_validate(config["response_schema"])
+            assert validated.type == gtypes.Type.OBJECT
 
     async def test_system_prompt(self, backend):
         mock_resp = SimpleNamespace(

--- a/tests/unit/lib/text_backends/test_gemini.py
+++ b/tests/unit/lib/text_backends/test_gemini.py
@@ -13,6 +13,7 @@ from lib.text_backends.base import (
     TextGenerationResult,
 )
 from lib.text_backends.gemini import GeminiTextBackend
+from tests.fakes import bounded_poll_clock
 
 
 @pytest.fixture
@@ -416,7 +417,7 @@ class TestStructuredFallback:
         gc = AsyncMock(side_effect=[_resp(_PROSE), transient, transient, transient])
         backend._test_client.aio.models.generate_content = gc
 
-        with patch("lib.retry.asyncio.sleep", new=AsyncMock()):
+        with bounded_poll_clock():
             with pytest.raises(ConnectionError):
                 await backend.generate(TextGenerationRequest(prompt="p", response_schema=_OverviewModel))
 

--- a/tests/unit/lib/text_backends/test_instructor_support.py
+++ b/tests/unit/lib/text_backends/test_instructor_support.py
@@ -1,6 +1,9 @@
 """instructor_support 模块测试。"""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -106,6 +109,39 @@ def _tools_rejected_error() -> InstructorRetryException:
     return instructor_api_call_exhausted(_bad_request("tools is not supported by this endpoint"))
 
 
+@contextmanager
+def _recorded_instructor(
+    result: tuple[Any, Any], *, is_async: bool = False
+) -> Iterator[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
+    """instructor 入口的记录器：记下 from_openai 与 create_with_completion 的参数。
+
+    mode 选择、导线参数名这些契约都是「最终发往端点的调用长什么样」，断言落在记录的参数上，
+    而不是替身的调用对象。
+    """
+    patched_with: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
+
+    class _Completions:
+        def create_with_completion(self, **kwargs: Any) -> Any:
+            calls.append(kwargs)
+            if is_async:
+
+                async def _await_result() -> tuple[Any, Any]:
+                    return result
+
+                return _await_result()
+            return result
+
+    patched = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    def _from_openai(client: Any, **kwargs: Any) -> Any:
+        patched_with.append({"client": client, **kwargs})
+        return patched
+
+    with patch("lib.text_backends.instructor_support.instructor.from_openai", _from_openai):
+        yield patched_with, calls
+
+
 class TestGenerateStructuredViaInstructor:
     def test_returns_json_and_tokens(self):
         """正确返回 JSON 文本和 token 统计。"""
@@ -135,23 +171,14 @@ class TestGenerateStructuredViaInstructor:
         assert output_tokens == 20
 
     def test_passes_mode_and_retries(self):
-        """正确传递 mode 和 max_retries 参数。"""
-        from instructor import Mode
-
+        """mode 交给 from_openai，其余参数原样上线。"""
         mock_client = MagicMock()
         sample = SampleModel(name="Bob", age=25)
         mock_completion = SimpleNamespace(
             usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
         )
 
-        with patch("lib.text_backends.instructor_support.instructor") as mock_instructor:
-            mock_patched = MagicMock()
-            mock_instructor.from_openai.return_value = mock_patched
-            mock_patched.chat.completions.create_with_completion.return_value = (
-                sample,
-                mock_completion,
-            )
-
+        with _recorded_instructor((sample, mock_completion)) as (patched_with, calls):
             generate_structured_via_instructor(
                 client=mock_client,
                 model="test-model",
@@ -161,15 +188,15 @@ class TestGenerateStructuredViaInstructor:
                 max_retries=3,
             )
 
-            # 验证 from_openai 使用了正确的 mode
-            mock_instructor.from_openai.assert_called_once_with(mock_client, mode=Mode.MD_JSON)
-            # 验证 create_with_completion 使用了正确的参数
-            mock_patched.chat.completions.create_with_completion.assert_called_once_with(
-                model="test-model",
-                messages=[{"role": "user", "content": "test"}],
-                response_model=SampleModel,
-                max_retries=3,
-            )
+        assert patched_with == [{"client": mock_client, "mode": Mode.MD_JSON}]
+        assert calls == [
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "test"}],
+                "response_model": SampleModel,
+                "max_retries": 3,
+            }
+        ]
 
     def test_handles_none_usage(self):
         """completion.usage 为 None 时返回 None token 统计。"""
@@ -356,13 +383,11 @@ class TestInstructorFallbackSync:
         assert call_kwargs["response_format"] == {"type": "json_object"}
 
     def test_pydantic_branch_forwards_token_param(self):
-        """Pydantic 分支把 token_param 转发给 generate_structured_via_instructor。"""
+        """Pydantic 分支的 token_param 一路传到导线：值以 max_completion_tokens 为参数名上线。"""
         sample = SampleModel(name="Alice", age=30)
+        completion = SimpleNamespace(usage=None)
 
-        with patch(
-            "lib.text_backends.instructor_support.generate_structured_via_instructor",
-            return_value=(sample.model_dump_json(), 50, 20),
-        ) as mock_gen:
+        with _recorded_instructor((sample, completion)) as (_patched_with, calls):
             instructor_fallback_sync(
                 client=MagicMock(),
                 model="test-model",
@@ -373,8 +398,15 @@ class TestInstructorFallbackSync:
                 token_param="max_completion_tokens",
             )
 
-        assert mock_gen.call_args[1]["token_param"] == "max_completion_tokens"
-        assert mock_gen.call_args[1]["max_tokens"] == 500
+        assert calls == [
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "test"}],
+                "response_model": SampleModel,
+                "max_retries": 2,
+                "max_completion_tokens": 500,
+            }
+        ]
 
     def test_dict_branch_default_token_param(self):
         """dict 分支默认以 max_tokens 为参数名上线。"""
@@ -868,13 +900,11 @@ class TestInstructorFallbackAsync:
         assert result.output_tokens == 12
 
     async def test_pydantic_branch_forwards_token_param_async(self):
-        """异步 Pydantic 分支把 token_param 转发给 generate_structured_via_instructor_async。"""
+        """异步 Pydantic 分支的 token_param 一路传到导线：值以 max_completion_tokens 为参数名上线。"""
         sample = SampleModel(name="Bob", age=25)
+        completion = SimpleNamespace(usage=None)
 
-        with patch(
-            "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
-            return_value=(sample.model_dump_json(), 40, 18),
-        ) as mock_gen:
+        with _recorded_instructor((sample, completion), is_async=True) as (_patched_with, calls):
             await instructor_fallback_async(
                 client=AsyncMock(),
                 model="async-model",
@@ -885,8 +915,15 @@ class TestInstructorFallbackAsync:
                 token_param="max_completion_tokens",
             )
 
-        assert mock_gen.call_args[1]["token_param"] == "max_completion_tokens"
-        assert mock_gen.call_args[1]["max_tokens"] == 600
+        assert calls == [
+            {
+                "model": "async-model",
+                "messages": [{"role": "user", "content": "test"}],
+                "response_model": SampleModel,
+                "max_retries": 2,
+                "max_completion_tokens": 600,
+            }
+        ]
 
     async def test_dict_branch_default_token_param_async(self):
         """异步 dict 分支默认以 max_tokens 为参数名上线。"""

--- a/tests/unit/lib/text_backends/test_openai_text_backend.py
+++ b/tests/unit/lib/text_backends/test_openai_text_backend.py
@@ -17,7 +17,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
 )
-from tests.fakes import bounded_poll_clock, instructor_api_call_exhausted
+from tests.fakes import bounded_poll_clock, captured_openai_clients, instructor_api_call_exhausted
 
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
@@ -40,7 +40,7 @@ def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
 
 class TestOpenAITextBackend:
     def test_name_and_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -48,14 +48,14 @@ class TestOpenAITextBackend:
             assert backend.model == "gpt-5.4-mini"
 
     def test_custom_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key", model="gpt-5.4")
             assert backend.model == "gpt-5.4"
 
     def test_capabilities(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -67,7 +67,7 @@ class TestOpenAITextBackend:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("Test output", 15, 8))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -90,7 +90,7 @@ class TestOpenAITextBackend:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("Response"))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -112,7 +112,7 @@ class TestOpenAITextBackend:
         img_path = tmp_path / "test.png"
         img_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -135,7 +135,7 @@ class TestOpenAITextBackend:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(schema_response))
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -160,7 +160,7 @@ class TestOpenAITextBackend:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=response)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -196,7 +196,7 @@ class TestInstructorFallback:
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(schema_response))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -231,7 +231,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -269,7 +269,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -308,7 +308,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -344,7 +344,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -371,7 +371,7 @@ class TestInstructorFallback:
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(violating_json))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -406,7 +406,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -437,7 +437,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched) as mock_from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -468,7 +468,7 @@ class TestInstructorFallback:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", side_effect=[tools_patched, md_json_patched]) as mock_from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -489,7 +489,7 @@ class TestInstructorFallback:
             side_effect=[_make_bad_request_error(), _make_mock_response(fallback_json, 12, 6)]
         )
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -514,7 +514,7 @@ class TestInstructorFallback:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=_make_bad_request_error())
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
@@ -536,7 +536,7 @@ class TestInstructorFallback:
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("非 JSON 散文"))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch(
                 "lib.text_backends.instructor_support.instructor_fallback_async",
                 new=AsyncMock(side_effect=ConnectionError("503 service unavailable")),
@@ -561,7 +561,7 @@ class TestMaxOutputTokens:
     async def test_official_plain_passes_max_completion_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k")
@@ -574,7 +574,7 @@ class TestMaxOutputTokens:
     async def test_official_structured_passes_max_completion_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response(json.dumps({"name": "x"})))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             class MyModel(BaseModel):
@@ -590,7 +590,7 @@ class TestMaxOutputTokens:
     async def test_no_max_tokens_means_key_absent(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k")
@@ -603,7 +603,7 @@ class TestMaxOutputTokens:
     async def test_custom_base_url_uses_max_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k", base_url="https://vllm.example.com/v1")
@@ -616,7 +616,7 @@ class TestMaxOutputTokens:
     async def test_explicit_official_base_url_uses_max_completion_tokens(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("ok"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k", base_url="https://api.openai.com/v1")
@@ -633,7 +633,7 @@ class TestMaxOutputTokens:
         mock_client.chat.completions.create = AsyncMock(
             side_effect=[_make_bad_request_error(), _make_mock_response(fallback_json)]
         )
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k")
@@ -655,7 +655,7 @@ class TestMaxOutputTokens:
         mock_client.chat.completions.create = AsyncMock(
             side_effect=[_make_bad_request_error(), _make_mock_response(fallback_json)]
         )
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k", base_url="https://vllm.example.com/v1")
@@ -686,7 +686,7 @@ class TestMaxOutputTokens:
         )
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             patch("instructor.from_openai", return_value=mock_patched),
         ):
             from lib.text_backends.openai import OpenAITextBackend
@@ -713,7 +713,7 @@ class TestTruncation:
         response.choices[0].finish_reason = "length"
         mock_client.chat.completions.create = AsyncMock(return_value=response)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             class MyModel(BaseModel):
@@ -733,7 +733,7 @@ class TestTruncation:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=response)
 
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="k")

--- a/tests/unit/lib/text_backends/test_openai_text_backend.py
+++ b/tests/unit/lib/text_backends/test_openai_text_backend.py
@@ -197,7 +197,7 @@ class TestInstructorFallback:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.text_backends.openai._instructor_fallback") as mock_fallback,
+            patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
 
@@ -209,7 +209,8 @@ class TestInstructorFallback:
             result = await backend.generate(request)
 
         assert result.text == schema_response
-        mock_fallback.assert_not_called()
+        # 降级路径的唯一入口是 instructor 客户端：未构造即证明没走降级
+        from_openai.assert_not_called()
 
     async def test_non_json_response_triggers_instructor_fallback_pydantic(self):
         """原生返回 200 但内容非 JSON（OpenAI 兼容代理静默忽略 response_format），应降级到 Instructor。"""
@@ -371,7 +372,7 @@ class TestInstructorFallback:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.text_backends.openai._instructor_fallback") as mock_fallback,
+            patch("instructor.from_openai") as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
 
@@ -386,7 +387,7 @@ class TestInstructorFallback:
             result = await backend.generate(request)
 
         assert result.text == violating_json
-        mock_fallback.assert_not_called()
+        from_openai.assert_not_called()
 
     async def test_bad_request_error_triggers_instructor_fallback_pydantic(self):
         """原生 response_format 抛 BadRequestError 且 schema 为 Pydantic 类时，走 Instructor 降级。"""

--- a/tests/unit/lib/text_backends/test_openai_text_backend.py
+++ b/tests/unit/lib/text_backends/test_openai_text_backend.py
@@ -17,7 +17,7 @@ from lib.text_backends.base import (
     TextCapability,
     TextGenerationRequest,
 )
-from tests.fakes import instructor_api_call_exhausted
+from tests.fakes import bounded_poll_clock, instructor_api_call_exhausted
 
 
 def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
@@ -541,7 +541,7 @@ class TestInstructorFallback:
                 "lib.text_backends.instructor_support.instructor_fallback_async",
                 new=AsyncMock(side_effect=ConnectionError("503 service unavailable")),
             ) as mock_instructor,
-            patch("lib.retry.asyncio.sleep", new=AsyncMock()),
+            bounded_poll_clock(),
         ):
             from lib.text_backends.openai import OpenAITextBackend
 

--- a/tests/unit/lib/text_backends/test_registry.py
+++ b/tests/unit/lib/text_backends/test_registry.py
@@ -32,7 +32,7 @@ class FakeTextBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_text_registry():
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()
     yield

--- a/tests/unit/lib/video_backends/test_agnes_video_backend.py
+++ b/tests/unit/lib/video_backends/test_agnes_video_backend.py
@@ -1,43 +1,62 @@
-"""AgnesVideoBackend 单元测试（mock httpx，注入时钟、不打真实墙钟）。"""
+"""AgnesVideoBackend 单元测试（respx 捕获出站请求，假表压缩轮询等待）。"""
 
 from __future__ import annotations
 
 import base64
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import NamedTuple
 
 import httpx
 import pytest
+import respx
 
 from lib.providers import PROVIDER_AGNES
+from lib.video_backends.agnes import AgnesVideoBackend
 from lib.video_backends.base import (
+    AmbiguousSubmitError,
     ResumeExpiredError,
     VideoCapabilityError,
     VideoGenerationRequest,
 )
-from tests.fakes import bounded_poll_clock
+from tests.fakes import bounded_poll_clock, captured_provider_job_ids
+from tests.http_capture import capture_http, only_request, request_json
+
+_BASE_URL = "https://x/v1"
+_GATEWAY_BASE_URL = "https://apihub.agnes-ai.com/v1"
+# 成片 CDN 与网关成片库两个下载域名，供下载路由整体拦截。
+_DOWNLOAD_HOSTS = r"https://(cdn\.agnes|platform-outputs\.agnes-ai\.com)/"
 
 
-def _make_response(status_code: int, json_body: dict) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    resp.raise_for_status = MagicMock()
-    return resp
+class _AgnesRoutes(NamedTuple):
+    """Agnes 的四条出站流量：建任务、任务轮询、成片查询、成片下载。"""
+
+    submit: respx.Route
+    poll: respx.Route
+    query: respx.Route
+    download: respx.Route
 
 
-def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://apihub.agnes-ai.com/v1/videos")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"Server error '{status_code}'", request=request, response=response)
+@contextmanager
+def _agnes_api(*, base_url: str = _BASE_URL) -> Iterator[_AgnesRoutes]:
+    host = base_url.removesuffix("/v1")
+    with capture_http() as router:
+        yield _AgnesRoutes(
+            submit=router.post(f"{base_url}/videos"),
+            poll=router.get(url__regex=rf"^{re.escape(base_url)}/videos/[^/]+$"),
+            query=router.get(f"{host}/agnesapi"),
+            download=router.get(url__regex=rf"^{_DOWNLOAD_HOSTS}"),
+        )
 
 
-def _fake_download_factory(payload: bytes = b"mp4-bytes"):
-    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(payload)
+def _json(body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=body)
 
-    return _fake
+
+def _queued(task_id: str = "task-1") -> httpx.Response:
+    return _json({"task_id": task_id, "status": "queued"})
 
 
 def _completed(task_id: str = "task-1", url: str = "https://cdn.agnes/out.mp4", **extra) -> dict:
@@ -55,13 +74,15 @@ def _completed(task_id: str = "task-1", url: str = "https://cdn.agnes/out.mp4", 
     return body
 
 
-def _mock_client(*, post=None, get=None) -> AsyncMock:
-    client = AsyncMock()
-    client.post = post or AsyncMock()
-    client.get = get or AsyncMock()
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
+    params: dict = {
+        "prompt": "p",
+        "output_path": tmp_path / "o.mp4",
+        "aspect_ratio": "9:16",
+        "duration_seconds": 5,
+    }
+    params.update(overrides)
+    return VideoGenerationRequest(**params)
 
 
 def _write_image(path: Path, payload: bytes) -> Path:
@@ -69,23 +90,21 @@ def _write_image(path: Path, payload: bytes) -> Path:
     return path
 
 
+def _sent_payload(routes: _AgnesRoutes) -> dict:
+    return request_json(only_request(routes.submit))
+
+
 class TestCapabilities:
     def test_name_and_model(self):
-        from lib.video_backends.agnes import AgnesVideoBackend
-
-        backend = AgnesVideoBackend(api_key="sk-test", base_url="https://apihub.agnes-ai.com/v1")
+        backend = AgnesVideoBackend(api_key="sk-test", base_url=_GATEWAY_BASE_URL)
         assert backend.name == PROVIDER_AGNES
         assert backend.model == "agnes-video-v2.0"
 
     def test_default_model_when_unset(self):
-        from lib.video_backends.agnes import AgnesVideoBackend
-
         backend = AgnesVideoBackend(api_key="sk-test")
         assert backend.model == "agnes-video-v2.0"
 
     def test_video_capabilities(self):
-        from lib.video_backends.agnes import AgnesVideoBackend
-
         backend = AgnesVideoBackend(api_key="sk-test")
         caps = backend.video_capabilities
         assert caps.first_frame is True
@@ -153,30 +172,18 @@ class TestDurationCoercion:
 
 class TestTextToVideo:
     async def test_happy_path_submits_and_polls(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
-        poll_resp = _make_response(200, _completed("task-42", "https://cdn.agnes/out.mp4", seconds="5.0"))
+        with _agnes_api(base_url=_GATEWAY_BASE_URL) as routes:
+            routes.submit.mock(return_value=_queued("task-42"))
+            routes.poll.mock(return_value=_json(_completed("task-42", seconds="5.0")))
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4-bytes"))
 
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"mp4-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="sk-test", base_url="https://apihub.agnes-ai.com/v1")
+            backend = AgnesVideoBackend(api_key="sk-test", base_url=_GATEWAY_BASE_URL)
             result = await backend.generate(
-                VideoGenerationRequest(
+                _request(
+                    tmp_path,
                     prompt="A cat running",
                     output_path=tmp_path / "out.mp4",
-                    aspect_ratio="9:16",
                     resolution="720p",
-                    duration_seconds=5,
                     seed=7,
                 )
             )
@@ -191,9 +198,9 @@ class TestTextToVideo:
         # Agnes 无音频能力，成片恒无声
         assert result.generate_audio is False
 
-        post_call = client.post.call_args
-        assert post_call.args[0] == "https://apihub.agnes-ai.com/v1/videos"
-        body = post_call.kwargs["json"]
+        submitted = only_request(routes.submit)
+        assert str(submitted.url) == f"{_GATEWAY_BASE_URL}/videos"
+        body = request_json(submitted)
         assert body["model"] == "agnes-video-v2.0"
         assert body["prompt"] == "A cat running"
         assert body["height"] == 1280
@@ -204,42 +211,30 @@ class TestTextToVideo:
         # 文生视频：无任何图像通道
         assert "image" not in body
         assert "extra_body" not in body
-        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        assert submitted.headers["Authorization"] == "Bearer sk-test"
         # submit 用长超时覆盖上游长阻塞
-        assert post_call.kwargs["timeout"] == 300.0
+        assert submitted.extensions["timeout"]["read"] == 300.0
 
-        # 下载从 remixed_from_video_id 成片 URL，不带 auth
-        fake_download.assert_called_once()
-        assert fake_download.call_args.args[0] == "https://cdn.agnes/out.mp4"
+        # 下载打完成态的成片 URL，不带鉴权头
+        downloaded = only_request(routes.download)
+        assert str(downloaded.url) == "https://cdn.agnes/out.mp4"
+        assert "Authorization" not in downloaded.headers
 
     async def test_polls_through_in_progress(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
-        in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress", "progress": 40})
-        completed = _make_response(200, _completed("t3"))
+        in_progress = _json({"task_id": "t3", "status": "in_progress", "progress": 40})
 
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(side_effect=[in_progress, in_progress, completed]),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_queued("t3"))
+            routes.poll.mock(side_effect=[in_progress, in_progress, _json(_completed("t3"))])
+            routes.download.mock(return_value=httpx.Response(200, content=b"v"))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
-            )
+            assert routes.poll.call_count == 3
+            assert routes.download.call_count == 1
 
         assert result.task_id == "t3"
-        assert client.get.call_count == 3
-        fake_download.assert_called_once()
 
 
 class TestImageChannels:
@@ -248,71 +243,34 @@ class TestImageChannels:
         img_bytes = b"\x89PNG\r\nfake-start"
         img_path = _write_image(tmp_path / "start.png", img_bytes)
 
-        create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
-        poll_resp = _make_response(200, _completed("t1"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t1"))
+            routes.poll.mock(return_value=_json(_completed("t1")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path, start_image=img_path))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    start_image=img_path,
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            body = _sent_payload(routes)
 
-        sent = client.post.call_args.kwargs["json"]["image"]
-        expected = base64.b64encode(img_bytes).decode("ascii")
-        assert sent == expected
+        sent = body["image"]
+        assert sent == base64.b64encode(img_bytes).decode("ascii")
         # 裸 base64，绝不带 data: 前缀
         assert not sent.startswith("data:")
-        assert "extra_body" not in client.post.call_args.kwargs["json"]
+        assert "extra_body" not in body
 
     async def test_first_last_keyframes_extra_body(self, tmp_path: Path):
         start = _write_image(tmp_path / "s.png", b"start-bytes")
         end = _write_image(tmp_path / "e.png", b"end-bytes")
 
-        create_resp = _make_response(200, {"task_id": "t-kf", "status": "queued"})
-        poll_resp = _make_response(200, _completed("t-kf"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-kf"))
+            routes.poll.mock(return_value=_json(_completed("t-kf")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path, start_image=start, end_image=end))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    start_image=start,
-                    end_image=end,
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            body = _sent_payload(routes)
 
-        body = client.post.call_args.kwargs["json"]
         assert "image" not in body  # 单通道：keyframes 走 extra_body，不占顶层 image
         extra = body["extra_body"]
         assert extra["mode"] == "keyframes"
@@ -326,33 +284,15 @@ class TestImageChannels:
         ref1 = _write_image(tmp_path / "r1.png", b"ref-1")
         ref2 = _write_image(tmp_path / "r2.png", b"ref-2")
 
-        create_resp = _make_response(200, {"task_id": "t-ref", "status": "queued"})
-        poll_resp = _make_response(200, _completed("t-ref"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-ref"))
+            routes.poll.mock(return_value=_json(_completed("t-ref")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path, reference_images=[ref1, ref2]))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    reference_images=[ref1, ref2],
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            body = _sent_payload(routes)
 
-        body = client.post.call_args.kwargs["json"]
         assert "image" not in body
         extra = body["extra_body"]
         assert "mode" not in extra  # 参考生视频不带 keyframes mode
@@ -363,447 +303,273 @@ class TestImageChannels:
 
     async def test_reference_images_exceeded_raises(self, tmp_path: Path):
         refs = [_write_image(tmp_path / f"r{i}.png", f"r{i}".encode()) for i in range(5)]
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("超限不应提交")))
 
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        reference_images=refs,
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
+                await backend.generate(_request(tmp_path, reference_images=refs))
+
             assert ei.value.code == "video_reference_images_exceeded"
+            assert routes.submit.call_count == 0
 
     @pytest.mark.parametrize("with_start", [True, False])
     async def test_reference_images_with_frame_fails_loud(self, tmp_path: Path, with_start: bool):
         """参考图与首/尾帧同时给出时 fail-loud（单通道互斥），不静默走参考图分支丢掉关键帧。"""
         ref = _write_image(tmp_path / "r.png", b"ref")
         frame = _write_image(tmp_path / "f.png", b"frame")
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("混合输入不应提交")))
 
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
                 await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
+                    _request(
+                        tmp_path,
                         reference_images=[ref],
                         start_image=frame if with_start else None,
                         end_image=None if with_start else frame,
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
                     )
                 )
+
             assert ei.value.code == "video_reference_images_with_frames_unsupported"
-        client.post.assert_not_called()
+            assert routes.submit.call_count == 0
 
     async def test_end_image_only_fails_loud(self, tmp_path: Path):
         """仅提供尾帧（无首帧）时 fail-loud——Agnes 无独立尾帧通道，不静默退化为文生视频。"""
         end = _write_image(tmp_path / "e.png", b"end")
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("仅尾帧不应提交")))
 
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        end_image=end,
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
+                await backend.generate(_request(tmp_path, end_image=end))
+
             assert ei.value.code == "video_end_image_requires_start_image"
-        client.post.assert_not_called()
+            assert routes.submit.call_count == 0
 
     async def test_missing_start_image_fails_loud(self, tmp_path: Path):
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺图不应提交")))
-
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        start_image=tmp_path / "missing.png",
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
+                await backend.generate(_request(tmp_path, start_image=tmp_path / "missing.png"))
+
             assert ei.value.code == "video_start_image_unreadable"
+            assert routes.submit.call_count == 0
 
     async def test_missing_end_image_fails_loud_with_end_code(self, tmp_path: Path):
         """首尾帧模式下尾帧缺失：错误码指向尾帧而非首帧。"""
         start = _write_image(tmp_path / "s.png", b"start-bytes")
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("缺尾帧不应提交")))
 
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        start_image=start,
-                        end_image=tmp_path / "missing-end.png",
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
+                await backend.generate(_request(tmp_path, start_image=start, end_image=tmp_path / "missing-end.png"))
+
             assert ei.value.code == "video_end_image_unreadable"
+            assert routes.submit.call_count == 0
 
     async def test_empty_path_objects_degrade_to_text_to_video(self, tmp_path: Path):
         """空 Path（``Path("")`` 塌成 ``Path(".")``）应归一化为 None，回落文生视频而非误报无法读取。"""
-        create_resp = _make_response(200, {"task_id": "t-empty", "status": "queued"})
-        poll_resp = _make_response(200, _completed("t-empty"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-empty"))
+            routes.poll.mock(return_value=_json(_completed("t-empty")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path, start_image=Path(""), reference_images=[Path("")]))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    start_image=Path(""),
-                    reference_images=[Path("")],
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            body = _sent_payload(routes)
 
-        body = client.post.call_args.kwargs["json"]
         assert "image" not in body
         assert "extra_body" not in body
 
 
 class TestFailureAndTimeout:
     async def test_failed_status_raises(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
-        poll_resp = _make_response(200, {"task_id": "t2", "status": "failed", "error": {"message": "upstream down"}})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock()
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t2"))
+            routes.poll.mock(
+                return_value=_json({"task_id": "t2", "status": "failed", "error": {"message": "upstream down"}})
+            )
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(RuntimeError, match="upstream down"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
+                await backend.generate(_request(tmp_path))
 
-        fake_download.assert_not_called()
+            assert routes.download.call_count == 0
 
     async def test_non_failed_terminal_status_fails_fast(self, tmp_path: Path):
         """上游以 cancelled 等非 failed 失败态收尾时快速失败，不轮询到 timeout。"""
-        create_resp = _make_response(200, {"task_id": "t-cxl", "status": "queued"})
-        cancelled = _make_response(
-            200, {"task_id": "t-cxl", "status": "cancelled", "error": {"message": "user cancelled"}}
-        )
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=cancelled),
-        )
-        fake_download = AsyncMock()
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-cxl"))
+            routes.poll.mock(
+                return_value=_json({"task_id": "t-cxl", "status": "cancelled", "error": {"message": "user cancelled"}})
+            )
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(RuntimeError, match="user cancelled"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        fake_download.assert_not_called()
+                await backend.generate(_request(tmp_path))
+
+            assert routes.poll.call_count == 1
+            assert routes.download.call_count == 0
 
     async def test_completed_without_video_url_or_video_id_raises(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t-nourl", "status": "queued"})
-        poll_resp = _make_response(200, {"task_id": "t-nourl", "status": "completed"})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock()
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-nourl"))
+            routes.poll.mock(return_value=_json({"task_id": "t-nourl", "status": "completed"}))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(RuntimeError, match="缺少成片 URL 与 video_id"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        fake_download.assert_not_called()
+                await backend.generate(_request(tmp_path))
+
+            assert routes.download.call_count == 0
 
     async def test_completed_with_null_remixed_from_video_id_uses_video_id_query(self, tmp_path: Path):
         """普通图生/文生视频完成态 remixed_from_video_id 恒为 null，成片地址须按 video_id
         二次查询取得。"""
-        create_resp = _make_response(200, {"task_id": "t-null-remix", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-null-remix",
-                "video_id": "vid-123",
-                "status": "completed",
-                "remixed_from_video_id": None,
-                "seconds": "8.0",
-            },
-        )
-        query_resp = _make_response(200, {"video_id": "vid-123", "url": "https://cdn.agnes/queried.mp4"})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(side_effect=[poll_resp, query_resp]),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"queried-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://apihub.agnes-ai.com/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api(base_url=_GATEWAY_BASE_URL) as routes:
+            routes.submit.mock(return_value=_queued("t-null-remix"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-null-remix",
+                        "video_id": "vid-123",
+                        "status": "completed",
+                        "remixed_from_video_id": None,
+                        "seconds": "8.0",
+                    }
                 )
             )
+            routes.query.mock(return_value=_json({"video_id": "vid-123", "url": "https://cdn.agnes/queried.mp4"}))
+            routes.download.mock(return_value=httpx.Response(200, content=b"queried-bytes"))
+
+            backend = AgnesVideoBackend(api_key="k", base_url=_GATEWAY_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
+
+            # 二次查询打网关根下的 /agnesapi，按 video_id 传参（不带 /v1，也不用 task_id）
+            assert str(only_request(routes.query).url) == "https://apihub.agnes-ai.com/agnesapi?video_id=vid-123"
 
         assert result.video_uri == "https://cdn.agnes/queried.mp4"
         assert result.duration_seconds == 8
         assert result.video_path.read_bytes() == b"queried-bytes"
-        # 二次查询打网关根下的 /agnesapi，按 video_id 传参（不带 /v1，也不用 task_id）
-        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/agnesapi"
-        assert client.get.call_args_list[1].kwargs["params"] == {"video_id": "vid-123"}
 
     async def test_completed_with_direct_url_field_skips_video_id_query(self, tmp_path: Path):
         """完成态直接带 url 字段时直接下载，不发起 video_id 二次查询。"""
-        create_resp = _make_response(200, {"task_id": "t-direct", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-direct",
-                "video_id": "vid-should-not-be-queried",
-                "status": "completed",
-                "url": "https://cdn.agnes/direct.mp4",
-                "remixed_from_video_id": None,
-            },
-        )
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"direct-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-direct"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-direct",
+                        "video_id": "vid-should-not-be-queried",
+                        "status": "completed",
+                        "url": "https://cdn.agnes/direct.mp4",
+                        "remixed_from_video_id": None,
+                    }
                 )
             )
 
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
+
+            assert routes.query.call_count == 0  # 未发起二次查询
+
         assert result.video_uri == "https://cdn.agnes/direct.mp4"
-        assert client.get.call_count == 1  # 未发起二次查询
 
     async def test_completed_with_url_shaped_remixed_from_video_id_downloads_directly(self, tmp_path: Path):
         """旧网关把成片 URL 回填在 remixed_from_video_id：值是 URL 形态时仍作下载地址，
         不发起 video_id 二次查询。"""
-        create_resp = _make_response(200, {"task_id": "t-legacy", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-legacy",
-                "video_id": "vid-should-not-be-queried",
-                "status": "completed",
-                "remixed_from_video_id": "https://cdn.agnes/legacy.mp4",
-            },
-        )
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"legacy-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-legacy"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-legacy",
+                        "video_id": "vid-should-not-be-queried",
+                        "status": "completed",
+                        "remixed_from_video_id": "https://cdn.agnes/legacy.mp4",
+                    }
                 )
             )
 
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
+
+            assert routes.query.call_count == 0
+
         assert result.video_uri == "https://cdn.agnes/legacy.mp4"
-        assert client.get.call_count == 1
 
     async def test_remixed_from_video_id_non_url_value_not_used_as_download_url(self, tmp_path: Path):
         """remixed_from_video_id 是非 URL 形态的 remix 来源 ID 时不得当下载地址，转向 video_id 二次查询。"""
-        create_resp = _make_response(200, {"task_id": "t-remix-id", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-remix-id",
-                "video_id": "vid-456",
-                "status": "completed",
-                "remixed_from_video_id": "src-video-abc",  # 非 URL 形态：真正的 remix 来源 ID
-            },
-        )
-        query_resp = _make_response(200, {"url": "https://cdn.agnes/from-query.mp4"})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(side_effect=[poll_resp, query_resp]),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-remix-id"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-remix-id",
+                        "video_id": "vid-456",
+                        "status": "completed",
+                        # 非 URL 形态：真正的 remix 来源 ID
+                        "remixed_from_video_id": "src-video-abc",
+                    }
                 )
             )
+            routes.query.mock(return_value=_json({"url": "https://cdn.agnes/from-query.mp4"}))
+
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
 
         assert result.video_uri == "https://cdn.agnes/from-query.mp4"
 
     async def test_metadata_url_takes_priority_over_url_shaped_remixed_from_video_id(self, tmp_path: Path):
         """顶层 remixed_from_video_id 是 URL 形态、metadata.url 也存在时，metadata.url
         才是权威成片地址，remixed_from_video_id 只是兼容兜底，不得抢先命中。"""
-        create_resp = _make_response(200, {"task_id": "t-meta-priority", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-meta-priority",
-                "status": "completed",
-                "remixed_from_video_id": "https://cdn.agnes/legacy-compat.mp4",
-                "metadata": {"url": "https://cdn.agnes/authoritative.mp4"},
-            },
-        )
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-meta-priority"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-meta-priority",
+                        "status": "completed",
+                        "remixed_from_video_id": "https://cdn.agnes/legacy-compat.mp4",
+                        "metadata": {"url": "https://cdn.agnes/authoritative.mp4"},
+                    }
                 )
             )
 
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
+
+            # 顶层/metadata 已命中权威字段，未发起二次查询
+            assert routes.query.call_count == 0
+
         assert result.video_uri == "https://cdn.agnes/authoritative.mp4"
-        assert client.get.call_count == 1  # 顶层/metadata 已命中权威字段，未发起二次查询
 
     async def test_video_id_query_url_under_metadata_is_used(self, tmp_path: Path):
         """成片查询把下载地址放在 metadata.url：顶层无直接 URL 字段时下探 metadata 取到。"""
-        create_resp = _make_response(200, {"task_id": "t-meta", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {"task_id": "t-meta", "video_id": "vid-meta", "status": "completed", "remixed_from_video_id": None},
-        )
-        query_resp = _make_response(
-            200,
-            {
-                "video_id": "vid-meta",
-                "status": "completed",
-                "seconds": "8.0",
-                "metadata": {"url": "https://platform-outputs.agnes-ai.com/videos/meta.mp4"},
-            },
-        )
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(side_effect=[poll_resp, query_resp]),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"meta-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-meta"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-meta",
+                        "video_id": "vid-meta",
+                        "status": "completed",
+                        "remixed_from_video_id": None,
+                    }
                 )
             )
+            routes.query.mock(
+                return_value=_json(
+                    {
+                        "video_id": "vid-meta",
+                        "status": "completed",
+                        "seconds": "8.0",
+                        "metadata": {"url": "https://platform-outputs.agnes-ai.com/videos/meta.mp4"},
+                    }
+                )
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"meta-bytes"))
+
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
 
         assert result.video_uri == "https://platform-outputs.agnes-ai.com/videos/meta.mp4"
         assert result.video_path.read_bytes() == b"meta-bytes"
@@ -811,165 +577,84 @@ class TestFailureAndTimeout:
         assert result.duration_seconds == 8
 
     async def test_video_id_query_without_url_raises_descriptive_error(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t-bad-query", "status": "queued"})
-        poll_resp = _make_response(200, {"task_id": "t-bad-query", "video_id": "vid-789", "status": "completed"})
-        query_resp = _make_response(200, {"video_id": "vid-789", "status": "unexpected"})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(side_effect=[poll_resp, query_resp]),
-        )
-        fake_download = AsyncMock()
+        with _agnes_api() as routes:
+            routes.submit.mock(return_value=_queued("t-bad-query"))
+            routes.poll.mock(
+                return_value=_json({"task_id": "t-bad-query", "video_id": "vid-789", "status": "completed"})
+            )
+            routes.query.mock(return_value=_json({"video_id": "vid-789", "status": "unexpected"}))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(RuntimeError, match="video_id 查询响应缺少成片 URL"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        fake_download.assert_not_called()
+                await backend.generate(_request(tmp_path))
+
+            assert routes.download.call_count == 0
 
     async def test_polling_timeout_raises(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t-timeout", "status": "queued"})
-        in_progress = _make_response(200, {"task_id": "t-timeout", "status": "in_progress"})
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=in_progress),
-        )
-        fake_download = AsyncMock()
+        """终态迟迟不来时按 max_wait 抛 TimeoutError，不无限轮询下去。"""
+        with _agnes_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_queued("t-timeout"))
+            routes.poll.mock(return_value=_json({"task_id": "t-timeout", "status": "in_progress"}))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes._MIN_POLL_TIMEOUT_SECONDS", 0.01),
-            patch("lib.video_backends.agnes._POLL_TIMEOUT_PER_SECOND", 0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(TimeoutError, match="Agnes"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        fake_download.assert_not_called()
+                await backend.generate(_request(tmp_path))
+
+            assert routes.poll.call_count > 1
+            assert routes.download.call_count == 0
 
 
 class TestSubmitResilience:
     async def test_submit_retries_on_503_busy(self, tmp_path: Path):
         """503 Service busy → 经 should_retry_submit 的 status_code 闸门重试。"""
-        busy = MagicMock()
-        busy.status_code = 503
-        busy.raise_for_status = MagicMock(side_effect=_make_http_error(503, "Service busy"))
-        create_resp = _make_response(200, {"task_id": "t-retry", "status": "queued"})
-        poll_resp = _make_response(200, _completed("t-retry"))
+        busy = httpx.Response(503, text="Service busy")
 
-        client = _mock_client(
-            post=AsyncMock(side_effect=[busy, busy, create_resp]),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _agnes_api() as routes, bounded_poll_clock():
+            routes.submit.mock(side_effect=[busy, busy, _queued("t-retry")])
+            routes.poll.mock(return_value=_json(_completed("t-retry")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            bounded_poll_clock(),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.generate(_request(tmp_path))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
-            )
+            assert routes.submit.call_count == 3
 
         assert result.task_id == "t-retry"
-        assert client.post.call_count == 3
 
     async def test_submit_non_retryable_4xx_fails_fast(self, tmp_path: Path):
-        bad = _make_response(400, {"error": "bad request"})
-        bad.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
-        client = _mock_client(
-            post=AsyncMock(return_value=bad),
-            get=AsyncMock(side_effect=AssertionError("4xx 应在提交阶段失败，不该轮询")),
-        )
+        with _agnes_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"error": "bad request"}, status_code=400))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            bounded_poll_clock(),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(httpx.HTTPStatusError):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        assert client.post.call_count == 1
+                await backend.generate(_request(tmp_path))
+
+            assert routes.submit.call_count == 1
+            assert routes.poll.call_count == 0  # 4xx 在提交阶段失败，不该轮询
 
     async def test_submit_read_timeout_wraps_ambiguous(self, tmp_path: Path):
-        from lib.video_backends.base import AmbiguousSubmitError
+        with _agnes_api() as routes, bounded_poll_clock():
+            routes.submit.mock(side_effect=httpx.ReadTimeout("read timed out"))
 
-        client = _mock_client(
-            post=AsyncMock(side_effect=httpx.ReadTimeout("read timed out")),
-            get=AsyncMock(side_effect=AssertionError("歧义态不该轮询")),
-        )
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            bounded_poll_clock(),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(AmbiguousSubmitError):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
-        assert client.post.call_count == 1
+                await backend.generate(_request(tmp_path))
+
+            assert routes.submit.call_count == 1
+            assert routes.poll.call_count == 0  # 歧义态不该轮询
 
 
 class TestResume:
     async def test_resume_polls_existing_job_no_submit(self, tmp_path: Path):
-        poll_resp = _make_response(200, _completed("task-resume", "https://cdn/resumed.mp4"))
-        client = _mock_client(
-            post=AsyncMock(side_effect=AssertionError("resume 不应 POST create")),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"resumed"))
+        with _agnes_api() as routes:
+            routes.poll.mock(return_value=_json(_completed("task-resume", "https://cdn.agnes/resumed.mp4")))
+            routes.download.mock(return_value=httpx.Response(200, content=b"resumed"))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            result = await backend.resume_video("task-resume", _request(tmp_path, output_path=tmp_path / "out.mp4"))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            result = await backend.resume_video(
-                "task-resume",
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                ),
-            )
+            assert routes.submit.call_count == 0  # resume 不 POST create
+            assert only_request(routes.poll).url.path.endswith("/videos/task-resume")
 
-        client.post.assert_not_called()
-        assert client.get.call_args.args[0].endswith("/videos/task-resume")
         assert result.task_id == "task-resume"
         assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
 
@@ -977,154 +662,90 @@ class TestResume:
         """resume 已完成任务、完成态只带 video_id 时，与首跑共用同一套终态解析：经二次查询取回
         成片，全程不 POST 建任务（不重复计费）。
         """
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "task-resume-vid",
-                "video_id": "vid-resume",
-                "status": "completed",
-                "remixed_from_video_id": None,
-                "seconds": "8.0",
-            },
-        )
-        query_resp = _make_response(200, {"video_id": "vid-resume", "url": "https://cdn.agnes/resume-queried.mp4"})
-        client = _mock_client(
-            post=AsyncMock(side_effect=AssertionError("resume 不应 POST create")),
-            get=AsyncMock(side_effect=[poll_resp, query_resp]),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"resume-queried"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://apihub.agnes-ai.com/v1")
-            result = await backend.resume_video(
-                "task-resume-vid",
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                ),
+        with _agnes_api(base_url=_GATEWAY_BASE_URL) as routes:
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "task-resume-vid",
+                        "video_id": "vid-resume",
+                        "status": "completed",
+                        "remixed_from_video_id": None,
+                        "seconds": "8.0",
+                    }
+                )
             )
+            routes.query.mock(
+                return_value=_json({"video_id": "vid-resume", "url": "https://cdn.agnes/resume-queried.mp4"})
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"resume-queried"))
 
-        client.post.assert_not_called()
-        assert client.get.call_args_list[0].args[0].endswith("/videos/task-resume-vid")
-        assert client.get.call_args_list[1].args[0] == "https://apihub.agnes-ai.com/agnesapi"
-        assert client.get.call_args_list[1].kwargs["params"] == {"video_id": "vid-resume"}
+            backend = AgnesVideoBackend(api_key="k", base_url=_GATEWAY_BASE_URL)
+            result = await backend.resume_video("task-resume-vid", _request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert routes.submit.call_count == 0
+            assert only_request(routes.poll).url.path.endswith("/videos/task-resume-vid")
+            assert str(only_request(routes.query).url) == "https://apihub.agnes-ai.com/agnesapi?video_id=vid-resume"
+
         assert result.video_uri == "https://cdn.agnes/resume-queried.mp4"
         assert result.duration_seconds == 8
         assert (tmp_path / "out.mp4").read_bytes() == b"resume-queried"
 
     async def test_resume_404_raises_resume_expired_without_retry(self, tmp_path: Path):
-        not_found = _make_response(404, {"error": "task not found"})
-        not_found.raise_for_status = MagicMock(side_effect=_make_http_error(404, "task not found"))
-        client = _mock_client(get=AsyncMock(return_value=not_found))
+        with _agnes_api() as routes:
+            routes.poll.mock(return_value=_json({"error": "task not found"}, status_code=404))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(ResumeExpiredError) as ei:
-                await backend.resume_video(
-                    "task-404",
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                    ),
-                )
+                await backend.resume_video("task-404", _request(tmp_path, output_path=tmp_path / "out.mp4"))
+
             assert ei.value.job_id == "task-404"
             assert ei.value.provider == PROVIDER_AGNES
-            assert client.get.call_count == 1
+            assert routes.poll.call_count == 1
 
 
 class TestDurationValidation:
     @pytest.mark.parametrize("duration", [0, 19, 30])
     async def test_out_of_range_duration_fails_loud_without_submit(self, tmp_path: Path, duration: int):
         """越界时长（< 1 或 > 18）在建单前 fail-loud，不静默截帧到 441、不 POST、不错记计费时长。"""
-        client = _mock_client(post=AsyncMock(side_effect=AssertionError("越界时长不应提交")))
-
-        with patch("httpx.AsyncClient", return_value=client):
-            from lib.video_backends.agnes import AgnesVideoBackend
-
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
+        with _agnes_api() as routes:
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
             with pytest.raises(VideoCapabilityError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=duration
-                    )
-                )
+                await backend.generate(_request(tmp_path, duration_seconds=duration))
+
             assert ei.value.code == "video_duration_not_supported"
-        client.post.assert_not_called()
+            assert routes.submit.call_count == 0
 
 
 class TestProviderJobIdPersistence:
     async def test_persists_agnes_task_id_for_worker_request(self, tmp_path: Path):
         """worker 路径（request.task_id 非空）下，submit 返回的 Agnes task_id 作为 job_id 写回，覆盖 resume 契约。"""
-        create_resp = _make_response(200, {"task_id": "agnes-task-42", "status": "queued"})
-        poll_resp = _make_response(200, _completed("agnes-task-42"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-        persist = AsyncMock()
+        with _agnes_api() as routes, captured_provider_job_ids() as persisted:
+            routes.submit.mock(return_value=_queued("agnes-task-42"))
+            routes.poll.mock(return_value=_json(_completed("agnes-task-42")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-            patch("lib.video_backends.base.persist_provider_job_id", persist),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path, task_id="worker-task-99"))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                    task_id="worker-task-99",
-                )
-            )
-
-        persist.assert_awaited_once()
-        args, kwargs = persist.call_args
-        assert args[0] == "worker-task-99"  # worker 任务 id
-        assert args[1] == "agnes-task-42"  # Agnes submit 返回的 task_id 作为 job_id 写回
-        assert kwargs["provider"] == PROVIDER_AGNES
+        assert persisted == [
+            {
+                "task_id": "worker-task-99",  # worker 任务 id
+                "job_id": "agnes-task-42",  # Agnes submit 返回的 task_id 作为 job_id 写回
+                "provider": PROVIDER_AGNES,
+                "endpoint": None,
+                "base_url": None,
+            }
+        ]
 
     async def test_non_worker_request_skips_persistence(self, tmp_path: Path):
         """非 worker 路径（task_id=None）不调用持久化，避免空 task_id 写库。"""
-        create_resp = _make_response(200, {"task_id": "agnes-task-1", "status": "queued"})
-        poll_resp = _make_response(200, _completed("agnes-task-1"))
-        client = _mock_client(
-            post=AsyncMock(return_value=create_resp),
-            get=AsyncMock(return_value=poll_resp),
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-        persist = AsyncMock()
+        with _agnes_api() as routes, captured_provider_job_ids() as persisted:
+            routes.submit.mock(return_value=_queued("agnes-task-1"))
+            routes.poll.mock(return_value=_json(_completed("agnes-task-1")))
 
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.agnes._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.agnes.download_video", fake_download),
-            patch("lib.video_backends.base.persist_provider_job_id", persist),
-        ):
-            from lib.video_backends.agnes import AgnesVideoBackend
+            backend = AgnesVideoBackend(api_key="k", base_url=_BASE_URL)
+            await backend.generate(_request(tmp_path))
 
-            backend = AgnesVideoBackend(api_key="k", base_url="https://x/v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
-            )
-
-        persist.assert_not_called()
+        assert persisted == []
 
 
 class TestRegistration:
@@ -1132,5 +753,5 @@ class TestRegistration:
         from lib.video_backends import create_backend, get_registered_backends
 
         assert PROVIDER_AGNES in get_registered_backends()
-        backend = create_backend(PROVIDER_AGNES, api_key="sk-test", base_url="https://x/v1")
+        backend = create_backend(PROVIDER_AGNES, api_key="sk-test", base_url=_BASE_URL)
         assert backend.name == PROVIDER_AGNES

--- a/tests/unit/lib/video_backends/test_dashscope_integration.py
+++ b/tests/unit/lib/video_backends/test_dashscope_integration.py
@@ -9,6 +9,7 @@ import pytest
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.providers import PROVIDER_DASHSCOPE, PROVIDER_OPENAI
+from tests.fakes import captured_openai_clients
 
 
 def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> MagicMock:
@@ -30,7 +31,7 @@ class TestTextProviderBilling:
     """隐患 3 回归：dashscope 文本复用 OpenAI 后端必须以 'dashscope' 记账，否则计费命中 USD。"""
 
     def test_provider_name_override(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             b = OpenAITextBackend(api_key="k", model="qwen-plus", provider_name="dashscope")
@@ -39,7 +40,7 @@ class TestTextProviderBilling:
     async def test_result_provider_is_dashscope(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_text_response("hi"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.base import TextGenerationRequest
             from lib.text_backends.openai import OpenAITextBackend
 
@@ -49,7 +50,7 @@ class TestTextProviderBilling:
         assert result.model == "qwen-plus"
 
     def test_default_provider_still_openai(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             assert OpenAITextBackend(api_key="k").name == PROVIDER_OPENAI

--- a/tests/unit/lib/video_backends/test_dashscope_video_backend.py
+++ b/tests/unit/lib/video_backends/test_dashscope_video_backend.py
@@ -1146,9 +1146,7 @@ class TestWan3:
                 )
             )
 
-        assert [(r["base_url"], r["endpoint"]) for r in persisted] == [
-            ("https://maas-a.example.com/ws-1/api/v1", None)
-        ]
+        assert [(r["base_url"], r["endpoint"]) for r in persisted] == [("https://maas-a.example.com/ws-1/api/v1", None)]
 
     async def test_resume_polls_submitted_base_url_after_config_change(self, tmp_path: Path):
         """在途改 wan3_base_url 后续跑：轮询仍打提交时的域名，而非当下配置解析出的域名。"""

--- a/tests/unit/lib/video_backends/test_dashscope_video_backend.py
+++ b/tests/unit/lib/video_backends/test_dashscope_video_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -15,6 +16,7 @@ from lib.video_backends.base import (
     VideoCapabilityError,
     VideoGenerationRequest,
 )
+from tests.fakes import captured_provider_job_ids
 
 
 def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
@@ -57,18 +59,39 @@ def _succeeded(url: str = "https://x/o.mp4", duration: int = 5) -> dict:
     }
 
 
-def _client(*, post=None, get=None) -> AsyncMock:
-    c = AsyncMock()
-    if post is not None:
-        c.post = post
-    if get is not None:
-        c.get = get
-    c.__aenter__ = AsyncMock(return_value=c)
-    c.__aexit__ = AsyncMock(return_value=None)
-    return c
+class _RecordingClient:
+    """httpx.AsyncClient 替身：记录每次 post/get 的 url 与参数，响应由传入的替身产出。
+
+    提交体、端点、鉴权头这些契约都是「发出去的请求长什么样」，断言落在 ``posts`` / ``gets``
+    里的请求内容上，而不是替身的调用对象。
+    """
+
+    def __init__(self, *, post: AsyncMock | None = None, get: AsyncMock | None = None) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.gets: list[dict[str, Any]] = []
+        self._post = post or AsyncMock()
+        self._get = get or AsyncMock()
+
+    async def post(self, url: str, **kwargs: Any):
+        self.posts.append({"url": url, **kwargs})
+        return await self._post(url, **kwargs)
+
+    async def get(self, url: str, **kwargs: Any):
+        self.gets.append({"url": url, **kwargs})
+        return await self._get(url, **kwargs)
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
 
 
-def _patches(client: AsyncMock, download: AsyncMock):
+def _client(*, post=None, get=None) -> _RecordingClient:
+    return _RecordingClient(post=post, get=get)
+
+
+def _patches(client: _RecordingClient, download: AsyncMock):
     return (
         patch("httpx.AsyncClient", return_value=client),
         patch("lib.video_backends.dashscope.download_video", download),
@@ -231,7 +254,7 @@ class TestReferenceToVideo:
                 )
             )
 
-        body = post.call_args.kwargs["json"]
+        body = client.posts[-1]["json"]
         assert body["model"] == "happyhorse-1.0-r2v"
         media = body["input"]["media"]
         assert len(media) == 2
@@ -242,8 +265,8 @@ class TestReferenceToVideo:
         assert body["parameters"]["watermark"] is False
         assert body["parameters"]["ratio"] == "16:9"
         # submit 端点 + async 头
-        assert post.call_args.args[0].endswith("/api/v1/services/aigc/video-generation/video-synthesis")
-        assert post.call_args.kwargs["headers"]["X-DashScope-Async"] == "enable"
+        assert client.posts[-1]["url"].endswith("/api/v1/services/aigc/video-generation/video-synthesis")
+        assert client.posts[-1]["headers"]["X-DashScope-Async"] == "enable"
         # 计费时长取 usage.duration（非请求值 5）
         assert result.duration_seconds == 8
         assert result.provider == PROVIDER_DASHSCOPE
@@ -265,7 +288,7 @@ class TestReferenceToVideo:
                     prompt="p", output_path=tmp_path / "o.mp4", reference_images=refs, resolution="720p"
                 )
             )
-        assert len(post.call_args.kwargs["json"]["input"]["media"]) == 9
+        assert len(client.posts[-1]["json"]["input"]["media"]) == 9
 
     async def test_r2v_ref_limit_wan_5(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
@@ -282,7 +305,7 @@ class TestReferenceToVideo:
                     prompt="p", output_path=tmp_path / "o.mp4", reference_images=refs, resolution="1080p"
                 )
             )
-        assert len(post.call_args.kwargs["json"]["input"]["media"]) == 5
+        assert len(client.posts[-1]["json"]["input"]["media"]) == 5
 
     async def test_r2v_all_refs_missing_fail_loud(self, tmp_path: Path):
         # r2v 参考图缺失/不可读（含空串过滤后仍有声明项）须 fail-loud 报错列名，不静默退化
@@ -407,11 +430,11 @@ class TestFirstFrameAndTextOnly:
             await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", start_image=start, resolution="720p")
             )
-        media = post.call_args.kwargs["json"]["input"]["media"]
+        media = client.posts[-1]["json"]["input"]["media"]
         assert media == [{"type": "first_frame", "url": media[0]["url"]}]
         assert media[0]["url"].startswith("data:image/png;base64,")
         # 带首帧（图生视频）按首帧定宽高比：默认 aspect_ratio 非空也不得下传 ratio，否则上游拒绝
-        assert "ratio" not in post.call_args.kwargs["json"]["parameters"]
+        assert "ratio" not in client.posts[-1]["json"]["parameters"]
 
     async def test_t2v_no_media(self, tmp_path: Path):
         post = AsyncMock(return_value=_resp(_submit()))
@@ -423,8 +446,8 @@ class TestFirstFrameAndTextOnly:
 
             b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")
             await b.generate(VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="1080p"))
-        assert "media" not in post.call_args.kwargs["json"]["input"]
-        assert post.call_args.kwargs["json"]["parameters"]["resolution"] == "1080P"
+        assert "media" not in client.posts[-1]["json"]["input"]
+        assert client.posts[-1]["json"]["parameters"]["resolution"] == "1080P"
 
     async def test_happyhorse_11_i2v_payload(self, tmp_path: Path):
         """1.1 与 1.0 同口径：水印显式关（官方默认开），480P 档位透传为大写。"""
@@ -440,11 +463,11 @@ class TestFirstFrameAndTextOnly:
             await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", start_image=start, resolution="480p")
             )
-        params = post.call_args.kwargs["json"]["parameters"]
-        assert post.call_args.kwargs["json"]["model"] == "happyhorse-1.1-i2v"
+        params = client.posts[-1]["json"]["parameters"]
+        assert client.posts[-1]["json"]["model"] == "happyhorse-1.1-i2v"
         assert params["watermark"] is False
         assert params["resolution"] == "480P"
-        assert post.call_args.kwargs["json"]["input"]["media"][0]["type"] == "first_frame"
+        assert client.posts[-1]["json"]["input"]["media"][0]["type"] == "first_frame"
 
 
 class TestPollingAndFailures:
@@ -466,7 +489,7 @@ class TestPollingAndFailures:
             result = await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
             )
-        assert get.call_count == 3
+        assert len(client.gets) == 3
         assert result.task_id == "t3"
 
     async def test_failed_raises(self, tmp_path: Path):
@@ -514,7 +537,7 @@ class TestResume:
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p"),
             )
         post.assert_not_called()
-        assert get.call_args.args[0].endswith("/tasks/t-resume")
+        assert client.gets[-1]["url"].endswith("/tasks/t-resume")
         assert result.task_id == "t-resume"
 
     async def test_resume_unknown_raises_resume_expired(self, tmp_path: Path):
@@ -548,7 +571,7 @@ class TestResume:
                     "t-404",
                     VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p"),
                 )
-            assert get.call_count == 1
+            assert len(client.gets) == 1
 
 
 class TestPersist:
@@ -556,9 +579,8 @@ class TestPersist:
         post = AsyncMock(return_value=_resp(_submit("job-9")))
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
-        persist = AsyncMock()
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.video_backends.base.persist_provider_job_id", persist):
+        with p1, p2, p3, captured_provider_job_ids() as persisted:
             from lib.video_backends.dashscope import DashScopeVideoBackend
 
             b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-i2v")
@@ -567,10 +589,9 @@ class TestPersist:
                     prompt="p", output_path=tmp_path / "o.mp4", resolution="720p", task_id="db-task-1"
                 )
             )
-        persist.assert_called_once()
-        assert persist.call_args.args[0] == "db-task-1"
-        assert persist.call_args.args[1] == "job-9"
-        assert persist.call_args.kwargs["provider"] == PROVIDER_DASHSCOPE
+        assert [(r["task_id"], r["job_id"], r["provider"]) for r in persisted] == [
+            ("db-task-1", "job-9", PROVIDER_DASHSCOPE)
+        ]
 
 
 class TestSubmit413:
@@ -599,7 +620,7 @@ class TestSubmit413:
                 )
         # 保留 status_code 让咽喉层识别 413；413 非 retryable → fail-fast 单次提交
         assert ei.value.response.status_code == 413
-        assert post.call_count == 1
+        assert len(client.posts) == 1
         download.assert_not_called()
 
 
@@ -622,7 +643,7 @@ class TestRetryStatusGating:
             with pytest.raises(httpx.HTTPStatusError) as ei:
                 await b.generate(VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p"))
         assert ei.value.response.status_code == 400
-        assert post.call_count == 1
+        assert len(client.posts) == 1
 
     async def test_submit_real_503_retries_then_succeeds(self, tmp_path: Path):
         # 真 5xx：按 status_code 重试，第三次成功。
@@ -639,7 +660,7 @@ class TestRetryStatusGating:
             result = await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
             )
-        assert post.call_count == 3
+        assert len(client.posts) == 3
         assert result.task_id == "t-ok"
 
     async def test_submit_connect_error_retries(self, tmp_path: Path):
@@ -655,7 +676,7 @@ class TestRetryStatusGating:
             result = await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
             )
-        assert post.call_count == 2
+        assert len(client.posts) == 2
         assert result.task_id == "t-ok"
 
     async def test_poll_timeout_retries(self, tmp_path: Path):
@@ -671,7 +692,7 @@ class TestRetryStatusGating:
             result = await b.generate(
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", resolution="720p")
             )
-        assert get.call_count == 2
+        assert len(client.gets) == 2
         assert result.task_id == "t-poll"
 
 
@@ -1097,8 +1118,8 @@ class TestWan3:
         await b._poll_once(client, "t-wan3", b._request_base_url)
         from lib.video_backends.dashscope import _VIDEO_ENDPOINT
 
-        assert post.await_args.args[0] == f"https://maas-cn-hangzhou.example.com/ws-123/api/v1{_VIDEO_ENDPOINT}"
-        assert get.await_args.args[0] == "https://maas-cn-hangzhou.example.com/ws-123/api/v1/tasks/t-wan3"
+        assert client.posts[-1]["url"] == f"https://maas-cn-hangzhou.example.com/ws-123/api/v1{_VIDEO_ENDPOINT}"
+        assert client.gets[-1]["url"] == "https://maas-cn-hangzhou.example.com/ws-123/api/v1/tasks/t-wan3"
 
     def test_falls_back_to_shared_base_url(self):
         b = self._backend()
@@ -1116,9 +1137,8 @@ class TestWan3:
         post = AsyncMock(return_value=_resp(_submit("t-wan3")))
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
-        persist = AsyncMock()
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.video_backends.base.persist_provider_job_id", persist):
+        with p1, p2, p3, captured_provider_job_ids() as persisted:
             b = self._backend(wan3_base_url="https://maas-a.example.com/ws-1/api/v1")
             await b.generate(
                 VideoGenerationRequest(
@@ -1126,8 +1146,9 @@ class TestWan3:
                 )
             )
 
-        assert persist.call_args.kwargs["base_url"] == "https://maas-a.example.com/ws-1/api/v1"
-        assert persist.call_args.kwargs["endpoint"] is None
+        assert [(r["base_url"], r["endpoint"]) for r in persisted] == [
+            ("https://maas-a.example.com/ws-1/api/v1", None)
+        ]
 
     async def test_resume_polls_submitted_base_url_after_config_change(self, tmp_path: Path):
         """在途改 wan3_base_url 后续跑：轮询仍打提交时的域名，而非当下配置解析出的域名。"""
@@ -1147,7 +1168,7 @@ class TestWan3:
                 ),
             )
 
-        assert get.await_args.args[0] == "https://maas-a.example.com/ws-1/api/v1/tasks/t-wan3"
+        assert client.gets[-1]["url"] == "https://maas-a.example.com/ws-1/api/v1/tasks/t-wan3"
 
 
 class TestCustomProviderBaseUrlReplay:
@@ -1171,9 +1192,8 @@ class TestCustomProviderBaseUrlReplay:
         post = AsyncMock(return_value=_resp(_submit("job-c1")))
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
-        persist = AsyncMock()
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.video_backends.base.persist_provider_job_id", persist):
+        with p1, p2, p3, captured_provider_job_ids() as persisted:
             backend = self._wrapped("https://custom-a.example.com")
             await backend.generate(
                 VideoGenerationRequest(
@@ -1181,8 +1201,9 @@ class TestCustomProviderBaseUrlReplay:
                 )
             )
 
-        assert persist.call_args.kwargs["endpoint"] == "dashscope-async-video"
-        assert persist.call_args.kwargs["base_url"] == "https://custom-a.example.com/api/v1"
+        assert [(r["endpoint"], r["base_url"]) for r in persisted] == [
+            ("dashscope-async-video", "https://custom-a.example.com/api/v1")
+        ]
 
     async def test_resume_polls_submitted_domain_after_base_url_change(self, tmp_path: Path):
         """在途改自定义供应商的 base_url 后续跑：轮询打提交时的域名，job 仍在该域名上。"""
@@ -1202,4 +1223,4 @@ class TestCustomProviderBaseUrlReplay:
                 ),
             )
 
-        assert get.await_args.args[0] == "https://custom-a.example.com/api/v1/tasks/job-c1"
+        assert client.gets[-1]["url"] == "https://custom-a.example.com/api/v1/tasks/job-c1"

--- a/tests/unit/lib/video_backends/test_dashscope_video_backend.py
+++ b/tests/unit/lib/video_backends/test_dashscope_video_backend.py
@@ -16,7 +16,7 @@ from lib.video_backends.base import (
     VideoCapabilityError,
     VideoGenerationRequest,
 )
-from tests.fakes import captured_provider_job_ids
+from tests.fakes import bounded_poll_clock, captured_provider_job_ids
 
 
 def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
@@ -636,7 +636,7 @@ class TestRetryStatusGating:
         post = AsyncMock(return_value=bad)
         client = _client(post=post)
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+        with p1, p2, p3, bounded_poll_clock():
             from lib.video_backends.dashscope import DashScopeVideoBackend
 
             b = DashScopeVideoBackend(api_key="sk", model="wan2.7-t2v")
@@ -653,7 +653,7 @@ class TestRetryStatusGating:
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+        with p1, p2, p3, bounded_poll_clock():
             from lib.video_backends.dashscope import DashScopeVideoBackend
 
             b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")
@@ -669,7 +669,7 @@ class TestRetryStatusGating:
         get = AsyncMock(return_value=_resp(_succeeded()))
         client = _client(post=post, get=get)
         p1, p2, p3 = _patches(client, AsyncMock())
-        with p1, p2, p3, patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
+        with p1, p2, p3, bounded_poll_clock():
             from lib.video_backends.dashscope import DashScopeVideoBackend
 
             b = DashScopeVideoBackend(api_key="sk", model="happyhorse-1.0-t2v")

--- a/tests/unit/lib/video_backends/test_grok_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_video_backend.py
@@ -9,6 +9,7 @@ import pytest
 
 from lib.providers import PROVIDER_GROK
 from lib.video_backends.base import VideoGenerationRequest
+from tests.fakes import bounded_poll_clock
 
 
 @pytest.fixture
@@ -107,7 +108,7 @@ class TestGrokVideoBackend:
 
         with (
             patch("lib.video_backends.grok.create_grok_client", return_value=mock_client),
-            patch("lib.retry.asyncio.sleep", new=AsyncMock()),
+            bounded_poll_clock(),
         ):
             backend = GrokVideoBackend(api_key="test-key")
             request = VideoGenerationRequest(

--- a/tests/unit/lib/video_backends/test_grok_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_video_backend.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from lib.providers import PROVIDER_GROK
 from lib.video_backends.base import VideoGenerationRequest
 from tests.fakes import bounded_poll_clock
+from tests.http_capture import capture_http
+
+
+@contextmanager
+def _video_download(url: str, content: bytes) -> Iterator[respx.Route]:
+    """成片下载的出站流：base 层用真实 httpx 流式取字节，走 respx 在 transport 层拦截。"""
+    with capture_http() as router:
+        yield router.get(url).mock(return_value=httpx.Response(200, content=content))
 
 
 @pytest.fixture
@@ -62,17 +74,7 @@ class TestGrokVideoBackend:
         with patch("lib.video_backends.grok.create_grok_client", return_value=mock_client):
             backend = GrokVideoBackend(api_key="test-key")
 
-            mock_http_response = AsyncMock()
-            mock_http_response.status_code = 200
-            mock_http_response.raise_for_status = MagicMock()
-            mock_http_response.aiter_bytes = lambda chunk_size=None: _async_iter([b"fake-video-data"])
-
-            mock_http_client = AsyncMock()
-            mock_http_client.stream = _async_context_manager(mock_http_response)
-            mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-            mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-            with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
+            with _video_download(mock_response.url, b"fake-video-data"):
                 request = VideoGenerationRequest(
                     prompt="A cat walking",
                     output_path=video_output_path,
@@ -143,17 +145,7 @@ class TestGrokVideoBackend:
         with patch("lib.video_backends.grok.create_grok_client", return_value=mock_client):
             backend = GrokVideoBackend(api_key="test-key")
 
-            mock_http_response = AsyncMock()
-            mock_http_response.status_code = 200
-            mock_http_response.raise_for_status = MagicMock()
-            mock_http_response.aiter_bytes = lambda chunk_size=None: _async_iter([b"fake-video-data"])
-
-            mock_http_client = AsyncMock()
-            mock_http_client.stream = _async_context_manager(mock_http_response)
-            mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-            mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-            with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
+            with _video_download(mock_response.url, b"fake-video-data"):
                 request = VideoGenerationRequest(
                     prompt="Animate this scene",
                     output_path=video_output_path,
@@ -204,17 +196,7 @@ class TestGrokVideoBackend:
         with patch("lib.video_backends.grok.create_grok_client", return_value=mock_client):
             backend = GrokVideoBackend(api_key="test-key")
 
-            mock_http_response = AsyncMock()
-            mock_http_response.status_code = 200
-            mock_http_response.raise_for_status = MagicMock()
-            mock_http_response.aiter_bytes = lambda chunk_size=None: _async_iter([b"fake-video-data"])
-
-            mock_http_client = AsyncMock()
-            mock_http_client.stream = _async_context_manager(mock_http_response)
-            mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-            mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-            with patch("lib.video_backends.base.httpx.AsyncClient", return_value=mock_http_client):
+            with _video_download(mock_response.url, b"fake-video-data"):
                 request = VideoGenerationRequest(
                     prompt="A cat walking",
                     output_path=video_output_path,
@@ -225,18 +207,3 @@ class TestGrokVideoBackend:
                 result = await backend.generate(request)
 
             assert result.duration_seconds == expected
-
-
-async def _async_iter(items):
-    for item in items:
-        yield item
-
-
-def _async_context_manager(mock_response):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _stream(*args, **kwargs):
-        yield mock_response
-
-    return _stream

--- a/tests/unit/lib/video_backends/test_minimax_integration.py
+++ b/tests/unit/lib/video_backends/test_minimax_integration.py
@@ -9,6 +9,7 @@ import pytest
 from lib.pricing.lookup import lookup_pricing
 from lib.pricing.strategies import PricingParams, calculate_pricing
 from lib.providers import PROVIDER_MINIMAX, PROVIDER_OPENAI
+from tests.fakes import captured_openai_clients
 
 
 def _text_response(content: str = "ok", in_tok: int = 10, out_tok: int = 5) -> MagicMock:
@@ -58,7 +59,7 @@ class TestTextProviderBilling:
     """文本复用 OpenAI 后端必须以 'minimax' 记账，否则计费命中 USD。"""
 
     def test_provider_name_override(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.text_backends.openai import OpenAITextBackend
 
             b = OpenAITextBackend(api_key="k", model="MiniMax-M2.7", provider_name=PROVIDER_MINIMAX)
@@ -67,7 +68,7 @@ class TestTextProviderBilling:
     async def test_result_provider_is_minimax(self):
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_text_response("hi"))
-        with patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with captured_openai_clients(mock_client):
             from lib.text_backends.base import TextGenerationRequest
             from lib.text_backends.openai import OpenAITextBackend
 

--- a/tests/unit/lib/video_backends/test_minimax_video_backend.py
+++ b/tests/unit/lib/video_backends/test_minimax_video_backend.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +16,20 @@ from lib.providers import PROVIDER_MINIMAX
 from lib.video_backends.base import ReferenceAudioMode, VideoCapabilityError, VideoGenerationRequest
 from lib.video_backends.minimax import MiniMaxVideoBackend, _safe_body_for_log
 from lib.video_frame_slots import resolve_first_frame_aspect_ratio
+from tests.fakes import captured_provider_job_ids
+
+
+@contextmanager
+def _recorded_model_lookups() -> Iterator[list[tuple[str, str]]]:
+    """registry 查表的记录器：收下 (provider, model) 查询名，回一份固定的 H3 声明。"""
+    queried: list[tuple[str, str]] = []
+
+    def _lookup(provider: str, name: str) -> Any:
+        queried.append((provider, name))
+        return MagicMock(resolutions=["768p"], supported_durations=[6])
+
+    with patch("lib.video_backends.minimax.model_info_for", _lookup):
+        yield queried
 
 
 def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
@@ -130,11 +147,10 @@ class TestConstructionAndCapabilities:
     def test_h3_output_specs_query_uses_canonical_name(self, model):
         # 直接断言查询参数已归一化为 canonical 名，不依赖兜底值与 registry 声明恰好相等这种
         # 巧合。
-        with patch("lib.video_backends.minimax.model_info_for") as mock_lookup:
-            mock_lookup.return_value = MagicMock(resolutions=["768p"], supported_durations=[6])
+        with _recorded_model_lookups() as queried:
             b = _backend(model)
             b._v2_output_specs()
-        assert mock_lookup.call_args.args[1] == "MiniMax-H3"
+        assert [name for _provider, name in queried] == ["MiniMax-H3"]
 
     def test_h3_output_specs_missing_registry_entry_fails_loud(self):
         # 本方法只查固定的 canonical 名，缺失只可能是 registry 条目被误删/改名——这类配置
@@ -309,12 +325,10 @@ class TestGenerateHappyPath:
             patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
             patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
-            patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist,
+            captured_provider_job_ids() as persisted,
         ):
             await _backend().generate(_request(tmp_path, task_id="local-task-1"))
-        persist.assert_awaited_once()
-        assert persist.await_args is not None
-        assert persist.await_args.args[1] == "task-x"
+        assert [(r["task_id"], r["job_id"]) for r in persisted] == [("local-task-1", "task-x")]
 
 
 class TestH3V2Capabilities:

--- a/tests/unit/lib/video_backends/test_minimax_video_backend.py
+++ b/tests/unit/lib/video_backends/test_minimax_video_backend.py
@@ -91,9 +91,7 @@ def _minimax_routes(
             patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
             patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as download,
         ):
-            yield _MiniMaxRoutes(
-                submit=submit_route, query=query_route, retrieve=retrieve_route, download=download
-            )
+            yield _MiniMaxRoutes(submit=submit_route, query=query_route, retrieve=retrieve_route, download=download)
 
 
 def _v2_query(status: str, *, url: str = "", error: str = "") -> dict:

--- a/tests/unit/lib/video_backends/test_minimax_video_backend.py
+++ b/tests/unit/lib/video_backends/test_minimax_video_backend.py
@@ -6,10 +6,12 @@ import base64
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from lib.config.registry import model_info_for
 from lib.providers import PROVIDER_MINIMAX
@@ -17,6 +19,7 @@ from lib.video_backends.base import ReferenceAudioMode, VideoCapabilityError, Vi
 from lib.video_backends.minimax import MiniMaxVideoBackend, _safe_body_for_log
 from lib.video_frame_slots import resolve_first_frame_aspect_ratio
 from tests.fakes import captured_provider_job_ids
+from tests.http_capture import capture_http, only_request, request_json
 
 
 @contextmanager
@@ -32,12 +35,8 @@ def _recorded_model_lookups() -> Iterator[list[tuple[str, str]]]:
         yield queried
 
 
-def _resp(json_body: dict, status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    resp.raise_for_status = MagicMock()
-    return resp
+def _resp(json_body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=json_body)
 
 
 def _submit(task_id: str = "t-1") -> dict:
@@ -59,15 +58,42 @@ def _retrieve(url: str = "https://x/o.mp4") -> dict:
     return {"file": {"file_id": "f-1", "download_url": url}, "base_resp": {"status_code": 0}}
 
 
-def _client(*, post=None, get=None) -> AsyncMock:
-    c = AsyncMock()
-    if post is not None:
-        c.post = post
-    if get is not None:
-        c.get = get
-    c.__aenter__ = AsyncMock(return_value=c)
-    c.__aexit__ = AsyncMock(return_value=None)
-    return c
+class _MiniMaxRoutes(NamedTuple):
+    submit: respx.Route
+    query: respx.Route
+    retrieve: respx.Route
+    download: AsyncMock
+
+
+@contextmanager
+def _minimax_routes(
+    *,
+    submit: httpx.Response | list[httpx.Response] | None = None,
+    query: httpx.Response | list[httpx.Response] | None = None,
+    retrieve: httpx.Response | list[httpx.Response] | None = None,
+) -> Iterator[_MiniMaxRoutes]:
+    """MiniMax 视频的三条出站流：提交、查询、取回（v2 只用前两条）。
+
+    走 respx 在 transport 层拦截，断言落在真实序列化后的请求上。成片下载是 backend 的
+    另一段 seam，仍按协作者边界接管；轮询间隔压到 0，等待本身不是断言对象。
+    """
+
+    def _mock(route: respx.Route, resp: httpx.Response | list[httpx.Response] | None) -> respx.Route:
+        if isinstance(resp, list):
+            return route.mock(side_effect=resp)
+        return route.mock(return_value=resp if resp is not None else httpx.Response(200, json={}))
+
+    with capture_http() as router:
+        submit_route = _mock(router.post(url__regex=r"https://[^/]+/v[12]/video_generation"), submit)
+        query_route = _mock(router.get(url__regex=r"https://[^/]+/v[12]/query/video_generation.*"), query)
+        retrieve_route = _mock(router.get(url__regex=r"https://[^/]+/v1/files/retrieve.*"), retrieve)
+        with (
+            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
+            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as download,
+        ):
+            yield _MiniMaxRoutes(
+                submit=submit_route, query=query_route, retrieve=retrieve_route, download=download
+            )
 
 
 def _v2_query(status: str, *, url: str = "", error: str = "") -> dict:
@@ -258,73 +284,52 @@ class TestS2V01SubjectReference:
     async def test_generate_two_step_via_subject_reference(self, tmp_path):
         face = tmp_path / "face.png"
         face.write_bytes(b"\x89PNG\r\n")
-        captured: dict = {}
-
-        async def _post(url, json, headers):
-            captured["json"] = json
-            return _resp(_submit("s2v-task"))
-
-        post = AsyncMock(side_effect=_post)
-        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f")), _resp(_retrieve("https://x/s2v.mp4"))])
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
-        ):
+        with _minimax_routes(
+            submit=_resp(_submit("s2v-task")),
+            query=_resp(_query("Success", file_id="f")),
+            retrieve=_resp(_retrieve("https://x/s2v.mp4")),
+        ) as routes:
             result = await _backend("S2V-01").generate(_request(tmp_path, reference_images=[face]))
 
         assert result.video_uri == "https://x/s2v.mp4"
-        assert captured["json"]["model"] == "S2V-01"
-        assert captured["json"]["subject_reference"][0]["type"] == "character"
+        submitted = request_json(only_request(routes.submit))
+        assert submitted["model"] == "S2V-01"
+        assert submitted["subject_reference"][0]["type"] == "character"
 
 
 class TestGenerateHappyPath:
     async def test_two_step_url_extraction(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit("task-9")))
-        get = AsyncMock(
-            side_effect=[
-                _resp(_query("Processing")),
-                _resp(_query("Success", file_id="file-9")),
-                _resp(_retrieve("https://x/final.mp4")),
-            ]
-        )
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
-        ):
+        with _minimax_routes(
+            submit=_resp(_submit("task-9")),
+            query=[_resp(_query("Processing")), _resp(_query("Success", file_id="file-9"))],
+            retrieve=_resp(_retrieve("https://x/final.mp4")),
+        ) as routes:
             result = await _backend().generate(_request(tmp_path, duration_seconds=10))
 
         assert result.provider == PROVIDER_MINIMAX
         assert result.task_id == "task-9"
         assert result.video_uri == "https://x/final.mp4"
         assert result.duration_seconds == 10
-        dl.assert_awaited_once()
-        # submit + 2 query + 1 retrieve
-        assert get.await_count == 3
+        routes.download.assert_awaited_once()
+        # 2 次查询轮询 + 1 次取回
+        assert routes.query.call_count == 2
+        assert routes.retrieve.call_count == 1
 
     async def test_fail_status_raises(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit()))
-        get = AsyncMock(return_value=_resp(_query("Fail", base_resp={"status_code": 2013, "status_msg": "invalid"})))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        with _minimax_routes(
+            submit=_resp(_submit()),
+            query=_resp(_query("Fail", base_resp={"status_code": 2013, "status_msg": "invalid"})),
         ):
             with pytest.raises(RuntimeError, match="2013"):
                 await _backend().generate(_request(tmp_path))
 
     async def test_persists_provider_job_id_when_task_id_present(self, tmp_path):
-        post = AsyncMock(return_value=_resp(_submit("task-x")))
-        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f")), _resp(_retrieve())])
-        client = _client(post=post, get=get)
         with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+            _minimax_routes(
+                submit=_resp(_submit("task-x")),
+                query=_resp(_query("Success", file_id="f")),
+                retrieve=_resp(_retrieve()),
+            ),
             captured_provider_job_ids() as persisted,
         ):
             await _backend().generate(_request(tmp_path, task_id="local-task-1"))
@@ -463,90 +468,60 @@ class TestH3V2Payload:
 
 class TestH3V2Generate:
     async def test_single_step_url_extraction(self, tmp_path):
-        captured: dict = {}
-
-        async def _post(url, json, headers):
-            captured["url"] = url
-            captured["json"] = json
-            return _resp(_submit("h3-task"))
-
-        async def _get(url, params=None, headers=None):
-            captured["query_url"] = url
-            captured["query_params"] = params
-            return _resp(_v2_query("succeeded", url="https://x/h3.mp4"))
-
-        client = _client(post=AsyncMock(side_effect=_post), get=AsyncMock(side_effect=_get))
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
-        ):
+        with _minimax_routes(
+            submit=_resp(_submit("h3-task")),
+            query=_resp(_v2_query("succeeded", url="https://x/h3.mp4")),
+        ) as routes:
             result = await _h3().generate(_request(tmp_path, duration_seconds=5))
 
-        assert captured["url"].endswith("/v2/video_generation")
+        assert only_request(routes.submit).url.path.endswith("/v2/video_generation")
         # v2 把 task_id 放路径段，且成功响应直接带下载地址，无 files/retrieve 这一步。
-        assert captured["query_url"].endswith("/v2/query/video_generation/h3-task")
-        assert captured["query_params"] is None
+        queried = only_request(routes.query).url
+        assert queried.path.endswith("/v2/query/video_generation/h3-task")
+        assert not queried.query
+        assert routes.retrieve.call_count == 0
         assert result.video_uri == "https://x/h3.mp4"
         assert result.task_id == "h3-task"
-        dl.assert_awaited_once()
+        routes.download.assert_awaited_once()
 
     async def test_running_status_keeps_polling(self, tmp_path):
-        get = AsyncMock(side_effect=[_resp(_v2_query("running")), _resp(_v2_query("succeeded", url="https://x/o.mp4"))])
-        client = _client(post=AsyncMock(return_value=_resp(_submit())), get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
-        ):
+        with _minimax_routes(
+            submit=_resp(_submit()),
+            query=[_resp(_v2_query("running")), _resp(_v2_query("succeeded", url="https://x/o.mp4"))],
+        ) as routes:
             result = await _h3().generate(_request(tmp_path))
-        assert get.await_count == 2
+        assert routes.query.call_count == 2
         assert result.video_uri == "https://x/o.mp4"
 
     @pytest.mark.parametrize("status", ["failed", "cancelled"])
     async def test_terminal_failure_statuses_raise(self, tmp_path, status):
-        client = _client(
-            post=AsyncMock(return_value=_resp(_submit())),
-            get=AsyncMock(return_value=_resp(_v2_query(status, error="quota exhausted"))),
-        )
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
+        with _minimax_routes(
+            submit=_resp(_submit()),
+            query=_resp(_v2_query(status, error="quota exhausted")),
         ):
             with pytest.raises(RuntimeError, match="quota exhausted"):
                 await _h3().generate(_request(tmp_path))
 
     async def test_resume_polls_v2_endpoint(self, tmp_path):
-        post = AsyncMock()  # must NOT be called
-        get = AsyncMock(return_value=_resp(_v2_query("succeeded", url="https://x/r2.mp4")))
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()),
-        ):
+        with _minimax_routes(query=_resp(_v2_query("succeeded", url="https://x/r2.mp4"))) as routes:
             result = await _h3().resume_video("h3-resume", _request(tmp_path))
 
-        post.assert_not_called()
-        assert get.await_args is not None
-        assert get.await_args.args[0].endswith("/v2/query/video_generation/h3-resume")
+        # 续跑只查不提交
+        assert routes.submit.call_count == 0
+        assert only_request(routes.query).url.path.endswith("/v2/query/video_generation/h3-resume")
         assert result.video_uri == "https://x/r2.mp4"
 
 
 class TestResume:
     async def test_resume_polls_without_resubmit(self, tmp_path):
-        post = AsyncMock()  # must NOT be called
-        get = AsyncMock(side_effect=[_resp(_query("Success", file_id="f-r")), _resp(_retrieve("https://x/r.mp4"))])
-        client = _client(post=post, get=get)
-        with (
-            patch("lib.video_backends.minimax.httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.minimax.MINIMAX_VIDEO_POLL_INTERVAL_SECONDS", 0),
-            patch("lib.video_backends.minimax.download_video", new=AsyncMock()) as dl,
-        ):
+        with _minimax_routes(
+            query=_resp(_query("Success", file_id="f-r")),
+            retrieve=_resp(_retrieve("https://x/r.mp4")),
+        ) as routes:
             result = await _backend().resume_video("task-resume", _request(tmp_path))
 
-        post.assert_not_called()
+        # 续跑只查不提交
+        assert routes.submit.call_count == 0
         assert result.task_id == "task-resume"
         assert result.video_uri == "https://x/r.mp4"
-        dl.assert_awaited_once()
+        routes.download.assert_awaited_once()

--- a/tests/unit/lib/video_backends/test_newapi_video_backend.py
+++ b/tests/unit/lib/video_backends/test_newapi_video_backend.py
@@ -1,95 +1,109 @@
-"""NewAPIVideoBackend 单元测试（mock httpx）。"""
+"""NewAPIVideoBackend 单元测试（respx 捕获出站请求，假表压缩轮询等待）。"""
 
 from __future__ import annotations
 
 import base64
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import NamedTuple
 
 import httpx
 import pytest
+import respx
 
 from lib.providers import PROVIDER_NEWAPI
-from lib.video_backends.base import VideoGenerationRequest
+from lib.video_backends.base import AmbiguousSubmitError, ResumeExpiredError, VideoGenerationRequest
+from lib.video_backends.newapi import NewAPIVideoBackend
 from tests.fakes import bounded_poll_clock
+from tests.http_capture import capture_http, only_request, request_json
+
+_BASE_URL = "https://x/v1"
+_GENERATIONS_PATH = "/video/generations"
 
 
-def _make_response(status_code: int, json_body: dict) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    resp.raise_for_status = MagicMock()
-    return resp
+class _NewAPIRoutes(NamedTuple):
+    """NewAPI 的三条出站流量：建任务、任务轮询、成片下载。"""
+
+    submit: respx.Route
+    poll: respx.Route
+    download: respx.Route
 
 
-def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
-    """构造 httpx.HTTPStatusError，用于模拟 raise_for_status() 抛出的 5xx。"""
-    request = httpx.Request("POST", "https://x/v1/video/generations")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"Server error '{status_code}'", request=request, response=response)
+@contextmanager
+def _newapi(*, base_url: str = _BASE_URL) -> Iterator[_NewAPIRoutes]:
+    with capture_http() as router:
+        yield _NewAPIRoutes(
+            submit=router.post(f"{base_url}{_GENERATIONS_PATH}"),
+            poll=router.get(url__regex=rf"^{re.escape(base_url + _GENERATIONS_PATH)}/[^/]+$"),
+            download=router.get(url__regex=r"^https://cdn"),
+        )
 
 
-def _fake_download_factory(payload: bytes = b"mp4-bytes"):
-    """返回一个模拟 `download_video` 的异步函数，写入 payload 到 output_path。"""
+def _json(body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=body)
 
-    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(payload)
 
-    return _fake
+def _queued(task_id: str = "t-proxy") -> httpx.Response:
+    return _json({"task_id": task_id, "status": "queued"})
+
+
+def _done(task_id: str = "t-proxy", url: str = "https://cdn/v.mp4", **extra) -> httpx.Response:
+    body = {"task_id": task_id, "status": "completed", "url": url, "metadata": {"duration": 5}}
+    body.update(extra)
+    return _json(body)
+
+
+def _request(tmp_path: Path, **overrides) -> VideoGenerationRequest:
+    params: dict = {
+        "prompt": "p",
+        "output_path": tmp_path / "o.mp4",
+        "aspect_ratio": "9:16",
+        "duration_seconds": 5,
+    }
+    params.update(overrides)
+    return VideoGenerationRequest(**params)
+
+
+def _backend(base_url: str = _BASE_URL, model: str = "m") -> NewAPIVideoBackend:
+    return NewAPIVideoBackend(api_key="k", base_url=base_url, model=model)
 
 
 class TestNewAPIVideoBackend:
     def test_name_and_model(self):
-        from lib.video_backends.newapi import NewAPIVideoBackend
-
         backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://example.com/v1", model="kling-v1")
         assert backend.name == PROVIDER_NEWAPI
         assert backend.model == "kling-v1"
 
     def test_capabilities(self):
-        from lib.video_backends.newapi import NewAPIVideoBackend
-
-        backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://x/v1", model="m")
-        assert backend.video_capabilities.max_reference_images == 0
+        assert _backend().video_capabilities.max_reference_images == 0
 
     async def test_text_to_video_happy_path(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "task-42", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "task-42",
-                "status": "completed",
-                "url": "https://cdn.example.com/out.mp4",
-                "format": "mp4",
-                "metadata": {"duration": 5, "fps": 24, "width": 720, "height": 1280, "seed": 0},
-            },
-        )
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"mp4-bytes"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
+        with _newapi(base_url="https://example.com/v1") as routes:
+            routes.submit.mock(return_value=_queued("task-42"))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "task-42",
+                        "status": "completed",
+                        "url": "https://cdn.example.com/out.mp4",
+                        "format": "mp4",
+                        "metadata": {"duration": 5, "fps": 24, "width": 720, "height": 1280, "seed": 0},
+                    }
+                )
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4-bytes"))
 
             backend = NewAPIVideoBackend(api_key="sk-test", base_url="https://example.com/v1", model="kling-v1")
-            request = VideoGenerationRequest(
-                prompt="A cat running",
-                output_path=tmp_path / "out.mp4",
-                aspect_ratio="9:16",
-                resolution="720p",
-                duration_seconds=5,
+            result = await backend.generate(
+                _request(
+                    tmp_path,
+                    prompt="A cat running",
+                    output_path=tmp_path / "out.mp4",
+                    resolution="720p",
+                )
             )
-            result = await backend.generate(request)
 
         assert result.video_path == tmp_path / "out.mp4"
         assert result.video_path.read_bytes() == b"mp4-bytes"
@@ -98,596 +112,231 @@ class TestNewAPIVideoBackend:
         assert result.duration_seconds == 5
         assert result.task_id == "task-42"
 
-        post_call = mock_client.post.call_args
-        assert post_call.args[0].endswith("/video/generations")
-        assert post_call.kwargs["json"]["model"] == "kling-v1"
-        assert post_call.kwargs["json"]["prompt"] == "A cat running"
-        assert post_call.kwargs["json"]["width"] == 720
-        assert post_call.kwargs["json"]["height"] == 1280
-        assert post_call.kwargs["json"]["duration"] == 5
-        assert post_call.kwargs["json"]["n"] == 1
-        assert "image" not in post_call.kwargs["json"]
-        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
+        submitted = only_request(routes.submit)
+        assert submitted.url.path.endswith(_GENERATIONS_PATH)
+        body = request_json(submitted)
+        assert body["model"] == "kling-v1"
+        assert body["prompt"] == "A cat running"
+        assert body["width"] == 720
+        assert body["height"] == 1280
+        assert body["duration"] == 5
+        assert body["n"] == 1
+        assert "image" not in body
+        assert submitted.headers["Authorization"] == "Bearer sk-test"
 
-        # 下载走 base.download_video，URL 正确且不带 auth（base.download_video 不接 headers 参数）
-        fake_download.assert_called_once()
-        download_call = fake_download.call_args
-        assert download_call.args[0] == "https://cdn.example.com/out.mp4"
-        assert download_call.args[1] == tmp_path / "out.mp4"
+        # 下载走 base.download_video，URL 正确且不带鉴权头
+        downloaded = only_request(routes.download)
+        assert str(downloaded.url) == "https://cdn.example.com/out.mp4"
+        assert "Authorization" not in downloaded.headers
 
     async def test_image_to_video_encodes_base64(self, tmp_path: Path):
         img_bytes = b"\x89PNG\r\nfake"
         img_path = tmp_path / "start.png"
         img_path.write_bytes(img_bytes)
 
-        create_resp = _make_response(200, {"task_id": "t1", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t1",
-                "status": "completed",
-                "url": "https://cdn/x.mp4",
-                "metadata": {"duration": 5},
-            },
-        )
+        with _newapi() as routes:
+            routes.submit.mock(return_value=_queued("t1"))
+            routes.poll.mock(return_value=_done("t1", "https://cdn/x.mp4"))
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+            await _backend(model="kling-v1").generate(_request(tmp_path, start_image=img_path, resolution="720p"))
 
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+            sent_image = request_json(only_request(routes.submit))["image"]
 
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="kling-v1")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    start_image=img_path,
-                    resolution="720p",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
-
-        sent_image = mock_client.post.call_args.kwargs["json"]["image"]
-        expected = "data:image/png;base64," + base64.b64encode(img_bytes).decode()
-        assert sent_image == expected
+        assert sent_image == "data:image/png;base64," + base64.b64encode(img_bytes).decode()
 
     async def test_start_image_missing_is_ignored(self, tmp_path: Path, caplog):
         """start_image 文件不存在时应 warning 并走纯文生路径。"""
-        create_resp = _make_response(200, {"task_id": "t-missing", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {"task_id": "t-missing", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
-        )
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
         with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
+            _newapi() as routes,
             caplog.at_level("WARNING", logger="lib.video_backends.newapi"),
         ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
+            routes.submit.mock(return_value=_queued("t-missing"))
+            routes.poll.mock(return_value=_done("t-missing"))
 
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    start_image=tmp_path / "does_not_exist.png",
-                    resolution="720p",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
+            await _backend().generate(
+                _request(tmp_path, start_image=tmp_path / "does_not_exist.png", resolution="720p")
             )
 
-        assert "image" not in mock_client.post.call_args.kwargs["json"]
+            body = request_json(only_request(routes.submit))
+
+        assert "image" not in body
         assert any("start_image 文件不存在" in rec.message for rec in caplog.records)
 
     async def test_failed_status_raises(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t2", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t2",
-                "status": "failed",
-                "error": {"code": 500, "message": "upstream down"},
-            },
-        )
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock()
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            with pytest.raises(RuntimeError, match="upstream down"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        resolution="720p",
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
-
-        fake_download.assert_not_called()
-
-    async def test_polls_through_in_progress(self, tmp_path: Path):
-        create_resp = _make_response(200, {"task_id": "t3", "status": "queued"})
-        in_progress = _make_response(200, {"task_id": "t3", "status": "in_progress"})
-        completed = _make_response(
-            200,
-            {
-                "task_id": "t3",
-                "status": "completed",
-                "url": "https://cdn/v.mp4",
-                "metadata": {"duration": 5},
-            },
-        )
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(side_effect=[in_progress, in_progress, completed])
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    resolution="720p",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
+        with _newapi() as routes:
+            routes.submit.mock(return_value=_queued("t2"))
+            routes.poll.mock(
+                return_value=_json(
+                    {"task_id": "t2", "status": "failed", "error": {"code": 500, "message": "upstream down"}}
                 )
             )
 
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await _backend().generate(_request(tmp_path, resolution="720p"))
+
+            assert routes.download.call_count == 0
+
+    async def test_polls_through_in_progress(self, tmp_path: Path):
+        in_progress = _json({"task_id": "t3", "status": "in_progress"})
+
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_queued("t3"))
+            routes.poll.mock(side_effect=[in_progress, in_progress, _done("t3")])
+            routes.download.mock(return_value=httpx.Response(200, content=b"v"))
+
+            result = await _backend().generate(_request(tmp_path, resolution="720p"))
+
+            assert routes.poll.call_count == 3
+            assert routes.download.call_count == 1
+
         assert result.task_id == "t3"
-        # 3 次 poll（in_progress → in_progress → completed），下载不经过 mock_client
-        assert mock_client.get.call_count == 3
-        fake_download.assert_called_once()
 
     async def test_polling_timeout_raises(self, tmp_path: Path):
         """轮询超时应抛 TimeoutError 且不触发下载。"""
-        create_resp = _make_response(200, {"task_id": "t-timeout", "status": "queued"})
-        in_progress = _make_response(200, {"task_id": "t-timeout", "status": "in_progress"})
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_queued("t-timeout"))
+            routes.poll.mock(return_value=_json({"task_id": "t-timeout", "status": "in_progress"}))
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=in_progress)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock()
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi._MIN_POLL_TIMEOUT_SECONDS", 0.01),
-            patch("lib.video_backends.newapi._POLL_TIMEOUT_PER_SECOND", 0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(TimeoutError, match="NewAPI"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "o.mp4",
-                        resolution="720p",
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    )
-                )
+                await _backend().generate(_request(tmp_path, resolution="720p"))
 
-        fake_download.assert_not_called()
+            assert routes.poll.call_count > 1
+            assert routes.download.call_count == 0
 
     async def test_zero_duration_from_api_is_preserved(self, tmp_path: Path):
         """回归: API 返回 duration=0 时不应被 falsy 回退到请求值（is None 判空）。"""
-        create_resp = _make_response(200, {"task_id": "t-zero", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "t-zero",
-                "status": "completed",
-                "url": "https://cdn/v.mp4",
-                "metadata": {"duration": 0},
-            },
-        )
+        with _newapi() as routes:
+            routes.submit.mock(return_value=_queued("t-zero"))
+            routes.poll.mock(return_value=_done("t-zero", metadata={"duration": 0}))
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    resolution="720p",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            result = await _backend().generate(_request(tmp_path, resolution="720p"))
 
         # API 明确返回 0，应如实保留，不是回退到 request.duration_seconds=5
         assert result.duration_seconds == 0
 
     async def test_create_retries_on_5xx(self, tmp_path: Path):
         """5xx HTTPStatusError 应通过 should_retry_submit 的 status_code 闸门重试。"""
-        failing_resp = MagicMock()
-        failing_resp.status_code = 503
-        failing_resp.raise_for_status = MagicMock(side_effect=_make_http_error(503, "upstream busy"))
+        busy = httpx.Response(503, text="upstream busy")
 
-        create_resp = _make_response(200, {"task_id": "t-retry", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {"task_id": "t-retry", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
-        )
+        with _newapi() as routes, bounded_poll_clock():
+            # 前两次创建任务 503，第三次成功
+            routes.submit.mock(side_effect=[busy, busy, _queued("t-retry")])
+            routes.poll.mock(return_value=_done("t-retry"))
 
-        mock_client = AsyncMock()
-        # 前两次创建任务 503，第三次成功
-        mock_client.post = AsyncMock(side_effect=[failing_resp, failing_resp, create_resp])
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+            result = await _backend().generate(_request(tmp_path, resolution="720p"))
 
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            # 压缩重试退避时间到 0，避免测试变慢
-            patch("lib.video_backends.newapi.DEFAULT_BACKOFF_SECONDS", (0, 0, 0)),
-            bounded_poll_clock(),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p",
-                    output_path=tmp_path / "o.mp4",
-                    resolution="720p",
-                    aspect_ratio="9:16",
-                    duration_seconds=5,
-                )
-            )
+            assert routes.submit.call_count == 3
 
         assert result.task_id == "t-retry"
-        assert mock_client.post.call_count == 3
 
     async def test_create_non_retryable_4xx_fails_fast(self, tmp_path: Path):
         """创建任务遇确定性 4xx（400）应一次失败，不重试。"""
-        bad_resp = _make_response(400, {"error": "bad request"})
-        bad_resp.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"error": "bad request"}, status_code=400))
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=bad_resp)
-        mock_client.get = AsyncMock(side_effect=AssertionError("4xx 应在创建阶段失败，不该轮询"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            bounded_poll_clock(),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(httpx.HTTPStatusError):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
+                await _backend().generate(_request(tmp_path))
 
-        assert mock_client.post.call_count == 1, "确定性 4xx 不该被 retry"
+            assert routes.submit.call_count == 1, "确定性 4xx 不该被 retry"
+            assert routes.poll.call_count == 0, "4xx 应在创建阶段失败，不该轮询"
 
     async def test_create_read_timeout_fails_fast_with_manual_retry_hint(self, tmp_path: Path):
         """create 阶段 ReadTimeout（请求可能已送达）→ 不重试、单次失败、错误信息含手动重试提示。"""
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
-        mock_client.get = AsyncMock(side_effect=AssertionError("歧义态应在创建阶段失败，不该轮询"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(side_effect=httpx.ReadTimeout("read timed out"))
 
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            bounded_poll_clock(),
-        ):
-            from lib.video_backends.base import AmbiguousSubmitError
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(AmbiguousSubmitError, match="手动重试"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
+                await _backend().generate(_request(tmp_path))
 
-        assert mock_client.post.call_count == 1, "歧义态不该被 retry"
+            assert routes.submit.call_count == 1, "歧义态不该被 retry"
+            assert routes.poll.call_count == 0
 
     async def test_create_connect_error_retries(self, tmp_path: Path):
         """create 阶段 ConnectError（请求确定未送达）→ 重试，第三次成功。"""
-        create_resp = _make_response(200, {"task_id": "t-conn", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {"task_id": "t-conn", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
-        )
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(
-            side_effect=[httpx.ConnectError("refused"), httpx.ConnectError("refused"), create_resp]
-        )
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            bounded_poll_clock(),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(
+                side_effect=[httpx.ConnectError("refused"), httpx.ConnectError("refused"), _queued("t-conn")]
             )
+            routes.poll.mock(return_value=_done("t-conn"))
+
+            result = await _backend().generate(_request(tmp_path))
+
+            assert routes.submit.call_count == 3, "ConnectError 请求确定未送达，应重试"
 
         assert result.task_id == "t-conn"
-        assert mock_client.post.call_count == 3, "ConnectError 请求确定未送达，应重试"
 
     async def test_poll_read_timeout_retries(self, tmp_path: Path):
         """poll 阶段 ReadTimeout（幂等 GET）→ 重试，不回归。"""
-        create_resp = _make_response(200, {"task_id": "t-pr", "status": "queued"})
-        poll_resp = _make_response(
-            200,
-            {"task_id": "t-pr", "status": "completed", "url": "https://cdn/v.mp4", "metadata": {"duration": 5}},
-        )
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(side_effect=[httpx.ReadTimeout("read timed out"), poll_resp])
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"v"))
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_queued("t-pr"))
+            routes.poll.mock(side_effect=[httpx.ReadTimeout("read timed out"), _done("t-pr")])
 
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
+            result = await _backend().generate(_request(tmp_path))
 
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
-            )
+            assert routes.poll.call_count == 2, "poll 网络超时应重试"
 
         assert result.task_id == "t-pr"
-        assert mock_client.get.call_count == 2, "poll 网络超时应重试"
 
     async def test_poll_non_retryable_4xx_fails_fast(self, tmp_path: Path):
         """轮询遇确定性 4xx（401，如 token 失效）应一次失败，不重试到 max_wait 超时。"""
-        create_resp = _make_response(200, {"task_id": "t-401", "status": "queued"})
-        unauthorized_resp = _make_response(401, {"error": "unauthorized"})
-        unauthorized_resp.raise_for_status = MagicMock(side_effect=_make_http_error(401, "unauthorized"))
+        with _newapi() as routes:
+            routes.submit.mock(return_value=_queued("t-401"))
+            routes.poll.mock(return_value=_json({"error": "unauthorized"}, status_code=401))
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=unauthorized_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(httpx.HTTPStatusError):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "o.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
-                )
+                await _backend().generate(_request(tmp_path))
 
-        assert mock_client.get.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
+            assert routes.poll.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
 
     async def test_resume_video_polls_existing_job(self, tmp_path: Path):
         """resume_video 仅 poll + 下载,不 POST create (ADR 0007)。"""
-        poll_resp = _make_response(
-            200,
-            {
-                "task_id": "task-resume",
-                "status": "completed",
-                "url": "https://cdn/resumed.mp4",
-                "metadata": {"duration": 5},
-            },
-        )
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=AssertionError("resume 不应 POST create"))
-        mock_client.get = AsyncMock(return_value=poll_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"resumed"))
+        with _newapi() as routes:
+            routes.poll.mock(return_value=_done("task-resume", "https://cdn/resumed.mp4"))
+            routes.download.mock(return_value=httpx.Response(200, content=b"resumed"))
 
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
+            result = await _backend().resume_video("task-resume", _request(tmp_path, output_path=tmp_path / "out.mp4"))
 
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.resume_video(
-                "task-resume",
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                ),
-            )
+            assert routes.submit.call_count == 0  # resume 不 POST create
+            assert only_request(routes.poll).url.path.endswith("/task-resume")
 
-        mock_client.post.assert_not_called()
-        # 应该 GET 到 .../video/generations/task-resume
-        assert mock_client.get.call_args.args[0].endswith("/task-resume")
         assert result.task_id == "task-resume"
         assert (tmp_path / "out.mp4").read_bytes() == b"resumed"
 
     async def test_poll_recognizes_expired_status(self, tmp_path: Path):
         """poll 返回 status='expired' → 抛 ResumeExpiredError。"""
-        from lib.video_backends.base import ResumeExpiredError
+        with _newapi() as routes:
+            routes.poll.mock(return_value=_json({"task_id": "task-x", "status": "expired"}))
 
-        expired_resp = _make_response(200, {"task_id": "task-x", "status": "expired"})
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=expired_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(ResumeExpiredError) as ei:
-                await backend.resume_video(
-                    "task-x",
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                    ),
-                )
+                await _backend().resume_video("task-x", _request(tmp_path, output_path=tmp_path / "out.mp4"))
+
             assert ei.value.job_id == "task-x"
             assert ei.value.provider == PROVIDER_NEWAPI
 
     async def test_resume_404_raises_resume_expired_without_retry(self, tmp_path: Path):
         """resume 路径下 GET 返 404 应立即转 ResumeExpiredError，不被 retryable 框架重试到超时。"""
-        from lib.video_backends.base import ResumeExpiredError
+        with _newapi() as routes:
+            routes.poll.mock(return_value=_json({"error": "task not found"}, status_code=404))
 
-        # 构造 404 response 让 raise_for_status 真抛 HTTPStatusError（_make_response 默认 mock 空，需手工设）
-        not_found_resp = _make_response(404, {"error": "task not found"})
-        not_found_resp.raise_for_status = MagicMock(side_effect=_make_http_error(404, "task not found"))
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=not_found_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(ResumeExpiredError) as ei:
-                await backend.resume_video(
-                    "task-404",
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                    ),
-                )
+                await _backend().resume_video("task-404", _request(tmp_path, output_path=tmp_path / "out.mp4"))
+
             assert ei.value.job_id == "task-404"
             assert ei.value.provider == PROVIDER_NEWAPI
             # 不应被 retry 框架重试多次（应仅 1 次 GET 调用立即抛错）
-            assert mock_client.get.call_count == 1, "404 应一击转 ResumeExpiredError，不该被 retry"
+            assert routes.poll.call_count == 1, "404 应一击转 ResumeExpiredError，不该被 retry"
 
     async def test_generate_expired_status_raises_runtime_error_not_resume_expired(self, tmp_path: Path):
         """generate 路径下 status='expired' 抛 RuntimeError，不带 [resume_expired] 语义。"""
-        from lib.video_backends.base import ResumeExpiredError
+        with _newapi() as routes:
+            routes.submit.mock(return_value=_json({"task_id": "task-new"}))
+            routes.poll.mock(return_value=_json({"task_id": "task-new", "status": "expired"}))
 
-        create_resp = _make_response(200, {"task_id": "task-new"})
-        expired_resp = _make_response(200, {"task_id": "task-new", "status": "expired"})
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=create_resp)
-        mock_client.get = AsyncMock(return_value=expired_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
             with pytest.raises(RuntimeError) as ei:
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p",
-                        output_path=tmp_path / "out.mp4",
-                        aspect_ratio="9:16",
-                        duration_seconds=5,
-                    ),
-                )
+                await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
             assert "expired" in str(ei.value).lower()
             assert not isinstance(ei.value, ResumeExpiredError), "generate 路径不应抛 ResumeExpiredError"
-
-
-def _mock_http_client(*, create_body: dict | None = None, poll_body: dict) -> AsyncMock:
-    client = AsyncMock()
-    client.post = AsyncMock(return_value=_make_response(200, create_body or {"task_id": "t-proxy"}))
-    client.get = AsyncMock(return_value=_make_response(200, poll_body))
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
 
 
 class TestProxyStatusSynonyms:
@@ -695,73 +344,50 @@ class TestProxyStatusSynonyms:
 
     @pytest.mark.parametrize("proxy_status", ["succeeded", "success", "SUCCEEDED", "  succeeded  "])
     async def test_success_synonyms_finish_polling_and_download(self, tmp_path: Path, proxy_status: str):
-        mock_client = _mock_http_client(
-            poll_body={"task_id": "t-proxy", "status": proxy_status, "url": "https://cdn/v.mp4"}
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"ok"))
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                )
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json({"task_id": "t-proxy", "status": proxy_status, "url": "https://cdn/v.mp4"})
             )
+            routes.download.mock(return_value=httpx.Response(200, content=b"ok"))
 
-        assert mock_client.get.call_count == 1
-        fake_download.assert_awaited_once()
+            result = await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert routes.poll.call_count == 1
+            assert routes.download.call_count == 1
+
         assert result.video_path == tmp_path / "out.mp4"
+        assert result.video_path.read_bytes() == b"ok"
 
     @pytest.mark.parametrize("proxy_status", ["error", "fail", "FAILED", "canceled"])
     async def test_failure_synonyms_raise_immediately(self, tmp_path: Path, proxy_status: str):
-        mock_client = _mock_http_client(
-            poll_body={"task_id": "t-proxy", "status": proxy_status, "error": {"message": "upstream down"}}
-        )
-        fake_download = AsyncMock()
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            with pytest.raises(RuntimeError, match="upstream down"):
-                await backend.generate(
-                    VideoGenerationRequest(
-                        prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
-                    )
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json(
+                    {"task_id": "t-proxy", "status": proxy_status, "error": {"message": "upstream down"}}
                 )
-
-        assert mock_client.get.call_count == 1
-        fake_download.assert_not_awaited()
-
-    async def test_uppercase_expired_still_splits_generate_and_resume(self, tmp_path: Path):
-        from lib.video_backends.base import ResumeExpiredError
-
-        mock_client = _mock_http_client(poll_body={"task_id": "t-proxy", "status": "EXPIRED"})
-
-        with bounded_poll_clock(), patch("httpx.AsyncClient", return_value=mock_client):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            request = VideoGenerationRequest(
-                prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
             )
 
+            with pytest.raises(RuntimeError, match="upstream down"):
+                await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert routes.poll.call_count == 1
+            assert routes.download.call_count == 0
+
+    async def test_uppercase_expired_still_splits_generate_and_resume(self, tmp_path: Path):
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(return_value=_json({"task_id": "t-proxy", "status": "EXPIRED"}))
+
+            request = _request(tmp_path, output_path=tmp_path / "out.mp4")
+
             with pytest.raises(RuntimeError) as ei:
-                await backend.generate(request)
+                await _backend().generate(request)
             assert not isinstance(ei.value, ResumeExpiredError)
 
             with pytest.raises(ResumeExpiredError) as resume_ei:
-                await backend.resume_video("t-proxy", request)
+                await _backend().resume_video("t-proxy", request)
             assert resume_ei.value.job_id == "t-proxy"
 
 
@@ -770,114 +396,85 @@ class TestWrappedResponseShape:
     扁平形状保持最高优先级、行为不变。"""
 
     async def test_wrapped_status_and_result_url(self, tmp_path: Path):
-        mock_client = _mock_http_client(
-            poll_body={
-                "code": "success",
-                "data": {"task_id": "t-proxy", "status": "SUCCESS", "result_url": "https://cdn/wrapped.mp4"},
-            }
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory(b"wrapped"))
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "code": "success",
+                        "data": {
+                            "task_id": "t-proxy",
+                            "status": "SUCCESS",
+                            "result_url": "https://cdn/wrapped.mp4",
+                        },
+                    }
                 )
             )
+            routes.download.mock(return_value=httpx.Response(200, content=b"wrapped"))
 
-        assert fake_download.await_args.args[0] == "https://cdn/wrapped.mp4"
+            result = await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert str(only_request(routes.download).url) == "https://cdn/wrapped.mp4"
+
         assert result.duration_seconds == 5
         assert (tmp_path / "out.mp4").read_bytes() == b"wrapped"
 
     async def test_flat_url_wins_over_wrapped(self, tmp_path: Path):
-        mock_client = _mock_http_client(
-            poll_body={
-                "task_id": "t-proxy",
-                "status": "completed",
-                "url": "https://cdn/flat.mp4",
-                "data": {"result_url": "https://cdn/wrapped.mp4"},
-            }
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory())
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-proxy",
+                        "status": "completed",
+                        "url": "https://cdn/flat.mp4",
+                        "data": {"result_url": "https://cdn/wrapped.mp4"},
+                    }
                 )
             )
 
-        assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"
+            await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert str(only_request(routes.download).url) == "https://cdn/flat.mp4"
 
     async def test_flat_result_url_wins_over_wrapped(self, tmp_path: Path):
         """混合形状下扁平字段整体优先于包装体，不因字段名不同而让位。"""
-        mock_client = _mock_http_client(
-            poll_body={
-                "task_id": "t-proxy",
-                "status": "completed",
-                "result_url": "https://cdn/flat.mp4",
-                "data": {"url": "https://cdn/wrapped.mp4"},
-            }
-        )
-        fake_download = AsyncMock(side_effect=_fake_download_factory())
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", fake_download),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "task_id": "t-proxy",
+                        "status": "completed",
+                        "result_url": "https://cdn/flat.mp4",
+                        "data": {"url": "https://cdn/wrapped.mp4"},
+                    }
                 )
             )
 
-        assert fake_download.await_args.args[0] == "https://cdn/flat.mp4"
+            await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
+
+            assert str(only_request(routes.download).url) == "https://cdn/flat.mp4"
 
     async def test_wrapped_metadata_feeds_duration_and_seed(self, tmp_path: Path):
         """包装体里的 metadata 与状态、视频地址同源，同样要取到——实际时长是计费依据。"""
-        mock_client = _mock_http_client(
-            poll_body={
-                "code": "success",
-                "data": {
-                    "task_id": "t-proxy",
-                    "status": "SUCCESS",
-                    "result_url": "https://cdn/wrapped.mp4",
-                    "metadata": {"duration": 8, "seed": 4242},
-                },
-            }
-        )
-
-        with (
-            bounded_poll_clock(),
-            patch("httpx.AsyncClient", return_value=mock_client),
-            patch("lib.video_backends.newapi.download_video", AsyncMock(side_effect=_fake_download_factory())),
-        ):
-            from lib.video_backends.newapi import NewAPIVideoBackend
-
-            backend = NewAPIVideoBackend(api_key="k", base_url="https://x/v1", model="m")
-            result = await backend.generate(
-                VideoGenerationRequest(
-                    prompt="p", output_path=tmp_path / "out.mp4", aspect_ratio="9:16", duration_seconds=5
+        with _newapi() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"task_id": "t-proxy"}))
+            routes.poll.mock(
+                return_value=_json(
+                    {
+                        "code": "success",
+                        "data": {
+                            "task_id": "t-proxy",
+                            "status": "SUCCESS",
+                            "result_url": "https://cdn/wrapped.mp4",
+                            "metadata": {"duration": 8, "seed": 4242},
+                        },
+                    }
                 )
             )
+
+            result = await _backend().generate(_request(tmp_path, output_path=tmp_path / "out.mp4"))
 
         assert result.duration_seconds == 8
         assert result.seed == 4242

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai import InternalServerError
@@ -12,7 +12,7 @@ from openai.types.video_create_error import VideoCreateError
 
 from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.base import VideoGenerationRequest
-from tests.fakes import bounded_poll_clock
+from tests.fakes import bounded_poll_clock, captured_openai_clients
 
 
 def _make_mock_video(status="completed", seconds="8", video_id="vid_123"):
@@ -43,7 +43,7 @@ def _stub_client_completed(client: AsyncMock, *, seconds="8", video_id="vid_123"
 
 class TestOpenAIVideoBackend:
     def test_name_and_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -51,14 +51,14 @@ class TestOpenAIVideoBackend:
             assert backend.model == "sora-2"
 
     def test_custom_model(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key", model="sora-2-pro")
             assert backend.model == "sora-2-pro"
 
     def test_capabilities(self):
-        with patch("lib.openai_shared.AsyncOpenAI"):
+        with captured_openai_clients():
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -70,7 +70,7 @@ class TestOpenAIVideoBackend:
         _stub_client_completed(mock_client, seconds="8", data=video_data)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -108,7 +108,7 @@ class TestOpenAIVideoBackend:
         _stub_client_completed(mock_client, seconds="4")
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -143,7 +143,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock()
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -166,7 +166,7 @@ class TestOpenAIVideoBackend:
         _stub_client_completed(mock_client, seconds="6")
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -190,7 +190,7 @@ class TestOpenAIVideoBackend:
         _stub_client_completed(mock_client, seconds=None)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -212,7 +212,7 @@ class TestOpenAIVideoBackend:
         _stub_client_completed(mock_client, seconds="4")
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -244,7 +244,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(side_effect=[error, error, _make_mock_content(b"video-data")])
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -278,7 +278,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(side_effect=error)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -311,7 +311,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(side_effect=error)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -350,7 +350,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -388,7 +388,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -419,7 +419,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock()
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -456,7 +456,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock()
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -483,7 +483,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(video_data))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -510,7 +510,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.retrieve = AsyncMock(return_value=expired_video)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -548,7 +548,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.retrieve = AsyncMock(side_effect=not_found)
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -574,7 +574,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="expired", video_id="vid_new"))
 
         with (
-            patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
+            captured_openai_clients(mock_client),
             bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
@@ -603,7 +603,7 @@ class TestProxyStatusSynonyms:
         mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status=proxy_status))
         mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
 
-        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with bounded_poll_clock(), captured_openai_clients(mock_client):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -629,7 +629,7 @@ class TestProxyStatusSynonyms:
         mock_client.videos.retrieve = AsyncMock(return_value=failed)
         mock_client.videos.download_content = AsyncMock()
 
-        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with bounded_poll_clock(), captured_openai_clients(mock_client):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -649,7 +649,7 @@ class TestProxyStatusSynonyms:
         mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued", video_id="vid_new"))
         mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="EXPIRED", video_id="vid_new"))
 
-        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with bounded_poll_clock(), captured_openai_clients(mock_client):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")
@@ -694,7 +694,7 @@ class TestFailureMessage:
         mock_client.videos.retrieve = AsyncMock(return_value=failed)
         mock_client.videos.download_content = AsyncMock()
 
-        with bounded_poll_clock(), patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client):
+        with bounded_poll_clock(), captured_openai_clients(mock_client):
             from lib.video_backends.openai import OpenAIVideoBackend
 
             backend = OpenAIVideoBackend(api_key="test-key")

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -71,7 +71,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -109,7 +109,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -144,7 +144,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -167,7 +167,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -191,7 +191,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -213,7 +213,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -245,8 +245,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -280,8 +279,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -311,12 +309,10 @@ class TestOpenAIVideoBackend:
         mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
         mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
         mock_client.videos.download_content = AsyncMock(side_effect=error)
-        mock_sleep = AsyncMock()
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.retry.asyncio.sleep", mock_sleep),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -330,9 +326,9 @@ class TestOpenAIVideoBackend:
             with pytest.raises(AuthenticationError):
                 await backend.generate(request)
 
-        # 不可重试错误：只调用 1 次下载，无 retry sleep
+        # 不可重试错误：只调用 1 次下载就抛出，不进入退避重试
         assert mock_client.videos.download_content.call_count == 1
-        mock_sleep.assert_not_called()
+        assert not output_path.exists()
 
     async def test_polls_until_completed_for_nonstandard_status(self, tmp_path: Path):
         """OpenAI 兼容网关返回非标 status（如 NOT_START / running）时，必须继续轮询直到 completed。
@@ -355,7 +351,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -370,22 +366,30 @@ class TestOpenAIVideoBackend:
 
         # 必须轮询 4 次（3 次非完成 + 1 次完成）才得到结果
         assert mock_client.videos.retrieve.call_count == 4
-        # 中间至少 sleep 了 3 次（每次轮询前都 sleep）
-        assert mock_sleep.await_count >= 3
         # 下载只在完成后调用一次
         assert mock_client.videos.download_content.call_count == 1
         assert result.video_path == output_path
 
     async def test_first_retrieve_completed_skips_polling_sleep(self, tmp_path: Path):
-        """首次 retrieve 即返回 completed 时应 fast-path 直接返回，不进入 poll_with_retry 的固定 sleep。"""
+        """首次 retrieve 即返回 completed 时走 fast-path：只查一次就下载，不进 poll_with_retry。
+
+        poll_with_retry 是「先查再等」，落进轮询循环必然多出一次 retrieve，记录的查询次数
+        足以判定 fast-path 有没有生效。
+        """
+        retrieved: list[str] = []
+
+        async def _retrieve(video_id: str):
+            retrieved.append(video_id)
+            return _make_mock_video(status="completed", seconds="8")
+
         mock_client = AsyncMock()
         mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))
-        mock_client.videos.retrieve = AsyncMock(return_value=_make_mock_video(status="completed", seconds="8"))
+        mock_client.videos.retrieve = _retrieve
         mock_client.videos.download_content = AsyncMock(return_value=_make_mock_content(b"v"))
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -398,9 +402,9 @@ class TestOpenAIVideoBackend:
             )
             await backend.generate(request)
 
-        # fast-path：只查一次，不进入 poll_with_retry → 不 sleep
-        assert mock_client.videos.retrieve.call_count == 1
-        mock_sleep.assert_not_awaited()
+        # fast-path：只查一次，不进入 poll_with_retry
+        assert retrieved == ["vid_123"]
+        assert output_path.read_bytes() == b"v"
 
     async def test_first_retrieve_failed_skips_polling(self, tmp_path: Path):
         """首次 retrieve 即返回 failed 时应 fast-path 直接抛错，不进入 poll_with_retry 的 sleep。"""
@@ -416,7 +420,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -431,8 +435,8 @@ class TestOpenAIVideoBackend:
                 await backend.generate(request)
 
         assert mock_client.videos.retrieve.call_count == 1
-        mock_sleep.assert_not_awaited()
         mock_client.videos.download_content.assert_not_called()
+        assert not output_path.exists()
 
     async def test_polls_failed_status_raises_without_download(self, tmp_path: Path):
         """轮询期间出现 status='failed' 应直接抛错，不进入下载。"""
@@ -453,7 +457,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -480,7 +484,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -507,7 +511,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -545,7 +549,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 
@@ -571,7 +575,7 @@ class TestOpenAIVideoBackend:
 
         with (
             patch("lib.openai_shared.AsyncOpenAI", return_value=mock_client),
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             from lib.video_backends.openai import OpenAIVideoBackend
 

--- a/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
+++ b/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
@@ -405,8 +405,9 @@ class TestV2BackendHttp:
                 VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5),
             )
 
-            # resume 只 poll，不再 submit
+            # resume 只 poll，不再 submit；续跑的 id 必须进到轮询 query
             assert routes.submit.call_count == 0
+            assert routes.poll.calls.last.request.url.params["generation_id"] == "gen-resume"
 
         assert result.task_id == "gen-resume"
         assert result.video_path.read_bytes() == b"r"

--- a/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
+++ b/tests/unit/lib/video_backends/test_v2_video_generations_backend.py
@@ -1,15 +1,18 @@
-"""V2VideoGenerationsBackend 纯函数单测（请求体映射 / 状态归一 / 多路径提取）。
+"""V2VideoGenerationsBackend 单测（纯函数 + respx 捕获的 HTTP 流程）。
 
-只测外部可观察行为与纯函数，不跑真实 HTTP。
+请求体映射 / 状态归一 / 多路径提取走纯函数；submit → poll → 下载由 respx 在 transport 层拦截。
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import NamedTuple
 
 import httpx
 import pytest
+import respx
 
 from lib.video_backends.base import (
     AmbiguousSubmitError,
@@ -18,6 +21,7 @@ from lib.video_backends.base import (
     first_str_by_paths,
 )
 from lib.video_backends.v2_video_generations import (
+    _LARGE_IMAGE_WARN_BYTES,
     _TASK_ID_PATHS,
     _VIDEO_URL_PATHS,
     PROVIDER_V2_VIDEO,
@@ -30,42 +34,33 @@ from lib.video_backends.v2_video_generations import (
 from lib.video_backends.v2_video_generations import (
     V2VideoGenerationsBackend as _V2Backend,
 )
-from tests.fakes import bounded_poll_clock
+from tests.fakes import bounded_poll_clock, captured_provider_job_ids
+from tests.http_capture import capture_http, only_request, request_json
+
+_ROOT = "https://api.aimlapi.com"
+_GENERATIONS_URL = f"{_ROOT}/v2/video/generations"
 
 
-def _make_response(status_code: int, json_body: dict) -> MagicMock:
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    # 真字符串而非 MagicMock：submit_post 在 >=400 时记 resp.text[:500]，让该日志切片走真实 str 路径。
-    resp.text = str(json_body)
-    resp.raise_for_status = MagicMock()
-    return resp
+class _V2Routes(NamedTuple):
+    """V2 端点的三条出站流量：建任务、任务轮询（同 URL、GET）、成片下载。"""
+
+    submit: respx.Route
+    poll: respx.Route
+    download: respx.Route
 
 
-def _make_http_error(status_code: int, message: str) -> httpx.HTTPStatusError:
-    request = httpx.Request("GET", "https://x/v2/video/generations")
-    response = httpx.Response(status_code, request=request, text=message)
-    return httpx.HTTPStatusError(f"error '{status_code}'", request=request, response=response)
+@contextmanager
+def _v2_api() -> Iterator[_V2Routes]:
+    with capture_http() as router:
+        yield _V2Routes(
+            submit=router.post(_GENERATIONS_URL),
+            poll=router.get(_GENERATIONS_URL),
+            download=router.get(url__regex=r"^https://cdn"),
+        )
 
 
-def _fake_download_factory(payload: bytes = b"mp4-bytes"):
-    async def _fake(url: str, output_path: Path, *, timeout: int = 120) -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(payload)
-
-    return _fake
-
-
-def _mock_client(*, post=None, get=None) -> AsyncMock:
-    client = AsyncMock()
-    if post is not None:
-        client.post = AsyncMock(return_value=post) if not isinstance(post, list) else AsyncMock(side_effect=post)
-    if get is not None:
-        client.get = AsyncMock(return_value=get) if not isinstance(get, list) else AsyncMock(side_effect=get)
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
+def _json(body: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=body)
 
 
 def _req(tmp_path: Path, **kwargs) -> VideoGenerationRequest:
@@ -277,10 +272,12 @@ class TestBuildRequestBodyBranches:
     def test_large_image_warns(self, tmp_path, caplog):
         import logging
 
-        img = _write_img(tmp_path, "big.png")
-        with patch("lib.video_backends.v2_video_generations._LARGE_IMAGE_WARN_BYTES", 0):
-            with caplog.at_level(logging.WARNING, logger="lib.video_backends.v2_video_generations"):
-                body = build_request_body("m", _req(tmp_path, start_image=img))
+        img = tmp_path / "big.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\0" * _LARGE_IMAGE_WARN_BYTES)
+
+        with caplog.at_level(logging.WARNING, logger="lib.video_backends.v2_video_generations"):
+            body = build_request_body("m", _req(tmp_path, start_image=img))
+
         assert body["image_url"].startswith("data:image/png;base64,")
         assert any("图片较大" in r.message for r in caplog.records)
 
@@ -301,11 +298,11 @@ class TestBuildRequestBodyBranches:
 
 
 class TestV2BackendHttp:
-    """V2 backend HTTP 流程（submit → poll → 提取 → 下载 / resume），全程 mock httpx，不跑真实网络。"""
+    """V2 backend HTTP 流程（submit → poll → 提取 → 下载 / resume）。"""
 
     @staticmethod
     def _backend() -> _V2Backend:
-        return _V2Backend(api_key="sk-test", base_url="https://api.aimlapi.com", model="seedance-1.0")
+        return _V2Backend(api_key="sk-test", base_url=_ROOT, model="seedance-1.0")
 
     def test_name_model_and_video_capabilities(self):
         b = self._backend()
@@ -323,237 +320,201 @@ class TestV2BackendHttp:
         with pytest.raises(ValueError, match="base_url"):
             _V2Backend(api_key="k", base_url="", model="m")
 
-    @pytest.mark.asyncio
     async def test_generate_happy_path(self, tmp_path: Path):
-        client = _mock_client(
-            post=_make_response(200, {"id": "gen-1", "status": "queued"}),
-            get=[
-                _make_response(200, {"id": "gen-1", "status": "generating"}),
-                _make_response(200, {"id": "gen-1", "status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
-            ],
-        )
-        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-        ):
-            req = VideoGenerationRequest(prompt="a cat", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            result = await self._backend().generate(req)
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"id": "gen-1", "status": "queued"}))
+            routes.poll.mock(
+                side_effect=[
+                    _json({"id": "gen-1", "status": "generating"}),
+                    _json({"id": "gen-1", "status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+                ]
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4"))
+
+            result = await self._backend().generate(
+                VideoGenerationRequest(prompt="a cat", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            )
+
+            submitted = only_request(routes.submit)
+            assert str(submitted.url) == _GENERATIONS_URL
+            assert request_json(submitted)["model"] == "seedance-1.0"
+            assert submitted.headers["Authorization"] == "Bearer sk-test"
+            assert routes.poll.calls.last.request.url.params["generation_id"] == "gen-1"
+
         assert result.video_path.read_bytes() == b"mp4"
         assert result.provider == PROVIDER_V2_VIDEO
         assert result.model == "seedance-1.0"
         assert result.task_id == "gen-1"
         assert result.video_uri == "https://cdn/v.mp4"
-        post_call = client.post.call_args
-        assert post_call.args[0] == "https://api.aimlapi.com/v2/video/generations"
-        assert post_call.kwargs["json"]["model"] == "seedance-1.0"
-        assert post_call.kwargs["headers"]["Authorization"] == "Bearer sk-test"
-        assert client.get.call_args.kwargs["params"] == {"generation_id": "gen-1"}
-        fake_dl.assert_awaited_once()
 
-    @pytest.mark.asyncio
     async def test_generate_persists_job_id_when_task_id_set(self, tmp_path: Path):
-        client = _mock_client(
-            post=_make_response(200, {"id": "gen-9"}),
-            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
-        )
-        persist = AsyncMock()
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch(
-                "lib.video_backends.v2_video_generations.download_video",
-                AsyncMock(side_effect=_fake_download_factory()),
-            ),
-            patch("lib.video_backends.base.persist_provider_job_id", persist),
-        ):
-            req = VideoGenerationRequest(
-                prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5, task_id="task-77"
+        with _v2_api() as routes, captured_provider_job_ids() as persisted:
+            routes.submit.mock(return_value=_json({"id": "gen-9"}))
+            routes.poll.mock(return_value=_json({"status": "completed", "video": {"url": "https://cdn/v.mp4"}}))
+
+            await self._backend().generate(
+                VideoGenerationRequest(
+                    prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5, task_id="task-77"
+                )
             )
-            await self._backend().generate(req)
-        persist.assert_awaited_once()
-        call = persist.await_args
-        assert call is not None
-        assert call.args[0] == "task-77"
-        assert call.args[1] == "gen-9"
 
-    @pytest.mark.asyncio
+        assert [(r["task_id"], r["job_id"]) for r in persisted] == [("task-77", "gen-9")]
+
     async def test_generate_missing_task_id_raises(self, tmp_path: Path):
-        client = _mock_client(post=_make_response(200, {"status": "queued"}))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+        with _v2_api() as routes:
+            routes.submit.mock(return_value=_json({"status": "queued"}))
+
             with pytest.raises(RuntimeError, match="task_id"):
-                await self._backend().generate(req)
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
 
-    @pytest.mark.asyncio
+            assert routes.poll.call_count == 0
+
     async def test_generate_missing_video_url_raises(self, tmp_path: Path):
-        client = _mock_client(
-            post=_make_response(200, {"id": "g"}),
-            get=_make_response(200, {"status": "completed"}),
-        )
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+        with _v2_api() as routes:
+            routes.submit.mock(return_value=_json({"id": "g"}))
+            routes.poll.mock(return_value=_json({"status": "completed"}))
+
             with pytest.raises(RuntimeError, match="视频 URL"):
-                await self._backend().generate(req)
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
 
-    @pytest.mark.asyncio
+            assert routes.download.call_count == 0
+
     async def test_generate_failed_status_raises(self, tmp_path: Path):
-        client = _mock_client(
-            post=_make_response(200, {"id": "g"}),
-            get=_make_response(200, {"status": "error", "error": {"message": "boom"}}),
-        )
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", AsyncMock()),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            with pytest.raises(RuntimeError, match="boom"):
-                await self._backend().generate(req)
+        with _v2_api() as routes:
+            routes.submit.mock(return_value=_json({"id": "g"}))
+            routes.poll.mock(return_value=_json({"status": "error", "error": {"message": "boom"}}))
 
-    @pytest.mark.asyncio
+            with pytest.raises(RuntimeError, match="boom"):
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
+
+            assert routes.download.call_count == 0
+
     async def test_resume_video_poll_and_download(self, tmp_path: Path):
-        client = _mock_client(get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/r.mp4"}}))
-        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"r"))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            result = await self._backend().resume_video("gen-resume", req)
+        with _v2_api() as routes:
+            routes.poll.mock(return_value=_json({"status": "completed", "video": {"url": "https://cdn/r.mp4"}}))
+            routes.download.mock(return_value=httpx.Response(200, content=b"r"))
+
+            result = await self._backend().resume_video(
+                "gen-resume",
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5),
+            )
+
+            # resume 只 poll，不再 submit
+            assert routes.submit.call_count == 0
+
         assert result.task_id == "gen-resume"
         assert result.video_path.read_bytes() == b"r"
-        # resume 只 poll，不再 submit
-        client.post.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_resume_404_raises_resume_expired(self, tmp_path: Path):
-        resp404 = _make_response(404, {})
-        resp404.raise_for_status = MagicMock(side_effect=_make_http_error(404, "not found"))
-        client = _mock_client(get=resp404)
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            with pytest.raises(ResumeExpiredError):
-                await self._backend().resume_video("gen-expired", req)
+        with _v2_api() as routes:
+            routes.poll.mock(return_value=_json({}, status_code=404))
 
-    @pytest.mark.asyncio
+            with pytest.raises(ResumeExpiredError):
+                await self._backend().resume_video(
+                    "gen-expired",
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5),
+                )
+
+            assert routes.poll.call_count == 1
+
     async def test_create_non_retryable_4xx_fails_fast(self, tmp_path: Path):
         """创建任务遇确定性 4xx（400）应一次失败，不重试。"""
-        resp400 = _make_response(400, {"error": "bad request"})
-        resp400.raise_for_status = MagicMock(side_effect=_make_http_error(400, "bad request"))
-        client = _mock_client(post=resp400)
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            bounded_poll_clock(),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            with pytest.raises(httpx.HTTPStatusError):
-                await self._backend().generate(req)
-        assert client.post.call_count == 1, "确定性 4xx 不该被 retry"
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"error": "bad request"}, status_code=400))
 
-    @pytest.mark.asyncio
+            with pytest.raises(httpx.HTTPStatusError):
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
+
+            assert routes.submit.call_count == 1, "确定性 4xx 不该被 retry"
+
     async def test_poll_non_retryable_4xx_fails_fast(self, tmp_path: Path):
         """轮询遇确定性 4xx（401，如 token 轮换失效）应一次失败，不重试到 max_wait 超时。"""
-        resp401 = _make_response(401, {"error": "unauthorized"})
-        resp401.raise_for_status = MagicMock(side_effect=_make_http_error(401, "unauthorized"))
-        client = _mock_client(post=_make_response(200, {"id": "gen-401", "status": "queued"}), get=resp401)
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            with pytest.raises(httpx.HTTPStatusError):
-                await self._backend().generate(req)
-        assert client.get.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
+        with _v2_api() as routes:
+            routes.submit.mock(return_value=_json({"id": "gen-401", "status": "queued"}))
+            routes.poll.mock(return_value=_json({"error": "unauthorized"}, status_code=401))
 
-    @pytest.mark.asyncio
+            with pytest.raises(httpx.HTTPStatusError):
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
+
+            assert routes.poll.call_count == 1, "轮询确定性 4xx 应一击失败，不重试到超时"
+
     async def test_create_read_timeout_fails_fast_with_manual_retry_hint(self, tmp_path: Path):
         """create 阶段 ReadTimeout（请求可能已送达）→ 不重试、单次失败、错误信息含手动重试提示。"""
-        # list 形式 → side_effect，AsyncMock 会抛出该异常（单值形式会被当 return_value 返回）。
-        client = _mock_client(post=[httpx.ReadTimeout("read timed out")])
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            bounded_poll_clock(),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            with pytest.raises(AmbiguousSubmitError, match="手动重试"):
-                await self._backend().generate(req)
-        assert client.post.call_count == 1, "歧义态不该被 retry"
-        client.get.assert_not_called()
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(side_effect=httpx.ReadTimeout("read timed out"))
 
-    @pytest.mark.asyncio
+            with pytest.raises(AmbiguousSubmitError, match="手动重试"):
+                await self._backend().generate(
+                    VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+                )
+
+            assert routes.submit.call_count == 1, "歧义态不该被 retry"
+            assert routes.poll.call_count == 0
+
     async def test_create_connect_error_retries(self, tmp_path: Path):
         """create 阶段 ConnectError（请求确定未送达）→ 重试，第三次成功。"""
-        client = _mock_client(
-            post=[
-                httpx.ConnectError("refused"),
-                httpx.ConnectError("refused"),
-                _make_response(200, {"id": "gen-ok", "status": "queued"}),
-            ],
-            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
-        )
-        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-            bounded_poll_clock(),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            result = await self._backend().generate(req)
-        assert result.task_id == "gen-ok"
-        assert client.post.call_count == 3, "ConnectError 请求确定未送达，应重试"
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(
+                side_effect=[
+                    httpx.ConnectError("refused"),
+                    httpx.ConnectError("refused"),
+                    _json({"id": "gen-ok", "status": "queued"}),
+                ]
+            )
+            routes.poll.mock(return_value=_json({"status": "completed", "video": {"url": "https://cdn/v.mp4"}}))
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4"))
 
-    @pytest.mark.asyncio
+            result = await self._backend().generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            )
+
+            assert routes.submit.call_count == 3, "ConnectError 请求确定未送达，应重试"
+
+        assert result.task_id == "gen-ok"
+
     async def test_create_retries_on_5xx(self, tmp_path: Path):
         """create 阶段收到 503 响应（服务端明示创建失败）→ 维持重试（现状保持）。"""
-        resp503 = _make_response(503, {"error": "upstream busy"})
-        resp503.raise_for_status = MagicMock(side_effect=_make_http_error(503, "upstream busy"))
-        client = _mock_client(
-            post=[resp503, resp503, _make_response(200, {"id": "gen-503", "status": "queued"})],
-            get=_make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
-        )
-        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-            bounded_poll_clock(),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            result = await self._backend().generate(req)
-        assert result.task_id == "gen-503"
-        assert client.post.call_count == 3, "5xx 应维持重试"
+        busy = _json({"error": "upstream busy"}, status_code=503)
 
-    @pytest.mark.asyncio
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(side_effect=[busy, busy, _json({"id": "gen-503", "status": "queued"})])
+            routes.poll.mock(return_value=_json({"status": "completed", "video": {"url": "https://cdn/v.mp4"}}))
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4"))
+
+            result = await self._backend().generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            )
+
+            assert routes.submit.call_count == 3, "5xx 应维持重试"
+
+        assert result.task_id == "gen-503"
+
     async def test_poll_read_timeout_retries(self, tmp_path: Path):
         """poll 阶段 ReadTimeout（幂等 GET）→ 重试，不回归。"""
-        client = _mock_client(
-            post=_make_response(200, {"id": "gen-p", "status": "queued"}),
-            get=[
-                httpx.ReadTimeout("read timed out"),
-                _make_response(200, {"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
-            ],
-        )
-        fake_dl = AsyncMock(side_effect=_fake_download_factory(b"mp4"))
-        with (
-            patch("httpx.AsyncClient", return_value=client),
-            patch("lib.video_backends.v2_video_generations._POLL_INTERVAL_SECONDS", 0.0),
-            patch("lib.video_backends.v2_video_generations.download_video", fake_dl),
-        ):
-            req = VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
-            result = await self._backend().generate(req)
+        with _v2_api() as routes, bounded_poll_clock():
+            routes.submit.mock(return_value=_json({"id": "gen-p", "status": "queued"}))
+            routes.poll.mock(
+                side_effect=[
+                    httpx.ReadTimeout("read timed out"),
+                    _json({"status": "completed", "video": {"url": "https://cdn/v.mp4"}}),
+                ]
+            )
+            routes.download.mock(return_value=httpx.Response(200, content=b"mp4"))
+
+            result = await self._backend().generate(
+                VideoGenerationRequest(prompt="p", output_path=tmp_path / "o.mp4", duration_seconds=5)
+            )
+
+            assert routes.poll.call_count == 2, "poll 网络超时应重试"
+
         assert result.task_id == "gen-p"
-        assert client.get.call_count == 2, "poll 网络超时应重试"

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -14,6 +14,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
 )
 from lib.video_frame_slots import FIRST_FRAME_ADAPTIVE_RATIO, resolve_first_frame_aspect_ratio
+from tests.fakes import captured_ark_clients
 
 
 @pytest.fixture
@@ -657,17 +658,14 @@ class TestArkServiceTierParam:
 
 class TestArkVideoBackendBaseUrl:
     def test_custom_base_url_passed_through(self):
-        with patch("lib.video_backends.ark.create_ark_client") as mock_create:
+        with captured_ark_clients("lib.video_backends.ark") as created:
             ArkVideoBackend(api_key="k", base_url="https://ark.cn-beijing.volces.com/api/plan/v3")
-            mock_create.assert_called_once_with(
-                api_key="k",
-                base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
-            )
+        assert created == [{"api_key": "k", "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"}]
 
     def test_default_base_url_is_none(self):
-        with patch("lib.video_backends.ark.create_ark_client") as mock_create:
+        with captured_ark_clients("lib.video_backends.ark") as created:
             ArkVideoBackend(api_key="k")
-            mock_create.assert_called_once_with(api_key="k", base_url=None)
+        assert created == [{"api_key": "k", "base_url": None}]
 
 
 class TestIsArkNotFound:

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -14,7 +14,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
 )
 from lib.video_frame_slots import FIRST_FRAME_ADAPTIVE_RATIO, resolve_first_frame_aspect_ratio
-from tests.fakes import captured_ark_clients
+from tests.fakes import bounded_poll_clock, captured_ark_clients
 
 
 @pytest.fixture
@@ -331,7 +331,7 @@ class TestArkRetryBehavior:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with bounded_poll_clock():
                 result = await ark_backend.generate(request)
         finally:
             patcher.stop()
@@ -365,8 +365,7 @@ class TestArkRetryBehavior:
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
             with (
-                patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
-                patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+                bounded_poll_clock(),
             ):
                 result = await ark_backend.generate(request)
         finally:
@@ -388,7 +387,7 @@ class TestArkRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with bounded_poll_clock():
                 await ark_backend.generate(request)
 
         # 创建只调用一次，轮询只尝试一次就抛出
@@ -621,7 +620,7 @@ class TestArkServiceTierParam:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with bounded_poll_clock():
                 await ark_backend.generate(request)
         finally:
             patcher.stop()
@@ -647,7 +646,7 @@ class TestArkServiceTierParam:
         patcher = _mock_httpx_stream()
         try:
             request = VideoGenerationRequest(prompt="test", output_path=output)
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with bounded_poll_clock():
                 await ark_backend.generate(request)
         finally:
             patcher.stop()

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -4,7 +4,9 @@ import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import (
@@ -36,28 +38,15 @@ def ark_backend(mock_ark_client):
 
 
 def _mock_httpx_stream(data: bytes = b"fake-mp4-data"):
-    """Create a patched httpx mock that supports async stream context manager."""
-    patcher = patch("lib.video_backends.base.httpx")
-    mock_httpx = patcher.start()
+    """成片下载的出站流：respx 在 transport 层拦截，任一下载 URL 都回给定字节。
 
-    mock_stream_response = MagicMock()
-    mock_stream_response.status_code = 200
-    mock_stream_response.raise_for_status = MagicMock()
-
-    async def _aiter_bytes(chunk_size=65536):
-        yield data
-
-    mock_stream_response.aiter_bytes = _aiter_bytes
-    mock_stream_response.__aenter__ = AsyncMock(return_value=mock_stream_response)
-    mock_stream_response.__aexit__ = AsyncMock(return_value=None)
-
-    mock_http_client = AsyncMock()
-    mock_http_client.stream = MagicMock(return_value=mock_stream_response)
-    mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-    mock_http_client.__aexit__ = AsyncMock(return_value=None)
-    mock_httpx.AsyncClient.return_value = mock_http_client
-
-    return patcher
+    保留 start/stop 形态（调用方以 try/finally 收尾），换掉的是拦截层——落在断言范围内的
+    是真实序列化后的流式 GET，而不是客户端替身记录的调用参数。
+    """
+    router = respx.mock(assert_all_called=False)
+    router.start()
+    router.get(url__regex=r".*").mock(return_value=httpx.Response(200, content=data))
+    return router
 
 
 class TestArkProperties:

--- a/tests/unit/lib/video_backends/test_video_backend_base.py
+++ b/tests/unit/lib/video_backends/test_video_backend_base.py
@@ -1,4 +1,6 @@
+import itertools
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -28,11 +30,18 @@ from lib.video_backends.base import (
     should_retry_submit,
     submit_post,
 )
+from tests.fakes import bounded_poll_clock, captured_provider_job_ids
 
 
 class _FakeClock:
-    def __init__(self, times: list[float]) -> None:
-        self._times = iter(times)
+    """轮询时钟替身：sleep 只记不等，monotonic 按给定序列或固定步长推进。
+
+    不传 times 时表按 step 无限推进——终态判定失灵的回归会在若干轮内撞上 max_wait 抛
+    TimeoutError，而不是以近乎为零的真实耗时空转成挂起。
+    """
+
+    def __init__(self, times: list[float] | None = None, *, step: float = 1.0) -> None:
+        self._times: Iterator[float] = iter(times) if times is not None else itertools.count(0.0, step)
         self.sleeps: list[float] = []
 
     def monotonic(self) -> float:
@@ -113,14 +122,14 @@ class TestPollWithRetry:
         """poll_fn 首次返回即完成。"""
         poll_fn = AsyncMock(return_value="done_result")
 
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await poll_with_retry(
-                poll_fn=poll_fn,
-                is_done=lambda r: r == "done_result",
-                is_failed=lambda r: None,
-                poll_interval=1,
-                max_wait=10,
-            )
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done_result",
+            is_failed=lambda r: None,
+            poll_interval=1,
+            max_wait=10,
+            clock=_FakeClock(),
+        )
 
         assert result == "done_result"
         assert poll_fn.await_count == 1
@@ -129,14 +138,14 @@ class TestPollWithRetry:
         """多次轮询后完成。"""
         poll_fn = AsyncMock(side_effect=["pending", "pending", "done"])
 
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await poll_with_retry(
-                poll_fn=poll_fn,
-                is_done=lambda r: r == "done",
-                is_failed=lambda r: None,
-                poll_interval=1,
-                max_wait=60,
-            )
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done",
+            is_failed=lambda r: None,
+            poll_interval=1,
+            max_wait=60,
+            clock=_FakeClock(),
+        )
 
         assert result == "done"
         assert poll_fn.await_count == 3
@@ -145,14 +154,14 @@ class TestPollWithRetry:
         """轮询瞬态错误后重试成功。"""
         poll_fn = AsyncMock(side_effect=[ConnectionError("reset"), "done"])
 
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await poll_with_retry(
-                poll_fn=poll_fn,
-                is_done=lambda r: r == "done",
-                is_failed=lambda r: None,
-                poll_interval=1,
-                max_wait=60,
-            )
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done",
+            is_failed=lambda r: None,
+            poll_interval=1,
+            max_wait=60,
+            clock=_FakeClock(),
+        )
 
         assert result == "done"
         assert poll_fn.await_count == 2
@@ -162,14 +171,14 @@ class TestPollWithRetry:
         poll_fn = AsyncMock(side_effect=ValueError("invalid"))
 
         with pytest.raises(ValueError, match="invalid"):
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await poll_with_retry(
-                    poll_fn=poll_fn,
-                    is_done=lambda r: True,
-                    is_failed=lambda r: None,
-                    poll_interval=1,
-                    max_wait=60,
-                )
+            await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: True,
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+                clock=_FakeClock(),
+            )
 
         assert poll_fn.await_count == 1
 
@@ -212,30 +221,33 @@ class TestPollWithRetry:
         poll_fn = AsyncMock(return_value="failed_result")
 
         with pytest.raises(RuntimeError, match="任务失败"):
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await poll_with_retry(
-                    poll_fn=poll_fn,
-                    is_done=lambda r: False,
-                    is_failed=lambda r: "任务失败" if r == "failed_result" else None,
-                    poll_interval=1,
-                    max_wait=60,
-                )
-
-    async def test_on_progress_called(self):
-        """on_progress 回调被调用。"""
-        poll_fn = AsyncMock(side_effect=["pending", "done"])
-        progress_calls = []
-
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
             await poll_with_retry(
                 poll_fn=poll_fn,
-                is_done=lambda r: r == "done",
-                is_failed=lambda r: None,
+                is_done=lambda r: False,
+                is_failed=lambda r: "任务失败" if r == "failed_result" else None,
                 poll_interval=1,
                 max_wait=60,
-                on_progress=lambda r, elapsed: progress_calls.append(r),
+                clock=_FakeClock(),
             )
 
+    async def test_on_progress_called(self):
+        """on_progress 每轮非终态回调一次，终态轮不回调。"""
+        poll_fn = AsyncMock(side_effect=["pending", "done"])
+        progress_calls = []
+        clock = _FakeClock([0.0, 1.0, 2.0, 3.0])
+
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done",
+            is_failed=lambda r: None,
+            poll_interval=1,
+            max_wait=60,
+            on_progress=lambda r, elapsed: progress_calls.append(r),
+            clock=clock,
+        )
+
+        assert result == "done"
+        assert clock.sleeps == [1]
         assert progress_calls == ["pending"]
 
     async def test_retry_if_overrides_default_and_fails_fast(self):
@@ -243,15 +255,15 @@ class TestPollWithRetry:
         poll_fn = AsyncMock(side_effect=ConnectionError("would normally retry"))
 
         with pytest.raises(ConnectionError):
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-                await poll_with_retry(
-                    poll_fn=poll_fn,
-                    is_done=lambda r: True,
-                    is_failed=lambda r: None,
-                    poll_interval=1,
-                    max_wait=60,
-                    retry_if=lambda e: False,
-                )
+            await poll_with_retry(
+                poll_fn=poll_fn,
+                is_done=lambda r: True,
+                is_failed=lambda r: None,
+                poll_interval=1,
+                max_wait=60,
+                retry_if=lambda e: False,
+                clock=_FakeClock(),
+            )
 
         assert poll_fn.await_count == 1
 
@@ -259,15 +271,15 @@ class TestPollWithRetry:
         """retry_if 返回 True 时重试，即便异常类型默认不可重试。"""
         poll_fn = AsyncMock(side_effect=[ValueError("transient"), "done"])
 
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
-            result = await poll_with_retry(
-                poll_fn=poll_fn,
-                is_done=lambda r: r == "done",
-                is_failed=lambda r: None,
-                poll_interval=1,
-                max_wait=60,
-                retry_if=lambda e: isinstance(e, ValueError),
-            )
+        result = await poll_with_retry(
+            poll_fn=poll_fn,
+            is_done=lambda r: r == "done",
+            is_failed=lambda r: None,
+            poll_interval=1,
+            max_wait=60,
+            retry_if=lambda e: isinstance(e, ValueError),
+            clock=_FakeClock(),
+        )
 
         assert result == "done"
         assert poll_fn.await_count == 2
@@ -598,7 +610,7 @@ class TestPersistJobIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
             caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
         ):
             await persist_provider_job_id("task-1", "job-1", provider="openai")
@@ -622,7 +634,7 @@ class TestPersistJobIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
             caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
         ):
             with pytest.raises(OperationalError):
@@ -654,7 +666,7 @@ class TestPersistJobIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             with pytest.raises(ValueError, match="not retryable"):
                 await persist_provider_job_id("task-V", "job-V", provider="newapi")
@@ -685,7 +697,7 @@ class TestPersistJobIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             with pytest.raises(ValueError, match="timed out"):
                 await persist_provider_job_id("task-T", "job-T", provider="gemini")
@@ -705,56 +717,56 @@ class TestProviderJobIdPersistenceMixin:
 
     async def test_worker_path_persists_via_module_helper(self):
         """worker 路径（task_id 非空）经统一点转调模块级 persist_provider_job_id。"""
-        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+        with captured_provider_job_ids() as persisted:
             await self._backend()._persist_provider_job_id(
                 self._request(task_id="local-task-1"), "job-1", provider="ark"
             )
-        persist.assert_awaited_once_with("local-task-1", "job-1", provider="ark", endpoint=None, base_url=None)
+        assert persisted == [
+            {
+                "task_id": "local-task-1",
+                "job_id": "job-1",
+                "provider": "ark",
+                "endpoint": None,
+                "base_url": None,
+            }
+        ]
 
     async def test_worker_path_persists_execution_endpoint(self):
         """自定义供应商包装层注入的 endpoint 与 job_id 一并落库，供续跑比对协议是否被换掉。"""
         request = self._request(task_id="local-task-1")
         request.execution_endpoint = "openai-video"
-        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+        with captured_provider_job_ids() as persisted:
             await self._backend()._persist_provider_job_id(request, "job-1", provider="ark")
-        persist.assert_awaited_once_with(
-            "local-task-1", "job-1", provider="ark", endpoint="openai-video", base_url=None
-        )
+        assert [(r["endpoint"], r["base_url"]) for r in persisted] == [("openai-video", None)]
 
     async def test_worker_path_persists_backend_domain_when_builtin(self):
         """内置供应商由 backend 传入实际请求域名 → 落域名列供续跑回放，协议标识位保持空。"""
-        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+        with captured_provider_job_ids() as persisted:
             await self._backend()._persist_provider_job_id(
                 self._request(task_id="local-task-1"),
                 "job-1",
                 provider="dashscope",
                 endpoint="https://maas.example.com/api/v1",
             )
-        persist.assert_awaited_once_with(
-            "local-task-1", "job-1", provider="dashscope", endpoint=None, base_url="https://maas.example.com/api/v1"
-        )
+        assert [(r["endpoint"], r["base_url"]) for r in persisted] == [(None, "https://maas.example.com/api/v1")]
 
     async def test_execution_endpoint_and_backend_domain_land_in_separate_columns(self):
         """自定义供应商：协议标识走 endpoint 位供比对，域名走 base_url 位供回放，互不覆盖。"""
         request = self._request(task_id="local-task-1")
         request.execution_endpoint = "dashscope-async-video"
-        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+        with captured_provider_job_ids() as persisted:
             await self._backend()._persist_provider_job_id(
                 request, "job-1", provider="dashscope", endpoint="https://maas.example.com/api/v1"
             )
-        persist.assert_awaited_once_with(
-            "local-task-1",
-            "job-1",
-            provider="dashscope",
-            endpoint="dashscope-async-video",
-            base_url="https://maas.example.com/api/v1",
-        )
+        assert [(r["endpoint"], r["base_url"]) for r in persisted] == [
+            ("dashscope-async-video", "https://maas.example.com/api/v1")
+        ]
 
     async def test_non_worker_path_skips_persist(self):
         """非 worker 路径（grid / 直生 / 测试，task_id=None）跳过持久化，不触碰 DB。"""
-        with patch("lib.video_backends.base.persist_provider_job_id", new=AsyncMock()) as persist:
+        with captured_provider_job_ids() as persisted:
             await self._backend()._persist_provider_job_id(self._request(task_id=None), "job-1", provider="ark")
-        persist.assert_not_awaited()
+        assert persisted == []
 
     async def test_persist_failure_propagates_fail_fast(self):
         """持久化失败抛出原异常，由 worker finally 兜底 mark_failed（fail-fast，不吞）。"""
@@ -793,7 +805,7 @@ class TestPersistApiCallIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
             caplog.at_level(logging.INFO, logger="lib.video_backends.base"),
         ):
             await persist_api_call_id("task-1", 42)
@@ -815,7 +827,7 @@ class TestPersistApiCallIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
             caplog.at_level(logging.ERROR, logger="lib.video_backends.base"),
         ):
             with pytest.raises(OperationalError):
@@ -844,7 +856,7 @@ class TestPersistApiCallIdRetry:
 
         with (
             patch("lib.generation_queue.get_generation_queue", return_value=fake_queue),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             with pytest.raises(ValueError, match="not retryable"):
                 await persist_api_call_id("task-V", 7)

--- a/tests/unit/lib/video_backends/test_video_backend_gemini.py
+++ b/tests/unit/lib/video_backends/test_video_backend_gemini.py
@@ -1,5 +1,7 @@
 """GeminiVideoBackend 单元测试 — mock genai SDK。"""
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,12 +12,25 @@ from lib.video_backends.base import (
 )
 
 
+class _RecordingRateLimiter:
+    """限流器替身：记录每次取配额时报的模型名，不做等待。
+
+    「按型号取配额」这个契约落在 ``acquired`` 记录的模型名上，而不是替身的调用对象。
+    """
+
+    def __init__(self) -> None:
+        self.acquired: list[str] = []
+
+    def acquire(self, model: str) -> None:
+        self.acquired.append(model)
+
+    async def acquire_async(self, model: str) -> None:
+        self.acquired.append(model)
+
+
 @pytest.fixture
 def mock_rate_limiter():
-    rl = MagicMock()
-    rl.acquire = MagicMock()
-    rl.acquire_async = AsyncMock()
-    return rl
+    return _RecordingRateLimiter()
 
 
 @pytest.fixture
@@ -209,7 +224,7 @@ class TestGeminiVideoBackendGenerate:
         )
 
         await gemini_backend.generate(request)
-        mock_rate_limiter.acquire_async.assert_called_once_with(gemini_backend._video_model)
+        assert mock_rate_limiter.acquired == [gemini_backend._video_model]
 
     async def test_no_negative_prompt_in_config(self, gemini_backend, tmp_path):
         """negative_prompt 改走 prompt 文本通道，GenerateVideosConfig 不再带该字段。"""
@@ -324,15 +339,35 @@ class TestPrepareImageParam:
 # ── _download_video 测试 ──────────────────────────────────
 
 
+class _AiStudioFileRef:
+    """AI Studio 文件引用替身：先 download 取到字节，save 才能把它落到给定路径。
+
+    这一支的契约是「下载后落盘到 output_path」，断言落在真实文件内容上；顺序颠倒
+    （未下载先落盘）在替身里直接 fail-loud。
+    """
+
+    def __init__(self, content: bytes = b"aistudio-bytes") -> None:
+        self._content = content
+        self._downloaded = False
+
+    def download(self) -> None:
+        self._downloaded = True
+
+    def save(self, path: str) -> None:
+        if not self._downloaded:
+            raise RuntimeError("save 前须先 files.download 取到字节")
+        Path(path).write_bytes(self._content)
+
+
 class TestDownloadVideo:
     def test_aistudio_download(self, gemini_backend, tmp_path):
         output = tmp_path / "video.mp4"
-        mock_ref = MagicMock()
+        ref = _AiStudioFileRef()
+        gemini_backend._client = SimpleNamespace(files=SimpleNamespace(download=lambda file: file.download()))
 
-        gemini_backend._download_video(mock_ref, output)
+        gemini_backend._download_video(ref, output)
 
-        gemini_backend._client.files.download.assert_called_once_with(file=mock_ref)
-        mock_ref.save.assert_called_once_with(str(output))
+        assert output.read_bytes() == b"aistudio-bytes"
 
     def test_vertex_download_from_bytes(self, gemini_backend, tmp_path):
         gemini_backend._backend_type = "vertex"

--- a/tests/unit/lib/video_backends/test_video_backend_gemini.py
+++ b/tests/unit/lib/video_backends/test_video_backend_gemini.py
@@ -10,6 +10,7 @@ from lib.video_backends.base import (
     VideoGenerationRequest,
     VideoGenerationResult,
 )
+from tests.fakes import bounded_poll_clock
 
 
 class _RecordingRateLimiter:
@@ -166,8 +167,7 @@ class TestGeminiVideoBackendGenerate:
             output_path=output,
         )
 
-        # patch asyncio.sleep 以避免实际等待
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+        with bounded_poll_clock():
             result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
@@ -263,7 +263,7 @@ class TestGeminiRetryBehavior:
         )
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+        with bounded_poll_clock():
             result = await gemini_backend.generate(request)
 
         assert result.provider == "gemini"
@@ -284,8 +284,7 @@ class TestGeminiRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with (
-            patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock),
-            patch("lib.retry.asyncio.sleep", new_callable=AsyncMock),
+            bounded_poll_clock(),
         ):
             result = await gemini_backend.generate(request)
 
@@ -305,7 +304,7 @@ class TestGeminiRetryBehavior:
 
         request = VideoGenerationRequest(prompt="test", output_path=output)
         with pytest.raises(ValueError, match="invalid response"):
-            with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+            with bounded_poll_clock():
                 await gemini_backend.generate(request)
 
         # 创建只调用一次
@@ -412,7 +411,7 @@ class TestGeminiResumeVideo:
         gemini_backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=pending_op)
 
         request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
-        with patch("lib.video_backends.base.asyncio.sleep", new_callable=AsyncMock):
+        with bounded_poll_clock():
             with pytest.raises(ResumeExpiredError) as ei:
                 await gemini_backend.resume_video("op-xyz", request)
         assert ei.value.job_id == "op-xyz"

--- a/tests/unit/lib/video_backends/test_video_backend_registry.py
+++ b/tests/unit/lib/video_backends/test_video_backend_registry.py
@@ -19,7 +19,7 @@ class _FakeBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_video_registry():
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()
     yield


### PR DESCRIPTION
Closes #1997

B6 backends/providers 域的测试处置：供应商 text/image/video/audio 后端测试、backend 装配/注册测试、根级 provider 散件 9 文件。纯测试改动，`lib/` `server/` `frontend/` 零文件。

## 做了什么

- **出站 HTTP 迁 respx**（`tests/http_capture.py` 的 `capture_http()`）：dashscope 音频、grok 图像与视频、minimax 图像与视频、openai 图像、ark 视频、agnes 视频、newapi/v2 视频、kling 视频与图像、vidu 连接探针。断言对象从「客户端替身记下的调用参数」变成真实序列化后的请求，URL 拼接、query 编码、鉴权头因此进入断言范围。多条出站流的供应商用 NamedTuple-of-routes + `@contextmanager` 收口。
- **「测 mock 本身」改记录型替身**：instructor、OpenAI TTS、模型发现、gemini 视频限流器、Ark 系与 MiniMax 系后端、装配层与工厂层。断言用 `==` 比整条构造/请求记录，能抓多传与漏传。
- **轮询与退避等待收编到 `bounded_poll_clock()`**（本域约 40 处），替掉散落的 `monkeypatch.setattr("lib.retry.asyncio.sleep", AsyncMock())`。假表走 30s 步长的 `itertools.count`，终态判定写错时命中 `max_wait` 而不是挂死。
- **`patch("lib.openai_shared.AsyncOpenAI")` 收编**（CONTRIBUTING 第 97 行闸门：同一 patch 目标 ≥3 文件须收编）：8 个文件约 100 处统一走 `tests/fakes.py::captured_openai_clients`，agnes 的本地同形 helper 折入共享版。
- **零断言用例补真实断言**：`test_gemini.py::test_all_script_schemas_accepted_by_google_genai_schema` 补清单非空 + schema 校验；`test_vidu_shared.py::test_404_is_success` 改为断言返回 `None` **且** `route.call_count == 1`，把「真的发了探针并接受 404」与「提前 return 根本没查」区分开。
- 三个 registry 各自的 `_clean_registry` fixture 是不同实体，按 media 改区分性命名。

`tests/conftest.py` 与 `tests/fakes.py` 均为**纯追加**（B6 并行预裁「共享设施文件只增不改」）。

## 用例数变化逐条对账

AST 口径 8191 → 8181（删 12 增 2）；运行时 10282 → 10274 passed。差额来自新增的 `test_returns_resolver_provider_id_not_registry_backend_name` 带 3 组 parametrize：−12 + 4 = −8，两个数字自洽。

**A 组：`tests/unit/lib/text_backends/test_factory.py` 9 条（逐 provider 构造参数表，整组下沉）**

`test_creates_gemini_aistudio_backend`、`test_creates_ark_backend`、`test_creates_ark_agent_plan_backend_uses_plan_endpoint`、`test_user_base_url_overrides_default_for_ark_agent_plan`、`test_creates_vertex_backend`、`test_creates_openai_backend_passes_user_base_url`、`test_creates_grok_backend_omits_base_url_when_unset`、`test_creates_dashscope_backend_derives_base_url_and_passes_provider_name`、`test_creates_minimax_backend_derives_base_url_and_passes_provider_name`。

这 9 条断言的全是「`registry.create_backend` 收到什么参数」，而构造早已收口到 `assemble_backend`。逐 provider 的构造参数表在 `tests/unit/lib/backend_assembly/test_backend_assembly_specs.py` 按 `(provider, media)` 逐条覆盖（ark 回落 registry default、ark-agent-plan 的 `/api/plan/v3`、user base_url 覆盖、grok 省略 base_url、openai 透传、dashscope 与 minimax 派生 base_url 并透传 `provider_name`、gemini-aistudio 无条件透传、gemini-vertex 的 `backend=vertex` + `gcs_bucket` 均在），且该文件有一条 `text_keys` 全集相等断言兜底——新增文本 provider 而不补 spec 用例会直接判红。留在工厂侧是同一张表测两遍。

工厂自身独有的两条契约提取为新增用例：解析层给出的 provider/model/凭证确实到达 spec 闭包；返回的 `provider_id` 取解析层 id 而非 backend 注册名（parametrize 覆盖 gemini 双 id 共用 `"gemini"` 注册名、`ark-agent-plan` 复用 `ArkTextBackend` 报名 `"ark"` 这两族易错情形，计费归因依赖它）。

**B 组：`test_custom_provider_factory.py::TestUrlNormalization` 3 条（与他处重复）**

- `test_openai_appends_v1` 与 `TestEndpointDispatch::test_openai_chat` 同形。后者的 `base_url` 从默认的 `https://api.example.com/v1` 换成 host-only，补 `/v1` 的接线由它承接——原先默认值已带 `/v1`，那条接线其实没被覆盖，合并后覆盖反而变强。
- `test_google_strips_v1beta` / `test_google_empty_base_url` 断言的是 `ensure_google_base_url` 自身的归一化，`tests/unit/lib/config/test_normalize_base_url.py` 已逐分支覆盖。「gemini-generate 走的是这个归一化器」这层接线由存活的 `TestEndpointDispatch::test_gemini_generate` 承接（host-only 入、带尾斜杠出，是该归一化器的特征输出）。

无净覆盖损失。

## 需要显式申报的一处

**AC②「本域 patch 生产代码私有符号清零」含一处形态转换，实质耦合未消。** `tests/fakes.py::captured_backend_construction` 与三个 registry 测试把原先的 `monkeypatch.setattr(registry, "_BACKEND_FACTORIES", {})`（CONTRIBUTING 第 94 行闸门里字面列举的第二种禁形）改成了「import 私有 dict + 就地 `clear()`/`update()`」。审计脚本按 AST 抓 patch 调用，看不见这一形态，所以机械命中确实归零，但对生产私有符号的依赖仍在。

不在本 PR 内修，依据是 CONTRIBUTING 第 107 行的分诊③「需要在生产代码中加 seam 的转入 seam 收编批次」：四个 backend registry 都暴露模块级 `_BACKEND_FACTORIES` 却没有测试隔离缝，真修法是在生产侧给 registry 一个显式隔离入口，属生产改动。已记 follow-up。

## 审计 delta

| 指标 | 基线 6004c8f2a | 交付 d8b9de55b |
|---|---|---|
| test_functions | 8191 | 8181 |
| no_assertion_tests | 47 | 44 |
| duplicate_fixture_sites | 3 | 0 |
| patch_sites_total | 2270 | 2172 |
| integration_self_public_patch_sites | 12 | 12 |
| integration_collaborator_patch_sites | 736 | 698 |

`integration_self_public_patch_sites` 不变符合预期：12 处全在 server 侧，0 处落在 backends/providers 域，不在本票 AC 内。

本域三项机械命中（测 mock / patch 被测单元 / 零断言）复跑均为 0；根级 provider 散件 9 文件复跑同为 0。

## 验证

全部在 `/Users/pollochen/MyProjects/ArcReel/.claude/worktrees/issue-1997` 内执行，每条命令同命令内 `pwd` 佐证落点（本批次并行 worktree 存在漂移，`pwd` 是唯一可信判据）：

- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 1370 files already formatted
- `uv run basedpyright` → 0 errors, 1221 warnings
- `uv run lint-imports` → Contracts: 2 kept, 0 broken
- `uv run python -m pytest` → **10274 passed, 2 skipped**（188s）

## Follow-up 候选

- 四个 backend registry 的测试隔离缝（上面申报的那一处，生产侧改动）。
- `tests/unit/lib/video_backends/test_dashscope_video_backend.py` 的 28 个用例点迁 respx。该文件只有一个 `patch("httpx.AsyncClient")` 目标，但提交—轮询—重放是一条有状态的多段流程，本轮改造成记录型 `_RecordingClient`（三项 AC 已满足），迁 respx 的收益与改动量不成比例。配方现成：照 `_MiniMaxRoutes` 的 NamedTuple-of-routes 形态。
- kling 图像与视频测试直调生产私有方法 `_build_payload`（基线与交付同为 9 / 32 处，非本票引入）：提交体只经直调断言，不在 wire 上。
- `tests/integration/lib/video_backends/test_kling_video_backend.py` 迁 respx 后已无真实 DB、子进程或网络，按 CONTRIBUTING 分层表应属 `unit` 档（基线既有的档位错置，非本票引入）。

---

https://claude.ai/code/session_017dYPL4DmXdDbzyifcC6G3F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 全面增强图像、视频、音频和文本后端的集成测试，覆盖请求提交、轮询、下载、鉴权、重试、超时及错误处理。
  * 增加对任务恢复、任务 ID 持久化、状态解析、参数传递和不同服务地址配置的验证。
  * 使用受控时钟和真实 HTTP 传输拦截，提高测试稳定性，并减少对底层客户端行为的依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->