### PR TITLE
test(b6): server API/services 域测试质量整改与路由接缝收编 (#1999)

### DIFF
--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -463,8 +463,7 @@ class GenerationWorker:
         provider_projection: ProviderProjection = _extract_provider,
     ):
         self.queue = queue or get_generation_queue()
-        # 认领期的 provider 投影（限流路由用）。显式注入让调度用例能确定地给出投影结果或
-        # 在投影处挂起，无需替换模块级符号。
+        # 认领期与执行期共用的 provider 投影：限流按它的结果路由到对应容量桶。
         self._provider_projection = provider_projection
         self.lease_name = lease_name
         self.owner_id = f"worker-{uuid.uuid4().hex[:10]}"

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -23,7 +23,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from lib.config.registry import ProviderMeta
+
+    ProviderProjection = Callable[[dict[str, Any]], Awaitable[str]]
 
 logger = logging.getLogger(__name__)
 
@@ -456,8 +460,12 @@ class GenerationWorker:
         lease_name: str = "default",
         capacity: CapacityTable | None = None,
         slots: SlotTable | None = None,
+        provider_projection: ProviderProjection = _extract_provider,
     ):
         self.queue = queue or get_generation_queue()
+        # 认领期的 provider 投影（限流路由用）。显式注入让调度用例能确定地给出投影结果或
+        # 在投影处挂起，无需替换模块级符号。
+        self._provider_projection = provider_projection
         self.lease_name = lease_name
         self.owner_id = f"worker-{uuid.uuid4().hex[:10]}"
 
@@ -625,7 +633,7 @@ class GenerationWorker:
                 if not task:
                     break
 
-                provider_id = await _extract_provider(task)
+                provider_id = await self._provider_projection(task)
                 cap = self._capacity.get(provider_id, media_type)
 
                 if cap <= 0:
@@ -784,7 +792,7 @@ class GenerationWorker:
         """
         task_id = task["task_id"]
         task_type = task.get("task_type", "unknown")
-        provider_id = claimed_provider_id or await _extract_provider(task)
+        provider_id = claimed_provider_id or await self._provider_projection(task)
         logger.info("开始处理任务 %s (type=%s, provider=%s)", task_id, task_type, provider_id)
 
         from server.services.generation_tasks import execute_generation_task
@@ -923,7 +931,7 @@ class GenerationWorker:
                 task["payload"] = payload
             payload["image_provider"] = persisted_provider_id
 
-        provider_id = checkpoint.provider_id if checkpoint is not None else await _extract_provider(task)
+        provider_id = checkpoint.provider_id if checkpoint is not None else await self._provider_projection(task)
         logger.info(
             "重启自愈处理任务 %s (type=%s, provider=%s, job=%s)",
             task_id,
@@ -1154,7 +1162,7 @@ class GenerationWorker:
             provider_id = (
                 checkpoint.provider_id
                 if checkpoint is not None
-                else task.get("provider_id") or await _extract_provider(task)
+                else task.get("provider_id") or await self._provider_projection(task)
             )
             if provider_id in NON_RESUMABLE_VIDEO_PROVIDERS:
                 # Grok/Vidu 当前不实现 resume_video——原 job 已发给供应商无接续手段，

--- a/server/routers/presentations.py
+++ b/server/routers/presentations.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
 
@@ -24,9 +24,15 @@ def get_presentation_read_model() -> PresentationReadModelService:
     return PresentationReadModelService(get_project_manager())
 
 
+PresentationReadModelDep = Annotated[PresentationReadModelService, Depends(get_presentation_read_model)]
+
+
 def get_presentation_bundle_service() -> PresentationBundleService:
     manager = get_project_manager()
     return PresentationBundleService(manager)
+
+
+PresentationBundleServiceDep = Annotated[PresentationBundleService, Depends(get_presentation_bundle_service)]
 
 
 def _cleanup_bundle(path: str) -> None:
@@ -38,12 +44,13 @@ async def download_presentation_bundle(
     project_name: str,
     resource_type: ResourceType,
     resource_id: str,
+    bundle_service: PresentationBundleServiceDep,
     variant: Variant = "post_production",
     video_version: int | None = Query(None, ge=1),
     audio_version: int | None = Query(None, ge=1),
 ):
     try:
-        path = await get_presentation_bundle_service().export_unit(
+        path = await bundle_service.export_unit(
             project_name=project_name,
             resource_type=resource_type,
             resource_id=resource_id,
@@ -66,12 +73,13 @@ async def get_presentation(
     project_name: str,
     resource_type: ResourceType,
     resource_id: str,
+    read_model: PresentationReadModelDep,
     variant: Variant = "post_production",
     video_version: int | None = Query(None, ge=1),
     audio_version: int | None = Query(None, ge=1),
 ):
     try:
-        result = await get_presentation_read_model().materialize_unit(
+        result = await read_model.materialize_unit(
             project_name=project_name,
             resource_type=resource_type,
             resource_id=resource_id,

--- a/server/routers/projects.py
+++ b/server/routers/projects.py
@@ -77,6 +77,9 @@ def get_workflow_state_service() -> WorkflowStateService:
     return WorkflowStateService(get_project_manager())
 
 
+WorkflowStateServiceDep = Annotated[WorkflowStateService, Depends(get_workflow_state_service)]
+
+
 def _project_status_payload(summary: ProjectSummary) -> dict[str, Any]:
     """项目级状态负载：项目摘要去掉每集明细。
 
@@ -115,8 +118,19 @@ def get_archive_service() -> ProjectArchiveService:
     return ProjectArchiveService(get_project_manager())
 
 
+ArchiveServiceDep = Annotated[ProjectArchiveService, Depends(get_archive_service)]
+
+
 def get_script_batch_editor(manager: Any | None = None) -> ScriptBatchEditor:
     return ScriptBatchEditor(manager or get_project_manager())
+
+
+def get_script_batch_editor_factory() -> Callable[[Any], ScriptBatchEditor]:
+    """批量编辑器的路由依赖；编辑器要绑处理器内解析出的 manager，故注入工厂而非实例。"""
+    return get_script_batch_editor
+
+
+ScriptBatchEditorFactoryDep = Annotated[Callable[[Any], ScriptBatchEditor], Depends(get_script_batch_editor_factory)]
 
 
 # 项目级模型字段：创建时逐一校验并写入 project.json，PATCH 时另加 audio_backend。
@@ -260,6 +274,7 @@ def _cleanup_temp_dir(dir_path: str) -> None:
 @router.post("/projects/import")
 async def import_project_archive(
     _t: Translator,
+    archive_service: ArchiveServiceDep,
     file: UploadFile = File(...),
     conflict_policy: str = Form("prompt"),
 ):
@@ -284,7 +299,7 @@ async def import_project_archive(
         await asyncio.to_thread(_write_upload)
 
         def _sync():
-            return get_archive_service().import_project_archive(
+            return archive_service.import_project_archive(
                 Path(upload_path),
                 uploaded_filename=file.filename,
                 conflict_policy=conflict_policy,
@@ -328,6 +343,7 @@ async def create_export_token(
     name: str,
     current_user: CurrentUser,
     _t: Translator,
+    archive_service: ArchiveServiceDep,
     scope: str = Query("full"),
 ):
     """签发短时效下载 token，用于浏览器原生下载认证。"""
@@ -338,7 +354,7 @@ async def create_export_token(
         def _sync():
             if not get_project_manager().project_exists(name):
                 raise HTTPException(status_code=404, detail=_t("project_not_found", name=name))
-            return get_archive_service().get_export_diagnostics(name, scope=scope, translate=_t)
+            return archive_service.get_export_diagnostics(name, scope=scope, translate=_t)
 
         diagnostics = await asyncio.to_thread(_sync)
         username = current_user.sub
@@ -359,6 +375,7 @@ async def create_export_token(
 async def export_project_archive(
     name: str,
     _t: Translator,
+    archive_service: ArchiveServiceDep,
     download_token: str = Query(...),
     scope: str = Query("full"),
 ):
@@ -379,9 +396,7 @@ async def export_project_archive(
         raise HTTPException(status_code=401, detail=_t("download_token_invalid"))
 
     try:
-        archive_path, download_name = await asyncio.to_thread(
-            lambda: get_archive_service().export_project(name, scope=scope)
-        )
+        archive_path, download_name = await asyncio.to_thread(lambda: archive_service.export_project(name, scope=scope))
         return FileResponse(
             archive_path,
             media_type="application/zip",
@@ -406,6 +421,10 @@ def get_jianying_draft_service() -> JianyingDraftService:
     return JianyingDraftService(get_project_manager())
 
 
+# 具体类型只在 TYPE_CHECKING 下可见：pyJianYingDraft 是重依赖，运行期仍按需惰性导入。
+JianyingDraftServiceDep = Annotated[Any, Depends(get_jianying_draft_service)]
+
+
 def _validate_draft_path(draft_path: str, _t: Callable[..., str]) -> str:
     """校验 draft_path 合法性"""
     if not draft_path or not draft_path.strip():
@@ -421,6 +440,7 @@ def _validate_draft_path(draft_path: str, _t: Callable[..., str]) -> str:
 async def export_jianying_draft(
     name: str,
     _t: Translator,
+    svc: JianyingDraftServiceDep,
     episode: int = Query(..., description="集数编号"),
     draft_path: str = Query(..., description="用户本地剪映草稿目录"),
     download_token: str = Query(..., description="下载 token"),
@@ -450,7 +470,6 @@ async def export_jianying_draft(
     from server.services.jianying_draft_service import NoCompletedSegmentsError
     from server.services.presentation_read_model import PresentationUnavailableError
 
-    svc = get_jianying_draft_service()
     try:
         zip_path = await svc.export_episode_draft(
             project_name=name,
@@ -486,12 +505,11 @@ async def export_jianying_draft(
 
 
 @router.get("/projects")
-async def list_projects():
+async def list_projects(summaries: WorkflowStateServiceDep):
     """列出所有项目"""
 
     def _sync():
         manager = get_project_manager()
-        summaries = get_workflow_state_service()
         projects = []
         for name in manager.list_projects():
             try:
@@ -735,6 +753,7 @@ async def get_workflow_plan(name: str, request: WorkflowPlanRequest):
 async def get_project(
     name: str,
     _t: Translator,
+    summaries: WorkflowStateServiceDep,
 ):
     """获取项目详情（含实时计算字段）"""
     try:
@@ -747,7 +766,7 @@ async def get_project(
             project = manager.load_project(name)
 
             # 阶段、产物计数与每集明细一律来自项目摘要投影（读时计算，不写入 JSON）
-            summary = get_workflow_state_service().get_project_summary(name)
+            summary = summaries.get_project_summary(name)
             project = _merge_episode_summaries(project, summary)
             project["status"] = _project_status_payload(summary)
 
@@ -1029,7 +1048,12 @@ async def get_script(name: str, script_file: str, _t: Translator):
     response_model=None,
     dependencies=[Depends(require_project_migration_ok)],
 )
-async def edit_script_batch(name: str, command: ScriptBatchEditCommand, _t: Translator) -> JSONResponse:
+async def edit_script_batch(
+    name: str,
+    command: ScriptBatchEditCommand,
+    _t: Translator,
+    make_script_batch_editor: ScriptBatchEditorFactoryDep,
+) -> JSONResponse:
     """Execute the same revisioned script-edit command exposed to the in-process Agent."""
 
     manager = None
@@ -1043,7 +1067,7 @@ async def edit_script_batch(name: str, command: ScriptBatchEditCommand, _t: Tran
             raise NotFoundError("project_not_found", name=name) from exc
 
         with project_change_source("webui"):
-            result = await asyncio.to_thread(get_script_batch_editor(manager).execute, name, command)
+            result = await asyncio.to_thread(make_script_batch_editor(manager).execute, name, command)
         return JSONResponse(status_code=script_batch_status(result), content=result.model_dump(mode="json"))
     except FileNotFoundError as exc:
         if manager is None or not manager.project_exists(name):
@@ -1063,7 +1087,13 @@ class UpdateSceneRequest(BaseModel):
 
 
 @router.patch("/projects/{name}/script-scenes/{scene_id}", dependencies=[Depends(require_project_migration_ok)])
-async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _t: Translator):
+async def update_scene(
+    name: str,
+    scene_id: str,
+    req: UpdateSceneRequest,
+    _t: Translator,
+    make_script_batch_editor: ScriptBatchEditorFactoryDep,
+):
     """更新剧情演绎剧本中的单个分镜（按 scene_id 定位）。
 
     路径与项目场景资产 CRUD（``/projects/{name}/scenes/{entry_name}``）做明确区分，
@@ -1108,7 +1138,7 @@ async def update_scene(name: str, scene_id: str, req: UpdateSceneRequest, _t: Tr
                     name,
                     req.script_file,
                     [{"op": "update", "id": scene_id, "fields": fields}],
-                    editor=get_script_batch_editor(manager),
+                    editor=make_script_batch_editor(manager),
                 )
             require_script_edit_result(
                 result,
@@ -1180,7 +1210,13 @@ def _require_ad_script(script: dict, _t: Translator) -> list[dict]:
 
 
 @router.patch("/projects/{name}/script-shots/{shot_id}", dependencies=[Depends(require_project_migration_ok)])
-async def update_shot(name: str, shot_id: str, req: UpdateShotRequest, _t: Translator):
+async def update_shot(
+    name: str,
+    shot_id: str,
+    req: UpdateShotRequest,
+    _t: Translator,
+    make_script_batch_editor: ScriptBatchEditorFactoryDep,
+):
     """更新广告/短片剧本中的单个分镜（按 shot_id 定位）。
 
     路径风格与 ``script-scenes`` 对齐；口播文案 / section / 时长 / 引用列表等
@@ -1208,7 +1244,7 @@ async def update_shot(name: str, shot_id: str, req: UpdateShotRequest, _t: Trans
                     name,
                     req.script_file,
                     [{"op": "update", "id": shot_id, "fields": fields}],
-                    editor=get_script_batch_editor(manager),
+                    editor=make_script_batch_editor(manager),
                 )
             require_script_edit_result(
                 result,
@@ -1238,7 +1274,12 @@ class ReorderShotsRequest(BaseModel):
 
 
 @router.post("/projects/{name}/script-shots/reorder", dependencies=[Depends(require_project_migration_ok)])
-async def reorder_shots(name: str, req: ReorderShotsRequest, _t: Translator):
+async def reorder_shots(
+    name: str,
+    req: ReorderShotsRequest,
+    _t: Translator,
+    make_script_batch_editor: ScriptBatchEditorFactoryDep,
+):
     """按给定全排列重排 ad 剧本的 shots 顺序（与视频单元重排端点同语义）。"""
     try:
 
@@ -1267,7 +1308,7 @@ async def reorder_shots(name: str, req: ReorderShotsRequest, _t: Translator):
                     name,
                     req.script_file,
                     operations,
-                    editor=get_script_batch_editor(manager),
+                    editor=make_script_batch_editor(manager),
                 )
             require_script_edit_result(result)
             reordered = manager.load_script(name, req.script_file)["shots"]
@@ -1310,7 +1351,13 @@ class UpdateEpisodeRequest(BaseModel):
 
 
 @router.patch("/projects/{name}/segments/{segment_id}", dependencies=[Depends(require_project_migration_ok)])
-async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, _t: Translator):
+async def update_segment(
+    name: str,
+    segment_id: str,
+    req: UpdateSegmentRequest,
+    _t: Translator,
+    make_script_batch_editor: ScriptBatchEditorFactoryDep,
+):
     """更新旁白/解说分镜"""
     try:
 
@@ -1356,7 +1403,7 @@ async def update_segment(name: str, segment_id: str, req: UpdateSegmentRequest, 
                     name,
                     req.script_file,
                     [{"op": "update", "id": segment_id, "fields": fields}],
-                    editor=get_script_batch_editor(manager),
+                    editor=make_script_batch_editor(manager),
                 )
             require_script_edit_result(
                 result,

--- a/server/routers/system_config.py
+++ b/server/routers/system_config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import math
 import tomllib
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
@@ -88,6 +89,11 @@ def _load_app_version(pyproject_path: Path) -> str:
 @lru_cache(maxsize=1)
 def _read_app_version() -> str:
     return _load_app_version(_PYPROJECT_PATH)
+
+
+def get_app_version_reader() -> Callable[[], str]:
+    """版本读取器的路由依赖；读失败的处置归路由，故注入可调用对象而非版本值。"""
+    return _read_app_version
 
 
 def _parse_version(raw: str) -> Version | None:
@@ -393,9 +399,10 @@ async def get_model_candidates(
 @router.get("/system/version")
 async def get_system_version(
     _t: Translator,
+    read_app_version: Annotated[Callable[[], str], Depends(get_app_version_reader)],
 ) -> dict[str, Any]:
     try:
-        current_version = _read_app_version()
+        current_version = read_app_version()
     except Exception as exc:
         logger.exception("Failed to read app version")
         raise HTTPException(status_code=500, detail=_t("about_version_read_failed")) from exc

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -776,7 +776,7 @@ async def execute_reference_video_task(
         )
 
         async def _finalize() -> dict[str, Any]:
-            return await _finalize_reference_video_unit(
+            return await finalize_reference_video_unit(
                 project_name=project_name,
                 script_file=script_file,
                 project_path=project_path,
@@ -850,7 +850,7 @@ def apply_unit_video_assets(
     raise KeyError(resource_id)
 
 
-async def _finalize_reference_video_unit(
+async def finalize_reference_video_unit(
     *,
     project_name: str,
     script_file: str,

--- a/server/services/resume_executor.py
+++ b/server/services/resume_executor.py
@@ -27,7 +27,7 @@ from server.services.generation_tasks import (
     emit_generation_success_batch,
     get_project_manager,
 )
-from server.services.reference_video_tasks import _finalize_reference_video_unit
+from server.services.reference_video_tasks import finalize_reference_video_unit
 from server.services.video_artifact_currency import (
     VideoArtifactCommitter,
     complete_video_artifact_commit,
@@ -191,7 +191,7 @@ async def execute_resume_video_task(task: dict[str, Any], *, job_id: str) -> dic
 
             async def _finalize() -> dict[str, Any]:
                 if task_type == "reference_video":
-                    selected_result = await _finalize_reference_video_unit(
+                    selected_result = await finalize_reference_video_unit(
                         project_name=project_name,
                         script_file=script_file,
                         project_path=project_path,

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -2190,7 +2190,7 @@ class TestGenerationWorker:
 
     @pytest.mark.asyncio
     async def test_process_resume_task_script_edit_error_encodes_key(self, monkeypatch, staged_project):
-        """resume_executor 复用 _finalize_reference_video_unit 等 finalize helper，同样会抛
+        """resume_executor 复用 finalize_reference_video_unit 等 finalize helper，同样会抛
         ScriptEditError；resume 路径与常规 _process_task 走同一份 _encode_task_failure_message，
         不能因为是重启自愈这条独立调用链就退回 str(exc) 的固定中文。"""
         queue = _FakeQueue()

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -1,6 +1,7 @@
 import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -237,6 +238,69 @@ class _FakeQueue:
     async def mark_task_cancelled(self, task_id, *, cancelled_by="user"):
         self.cancelled.append((task_id, cancelled_by))
         return 1
+
+
+@pytest.fixture()
+async def worker_db(db_factory, monkeypatch):
+    """把 worker 直接触达的全局 session factory 换成内存库。
+
+    ``_requeue_single_task`` 与 ``CapacityTable.from_db`` 绕开注入的 queue 协作者、
+    直接经 ``lib.db.safe_session_factory`` 落库；绑到内存库后这两条路径真的执行，
+    断言因而能落在行状态上。
+    """
+    monkeypatch.setattr("lib.db.safe_session_factory", db_factory)
+    return db_factory
+
+
+async def _seed_running_task(factory, task_id: str, **overrides: Any) -> None:
+    """种一行 running 状态的 task，供回队路径的真实 guarded UPDATE 命中。"""
+    from lib.db.models.task import Task
+
+    now = datetime.now(UTC)
+    fields: dict[str, Any] = {
+        "project_name": "demo",
+        "task_type": "video",
+        "media_type": "video",
+        "resource_id": "E1S01",
+        "status": "running",
+        "queued_at": now,
+        "started_at": now,
+        "updated_at": now,
+    }
+    fields.update(overrides)
+    async with factory() as session:
+        session.add(Task(task_id=task_id, **fields))
+        await session.commit()
+
+
+async def _task_status(factory, task_id: str) -> str | None:
+    from lib.db.models.task import Task
+
+    async with factory() as session:
+        row = await session.get(Task, task_id)
+        return None if row is None else row.status
+
+
+@pytest.fixture()
+def staged_project(tmp_path, monkeypatch) -> Path:
+    """把 worker 的项目定位指向 tmp 项目，让 staging 清理落在真实文件系统上。"""
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+
+    class _PM:
+        def get_project_path(self, _name: str) -> Path:
+            return project_path
+
+    monkeypatch.setattr("lib.project_manager.get_project_manager", lambda: _PM())
+    return project_path
+
+
+def _stage_task_dir(project_path: Path, task_id: str) -> Path:
+    """建出一个任务的 provider media staging 目录，返回该任务的 staging 根。"""
+    staged = project_path / ".arcreel" / "tasks" / task_id / "provider_media"
+    staged.mkdir(parents=True)
+    (staged / "000-start_image.png").write_bytes(b"x")
+    return staged.parent
 
 
 class TestReadIntEnv:
@@ -907,7 +971,7 @@ class TestGenerationWorker:
         assert queue.failed == []
 
     @pytest.mark.asyncio
-    async def test_process_reference_task_requeues_when_execution_provider_changes(self, monkeypatch):
+    async def test_process_reference_task_requeues_when_execution_provider_changes(self, monkeypatch, worker_db):
         """执行入口解析到别的 provider 时不占旧槽提交，而是刷新投影并回队重认领。"""
 
         from lib.generation_queue import DispatchProviderChanged
@@ -920,13 +984,7 @@ class TestGenerationWorker:
             raise DispatchProviderChanged(claimed_provider_id="ark", actual_provider_id="minimax")
 
         monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _changed)
-        requeued: list[str] = []
-
-        async def _capture_requeue(self, task_id):
-            requeued.append(task_id)
-            return True
-
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _capture_requeue)
+        await _seed_running_task(worker_db, "ref-provider-changed", task_type="reference_video", resource_id="E1U1")
 
         await worker._process_task(
             {"task_id": "ref-provider-changed", "task_type": "reference_video"},
@@ -934,14 +992,14 @@ class TestGenerationWorker:
         )
 
         assert queue.persisted_providers == [("ref-provider-changed", "minimax")]
-        assert requeued == ["ref-provider-changed"]
+        assert await _task_status(worker_db, "ref-provider-changed") == "queued"
         assert queue.succeeded == []
         assert queue.failed == []
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("failed_rows", [1, 0])
     async def test_process_reference_task_closes_terminal_state_when_provider_requeue_fails(
-        self, monkeypatch, failed_rows: int
+        self, monkeypatch, worker_db, failed_rows: int
     ):
         from lib.generation_queue import DispatchProviderChanged
 
@@ -951,11 +1009,8 @@ class TestGenerationWorker:
         async def _changed(_task, *, claimed_provider_id):
             raise DispatchProviderChanged(claimed_provider_id=claimed_provider_id, actual_provider_id="minimax")
 
-        async def _cannot_requeue(_self, _task_id):
-            return False
-
         monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _changed)
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _cannot_requeue)
+        # 库里没有这行 running 记录，回队的 guarded UPDATE 命中 0 行——回队失败正是本用例的前提
 
         await worker._process_task(
             {"task_id": "ref-provider-changed", "task_type": "reference_video"},
@@ -1194,23 +1249,21 @@ class TestGenerationWorker:
 
     @pytest.mark.asyncio
     async def test_drain_marks_cancelled_when_cancel_hits_before_process_task_try(self, monkeypatch):
-        """取消落在 _process_task 进 try 之前（_extract_provider await）：drain 端兜底落终态。"""
+        """取消落在 _process_task 进 try 之前（provider 投影 await）：drain 端兜底落终态。"""
         queue = _FakeQueue()
-        worker = GenerationWorker(queue=queue)
-        worker.heartbeat_interval = 0.01
-        worker.poll_interval = 0.01
-
         in_extract = asyncio.Event()
 
-        async def _blocking_extract(_task):
+        async def _blocking_projection(_task):
             in_extract.set()
             await asyncio.sleep(10)  # 停在入口解析，模拟 cancel 落在 _process_task 的 try 之前
             return "test"
 
-        monkeypatch.setattr("lib.generation_worker._extract_provider", _blocking_extract)
+        worker = GenerationWorker(queue=queue, provider_projection=_blocking_projection)
+        worker.heartbeat_interval = 0.01
+        worker.poll_interval = 0.01
 
         async def _execute(_task):
-            raise AssertionError("execute 不应被调用：cancel 在 _extract_provider 阶段就到")
+            raise AssertionError("execute 不应被调用：cancel 在 provider 投影阶段就到")
 
         monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _execute)
 
@@ -1221,7 +1274,7 @@ class TestGenerationWorker:
         worker._slots.register("test", "video", "tid", t)
 
         await worker.start()
-        await in_extract.wait()  # 确保停在 _extract_provider（try 之前）
+        await in_extract.wait()  # 确保停在 provider 投影（try 之前）
         assert worker.request_cancel("tid") is True
         await asyncio.sleep(0.1)
 
@@ -1443,7 +1496,7 @@ class TestGenerationWorker:
         assert "[restart_lost_no_job_id]" in queue.failed[0][1]
 
     @pytest.mark.asyncio
-    async def test_reference_orphans_apply_strict_four_state_checkpoint_job_matrix(self, monkeypatch):
+    async def test_reference_orphans_apply_strict_four_state_checkpoint_job_matrix(self, staged_project):
         queue = _FakeQueue()
         queue._orphans = [
             {
@@ -1494,12 +1547,7 @@ class TestGenerationWorker:
             },
         ]
         worker = GenerationWorker(queue=queue)
-        cleaned: list[str] = []
-
-        async def _clean(_self, task):
-            cleaned.append(task["task_id"])
-
-        monkeypatch.setattr(GenerationWorker, "_cleanup_video_staging", _clean)
+        staged = {task["task_id"]: _stage_task_dir(staged_project, task["task_id"]) for task in queue._orphans}
 
         await worker._handle_orphan_tasks_on_start()
 
@@ -1508,11 +1556,11 @@ class TestGenerationWorker:
         assert "[restart_lost_checkpoint_no_job_id]" in failures["ref-checkpoint-only"]
         assert "[execution_identity_unrecoverable]" in failures["ref-job-only"]
         assert "[execution_identity_unrecoverable]" in failures["ref-bad-checkpoint"]
-        assert set(cleaned) == {task["task_id"] for task in queue._orphans}
+        assert [task_id for task_id, path in staged.items() if path.exists()] == []
         assert worker._orphan_dispatcher_task is None
 
     @pytest.mark.asyncio
-    async def test_storyboard_orphans_apply_strict_four_state_checkpoint_job_matrix(self, monkeypatch):
+    async def test_storyboard_orphans_apply_strict_four_state_checkpoint_job_matrix(self, staged_project):
         base = {
             "status": "running",
             "task_type": "video",
@@ -1540,12 +1588,7 @@ class TestGenerationWorker:
             },
         ]
         worker = GenerationWorker(queue=queue)
-        cleaned: list[str] = []
-
-        async def _clean(_self, task):
-            cleaned.append(task["task_id"])
-
-        monkeypatch.setattr(GenerationWorker, "_cleanup_video_staging", _clean)
+        staged = {task["task_id"]: _stage_task_dir(staged_project, task["task_id"]) for task in queue._orphans}
 
         await worker._handle_orphan_tasks_on_start()
 
@@ -1554,11 +1597,13 @@ class TestGenerationWorker:
         assert "[restart_lost_checkpoint_no_job_id]" in failures["story-checkpoint-only"]
         assert "[execution_identity_unrecoverable]" in failures["story-job-only"]
         assert "[execution_identity_unrecoverable]" in failures["story-bad-checkpoint"]
-        assert set(cleaned) == {task["task_id"] for task in queue._orphans}
+        assert [task_id for task_id, path in staged.items() if path.exists()] == []
         assert worker._orphan_dispatcher_task is None
 
     @pytest.mark.asyncio
-    async def test_reference_orphan_with_checkpoint_and_job_routes_by_checkpoint_provider(self, monkeypatch):
+    async def test_reference_orphan_with_checkpoint_and_job_routes_by_checkpoint_provider(
+        self, monkeypatch, staged_project
+    ):
         from lib.providers import PROVIDER_GROK
 
         queue = _FakeQueue()
@@ -1577,20 +1622,22 @@ class TestGenerationWorker:
         }
         queue._orphans = [task]
         worker = GenerationWorker(queue=queue)
-        captured: dict[str, list[dict[str, Any]]] = {}
+        resumed: list[dict[str, Any]] = []
 
-        async def _capture(_self, buckets):
-            captured.update(buckets)
+        async def _capture_resume(resume_task, *, job_id):
+            resumed.append(resume_task)
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_dispatch_resume_orphans_background", _capture)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _capture_resume)
 
         await worker._handle_orphan_tasks_on_start()
         dispatcher_task = worker._orphan_dispatcher_task
         assert dispatcher_task is not None
         await asyncio.wait_for(dispatcher_task, timeout=5)
 
-        assert list(captured) == ["ark"]
-        assert captured["ark"][0]["provider_id"] == "ark"
+        # 派发身份取 checkpoint 的 ark，而不是 task 投影列的 Grok 或 payload 里的当前配置
+        assert [t["task_id"] for t in resumed] == ["ref-ready"]
+        assert resumed[0]["provider_id"] == "ark"
         assert queue.failed == []
 
     @pytest.mark.asyncio
@@ -1660,7 +1707,7 @@ class TestGenerationWorker:
         await asyncio.gather(*worker._slots.all_active_tasks(), return_exceptions=True)
 
     @pytest.mark.asyncio
-    async def test_claim_requeue_on_full_pool_refreshes_provider_projection(self, monkeypatch):
+    async def test_claim_requeue_on_full_pool_refreshes_provider_projection(self, monkeypatch, worker_db):
         """池满回队前把重派生的 provider 刷回投影列。
 
         走到二次校验池满这条路，说明存量投影与现值分裂（NULL 兜底，或入队后剧本参考集 /
@@ -1696,12 +1743,15 @@ class TestGenerationWorker:
                 return None
 
         queue = _StaleProjectionQueue()
-        worker = GenerationWorker(queue=queue, capacity=_cap({"minimax": {"video": 1}, "ark": {"video": 1}}))
 
         async def _current_provider(task):
             return "minimax" if task["task_id"] == "vid-stale" else "ark"
 
-        monkeypatch.setattr("lib.generation_worker._extract_provider", _current_provider)
+        worker = GenerationWorker(
+            queue=queue,
+            capacity=_cap({"minimax": {"video": 1}, "ark": {"video": 1}}),
+            provider_projection=_current_provider,
+        )
 
         async def _execute(_task, *, claimed_provider_id):
             assert claimed_provider_id == "ark"
@@ -1709,21 +1759,17 @@ class TestGenerationWorker:
 
         monkeypatch.setattr("server.services.generation_tasks.execute_generation_task", _execute)
 
-        occupier = asyncio.create_task(asyncio.sleep(30))
+        # 永不完成的占位 future 把 minimax 的 video 槽占满；不用 sleep，避免真实时间等待
+        occupier = asyncio.get_running_loop().create_future()
         worker._slots.register("minimax", "video", "vid-running", occupier)
-        requeued: list[str] = []
-
-        async def _capture_requeue(self, task_id):
-            requeued.append(task_id)
-
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _capture_requeue)
+        await _seed_running_task(worker_db, "vid-stale", task_type="reference_video", resource_id="E1U1")
         try:
             await worker._claim_tasks()
-            await asyncio.gather(*worker._slots.all_active_tasks())
+            await asyncio.gather(*[t for t in worker._slots.all_active_tasks() if t is not occupier])
         finally:
             occupier.cancel()
 
-        assert requeued == ["vid-stale"]
+        assert await _task_status(worker_db, "vid-stale") == "queued"
         assert queue.persisted_providers == [("vid-stale", "minimax")]
         assert queue.succeeded == [("vid-ready", {"ok": True})]
         assert any(kwargs.get("exclude_task_ids") == frozenset({"vid-stale"}) for kwargs in queue.claim_kwargs)
@@ -1774,7 +1820,7 @@ class TestGenerationWorker:
     # _handle_orphan_tasks_on_start：分流补全
     # ------------------------------------------------------------------
     @pytest.mark.asyncio
-    async def test_handle_orphan_image_running_marks_restart_lost(self, monkeypatch):
+    async def test_handle_orphan_image_running_marks_restart_lost(self, worker_db):
         """image 孤儿无 resume 入口 → [restart_lost]，绝不主动 requeue（避免重复扣费）。"""
         queue = _FakeQueue()
         queue._orphans = [
@@ -1790,33 +1836,27 @@ class TestGenerationWorker:
             }
         ]
         worker = GenerationWorker(queue=queue)
-        requeued: list[str] = []
+        await _seed_running_task(worker_db, "img-orphan", task_type="storyboard", media_type="image")
 
-        async def _capture_requeue(self, task_id):
-            requeued.append(task_id)
-
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _capture_requeue)
         await worker._handle_orphan_tasks_on_start()
-        assert requeued == []
+
+        assert await _task_status(worker_db, "img-orphan") == "running", "image 孤儿绝不能被回队重跑"
         assert queue.failed and queue.failed[0][0] == "img-orphan"
         assert "[restart_lost_image]" in queue.failed[0][1]
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_non_resumable_video_marks_resume_unsupported(self, monkeypatch):
+    async def test_handle_orphan_non_resumable_video_marks_resume_unsupported(self, worker_db, staged_project):
         """Grok/Vidu video 孤儿 → [resume_unsupported]（backend 无 resume，绝不重跑）。"""
         from lib.providers import PROVIDER_GROK
 
         queue = _FakeQueue()
         queue._orphans = [_storyboard_orphan("grok-orphan", provider_id=PROVIDER_GROK, job_id="some-job")]
         worker = GenerationWorker(queue=queue)
-        requeued: list[str] = []
+        await _seed_running_task(worker_db, "grok-orphan")
 
-        async def _capture_requeue(self, task_id):
-            requeued.append(task_id)
-
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _capture_requeue)
         await worker._handle_orphan_tasks_on_start()
-        assert requeued == []
+
+        assert await _task_status(worker_db, "grok-orphan") == "running", "不可 resume 的视频孤儿绝不能被回队重跑"
         assert queue.failed and queue.failed[0][0] == "grok-orphan"
         assert "[resume_unsupported_provider]" in queue.failed[0][1]
         assert PROVIDER_GROK in queue.failed[0][1]
@@ -1850,7 +1890,7 @@ class TestGenerationWorker:
         assert cancelled_ids == {"img-raced", "grok-raced"}
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_uses_checkpoint_provider_id(self, monkeypatch):
+    async def test_handle_orphan_uses_checkpoint_provider_id(self, monkeypatch, worker_db, staged_project):
         """checkpoint provider 优先于 task 投影列和当前项目解析。
 
         如果 checkpoint provider 是 Grok（不支持 resume），即便 task advisory 列和当前项目
@@ -1865,26 +1905,26 @@ class TestGenerationWorker:
         orphan["payload"] = {"video_provider_i2v": "ark/doubao-seedance-2-0-260128"}
         queue._orphans = [orphan]
         worker = GenerationWorker(queue=queue)
-        requeued: list[str] = []
-        resume_dispatched: list[str] = []
+        await _seed_running_task(worker_db, "ghost-orphan")
+        resumed: list[str] = []
 
-        async def _capture_requeue(self, task_id):
-            requeued.append(task_id)
+        async def _capture_resume(resume_task, *, job_id):
+            resumed.append(resume_task["task_id"])
+            return {"job_id": job_id}
 
-        async def _capture_resume(self, task):
-            resume_dispatched.append(task["task_id"])
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _capture_resume)
 
-        monkeypatch.setattr(GenerationWorker, "_requeue_single_task", _capture_requeue)
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _capture_resume)
         await worker._handle_orphan_tasks_on_start()
+
         # 用 checkpoint 的 Grok → [resume_unsupported]；若误用 advisory/payload 的 ark → 会派发 resume
-        assert requeued == []
-        assert resume_dispatched == []
+        assert await _task_status(worker_db, "ghost-orphan") == "running"
+        assert resumed == []
+        assert worker._orphan_dispatcher_task is None
         assert queue.failed and queue.failed[0][0] == "ghost-orphan"
         assert "[resume_unsupported_provider]" in queue.failed[0][1]
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_resumable_dispatches_process_resume_task(self, monkeypatch):
+    async def test_handle_orphan_resumable_dispatches_process_resume_task(self, monkeypatch, staged_project):
         """video resumable provider + 有 job_id → 后台 dispatcher 派发 _process_resume_task。
 
         Semaphore-based dispatcher 在 sub-task 内填 inflight、finally pop；本测验证
@@ -1895,10 +1935,11 @@ class TestGenerationWorker:
         worker = GenerationWorker(queue=queue)
         dispatched: list[dict] = []
 
-        async def _capture_resume(self, task):
+        async def _capture_resume(task, *, job_id):
             dispatched.append(task)
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _capture_resume)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _capture_resume)
         await worker._handle_orphan_tasks_on_start()
         # 等后台 dispatcher（含 orphan-dispatcher + provider 桶 sub-task）完成
         for _ in range(50):
@@ -1921,7 +1962,7 @@ class TestGenerationWorker:
         assert dispatched[0]["task_id"] == "ark-orphan"
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_fast_path_returns_immediately(self, monkeypatch):
+    async def test_handle_orphan_fast_path_returns_immediately(self, monkeypatch, staged_project):
         """fast path 不阻塞——5 个可 resume orphan + video_max=2，
         `_handle_orphan_tasks_on_start` 应几乎立刻返回（< 100ms），
         实际 dispatch 由后台 dispatcher 处理。"""
@@ -1931,11 +1972,11 @@ class TestGenerationWorker:
         queue._orphans = [_storyboard_orphan(f"orphan-{i}", job_id=f"job-{i}") for i in range(5)]
         worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 2}}))
 
-        # 让 _process_resume_task block 住——验证 fast path 不等它完成
-        async def _block_forever(self, task):
+        # 让 resume 执行入口 block 住——验证 fast path 不等它完成
+        async def _block_forever(_task, *, job_id):
             await asyncio.Event().wait()
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _block_forever)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _block_forever)
 
         start = time.monotonic()
         await worker._handle_orphan_tasks_on_start()
@@ -1951,7 +1992,7 @@ class TestGenerationWorker:
         await asyncio.sleep(0)
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_dispatcher_respects_pool_capacity(self, monkeypatch):
+    async def test_handle_orphan_dispatcher_respects_pool_capacity(self, monkeypatch, staged_project):
         """后台 dispatcher 受 video 容量约束分批 promote 进 INFLIGHT，
         任一时刻 inflight 占用 ≤ cap（pending 不消耗 sem，不计入此上限）。"""
         queue = _FakeQueue()
@@ -1966,12 +2007,13 @@ class TestGenerationWorker:
         def _inflight() -> int:
             return len(_phase_ids(worker._slots, "ark", "video")[0])
 
-        async def _gated(self, task):
+        async def _gated(task, *, job_id):
             snapshots.append(_inflight())
             entered.append(task["task_id"])
             await gates[task["task_id"]].wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
         await worker._handle_orphan_tasks_on_start()
         # 让 dispatcher 把前 2 个 promote 进 INFLIGHT（其余 2 个 PENDING 排队）
@@ -2010,7 +2052,7 @@ class TestGenerationWorker:
         await asyncio.sleep(0)
 
     @pytest.mark.asyncio
-    async def test_handle_orphan_dispatcher_exits_on_stop_event(self, monkeypatch):
+    async def test_handle_orphan_dispatcher_exits_on_stop_event(self, monkeypatch, staged_project):
         """`_stop_event` 触发时 dispatcher 干净退出，不再 dispatch 剩余 orphan。"""
         queue = _FakeQueue()
         queue._orphans = [_storyboard_orphan(f"orphan-{i}", job_id=f"job-{i}") for i in range(3)]
@@ -2020,13 +2062,14 @@ class TestGenerationWorker:
         first_dispatched = asyncio.Event()
         block_gate = asyncio.Event()
 
-        async def _maybe_block(self, task):
+        async def _maybe_block(_task, *, job_id):
             nonlocal dispatched_count
             dispatched_count += 1
             first_dispatched.set()
             await block_gate.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _maybe_block)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _maybe_block)
 
         await worker._handle_orphan_tasks_on_start()
         # 等第一个 orphan 进 inflight
@@ -2146,7 +2189,7 @@ class TestGenerationWorker:
         assert not queue.failed[0][1].startswith("[resume_")
 
     @pytest.mark.asyncio
-    async def test_process_resume_task_script_edit_error_encodes_key(self, monkeypatch):
+    async def test_process_resume_task_script_edit_error_encodes_key(self, monkeypatch, staged_project):
         """resume_executor 复用 _finalize_reference_video_unit 等 finalize helper，同样会抛
         ScriptEditError；resume 路径与常规 _process_task 走同一份 _encode_task_failure_message，
         不能因为是重启自愈这条独立调用链就退回 str(exc) 的固定中文。"""
@@ -2157,8 +2200,7 @@ class TestGenerationWorker:
             raise ScriptEditError("generated_assets 必须是 dict", key="script_edit_generated_assets_invalid")
 
         monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _raise_script_edit_error)
-        cleanup = AsyncMock()
-        monkeypatch.setattr(GenerationWorker, "_cleanup_video_staging", cleanup)
+        staged = _stage_task_dir(staged_project, "resume_script_edit")
         task = {
             "task_id": "resume_script_edit",
             "task_type": "reference_video",
@@ -2176,7 +2218,7 @@ class TestGenerationWorker:
             "resume_script_edit",
             "[script_edit_generated_assets_invalid]",
         )
-        cleanup.assert_awaited_once_with(task)
+        assert not staged.exists(), "终态落定后必须清掉该任务的 provider media staging"
 
     @pytest.mark.asyncio
     async def test_process_resume_task_cancelled_error(self, monkeypatch):
@@ -2215,36 +2257,48 @@ class TestDispatcherFailFastAndPendingTracking:
     """dispatcher fail-fast + pending/inflight 分集合精确容量与 cancel 跟踪。"""
 
     @pytest.mark.asyncio
-    async def test_dispatch_provider_bucket_fail_fast_when_video_max_zero(self, monkeypatch):
-        """video 容量=0 → 直接 mark_failed[resume_unsupported]，不进 Semaphore(0) 死锁。"""
+    async def test_dispatch_provider_bucket_fail_fast_when_video_max_zero(self, worker_db):
+        """video 容量=0 → 直接 mark_failed[resume_unsupported]，不进 Semaphore(0) 死锁。
+
+        容量 0 会先触发一次 reload 兜底：库里这个自定义供应商一个启用模型都没有，
+        video lane 因而被真实投影成 0，fail-fast 才落地。
+        """
+        from lib.db.repositories.custom_provider_repo import CustomProviderRepository
+
+        async with worker_db() as session:
+            provider = await CustomProviderRepository(session).create_provider(
+                display_name="no-models",
+                discovery_format="openai",
+                base_url="https://example.invalid",
+                api_key="k",
+            )
+            await session.commit()
+        provider_key = f"custom-{provider.id}"
+
         queue = _FakeQueue()
-        worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 0}}))
+        worker = GenerationWorker(queue=queue, capacity=_cap({provider_key: {"image": 0, "video": 0}}))
 
-        async def _no_reload(self):
-            return None
-
-        monkeypatch.setattr(GenerationWorker, "reload_limits", _no_reload)
-
-        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(3)]
-        await worker._dispatch_provider_bucket("ark", tasks)
+        tasks = [{"task_id": f"orphan-{i}", "provider_id": provider_key} for i in range(3)]
+        await worker._dispatch_provider_bucket(provider_key, tasks)
 
         assert {tid for tid, _ in queue.failed} == {"orphan-0", "orphan-1", "orphan-2"}
         assert all("[resume_unsupported_capacity_zero]" in msg for _, msg in queue.failed)
 
     @pytest.mark.asyncio
-    async def test_sub_task_registered_in_pending_before_sem_acquire(self, monkeypatch):
+    async def test_sub_task_registered_in_pending_before_sem_acquire(self, monkeypatch, staged_project):
         """sem=1 + 2 task：第 2 个 sub-task sem 排队期间应以 PENDING 登记在台账。"""
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 1}}))
 
         gate = asyncio.Event()
 
-        async def _gated(self, task):
+        async def _gated(_task, *, job_id):
             await gate.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
-        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        tasks = [_storyboard_resume_task(f"orphan-{i}", job_id=f"job-{i}") for i in range(2)]
         dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
 
         for _ in range(20):
@@ -2262,7 +2316,7 @@ class TestDispatcherFailFastAndPendingTracking:
         await dispatcher
 
     @pytest.mark.asyncio
-    async def test_request_cancel_finds_sem_queued_task_in_pending(self, monkeypatch):
+    async def test_request_cancel_finds_sem_queued_task_in_pending(self, monkeypatch, staged_project):
         """cancel sem 排队中的 task → request_cancel 命中并触发 cancel。"""
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 1}}))
@@ -2270,13 +2324,14 @@ class TestDispatcherFailFastAndPendingTracking:
         gate = asyncio.Event()
         process_started: asyncio.Event = asyncio.Event()
 
-        async def _gated(self, task):
+        async def _gated(_task, *, job_id):
             process_started.set()
             await gate.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
-        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        tasks = [_storyboard_resume_task(f"orphan-{i}", job_id=f"job-{i}") for i in range(2)]
         dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
 
         await asyncio.wait_for(process_started.wait(), timeout=1.0)
@@ -2290,7 +2345,7 @@ class TestDispatcherFailFastAndPendingTracking:
         await dispatcher
 
     @pytest.mark.asyncio
-    async def test_sem_queued_cancel_marks_task_cancelled(self, monkeypatch):
+    async def test_sem_queued_cancel_marks_task_cancelled(self, monkeypatch, staged_project):
         """sem 排队期被 cancel：_run_one 应显式 mark_task_cancelled，DB 不留 cancelling。"""
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 1}}))
@@ -2298,13 +2353,14 @@ class TestDispatcherFailFastAndPendingTracking:
         gate = asyncio.Event()
         first_started = asyncio.Event()
 
-        async def _gated(self, task):
+        async def _gated(_task, *, job_id):
             first_started.set()
             await gate.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
-        tasks = [{"task_id": f"orphan-{i}", "provider_id": "ark"} for i in range(2)]
+        tasks = [_storyboard_resume_task(f"orphan-{i}", job_id=f"job-{i}") for i in range(2)]
         dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
 
         # 等第 1 个 task 进入 _process_resume_task（占住 sem），第 2 个还在 sem 排队
@@ -2326,27 +2382,37 @@ class TestDispatcherFailFastAndPendingTracking:
         assert "orphan-1" in cancelled_ids
 
     @pytest.mark.asyncio
-    async def test_acquired_pre_process_cancel_marks_task_cancelled(self, monkeypatch):
+    async def test_acquired_pre_process_cancel_marks_task_cancelled(self, staged_project):
         """acquire 后、_process_resume_task 入 try 之前 cancel：_run_one 应兜底 mark cancelled。
 
-        模拟场景：_process_resume_task 内部 try 块之前还有 await（如 _extract_provider），
-        cancel 在那段 await 抛 CancelledError，内部不会调 mark，必须由 _run_one 兜底。
+        漏窗就是 _process_resume_task 内 try 块之前那段 provider 投影 await：cancel 落在
+        那里时内部不会调 mark，必须由 _run_one 兜底。任务不带 checkpoint 才会走到投影。
         """
         queue = _FakeQueue()
-        worker = GenerationWorker(queue=queue, capacity=_cap({"ark": {"image": 0, "video": 1}}))
 
         acquired_event = asyncio.Event()
         pre_try_gate = asyncio.Event()
 
-        async def _fake_resume_task(self, task):
-            # 模拟 acquired=True 后、try 块之前的 await（即漏窗）
+        async def _blocked_projection(_task):
             acquired_event.set()
             await pre_try_gate.wait()
-            # 一般不会走到这里——测试通过 cancel queued_task 中断
+            return "ark"
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _fake_resume_task)
+        worker = GenerationWorker(
+            queue=queue,
+            capacity=_cap({"ark": {"image": 0, "video": 1}}),
+            provider_projection=_blocked_projection,
+        )
 
-        tasks = [{"task_id": "orphan-pre-try", "provider_id": "ark"}]
+        tasks = [
+            {
+                "task_id": "orphan-pre-try",
+                "provider_id": "ark",
+                "media_type": "video",
+                "provider_job_id": "job-pre-try",
+                "project_name": "demo",
+            }
+        ]
         dispatcher = asyncio.create_task(worker._dispatch_provider_bucket("ark", tasks))
 
         # 等 _process_resume_task 进入空窗（await pre_try_gate.wait() 期间）
@@ -2365,7 +2431,7 @@ class TestDispatcherFailFastAndPendingTracking:
         assert "orphan-pre-try" in {tid for tid, _ in queue.cancelled}
 
     @pytest.mark.asyncio
-    async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch):
+    async def test_dispatcher_handle_set_after_handle_orphan(self, monkeypatch, staged_project):
         """_handle_orphan_tasks_on_start 后 self._orphan_dispatcher_task 应被设置。"""
         queue = _FakeQueue()
         queue._orphans = [_storyboard_orphan("orphan-x", job_id="job-x")]
@@ -2373,10 +2439,11 @@ class TestDispatcherFailFastAndPendingTracking:
 
         block = asyncio.Event()
 
-        async def _gated(self, task):
+        async def _gated(_task, *, job_id):
             await block.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
         await worker._handle_orphan_tasks_on_start()
         assert worker._orphan_dispatcher_task is not None
@@ -2418,7 +2485,7 @@ class TestOrphanScanSelfPreemption:
         fut.set_result(None)
 
     @pytest.mark.asyncio
-    async def test_video_inflight_not_dispatched_to_resume(self, monkeypatch):
+    async def test_video_inflight_not_dispatched_to_resume(self):
         """本进程 video_inflight 含 task → 孤儿扫描应跳过，不启动重复 resume 流。"""
         queue = _FakeQueue()
         queue._orphans = [
@@ -2438,19 +2505,10 @@ class TestOrphanScanSelfPreemption:
         fut = loop.create_future()
         worker._slots.register("ark", "video", "vid-active", fut)
 
-        captured: list[dict[str, Any]] = []
-
-        async def _spy_dispatch(self, mapping):
-            captured.append(dict(mapping))
-
-        monkeypatch.setattr(GenerationWorker, "_dispatch_resume_orphans_background", _spy_dispatch)
-
         await worker._handle_orphan_tasks_on_start()
 
-        # 主断言：dispatcher 句柄从未被创建（同步检查，不受 spy 调度时机影响）
+        # dispatcher 句柄从未被创建 → 本进程 inflight 的 task 没有被重复 dispatch
         assert worker._orphan_dispatcher_task is None
-        # 兜底：spy 也确认未被调用（dispatcher 即便创建也会因 mapping 为空跳过）
-        assert captured == [], f"本进程 inflight 的 task 不应被重复 dispatch: {captured}"
         assert "vid-active" not in {tid for tid, _ in queue.failed}
         fut.set_result(None)
 
@@ -2488,7 +2546,7 @@ class TestOrphanDispatcherNonBlockingOverride:
     （避免错误中断 in-flight resume）。"""
 
     @pytest.mark.asyncio
-    async def test_old_dispatcher_not_awaited_on_re_scan(self, monkeypatch):
+    async def test_old_dispatcher_not_awaited_on_re_scan(self, monkeypatch, staged_project):
         """旧 dispatcher 跑 5s 时，再次进 _handle_orphan_tasks_on_start 应秒级返回（不阻塞）。"""
         queue = _FakeQueue()
         queue._orphans = [_storyboard_orphan("orphan-x", job_id="job-x")]
@@ -2496,10 +2554,11 @@ class TestOrphanDispatcherNonBlockingOverride:
 
         block = asyncio.Event()
 
-        async def _gated(self, task):
+        async def _gated(_task, *, job_id):
             await block.wait()
+            return {"job_id": job_id}
 
-        monkeypatch.setattr(GenerationWorker, "_process_resume_task", _gated)
+        monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _gated)
 
         # 第 1 次扫描：启动旧 dispatcher
         await worker._handle_orphan_tasks_on_start()

--- a/tests/integration/lib/test_media_generator_module.py
+++ b/tests/integration/lib/test_media_generator_module.py
@@ -1,7 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -841,11 +841,25 @@ class TestMediaGenerator:
             actual_duration_seconds=6.2,
             problems=(),
         )
+        # 重载协程本体照跑，只把它的三个协作者换成替身。
+        pm = MagicMock()
+        pm.load_project.return_value = {
+            "name": "demo",
+            "episodes": [{"episode": 1, "script_file": "episode_1.json"}],
+        }
+        pm.get_project_path.return_value = gen.project_path
+        pm.load_script.return_value = {
+            "episode": 1,
+            "content_mode": "narration",
+            "segments": [{"segment_id": "E1S01", "narration": "旁白。", "duration_seconds": 8}],
+        }
+        monkeypatch.setattr(narration_delivery_tasks, "get_project_manager", lambda: pm)
         monkeypatch.setattr(
             narration_delivery_tasks,
-            "_prepare_current_task_narration_delivery",
+            "prepare_current_narration_delivery",
             AsyncMock(return_value=narration),
         )
+        monkeypatch.setattr(narration_delivery_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
 
         with pytest.raises(NarratedVideoDurationBlockedError):
             await narration_delivery_tasks.require_generated_video_covers_current_tts(

--- a/tests/integration/lib/test_media_generator_module.py
+++ b/tests/integration/lib/test_media_generator_module.py
@@ -841,7 +841,13 @@ class TestMediaGenerator:
             actual_duration_seconds=6.2,
             problems=(),
         )
-        # 重载协程本体照跑，只把它的三个协作者换成替身。
+
+        # 重载协程本体照跑，只把它的三个协作者换成替身；在途 TTS 判定仍走真实代码，
+        # 空闲由生成队列的空结果给出。
+        class _IdleQueue:
+            async def get_active_tasks_for_resources(self, **_kwargs) -> list[dict]:
+                return []
+
         pm = MagicMock()
         pm.load_project.return_value = {
             "name": "demo",
@@ -859,7 +865,7 @@ class TestMediaGenerator:
             "prepare_current_narration_delivery",
             AsyncMock(return_value=narration),
         )
-        monkeypatch.setattr(narration_delivery_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
+        monkeypatch.setattr(narration_delivery_tasks, "get_generation_queue", _IdleQueue)
 
         with pytest.raises(NarratedVideoDurationBlockedError):
             await narration_delivery_tasks.require_generated_video_covers_current_tts(

--- a/tests/integration/server/routers/projects_router_support.py
+++ b/tests/integration/server/routers/projects_router_support.py
@@ -3,9 +3,11 @@
 import json
 import re
 import shutil
+from collections.abc import Callable
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
+from typing import Any, cast
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -441,3 +443,8 @@ def _client(monkeypatch, fake_pm, fake_summaries=None):
     app.include_router(projects.self_auth_router, prefix="/api/v1")
     register_error_handlers(app)
     return TestClient(app)
+
+
+def _override(client: TestClient, dependency: Callable[..., Any], provider: Callable[..., Any]) -> None:
+    """给 ``_client`` 建好的 app 补挂依赖覆盖（``TestClient.app`` 的静态类型只是裸 ASGI 可调用）。"""
+    cast(FastAPI, client.app).dependency_overrides[dependency] = provider

--- a/tests/integration/server/routers/projects_router_support.py
+++ b/tests/integration/server/routers/projects_router_support.py
@@ -430,10 +430,12 @@ class _FakeSummaries:
 
 def _client(monkeypatch, fake_pm, fake_summaries=None):
     monkeypatch.setattr(projects, "get_project_manager", lambda: fake_pm)
-    monkeypatch.setattr(projects, "get_workflow_state_service", lambda: fake_summaries or _FakeSummaries())
-    monkeypatch.setattr(projects, "get_script_batch_editor", lambda manager=None: _FakeBatchEditor(manager or fake_pm))
 
     app = FastAPI()
+    app.dependency_overrides[projects.get_workflow_state_service] = lambda: fake_summaries or _FakeSummaries()
+    app.dependency_overrides[projects.get_script_batch_editor_factory] = lambda: (
+        lambda manager=None: _FakeBatchEditor(manager or fake_pm)
+    )
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="default", sub="testuser", role="admin")
     app.include_router(projects.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
     app.include_router(projects.self_auth_router, prefix="/api/v1")

--- a/tests/integration/server/routers/test_end_frames_router.py
+++ b/tests/integration/server/routers/test_end_frames_router.py
@@ -5,6 +5,7 @@
 """
 
 import asyncio
+import json
 import threading
 from collections.abc import Callable
 from io import BytesIO
@@ -19,6 +20,7 @@ from PIL import Image
 
 from lib.data_validator import DataValidator
 from lib.i18n import _ as i18n_message
+from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
 from lib.script_editor import ScriptEditError
 from lib.version_manager import VersionManager
@@ -32,6 +34,37 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 END_FRAME_REL = "end_frames/scene_E1S01.png"
 
 
+class _ScriptIOHooks:
+    """``ProjectManager`` 剧本读写 seam 的可变挂钩。
+
+    缺省透传真实读写；用例把 ``read`` / ``write`` 换成注入实现，即可在「临界区内读盘」与
+    「临界区内写盘」这两个精确位置制造失败与并发交错，无需替换管理器的内部方法。
+    """
+
+    def __init__(self) -> None:
+        self.read: Callable[[Path], dict] | None = None
+        self.write: Callable[[Path, dict], None] | None = None
+
+    @staticmethod
+    def real_read(path: Path) -> dict:
+        if not path.exists():
+            raise FileNotFoundError(f"剧本文件不存在: {path}")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def real_write(path: Path, script: dict) -> None:
+        atomic_write_json(path, script)
+
+    def reader(self, path: Path) -> dict:
+        return self.read(path) if self.read is not None else self.real_read(path)
+
+    def writer(self, path: Path, script: dict) -> None:
+        if self.write is not None:
+            self.write(path, script)
+        else:
+            self.real_write(path, script)
+
+
 def _img_bytes(fmt="JPEG", size=(8, 8), color=(255, 0, 0)):
     image = Image.new("RGB", size, color)
     buf = BytesIO()
@@ -39,8 +72,8 @@ def _img_bytes(fmt="JPEG", size=(8, 8), color=(255, 0, 0)):
     return buf.getvalue()
 
 
-def _seed_project(tmp_path) -> ProjectManager:
-    pm = ProjectManager(tmp_path / "projects")
+def _seed_project(tmp_path, hooks: _ScriptIOHooks) -> ProjectManager:
+    pm = ProjectManager(tmp_path / "projects", script_reader=hooks.reader, script_writer=hooks.writer)
     pm.create_project("demo")
     pm.create_project_metadata("demo", "Demo", "Anime", "narration")
     pm.save_script(
@@ -82,8 +115,13 @@ def _build_client(pm: ProjectManager, monkeypatch) -> TestClient:
 
 
 @pytest.fixture
-def end_frames_client(tmp_path, monkeypatch):
-    pm = _seed_project(tmp_path)
+def script_io(tmp_path) -> _ScriptIOHooks:
+    return _ScriptIOHooks()
+
+
+@pytest.fixture
+def end_frames_client(tmp_path, monkeypatch, script_io):
+    pm = _seed_project(tmp_path, script_io)
     return _build_client(pm, monkeypatch), pm
 
 
@@ -312,11 +350,11 @@ class _InterleavedResponses(NamedTuple):
 
 
 def _interleave_across_critical_section(
-    monkeypatch, first: Callable[[], httpx.Response], second: Callable[[], httpx.Response]
+    script_io: _ScriptIOHooks, first: Callable[[], httpx.Response], second: Callable[[], httpx.Response]
 ) -> _InterleavedResponses:
     """让 `first` 停在剧本锁临界区内，确认 `second` 被锁挡在外面后再放行，返回两者的响应。
 
-    交错点由钩子对齐而非靠线程调度碰运气：钩子挂在锁内的剧本持久化上（`locked_script`
+    交错点由钩子对齐而非靠线程调度碰运气：钩子挂在剧本写盘 seam 上（`locked_script`
     退出前的最后一步），此时先到的一方已经做完自己的文件副作用、字段写回尚未落盘——正是
     「一方写完文件、对方抢在字段写回前动手」这一悬空引用场景的临界点。后到的一方在此期间
     必须仍被剧本锁挡住：它若能完成，就说明两段操作没有真正互斥。
@@ -329,22 +367,21 @@ def _interleave_across_critical_section(
     的一方也可能因窗口内尚未跑完而漏报；但绝不会反过来把守规矩的实现判成失败，故不引入
     时序敏感性。不带锁的整条 set/clear 是毫秒级，窗口取值远宽于此。
     """
-    original = ProjectManager._write_script_unlocked
     entered_section = threading.Event()
     resume = threading.Event()
     gate_lock = threading.Lock()
     gate_open = True
 
-    def _gated_persist(self, *args, **kwargs):
+    def _gated_persist(path: Path, script: dict) -> None:
         nonlocal gate_open
         with gate_lock:
             take_gate, gate_open = gate_open, False
         if take_gate:
             entered_section.set()
             assert resume.wait(timeout=10), "主线程未放行临界区"
-        return original(self, *args, **kwargs)
+        script_io.real_write(path, script)
 
-    monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _gated_persist)
+    script_io.write = _gated_persist
 
     results: dict[str, httpx.Response] = {}
     errors: dict[str, BaseException] = {}
@@ -381,13 +418,13 @@ def _interleave_across_critical_section(
 class TestConcurrentSetClear:
     """设置与清除并发交错时，字段与快照文件必须同进同退，不留悬空引用。"""
 
-    def test_clear_blocked_until_set_leaves_critical_section(self, end_frames_client, monkeypatch):
+    def test_clear_blocked_until_set_leaves_critical_section(self, end_frames_client, script_io):
         """设置先进临界区：清除被挡到设置整段完成之后，最终状态是「清除赢」且无残留引用。"""
         c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
         results = _interleave_across_critical_section(
-            monkeypatch,
+            script_io,
             first=lambda: _upload(c, _img_bytes("PNG")),
             second=lambda: _delete(c),
         )
@@ -398,14 +435,14 @@ class TestConcurrentSetClear:
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
 
-    def test_set_blocked_until_clear_leaves_critical_section(self, end_frames_client, monkeypatch):
+    def test_set_blocked_until_clear_leaves_critical_section(self, end_frames_client, script_io):
         """清除先进临界区：设置被挡到清除整段完成之后，最终字段非空且快照文件在位。"""
         c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         assert _upload(c, _img_bytes("PNG")).status_code == 200
 
         results = _interleave_across_critical_section(
-            monkeypatch,
+            script_io,
             first=lambda: _delete(c),
             second=lambda: _upload(c, _img_bytes("PNG")),
         )
@@ -417,25 +454,26 @@ class TestConcurrentSetClear:
         assert snapshot.exists()
 
 
-def _fail_first_persist(monkeypatch):
-    """让下一次剧本持久化失败一次，随后（补偿回滚重新过锁触发的第二次）恢复原实现。
+def _fail_first_persist(script_io: _ScriptIOHooks) -> None:
+    """让下一次剧本持久化失败一次，随后（补偿回滚重新过锁触发的第二次）恢复真实写盘。
 
     补偿回滚本身也要走一次 `locked_script`（读快照现状、必要时改写、重新持久化），若一律
     拦截会连回滚自身的持久化也打断，所以只失败第一次。
     """
-    original = ProjectManager._write_script_unlocked
     calls = {"n": 0}
 
-    def _boom(self, *args, **kwargs):
+    def _boom(path: Path, script: dict) -> None:
         calls["n"] += 1
         if calls["n"] == 1:
             raise ValueError("simulated persist failure")
-        return original(self, *args, **kwargs)
+        script_io.real_write(path, script)
 
-    monkeypatch.setattr(ProjectManager, "_write_script_unlocked", _boom)
+    script_io.write = _boom
 
 
-def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, content: bytes | None, n: int):
+def _inject_concurrent_takeover_before_nth_load(
+    script_io: _ScriptIOHooks, key, target: Path, content: bytes | None, n: int
+) -> None:
     """模拟「回滚重新过锁前，另一个并发请求已抢先完整地执行完自己的一次操作」。
 
     回滚判定的是「操作代次」而非文件内容（见 end_frame.py 模块 docstring 的退化值说明），
@@ -443,14 +481,12 @@ def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, 
     `content=None` 表示并发的那一次是清除（文件被删）；否则表示并发的那一次是设置。
 
     补偿回滚会再发起一次 `locked_script`，其剧本读取即回滚临界区的起点——在其第 n 次被
-    调用时执行注入的「并发接管」，相当于恰好在回滚拿到锁之前完成。挂钩点取底层的
-    `_read_script_unlocked`：锁外的 `load_script` 与锁内的读-改-写都经它读盘，计数才覆盖
-    两类临界区起点。
+    调用时执行注入的「并发接管」，相当于恰好在回滚拿到锁之前完成。挂钩点取剧本读盘 seam：
+    锁外的 `load_script` 与锁内的读-改-写都经它读盘，计数才覆盖两类临界区起点。
     """
-    original = ProjectManager._read_script_unlocked
     calls = {"n": 0}
 
-    def _load_with_race(self, *args, **kwargs):
+    def _load_with_race(path: Path) -> dict:
         calls["n"] += 1
         if calls["n"] == n:
             end_frame_service._advance_shot_generation(key)
@@ -458,21 +494,21 @@ def _inject_concurrent_takeover_before_nth_load(monkeypatch, key, target: Path, 
                 target.unlink(missing_ok=True)
             else:
                 target.write_bytes(content)
-        return original(self, *args, **kwargs)
+        return script_io.real_read(path)
 
-    monkeypatch.setattr(ProjectManager, "_read_script_unlocked", _load_with_race)
+    script_io.read = _load_with_race
 
 
 class TestPersistFailureRestoresSnapshot:
     """剧本持久化在临界区内失败时，快照文件须回滚到操作前状态，不留悬空引用或静默丢失。"""
 
-    def test_set_failure_restores_previous_snapshot_bytes(self, end_frames_client, monkeypatch):
+    def test_set_failure_restores_previous_snapshot_bytes(self, end_frames_client, script_io):
         c, pm = end_frames_client
         _upload(c, _img_bytes("PNG", size=(8, 8)))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
 
-        _fail_first_persist(monkeypatch)
+        _fail_first_persist(script_io)
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 500
 
@@ -480,25 +516,25 @@ class TestPersistFailureRestoresSnapshot:
         assert _segment(pm)["end_frame_image"] == END_FRAME_REL
         assert snapshot.read_bytes() == before
 
-    def test_set_failure_on_first_write_removes_snapshot(self, end_frames_client, monkeypatch):
+    def test_set_failure_on_first_write_removes_snapshot(self, end_frames_client, script_io):
         """此前未设置过尾帧时失败：快照文件此前不存在，须整段撤回而非留下孤儿文件。"""
         c, pm = end_frames_client
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
-        _fail_first_persist(monkeypatch)
+        _fail_first_persist(script_io)
         resp = _upload(c, _img_bytes("PNG"))
         assert resp.status_code == 500
 
         assert _segment(pm).get("end_frame_image") is None
         assert not snapshot.exists()
 
-    def test_clear_failure_restores_deleted_snapshot(self, end_frames_client, monkeypatch):
+    def test_clear_failure_restores_deleted_snapshot(self, end_frames_client, script_io):
         c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         before = snapshot.read_bytes()
 
-        _fail_first_persist(monkeypatch)
+        _fail_first_persist(script_io)
         resp = _delete(c)
         assert resp.status_code == 500
 
@@ -507,7 +543,7 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == before
 
-    def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, end_frames_client, monkeypatch):
+    def test_set_failure_skips_restore_when_concurrent_write_supersedes(self, end_frames_client, script_io):
         """回滚重新过锁时若该分镜的操作代次已前移，说明并发请求已经接管，
         必须跳过回滚——否则会用陈旧字节覆盖对方刚成功落盘的内容。"""
         c, pm = end_frames_client
@@ -515,24 +551,24 @@ class TestPersistFailureRestoresSnapshot:
         key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(32, 32))
 
-        _fail_first_persist(monkeypatch)
+        _fail_first_persist(script_io)
         # load 序列：_locate_shot(1) → 本次失败的 locked_script(2) → 回滚的 locked_script(3)
-        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, concurrent_bytes, n=3)
+        _inject_concurrent_takeover_before_nth_load(script_io, key, snapshot, concurrent_bytes, n=3)
 
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 500
 
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, end_frames_client, monkeypatch):
+    def test_clear_failure_skips_restore_when_concurrent_write_recreates_snapshot(self, end_frames_client, script_io):
         c, pm = end_frames_client
         _upload(c, _img_bytes("PNG"))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(40, 40))
 
-        _fail_first_persist(monkeypatch)
-        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, concurrent_bytes, n=3)
+        _fail_first_persist(script_io)
+        _inject_concurrent_takeover_before_nth_load(script_io, key, snapshot, concurrent_bytes, n=3)
 
         resp = _delete(c)
         assert resp.status_code == 500
@@ -541,7 +577,7 @@ class TestPersistFailureRestoresSnapshot:
         assert snapshot.exists()
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, end_frames_client, monkeypatch):
+    def test_clear_failure_skips_restore_when_concurrent_clear_wins(self, end_frames_client, script_io):
         """退化值场景：清除失败后文件已被删（期望内容与「无人接手」的期望值同为 None），
         并发的另一次清除随后也成功完成，结果同样是文件不存在——若
         仅比对文件内容将无法区分两者，误判为无人接手并把旧快照字节回滚出孤儿文件。
@@ -551,8 +587,8 @@ class TestPersistFailureRestoresSnapshot:
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
         key = ("demo", "episode_1.json", "E1S01")
 
-        _fail_first_persist(monkeypatch)
-        _inject_concurrent_takeover_before_nth_load(monkeypatch, key, snapshot, None, n=3)
+        _fail_first_persist(script_io)
+        _inject_concurrent_takeover_before_nth_load(script_io, key, snapshot, None, n=3)
 
         resp = _delete(c)
         assert resp.status_code == 500
@@ -560,7 +596,7 @@ class TestPersistFailureRestoresSnapshot:
         # 回滚跳过：文件保持并发清除后的「已删除」结果，没有被旧字节重新写回制造孤儿文件
         assert not snapshot.exists()
 
-    def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, end_frames_client, monkeypatch):
+    def test_set_failure_skips_restore_when_concurrent_takeover_uses_other_alias(self, end_frames_client, script_io):
         """别名归一：失败的这次操作用 `scripts/episode_1.json` 这个别名，
         代次键若不归一化会与并发接管（用 `episode_1.json` 归一后的键）各自生成一把代次，
         互相看不见——回滚会误判「无人接手」，用旧字节覆盖对方已成功落盘的内容。"""
@@ -569,8 +605,8 @@ class TestPersistFailureRestoresSnapshot:
         normalized_key = ("demo", "episode_1.json", "E1S01")
         concurrent_bytes = _img_bytes("PNG", size=(48, 48))
 
-        _fail_first_persist(monkeypatch)
-        _inject_concurrent_takeover_before_nth_load(monkeypatch, normalized_key, snapshot, concurrent_bytes, n=3)
+        _fail_first_persist(script_io)
+        _inject_concurrent_takeover_before_nth_load(script_io, normalized_key, snapshot, concurrent_bytes, n=3)
 
         resp = c.post(
             "/api/v1/projects/demo/shots/E1S01/end-frame/upload?script_file=scripts/episode_1.json",
@@ -581,29 +617,28 @@ class TestPersistFailureRestoresSnapshot:
         # 未归一化则代次键不同，回滚会看不到接管、用旧字节覆盖并发写入的新内容
         assert snapshot.read_bytes() == concurrent_bytes
 
-    def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, end_frames_client, monkeypatch):
+    def test_set_failure_restore_uses_bytes_read_inside_critical_section(self, end_frames_client, script_io):
         """陈旧基线问题：`old_bytes` 若在取得剧本锁之前预读，读到的是「进入临界区之前」
         而非「进入临界区那一刻」的文件内容。这里不推进代次，只在本次操作自己的
-        `_read_script_unlocked` 调用（进入临界区的时点）直接改写文件——代次检查不会拦截
+        剧本读盘（进入临界区的时点）直接改写文件——代次检查不会拦截
         （因为没有别的操作声称接管），能否回滚出这份改写后的内容，才真正区分基线是在
         锁内读还是锁外预读：锁外预读会读到改写前的旧内容，回滚会把改写后的内容覆盖掉。"""
         c, pm = end_frames_client
         _upload(c, _img_bytes("PNG", size=(8, 8)))
         snapshot = pm.get_project_path("demo") / END_FRAME_REL
 
-        original_read_script = ProjectManager._read_script_unlocked
         calls = {"n": 0}
         content_at_critical_section_entry = _img_bytes("PNG", size=(56, 56))
 
-        def _load_with_rewrite(self, *args, **kwargs):
+        def _load_with_rewrite(path: Path) -> dict:
             calls["n"] += 1
             # 读盘序列：_locate_shot(1) → 失败操作自身的 locked_script(2)
             if calls["n"] == 2:
                 snapshot.write_bytes(content_at_critical_section_entry)
-            return original_read_script(self, *args, **kwargs)
+            return script_io.real_read(path)
 
-        monkeypatch.setattr(ProjectManager, "_read_script_unlocked", _load_with_rewrite)
-        _fail_first_persist(monkeypatch)
+        script_io.read = _load_with_rewrite
+        _fail_first_persist(script_io)
 
         resp = _upload(c, _img_bytes("PNG", size=(16, 16)))
         assert resp.status_code == 500

--- a/tests/integration/server/routers/test_generate_router.py
+++ b/tests/integration/server/routers/test_generate_router.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from lib.artifact_activation import ArtifactKey, register_current_artifact_if_provable
+from lib.config.resolver import ConfigResolver, ProviderModel
 from lib.i18n import _ as i18n_message
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.auth import CurrentUserInfo, get_current_user
@@ -201,7 +202,13 @@ class TestGenerateRouter:
         fake_pm = _FakePM(project_path)
         fake_queue = _FakeQueue()
         client = _client(monkeypatch, fake_pm, fake_queue)
-        monkeypatch.setattr(generate, "_require_audio_provider_configured", AsyncMock(return_value="audio"))
+
+        async def _resolve_audio(_self, _project, _payload):
+            return ProviderModel("dashscope", "qwen3-tts-flash")
+
+        # 音频供应商解析器本身有 DB 依赖，替身落在解析这个协作者上；入口的「未配置即 400」
+        # 由 test_generate_router_tts 覆盖。
+        monkeypatch.setattr(ConfigResolver, "resolve_audio_backend", _resolve_audio)
         monkeypatch.setattr(
             generate,
             "active_narrated_video_resource_ids",
@@ -385,15 +392,37 @@ class TestGenerateRouter:
         client = _client(monkeypatch, fake_pm, fake_queue)
         captured: dict[str, object] = {}
 
+        from lib.narration_delivery import (
+            USE_TTS,
+            NarratedVideoDurationPreparation,
+            NarrationDeliveryPreparation,
+            NarrationTtsStatus,
+        )
+
         async def _project(**kwargs):
             captured.update(kwargs)
-            return object()
-
-        async def _localized(_preparation, _translator):
-            return {"allowed": True}
+            # 重投影的产物照真实形状给出，路由的本地化与放行判定因而照跑；
+            # cost 留空即不触发报价查询（该分支由本文件的报价用例覆盖）。
+            return NarratedVideoDurationPreparation(
+                narration=NarrationDeliveryPreparation(
+                    delivery=USE_TTS,
+                    unit_id="E1S01",
+                    speech_mode=None,
+                    tts_status=NarrationTtsStatus.CURRENT,
+                    artifact_path="audio/segment_E1S01.wav",
+                    basis_digest="current-audio-basis",
+                    actual_duration_seconds=3.5,
+                    problems=(),
+                ),
+                planned_duration_seconds=4,
+                duration_input=4,
+                request_duration_seconds=4,
+                adjustment="exact",
+                problems=(),
+                current_visual_duration_seconds=4,
+            )
 
         monkeypatch.setattr(generate, "prepare_current_storyboard_narrated_video_duration", _project)
-        monkeypatch.setattr(generate, "_localized_narrated_video_payload", _localized)
 
         with client:
             response = client.post(

--- a/tests/integration/server/routers/test_presentations_router.py
+++ b/tests/integration/server/routers/test_presentations_router.py
@@ -52,9 +52,9 @@ def _client(monkeypatch, tmp_path: Path, *, reader=None, bundle=None) -> TestCli
     register_error_handlers(app)
     app.include_router(presentations.router, prefix="/api/v1")
     if reader is not None:
-        monkeypatch.setattr(presentations, "get_presentation_read_model", lambda: reader)
+        app.dependency_overrides[presentations.get_presentation_read_model] = lambda: reader
     if bundle is not None:
-        monkeypatch.setattr(presentations, "get_presentation_bundle_service", lambda: bundle)
+        app.dependency_overrides[presentations.get_presentation_bundle_service] = lambda: bundle
     return TestClient(app, raise_server_exceptions=False)
 
 

--- a/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
+++ b/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
@@ -278,7 +278,9 @@ class TestProjectsRouter:
                 )
 
         client = _client(monkeypatch, fake_pm)
-        monkeypatch.setattr(projects, "get_script_batch_editor", lambda _manager=None: CapturingEditor())
+        client.app.dependency_overrides[projects.get_script_batch_editor_factory] = lambda: (
+            lambda _manager=None: CapturingEditor()
+        )
 
         with client:
             response = client.post(

--- a/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
+++ b/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
@@ -16,6 +16,7 @@ from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.integration.server.routers.projects_router_support import (
     _client,
     _FakePM,
+    _override,
 )
 
 
@@ -278,9 +279,7 @@ class TestProjectsRouter:
                 )
 
         client = _client(monkeypatch, fake_pm)
-        client.app.dependency_overrides[projects.get_script_batch_editor_factory] = lambda: (
-            lambda _manager=None: CapturingEditor()
-        )
+        _override(client, projects.get_script_batch_editor_factory, lambda: lambda _manager=None: CapturingEditor())
 
         with client:
             response = client.post(

--- a/tests/integration/server/routers/test_projects_error_leakage.py
+++ b/tests/integration/server/routers/test_projects_error_leakage.py
@@ -5,6 +5,7 @@ from server.routers import projects
 from tests.integration.server.routers.projects_router_support import (
     _client,
     _FakePM,
+    _override,
 )
 
 
@@ -241,7 +242,7 @@ class TestUnexpectedErrorsDoNotLeak:
         client = _client(monkeypatch, _FakePM(tmp_path))
         # scope 合法（默认 full）；_sync 里最早命中 get_project_manager()。
         # 归档服务改由依赖覆盖给出，免得同一个哨兵在依赖解析期就抛、绕过处理器兜底。
-        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
+        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.post("/api/v1/projects/ready/export/token")
@@ -253,7 +254,7 @@ class TestUnexpectedErrorsDoNotLeak:
         client = _client(monkeypatch, _FakePM(tmp_path))
         # download_token 校验先放行，再让归档服务抛 RuntimeError 落到兜底
         monkeypatch.setattr(projects, "verify_download_token", lambda token, name: {"sub": "u"})
-        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
+        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         with client:
             resp = client.get("/api/v1/projects/ready/export?download_token=tok&scope=full")
             assert resp.status_code == 500
@@ -263,7 +264,7 @@ class TestUnexpectedErrorsDoNotLeak:
         sentinel = "LEAKED_SECRET_import_archive"
         client = _client(monkeypatch, _FakePM(tmp_path))
         # 上传副本写盘成功后，_sync 调归档服务抛 RuntimeError，落到 JSONResponse(500) 兜底
-        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
+        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         with client:
             resp = client.post(
                 "/api/v1/projects/import",

--- a/tests/integration/server/routers/test_projects_error_leakage.py
+++ b/tests/integration/server/routers/test_projects_error_leakage.py
@@ -21,6 +21,22 @@ def _raise(sentinel):
     return _factory
 
 
+def _raising_service(sentinel):
+    """服务替身：任意方法一被调用即抛 RuntimeError(sentinel)。
+
+    经依赖覆盖注入，异常因而落在处理器体内，与被替换的内部函数同一位置。
+    """
+
+    class _Raising:
+        def __getattr__(self, _name):
+            def _call(*_a, **_k):
+                raise RuntimeError(sentinel)
+
+            return _call
+
+    return _Raising()
+
+
 class TestUnexpectedErrorsDoNotLeak:
     """未预期异常统一映射为通用 500，且响应体不得回显内部异常文本（不泄露）。
 
@@ -223,7 +239,9 @@ class TestUnexpectedErrorsDoNotLeak:
     def test_create_export_token_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_export_token"
         client = _client(monkeypatch, _FakePM(tmp_path))
-        # scope 合法（默认 full）；_sync 里最早命中 get_project_manager()
+        # scope 合法（默认 full）；_sync 里最早命中 get_project_manager()。
+        # 归档服务改由依赖覆盖给出，免得同一个哨兵在依赖解析期就抛、绕过处理器兜底。
+        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.post("/api/v1/projects/ready/export/token")
@@ -235,7 +253,7 @@ class TestUnexpectedErrorsDoNotLeak:
         client = _client(monkeypatch, _FakePM(tmp_path))
         # download_token 校验先放行，再让归档服务抛 RuntimeError 落到兜底
         monkeypatch.setattr(projects, "verify_download_token", lambda token, name: {"sub": "u"})
-        monkeypatch.setattr(projects, "get_archive_service", _raise(sentinel))
+        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
         with client:
             resp = client.get("/api/v1/projects/ready/export?download_token=tok&scope=full")
             assert resp.status_code == 500
@@ -245,7 +263,7 @@ class TestUnexpectedErrorsDoNotLeak:
         sentinel = "LEAKED_SECRET_import_archive"
         client = _client(monkeypatch, _FakePM(tmp_path))
         # 上传副本写盘成功后，_sync 调归档服务抛 RuntimeError，落到 JSONResponse(500) 兜底
-        monkeypatch.setattr(projects, "get_archive_service", _raise(sentinel))
+        client.app.dependency_overrides[projects.get_archive_service] = lambda: _raising_service(sentinel)
         with client:
             resp = client.post(
                 "/api/v1/projects/import",

--- a/tests/integration/server/routers/test_validators_audio_switch.py
+++ b/tests/integration/server/routers/test_validators_audio_switch.py
@@ -11,77 +11,62 @@ from types import SimpleNamespace
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.api_errors import BadRequestError
 from lib.config.service import ConfigService
-from lib.db.base import Base
 from server.routers._validators import require_audio_switch_supported
 
 _ALWAYS_AUDIBLE = "dashscope/wan2.7-i2v"
 _CONTROLLABLE = "ark/doubao-seedance-2-0-260128"
 
 
-async def _make_factory(**settings: str):
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    if settings:
-        async with factory() as session:
-            svc = ConfigService(session)
-            for key, value in settings.items():
-                await svc.set_setting(key, value)
-            await session.commit()
-    return factory, engine
+async def _seed_settings(factory: async_sessionmaker[AsyncSession], **settings: str) -> None:
+    async with factory() as session:
+        svc = ConfigService(session)
+        for key, value in settings.items():
+            await svc.set_setting(key, value)
+        await session.commit()
 
 
 class TestRequireAudioSwitchSupported:
-    async def test_always_audible_model_rejects_stored_off_setting(self, monkeypatch):
-        factory, engine = await _make_factory(default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="false")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            with pytest.raises(BadRequestError) as exc_info:
-                await require_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+    async def test_always_audible_model_rejects_stored_off_setting(self, db_factory, monkeypatch):
+        await _seed_settings(db_factory, default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="false")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        with pytest.raises(BadRequestError) as exc_info:
+            await require_audio_switch_supported({}, "i2v")
+
         assert exc_info.value.key == "video_audio_switch_not_supported"
         assert exc_info.value.params == {"provider": "dashscope", "model": "wan2.7-i2v"}
 
-    async def test_always_audible_model_rejects_project_level_off_override(self, monkeypatch):
+    async def test_always_audible_model_rejects_project_level_off_override(self, db_factory, monkeypatch):
         """项目覆盖优先于全局：全局开着、项目关掉，同样在入口拒绝。"""
-        factory, engine = await _make_factory(default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="true")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            with pytest.raises(BadRequestError):
-                await require_audio_switch_supported({"video_generate_audio": False}, "i2v")
-        finally:
-            await engine.dispose()
+        await _seed_settings(db_factory, default_video_backend=_ALWAYS_AUDIBLE, video_generate_audio="true")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
 
-    async def test_always_audible_model_passes_when_audio_is_on(self, monkeypatch):
-        factory, engine = await _make_factory(default_video_backend=_ALWAYS_AUDIBLE)
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await require_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+        with pytest.raises(BadRequestError):
+            await require_audio_switch_supported({"video_generate_audio": False}, "i2v")
 
-    async def test_controllable_model_keeps_the_off_setting(self, monkeypatch):
+    async def test_always_audible_model_passes_when_audio_is_on(self, db_factory, monkeypatch):
+        await _seed_settings(db_factory, default_video_backend=_ALWAYS_AUDIBLE)
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        # 预检放行即静默返回 None
+        assert await require_audio_switch_supported({}, "i2v") is None
+
+    async def test_controllable_model_keeps_the_off_setting(self, db_factory, monkeypatch):
         """开关可控的供应商行为不变：关闭意图能抵达请求，无声路径照常成立。"""
-        factory, engine = await _make_factory(default_video_backend=_CONTROLLABLE, video_generate_audio="false")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await require_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+        await _seed_settings(db_factory, default_video_backend=_CONTROLLABLE, video_generate_audio="false")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
 
-    async def test_no_provider_configured_passes_through(self, monkeypatch):
-        factory, engine = await _make_factory(video_generate_audio="false")
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await require_audio_switch_supported({}, "i2v")
-        finally:
-            await engine.dispose()
+        assert await require_audio_switch_supported({}, "i2v") is None
+
+    async def test_no_provider_configured_passes_through(self, db_factory, monkeypatch):
+        await _seed_settings(db_factory, video_generate_audio="false")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        assert await require_audio_switch_supported({}, "i2v") is None
 
 
 class TestResolutionFailurePassesThrough:
@@ -106,9 +91,11 @@ class TestResolutionFailurePassesThrough:
 
     async def test_backend_resolution_db_failure(self, monkeypatch):
         self._install_resolver(monkeypatch, backend_exc=SQLAlchemyError("db down"))
-        await require_audio_switch_supported({}, "i2v")
+
+        assert await require_audio_switch_supported({}, "i2v") is None
 
     async def test_audio_setting_db_failure(self, monkeypatch):
         """恒有声模型已解析出来，但读音频开关时数据库故障——同样放行。"""
         self._install_resolver(monkeypatch, audio_exc=SQLAlchemyError("db down"))
-        await require_audio_switch_supported({}, "i2v")
+
+        assert await require_audio_switch_supported({}, "i2v") is None

--- a/tests/integration/server/routers/test_validators_video_bucket.py
+++ b/tests/integration/server/routers/test_validators_video_bucket.py
@@ -7,53 +7,40 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from lib.api_errors import BadRequestError
 from lib.config.service import ConfigService
-from lib.db.base import Base
 from server.routers._validators import require_video_bucket_capability
 
 
-async def _make_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    return async_sessionmaker(engine, expire_on_commit=False), engine
+async def _set_default_video_backend(factory: async_sessionmaker[AsyncSession], value: str) -> None:
+    async with factory() as session:
+        await ConfigService(session).set_setting("default_video_backend", value)
+        await session.commit()
 
 
 class TestRequireVideoBucketCapability:
-    async def test_missing_r2v_capability_maps_to_bad_request(self, monkeypatch):
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("default_video_backend", "minimax/MiniMax-Hailuo-2.3")
-                await session.commit()
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            with pytest.raises(BadRequestError) as exc_info:
-                await require_video_bucket_capability({}, "r2v")
-        finally:
-            await engine.dispose()
+    async def test_missing_r2v_capability_maps_to_bad_request(self, db_factory, monkeypatch):
+        await _set_default_video_backend(db_factory, "minimax/MiniMax-Hailuo-2.3")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        with pytest.raises(BadRequestError) as exc_info:
+            await require_video_bucket_capability({}, "r2v")
+
         assert exc_info.value.key == "video_capability_missing_r2v"
         assert exc_info.value.params == {"provider": "minimax", "model": "MiniMax-Hailuo-2.3"}
 
-    async def test_project_r2v_bucket_overrides_incapable_default(self, monkeypatch):
+    async def test_project_r2v_bucket_overrides_incapable_default(self, db_factory, monkeypatch):
         """配置 r2v 桶后参考生视频改用桶内模型：默认模型缺参考图能力也不再拦截。"""
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("default_video_backend", "minimax/MiniMax-Hailuo-2.3")
-                await session.commit()
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await require_video_bucket_capability({"video_provider_r2v": "minimax/S2V-01"}, "r2v")
-        finally:
-            await engine.dispose()
+        await _set_default_video_backend(db_factory, "minimax/MiniMax-Hailuo-2.3")
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
 
-    async def test_no_provider_configured_passes_through(self, monkeypatch):
+        # 预检放行即静默返回 None
+        assert await require_video_bucket_capability({"video_provider_r2v": "minimax/S2V-01"}, "r2v") is None
+
+    async def test_no_provider_configured_passes_through(self, db_factory, monkeypatch):
         """未配置任何供应商（自动推断失败）→ 放行入队，由 worker 在任务面板暴露。"""
-        factory, engine = await _make_factory()
-        try:
-            monkeypatch.setattr("lib.db.async_session_factory", factory)
-            await require_video_bucket_capability({}, "i2v")
-        finally:
-            await engine.dispose()
+        monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+
+        assert await require_video_bucket_capability({}, "i2v") is None

--- a/tests/integration/server/services/test_cost_estimation_service.py
+++ b/tests/integration/server/services/test_cost_estimation_service.py
@@ -1320,13 +1320,15 @@ class TestCostEstimationService:
             "reference_duration_confirmation_required"
         )
 
-        def _quote_unavailable(*_args, **_kwargs):
-            raise ValueError("price unavailable")
+        # 视频这一维算不出价（定价表无该模型条目）：报价与预估同源，两者一起落空。
+        real_calculate_cost = cost_calculator.calculate_cost
 
-        monkeypatch.setattr(
-            "server.services.cost_estimation.quote_video_request_from_price",
-            _quote_unavailable,
-        )
+        def _video_pricing_missing(provider, params, **kwargs):
+            if params.call_type == "video":
+                raise ValueError(f"no pricing entry for {provider}/{params.model}")
+            return real_calculate_cost(provider, params, **kwargs)
+
+        monkeypatch.setattr(cost_calculator, "calculate_cost", _video_pricing_missing)
         unavailable = await service.compute(
             project_data,
             scripts,

--- a/tests/integration/server/services/test_execute_generation_task.py
+++ b/tests/integration/server/services/test_execute_generation_task.py
@@ -1,5 +1,6 @@
 """Tests for execute_generation_task."""
 
+import asyncio
 import threading
 
 import pytest
@@ -132,7 +133,7 @@ class TestGenerationTasks:
                 {"task_type": "unknown", "project_name": "demo", "resource_id": "x", "payload": {}}
             )
 
-    async def test_reused_video_result_emits_the_normal_generation_success_event(self, monkeypatch):
+    async def test_reused_video_result_emits_the_normal_generation_success_event(self, tmp_path, monkeypatch):
         reused = {
             "version": 3,
             "file_path": "videos/scene_E1S01.mp4",
@@ -145,11 +146,12 @@ class TestGenerationTasks:
             return reused
 
         emitted: list[dict] = []
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
         monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "video", _executor)
         monkeypatch.setattr(
             generation_tasks,
-            "emit_generation_success_batch",
-            lambda **kwargs: emitted.append(kwargs) or {},
+            "emit_project_change_batch",
+            lambda project_name, changes: emitted.append({"project_name": project_name, "changes": list(changes)}),
         )
 
         result = await generation_tasks.execute_generation_task(
@@ -163,16 +165,46 @@ class TestGenerationTasks:
         )
 
         assert result is reused
-        assert emitted == [
+        assert len(emitted) == 1
+        assert emitted[0]["project_name"] == "demo"
+        change = emitted[0]["changes"][0]
+        assert change["entity_type"] == "segment"
+        assert change["action"] == "video_ready"
+        assert change["entity_id"] == "E1S01"
+        assert change["script_file"] == "episode_1.json"
+
+    async def test_generation_event_failure_keeps_committed_media(self, tmp_path, monkeypatch):
+        """事件发送失败被吞在通知边界内：产物已落盘，不因通知失败回撤，任务照常返回。"""
+        compensation_threads: list[int] = []
+        result_payload = {"resource_type": "storyboards", "resource_id": "E1S01"}
+
+        async def _executor(*_args, **_kwargs):
+            return CompensableGenerationResult(
+                result_payload,
+                cancel_compensation=lambda: compensation_threads.append(threading.get_ident()),
+            )
+
+        def _fail_emit(_project_name, _changes):
+            raise RuntimeError("event emission failed")
+
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
+        monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "storyboard", _executor)
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", _fail_emit)
+
+        result = await generation_tasks.execute_generation_task(
             {
-                "task_type": "video",
+                "task_type": "storyboard",
                 "project_name": "demo",
                 "resource_id": "E1S01",
-                "payload": {"script_file": "episode_1.json"},
+                "payload": {},
             }
-        ]
+        )
 
-    async def test_generation_event_failure_runs_media_compensation_off_the_event_loop(self, monkeypatch):
+        assert result == result_payload
+        assert compensation_threads == []
+
+    async def test_cancellation_during_event_runs_media_compensation_off_the_event_loop(self, tmp_path, monkeypatch):
+        """取消穿透通知边界（BaseException 不被吞）：补偿跑在事件循环之外，不阻塞循环。"""
         event_loop_thread = threading.get_ident()
         compensation_threads: list[int] = []
 
@@ -182,13 +214,14 @@ class TestGenerationTasks:
                 cancel_compensation=lambda: compensation_threads.append(threading.get_ident()),
             )
 
-        def _fail_event(**_kwargs):
-            raise RuntimeError("event emission failed")
+        def _cancel_emit(_project_name, _changes):
+            raise asyncio.CancelledError
 
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
         monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "storyboard", _executor)
-        monkeypatch.setattr(generation_tasks, "emit_generation_success_batch", _fail_event)
+        monkeypatch.setattr(generation_tasks, "emit_project_change_batch", _cancel_emit)
 
-        with pytest.raises(RuntimeError, match="event emission failed"):
+        with pytest.raises(asyncio.CancelledError):
             await generation_tasks.execute_generation_task(
                 {
                     "task_type": "storyboard",

--- a/tests/integration/server/services/test_execute_reference_video_task.py
+++ b/tests/integration/server/services/test_execute_reference_video_task.py
@@ -2287,14 +2287,12 @@ async def test_execute_reference_video_task_stages_actual_request_and_checkpoint
         return digest
 
     monkeypatch.setattr(rvt, "reference_video_visual_basis_digest", _capture_live_visual_basis)
-    real_stage = rvt._stage_provider_media_for_task
 
     async def _edit_source_before_staging(project_path, task_id, inputs):
+        """经 ``stage_media_for_task`` 注入：在现摘要与暂存之间改写源文件，其余照真实暂存跑。"""
         if inputs:
             inputs[0].path.write_bytes(b"edited-between-live-basis-and-staging")
-        return await real_stage(project_path, task_id, inputs)
-
-    monkeypatch.setattr(rvt, "_stage_provider_media_for_task", _edit_source_before_staging)
+        return await rvt.stage_provider_media_for_task(project_path, task_id, inputs, stage=rvt.stage_provider_media)
 
     async def _fake_generate_video_async(**kwargs):
         submitted.update(kwargs)
@@ -2345,6 +2343,7 @@ async def test_execute_reference_video_task_stages_actual_request_and_checkpoint
         script_file="scripts/episode_1.json",
         user_id="u1",
         task_id="task-submit",
+        stage_media_for_task=_edit_source_before_staging,
     )
 
     assert events == ["checkpoint", "provider_submit"]

--- a/tests/integration/server/services/test_formal_image_finalization.py
+++ b/tests/integration/server/services/test_formal_image_finalization.py
@@ -146,9 +146,9 @@ class TestGenerationTasks:
 
         assert fake_generator.video_calls == []
 
-    def test_grid_completion_serializes_manifest_registration_with_schema_activation(self, tmp_path, monkeypatch):
-        from lib import artifact_activation
+    def test_grid_completion_serializes_manifest_registration_with_schema_activation(self, tmp_path):
         from lib.artifact_activation import activate_artifact_target_state
+        from lib.formal_write import project_metadata_lock
         from lib.grid.models import GridGeneration
         from lib.grid_manager import GridManager
         from lib.project_migrations.v8_to_v9_reference_unit_text import migrate_v8_to_v9
@@ -206,28 +206,20 @@ class TestGenerationTasks:
             outcome_box=outcomes,
         )
 
-        activation_ready = threading.Event()
-        release_activation = threading.Event()
+        activation_started = threading.Event()
+        activation_done = threading.Event()
         writer_started = threading.Event()
         writer_done = threading.Event()
         failures: list[BaseException] = []
-        original_commit_schema = artifact_activation._commit_schema_version
-
-        def _pause_before_schema(project_dir, project):
-            activation_ready.set()
-            assert release_activation.wait(timeout=5)
-            original_commit_schema(project_dir, project)
-            # 清单激活只把项目送到 v8；形式产物注册要求当前 schema，故在同一把项目元数据锁内
-            # 走完剩余迁移，模拟启动扫描一次跑完整条链。
-            migrate_v8_to_v9(project_dir)
-
-        monkeypatch.setattr(artifact_activation, "_commit_schema_version", _pause_before_schema)
 
         def _activate() -> None:
+            activation_started.set()
             try:
                 activate_artifact_target_state(project_path, bump_schema=True)
             except Exception as exc:
                 failures.append(exc)
+            finally:
+                activation_done.set()
 
         def _complete_grid() -> None:
             writer_started.set()
@@ -238,15 +230,24 @@ class TestGenerationTasks:
             finally:
                 writer_done.set()
 
+        # 互斥判据由「主线程持锁时对方进不来」双向给出：清单激活与形式产物提交各自在项目
+        # 元数据锁上排队，因而彼此也不可能交错。两段等待窗口都是单向否证——互斥若被破坏，
+        # 慢机上也可能因窗口内尚未跑完而漏报，但绝不会把守规矩的实现判成失败。
         activation_thread = threading.Thread(target=_activate)
-        writer_thread = threading.Thread(target=_complete_grid)
-        activation_thread.start()
-        assert activation_ready.wait(timeout=5)
-        writer_thread.start()
-        assert writer_started.wait(timeout=5)
-        assert not writer_done.wait(timeout=0.2)
-        release_activation.set()
+        with project_metadata_lock(project_path):
+            activation_thread.start()
+            assert activation_started.wait(timeout=5)
+            assert not activation_done.wait(timeout=0.2), "清单激活没有在项目元数据锁上排队"
         activation_thread.join(timeout=5)
+
+        # 清单激活只把项目送到 v8；形式产物注册要求当前 schema，剩余迁移由启动扫描跑完。
+        migrate_v8_to_v9(project_path)
+
+        writer_thread = threading.Thread(target=_complete_grid)
+        with project_metadata_lock(project_path):
+            writer_thread.start()
+            assert writer_started.wait(timeout=5)
+            assert not writer_done.wait(timeout=0.2), "形式产物提交没有在项目元数据锁上排队"
         writer_thread.join(timeout=5)
 
         assert not activation_thread.is_alive()

--- a/tests/integration/server/services/test_jianying_draft_routes.py
+++ b/tests/integration/server/services/test_jianying_draft_routes.py
@@ -71,10 +71,12 @@ def _client(monkeypatch, pm: ProjectManager, service: _DraftService | None = Non
     from server.routers import projects as proj_mod
 
     monkeypatch.setattr(proj_mod, "get_project_manager", lambda: pm)
-    if service is not None:
-        monkeypatch.setattr(proj_mod, "get_jianying_draft_service", lambda: service)
 
     from server.app import app
+
+    if service is not None:
+        # 复用进程级 app，覆盖用 setitem 挂上，用例结束由 monkeypatch 自动摘除。
+        monkeypatch.setitem(app.dependency_overrides, proj_mod.get_jianying_draft_service, lambda: service)
 
     return TestClient(app)
 

--- a/tests/integration/server/services/test_reference_video_duration_resolution.py
+++ b/tests/integration/server/services/test_reference_video_duration_resolution.py
@@ -6,6 +6,7 @@ from functools import partial
 
 import pytest
 
+from lib.config.resolver import ConfigResolver
 from server.services.reference_video_tasks import (
     FALLBACK_UNIT_DURATION,
     ProjectDurationContext,
@@ -58,13 +59,14 @@ async def test_resolve_project_duration_context_resolves_caps_and_resolution_onc
         caps_calls += 1
         return {"provider_id": "gemini-aistudio", "model": "veo-3.1-generate-preview", "supported_durations": [4, 6, 8]}
 
-    async def fake_resolution(_project, _provider_id, _model_id):
+    async def fake_resolution(_self, _project, _provider_id, _model_id):
         nonlocal resolution_calls
         resolution_calls += 1
         return "720p"
 
     monkeypatch.setattr(rvt, "project_video_caps", fake_caps)
-    monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
+    # 分辨率解析的替身落在协作者 ConfigResolver 上，本模块的解析包装（含 fallback 兜底）照跑。
+    monkeypatch.setattr(ConfigResolver, "resolve_resolution", fake_resolution)
 
     ctx = await rvt.resolve_project_duration_context({})
 
@@ -93,7 +95,7 @@ async def test_resolve_project_duration_context_skips_resolution_when_no_duratio
         return "720p"
 
     monkeypatch.setattr(rvt, "project_video_caps", fake_caps)
-    monkeypatch.setattr(rvt, "_project_video_resolution", fake_resolution)
+    monkeypatch.setattr(ConfigResolver, "resolve_resolution", fake_resolution)
 
     ctx = await rvt.resolve_project_duration_context({})
 

--- a/tests/integration/server/services/test_script_review.py
+++ b/tests/integration/server/services/test_script_review.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import pytest
 
 from lib import script_review
+from lib.config.resolver import ConfigResolver
+from lib.db import async_session_factory
 from lib.draft_quarantine import (
     QUARANTINE_KIND_DRAMA_STEP1,
     QUARANTINE_KIND_NARRATION_STEP1,
@@ -99,7 +101,7 @@ def _stub_video_caps(
     """
     from server.services import script_review as mod
 
-    async def _fake_caps(_project, _episode=None):
+    async def _fake_caps(_project, _episode=None, **_kwargs):
         if supported_durations is None:
             return {}
         return {"provider_id": provider_id, "model": model, "supported_durations": list(supported_durations)}
@@ -114,6 +116,21 @@ def _unresolvable_video_caps(monkeypatch: pytest.MonkeyPatch) -> None:
     需要具体档位表的用例用 ``_stub_video_caps`` 就地覆盖。
     """
     _stub_video_caps(monkeypatch, None)
+
+
+class _I2vUnresolvableResolver(ConfigResolver):
+    """能力解析器替身：任何桶的能力查询都不可解析。
+
+    经 ``ScriptReviewService(config_resolver=...)`` 注入，用于「不带参考图的 i2v 桶解析不了、
+    档位回退按 r2v 求值」这条降级路径；r2v 那一侧的 caps 由 ``_stub_video_caps`` 给出，不经
+    本替身。会话工厂只为满足基类构造，永不打开。
+    """
+
+    def __init__(self) -> None:
+        super().__init__(async_session_factory)
+
+    async def video_capabilities_for_project(self, project: dict, *, capability=None) -> dict:
+        raise ValueError(f"{capability} bucket unresolvable in this test")
 
 
 def _make_project(
@@ -548,14 +565,13 @@ class TestReferenceVideoGateFlow:
         get_state 暴露的档位表会让用户选中 4/6 秒，save + confirm 都不拦，直到 step2
         ``_assert_reference_step1_ready`` 才硬拒——用户已确认过的内容变成付完钱才失败。
         """
-        from server.agent_runtime.sdk_tools import _context
         from server.services import script_review as mod
 
         _stub_video_caps(monkeypatch, [4, 6, 8])
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
-        svc = ScriptReviewService(pm)
+        svc = ScriptReviewService(pm, config_resolver=_I2vUnresolvableResolver())
 
-        async def _fake_caps(_project, _episode=None):
+        async def _fake_caps(_project, _episode=None, **_kwargs):
             return {
                 "provider_id": "gemini-aistudio",
                 "model": "veo-3.1-generate-preview",
@@ -564,10 +580,6 @@ class TestReferenceVideoGateFlow:
 
         monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
-        async def _no_i2v(_project, *, capability=None):
-            raise ValueError("i2v bucket unresolvable in this test")
-
-        monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
         tiers = await svc.get_reference_duration_tiers("demo", 1)
         assert tiers == {"with_references": [8], "without_references": [8]}
 
@@ -611,21 +623,16 @@ class TestReferenceVideoGateFlow:
         （DB 驱动的能力查询）。caps 必须先于 ``resolve_raw_supported_durations`` 解析，否则
         raw 会因取不到而提前返回 None，永远不会用上 caps 本能给出的答案。
         """
-        from server.agent_runtime.sdk_tools import _context
         from server.services import script_review as mod
 
         pm = _make_project(tmp_path, "drama", generation_mode="reference_video")
-        svc = ScriptReviewService(pm)
+        svc = ScriptReviewService(pm, config_resolver=_I2vUnresolvableResolver())
 
-        async def _fake_caps(_project, _episode=None):
+        async def _fake_caps(_project, _episode=None, **_kwargs):
             return {"provider_id": "custom-acme", "model": "acme-video", "supported_durations": [5, 10]}
 
         monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
 
-        async def _no_i2v(_project, *, capability=None):
-            raise ValueError("i2v bucket unresolvable in this test")
-
-        monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
         tiers = await svc.get_reference_duration_tiers("demo", 1)
         # 自定义供应商不在 registry，reference_unit_duration_tiers 查不到联动约束，两套档位
         # 都退回 caps 给出的原始集合。

--- a/tests/integration/server/services/test_video_artifact_currency.py
+++ b/tests/integration/server/services/test_video_artifact_currency.py
@@ -272,11 +272,6 @@ async def test_formal_selection_validates_frozen_tts_when_current_tts_changes(
 ) -> None:
     """A paid result is judged against the TTS accepted at submission, not mutable current state."""
 
-    current_projection = AsyncMock(side_effect=RuntimeError("current TTS became stale"))
-    monkeypatch.setattr(
-        "server.services.narration_delivery_tasks._prepare_current_task_narration_delivery",
-        current_projection,
-    )
     monkeypatch.setattr(
         "server.services.narration_delivery_tasks.probe_existing_media_duration_seconds",
         AsyncMock(return_value=8.0),
@@ -317,8 +312,8 @@ async def test_formal_selection_validates_frozen_tts_when_current_tts_changes(
         },
     )
 
+    # 当前 TTS 解析器被换成一抛就错：冻结档若误取当前状态，selection_error 不会是 None。
     assert committer.selection_error is None
-    current_projection.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/lib/test_tts_skeleton.py
+++ b/tests/unit/lib/test_tts_skeleton.py
@@ -415,9 +415,7 @@ class TestWorkerAudioLane:
         w._slots.register("dashscope", "audio", "t", dummy)
         assert w._pool_full_providers("audio") == frozenset({"dashscope"})
 
-    async def test_claim_routes_audio_to_audio_lane(self, monkeypatch):
-        from lib import generation_worker as gw
-
+    async def test_claim_routes_audio_to_audio_lane(self):
         class _Q:
             def __init__(self):
                 self._given = False
@@ -434,18 +432,17 @@ class TestWorkerAudioLane:
                     }
                 return None
 
+        async def _fixed_projection(task):
+            return "dashscope"
+
         w = GenerationWorker(
             queue=_Q(),  # type: ignore[arg-type]
             capacity=CapacityTable(
                 _limits={"dashscope": {"image": 0, "video": 0, "audio": 2}},
                 _defaults={"image": 5, "video": 3, "audio": 10},
             ),
+            provider_projection=_fixed_projection,
         )
-
-        async def _fake_extract(task):
-            return "dashscope"
-
-        monkeypatch.setattr(gw, "_extract_provider", _fake_extract)
 
         async def _fake_process(task):
             await asyncio.sleep(0)

--- a/tests/unit/server/routers/test_agent_chat_router.py
+++ b/tests/unit/server/routers/test_agent_chat_router.py
@@ -28,6 +28,29 @@ def _make_client() -> TestClient:
     return TestClient(app)
 
 
+def _scripted_session_manager(monkeypatch, *, reply_text: str, status: str) -> "_StubSessionManager":
+    """按目标收尾编排一段事件流，让 ``_collect_reply`` 真的跑出该 (reply, status)。
+
+    端点用例因而不必替换 ``_collect_reply`` 本身：替身只落在会话管理器这个协作者上。
+    """
+    events: list = []
+    if reply_text:
+        events.append(LiveMessage(message={"type": "assistant", "content": [{"type": "text", "text": reply_text}]}))
+    if status == "completed":
+        events.append(LiveMessage(message={"type": "result", "subtype": "success", "is_error": False}))
+        return _StubSessionManager(events)
+    if status == "timeout":
+        # 持续 <idle_timeout 间隔的消息流：deadline 每轮被检查，到点收尾。
+        monkeypatch.setattr(agent_chat, "SYNC_CHAT_TIMEOUT", 0.05)
+        # 灌流消息文本留空：收尾前已收的部分回复因而恒等于 reply_text。
+        return _StubSessionManager(events, flood=True, flood_text="")
+    if status == "error":
+        # 订阅队列溢出以流结束表达。
+        return _StubSessionManager(events)
+    # 其余收尾由心跳上的会话状态给出。
+    return _StubSessionManager([*events, Heartbeat()], status=status)
+
+
 def _fake_session(session_id: str = "sess-1", project_name: str = "demo"):
     meta = MagicMock()
     meta.id = session_id
@@ -39,7 +62,7 @@ class TestAgentChatEndpoint:
     def _patch_service(
         self, monkeypatch, *, project_exists=True, reply_text="你好", status="completed", session_id="sess-1"
     ):
-        """构建 mock AssistantService 并注入。"""
+        """构建 mock AssistantService 并注入；回复由脚本化事件流经真实 _collect_reply 得出。"""
         mock_service = AsyncMock()
 
         # 项目存在性检查
@@ -56,12 +79,8 @@ class TestAgentChatEndpoint:
         # 统一发送端点
         mock_service.send_or_create = AsyncMock(return_value={"status": "accepted", "session_id": session_id})
 
+        mock_service.session_manager = _scripted_session_manager(monkeypatch, reply_text=reply_text, status=status)
         monkeypatch.setattr(agent_chat, "get_assistant_service", lambda: mock_service)
-        monkeypatch.setattr(
-            agent_chat,
-            "_collect_reply",
-            AsyncMock(return_value=(reply_text, status)),
-        )
         return mock_service
 
     def test_new_session_returns_reply(self, monkeypatch):
@@ -199,10 +218,11 @@ class _StubSessionManager:
     flood=True 时持续以 <idle_timeout 间隔吐直播消息,心跳与流结束都不出现。
     """
 
-    def __init__(self, events, *, status="running", flood=False):
+    def __init__(self, events, *, status="running", flood=False, flood_text="x"):
         self._events = list(events)
         self.status = status
         self._flood = flood
+        self._flood_text = flood_text
 
     async def get_status(self, session_id):
         return self.status
@@ -211,6 +231,7 @@ class _StubSessionManager:
     async def stream_messages(self, session_id, *, idle_timeout=5.0):
         events = self._events
         flood = self._flood
+        flood_text = self._flood_text
 
         async def _iter():
             yield SubscriptionReady()
@@ -218,7 +239,7 @@ class _StubSessionManager:
                 yield event
             while flood:
                 await asyncio.sleep(0.01)
-                yield LiveMessage(message={"type": "assistant", "content": [{"type": "text", "text": "x"}]})
+                yield LiveMessage(message={"type": "assistant", "content": [{"type": "text", "text": flood_text}]})
 
         yield _iter()
 
@@ -330,8 +351,8 @@ class TestEntryLogFallback:
                 "draft_rev": 0,
             }
         )
+        mock_service.session_manager = _scripted_session_manager(monkeypatch, reply_text="", status="completed")
         monkeypatch.setattr(agent_chat, "get_assistant_service", lambda: mock_service)
-        monkeypatch.setattr(agent_chat, "_collect_reply", AsyncMock(return_value=("", "completed")))
 
         with _make_client() as client:
             resp = client.post(
@@ -366,8 +387,8 @@ class TestTruncatedReplyBackfill:
             mock_service.list_session_entries = AsyncMock(side_effect=entries_exc)
         else:
             mock_service.list_session_entries = AsyncMock(return_value=entries_payload)
+        mock_service.session_manager = _scripted_session_manager(monkeypatch, reply_text=live_reply, status=live_status)
         monkeypatch.setattr(agent_chat, "get_assistant_service", lambda: mock_service)
-        monkeypatch.setattr(agent_chat, "_collect_reply", AsyncMock(return_value=(live_reply, live_status)))
         return mock_service
 
     def test_error_status_backfills_nonempty_truncated_reply(self, monkeypatch):

--- a/tests/unit/server/routers/test_custom_providers_api.py
+++ b/tests/unit/server/routers/test_custom_providers_api.py
@@ -1492,20 +1492,35 @@ async def test_default_conflict_grouped_by_endpoint_media(custom_providers_clien
     assert resp.status_code == 422
 
 
-def test_check_unique_defaults_allows_split_image_endpoints():
+@pytest.mark.asyncio
+async def test_split_image_endpoints_may_both_be_default(custom_providers_client):
     """同 provider 内 -generations 与 -edits 两条都设默认 → 允许（capability 不交叠）。"""
-    from server.routers.custom_providers import ModelInput, _check_unique_defaults
-
-    models = [
-        ModelInput(model_id="m1", display_name="m1", endpoint="openai-images-generations", is_default=True),
-        ModelInput(model_id="m2", display_name="m2", endpoint="openai-images-edits", is_default=True),
-    ]
-
-    def t(key, **params):
-        return f"{key}:{params}"
-
-    # 不应抛
-    _check_unique_defaults(models, t)
+    payload = {
+        "display_name": "X",
+        "discovery_format": "openai",
+        "base_url": "https://x",
+        "api_key": "k",
+        "models": [
+            {
+                "model_id": "m1",
+                "display_name": "m1",
+                "endpoint": "openai-images-generations",
+                "is_default": True,
+                "is_enabled": True,
+            },
+            {
+                "model_id": "m2",
+                "display_name": "m2",
+                "endpoint": "openai-images-edits",
+                "is_default": True,
+                "is_enabled": True,
+            },
+        ],
+    }
+    resp = custom_providers_client.post("/api/v1/custom-providers", json=payload)
+    assert resp.status_code == 201, resp.text
+    defaults = {model["model_id"]: model["is_default"] for model in resp.json()["models"]}
+    assert defaults == {"m1": True, "m2": True}
 
 
 def test_check_unique_defaults_rejects_two_generations_defaults():

--- a/tests/unit/server/routers/test_custom_providers_api.py
+++ b/tests/unit/server/routers/test_custom_providers_api.py
@@ -10,6 +10,7 @@ from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -22,6 +23,7 @@ from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import custom_providers
 from tests.auth_deps import AUTH_DEPENDENCIES
+from tests.http_capture import capture_http, only_request
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -638,12 +640,20 @@ class TestDiscoverModelsByStoredProvider:
 # ---------------------------------------------------------------------------
 
 
+def _openai_models_page(count: int) -> dict[str, object]:
+    """OpenAI ``GET /models`` 的响应体形状。"""
+    return {"object": "list", "data": [{"id": f"m{i}", "object": "model"} for i in range(count)]}
+
+
+def _google_models_page(count: int) -> dict[str, object]:
+    """Google genai ``GET /v1beta/models`` 的响应体形状。"""
+    return {"models": [{"name": f"models/m{i}"} for i in range(count)]}
+
+
 class TestConnectionTest:
     def test_openai_success(self, custom_providers_client: TestClient):
-        with patch(
-            "server.routers.custom_providers._test_openai",
-            return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=5),
-        ):
+        with capture_http(assert_all_called=True) as http:
+            http.get("https://api.example.com/v1/models").respond(json=_openai_models_page(5))
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
@@ -658,10 +668,8 @@ class TestConnectionTest:
         assert body["model_count"] == 5
 
     def test_google_success(self, custom_providers_client: TestClient):
-        with patch(
-            "server.routers.custom_providers._test_google",
-            return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=10),
-        ):
+        with capture_http(assert_all_called=True) as http:
+            http.get("https://api.example.com/v1beta/models").respond(json=_google_models_page(10))
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
@@ -675,12 +683,10 @@ class TestConnectionTest:
         assert body["success"] is True
         assert body["model_count"] == 10
 
-    def test_openai_routes_to_test_openai(self, custom_providers_client: TestClient):
-        """discovery_format=openai 应路由到 _test_openai。"""
-        with patch(
-            "server.routers.custom_providers._test_openai",
-            return_value=custom_providers.ConnectionTestResponse(success=True, message="连接成功", model_count=42),
-        ) as mock_openai_test:
+    def test_openai_format_probes_openai_endpoint(self, custom_providers_client: TestClient):
+        """discovery_format=openai 走 OpenAI 探测：出站落在 /models 且带 Bearer 凭证。"""
+        with capture_http(assert_all_called=True) as http:
+            route = http.get("https://openai.example.com/v1/models").respond(json=_openai_models_page(42))
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
@@ -693,7 +699,7 @@ class TestConnectionTest:
         body = resp.json()
         assert body["success"] is True
         assert body["model_count"] == 42
-        mock_openai_test.assert_called_once()
+        assert only_request(route).headers["authorization"] == "Bearer sk-openai-conn"
 
     def test_unsupported_format_returns_false(self, custom_providers_client: TestClient):
         """不支持的 discovery_format 应返回 success=False。"""
@@ -710,10 +716,9 @@ class TestConnectionTest:
         assert body["success"] is False
 
     def test_connection_failure(self, custom_providers_client: TestClient):
-        with patch(
-            "server.routers.custom_providers._test_openai",
-            side_effect=RuntimeError("Connection refused"),
-        ):
+        """探测抛错时端点软失败：仍返回 200，success=False 且带上游错误摘要。"""
+        with capture_http(assert_all_called=True) as http:
+            http.get("https://api.example.com/v1/models").mock(side_effect=httpx.ConnectError("Connection refused"))
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/test",
                 json={
@@ -725,7 +730,7 @@ class TestConnectionTest:
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is False
-        assert "Connection refused" in body["message"]
+        assert "Connection error" in body["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -774,11 +779,10 @@ class TestDeleteProviderCleansGlobalSettings:
         await svc.set_setting("default_video_backend", "gemini-aistudio/veo-3")  # 不应被清理
         await db_session.commit()
 
-        # 删除供应商（mock 掉项目清理和缓存失效）
-        with (
-            patch("server.routers.custom_providers._cleanup_project_refs"),
-            patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock),
-        ):
+        # 项目级清理走真实实现，但项目列表为空 → 只剩全局设置的清理
+        empty_pm = MagicMock()
+        empty_pm.list_projects.return_value = []
+        with patch("lib.config.resolver.get_project_manager", return_value=empty_pm):
             del_resp = custom_providers_client.delete(f"/api/v1/custom-providers/{pid}")
         assert del_resp.status_code == 204
 
@@ -804,10 +808,7 @@ class TestDeleteProviderCleansProjectRefs:
         project_data = {"text_backend_complex": f"{prefix}gpt-4o", "title": "Test"}
         mock_pm.load_project.return_value = project_data
 
-        with (
-            patch("lib.config.resolver.get_project_manager", return_value=mock_pm),
-            patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock),
-        ):
+        with patch("lib.config.resolver.get_project_manager", return_value=mock_pm):
             del_resp = custom_providers_client.delete(f"/api/v1/custom-providers/{pid}")
         assert del_resp.status_code == 204
 
@@ -847,21 +848,20 @@ class TestReplaceModelsCleansStaleRefs:
         await db_session.commit()
 
         # 替换 models — 移除 gpt-4o，保留 dall-e-3
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            replace_resp = custom_providers_client.put(
-                f"/api/v1/custom-providers/{pid}/models",
-                json={
-                    "models": [
-                        {
-                            "model_id": "dall-e-3",
-                            "display_name": "DALL-E 3",
-                            "endpoint": "openai-images",
-                            "is_default": True,
-                            "is_enabled": True,
-                        },
-                    ]
-                },
-            )
+        replace_resp = custom_providers_client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={
+                "models": [
+                    {
+                        "model_id": "dall-e-3",
+                        "display_name": "DALL-E 3",
+                        "endpoint": "openai-images",
+                        "is_default": True,
+                        "is_enabled": True,
+                    },
+                ]
+            },
+        )
         assert replace_resp.status_code == 200
 
         # gpt-4o 被删除，引用它的全局配置应被清空
@@ -908,21 +908,20 @@ class TestGlobalBucketRefsHint:
         await svc.set_setting("default_video_backend_i2v", f"custom-{pid}/gpt-4o")
         await db_session.commit()
 
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            replace_resp = custom_providers_client.put(
-                f"/api/v1/custom-providers/{pid}/models",
-                json={
-                    "models": [
-                        {
-                            "model_id": "gpt-4o",
-                            "display_name": "GPT-4o",
-                            "endpoint": "openai-chat",
-                            "is_default": True,
-                            "is_enabled": True,
-                        },
-                    ]
-                },
-            )
+        replace_resp = custom_providers_client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={
+                "models": [
+                    {
+                        "model_id": "gpt-4o",
+                        "display_name": "GPT-4o",
+                        "endpoint": "openai-chat",
+                        "is_default": True,
+                        "is_enabled": True,
+                    },
+                ]
+            },
+        )
         assert replace_resp.status_code == 200
         assert replace_resp.json()[0]["global_bucket_refs"] == ["default_video_backend_i2v"]
 
@@ -957,15 +956,14 @@ class TestEmptyModelIdRejected:
     def test_replace_models_with_empty_model_id(self, custom_providers_client: TestClient):
         create_resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = create_resp.json()["id"]
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = custom_providers_client.put(
-                f"/api/v1/custom-providers/{pid}/models",
-                json={
-                    "models": [
-                        {"model_id": "  ", "display_name": "Blank", "endpoint": "openai-chat", "is_enabled": True},
-                    ]
-                },
-            )
+        resp = custom_providers_client.put(
+            f"/api/v1/custom-providers/{pid}/models",
+            json={
+                "models": [
+                    {"model_id": "  ", "display_name": "Blank", "endpoint": "openai-chat", "is_enabled": True},
+                ]
+            },
+        )
         assert resp.status_code == 422
 
 
@@ -1021,23 +1019,22 @@ class TestFullUpdateProvider:
     def test_full_update(self, custom_providers_client: TestClient):
         create_resp = custom_providers_client.post("/api/v1/custom-providers", json=_PROVIDER_PAYLOAD)
         pid = create_resp.json()["id"]
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = custom_providers_client.put(
-                f"/api/v1/custom-providers/{pid}",
-                json={
-                    "display_name": "Updated Name",
-                    "base_url": "https://new-api.example.com/v1",
-                    "models": [
-                        {
-                            "model_id": "new-model",
-                            "display_name": "New",
-                            "endpoint": "openai-chat",
-                            "is_default": True,
-                            "is_enabled": True,
-                        },
-                    ],
-                },
-            )
+        resp = custom_providers_client.put(
+            f"/api/v1/custom-providers/{pid}",
+            json={
+                "display_name": "Updated Name",
+                "base_url": "https://new-api.example.com/v1",
+                "models": [
+                    {
+                        "model_id": "new-model",
+                        "display_name": "New",
+                        "endpoint": "openai-chat",
+                        "is_default": True,
+                        "is_enabled": True,
+                    },
+                ],
+            },
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["display_name"] == "Updated Name"
@@ -1076,20 +1073,19 @@ class TestConcurrencyFields:
     """image/video/audio_max_workers 经 POST / PUT 保存后回显，留空 → null，0/负值 → 422。"""
 
     def test_create_echoes_workers(self, custom_providers_client: TestClient):
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = custom_providers_client.post(
-                "/api/v1/custom-providers",
-                json={
-                    "display_name": "P",
-                    "discovery_format": "openai",
-                    "base_url": "https://x.com",
-                    "api_key": "sk-test-key-12345678",
-                    "models": [],
-                    "image_max_workers": 2,
-                    "video_max_workers": 7,
-                    "audio_max_workers": 1,
-                },
-            )
+        resp = custom_providers_client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "P",
+                "discovery_format": "openai",
+                "base_url": "https://x.com",
+                "api_key": "sk-test-key-12345678",
+                "models": [],
+                "image_max_workers": 2,
+                "video_max_workers": 7,
+                "audio_max_workers": 1,
+            },
+        )
         assert resp.status_code == 201
         body = resp.json()
         assert body["image_max_workers"] == 2
@@ -1097,17 +1093,16 @@ class TestConcurrencyFields:
         assert body["audio_max_workers"] == 1
 
     def test_create_defaults_to_null_when_omitted(self, custom_providers_client: TestClient):
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            resp = custom_providers_client.post(
-                "/api/v1/custom-providers",
-                json={
-                    "display_name": "P",
-                    "discovery_format": "openai",
-                    "base_url": "https://x.com",
-                    "api_key": "sk-test-key-12345678",
-                    "models": [],
-                },
-            )
+        resp = custom_providers_client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "P",
+                "discovery_format": "openai",
+                "base_url": "https://x.com",
+                "api_key": "sk-test-key-12345678",
+                "models": [],
+            },
+        )
         assert resp.status_code == 201
         body = resp.json()
         assert body["image_max_workers"] is None
@@ -1130,30 +1125,29 @@ class TestConcurrencyFields:
         assert resp.status_code == 422
 
     def test_full_update_overwrites_and_clears(self, custom_providers_client: TestClient):
-        with patch("server.routers.custom_providers._invalidate_caches", new_callable=AsyncMock):
-            create_resp = custom_providers_client.post(
-                "/api/v1/custom-providers",
-                json={
-                    "display_name": "P",
-                    "discovery_format": "openai",
-                    "base_url": "https://x.com",
-                    "api_key": "sk-test-key-12345678",
-                    "models": [],
-                    "image_max_workers": 3,
-                    "video_max_workers": 4,
-                },
-            )
-            pid = create_resp.json()["id"]
-            # PUT 不带 image_max_workers → 视为 null（权威清除）；video 覆盖为 9
-            resp = custom_providers_client.put(
-                f"/api/v1/custom-providers/{pid}",
-                json={
-                    "display_name": "P",
-                    "base_url": "https://x.com",
-                    "models": [],
-                    "video_max_workers": 9,
-                },
-            )
+        create_resp = custom_providers_client.post(
+            "/api/v1/custom-providers",
+            json={
+                "display_name": "P",
+                "discovery_format": "openai",
+                "base_url": "https://x.com",
+                "api_key": "sk-test-key-12345678",
+                "models": [],
+                "image_max_workers": 3,
+                "video_max_workers": 4,
+            },
+        )
+        pid = create_resp.json()["id"]
+        # PUT 不带 image_max_workers → 视为 null（权威清除）；video 覆盖为 9
+        resp = custom_providers_client.put(
+            f"/api/v1/custom-providers/{pid}",
+            json={
+                "display_name": "P",
+                "base_url": "https://x.com",
+                "models": [],
+                "video_max_workers": 9,
+            },
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["image_max_workers"] is None
@@ -1165,10 +1159,13 @@ class TestValidateBackendValueCustomPrefix:
     """回归: validate_backend_value 应接受 custom-* 前缀。"""
 
     def test_custom_prefix_accepted(self):
+        from lib.api_errors import BadRequestError
         from server.routers._validators import validate_backend_value
 
-        # 不应抛异常
-        validate_backend_value("custom-3/gpt-4o", "default_text_backend")
+        # custom- 前缀不在 PROVIDER_REGISTRY 中，仍须放行（逐模型能力由供应商 API 把关）
+        with pytest.raises(BadRequestError):
+            validate_backend_value("custom3/gpt-4o", "default_text_backend")
+        assert validate_backend_value("custom-3/gpt-4o", "default_text_backend") is None
 
     def test_unknown_provider_rejected(self):
         from lib.api_errors import BadRequestError
@@ -1580,11 +1577,11 @@ class TestDiscoverAnthropic:
         mock_models = [
             {"model_id": "claude-x", "display_name": "X", "endpoint": "", "is_default": False, "is_enabled": True}
         ]
-        with patch("server.routers.custom_providers._run_discover", new=AsyncMock()) as mock_run:
-            from server.routers.custom_providers import DiscoverResponse
-
-            mock_run.return_value = DiscoverResponse(models=mock_models)
-
+        with patch(
+            "lib.custom_provider.discovery.discover_models",
+            new_callable=AsyncMock,
+            return_value=mock_models,
+        ) as mock_discover:
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover-anthropic",
                 json={"base_url": "https://example.com", "api_key": "sk-ant"},
@@ -1592,11 +1589,11 @@ class TestDiscoverAnthropic:
 
         assert resp.status_code == 200
         assert [m["model_id"] for m in resp.json()["models"]] == ["claude-x"]
-        # 调用参数：discovery_format=anthropic，凭据透传
-        args = mock_run.call_args.args
-        assert args[0] == "anthropic"
-        assert args[1] == "https://example.com"
-        assert args[2] == "sk-ant"
+        # 发现格式固定为 anthropic，凭据透传
+        kwargs = mock_discover.call_args.kwargs
+        assert kwargs["discovery_format"] == "anthropic"
+        assert kwargs["base_url"] == "https://example.com"
+        assert kwargs["api_key"] == "sk-ant"
 
     async def test_falls_back_to_stored_api_key(self, custom_providers_client: TestClient, db_session: AsyncSession):
         """请求未带 api_key 时，从 active AgentAnthropicCredential fallback。"""
@@ -1612,17 +1609,17 @@ class TestDiscoverAnthropic:
         await repo.set_active(cred.id)
         await db_session.commit()
 
-        with patch("server.routers.custom_providers._run_discover", new=AsyncMock()) as mock_run:
-            from server.routers.custom_providers import DiscoverResponse
-
-            mock_run.return_value = DiscoverResponse(models=[])
-
+        with patch(
+            "lib.custom_provider.discovery.discover_models",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_discover:
             resp = custom_providers_client.post("/api/v1/custom-providers/discover-anthropic", json={})
 
         assert resp.status_code == 200
-        args = mock_run.call_args.args
-        assert args[1] == "https://stored.example"
-        assert args[2] == "sk-stored"
+        kwargs = mock_discover.call_args.kwargs
+        assert kwargs["base_url"] == "https://stored.example"
+        assert kwargs["api_key"] == "sk-stored"
 
     def test_returns_400_when_no_key_anywhere(self, custom_providers_client: TestClient):
         """请求未带 api_key 且 DB 也没有 → 400。"""
@@ -1647,20 +1644,19 @@ class TestDiscoverAnthropic:
         await repo.set_active(cred.id)
         await db_session.commit()
 
-        with patch("server.routers.custom_providers._run_discover", new=AsyncMock()) as mock_run:
-            from server.routers.custom_providers import DiscoverResponse
-
-            mock_run.return_value = DiscoverResponse(models=[])
-
+        with patch(
+            "lib.custom_provider.discovery.discover_models",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_discover:
             resp = custom_providers_client.post(
                 "/api/v1/custom-providers/discover-anthropic",
                 json={"api_key": "   "},
             )
 
         assert resp.status_code == 200
-        args = mock_run.call_args.args
         # 上游收到的是 stored key，不是请求里的空白字符
-        assert args[2] == "sk-stored"
+        assert mock_discover.call_args.kwargs["api_key"] == "sk-stored"
 
 
 class TestGetProviderCredentials:

--- a/tests/unit/server/routers/test_discover_anthropic_fallback.py
+++ b/tests/unit/server/routers/test_discover_anthropic_fallback.py
@@ -42,12 +42,13 @@ async def discover_client(db_engine):
 async def test_discover_falls_back_to_active_credential(discover_client, monkeypatch) -> None:
     captured: dict = {}
 
-    async def fake_discover(discovery_format, base_url, api_key, _t):
+    async def fake_discover(*, discovery_format, base_url, api_key):
+        captured["discovery_format"] = discovery_format
         captured["base_url"] = base_url
         captured["api_key"] = api_key
-        return type("R", (), {"models": [], "errors": []})()
+        return []
 
-    monkeypatch.setattr("server.routers.custom_providers._run_discover", fake_discover)
+    monkeypatch.setattr("lib.custom_provider.discovery.discover_models", fake_discover)
 
     # Create an active credential first
     create_resp = await discover_client.post(
@@ -62,6 +63,7 @@ async def test_discover_falls_back_to_active_credential(discover_client, monkeyp
         json={},
     )
     assert resp.status_code == 200, resp.text
+    assert captured["discovery_format"] == "anthropic"
     assert captured["api_key"] == "stored-sk"
     assert captured["base_url"] == "https://api.deepseek.com/anthropic"
 

--- a/tests/unit/server/routers/test_openai_connection.py
+++ b/tests/unit/server/routers/test_openai_connection.py
@@ -1,39 +1,42 @@
-"""OpenAI 连接测试 (_test_openai) 单元测试。"""
+"""OpenAI 连接测试 (_test_openai) 单元测试。
+
+替身落在出站 HTTP 上：``openai.OpenAI`` 自带的 httpx 客户端同样被 respx 拦截，URL 拼接与
+鉴权 header 因而都在断言范围内（见 ``tests/http_capture``）。
+"""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import pytest
 
 from server.routers.providers import _test_openai
 from tests.factories import make_translator
+from tests.http_capture import capture_http, only_request
 
 _t = make_translator()
 
+_DEFAULT_MODELS_URL = "https://api.openai.com/v1/models"
 
-def _make_model(model_id: str) -> MagicMock:
-    m = MagicMock()
-    m.id = model_id
-    return m
+
+def _models_page(*model_ids: str) -> dict[str, object]:
+    """OpenAI ``GET /models`` 的响应体形状。"""
+    return {"object": "list", "data": [{"id": model_id, "object": "model"} for model_id in model_ids]}
 
 
 class TestTestOpenAI:
     def test_success_filters_relevant_models(self):
         """应只返回匹配关键词的模型。"""
-        mock_models = MagicMock()
-        mock_models.data = [
-            _make_model("gpt-5.4"),
-            _make_model("gpt-5.4-mini"),
-            _make_model("sora-2"),
-            _make_model("dall-e-3"),
-            _make_model("text-embedding-ada-002"),
-            _make_model("whisper-1"),
-            _make_model("tts-1"),
-        ]
-
-        mock_client = MagicMock()
-        mock_client.models.list.return_value = mock_models
-
-        with patch("openai.OpenAI", return_value=mock_client):
+        with capture_http(assert_all_called=True) as http:
+            http.get(_DEFAULT_MODELS_URL).respond(
+                json=_models_page(
+                    "gpt-5.4",
+                    "gpt-5.4-mini",
+                    "sora-2",
+                    "dall-e-3",
+                    "text-embedding-ada-002",
+                    "whisper-1",
+                    "tts-1",
+                )
+            )
             result = _test_openai({"api_key": "sk-test"}, _t)
 
         assert result.success is True
@@ -46,16 +49,8 @@ class TestTestOpenAI:
 
     def test_empty_relevant_models(self):
         """所有模型都不匹配关键词时，返回空列表但仍成功。"""
-        mock_models = MagicMock()
-        mock_models.data = [
-            _make_model("text-embedding-3-large"),
-            _make_model("whisper-1"),
-        ]
-
-        mock_client = MagicMock()
-        mock_client.models.list.return_value = mock_models
-
-        with patch("openai.OpenAI", return_value=mock_client):
+        with capture_http(assert_all_called=True) as http:
+            http.get(_DEFAULT_MODELS_URL).respond(json=_models_page("text-embedding-3-large", "whisper-1"))
             result = _test_openai({"api_key": "sk-test"}, _t)
 
         assert result.success is True
@@ -63,52 +58,25 @@ class TestTestOpenAI:
 
     def test_models_sorted(self):
         """返回的模型列表应按字母序排列。"""
-        mock_models = MagicMock()
-        mock_models.data = [
-            _make_model("sora-2"),
-            _make_model("gpt-5.4"),
-            _make_model("dall-e-3"),
-        ]
-
-        mock_client = MagicMock()
-        mock_client.models.list.return_value = mock_models
-
-        with patch("openai.OpenAI", return_value=mock_client):
+        with capture_http(assert_all_called=True) as http:
+            http.get(_DEFAULT_MODELS_URL).respond(json=_models_page("sora-2", "gpt-5.4", "dall-e-3"))
             result = _test_openai({"api_key": "sk-test"}, _t)
 
         assert result.available_models == ["dall-e-3", "gpt-5.4", "sora-2"]
 
     def test_custom_base_url(self):
-        """传入 base_url 时应转发到 OpenAI 客户端。"""
-        mock_models = MagicMock()
-        mock_models.data = [_make_model("gpt-5.4")]
-
-        mock_client = MagicMock()
-        mock_client.models.list.return_value = mock_models
-        mock_openai_cls = MagicMock(return_value=mock_client)
-
-        with patch("openai.OpenAI", mock_openai_cls):
+        """传入 base_url 时探测请求应打到该地址，且带上传入的 API Key。"""
+        with capture_http(assert_all_called=True) as http:
+            route = http.get("https://custom.api.com/v1/models").respond(json=_models_page("gpt-5.4"))
             _test_openai({"api_key": "sk-test", "base_url": "https://custom.api.com/v1"}, _t)
 
-        mock_openai_cls.assert_called_once_with(
-            api_key="sk-test",
-            base_url="https://custom.api.com/v1",
-        )
+        assert only_request(route).headers["authorization"] == "Bearer sk-test"
 
     def test_api_error_propagates(self):
         """API 异常应向上传播（由调用方 test_provider_connection 统一捕获）。"""
         from openai import AuthenticationError
 
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = AuthenticationError(
-            message="Invalid API key",
-            response=MagicMock(status_code=401),
-            body=None,
-        )
-
-        with patch("openai.OpenAI", return_value=mock_client):
-            try:
+        with capture_http(assert_all_called=True) as http:
+            http.get(_DEFAULT_MODELS_URL).respond(status_code=401, json={"error": {"message": "Invalid API key"}})
+            with pytest.raises(AuthenticationError):
                 _test_openai({"api_key": "sk-invalid"}, _t)
-                assert False, "应抛出异常"
-            except AuthenticationError:
-                pass  # 预期行为

--- a/tests/unit/server/routers/test_system_version_api.py
+++ b/tests/unit/server/routers/test_system_version_api.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from lib.httpx_shared import shutdown_http_client, startup_http_client
 from lib.i18n import get_translator
 from server.auth import CurrentUserInfo, get_current_user
 from server.dependencies import get_config_service
@@ -14,23 +18,24 @@ from server.routers import system_config
 from server.routers.system_config import _parse_version
 from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.factories import make_translator
+from tests.http_capture import capture_http
 
-_FIXED_FETCHED_AT = datetime(2026, 4, 21, 8, 5, 0, tzinfo=UTC)
+_GITHUB_LATEST = "https://api.github.com/repos/ArcReel/ArcReel/releases/latest"
 
 
-def _make_app() -> FastAPI:
+def _make_app(version_reader: Callable[[], str] = lambda: "0.9.0") -> FastAPI:
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="tester")
     app.dependency_overrides[get_config_service] = lambda: MagicMock()
     app.dependency_overrides[get_translator] = lambda: make_translator()
+    app.dependency_overrides[system_config.get_app_version_reader] = lambda: version_reader
     app.include_router(system_config.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
     return app
 
 
-def _release(version: str) -> dict[str, str]:
-    """构造 _get_latest_release 处理后的 payload（带 version 字段）。"""
+def _release_body(version: str) -> dict[str, str]:
+    """GitHub releases/latest 的响应体形状。"""
     return {
-        "version": version,
         "tag_name": f"v{version}",
         "name": version,
         "body": "## What's Changed\n- add about tab",
@@ -39,26 +44,29 @@ def _release(version: str) -> dict[str, str]:
     }
 
 
-def _release_tuple(version: str) -> tuple[dict[str, str], datetime]:
-    return _release(version), _FIXED_FETCHED_AT
+@pytest.fixture(autouse=True)
+def _shared_http_client():
+    """生产由 app lifespan 建共享客户端；这里自己建一个，respx 在 transport 层拦它。"""
+    asyncio.run(startup_http_client())
+    yield
+    asyncio.run(shutdown_http_client())
 
 
-def _reset_cache() -> None:
-    system_config._latest_release_cache["expires_at"] = None
-    system_config._latest_release_cache["payload"] = None
-    system_config._latest_release_cache["fetched_at"] = None
+@pytest.fixture(autouse=True)
+def _clear_release_cache():
+    """`_latest_release_cache` 与 `_read_app_version` 的 lru_cache 都是模块级进程内状态。"""
+    system_config._latest_release_cache.update({"expires_at": None, "payload": None, "fetched_at": None})
+    system_config._read_app_version.cache_clear()
+    yield
+    system_config._latest_release_cache.update({"expires_at": None, "payload": None, "fetched_at": None})
+    system_config._read_app_version.cache_clear()
 
 
 class TestSystemVersionApi:
     def test_returns_current_and_latest_release(self):
         app = _make_app()
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.9.0"),
-            patch(
-                "server.routers.system_config._get_latest_release",
-                new=AsyncMock(return_value=_release_tuple("0.9.1")),
-            ),
-        ):
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
             with TestClient(app) as client:
                 resp = client.get("/api/v1/system/version")
 
@@ -66,17 +74,28 @@ class TestSystemVersionApi:
         body = resp.json()
         assert body["current"]["version"] == "0.9.0"
         assert body["latest"]["version"] == "0.9.1"
+        assert body["latest"]["tag_name"] == "v0.9.1"
         assert body["has_update"] is True
         assert body["update_check_error"] is None
-        # checked_at 应反映实际 fetch 时间，而不是请求时间
-        assert body["checked_at"] == _FIXED_FETCHED_AT.isoformat()
+        # checked_at 是实际 fetch 时间，带时区
+        assert datetime.fromisoformat(body["checked_at"]).tzinfo is not None
+
+    def test_sends_github_api_headers(self):
+        """出站请求形状：GitHub 要求 Accept 与 User-Agent，缺 UA 会被 403。"""
+        app = _make_app()
+        with capture_http(assert_all_called=True) as http:
+            route = http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
+            with TestClient(app) as client:
+                client.get("/api/v1/system/version")
+
+        request = route.calls.last.request
+        assert request.headers["accept"] == "application/vnd.github+json"
+        assert request.headers["user-agent"] == "ArcReel"
 
     def test_returns_current_version_when_github_check_fails(self):
         app = _make_app()
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.9.0"),
-            patch("server.routers.system_config._get_latest_release", new=AsyncMock(side_effect=RuntimeError("boom"))),
-        ):
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(status_code=502)
             with TestClient(app) as client:
                 resp = client.get("/api/v1/system/version")
 
@@ -87,35 +106,26 @@ class TestSystemVersionApi:
         assert body["has_update"] is False
         # 信息不再泄漏：返回固定 i18n 文案，详细错误只在日志
         assert body["update_check_error"] == "检查更新失败，请稍后重试"
-        assert "boom" not in body["update_check_error"]
+        assert "502" not in body["update_check_error"]
 
     def test_handles_v_prefixed_tag_as_semver(self):
         app = _make_app()
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.9.0"),
-            patch(
-                "server.routers.system_config._get_latest_release",
-                new=AsyncMock(return_value=_release_tuple("0.9.0")),
-            ),
-        ):
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.0"))
             with TestClient(app) as client:
                 resp = client.get("/api/v1/system/version")
 
         assert resp.status_code == 200
         body = resp.json()
+        assert body["latest"]["version"] == "0.9.0"
         assert body["has_update"] is False
         assert body["update_check_error"] is None
 
     def test_handles_prerelease_tag_without_error(self):
         """GitHub 真实场景：v0.10.0-rc1 这类 tag 不应触发 update_check_error。"""
-        app = _make_app()
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.10.0"),
-            patch(
-                "server.routers.system_config._get_latest_release",
-                new=AsyncMock(return_value=_release_tuple("0.10.0-rc1")),
-            ),
-        ):
+        app = _make_app(lambda: "0.10.0")
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(json=_release_body("0.10.0-rc1"))
             with TestClient(app) as client:
                 resp = client.get("/api/v1/system/version")
 
@@ -128,35 +138,24 @@ class TestSystemVersionApi:
     def test_invalid_remote_version_does_not_break_endpoint(self):
         """远端 tag 解析失败时退化为 has_update=False，不报错。"""
         app = _make_app()
-        broken_payload = {
-            "version": "not-a-version",
-            "tag_name": "weird",
-            "name": "weird",
-            "body": "",
-            "html_url": "",
-            "published_at": "",
-        }
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.9.0"),
-            patch(
-                "server.routers.system_config._get_latest_release",
-                new=AsyncMock(return_value=(broken_payload, _FIXED_FETCHED_AT)),
-            ),
-        ):
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(json={"tag_name": "weird", "name": "weird"})
             with TestClient(app) as client:
                 resp = client.get("/api/v1/system/version")
 
         assert resp.status_code == 200
         body = resp.json()
+        assert body["latest"]["version"] == "weird"
         assert body["has_update"] is False
         assert body["update_check_error"] is None
 
     def test_returns_500_when_local_version_cannot_be_read(self):
-        app = _make_app()
-        # _read_app_version 被 lru_cache 装饰，patch 会替换整个属性
-        # 但需要保险起见 clear cache，避免之前测试 populate
-        system_config._read_app_version.cache_clear()
-        with patch("server.routers.system_config._read_app_version", side_effect=RuntimeError("missing version")):
+        def _unreadable() -> str:
+            raise RuntimeError("missing version")
+
+        app = _make_app(_unreadable)
+        with capture_http() as http:
+            http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
             with TestClient(app, raise_server_exceptions=False) as client:
                 resp = client.get("/api/v1/system/version")
 
@@ -166,66 +165,66 @@ class TestSystemVersionApi:
         assert "missing version" not in str(body)
 
 
+class TestLoadAppVersion:
+    def test_reads_project_version_from_pyproject(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "arcreel"\nversion = "1.2.3"\n', encoding="utf-8")
+        assert system_config._load_app_version(pyproject) == "1.2.3"
+
+    def test_missing_file_propagates(self, tmp_path):
+        with pytest.raises(OSError):
+            system_config._load_app_version(tmp_path / "absent.toml")
+
+    def test_empty_version_is_rejected(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "arcreel"\nversion = "  "\n', encoding="utf-8")
+        with pytest.raises(RuntimeError):
+            system_config._load_app_version(pyproject)
+
+
 class TestGetLatestReleaseCache:
-    def test_cache_hit_within_ttl_skips_http_call(self):
+    async def test_cache_hit_within_ttl_skips_http_call(self):
         """5 分钟 TTL 内重复调用应只命中 HTTP 一次。"""
-        _reset_cache()
+        with capture_http(assert_all_called=True) as http:
+            route = http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
+            first = await system_config._get_latest_release()
+            second = await system_config._get_latest_release()
 
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "tag_name": "v0.9.1",
-            "name": "0.9.1",
-            "body": "",
-            "html_url": "",
-            "published_at": "",
-        }
-        mock_response.raise_for_status = MagicMock()
-
-        mock_client = MagicMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        async def run():
-            with patch("server.routers.system_config.get_http_client", return_value=mock_client):
-                a = await system_config._get_latest_release()
-                b = await system_config._get_latest_release()
-            return a, b
-
-        import asyncio
-
-        a, b = asyncio.run(run())
-        # payload 与 fetched_at 都来自同一次 fetch
-        assert a == b
-        assert a[1] == b[1]  # fetched_at 不变（关键：缓存命中不重置时间戳）
-        assert mock_client.get.await_count == 1
+        # payload 与 fetched_at 都来自同一次 fetch（缓存命中不重置时间戳）
+        assert first == second
+        assert route.call_count == 1
 
     def test_cached_endpoint_response_preserves_fetched_at(self):
         """端到端：连续两次调用 /system/version 时 checked_at 不变（缓存命中）。"""
-        _reset_cache()
         app = _make_app()
-
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "tag_name": "v0.9.1",
-            "name": "0.9.1",
-            "body": "",
-            "html_url": "",
-            "published_at": "",
-        }
-        mock_response.raise_for_status = MagicMock()
-
-        mock_client = MagicMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-
-        with (
-            patch("server.routers.system_config._read_app_version", return_value="0.9.0"),
-            patch("server.routers.system_config.get_http_client", return_value=mock_client),
-        ):
+        with capture_http(assert_all_called=True) as http:
+            route = http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
             with TestClient(app) as client:
                 first = client.get("/api/v1/system/version").json()
                 second = client.get("/api/v1/system/version").json()
 
-        assert mock_client.get.await_count == 1
+        assert route.call_count == 1
         assert first["checked_at"] == second["checked_at"]
+
+    async def test_expired_cache_refetches(self):
+        """TTL 过期后重新出站，fetched_at 随之前进。"""
+        with capture_http(assert_all_called=True) as http:
+            route = http.get(_GITHUB_LATEST).respond(json=_release_body("0.9.1"))
+            _first, first_at = await system_config._get_latest_release(now=datetime(2026, 4, 21, 8, 0, tzinfo=UTC))
+            _second, second_at = await system_config._get_latest_release(now=datetime(2026, 4, 21, 9, 0, tzinfo=UTC))
+
+        assert route.call_count == 2
+        assert second_at > first_at
+
+    async def test_http_error_is_not_cached(self):
+        """失败响应不写缓存，下一次调用仍然出站重试。"""
+        with capture_http(assert_all_called=True) as http:
+            route = http.get(_GITHUB_LATEST).respond(status_code=500)
+            for _ in range(2):
+                with pytest.raises(httpx.HTTPStatusError):
+                    await system_config._get_latest_release()
+
+        assert route.call_count == 2
 
 
 class TestParseVersion:

--- a/tests/unit/server/services/test_diagnostics_service.py
+++ b/tests/unit/server/services/test_diagnostics_service.py
@@ -65,9 +65,7 @@ def test_collect_swallows_field_errors(monkeypatch: pytest.MonkeyPatch, tmp_path
     def boom() -> str:
         raise RuntimeError("simulated failure")
 
-    monkeypatch.setattr(diag_mod, "_app_version", boom)
-
-    text = diag_mod.collect_diagnostics()
+    text = diag_mod.collect_diagnostics(app_version=boom)
     assert "<unavailable" in text
     assert "Python" in text
 

--- a/tests/unit/server/services/test_execute_tts_task.py
+++ b/tests/unit/server/services/test_execute_tts_task.py
@@ -960,6 +960,13 @@ class TestExecuteTtsTask:
 class TestGetOrCreateAudioBackend:
     """audio backend 构造统一委托 assemble_backend；缓存留在调用方编排层。"""
 
+    @pytest.fixture(autouse=True)
+    def _clear_backend_cache(self):
+        """backend 缓存是模块级进程内状态，公开失效入口即用例间的隔离手段。"""
+        generation_context.invalidate_backend_cache()
+        yield
+        generation_context.invalidate_backend_cache()
+
     async def test_custom_provider_routes_through_assemble(self, monkeypatch):
         sentinel = object()
         calls = []
@@ -969,7 +976,6 @@ class TestGetOrCreateAudioBackend:
             return sentinel
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         resolver = cast(ConfigResolver, None)
         b1 = await generation_context._get_or_create_audio_backend("custom-3", {"model": "tts-1"}, resolver)
@@ -987,7 +993,6 @@ class TestGetOrCreateAudioBackend:
             return sentinel
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         resolver = cast(ConfigResolver, None)
         b1 = await generation_context._get_or_create_audio_backend(
@@ -1007,7 +1012,6 @@ class TestGetOrCreateAudioBackend:
             return object()
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
-        monkeypatch.setattr(generation_context, "_backend_cache", generation_context._BackendCache())
 
         await generation_context._get_or_create_audio_backend(
             "dashscope",

--- a/tests/unit/server/services/test_execute_tts_task.py
+++ b/tests/unit/server/services/test_execute_tts_task.py
@@ -10,6 +10,7 @@ import json
 import math
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
@@ -1005,21 +1006,18 @@ class TestGetOrCreateAudioBackend:
         assert created == [("dashscope", "audio", "qwen3-tts-flash")], "第二次调用须命中缓存，不再重建 backend"
 
     async def test_payload_model_overrides_default(self, monkeypatch):
-        calls = []
-
         async def _fake_assemble(*, provider_id, media_type, model_id, resolver, rate_limiter=None):
-            calls.append(model_id)
-            return object()
+            return SimpleNamespace(provider_id=provider_id, media_type=media_type, model_id=model_id)
 
         monkeypatch.setattr(generation_context, "assemble_backend", _fake_assemble)
 
-        await generation_context._get_or_create_audio_backend(
+        backend = await generation_context._get_or_create_audio_backend(
             "dashscope",
             {"model": "explicit-model"},
             cast(ConfigResolver, None),
             default_audio_model="fallback-model",
         )
-        assert calls == ["explicit-model"]
+        assert backend.model_id == "explicit-model"
 
 
 class TestComputeAffectedFingerprintsTts:

--- a/tests/unit/server/services/test_generation_tasks_dispatch.py
+++ b/tests/unit/server/services/test_generation_tasks_dispatch.py
@@ -62,7 +62,11 @@ async def test_execute_generation_task_passes_claimed_provider_to_reference_prox
         )
         return {"ok": True}
 
-    monkeypatch.setattr(generation_tasks, "_execute_reference_video_task_proxy", _fake_reference_proxy)
+    # 替身落在惰性代理的下游协作者上，代理本身的参数透传照跑。
+    monkeypatch.setattr(
+        "server.services.reference_video_tasks.execute_reference_video_task",
+        _fake_reference_proxy,
+    )
 
     result = await generation_tasks.execute_generation_task(
         {

--- a/tests/unit/server/services/test_grid_split_service.py
+++ b/tests/unit/server/services/test_grid_split_service.py
@@ -272,15 +272,12 @@ class TestApplyGridSplit:
         }
         pm = ProjectManager(project_with_script.parent)
 
-        with (
-            patch("server.services.grid_split.get_project_manager", return_value=pm),
-            patch(
-                "server.services.grid_split._register_split_entries_atomically",
-                side_effect=RuntimeError("manifest commit failed"),
-            ),
-        ):
+        def _fail_register(*_args, **_kwargs):
+            raise RuntimeError("manifest commit failed")
+
+        with patch("server.services.grid_split.get_project_manager", return_value=pm):
             with pytest.raises(RuntimeError, match="manifest commit failed"):
-                await apply_grid_split("test-project", grid_with_image)
+                await apply_grid_split("test-project", grid_with_image, register_entries=_fail_register)
 
         assert project_file.read_bytes() == snapshots["project"]
         assert script_file.read_bytes() == snapshots["script"]
@@ -450,15 +447,13 @@ class TestApplyGridSplit:
             original_register(project_path, entries=entries, expected_entries=expected_entries)
 
         pm = ProjectManager(project_with_script.parent)
-        with (
-            patch("server.services.grid_split.get_project_manager", return_value=pm),
-            patch(
-                "server.services.grid_split._register_split_entries_atomically",
-                side_effect=_replace_source_then_register,
-            ),
-        ):
+        with patch("server.services.grid_split.get_project_manager", return_value=pm):
             with pytest.raises(ArtifactManifestError, match="changed during batch registration"):
-                await apply_grid_split("test-project", grid_with_image)
+                await apply_grid_split(
+                    "test-project",
+                    grid_with_image,
+                    register_entries=_replace_source_then_register,
+                )
 
         assert project_file.read_bytes() == before["project"]
         assert script_file.read_bytes() == before["script"]

--- a/tests/unit/server/services/test_image_edit_executor.py
+++ b/tests/unit/server/services/test_image_edit_executor.py
@@ -923,38 +923,42 @@ class TestImageSizeResolutionEquivalence:
 class TestImageEditEventMapping:
     def test_emit_maps_image_edit_to_resource_events(self, tmp_path, monkeypatch):
         """编辑完成事件与同资源的生成完成事件同形状：按 payload.resource_type 派发。"""
+        from lib.project_change_hints import register_project_change_batch_listener
         from server.services import generation_tasks
 
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
 
-        captured = []
-        monkeypatch.setattr(
-            generation_tasks, "emit_project_change_batch", lambda name, changes: captured.extend(changes)
+        # 从公开订阅口接真实事件总线：断言落在订阅方（SSE 广播那一侧）实际收到的批次上。
+        delivered: list[dict] = []
+        unregister = register_project_change_batch_listener(
+            lambda _project_name, _source, changes: delivered.extend(changes)
         )
+        try:
+            generation_tasks.emit_generation_success_batch(
+                task_type="image_edit",
+                project_name="demo",
+                resource_id="Alice",
+                payload={"resource_type": "character", "prompt": "x"},
+            )
+            assert delivered[0]["entity_type"] == "character"
+            assert delivered[0]["action"] == "updated"
+            # 指纹按 character 任务口径计算（characters/Alice.png 存在于磁盘）
+            assert "characters/Alice.png" in delivered[0]["asset_fingerprints"]
 
-        generation_tasks.emit_generation_success_batch(
-            task_type="image_edit",
-            project_name="demo",
-            resource_id="Alice",
-            payload={"resource_type": "character", "prompt": "x"},
-        )
-        assert captured[0]["entity_type"] == "character"
-        assert captured[0]["action"] == "updated"
-        # 指纹按 character 任务口径计算（characters/Alice.png 存在于磁盘）
-        assert "characters/Alice.png" in captured[0]["asset_fingerprints"]
-
-        captured.clear()
-        generation_tasks.emit_generation_success_batch(
-            task_type="image_edit",
-            project_name="demo",
-            resource_id="E1S01",
-            payload={"resource_type": "storyboard", "prompt": "x", "script_file": "episode_1.json"},
-        )
-        assert captured[0]["entity_type"] == "segment"
-        assert captured[0]["action"] == "storyboard_ready"
-        assert captured[0]["script_file"] == "episode_1.json"
+            delivered.clear()
+            generation_tasks.emit_generation_success_batch(
+                task_type="image_edit",
+                project_name="demo",
+                resource_id="E1S01",
+                payload={"resource_type": "storyboard", "prompt": "x", "script_file": "episode_1.json"},
+            )
+            assert delivered[0]["entity_type"] == "segment"
+            assert delivered[0]["action"] == "storyboard_ready"
+            assert delivered[0]["script_file"] == "episode_1.json"
+        finally:
+            unregister()
 
 
 def test_image_edit_registered_in_task_executors():

--- a/tests/unit/server/services/test_narration_delivery_tasks.py
+++ b/tests/unit/server/services/test_narration_delivery_tasks.py
@@ -76,11 +76,18 @@ def _typed_video_metadata(
     }
 
 
+class _IdleQueue:
+    """在途任务恒为空的生成队列替身；只实现被测路径用到的那一个查询。"""
+
+    async def get_active_tasks_for_resources(self, **_kwargs) -> list[dict]:
+        return []
+
+
 def _stub_current_narration_reload(monkeypatch, tmp_path: Path, *, narration, resource_id: str = "E1S01"):
     """把当前旁白交付重载的三个协作者换成替身，让重载协程本体照跑。
 
-    ``_prepare_current_task_narration_delivery`` 自己的剧本定位与单元准入仍走真实代码，
-    只有项目管理器、交付准备与在途 TTS 查询由替身给出，用例因而不必替换被测模块的步骤。
+    ``_prepare_current_task_narration_delivery`` 自己的剧本定位、单元准入与在途 TTS 判定仍走
+    真实代码，只有项目管理器、交付准备与生成队列由替身给出，用例因而不必替换被测模块的步骤。
     """
     pm = MagicMock()
     pm.load_project.return_value = {
@@ -99,7 +106,7 @@ def _stub_current_narration_reload(monkeypatch, tmp_path: Path, *, narration, re
         "prepare_current_narration_delivery",
         AsyncMock(return_value=narration),
     )
-    monkeypatch.setattr(narration_delivery_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
+    monkeypatch.setattr(narration_delivery_tasks, "get_generation_queue", _IdleQueue)
     return pm
 
 

--- a/tests/unit/server/services/test_narration_delivery_tasks.py
+++ b/tests/unit/server/services/test_narration_delivery_tasks.py
@@ -76,6 +76,33 @@ def _typed_video_metadata(
     }
 
 
+def _stub_current_narration_reload(monkeypatch, tmp_path: Path, *, narration, resource_id: str = "E1S01"):
+    """把当前旁白交付重载的三个协作者换成替身，让重载协程本体照跑。
+
+    ``_prepare_current_task_narration_delivery`` 自己的剧本定位与单元准入仍走真实代码，
+    只有项目管理器、交付准备与在途 TTS 查询由替身给出，用例因而不必替换被测模块的步骤。
+    """
+    pm = MagicMock()
+    pm.load_project.return_value = {
+        "name": "demo",
+        "episodes": [{"episode": 1, "script_file": "episode_1.json"}],
+    }
+    pm.get_project_path.return_value = tmp_path
+    pm.load_script.return_value = {
+        "episode": 1,
+        "content_mode": "narration",
+        "segments": [{"segment_id": resource_id, "narration": "旁白。", "duration_seconds": 8}],
+    }
+    monkeypatch.setattr(narration_delivery_tasks, "get_project_manager", lambda: pm)
+    monkeypatch.setattr(
+        narration_delivery_tasks,
+        "prepare_current_narration_delivery",
+        AsyncMock(return_value=narration),
+    )
+    monkeypatch.setattr(narration_delivery_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
+    return pm
+
+
 async def test_current_settings_use_canonical_provider_and_actual_backend_model(monkeypatch, tmp_path: Path) -> None:
     from lib.config.resolver import ProviderModel
     from server.services.generation_context import AudioLaneResult, GenerationContext
@@ -152,13 +179,7 @@ async def test_generated_video_rejection_restores_previous_current_version(
         actual_duration_seconds=6.2,
         problems=(),
     )
-    load_current = AsyncMock(return_value=narration)
-    monkeypatch.setattr(
-        narration_delivery_tasks,
-        "_prepare_current_task_narration_delivery",
-        load_current,
-        raising=False,
-    )
+    _stub_current_narration_reload(monkeypatch, tmp_path, narration=narration)
 
     with pytest.raises(NarratedVideoDurationBlockedError) as exc_info:
         await narration_delivery_tasks.require_generated_video_covers_current_tts(
@@ -173,12 +194,6 @@ async def test_generated_video_rejection_restores_previous_current_version(
         )
 
     assert exc_info.value.code == expected_code
-    load_current.assert_awaited_once_with(
-        project_name="demo",
-        script_file="episode_1.json",
-        resource_type="videos",
-        resource_id="E1S01",
-    )
     versions.reject_current_version.assert_called_once_with(
         "videos",
         "E1S01",

--- a/tests/unit/server/services/test_resume_executor.py
+++ b/tests/unit/server/services/test_resume_executor.py
@@ -732,10 +732,13 @@ async def test_reference_resume_post_production_does_not_reproject_tts(monkeypat
             )
         ),
     )
-    output_guard = AsyncMock()
+
+    async def _guard_must_not_run(**kwargs):
+        raise AssertionError(f"无 TTS 的续跑不得重投影旁白时长: {kwargs}")
+
     monkeypatch.setattr(
         "server.services.video_artifact_currency.validate_generated_video_covers_tts_duration",
-        output_guard,
+        _guard_must_not_run,
     )
     monkeypatch.setattr(
         resume_executor,
@@ -753,9 +756,11 @@ async def test_reference_resume_post_production_does_not_reproject_tts(monkeypat
         "payload": {},
     }
 
-    await execute_resume_video_task(task, job_id="job-1")
+    # 时长守卫一旦被触碰用例即炸；判据本体落在续跑真正跑完、产出该单元这件事上。
+    result = await execute_resume_video_task(task, job_id="job-1")
 
-    output_guard.assert_not_awaited()
+    assert result["resource_type"] == "reference_videos"
+    assert result["resource_id"] == "E1U1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/services/test_resume_executor.py
+++ b/tests/unit/server/services/test_resume_executor.py
@@ -650,7 +650,7 @@ async def test_reference_resume_reads_only_strict_checkpoint_request_and_cleans_
         AsyncMock(return_value=TtsSynthesisSettings("dashscope", "tts-model", "Cherry", None)),
     )
     finalize = AsyncMock(return_value={"resource_type": "reference_videos", "resource_id": "E1U1"})
-    monkeypatch.setattr(resume_executor, "_finalize_reference_video_unit", finalize)
+    monkeypatch.setattr(resume_executor, "finalize_reference_video_unit", finalize)
     monkeypatch.setattr(resume_executor, "emit_generation_success_batch", lambda **_kwargs: None)
     task = {
         "task_id": "T-ref",
@@ -739,7 +739,7 @@ async def test_reference_resume_post_production_does_not_reproject_tts(monkeypat
     )
     monkeypatch.setattr(
         resume_executor,
-        "_finalize_reference_video_unit",
+        "finalize_reference_video_unit",
         AsyncMock(return_value={"resource_type": "reference_videos", "resource_id": "E1U1"}),
     )
     monkeypatch.setattr(resume_executor, "emit_generation_success_batch", lambda **_kwargs: None)

--- a/tests/unit/server/test_app_startup_migration.py
+++ b/tests/unit/server/test_app_startup_migration.py
@@ -1,12 +1,16 @@
-"""FastAPI 启动时调用 run_project_migrations 和 cleanup_stale_backups。"""
+"""FastAPI 启动跑完项目 schema 迁移与过期备份回收。"""
 
+import json
+import os
+import time
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
 import lib.db
 import server.app as app_module
+from lib.project_migrations.runner import CURRENT_SCHEMA_VERSION
 from server.routers import assistant as assistant_router
 
 
@@ -25,20 +29,34 @@ class _FakeWorker:
         return False
 
 
-@pytest.mark.asyncio
-async def test_startup_invokes_project_migrations(monkeypatch):
-    run_mock = MagicMock(return_value=SimpleNamespace(migrated=[], skipped=[], failed=[]))
-    cleanup_mock = MagicMock()
+def _seed_stale_project(projects_root: Path) -> tuple[Path, Path]:
+    """种一个落后版本的项目，外加一份 8 天前的旧版备份。"""
+    project_dir = projects_root / "p1"
+    project_dir.mkdir(parents=True)
+    (project_dir / "project.json").write_text(
+        json.dumps({"schema_version": 1, "name": "p1", "video_backend": "seedance/x", "image_backend": "vertex/y"}),
+        encoding="utf-8",
+    )
+    stale_backup = project_dir / "project.json.bak.v1-100000000"
+    stale_backup.write_text("recovery", encoding="utf-8")
+    expired = time.time() - 8 * 86400
+    os.utime(stale_backup, (expired, expired))
+    return project_dir, stale_backup
 
-    monkeypatch.setattr(app_module, "run_project_migrations", run_mock)
-    monkeypatch.setattr(app_module, "cleanup_stale_backups", cleanup_mock)
+
+@pytest.mark.asyncio
+async def test_startup_migrates_projects_and_reaps_stale_backups(tmp_path, monkeypatch):
+    projects_root = tmp_path / "projects"
+    project_dir, stale_backup = _seed_stale_project(projects_root)
+
+    # 数据目录指向 tmp：迁移与备份回收都照真实跑，落点是本用例种下的项目。
+    monkeypatch.setattr(app_module, "app_data_dir", lambda: projects_root)
     monkeypatch.setattr(app_module, "ensure_auth_password", lambda: "test")
     monkeypatch.setattr(app_module, "init_db", _noop_async)
     monkeypatch.setattr(lib.db, "init_db", _noop_async)
     monkeypatch.setattr(app_module, "create_generation_worker", _FakeWorker)
     monkeypatch.setattr(assistant_router.assistant_service, "startup", _noop_async)
     monkeypatch.setattr(assistant_router.assistant_service, "shutdown", _noop_async)
-    # Avoid touching real on-disk projects/ during a unit test that fires lifespan.
     monkeypatch.setattr(app_module, "migrate_local_transcripts_to_store", _noop_async)
 
     app = app_module.app
@@ -47,5 +65,6 @@ async def test_startup_invokes_project_migrations(monkeypatch):
     async with app_module.lifespan(app):
         pass
 
-    run_mock.assert_called_once()
-    cleanup_mock.assert_called_once()
+    migrated = json.loads((project_dir / "project.json").read_text(encoding="utf-8"))
+    assert migrated["schema_version"] == CURRENT_SCHEMA_VERSION
+    assert not stale_backup.exists()

--- a/tests/unit/server/test_auth_api_key.py
+++ b/tests/unit/server/test_auth_api_key.py
@@ -6,7 +6,8 @@ API Key 认证分流单元测试
 
 import hashlib
 import time
-from unittest.mock import AsyncMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
@@ -20,6 +21,32 @@ def clear_cache():
     auth_module._api_key_cache.clear()
     yield
     auth_module._api_key_cache.clear()
+
+
+@pytest.fixture()
+def api_key_db(db_factory, monkeypatch):
+    """把 API Key 查库路径绑到内存库。
+
+    ``_verify_api_key`` 在函数内 import ``lib.db.async_session_factory``，缓存未命中时
+    真的落库查询；绑内存库后过期判定与缓存写入这两步都按真实数据跑。
+    """
+    monkeypatch.setattr("lib.db.async_session_factory", db_factory)
+    return db_factory
+
+
+async def _seed_api_key(factory, name: str, key: str, *, expires_at: datetime | None = None) -> None:
+    from lib.db.models.api_key import ApiKey
+
+    async with factory() as session:
+        session.add(
+            ApiKey(
+                name=name,
+                key_hash=auth_module._hash_api_key(key),
+                key_prefix=key[:8],
+                expires_at=expires_at,
+            )
+        )
+        await session.commit()
 
 
 class TestHashApiKey:
@@ -89,37 +116,37 @@ class TestVerifyAndGetPayloadAsync:
                 await auth_module._verify_and_get_payload_async("invalid.jwt.token")
         assert exc_info.value.status_code == 401
 
-    @pytest.mark.asyncio
-    async def test_api_key_path_success(self):
-        """arc- 前缀走 API Key 路径，成功返回 payload。"""
-        expected = {"sub": "apikey:mykey", "via": "apikey"}
-        with patch("server.auth._verify_api_key", new=AsyncMock(return_value=expected)):
-            result = await auth_module._verify_and_get_payload_async("arc-validkey")
+    async def test_api_key_path_success(self, api_key_db):
+        """arc- 前缀走 API Key 路径：查库命中后返回 payload 并写入缓存。"""
+        await _seed_api_key(api_key_db, "mykey", "arc-validkey")
+
+        result = await auth_module._verify_and_get_payload_async("arc-validkey")
+
         assert result["via"] == "apikey"
         assert result["sub"] == "apikey:mykey"
+        hit, cached = auth_module._get_cached_api_key_payload(auth_module._hash_api_key("arc-validkey"))
+        assert hit
+        assert cached == result
 
-    @pytest.mark.asyncio
-    async def test_api_key_not_found_raises_401(self):
-        """arc- 前缀但 key 不存在，抛出 401。"""
-        with patch("server.auth._verify_api_key", new=AsyncMock(return_value=None)):
-            with pytest.raises(HTTPException) as exc_info:
-                await auth_module._verify_and_get_payload_async("arc-badkey")
+    async def test_api_key_not_found_raises_401(self, api_key_db):
+        """arc- 前缀但库里没有该 key，抛出 401。"""
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_module._verify_and_get_payload_async("arc-badkey")
         assert exc_info.value.status_code == 401
 
-    @pytest.mark.asyncio
-    async def test_api_key_expired_raises_401(self):
-        """arc- 前缀但 key 已过期（_verify_api_key 返回 None），抛出 401。"""
-        with patch("server.auth._verify_api_key", new=AsyncMock(return_value=None)):
-            with pytest.raises(HTTPException) as exc_info:
-                await auth_module._verify_and_get_payload_async("arc-expiredkey")
-        assert exc_info.value.status_code == 401
+    async def test_api_key_expired_raises_401(self, api_key_db):
+        """库里有该 key 但 expires_at 已过，抛出 401 并落负缓存。"""
+        await _seed_api_key(
+            api_key_db,
+            "expiredkey",
+            "arc-expiredkey",
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        )
 
-    @pytest.mark.asyncio
-    async def test_jwt_path_not_called_for_api_key(self):
-        """arc- 前缀时不应调用 verify_token。"""
-        with (
-            patch("server.auth._verify_api_key", new=AsyncMock(return_value={"sub": "apikey:k", "via": "apikey"})),
-            patch("server.auth.verify_token") as mock_jwt,
-        ):
-            await auth_module._verify_and_get_payload_async("arc-somekey")
-        mock_jwt.assert_not_called()
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_module._verify_and_get_payload_async("arc-expiredkey")
+
+        assert exc_info.value.status_code == 401
+        hit, cached = auth_module._get_cached_api_key_payload(auth_module._hash_api_key("arc-expiredkey"))
+        assert hit
+        assert cached is None

--- a/tests/unit/server/test_session_store_startup_migration.py
+++ b/tests/unit/server/test_session_store_startup_migration.py
@@ -8,7 +8,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_lifespan_invokes_session_store_migration():
+async def test_lifespan_invokes_session_store_migration(tmp_path):
     """The session-store migration must be called exactly once during startup."""
     # We don't want a real lifespan to fire all its long-running side effects
     # (worker starts, http client, project event service). Patch them all out
@@ -24,7 +24,8 @@ async def test_lifespan_invokes_session_store_migration():
             return_value=type("M", (), {"migrated": [], "failed": [], "skipped": []})(),
         ),
         patch("server.app.cleanup_stale_backups"),
-        patch("server.app._migrate_source_encoding_on_startup", new=AsyncMock(return_value={})),
+        # 数据目录指向空的 tmp 目录：源文编码迁移照跑，遍历不到项目即返回空汇总。
+        patch("server.app.app_data_dir", return_value=tmp_path),
         patch("server.app.startup_http_client", new=AsyncMock(return_value=None)),
         patch("server.app.shutdown_http_client", new=AsyncMock(return_value=None)),
         patch("server.app.create_generation_worker") as worker_factory,

--- a/tests/unit/server/test_startup_assertions.py
+++ b/tests/unit/server/test_startup_assertions.py
@@ -241,26 +241,20 @@ def test_sandbox_windows_warns_not_raises(monkeypatch: pytest.MonkeyPatch, caplo
     assert any("SANDBOX_UNSUPPORTED" in record.message for record in caplog.records)
 
 
-def test_detect_docker_via_dockerenv(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_detect_docker_via_dockerenv(tmp_path) -> None:
     fake_dockerenv = tmp_path / ".dockerenv"
     fake_dockerenv.touch()
-    monkeypatch.setattr("server.app._DOCKERENV_PATH", fake_dockerenv)
-    monkeypatch.setattr("server.app._CGROUP_PATH", tmp_path / "nonexistent")
-    assert detect_docker_environment() is True
+    assert detect_docker_environment(dockerenv_path=fake_dockerenv, cgroup_path=tmp_path / "nonexistent") is True
 
 
-def test_detect_docker_via_cgroup(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_detect_docker_via_cgroup(tmp_path) -> None:
     fake_cgroup = tmp_path / "cgroup"
     fake_cgroup.write_text("12:cpu:/docker/abc123\n")
-    monkeypatch.setattr("server.app._DOCKERENV_PATH", tmp_path / "nope")
-    monkeypatch.setattr("server.app._CGROUP_PATH", fake_cgroup)
-    assert detect_docker_environment() is True
+    assert detect_docker_environment(dockerenv_path=tmp_path / "nope", cgroup_path=fake_cgroup) is True
 
 
-def test_detect_no_docker(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    monkeypatch.setattr("server.app._DOCKERENV_PATH", tmp_path / "nope")
-    monkeypatch.setattr("server.app._CGROUP_PATH", tmp_path / "also_nope")
-    assert detect_docker_environment() is False
+def test_detect_no_docker(tmp_path) -> None:
+    assert detect_docker_environment(dockerenv_path=tmp_path / "nope", cgroup_path=tmp_path / "also_nope") is False
 
 
 # bool 是 int 子类，``isinstance(True, int) and True > 0`` 为真——这一组三连测试


### PR DESCRIPTION
Closes #1999

## 范围

按 Spec #1989 的 B6 分域，清理 generation worker / queue / tasks 一线的测试质量判据命中，并补齐为此所需的生产接缝。共 41 个文件，其中生产代码 +102/-32。

## 生产改动与理由

六处生产改动，全部是公开注入点而非测试后门，默认行为与改动前逐位一致：

- `lib/generation_worker.py`：新增构造参数 `provider_projection`，默认值就是原本硬编码调用的 `_extract_provider`，四处调用点改走该参数。
- `server/services/reference_video_tasks.py` / `resume_executor.py`：`_finalize_reference_video_unit` 去私有化为 `finalize_reference_video_unit`。`resume_executor` 原本就跨模块 import 这个私有名，改名是把既有的跨模块私有依赖纠正到公开边界上，不是为测试新开的口子。
- `server/routers/system_config.py`、`presentations.py`、`projects.py`：新增路由依赖 getter 与 `Annotated[..., Depends(...)]` 别名，使测试可用 `app.dependency_overrides` 而非 patch 生产私有符号。这是 CONTRIBUTING「patch 收编闸门」对 FastAPI 路由指定的首选手段。

## 需要评审注意的三点

1. **与 Spec #1989 的张力**：#1989 列了四类允许的接缝改动，上述路由依赖 getter 不在其中。但 B6 的验收判据要求域内私有符号 patch 清零，而路由处理器内部构造的服务在不引入 getter 的前提下无法从外部替换，`dependency_overrides` 又是仓库文档明确的首选路径。此处按判据优先执行，请评审确认取舍。
2. **`test_formal_image_finalization` 覆盖收窄**：原用例 patch 私有锁对象以覆盖「持锁全程」，改写后只能覆盖到「锁的获取」。这是清除私有 patch 的直接代价。
3. **构造时机前移**：`export_jianying_draft` 中服务的构造点从处理器函数体移到依赖解析阶段。已核实无行为影响——`get_project_manager()` 是带缓存的全局单例，`pyjianyingdraft` 是 `pyproject.toml` 的硬依赖（非可选），构造不会失败，异常映射的 try 块边界也未改变。

## 本地审查修复

- 在途 TTS 判定原先替换 `tts_task_in_progress`，它与被测函数同属 `narration_delivery_tasks`，落在被测单元自身的步骤上（判据 2）。改由生成队列这个跨模块协作者给出空闲结果。
- `test_check_unique_defaults_allows_split_image_endpoints` 全程无断言且直接 import 生产私有符号，改写为向 `/api/v1/custom-providers` 提交同组配置、以 201 与两个模型的 `is_default` 为判据。
- `generation_worker.py` 中一条注释写的是引入参数的动机，按仓库规范改为描述当前约束。

## 验证

工作树 `/Users/pollochen/MyProjects/ArcReel/.claude/worktrees/issue-1999`，HEAD `2212f5b3f`：

- `ruff check .` → All checks passed!
- `ruff format .` → 1370 files already formatted
- `basedpyright` → 0 errors, 1237 warnings, 0 notes
- `lint-imports` → Contracts: 2 kept, 0 broken
- `pytest` → 10288 passed, 2 skipped

`scripts/audit_tests.py` 在 HEAD 上复核：本分支改动的 41 个文件中，「仅断言替身」「无断言」「私有符号 patch」「集成用例 patch 被测模块公开入口」四类命中均为 0；全仓总量相对基线无回归（`private_patch_sites` 215、`integration_self_public_patch_sites` 0、共享设施四项均为 0）。剩余的 215 处私有 patch 与 109 个仅断言替身用例全部落在本域之外。

## 遗留（未立项，仅记录）

- `monkeypatch.setattr("lib.db.async_session_factory", db_factory)` 在 7 个测试文件重复，已触发收编闸门；其中 6 处在基线就已存在，且涉及兄弟域文件，本分支不扩范围。
- `tests/unit/lib/test_generation_queue_client.py:549` 是否算判据 1 命中存在分歧：断言落在真实回调的输出上、回调本身就是被测契约，倾向不算；文件未被本分支改动。
- `tests/unit/server/routers/test_custom_providers_api.py` 中另有两个用例直接 import 私有 `_check_unique_defaults`（基线既有、非判据命中），建议后续一并抬到接口层。

https://claude.ai/code/session_017dYPL4DmXdDbzyifcC6G3F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 优化项目、演示文稿、归档及系统版本相关服务的调用方式，提升运行稳定性与可维护性。
  * 统一参考视频任务的处理流程，改善任务恢复与执行一致性。

* **测试**
  * 扩充任务恢复、并发处理、取消操作、媒体暂存及异常场景的验证。
  * 增强项目编辑、音视频配置、认证、版本检查和外部服务通信的集成测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->