### PR TITLE
test(lib): lib 域内测试判据与替身收编，域内机械命中清零（#2000）

### DIFF
--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -95,8 +95,12 @@ def activate_artifact_target_state(
     *,
     bump_schema: bool,
     backup_file: Callable[[Path, int], None] | None = None,
+    commit_schema: Callable[[Path, Mapping[str, Any]], None] | None = None,
 ) -> bool:
-    """Commit one complete target state, optionally advancing schema last."""
+    """Commit one complete target state, optionally advancing schema last.
+
+    ``backup_file`` 与 ``commit_schema`` 是临界区内两个落盘步骤的注入点，缺省即生产实现。
+    """
 
     plan = plan_artifact_target_state(project_dir)
     current_schema = plan.project.get("schema_version")
@@ -132,7 +136,7 @@ def activate_artifact_target_state(
                             "artifact activation dependency drifted and Manifest rollback was incomplete"
                         ) from rollback_error
                 raise
-            _commit_schema_version(project_dir, plan.project)
+            (commit_schema or _commit_schema_version)(project_dir, plan.project)
             return True
     changed = adapter.replace_entries_atomically(plan.entries)
     return changed

--- a/tests/integration/lib/config/test_config_resolver.py
+++ b/tests/integration/lib/config/test_config_resolver.py
@@ -61,6 +61,12 @@ class _FakeConfigService:
         return [_make_ready_provider("gemini-aistudio", ["text", "image", "video"])]
 
 
+async def _video_caps(db_factory, project: dict) -> dict:
+    """按项目字典解析视频能力；项目落盘不参与本组判据，故 project_manager 只做占位。"""
+    with patch("lib.config.resolver.get_project_manager"):
+        return await ConfigResolver(db_factory).video_capabilities_for_project(project)
+
+
 class TestVideoGenerateAudio:
     """验证 video_generate_audio 的默认值、全局配置、项目级覆盖优先级。"""
 
@@ -375,10 +381,6 @@ class TestVideoBackendThreeLevelPriority:
 class TestVideoCapabilitiesBucketing:
     """读侧按 generation_mode 定桶：能力查询回答的是当前配置真正会执行的那个模型。"""
 
-    async def _caps(self, db_factory, project: dict) -> dict:
-        with patch("lib.config.resolver.get_project_manager"):
-            return await ConfigResolver(db_factory).video_capabilities_for_project(project)
-
     def test_generation_mode_maps_to_bucket(self):
         assert video_bucket_for_generation_mode("storyboard") == "i2v"
         assert video_bucket_for_generation_mode("reference_video") == "r2v"
@@ -390,7 +392,7 @@ class TestVideoCapabilitiesBucketing:
 
     async def test_i2v_bucket_shadows_project_default(self, db_factory):
         """图生视频项目读 i2v 桶，遮蔽项目默认层。"""
-        caps = await self._caps(
+        caps = await _video_caps(
             db_factory,
             {
                 "video_backend": "grok/grok-imagine-video",
@@ -402,7 +404,7 @@ class TestVideoCapabilitiesBucketing:
 
     async def test_r2v_bucket_shadows_project_default(self, db_factory):
         """参考生视频项目读 r2v 桶，遮蔽项目默认层。"""
-        caps = await self._caps(
+        caps = await _video_caps(
             db_factory,
             {
                 "video_backend": "grok/grok-imagine-video",
@@ -418,8 +420,8 @@ class TestVideoCapabilitiesBucketing:
             "video_provider_i2v": "kling/kling-v3",
             "video_provider_r2v": "minimax/S2V-01",
         }
-        i2v_caps = await self._caps(db_factory, {**project, "generation_mode": "storyboard"})
-        r2v_caps = await self._caps(db_factory, {**project, "generation_mode": "reference_video"})
+        i2v_caps = await _video_caps(db_factory, {**project, "generation_mode": "storyboard"})
+        r2v_caps = await _video_caps(db_factory, {**project, "generation_mode": "reference_video"})
         assert i2v_caps["model"] == "kling-v3"
         assert r2v_caps["model"] == "S2V-01"
         # 能力字典本身随之变：i2v 桶的型号不接受参考图
@@ -429,14 +431,14 @@ class TestVideoCapabilitiesBucketing:
     async def test_reference_video_project_errors_when_model_lacks_reference_support(self, db_factory):
         """参考生视频项目解析到无参考图能力的模型时报结构化错误，不静默换模型。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
-            await self._caps(db_factory, {"video_backend": "kling/kling-v3", "generation_mode": "reference_video"})
+            await _video_caps(db_factory, {"video_backend": "kling/kling-v3", "generation_mode": "reference_video"})
         assert excinfo.value.code == "video_capability_missing_r2v"
         assert excinfo.value.params == {"provider": "kling", "model": "kling-v3"}
 
     async def test_storyboard_project_errors_when_model_lacks_first_frame(self, db_factory):
         """图生视频项目解析到无首帧能力的模型时同样报错（桶换成 i2v）。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
-            await self._caps(db_factory, {"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
+            await _video_caps(db_factory, {"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
         assert excinfo.value.code == "video_capability_missing_i2v"
 
     async def test_duration_constraints_evaluate_on_bucket_model(self, db_factory):
@@ -446,7 +448,7 @@ class TestVideoCapabilitiesBucketing:
             "video_provider_r2v": "gemini-aistudio/veo-3.1-generate-preview",
             "generation_mode": "reference_video",
         }
-        caps = await self._caps(db_factory, project)
+        caps = await _video_caps(db_factory, project)
         assert caps["model"] == "veo-3.1-generate-preview"
         assert caps["supported_durations"] == [4, 6, 8]
         constrained = constrain_durations_for_project(
@@ -460,7 +462,7 @@ class TestVideoCapabilitiesBucketing:
 
     async def test_max_reference_images_follows_backend_declaration(self, db_factory):
         """viduq3-pro 不在 /reference2video 白名单：能力查询报 0，不报 registry 的并行声明。"""
-        caps = await self._caps(db_factory, {"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})
+        caps = await _video_caps(db_factory, {"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})
         assert caps["max_reference_images"] == 0
 
 
@@ -1652,10 +1654,6 @@ class TestStyleAnalysisVisionGuard:
 class TestProjectGenerationModeCaps:
     """能力解析按项目生成模式定轴：创建即定、全项目一种，能力不需要剧集上下文。"""
 
-    async def _caps(self, db_factory, project: dict) -> dict:
-        with patch("lib.config.resolver.get_project_manager"):
-            return await ConfigResolver(db_factory).video_capabilities_for_project(project)
-
     def test_caps_generation_mode_reads_project_field(self):
         assert caps_generation_mode({"generation_mode": "reference_video"}) == "reference_video"
         assert caps_generation_mode({"generation_mode": "storyboard"}) == "storyboard"
@@ -1675,8 +1673,8 @@ class TestProjectGenerationModeCaps:
             "video_provider_r2v": "minimax/S2V-01",
         }
         reference_project = {**storyboard_project, "generation_mode": "reference_video"}
-        assert (await self._caps(db_factory, storyboard_project))["model"] == "kling-v3"
-        assert (await self._caps(db_factory, reference_project))["model"] == "S2V-01"
+        assert (await _video_caps(db_factory, storyboard_project))["model"] == "kling-v3"
+        assert (await _video_caps(db_factory, reference_project))["model"] == "S2V-01"
 
     async def test_voice_consistency_follows_project_route(self, db_factory):
         """参考生视频按 native 解析，分镜图生视频降格 soft。"""
@@ -1685,16 +1683,16 @@ class TestProjectGenerationModeCaps:
             "video_provider_r2v": "ark/doubao-seedance-2-0-260128",
             "video_backend": "ark/doubao-seedance-2-0-260128",
         }
-        caps = await self._caps(db_factory, project)
+        caps = await _video_caps(db_factory, project)
         assert caps["voice_consistency"] == "native"
         assert caps["generation_mode"] == "reference_video"
-        assert (await self._caps(db_factory, {**project, "generation_mode": "storyboard"}))[
+        assert (await _video_caps(db_factory, {**project, "generation_mode": "storyboard"}))[
             "voice_consistency"
         ] == "soft"
 
     async def test_uses_reference_images_constraint_follows_project_route(self, db_factory):
         """caps 的 generation_mode 是下游时长约束的入参，参考生视频据此施加「参考图↔时长」约束。"""
-        caps = await self._caps(
+        caps = await _video_caps(
             db_factory, {"generation_mode": "reference_video", "video_provider_r2v": "minimax/S2V-01"}
         )
         assert caps["generation_mode"] == "reference_video"

--- a/tests/integration/lib/config/test_config_resolver.py
+++ b/tests/integration/lib/config/test_config_resolver.py
@@ -2,7 +2,6 @@ from typing import cast
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.config.resolver import (
     ConfigResolver,
@@ -13,16 +12,6 @@ from lib.config.resolver import (
     video_bucket_for_generation_mode,
 )
 from lib.config.service import ProviderStatus
-from lib.db.base import Base
-
-
-async def _make_session():
-    """创建内存 SQLite 数据库并返回 (factory, engine)。"""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    return factory, engine
 
 
 def _make_ready_provider(name: str, media_types: list[str]) -> ProviderStatus:
@@ -151,30 +140,22 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_video_backend(fake_svc, None)
         assert result == ("ark", "doubao-seedance-1-5-pro")
 
-    async def test_video_backend_auto_resolve(self):
+    async def test_video_backend_auto_resolve(self, db_factory):
         """DB 无值时走 auto-resolve，选第一个 ready 供应商的默认 video 模型。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
         # auto-resolve 会在 PROVIDER_REGISTRY 中找到 ready 供应商，不会走到 custom provider 分支
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                result = await resolver._resolve_default_video_backend(fake_svc, session)
-            assert result[0] in ("gemini-aistudio", "gemini-vertex", "ark", "grok")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            result = await resolver._resolve_default_video_backend(fake_svc, session)
+        assert result[0] in ("gemini-aistudio", "gemini-vertex", "ark", "grok")
 
-    async def test_video_backend_auto_resolve_no_ready_provider(self):
+    async def test_video_backend_auto_resolve_no_ready_provider(self, db_factory):
         """无 ready 供应商且无自定义供应商时抛出 ValueError。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={}, ready_providers=[])
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with pytest.raises(ValueError, match="未找到可用的 video 供应商"):
-                    await resolver._resolve_default_video_backend(fake_svc, session)
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with pytest.raises(ValueError, match="未找到可用的 video 供应商"):
+                await resolver._resolve_default_video_backend(fake_svc, session)
 
     async def test_image_backend_explicit(self):
         """DB 有显式值时直接返回。"""
@@ -185,29 +166,21 @@ class TestDefaultBackends:
         result = await resolver._resolve_default_image_backend(fake_svc, None)
         assert result == ("grok", "grok-2-image")
 
-    async def test_image_backend_auto_resolve(self):
+    async def test_image_backend_auto_resolve(self, db_factory):
         """DB 无值时走 auto-resolve。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                result = await resolver._resolve_default_image_backend(fake_svc, session)
-            assert result[0] in ("gemini-aistudio", "gemini-vertex", "ark", "grok")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            result = await resolver._resolve_default_image_backend(fake_svc, session)
+        assert result[0] in ("gemini-aistudio", "gemini-vertex", "ark", "grok")
 
-    async def test_image_backend_auto_resolve_no_ready_provider(self):
+    async def test_image_backend_auto_resolve_no_ready_provider(self, db_factory):
         """无 ready 供应商且无自定义供应商时抛出 ValueError。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={}, ready_providers=[])
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with pytest.raises(ValueError, match="未找到可用的 image 供应商"):
-                    await resolver._resolve_default_image_backend(fake_svc, session)
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with pytest.raises(ValueError, match="未找到可用的 image 供应商"):
+                await resolver._resolve_default_image_backend(fake_svc, session)
 
     async def test_default_image_backend_t2i_bucket_overrides_default_layer(self):
         """全局桶 default_image_backend_t2i 覆盖全局默认层 default_image_backend。"""
@@ -252,27 +225,23 @@ class TestDefaultBackends:
         assert result == ("grok", "grok-2-image")
 
     @pytest.mark.parametrize("capability", ["t2i", "i2i"])
-    async def test_default_image_backend_empty_bucket_falls_back_to_default_layer(self, capability: str):
+    async def test_default_image_backend_empty_bucket_falls_back_to_default_layer(self, db_factory, capability: str):
         """桶键为空字符串时回退默认层（docs/adr/0054）。
 
         语义锁：桶是可选覆盖，空值不再表示「不设默认 / 自动选择」。ready_providers=[] 让
         自动推断路径抛错，以此区分「回退到默认层」（期望）与「跳到自动推断」。
         """
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver.__new__(ConfigResolver)
-            fake_svc = _FakeConfigService(
-                settings={
-                    "default_image_backend": "grok/grok-2-image",
-                    f"default_image_backend_{capability}": "",
-                },
-                ready_providers=[],
-            )
-            async with factory() as session:
-                result = await resolver._resolve_default_image_backend(fake_svc, session, capability)
-            assert result == ("grok", "grok-2-image")
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService(
+            settings={
+                "default_image_backend": "grok/grok-2-image",
+                f"default_image_backend_{capability}": "",
+            },
+            ready_providers=[],
+        )
+        async with db_factory() as session:
+            result = await resolver._resolve_default_image_backend(fake_svc, session, capability)
+        assert result == ("grok", "grok-2-image")
 
     @pytest.mark.parametrize("capability", ["t2i", "i2i"])
     async def test_default_image_backend_only_default_layer_covers_all_buckets(self, capability: str):
@@ -286,107 +255,87 @@ class TestDefaultBackends:
 class TestProviderConfig:
     """验证供应商配置方法委托给 ConfigService。"""
 
-    async def test_provider_config(self):
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver.__new__(ConfigResolver)
-            fake_svc = _FakeConfigService()
-            async with factory() as session:
-                result = await resolver._resolve_provider_config(fake_svc, session, "gemini-aistudio")
-            assert result == {"api_key": "key-gemini-aistudio"}
-        finally:
-            await engine.dispose()
+    async def test_provider_config(self, db_factory):
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService()
+        async with db_factory() as session:
+            result = await resolver._resolve_provider_config(fake_svc, session, "gemini-aistudio")
+        assert result == {"api_key": "key-gemini-aistudio"}
 
-    async def test_all_provider_configs(self):
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver.__new__(ConfigResolver)
-            fake_svc = _FakeConfigService()
-            async with factory() as session:
-                result = await resolver._resolve_all_provider_configs(fake_svc, session)
-            assert "gemini-aistudio" in result
-        finally:
-            await engine.dispose()
+    async def test_all_provider_configs(self, db_factory):
+        resolver = ConfigResolver.__new__(ConfigResolver)
+        fake_svc = _FakeConfigService()
+        async with db_factory() as session:
+            result = await resolver._resolve_all_provider_configs(fake_svc, session)
+        assert "gemini-aistudio" in result
 
 
 class TestSessionReuse:
     """验证 session() 上下文管理器的 session 复用行为。"""
 
-    async def test_session_context_manager_reuses_single_session(self):
+    async def test_session_context_manager_reuses_single_session(self, db_factory):
         """resolver.session() 下多次调用只创建 1 个 session。"""
-        factory, engine = await _make_session()
-        try:
-            call_count = 0
-            real_call = factory.__call__
+        call_count = 0
+        real_call = db_factory.__call__
 
-            def counting_factory():
-                nonlocal call_count
-                call_count += 1
-                return real_call()
+        def counting_factory():
+            nonlocal call_count
+            call_count += 1
+            return real_call()
 
-            resolver = ConfigResolver(factory)
-            fake_backend = ("gemini-aistudio", "test-model")
+        resolver = ConfigResolver(db_factory)
+        fake_backend = ("gemini-aistudio", "test-model")
 
-            # 不使用 session()：每次调用创建新 session
-            call_count = 0
-            with (
-                patch.object(resolver, "_session_factory", side_effect=counting_factory),
-                patch.object(resolver, "_resolve_default_video_backend", return_value=fake_backend),
-                patch.object(resolver, "_resolve_default_image_backend", return_value=fake_backend),
-            ):
-                await resolver.default_video_backend()
-                await resolver.default_image_backend()
-            assert call_count == 2, f"不使用 session() 应创建 2 个 session，实际 {call_count}"
+        # 不使用 session()：每次调用创建新 session
+        call_count = 0
+        with (
+            patch.object(resolver, "_session_factory", side_effect=counting_factory),
+            patch.object(resolver, "_resolve_default_video_backend", return_value=fake_backend),
+            patch.object(resolver, "_resolve_default_image_backend", return_value=fake_backend),
+        ):
+            await resolver.default_video_backend()
+            await resolver.default_image_backend()
+        assert call_count == 2, f"不使用 session() 应创建 2 个 session，实际 {call_count}"
 
-            # 使用 session()：只创建 1 个 session
-            call_count = 0
-            with patch.object(resolver, "_session_factory", side_effect=counting_factory):
-                async with resolver.session() as r:
-                    with (
-                        patch.object(r, "_resolve_default_video_backend", return_value=fake_backend),
-                        patch.object(r, "_resolve_default_image_backend", return_value=fake_backend),
-                        patch.object(r, "_resolve_video_generate_audio", return_value=False),
-                    ):
-                        await r.default_video_backend()
-                        await r.default_image_backend()
-                        await r.video_generate_audio()
-            # session() 自身创建 1 个，内部调用复用 bound session 不再创建
-            assert call_count == 1, f"使用 session() 应只创建 1 个 session，实际 {call_count}"
-        finally:
-            await engine.dispose()
-
-    async def test_bound_resolver_shares_session_object(self):
-        """bound resolver 的 _open_session 返回同一个 session 对象。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            sessions_seen = []
-
+        # 使用 session()：只创建 1 个 session
+        call_count = 0
+        with patch.object(resolver, "_session_factory", side_effect=counting_factory):
             async with resolver.session() as r:
-                async with r._open_session() as (s1, _):
-                    sessions_seen.append(s1)
-                async with r._open_session() as (s2, _):
-                    sessions_seen.append(s2)
+                with (
+                    patch.object(r, "_resolve_default_video_backend", return_value=fake_backend),
+                    patch.object(r, "_resolve_default_image_backend", return_value=fake_backend),
+                    patch.object(r, "_resolve_video_generate_audio", return_value=False),
+                ):
+                    await r.default_video_backend()
+                    await r.default_image_backend()
+                    await r.video_generate_audio()
+        # session() 自身创建 1 个，内部调用复用 bound session 不再创建
+        assert call_count == 1, f"使用 session() 应只创建 1 个 session，实际 {call_count}"
 
-            assert sessions_seen[0] is sessions_seen[1]
-        finally:
-            await engine.dispose()
+    async def test_bound_resolver_shares_session_object(self, db_factory):
+        """bound resolver 的 _open_session 返回同一个 session 对象。"""
+        resolver = ConfigResolver(db_factory)
+        sessions_seen = []
 
-    async def test_unbound_resolver_creates_separate_sessions(self):
-        """未绑定的 resolver 每次 _open_session 创建不同 session。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            sessions_seen = []
-
-            async with resolver._open_session() as (s1, _):
+        async with resolver.session() as r:
+            async with r._open_session() as (s1, _):
                 sessions_seen.append(s1)
-            async with resolver._open_session() as (s2, _):
+            async with r._open_session() as (s2, _):
                 sessions_seen.append(s2)
 
-            assert sessions_seen[0] is not sessions_seen[1]
-        finally:
-            await engine.dispose()
+        assert sessions_seen[0] is sessions_seen[1]
+
+    async def test_unbound_resolver_creates_separate_sessions(self, db_factory):
+        """未绑定的 resolver 每次 _open_session 创建不同 session。"""
+        resolver = ConfigResolver(db_factory)
+        sessions_seen = []
+
+        async with resolver._open_session() as (s1, _):
+            sessions_seen.append(s1)
+        async with resolver._open_session() as (s2, _):
+            sessions_seen.append(s2)
+
+        assert sessions_seen[0] is not sessions_seen[1]
 
 
 class TestVideoBackendThreeLevelPriority:
@@ -426,13 +375,9 @@ class TestVideoBackendThreeLevelPriority:
 class TestVideoCapabilitiesBucketing:
     """读侧按 generation_mode 定桶：能力查询回答的是当前配置真正会执行的那个模型。"""
 
-    async def _caps(self, project: dict) -> dict:
-        factory, engine = await _make_session()
-        try:
-            with patch("lib.config.resolver.get_project_manager"):
-                return await ConfigResolver(factory).video_capabilities_for_project(project)
-        finally:
-            await engine.dispose()
+    async def _caps(self, db_factory, project: dict) -> dict:
+        with patch("lib.config.resolver.get_project_manager"):
+            return await ConfigResolver(db_factory).video_capabilities_for_project(project)
 
     def test_generation_mode_maps_to_bucket(self):
         assert video_bucket_for_generation_mode("storyboard") == "i2v"
@@ -443,63 +388,65 @@ class TestVideoCapabilitiesBucketing:
         assert video_bucket_for_generation_mode("grid") == "i2v"
         assert video_bucket_for_generation_mode(cast(str, ["reference_video"])) == "i2v"
 
-    async def test_i2v_bucket_shadows_project_default(self):
+    async def test_i2v_bucket_shadows_project_default(self, db_factory):
         """图生视频项目读 i2v 桶，遮蔽项目默认层。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "grok/grok-imagine-video",
                 "video_provider_i2v": "kling/kling-v3",
                 "generation_mode": "storyboard",
-            }
+            },
         )
         assert (caps["provider_id"], caps["model"]) == ("kling", "kling-v3")
 
-    async def test_r2v_bucket_shadows_project_default(self):
+    async def test_r2v_bucket_shadows_project_default(self, db_factory):
         """参考生视频项目读 r2v 桶，遮蔽项目默认层。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "grok/grok-imagine-video",
                 "video_provider_r2v": "minimax/S2V-01",
                 "generation_mode": "reference_video",
-            }
+            },
         )
         assert (caps["provider_id"], caps["model"]) == ("minimax", "S2V-01")
 
-    async def test_same_config_follows_generation_mode(self):
+    async def test_same_config_follows_generation_mode(self, db_factory):
         """同一份配置下切 generation_mode，能力查询随桶换到另一个模型。"""
         project = {
             "video_provider_i2v": "kling/kling-v3",
             "video_provider_r2v": "minimax/S2V-01",
         }
-        i2v_caps = await self._caps({**project, "generation_mode": "storyboard"})
-        r2v_caps = await self._caps({**project, "generation_mode": "reference_video"})
+        i2v_caps = await self._caps(db_factory, {**project, "generation_mode": "storyboard"})
+        r2v_caps = await self._caps(db_factory, {**project, "generation_mode": "reference_video"})
         assert i2v_caps["model"] == "kling-v3"
         assert r2v_caps["model"] == "S2V-01"
         # 能力字典本身随之变：i2v 桶的型号不接受参考图
         assert i2v_caps["max_reference_images"] == 0
         assert r2v_caps["max_reference_images"] == 1
 
-    async def test_reference_video_project_errors_when_model_lacks_reference_support(self):
+    async def test_reference_video_project_errors_when_model_lacks_reference_support(self, db_factory):
         """参考生视频项目解析到无参考图能力的模型时报结构化错误，不静默换模型。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
-            await self._caps({"video_backend": "kling/kling-v3", "generation_mode": "reference_video"})
+            await self._caps(db_factory, {"video_backend": "kling/kling-v3", "generation_mode": "reference_video"})
         assert excinfo.value.code == "video_capability_missing_r2v"
         assert excinfo.value.params == {"provider": "kling", "model": "kling-v3"}
 
-    async def test_storyboard_project_errors_when_model_lacks_first_frame(self):
+    async def test_storyboard_project_errors_when_model_lacks_first_frame(self, db_factory):
         """图生视频项目解析到无首帧能力的模型时同样报错（桶换成 i2v）。"""
         with pytest.raises(VideoBucketCapabilityError) as excinfo:
-            await self._caps({"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
+            await self._caps(db_factory, {"video_backend": "minimax/S2V-01", "generation_mode": "storyboard"})
         assert excinfo.value.code == "video_capability_missing_i2v"
 
-    async def test_duration_constraints_evaluate_on_bucket_model(self):
+    async def test_duration_constraints_evaluate_on_bucket_model(self, db_factory):
         """时长收窄按桶生效模型求值：参考生视频项目落 r2v 桶模型声明的「参考图↔时长」约束。"""
         project = {
             "video_provider_i2v": "kling/kling-v3",
             "video_provider_r2v": "gemini-aistudio/veo-3.1-generate-preview",
             "generation_mode": "reference_video",
         }
-        caps = await self._caps(project)
+        caps = await self._caps(db_factory, project)
         assert caps["model"] == "veo-3.1-generate-preview"
         assert caps["supported_durations"] == [4, 6, 8]
         constrained = constrain_durations_for_project(
@@ -511,28 +458,24 @@ class TestVideoCapabilitiesBucketing:
         )
         assert constrained == [8]
 
-    async def test_max_reference_images_follows_backend_declaration(self):
+    async def test_max_reference_images_follows_backend_declaration(self, db_factory):
         """viduq3-pro 不在 /reference2video 白名单：能力查询报 0，不报 registry 的并行声明。"""
-        caps = await self._caps({"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})
+        caps = await self._caps(db_factory, {"video_backend": "vidu/viduq3-pro", "generation_mode": "storyboard"})
         assert caps["max_reference_images"] == 0
 
 
 class TestVideoCapabilities:
     """验证 video_capabilities：第一步模型选择 + 第二步 model 能力查询。"""
 
-    async def test_registry_grok(self):
+    async def test_registry_grok(self, db_factory):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(
             settings={"default_video_backend": "grok/grok-imagine-video"},
         )
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {}
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {}
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["provider_id"] == "grok"
         assert caps["model"] == "grok-imagine-video"
         assert caps["source"] == "registry"
@@ -540,19 +483,15 @@ class TestVideoCapabilities:
         assert caps["max_duration"] == 15
         assert caps["max_reference_images"] == 7
 
-    async def test_registry_veo(self):
+    async def test_registry_veo(self, db_factory):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["provider_id"] == "gemini-aistudio"
         assert caps["model"] == "veo-3.1-generate-preview"
         assert caps["source"] == "registry"
@@ -561,255 +500,201 @@ class TestVideoCapabilities:
         # max_reference_images 来源：backend 的 VideoCapabilities 声明（与执行层同源）
         assert caps["max_reference_images"] == 3
 
-    async def test_reads_project_default_duration_and_modes(self):
+    async def test_reads_project_default_duration_and_modes(self, db_factory):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": "grok/grok-imagine-video",
-                        "default_duration": 6,
-                        "content_mode": "narration",
-                        "generation_mode": "reference_video",
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": "grok/grok-imagine-video",
+                    "default_duration": 6,
+                    "content_mode": "narration",
+                    "generation_mode": "reference_video",
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["default_duration"] == 6
         assert caps["content_mode"] == "narration"
         assert caps["generation_mode"] == "reference_video"
 
-    async def test_missing_default_duration_is_null(self):
+    async def test_missing_default_duration_is_null(self, db_factory):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": "grok/grok-imagine-video",
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": "grok/grok-imagine-video",
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["default_duration"] is None
 
-    async def test_unknown_model_raises(self):
+    async def test_unknown_model_raises(self, db_factory):
         """悬空模型引用在任务类型桶解析闸即报错，携带可本地化的 code。"""
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": "grok/nonexistent-model",
-                    }
-                    with pytest.raises(VideoBucketCapabilityError) as excinfo:
-                        await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": "grok/nonexistent-model",
+                }
+                with pytest.raises(VideoBucketCapabilityError) as excinfo:
+                    await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert excinfo.value.code == "video_capability_reference_unavailable"
         assert excinfo.value.capability == "i2v"
 
-    async def test_unknown_provider_raises(self):
+    async def test_unknown_provider_raises(self, db_factory):
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": "bogus-provider/some-model",
-                    }
-                    with pytest.raises(VideoBucketCapabilityError):
-                        await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": "bogus-provider/some-model",
+                }
+                with pytest.raises(VideoBucketCapabilityError):
+                    await resolver._resolve_video_capabilities(fake_svc, session, "demo")
 
-    async def test_video_capabilities_for_project_uses_passed_dict(self):
+    async def test_video_capabilities_for_project_uses_passed_dict(self, db_factory):
         """video_capabilities_for_project(dict) 不调用 load_project；直接消费传入 dict。
 
         防御 codex review 指出的"按目录名二次 load 可能读到同名错项目"风险。
         """
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                caps = await resolver.video_capabilities_for_project(
-                    {
-                        "video_backend": "grok/grok-imagine-video",
-                        "default_duration": 9,
-                    }
-                )
-                # 关键断言：load_project 一次都不能被调到
-                mock_pm.return_value.load_project.assert_not_called()
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager") as mock_pm:
+            caps = await resolver.video_capabilities_for_project(
+                {
+                    "video_backend": "grok/grok-imagine-video",
+                    "default_duration": 9,
+                }
+            )
+            # 关键断言：load_project 一次都不能被调到
+            mock_pm.return_value.load_project.assert_not_called()
         assert caps["provider_id"] == "grok"
         assert caps["max_duration"] == 15
         assert caps["default_duration"] == 9
         assert caps["max_reference_images"] == 7
 
-    async def test_max_reference_images_reads_backend_caps_for_openai_sora(self):
+    async def test_max_reference_images_reads_backend_caps_for_openai_sora(self, db_factory):
         """openai sora 的 max_reference_images 来自 backend 声明（=1），不依赖 provider 级 fallback。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project({"video_backend": "openai/sora-2"})
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project({"video_backend": "openai/sora-2"})
         assert caps["max_reference_images"] == 1
 
-    async def test_max_reference_images_reads_backend_caps_for_minimax_s2v(self):
+    async def test_max_reference_images_reads_backend_caps_for_minimax_s2v(self, db_factory):
         """minimax S2V-01 的 max_reference_images 来自 backend 声明（=1）；
 
         编排层据此只取 1 张参考图，不会向只吃单脸的 S2V-01 拼多张。S2V-01 不支持首帧，
         项目须是参考生视频才落进它所属的 r2v 桶。
         """
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project(
-                    {"video_backend": "minimax/S2V-01", "generation_mode": "reference_video"}
-                )
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project(
+                {"video_backend": "minimax/S2V-01", "generation_mode": "reference_video"}
+            )
         assert caps["max_reference_images"] == 1
 
-    async def test_max_reference_images_reads_backend_caps_for_ark_seedance(self):
+    async def test_max_reference_images_reads_backend_caps_for_ark_seedance(self, db_factory):
         """ark seedance 的 max_reference_images 来自 backend 声明（=9）。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project(
-                    {"video_backend": "ark/doubao-seedance-2-0-260128"}
-                )
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project({"video_backend": "ark/doubao-seedance-2-0-260128"})
         assert caps["max_reference_images"] == 9
 
-    async def test_max_reference_images_reads_backend_caps_for_kling_v3_omni(self):
+    async def test_max_reference_images_reads_backend_caps_for_kling_v3_omni(self, db_factory):
         """kling-v3-omni（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）；
 
         编排层据此裁剪参考图数量，与执行期 gate_video_request 依据的是同一个数。
         """
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3-omni"})
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3-omni"})
         assert caps["max_reference_images"] == 4
 
-    async def test_max_reference_images_reads_backend_caps_for_kling_video_o1(self):
+    async def test_max_reference_images_reads_backend_caps_for_kling_video_o1(self, db_factory):
         """kling-video-o1（多图主体 R2V）的 max_reference_images 来自 backend 声明（=4，保守值）。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-video-o1"})
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-video-o1"})
         assert caps["max_reference_images"] == 4
 
-    async def test_kling_v3_non_reference_model_has_zero_max_refs(self):
+    async def test_kling_v3_non_reference_model_has_zero_max_refs(self, db_factory):
         """kling-v3（声明 4K + 首尾帧但非多图主体）max_reference_images=0，不误报参考能力。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            with patch("lib.config.resolver.get_project_manager"):
-                caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3"})
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        with patch("lib.config.resolver.get_project_manager"):
+            caps = await resolver.video_capabilities_for_project({"video_backend": "kling/kling-v3"})
         assert caps["max_reference_images"] == 0
 
-    async def test_custom_provider_reads_db_supported_durations(self):
+    async def test_custom_provider_reads_db_supported_durations(self, db_factory):
         """custom-<id>/<model> 走 DB 分支，返回 source='custom'。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom X",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                model = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="my-video-model",
-                    display_name="My Video",
-                    endpoint="newapi-video",
-                    supported_durations="[5, 10]",
-                )
-                session.add(model)
-                await session.flush()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom X",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            model = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="my-video-model",
+                display_name="My Video",
+                endpoint="newapi-video",
+                supported_durations="[5, 10]",
+            )
+            session.add(model)
+            await session.flush()
 
-                project_backend = f"custom-{provider.id}/my-video-model"
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": project_backend,
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+            project_backend = f"custom-{provider.id}/my-video-model"
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": project_backend,
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["source"] == "custom"
         assert caps["supported_durations"] == [5, 10]
         assert caps["max_duration"] == 10
         # newapi-video endpoint 不接受参考图，max=0（来源：EndpointSpec.video_max_reference_images）
         assert caps["max_reference_images"] == 0
 
-    async def test_custom_video_openai_endpoint_resolves_max_one(self):
+    async def test_custom_video_openai_endpoint_resolves_max_one(self, db_factory):
         """custom-<id>/<model> 经 openai-video endpoint 解析出 max_reference_images=1（不再静默落 9）。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Sora",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                model = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="sora-like",
-                    display_name="Sora-like",
-                    endpoint="openai-video",
-                    supported_durations="[4, 8]",
-                )
-                session.add(model)
-                await session.flush()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Sora",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            model = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="sora-like",
+                display_name="Sora-like",
+                endpoint="openai-video",
+                supported_durations="[4, 8]",
+            )
+            session.add(model)
+            await session.flush()
 
-                project_backend = f"custom-{provider.id}/sora-like"
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": project_backend,
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+            project_backend = f"custom-{provider.id}/sora-like"
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": project_backend,
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["source"] == "custom"
         assert caps["max_reference_images"] == 1
 
-    async def test_custom_disabled_model_errors_like_execution_layer(self):
+    async def test_custom_disabled_model_errors_like_execution_layer(self, db_factory):
         """project 仍指向已禁用的 model 时，能力解析与执行路径同样在任务类型桶解析闸报悬空引用。
 
         不静默换成该供应商的默认启用 model（``docs/adr/0054``）：宣称一个用户没选过的模型的能力，
@@ -818,285 +703,257 @@ class TestVideoCapabilities:
 
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Fallback",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                disabled = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="disabled-model",
-                    display_name="Disabled",
-                    endpoint="ark-seedance",
-                    is_enabled=False,
-                    supported_durations="[5]",
-                    capability_overrides={"last_frame": True},
-                )
-                default = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="default-model",
-                    display_name="Default",
-                    endpoint="newapi-video",
-                    is_enabled=True,
-                    is_default=True,
-                    supported_durations="[5, 10]",
-                )
-                session.add_all([disabled, default])
-                await session.flush()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Fallback",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            disabled = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="disabled-model",
+                display_name="Disabled",
+                endpoint="ark-seedance",
+                is_enabled=False,
+                supported_durations="[5]",
+                capability_overrides={"last_frame": True},
+            )
+            default = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="default-model",
+                display_name="Default",
+                endpoint="newapi-video",
+                is_enabled=True,
+                is_default=True,
+                supported_durations="[5, 10]",
+            )
+            session.add_all([disabled, default])
+            await session.flush()
 
-                project_backend = f"custom-{provider.id}/disabled-model"
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": project_backend,
-                    }
-                    with pytest.raises(VideoBucketCapabilityError) as excinfo:
-                        await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+            project_backend = f"custom-{provider.id}/disabled-model"
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": project_backend,
+                }
+                with pytest.raises(VideoBucketCapabilityError) as excinfo:
+                    await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert excinfo.value.code == "video_capability_reference_unavailable"
 
 
 class TestVoiceConsistency:
-    """voice_consistency 二维派生（模型能力 × generation_mode）。全员经 `_make_session()` 落真实
+    """voice_consistency 二维派生（模型能力 × generation_mode）。全员经 `db_factory` 落真实
     in-memory DB，按 CONTRIBUTING.md 的 pytest markers 纪律归 integration。"""
 
-    async def _caps(self, project: dict) -> dict:
+    async def _caps(self, db_factory, project: dict) -> dict:
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = project
-                    return await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = project
+                return await resolver._resolve_video_capabilities(fake_svc, session, "demo")
 
-    async def test_seedance_2_reference_video_is_native(self):
+    async def test_seedance_2_reference_video_is_native(self, db_factory):
         """reference_audio_mode=direct 且 generation_mode=reference_video → native。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "ark/doubao-seedance-2-0-260128",
                 "generation_mode": "reference_video",
-            }
+            },
         )
         assert caps["voice_consistency"] == "native"
 
-    async def test_requested_generate_audio_is_exposed_separately_from_pricing_value(self):
+    async def test_requested_generate_audio_is_exposed_separately_from_pricing_value(self, db_factory):
         """caps 并列透出用户无声意图与计价口径：AI Studio Veo 恒按含音出账，但项目关掉音频时
         编排层必须读到 False（否则无声视频照旧上传参考音频）。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
                 "generation_mode": "reference_video",
                 "video_generate_audio": False,
-            }
+            },
         )
         assert caps["requested_generate_audio"] is False
         assert caps["generate_audio"] is True
 
-    async def test_requested_generate_audio_defaults_to_true(self):
-        caps = await self._caps({"video_backend": "ark/doubao-seedance-2-0-260128"})
+    async def test_requested_generate_audio_defaults_to_true(self, db_factory):
+        caps = await self._caps(db_factory, {"video_backend": "ark/doubao-seedance-2-0-260128"})
         assert caps["requested_generate_audio"] is True
 
-    async def test_seedance_2_non_reference_mode_downgrades_to_soft(self):
+    async def test_seedance_2_non_reference_mode_downgrades_to_soft(self, db_factory):
         """同一模型非参考生视频路径：native 蕴含有音轨，降格恒落 soft，不落 none。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "ark/doubao-seedance-2-0-260128",
                 "generation_mode": "storyboard",
-            }
+            },
         )
         assert caps["voice_consistency"] == "soft"
 
-    async def test_seedance_2_missing_generation_mode_downgrades_to_soft(self):
+    async def test_seedance_2_missing_generation_mode_downgrades_to_soft(self, db_factory):
         """generation_mode 缺省（非 reference_video）同样降格 soft。"""
-        caps = await self._caps({"video_backend": "ark/doubao-seedance-2-0-260128"})
+        caps = await self._caps(db_factory, {"video_backend": "ark/doubao-seedance-2-0-260128"})
         assert caps["voice_consistency"] == "soft"
 
-    async def test_aistudio_veo_always_soft_regardless_of_generation_mode(self):
+    async def test_aistudio_veo_always_soft_regardless_of_generation_mode(self, db_factory):
         """AI Studio Veo 无参考音频通道，即便走参考生视频路径也只能 soft（恒有声不推 none）。"""
         caps = await self._caps(
+            db_factory,
             {
                 "video_backend": "gemini-aistudio/veo-3.1-generate-preview",
                 "generation_mode": "reference_video",
-            }
+            },
         )
         assert caps["voice_consistency"] == "soft"
 
-    async def test_grok_imagine_soft(self):
+    async def test_grok_imagine_soft(self, db_factory):
         """Grok Imagine：恒有声、无参考音频通道 → soft。"""
-        caps = await self._caps({"video_backend": "grok/grok-imagine-video"})
+        caps = await self._caps(db_factory, {"video_backend": "grok/grok-imagine-video"})
         assert caps["voice_consistency"] == "soft"
 
-    async def test_sora_2_soft_after_token_correction(self):
+    async def test_sora_2_soft_after_token_correction(self, db_factory):
         """Sora 2 目录补 generate_audio 后派生 soft（不再因缺 token 误判 none）。"""
-        caps = await self._caps({"video_backend": "openai/sora-2"})
+        caps = await self._caps(db_factory, {"video_backend": "openai/sora-2"})
         assert caps["voice_consistency"] == "soft"
 
-    async def test_kling_v3_audio_models_are_soft(self):
+    async def test_kling_v3_audio_models_are_soft(self, db_factory):
         """可灵 v3 系声明音频能力 → soft（注入 Voice_Profiles）。"""
         for model_id in ("kling-v3", "kling-v3-omni"):
-            caps = await self._caps({"video_backend": f"kling/{model_id}"})
+            caps = await self._caps(db_factory, {"video_backend": f"kling/{model_id}"})
             assert caps["voice_consistency"] == "soft"
 
-    async def test_kling_turbo_true_silent_is_none(self):
+    async def test_kling_turbo_true_silent_is_none(self, db_factory):
         """可灵 v2-5-turbo 无音频开关 → none。"""
-        caps = await self._caps({"video_backend": "kling/kling-v2-5-turbo"})
+        caps = await self._caps(db_factory, {"video_backend": "kling/kling-v2-5-turbo"})
         assert caps["voice_consistency"] == "none"
 
-    async def test_minimax_true_silent_is_none(self):
+    async def test_minimax_true_silent_is_none(self, db_factory):
         """MiniMax 真无声模型 → none。"""
-        caps = await self._caps({"video_backend": "minimax/MiniMax-Hailuo-2.3"})
+        caps = await self._caps(db_factory, {"video_backend": "minimax/MiniMax-Hailuo-2.3"})
         assert caps["voice_consistency"] == "none"
 
-    async def test_agnes_true_silent_is_none(self):
+    async def test_agnes_true_silent_is_none(self, db_factory):
         """Agnes 真无声模型 → none。"""
-        caps = await self._caps({"video_backend": "agnes/agnes-video-v2.0"})
+        caps = await self._caps(db_factory, {"video_backend": "agnes/agnes-video-v2.0"})
         assert caps["voice_consistency"] == "none"
 
-    async def test_custom_provider_without_overrides_defaults_to_soft(self):
+    async def test_custom_provider_without_overrides_defaults_to_soft(self, db_factory):
         """自定义供应商无 generate_audio 目录声明：与 default_tier_generates_audio 同口径，
         无信号时假定有声，不凭空判定为真无声模型。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Voice",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                model = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="sora-like",
-                    display_name="Sora-like",
-                    endpoint="openai-video",
-                    supported_durations="[4, 8]",
-                )
-                session.add(model)
-                await session.flush()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Voice",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            model = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="sora-like",
+                display_name="Sora-like",
+                endpoint="openai-video",
+                supported_durations="[4, 8]",
+            )
+            session.add(model)
+            await session.flush()
 
-                project_backend = f"custom-{provider.id}/sora-like"
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": project_backend,
-                        "generation_mode": "reference_video",
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+            project_backend = f"custom-{provider.id}/sora-like"
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": project_backend,
+                    "generation_mode": "reference_video",
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         # openai-video endpoint 不带 reference_audio_capable，覆盖无法宣称 direct，故非 native；
         # 无音轨目录声明时假定有声 → soft，不落 none。
         assert caps["voice_consistency"] == "soft"
 
-    async def test_custom_provider_with_direct_override_and_reference_video_is_native(self):
+    async def test_custom_provider_with_direct_override_and_reference_video_is_native(self, db_factory):
         """自定义供应商覆盖 reference_audio_mode=direct + 上限 > 0，且走参考生视频路径 → native。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
         resolver = ConfigResolver.__new__(ConfigResolver)
         fake_svc = _FakeConfigService(settings={})
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Seedance",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                model = CustomProviderModel(
-                    provider_id=provider.id,
-                    model_id="seedance-like",
-                    display_name="Seedance-like",
-                    endpoint="ark-seedance",
-                    supported_durations="[4, 8]",
-                    # max_reference_images 覆盖是让该 model 落进 r2v 桶的前提：参考生视频项目按
-                    # r2v 定桶解析，ark-seedance 对未上表型号保守判 0，不覆盖会被解析闸挡在能力查询前
-                    capability_overrides={
-                        "reference_audio_mode": "direct",
-                        "max_reference_audio_count": 2,
-                        "max_reference_images": 4,
-                    },
-                )
-                session.add(model)
-                await session.flush()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Seedance",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            model = CustomProviderModel(
+                provider_id=provider.id,
+                model_id="seedance-like",
+                display_name="Seedance-like",
+                endpoint="ark-seedance",
+                supported_durations="[4, 8]",
+                # max_reference_images 覆盖是让该 model 落进 r2v 桶的前提：参考生视频项目按
+                # r2v 定桶解析，ark-seedance 对未上表型号保守判 0，不覆盖会被解析闸挡在能力查询前
+                capability_overrides={
+                    "reference_audio_mode": "direct",
+                    "max_reference_audio_count": 2,
+                    "max_reference_images": 4,
+                },
+            )
+            session.add(model)
+            await session.flush()
 
-                project_backend = f"custom-{provider.id}/seedance-like"
-                with patch("lib.config.resolver.get_project_manager") as mock_pm:
-                    mock_pm.return_value.load_project.return_value = {
-                        "video_backend": project_backend,
-                        "generation_mode": "reference_video",
-                    }
-                    caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
-        finally:
-            await engine.dispose()
+            project_backend = f"custom-{provider.id}/seedance-like"
+            with patch("lib.config.resolver.get_project_manager") as mock_pm:
+                mock_pm.return_value.load_project.return_value = {
+                    "video_backend": project_backend,
+                    "generation_mode": "reference_video",
+                }
+                caps = await resolver._resolve_video_capabilities(fake_svc, session, "demo")
         assert caps["voice_consistency"] == "native"
 
 
 class TestVideoPricingGenerateAudio:
     """video_pricing_generate_audio：能力接口解析不出时的计价降级口径。"""
 
-    async def test_falls_back_to_provider_rule_for_registry_unknown_model(self):
+    async def test_falls_back_to_provider_rule_for_registry_unknown_model(self, db_factory):
         """注册表已下线的 veo model id 仍按含音档出价，不因能力解析失败被低估为静音档。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            # veo-3.1-generate-001 只留在 gemini-vertex 注册表：能力查询抛错，而价目查询
-            # 仍会回落到 Gemini 家族费率出价。
-            result = await resolver.video_pricing_generate_audio("gemini-aistudio", "veo-3.1-generate-001")
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        # veo-3.1-generate-001 只留在 gemini-vertex 注册表：能力查询抛错，而价目查询
+        # 仍会回落到 Gemini 家族费率出价。
+        result = await resolver.video_pricing_generate_audio("gemini-aistudio", "veo-3.1-generate-001")
         assert result is True
 
-    async def test_falls_back_to_requested_value_for_unknown_provider(self):
+    async def test_falls_back_to_requested_value_for_unknown_provider(self, db_factory):
         """非恒含音 provider 解析不出能力时保留请求值——价目仍回落 Gemini 家族的含音费率。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            result = await resolver.video_pricing_generate_audio("unknown", "unknown")
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        result = await resolver.video_pricing_generate_audio("unknown", "unknown")
         assert result is True
 
-    async def test_keeps_requested_audio_for_vertex_unknown_model(self):
+    async def test_keeps_requested_audio_for_vertex_unknown_model(self, db_factory):
         """gemini-vertex 上注册表没有的 model：backend 照请求值下发并结算，估算不得降为静音档。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            # lite 只登记在 gemini-aistudio：把 backend 切到 vertex 却留着旧 model id 时，
-            # 能力查询抛 model not found，而价目查询仍按 Gemini 家族含音费率出价。
-            result = await resolver.video_pricing_generate_audio("gemini-vertex", "veo-3.1-lite-generate-preview")
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        # lite 只登记在 gemini-aistudio：把 backend 切到 vertex 却留着旧 model id 时，
+        # 能力查询抛 model not found，而价目查询仍按 Gemini 家族含音费率出价。
+        result = await resolver.video_pricing_generate_audio("gemini-vertex", "veo-3.1-lite-generate-preview")
         assert result is True
 
-    async def test_project_audio_off_survives_capability_failure(self):
+    async def test_project_audio_off_survives_capability_failure(self, db_factory):
         """项目关掉音频时降级路径同样按静音档出价，不凭空补成含音。"""
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            result = await resolver.video_pricing_generate_audio(
-                "gemini-vertex",
-                "veo-3.1-lite-generate-preview",
-                {"video_generate_audio": False},
-            )
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        result = await resolver.video_pricing_generate_audio(
+            "gemini-vertex",
+            "veo-3.1-lite-generate-preview",
+            {"video_generate_audio": False},
+        )
         assert result is False
 
 
@@ -1311,48 +1168,44 @@ class TestResolveVideoBackend:
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, {})
         assert (resolved.provider_id, resolved.model_id) == ("ark", "doubao-seedance-2-0-260128")
 
-    async def test_disabled_custom_model_resolves_to_runtime_default(self):
+    async def test_disabled_custom_model_resolves_to_runtime_default(self, db_factory):
         """身份解析直接交付执行层会实际调用的 model，不把禁用身份留给后续构造层修正。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Fallback",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                session.add_all(
-                    [
-                        CustomProviderModel(
-                            provider_id=provider.id,
-                            model_id="disabled-model",
-                            display_name="Disabled",
-                            endpoint="openai-video",
-                            is_enabled=False,
-                        ),
-                        CustomProviderModel(
-                            provider_id=provider.id,
-                            model_id="runtime-model",
-                            display_name="Runtime",
-                            endpoint="openai-video",
-                            is_enabled=True,
-                            is_default=True,
-                        ),
-                    ]
-                )
-                await session.commit()
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Fallback",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            session.add_all(
+                [
+                    CustomProviderModel(
+                        provider_id=provider.id,
+                        model_id="disabled-model",
+                        display_name="Disabled",
+                        endpoint="openai-video",
+                        is_enabled=False,
+                    ),
+                    CustomProviderModel(
+                        provider_id=provider.id,
+                        model_id="runtime-model",
+                        display_name="Runtime",
+                        endpoint="openai-video",
+                        is_enabled=True,
+                        is_default=True,
+                    ),
+                ]
+            )
+            await session.commit()
 
-                resolver = ConfigResolver(factory)
-                resolved = await resolver.resolve_video_backend(
-                    {"video_backend": f"custom-{provider.id}/disabled-model"}, None
-                )
-        finally:
-            await engine.dispose()
+            resolver = ConfigResolver(db_factory)
+            resolved = await resolver.resolve_video_backend(
+                {"video_backend": f"custom-{provider.id}/disabled-model"}, None
+            )
 
         assert (resolved.provider_id, resolved.model_id) == (f"custom-{provider.id}", "runtime-model")
 
@@ -1510,75 +1363,63 @@ class TestVideoBucketCapabilityGateCustomProvider:
             await session.commit()
             return provider.id
 
-    async def test_bucket_reference_to_missing_custom_model_raises(self):
+    async def test_bucket_reference_to_missing_custom_model_raises(self, db_factory):
         from lib.config.resolver import VideoBucketCapabilityError
 
-        factory, engine = await _make_session()
-        try:
-            provider_id = await self._seed_provider(factory, models=[])
-            resolver = ConfigResolver(factory)
-            with pytest.raises(VideoBucketCapabilityError) as exc_info:
-                await resolver.resolve_video_backend(
-                    {"video_provider_r2v": f"custom-{provider_id}/ghost-model"}, None, capability="r2v"
-                )
-        finally:
-            await engine.dispose()
+        provider_id = await self._seed_provider(db_factory, models=[])
+        resolver = ConfigResolver(db_factory)
+        with pytest.raises(VideoBucketCapabilityError) as exc_info:
+            await resolver.resolve_video_backend(
+                {"video_provider_r2v": f"custom-{provider_id}/ghost-model"}, None, capability="r2v"
+            )
         assert exc_info.value.code == "video_capability_reference_unavailable"
 
-    async def test_disabled_custom_model_raises_instead_of_converging(self):
+    async def test_disabled_custom_model_raises_instead_of_converging(self, db_factory):
         """桶解析路径不做有效身份收敛：禁用模型直接报悬空，而非静默换成该供应商默认模型。"""
         from lib.config.resolver import VideoBucketCapabilityError
 
-        factory, engine = await _make_session()
-        try:
-            provider_id = await self._seed_provider(
-                factory,
-                models=[
-                    {
-                        "model_id": "disabled-model",
-                        "display_name": "Disabled",
-                        "endpoint": "openai-video",
-                        "is_enabled": False,
-                    },
-                    {
-                        "model_id": "runtime-model",
-                        "display_name": "Runtime",
-                        "endpoint": "openai-video",
-                        "is_enabled": True,
-                        "is_default": True,
-                    },
-                ],
+        provider_id = await self._seed_provider(
+            db_factory,
+            models=[
+                {
+                    "model_id": "disabled-model",
+                    "display_name": "Disabled",
+                    "endpoint": "openai-video",
+                    "is_enabled": False,
+                },
+                {
+                    "model_id": "runtime-model",
+                    "display_name": "Runtime",
+                    "endpoint": "openai-video",
+                    "is_enabled": True,
+                    "is_default": True,
+                },
+            ],
+        )
+        resolver = ConfigResolver(db_factory)
+        with pytest.raises(VideoBucketCapabilityError) as exc_info:
+            await resolver.resolve_video_backend(
+                {"video_backend": f"custom-{provider_id}/disabled-model"}, None, capability="i2v"
             )
-            resolver = ConfigResolver(factory)
-            with pytest.raises(VideoBucketCapabilityError) as exc_info:
-                await resolver.resolve_video_backend(
-                    {"video_backend": f"custom-{provider_id}/disabled-model"}, None, capability="i2v"
-                )
-        finally:
-            await engine.dispose()
         assert exc_info.value.code == "video_capability_reference_unavailable"
 
-    async def test_enabled_custom_video_model_passes_gate(self):
-        factory, engine = await _make_session()
-        try:
-            provider_id = await self._seed_provider(
-                factory,
-                models=[
-                    {
-                        "model_id": "live-model",
-                        "display_name": "Live",
-                        "endpoint": "openai-video",
-                        "is_enabled": True,
-                        "is_default": True,
-                    }
-                ],
-            )
-            resolver = ConfigResolver(factory)
-            resolved = await resolver.resolve_video_backend(
-                {"video_provider_i2v": f"custom-{provider_id}/live-model"}, None, capability="i2v"
-            )
-        finally:
-            await engine.dispose()
+    async def test_enabled_custom_video_model_passes_gate(self, db_factory):
+        provider_id = await self._seed_provider(
+            db_factory,
+            models=[
+                {
+                    "model_id": "live-model",
+                    "display_name": "Live",
+                    "endpoint": "openai-video",
+                    "is_enabled": True,
+                    "is_default": True,
+                }
+            ],
+        )
+        resolver = ConfigResolver(db_factory)
+        resolved = await resolver.resolve_video_backend(
+            {"video_provider_i2v": f"custom-{provider_id}/live-model"}, None, capability="i2v"
+        )
         assert (resolved.provider_id, resolved.model_id) == (f"custom-{provider_id}", "live-model")
 
 
@@ -1610,68 +1451,52 @@ class TestReferencePayloadLimits:
         assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
         assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
-    async def test_default_when_unset(self):
+    async def test_default_when_unset(self, db_factory):
         from lib.config.service import (
             _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
             _DEFAULT_REFERENCE_TOTAL_MAX_BYTES,
         )
 
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            total, single = await resolver.reference_payload_limits("gemini-aistudio")
-            assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
-            assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        total, single = await resolver.reference_payload_limits("gemini-aistudio")
+        assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
+        assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
-    async def test_provider_override_applies(self):
+    async def test_provider_override_applies(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                svc = ConfigService(session)
-                await svc.set_provider_config("gemini-aistudio", "reference_total_max_bytes", "1000000")
-                await svc.set_provider_config("gemini-aistudio", "reference_single_max_bytes", "500000")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            total, single = await resolver.reference_payload_limits("gemini-aistudio")
-            assert (total, single) == (1000000, 500000)
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            svc = ConfigService(session)
+            await svc.set_provider_config("gemini-aistudio", "reference_total_max_bytes", "1000000")
+            await svc.set_provider_config("gemini-aistudio", "reference_single_max_bytes", "500000")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        total, single = await resolver.reference_payload_limits("gemini-aistudio")
+        assert (total, single) == (1000000, 500000)
 
-    async def test_unknown_provider_falls_back_to_default(self):
+    async def test_unknown_provider_falls_back_to_default(self, db_factory):
         from lib.config.service import _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
 
-        factory, engine = await _make_session()
-        try:
-            resolver = ConfigResolver(factory)
-            # 未知 provider → get_provider_config 抛 ValueError → catch 回退默认
-            total, single = await resolver.reference_payload_limits("totally-unknown-provider")
-            assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        # 未知 provider → get_provider_config 抛 ValueError → catch 回退默认
+        total, single = await resolver.reference_payload_limits("totally-unknown-provider")
+        assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES
 
-    async def test_non_numeric_override_falls_back(self):
+    async def test_non_numeric_override_falls_back(self, db_factory):
         from lib.config.service import (
             _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
             _DEFAULT_REFERENCE_TOTAL_MAX_BYTES,
             ConfigService,
         )
 
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                svc = ConfigService(session)
-                await svc.set_provider_config("gemini-aistudio", "reference_total_max_bytes", "not-a-number")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            total, single = await resolver.reference_payload_limits("gemini-aistudio")
-            assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES  # 非数字回退
-            assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            svc = ConfigService(session)
+            await svc.set_provider_config("gemini-aistudio", "reference_total_max_bytes", "not-a-number")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        total, single = await resolver.reference_payload_limits("gemini-aistudio")
+        assert total == _DEFAULT_REFERENCE_TOTAL_MAX_BYTES  # 非数字回退
+        assert single == _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
 
 class TestTextBackendTierResolution:
@@ -1827,13 +1652,9 @@ class TestStyleAnalysisVisionGuard:
 class TestProjectGenerationModeCaps:
     """能力解析按项目生成模式定轴：创建即定、全项目一种，能力不需要剧集上下文。"""
 
-    async def _caps(self, project: dict) -> dict:
-        factory, engine = await _make_session()
-        try:
-            with patch("lib.config.resolver.get_project_manager"):
-                return await ConfigResolver(factory).video_capabilities_for_project(project)
-        finally:
-            await engine.dispose()
+    async def _caps(self, db_factory, project: dict) -> dict:
+        with patch("lib.config.resolver.get_project_manager"):
+            return await ConfigResolver(db_factory).video_capabilities_for_project(project)
 
     def test_caps_generation_mode_reads_project_field(self):
         assert caps_generation_mode({"generation_mode": "reference_video"}) == "reference_video"
@@ -1846,7 +1667,7 @@ class TestProjectGenerationModeCaps:
         assert caps_generation_mode({"generation_mode": ""}) is None
         assert caps_generation_mode({"generation_mode": {"nested": "dict"}}) is None
 
-    async def test_bucket_follows_project_route(self):
+    async def test_bucket_follows_project_route(self, db_factory):
         """定桶按项目生成模式取对应桶键的模型。"""
         storyboard_project = {
             "generation_mode": "storyboard",
@@ -1854,24 +1675,28 @@ class TestProjectGenerationModeCaps:
             "video_provider_r2v": "minimax/S2V-01",
         }
         reference_project = {**storyboard_project, "generation_mode": "reference_video"}
-        assert (await self._caps(storyboard_project))["model"] == "kling-v3"
-        assert (await self._caps(reference_project))["model"] == "S2V-01"
+        assert (await self._caps(db_factory, storyboard_project))["model"] == "kling-v3"
+        assert (await self._caps(db_factory, reference_project))["model"] == "S2V-01"
 
-    async def test_voice_consistency_follows_project_route(self):
+    async def test_voice_consistency_follows_project_route(self, db_factory):
         """参考生视频按 native 解析，分镜图生视频降格 soft。"""
         project = {
             "generation_mode": "reference_video",
             "video_provider_r2v": "ark/doubao-seedance-2-0-260128",
             "video_backend": "ark/doubao-seedance-2-0-260128",
         }
-        caps = await self._caps(project)
+        caps = await self._caps(db_factory, project)
         assert caps["voice_consistency"] == "native"
         assert caps["generation_mode"] == "reference_video"
-        assert (await self._caps({**project, "generation_mode": "storyboard"}))["voice_consistency"] == "soft"
+        assert (await self._caps(db_factory, {**project, "generation_mode": "storyboard"}))[
+            "voice_consistency"
+        ] == "soft"
 
-    async def test_uses_reference_images_constraint_follows_project_route(self):
+    async def test_uses_reference_images_constraint_follows_project_route(self, db_factory):
         """caps 的 generation_mode 是下游时长约束的入参，参考生视频据此施加「参考图↔时长」约束。"""
-        caps = await self._caps({"generation_mode": "reference_video", "video_provider_r2v": "minimax/S2V-01"})
+        caps = await self._caps(
+            db_factory, {"generation_mode": "reference_video", "video_provider_r2v": "minimax/S2V-01"}
+        )
         assert caps["generation_mode"] == "reference_video"
         assert caps["max_reference_images"] == 1
 
@@ -1988,93 +1813,85 @@ class TestPayloadPinnedVideoModel:
         resolved = await resolver._resolve_video_provider_model(fake_svc, None, project, {"video_provider_i2v": "ark"})
         assert (resolved.provider_id, resolved.model_id) == ("grok", "grok-imagine-video")
 
-    async def test_custom_provider_pin_survives_resume_resolution(self):
+    async def test_custom_provider_pin_survives_resume_resolution(self, db_factory):
         """自定义供应商的视频任务中断续跑：沿用 checkpoint 回放的 model，不回落项目配置换模型。"""
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Pinned",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Pinned",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            session.add(
+                CustomProviderModel(
+                    provider_id=provider.id,
+                    model_id="pinned-model",
+                    display_name="Pinned",
+                    endpoint="openai-video",
+                    is_enabled=True,
+                    is_default=True,
                 )
-                session.add(provider)
-                await session.flush()
-                session.add(
-                    CustomProviderModel(
-                        provider_id=provider.id,
-                        model_id="pinned-model",
-                        display_name="Pinned",
-                        endpoint="openai-video",
-                        is_enabled=True,
-                        is_default=True,
-                    )
-                )
-                await session.commit()
-                provider_id = f"custom-{provider.id}"
+            )
+            await session.commit()
+            provider_id = f"custom-{provider.id}"
 
-                resolver = ConfigResolver(factory)
-                resolved = await resolver.resolve_video_backend(
-                    {"video_backend": "grok/grok-imagine-video"},
-                    {"video_provider_i2v": f"{provider_id}/pinned-model"},
-                )
-        finally:
-            await engine.dispose()
+            resolver = ConfigResolver(db_factory)
+            resolved = await resolver.resolve_video_backend(
+                {"video_backend": "grok/grok-imagine-video"},
+                {"video_provider_i2v": f"{provider_id}/pinned-model"},
+            )
 
         assert (resolved.provider_id, resolved.model_id) == (provider_id, "pinned-model")
 
-    async def test_disabled_pinned_custom_model_raises_instead_of_switching(self):
+    async def test_disabled_pinned_custom_model_raises_instead_of_switching(self, db_factory):
         """checkpoint 锁定的自定义 model 在 resume 前被禁用：报错，不收敛到默认 model。
 
         换 model 执行等于静默换模型，续跑更会拿另一个 backend 去轮原 model 的 provider_job_id。
         """
         from lib.db.models.custom_provider import CustomProvider, CustomProviderModel
 
-        factory, engine = await _make_session()
-        try:
-            async with factory() as session:
-                provider = CustomProvider(
-                    display_name="Custom Pinned",
-                    discovery_format="openai",
-                    base_url="https://example.com",
-                    api_key="xxx",
-                )
-                session.add(provider)
-                await session.flush()
-                session.add_all(
-                    [
-                        CustomProviderModel(
-                            provider_id=provider.id,
-                            model_id="pinned-model",
-                            display_name="Pinned",
-                            endpoint="openai-video",
-                            is_enabled=False,
-                            is_default=False,
-                        ),
-                        CustomProviderModel(
-                            provider_id=provider.id,
-                            model_id="other-model",
-                            display_name="Other",
-                            endpoint="openai-video",
-                            is_enabled=True,
-                            is_default=True,
-                        ),
-                    ]
-                )
-                await session.commit()
-                provider_id = f"custom-{provider.id}"
+        async with db_factory() as session:
+            provider = CustomProvider(
+                display_name="Custom Pinned",
+                discovery_format="openai",
+                base_url="https://example.com",
+                api_key="xxx",
+            )
+            session.add(provider)
+            await session.flush()
+            session.add_all(
+                [
+                    CustomProviderModel(
+                        provider_id=provider.id,
+                        model_id="pinned-model",
+                        display_name="Pinned",
+                        endpoint="openai-video",
+                        is_enabled=False,
+                        is_default=False,
+                    ),
+                    CustomProviderModel(
+                        provider_id=provider.id,
+                        model_id="other-model",
+                        display_name="Other",
+                        endpoint="openai-video",
+                        is_enabled=True,
+                        is_default=True,
+                    ),
+                ]
+            )
+            await session.commit()
+            provider_id = f"custom-{provider.id}"
 
-                resolver = ConfigResolver(factory)
-                with pytest.raises(VideoBucketCapabilityError) as excinfo:
-                    await resolver.resolve_video_backend(
-                        {"video_backend": "grok/grok-imagine-video"},
-                        {"video_provider_i2v": f"{provider_id}/pinned-model"},
-                    )
-        finally:
-            await engine.dispose()
+            resolver = ConfigResolver(db_factory)
+            with pytest.raises(VideoBucketCapabilityError) as excinfo:
+                await resolver.resolve_video_backend(
+                    {"video_backend": "grok/grok-imagine-video"},
+                    {"video_provider_i2v": f"{provider_id}/pinned-model"},
+                )
 
         assert excinfo.value.model_id == "pinned-model"
         assert excinfo.value.capability == "i2v"

--- a/tests/integration/lib/db/repositories/test_task_repo.py
+++ b/tests/integration/lib/db/repositories/test_task_repo.py
@@ -3,9 +3,7 @@
 import asyncio
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from lib.db.base import Base
 from lib.db.repositories.task_repo import TaskRepository
 from lib.i18n import _ as translate_message
 from lib.task_failure import encode_failure, render_failure
@@ -338,13 +336,8 @@ class TestTaskRepository:
         await repo.release_lease(name="default", owner_id="a")
         assert not await repo.is_worker_online(name="default")
 
-    async def test_worker_lease_concurrent_first_acquire(self, tmp_path):
-        db_path = tmp_path / "lease-race.db"
-        db_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-        async with db_engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-
-        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async def test_worker_lease_concurrent_first_acquire(self, file_db_factory):
+        factory = file_db_factory
         start = asyncio.Event()
 
         async def _attempt(owner_id: str) -> bool:
@@ -369,8 +362,6 @@ class TestTaskRepository:
             lease = await repo.get_worker_lease(name="default")
             assert lease is not None
             assert lease["owner_id"] in {"worker-a", "worker-b"}
-
-        await db_engine.dispose()
 
     async def test_list_tasks_with_filters(self, db_session):
         repo = TaskRepository(db_session)

--- a/tests/integration/lib/project_migrations/test_project_migration_v5_v6.py
+++ b/tests/integration/lib/project_migrations/test_project_migration_v5_v6.py
@@ -363,7 +363,12 @@ def test_migration_preserves_distinct_nfd_and_nfc_declared_media(tmp_path: Path)
     assert (scenes / "café.png").read_bytes() == b"nfc"
 
 
-def test_migration_failure_leaves_original_tree_untouched(tmp_path: Path, monkeypatch) -> None:
+def test_migration_failure_leaves_original_tree_untouched(tmp_path: Path) -> None:
+    """迁移在暂存树里失败时，原目录须逐字节不变、暂存目录不残留。
+
+    故障由一份读不动的剧本真实触发：改写剧本是暂存树迁移的必经步骤，坏 JSON 到那一步才炸，
+    此时暂存树已建好、原目录还没换过去——正是回滚要覆盖的窗口。
+    """
     project_dir = tmp_path / "demo"
     _write_json(
         project_dir / "project.json",
@@ -375,19 +380,16 @@ def test_migration_failure_leaves_original_tree_untouched(tmp_path: Path, monkey
             "products": {},
         },
     )
+    broken = project_dir / "scripts" / "episode_1.json"
+    broken.parent.mkdir(parents=True, exist_ok=True)
+    broken.write_text("{ 这不是合法 JSON", encoding="utf-8")
     original = (project_dir / "project.json").read_bytes()
 
-    def fail(_staged: Path) -> None:
-        raise RuntimeError("injected failure")
-
-    monkeypatch.setattr(
-        "lib.project_migrations.v5_to_v6_asset_namespace._migrate_staged_tree",
-        fail,
-    )
-    with pytest.raises(RuntimeError, match="injected failure"):
+    with pytest.raises(Exception):  # noqa: B017 - 坏 JSON 的具体异常类型由 load_json 决定
         migrate_v5_to_v6(project_dir)
 
     assert (project_dir / "project.json").read_bytes() == original
+    assert broken.read_text(encoding="utf-8") == "{ 这不是合法 JSON"
     assert not list(tmp_path.glob(".demo.v6-*"))
 
 

--- a/tests/integration/lib/project_migrations/test_project_migration_v5_v6.py
+++ b/tests/integration/lib/project_migrations/test_project_migration_v5_v6.py
@@ -385,7 +385,7 @@ def test_migration_failure_leaves_original_tree_untouched(tmp_path: Path) -> Non
     broken.write_text("{ 这不是合法 JSON", encoding="utf-8")
     original = (project_dir / "project.json").read_bytes()
 
-    with pytest.raises(Exception):  # noqa: B017 - 坏 JSON 的具体异常类型由 load_json 决定
+    with pytest.raises(json.JSONDecodeError):
         migrate_v5_to_v6(project_dir)
 
     assert (project_dir / "project.json").read_bytes() == original

--- a/tests/integration/lib/project_migrations/test_project_migration_v7_v8.py
+++ b/tests/integration/lib/project_migrations/test_project_migration_v7_v8.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import os
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from threading import Event, Thread
+from typing import Any
 
 import pytest
 
@@ -552,7 +554,7 @@ def test_formal_step1_registration_failure_restores_the_previous_file(tmp_path: 
     assert not formal_path.exists()
 
 
-def test_formal_step1_write_serializes_with_schema_last_activation(tmp_path: Path, monkeypatch) -> None:
+def test_formal_step1_write_serializes_with_schema_last_activation(tmp_path: Path) -> None:
     from lib import artifact_activation
     from lib.script_review import formal_step1_lock, write_formal_step1_locked
 
@@ -563,21 +565,20 @@ def test_formal_step1_write_serializes_with_schema_last_activation(tmp_path: Pat
     release_activation = Event()
     writer_done = Event()
     failures: list[BaseException] = []
-    original_commit_schema = artifact_activation._commit_schema_version
 
-    def _pause_before_schema(project_dir_arg, project):
+    def _pause_before_schema(project_dir_arg: Path, project: Mapping[str, Any]) -> None:
         activation_ready.set()
         assert release_activation.wait(timeout=5)
-        original_commit_schema(project_dir_arg, project)
+        artifact_activation._commit_schema_version(project_dir_arg, project)
         # 清单激活是迁移链的中间一步，它落的版本不是当前版本；后续步骤在同一个临界区内走完，
         # 等锁的写入方因此只会看到迁移前后两个完整状态，与启动扫描先迁完再对外服务同口径。
         migrate_v8_to_v9(project_dir_arg)
 
-    monkeypatch.setattr(artifact_activation, "_commit_schema_version", _pause_before_schema)
-
     def _activate() -> None:
         try:
-            artifact_activation.activate_artifact_target_state(project_dir, bump_schema=True)
+            artifact_activation.activate_artifact_target_state(
+                project_dir, bump_schema=True, commit_schema=_pause_before_schema
+            )
         except Exception as exc:
             failures.append(exc)
 
@@ -666,7 +667,6 @@ def test_formal_step1_transaction_holds_the_project_lock_through_the_write(tmp_p
 
 def test_v7_activation_holds_the_project_lock_while_backing_up_its_frozen_inputs(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from lib import artifact_activation
     from lib.formal_write import project_metadata_lock
@@ -681,19 +681,18 @@ def test_v7_activation_holds_the_project_lock_while_backing_up_its_frozen_inputs
     writer_started = Event()
     writer_done = Event()
     failures: list[BaseException] = []
-    original_backup = artifact_activation._ensure_activation_backup
 
-    def _pause_after_project_backup(source: Path, *, stamp: int) -> None:
-        original_backup(source, stamp=stamp)
+    def _pause_after_project_backup(source: Path, stamp: int) -> None:
+        artifact_activation._ensure_activation_backup(source, stamp=stamp)
         if source == project_path:
             backup_started.set()
             assert release_backup.wait(timeout=5)
 
-    monkeypatch.setattr(artifact_activation, "_ensure_activation_backup", _pause_after_project_backup)
-
     def _activate() -> None:
         try:
-            artifact_activation.activate_artifact_target_state(project_dir, bump_schema=True)
+            artifact_activation.activate_artifact_target_state(
+                project_dir, bump_schema=True, backup_file=_pause_after_project_backup
+            )
         except Exception as exc:
             failures.append(exc)
 
@@ -885,25 +884,20 @@ def test_v7_activation_rejects_symlinked_project_control_file_without_writes(tmp
     assert not list(project_dir.rglob("*.bak.v7-*"))
 
 
-def test_v7_schema_commit_failure_leaves_complete_manifest_retryable(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_v7_schema_commit_failure_leaves_complete_manifest_retryable(tmp_path: Path) -> None:
     project_dir, _project_data, _step1, _script = _project(tmp_path)
     from lib import artifact_activation
-
-    original = artifact_activation._commit_schema_version
 
     def fail_schema(*_args: object, **_kwargs: object) -> None:
         raise OSError("injected schema failure")
 
-    monkeypatch.setattr(artifact_activation, "_commit_schema_version", fail_schema)
+    # migrate_v7_to_v8 只是 activate_artifact_target_state 的一行委托（另有用例守这层委托），
+    # 失败注入直接对着被委托的入口下，不必为此给迁移函数加一层转发参数。
     with pytest.raises(OSError, match="injected schema failure"):
-        migrate_v7_to_v8(project_dir)
+        artifact_activation.activate_artifact_target_state(project_dir, bump_schema=True, commit_schema=fail_schema)
 
     assert _read_json(project_dir / "project.json")["schema_version"] == 7
     manifest_before = (project_dir / MANIFEST_FILENAME).read_bytes()
-    monkeypatch.setattr(artifact_activation, "_commit_schema_version", original)
 
     migrate_v7_to_v8(project_dir)
 
@@ -911,21 +905,24 @@ def test_v7_schema_commit_failure_leaves_complete_manifest_retryable(
     assert (project_dir / MANIFEST_FILENAME).read_bytes() == manifest_before
 
 
-def test_v7_schema_promotion_does_not_overwrite_a_concurrent_project_writer(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_v7_schema_promotion_does_not_overwrite_a_concurrent_project_writer(tmp_path: Path) -> None:
+    """并发写入方在 activation 持锁期间发起 project.json 更新：schema 提升写的是持锁前算出的
+    计划快照，落盘时不能把写入方的改动连带覆盖掉。
+
+    写入方在临界区内被放行，因而必然排在 activation 的整个提交之后拿到锁——它读到的是已提升
+    到 v8 的 project.json，标题与版本号须同时存活。
+    """
     project_dir, _project_data, _step1, _script = _project(tmp_path)
     from lib import artifact_activation
 
-    original_assert = artifact_activation._assert_preflight_unchanged
-    final_check_reached = Event()
+    project_path = project_dir / "project.json"
+    writer_released = Event()
     writer_finished = Event()
     writer_errors: list[Exception] = []
-    check_count = 0
 
     def _update_project() -> None:
-        final_check_reached.wait()
+        # 带超时等待：放行信号没发出时线程须自行退出，否则非守护线程会把整个进程吊死。
+        assert writer_released.wait(timeout=5)
         try:
             ProjectManager(tmp_path).update_project(
                 "demo",
@@ -936,26 +933,59 @@ def test_v7_schema_promotion_does_not_overwrite_a_concurrent_project_writer(
         finally:
             writer_finished.set()
 
-    def _assert_then_release_writer(project_path: Path, plan) -> None:
-        nonlocal check_count
-        original_assert(project_path, plan)
-        check_count += 1
-        if check_count == 3:
-            final_check_reached.set()
-            writer_finished.wait(timeout=0.2)
+    def _release_writer_inside_the_lock(source: Path, stamp: int) -> None:
+        artifact_activation._ensure_activation_backup(source, stamp=stamp)
+        if source == project_path:
+            writer_released.set()
+            # 写入方此刻必须还卡在项目锁上：拿得到锁就说明 activation 的临界区没罩住提升。
+            assert not writer_finished.wait(timeout=0.2)
 
     writer = Thread(target=_update_project)
     writer.start()
-    monkeypatch.setattr(artifact_activation, "_assert_preflight_unchanged", _assert_then_release_writer)
 
-    migrate_v7_to_v8(project_dir)
+    artifact_activation.activate_artifact_target_state(
+        project_dir, bump_schema=True, backup_file=_release_writer_inside_the_lock
+    )
 
     writer.join(timeout=2)
     assert not writer.is_alive()
     assert writer_errors == []
-    promoted = _read_json(project_dir / "project.json")
+    promoted = _read_json(project_path)
     assert promoted["schema_version"] == 8
     assert promoted["title"] == "Concurrent writer"
+
+
+def test_v7_activation_rolls_back_when_inputs_drift_inside_the_critical_section(tmp_path: Path) -> None:
+    """临界区内输入漂移：activation 须响亮失败，并把已经落下的清单回滚干净。
+
+    schema 提升写的是持锁前算出的计划快照，漂移后照提交就会把写入方的改动覆盖成快照里的旧值。
+    这一判在清单替换之后，回滚不彻底的话项目会停在「清单已是新态、schema 仍是 v7」的半提交
+    状态上，而下一次迁移会拿它当起点。
+    """
+    project_dir, _project_data, _step1, _script = _project(tmp_path)
+    from lib import artifact_activation
+
+    project_path = project_dir / "project.json"
+    manifest_path = project_dir / MANIFEST_FILENAME
+    assert not manifest_path.exists()
+
+    def _drift_project_after_backup(source: Path, stamp: int) -> None:
+        artifact_activation._ensure_activation_backup(source, stamp=stamp)
+        if source == project_path:
+            drifted = _read_json(project_path)
+            drifted["title"] = "Drifted inside the lock"
+            _write_json(project_path, drifted)
+
+    with pytest.raises(RuntimeError, match="project.json changed after artifact activation preflight"):
+        artifact_activation.activate_artifact_target_state(
+            project_dir, bump_schema=True, backup_file=_drift_project_after_backup
+        )
+
+    # 漂移写入原样留存，schema 未被快照里的旧值覆盖；清单回到激活前的「不存在」
+    landed = _read_json(project_path)
+    assert landed["title"] == "Drifted inside the lock"
+    assert landed["schema_version"] == 7
+    assert not manifest_path.exists()
 
 
 def test_script_save_rechecks_manifest_activation_inside_the_project_lock(

--- a/tests/integration/lib/test_artifact_manifest_storage.py
+++ b/tests/integration/lib/test_artifact_manifest_storage.py
@@ -334,7 +334,6 @@ def test_project_adapter_replace_failure_preserves_manifest_and_cleans_temp_file
 @pytest.mark.parametrize("force_python_link_fallback", [False, True])
 def test_project_adapter_blocks_escape_and_symlink_artifact_paths(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     force_python_link_fallback: bool,
 ) -> None:
     project = tmp_path / "project"
@@ -724,7 +723,6 @@ def test_project_adapter_reports_unavailable_opened_posix_root(tmp_path: Path) -
 @pytest.mark.skipif(os.name != "posix", reason="Python link checks backstop platforms without O_NOFOLLOW")
 def test_project_adapter_rejects_replaced_posix_project_root_symlink_without_no_follow(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -836,7 +834,6 @@ def test_project_adapter_keeps_manifest_write_on_opened_root_during_swap(
 @pytest.mark.parametrize("force_python_link_fallback", [False, True])
 def test_project_adapter_refuses_runtime_file_symlinks(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     runtime_path: str,
     force_python_link_fallback: bool,
 ) -> None:

--- a/tests/integration/lib/test_artifact_manifest_storage.py
+++ b/tests/integration/lib/test_artifact_manifest_storage.py
@@ -337,15 +337,15 @@ def test_project_adapter_blocks_escape_and_symlink_artifact_paths(
     monkeypatch: pytest.MonkeyPatch,
     force_python_link_fallback: bool,
 ) -> None:
-    if force_python_link_fallback:
-        monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     project = tmp_path / "project"
     project.mkdir()
     outside = tmp_path / "outside.json"
     outside.write_text('{"secret":true}', encoding="utf-8")
     (project / "linked-file.json").symlink_to(outside)
     (project / "linked-dir").symlink_to(tmp_path, target_is_directory=True)
-    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    manifest = ArtifactManifest(
+        ProjectArtifactManifestAdapter(project, nofollow_supported=not force_python_link_fallback)
+    )
     key = ArtifactKey.episode_script(1)
     basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
 
@@ -425,7 +425,7 @@ def test_project_adapter_blocks_file_symlink_swap_without_no_follow(
     artifact.write_text("inside", encoding="utf-8")
     outside = tmp_path / "outside.json"
     outside.write_text("outside", encoding="utf-8")
-    adapter = ProjectArtifactManifestAdapter(project)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
     original_open = os.open
     swapped = False
 
@@ -443,7 +443,6 @@ def test_project_adapter_blocks_file_symlink_swap_without_no_follow(
             swapped = True
         return original_open(path, flags, mode, dir_fd=dir_fd)
 
-    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     monkeypatch.setattr("lib.artifact_manifest.os.open", swap_file_then_open)
 
     observation = adapter.inspect_artifact("episode.json")
@@ -462,7 +461,7 @@ def test_project_adapter_blocks_parent_vanishing_during_fallback_revalidation(
     scripts = project / "scripts"
     scripts.mkdir(parents=True)
     (scripts / "episode.json").write_text("inside", encoding="utf-8")
-    adapter = ProjectArtifactManifestAdapter(project)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
     original_open = os.open
     moved_scripts = project / "removed-scripts"
     moved = False
@@ -481,7 +480,6 @@ def test_project_adapter_blocks_parent_vanishing_during_fallback_revalidation(
             moved = True
         return fd
 
-    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     monkeypatch.setattr("lib.artifact_manifest.os.open", move_parent_after_open)
 
     observation = adapter.inspect_artifact("scripts/episode.json")
@@ -731,11 +729,10 @@ def test_project_adapter_rejects_replaced_posix_project_root_symlink_without_no_
     project = tmp_path / "project"
     project.mkdir()
     (project / "episode.json").write_text("inside", encoding="utf-8")
-    adapter = ProjectArtifactManifestAdapter(project)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
     original_project = tmp_path / "original-project"
     project.rename(original_project)
     project.symlink_to(original_project, target_is_directory=True)
-    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
 
     observation = adapter.inspect_artifact("episode.json")
 
@@ -843,8 +840,6 @@ def test_project_adapter_refuses_runtime_file_symlinks(
     runtime_path: str,
     force_python_link_fallback: bool,
 ) -> None:
-    if force_python_link_fallback:
-        monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     project = tmp_path / "project"
     project.mkdir()
     artifact = project / "episode.json"
@@ -852,7 +847,9 @@ def test_project_adapter_refuses_runtime_file_symlinks(
     outside = tmp_path / "outside.json"
     outside.write_text("do not touch", encoding="utf-8")
     (project / runtime_path).symlink_to(outside)
-    manifest = ArtifactManifest(ProjectArtifactManifestAdapter(project))
+    manifest = ArtifactManifest(
+        ProjectArtifactManifestAdapter(project, nofollow_supported=not force_python_link_fallback)
+    )
     key = ArtifactKey.episode_script(1)
     basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"step1": "source"})
 
@@ -913,7 +910,7 @@ def test_project_adapter_rejects_manifest_symlink_swap_without_no_follow(
     project = tmp_path / "project"
     project.mkdir()
     (project / "episode.json").write_text("{}", encoding="utf-8")
-    adapter = ProjectArtifactManifestAdapter(project)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
     manifest = ArtifactManifest(adapter)
     key = ArtifactKey.episode_script(1)
     basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
@@ -938,7 +935,6 @@ def test_project_adapter_rejects_manifest_symlink_swap_without_no_follow(
             swapped = True
         return original_open(path, flags, mode, dir_fd=dir_fd)
 
-    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     monkeypatch.setattr("lib.artifact_manifest.os.open", swap_manifest_then_open)
 
     comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)
@@ -956,7 +952,7 @@ def test_project_adapter_rejects_lock_symlink_swap_without_no_follow(
     project = tmp_path / "project"
     project.mkdir()
     (project / "episode.json").write_text("{}", encoding="utf-8")
-    adapter = ProjectArtifactManifestAdapter(project)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
     manifest = ArtifactManifest(adapter)
     key = ArtifactKey.episode_script(1)
     basis = ArtifactBasis.build("test/script", kind_version=1, inputs={})
@@ -981,7 +977,6 @@ def test_project_adapter_rejects_lock_symlink_swap_without_no_follow(
             swapped = True
         return original_open(path, flags, mode, dir_fd=dir_fd)
 
-    monkeypatch.setattr("lib.artifact_manifest._O_NOFOLLOW", 0)
     monkeypatch.setattr("lib.artifact_manifest.os.open", swap_lock_then_open)
 
     comparison = manifest.compare(key, artifact_path="episode.json", basis=basis)

--- a/tests/integration/lib/test_audio_utils.py
+++ b/tests/integration/lib/test_audio_utils.py
@@ -143,31 +143,31 @@ class TestProbeExistingVideoDuration:
 
     async def test_prefers_video_stream_duration_over_longer_container_tail(self, tmp_path):
         probe = AsyncMock(return_value=b'{"streams":[{"duration":"1.000000"}],"format":{"duration":"1.500000"}}')
-        with (
-            patch("lib.audio_utils._ffprobe_available", return_value=True),
-            patch("lib.audio_utils._run_ffprobe", probe),
-        ):
-            duration = await audio_utils_module.probe_existing_video_duration_seconds(tmp_path / "clip.mp4")
+        duration = await audio_utils_module.probe_existing_video_duration_seconds(
+            tmp_path / "clip.mp4",
+            ffprobe_available=lambda: True,
+            run_ffprobe=probe,
+        )
 
         assert duration == 1.0
 
     async def test_falls_back_to_container_duration_when_stream_duration_is_absent(self, tmp_path):
         probe = AsyncMock(return_value=b'{"streams":[{}],"format":{"duration":"1.500000"}}')
-        with (
-            patch("lib.audio_utils._ffprobe_available", return_value=True),
-            patch("lib.audio_utils._run_ffprobe", probe),
-        ):
-            duration = await audio_utils_module.probe_existing_video_duration_seconds(tmp_path / "clip.mp4")
+        duration = await audio_utils_module.probe_existing_video_duration_seconds(
+            tmp_path / "clip.mp4",
+            ffprobe_available=lambda: True,
+            run_ffprobe=probe,
+        )
 
         assert duration == 1.5
 
     async def test_rejects_container_without_a_video_stream(self, tmp_path):
         probe = AsyncMock(return_value=b'{"streams":[],"format":{"duration":"1.500000"}}')
-        with (
-            patch("lib.audio_utils._ffprobe_available", return_value=True),
-            patch("lib.audio_utils._run_ffprobe", probe),
-        ):
-            duration = await audio_utils_module.probe_existing_video_duration_seconds(tmp_path / "clip.mp4")
+        duration = await audio_utils_module.probe_existing_video_duration_seconds(
+            tmp_path / "clip.mp4",
+            ffprobe_available=lambda: True,
+            run_ffprobe=probe,
+        )
 
         assert duration is None
 

--- a/tests/integration/lib/test_script_generator.py
+++ b/tests/integration/lib/test_script_generator.py
@@ -454,8 +454,12 @@ class TestScriptGenerator:
         )
 
         generator = ScriptGenerator(project_path)
-        await generator._assert_drama_step1_durations(
-            _drama_step1_content()["scenes"], episode=1, gen_mode="storyboard"
+
+        assert (
+            await generator._assert_drama_step1_durations(
+                _drama_step1_content()["scenes"], episode=1, gen_mode="storyboard"
+            )
+            is None
         )
 
     async def test_drama_step2_build_prompt_renders_step1_content(self, tmp_path):

--- a/tests/integration/lib/test_script_generator_reference_branch.py
+++ b/tests/integration/lib/test_script_generator_reference_branch.py
@@ -2,13 +2,15 @@
 
 import json as _json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.exc import OperationalError
 
 from lib import script_review
 from lib.artifact_activation import activate_artifact_target_state
+from lib.config.resolver import ConfigResolver
 from lib.draft_quarantine import (
     QUARANTINE_KIND_STEP1,
     QUARANTINE_KIND_STEP2,
@@ -70,9 +72,28 @@ def _write_step1(project_dir: Path, payload: str, episode: int = 1) -> None:
     _activate_project_artifacts(project_dir, episode)
 
 
-@pytest.fixture
-def reference_project(tmp_path: Path) -> Path:
-    """造一个 参考生视频的最小项目。"""
+class _StubConfigResolver:
+    """能力解析替身：``ScriptGenerator`` 只消费 ``video_capabilities_for_project`` 这一个读点。
+
+    ``caps=None`` 表达「解析不可用」，按生产上的真实形态抛 DB 错误，让
+    ``_fetch_video_capabilities`` 走它自己那条吞异常回退，而不是绕过回退直接喂进一个 None。
+    """
+
+    def __init__(self, caps: dict | None = None) -> None:
+        self._caps = caps
+
+    async def video_capabilities_for_project(self, project: dict, *, capability: object = None) -> dict:
+        if self._caps is None:
+            raise OperationalError("SELECT ...", {}, Exception("no such table: system_setting"))
+        return self._caps
+
+
+def _stub_resolver(caps: dict | None = None) -> ConfigResolver:
+    return cast(ConfigResolver, _StubConfigResolver(caps))
+
+
+def _write_reference_project(tmp_path: Path, *, video_backend: str) -> Path:
+    """造一个参考生视频的最小项目；``video_backend`` 决定 registry 侧的真实时长档位。"""
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
     (project_dir / "project.json").write_text(
@@ -81,7 +102,7 @@ def reference_project(tmp_path: Path) -> Path:
           "title": "t",
           "content_mode": "narration",
           "generation_mode": "reference_video",
-          "video_backend": "vidu/vidu2.0",
+          "video_backend": "__BACKEND__",
           "overview": {"synopsis": "s", "genre": "g", "theme": "th", "world_setting": "w"},
           "style": "国漫",
           "style_description": "水墨",
@@ -92,11 +113,27 @@ def reference_project(tmp_path: Path) -> Path:
             {"episode": 1, "title": "t1", "script_file": "scripts/episode_1.json",
              "generation_mode": "reference_video"}
           ]
-        }""".replace("__SCHEMA__", str(CURRENT_PROJECT_SCHEMA_VERSION)),
+        }""".replace("__SCHEMA__", str(CURRENT_PROJECT_SCHEMA_VERSION)).replace("__BACKEND__", video_backend),
         encoding="utf-8",
     )
     _write_step1(project_dir, STEP1_UNITS_JSON)
     return project_dir
+
+
+@pytest.fixture
+def reference_project(tmp_path: Path) -> Path:
+    """vidu2.0：raw 档位 [4, 8]，参考生视频下被参考图与分辨率两条约束收窄到 [4]。"""
+    return _write_reference_project(tmp_path, video_backend="vidu/vidu2.0")
+
+
+@pytest.fixture
+def wide_tier_reference_project(tmp_path: Path) -> Path:
+    """viduq3-turbo：raw 档位 1–16 秒，带参考图的 unit 收窄到 3–16 秒。
+
+    参考图约束只做收窄，故「带图档位严于不带图」是真实型号唯一能表达的方向；两档之间需要
+    差异的用例都取这个型号，不再拿替身编造反向的档位。
+    """
+    return _write_reference_project(tmp_path, video_backend="vidu/viduq3-turbo")
 
 
 @pytest.mark.asyncio
@@ -158,162 +195,113 @@ async def test_script_generator_overrides_llm_duration_with_step1_confirmed_valu
 
 @pytest.mark.asyncio
 async def test_script_generator_rejects_confirmed_duration_outside_effective_tiers(reference_project: Path):
-    """step1 校验用未收窄的 raw 档位（此处 [4,8]），但本集实际按参考图收窄到 [8]：确认时
-    合法的 4 秒不再是收窄后的合法值。这种情况下不能静默取档改写落盘——用户审阅通过的
-    时长/费用会被换成一个从未过目的值，须 fail-loud 要求重新审阅确认。
+    """step1 校验用未收窄的 raw 档位（vidu2.0 的 [4, 8]），但参考生视频下的生效档位被参考图与
+    分辨率两条约束收窄到 [4]：确认时合法的 8 秒不再是收窄后的合法值。这种情况下不能静默取档
+    改写落盘——用户审阅通过的时长/费用会被换成一个从未过目的值，须 fail-loud 要求重新审阅确认。
 
     拦截须发生在 TextBackend 调用之前：带引用与不带引用两种生效档位都不接受该确认时长时，
-    本次生成必然失败：放到输出解析阶段才拦，用户已经为它付了费。
+    本次生成必然失败；放到输出解析阶段才拦，用户已经为它付了费。
     """
+    _write_step1(
+        reference_project,
+        _json.dumps(
+            {"units": [{"unit_id": "E1U01", "text": "@[主角] 推开 @[酒馆] 的门", "duration_seconds": 8}]},
+            ensure_ascii=False,
+        ),
+    )
     fake_generator = MagicMock()
     fake_generator.model = "mock"
-    fake_generator.generate = AsyncMock(
-        return_value=MagicMock(
-            text=(
-                '{"episode":1,"title":"t",'
-                '"summary":"s","novel":{"title":"t","chapter":"1"},'
-                '"video_units":[{"unit_id":"E1U01",'
-                '"text":"@[主角] 推门",'
-                '"duration_seconds":8,"transition_to_next":"cut"}]}'
-            )
-        )
-    )
+    fake_generator.generate = AsyncMock()
 
-    gen = ScriptGenerator(reference_project, generator=fake_generator)
-    with (
-        # 显式固定 caps，不依赖真实 DB 解析结果——同 test_script_generator_takes_duration_
-        # tier_from_final_output_references_not_step1 的理由。
-        patch.object(ScriptGenerator, "_fetch_video_capabilities", AsyncMock(return_value={})),
-        patch.object(ScriptGenerator, "_resolve_supported_durations", return_value=[8]),
-    ):
-        with pytest.raises(ValueError, match="不在当前生效档位"):
-            await gen.generate(episode=1)
+    # caps 给空字典：档位一律回落到 project.json 自报身份查 registry，不受 DB 全局默认干扰。
+    gen = ScriptGenerator(reference_project, generator=fake_generator, config_resolver=_stub_resolver({}))
+    with pytest.raises(ValueError, match="不在当前生效档位"):
+        await gen.generate(episode=1)
     fake_generator.generate.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_script_generator_narrows_duration_tiers_per_unit_not_episode_wide(reference_project: Path):
-    """同集内一个 unit 带参考图（收窄到 [8]）、另一个不带（仍是 [4,8]）：后者本已合法的
-    确认值 4 秒不应因前者的收窄被连带改成 8——取档须按每个 unit 自己的参考图状态重算
+async def test_script_generator_narrows_duration_tiers_per_unit_not_episode_wide(
+    wide_tier_reference_project: Path,
+):
+    """同集内一个 unit 带参考图（收窄到 3–16 秒）、另一个不带（仍是 1–16 秒）：后者本已合法的
+    确认值 2 秒不应因前者的收窄被连带改成 3——取档须按每个 unit 自己的参考图状态重算
     生效档位，不套用 episode 级 any(...) 收窄出的粗粒度集合。
     """
-    drafts = reference_project / "drafts" / "episode_1"
-    (drafts / "step1_reference_units.json").write_text(
+    project = wide_tier_reference_project
+    _write_step1(
+        project,
         _json.dumps(
             {
                 "units": [
-                    {
-                        "unit_id": "E1U01",
-                        "text": "@[主角] 推门",
-                        "duration_seconds": 8,
-                    },
-                    {
-                        "unit_id": "E1U02",
-                        "text": "空镜",
-                        "duration_seconds": 4,
-                    },
+                    {"unit_id": "E1U01", "text": "@[主角] 推门", "duration_seconds": 3},
+                    {"unit_id": "E1U02", "text": "空镜", "duration_seconds": 2},
                 ]
             },
             ensure_ascii=False,
         ),
-        encoding="utf-8",
     )
 
     fake_generator = _fake_step2_generator("镜头1：中景。@[主角] 推门", "镜头1：空镜，风吹过门廊")
-
-    def _fake_supported_durations(self, caps=None, *, gen_mode, uses_reference_images=None):
-        return [8] if uses_reference_images else [4, 8]
-
-    gen = ScriptGenerator(reference_project, generator=fake_generator)
-    with patch.object(ScriptGenerator, "_resolve_supported_durations", _fake_supported_durations):
-        out = await gen.generate(episode=1)
+    gen = ScriptGenerator(project, generator=fake_generator, config_resolver=_stub_resolver({}))
+    out = await gen.generate(episode=1)
 
     data = _json.loads(out.read_text(encoding="utf-8"))
     units_by_id = {u["unit_id"]: u for u in data["video_units"]}
-    assert units_by_id["E1U01"]["duration_seconds"] == 8
-    assert units_by_id["E1U02"]["duration_seconds"] == 4  # 未被另一个带图 unit 的收窄连带改动
+    assert units_by_id["E1U01"]["duration_seconds"] == 3
+    assert units_by_id["E1U02"]["duration_seconds"] == 2  # 未被另一个带图 unit 的收窄连带改动
 
 
 @pytest.mark.asyncio
 async def test_script_generator_takes_duration_tier_from_final_output_references_not_step1(
-    reference_project: Path,
+    wide_tier_reference_project: Path,
 ):
-    """step1 拆分时某 unit 带引用（按带图档位确认，仅 8 秒合法），但 step2 输出给这个 unit
-    去掉了引用（回落到纯文本档位 [4, 8]，4 秒合法）：取档须按最终落地的 references 状态
-    重算，不能沿用 step1 的旧状态——按 step1 状态取档会把本已合法的确认值误判为不合法。
+    """step1 拆分时某 unit 带引用（带图档位最短 3 秒，2 秒只在未收窄的 raw 档位上过了校验），
+    但 step2 输出给这个 unit 去掉了引用（回落到纯文本档位 1–16 秒，2 秒合法）：取档须按最终
+    落地的 references 状态重算，不能沿用 step1 的旧状态——按 step1 状态取档会把本已合法的
+    确认值改写成 3 秒。
     """
-    drafts = reference_project / "drafts" / "episode_1"
-    (drafts / "step1_reference_units.json").write_text(
+    project = wide_tier_reference_project
+    _write_step1(
+        project,
         _json.dumps(
-            {
-                "units": [
-                    {
-                        "unit_id": "E1U01",
-                        "text": "@[主角] 推门",
-                        "duration_seconds": 4,
-                    }
-                ]
-            },
+            {"units": [{"unit_id": "E1U01", "text": "@[主角] 推门", "duration_seconds": 2}]},
             ensure_ascii=False,
         ),
-        encoding="utf-8",
     )
 
     fake_generator = _fake_step2_generator("镜头1：空镜，门廊在风里轻响")
-
-    def _fake_supported_durations(self, caps=None, *, gen_mode, uses_reference_images=None):
-        return [8] if uses_reference_images else [4, 8]
-
-    gen = ScriptGenerator(reference_project, generator=fake_generator)
-    with (
-        # 显式固定 caps，不依赖真实 DB 解析结果——_fetch_video_capabilities 解析失败时按
-        # 文档返回 None，环境不同（如缺 DB 迁移的测试容器）会让本测试的前提静默漂移。
-        patch.object(ScriptGenerator, "_fetch_video_capabilities", AsyncMock(return_value={})),
-        patch.object(ScriptGenerator, "_resolve_supported_durations", _fake_supported_durations),
-    ):
-        out = await gen.generate(episode=1)
+    gen = ScriptGenerator(project, generator=fake_generator, config_resolver=_stub_resolver({}))
+    out = await gen.generate(episode=1)
 
     data = _json.loads(out.read_text(encoding="utf-8"))
     unit = data["video_units"][0]
     assert extract_mentions(unit["text"]) == []
-    assert unit["duration_seconds"] == 4  # 按最终正文（无引用）取档合法，不因 step1 的带图状态被误判
+    assert unit["duration_seconds"] == 2  # 按最终正文（无引用）取档合法，不因 step1 的带图状态被误判
 
 
 @pytest.mark.asyncio
 async def test_script_generator_reclamps_duration_even_when_caps_unavailable(reference_project: Path):
-    """caps 解析失败（``_fetch_video_capabilities`` 按其文档在这种情况下返回 None）不代表
+    """caps 解析失败（DB 不可用，``_fetch_video_capabilities`` 按其文档吞掉异常返回 None）不代表
     取不到任何档位——``_resolve_supported_durations`` 自带 caps → registry 两级回退，
-    project.json 自报的模型身份仍能兜底。回填逻辑须无条件取档，
-    不能因为 caps 是 None 就保留一个未经取档的值。
-
-    与其它同类测试一样另 mock ``_resolve_supported_durations`` 本身（而非验证真实回退链
-    ——那是 config resolver 层的测试范畴）：caps=None 时的回退结果与 caps 非 None 时一样
-    都是 registry 声明的 [4, 8]，raw 值只要合法就不会触发
-    任何取档，测不出「取档有没有被跳过」这个真正要验证的行为；只有固定取档结果本身，
-    才能构造出「已确认值不在生效档位内」的场景来证明重取档确实执行了——如今这种不合法
-    直接 fail-loud，执行了就必抛错，不执行就会静默用未取档的 4 落盘成功。
+    project.json 自报的 vidu2.0 仍能兜底出 raw [4, 8] 并收窄到 [4]。回填逻辑须无条件取档，
+    不能因为 caps 是 None 就保留一个未经取档的值：确认值 8 秒落在收窄后的生效档位外，取档
+    执行了就必抛错，不执行则会静默用未取档的 8 落盘成功。
     """
+    _write_step1(
+        reference_project,
+        _json.dumps(
+            {"units": [{"unit_id": "E1U01", "text": "@[主角] 推开 @[酒馆] 的门", "duration_seconds": 8}]},
+            ensure_ascii=False,
+        ),
+    )
     fake_generator = MagicMock()
     fake_generator.model = "mock"
-    fake_generator.generate = AsyncMock(
-        return_value=MagicMock(
-            text=(
-                '{"episode":1,"title":"t",'
-                '"summary":"s","novel":{"title":"t","chapter":"1"},'
-                '"video_units":[{"unit_id":"E1U01",'
-                '"text":"@[主角] 推门",'
-                '"duration_seconds":8,"transition_to_next":"cut"}]}'
-            )
-        )
-    )
+    fake_generator.generate = AsyncMock()
 
-    gen = ScriptGenerator(reference_project, generator=fake_generator)
-    with (
-        patch.object(ScriptGenerator, "_fetch_video_capabilities", AsyncMock(return_value=None)),
-        patch.object(ScriptGenerator, "_resolve_supported_durations", return_value=[8]),
-    ):
-        with pytest.raises(ValueError, match="不在当前生效档位"):
-            await gen.generate(episode=1)
+    gen = ScriptGenerator(reference_project, generator=fake_generator, config_resolver=_stub_resolver(None))
+    with pytest.raises(ValueError, match="不在当前生效档位"):
+        await gen.generate(episode=1)
 
 
 @pytest.mark.asyncio
@@ -503,7 +491,7 @@ async def test_build_prompt_no_video_backend_raises_value_error(tmp_path: Path):
 
     设计意图：supported_durations 是单一真相源，必须由 caps（DB 全局默认）或 project.json 自报身份查 registry 提供；
     都拿不到才 fail loud，避免向 LLM 注入兜底 [4, 8] 误导生成。
-    用 mock 把 _fetch_video_capabilities 强制返 None，模拟无任何 model 配置的环境。
+    经 config_resolver seam 注入一个解析不可用的替身，模拟无任何 model 配置的环境。
     """
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
@@ -530,13 +518,9 @@ async def test_build_prompt_no_video_backend_raises_value_error(tmp_path: Path):
     drafts.mkdir(parents=True)
     (drafts / "step1_reference_units.json").write_text(STEP1_UNITS_JSON, encoding="utf-8")
 
-    gen = ScriptGenerator(project_dir)
-    with patch(
-        "lib.script_generator.ScriptGenerator._fetch_video_capabilities",
-        new=AsyncMock(return_value=None),
-    ):
-        with pytest.raises(ValueError, match="supported_durations"):
-            await gen.build_prompt(episode=1)
+    gen = ScriptGenerator(project_dir, config_resolver=_stub_resolver(None))
+    with pytest.raises(ValueError, match="supported_durations"):
+        await gen.build_prompt(episode=1)
 
 
 @pytest.mark.asyncio
@@ -544,12 +528,8 @@ async def test_fetch_video_capabilities_swallows_db_errors(reference_project: Pa
     """CI 回归：裸测试容器缺 migration 时 ConfigResolver 会抛 OperationalError；
     _fetch_video_capabilities 必须 fallback 返 None，不让 generate() 崩溃。
     """
-    gen = ScriptGenerator(reference_project)
-    with patch(
-        "lib.script_generator.ConfigResolver.video_capabilities_for_project",
-        new=AsyncMock(side_effect=OperationalError("SELECT ...", {}, Exception("no such table: system_setting"))),
-    ):
-        caps = await gen._fetch_video_capabilities()
+    gen = ScriptGenerator(reference_project, config_resolver=_stub_resolver(None))
+    caps = await gen._fetch_video_capabilities()
     assert caps is None
 
 
@@ -635,14 +615,10 @@ async def test_reference_step1_rejects_out_of_enum_duration(reference_project: P
         encoding="utf-8",
     )
 
-    gen = ScriptGenerator(reference_project)
     # 固定能力来源为 project.json 自报身份查 registry（vidu2.0 → [4, 8]），隔离 DB 全局默认干扰
-    with patch(
-        "lib.script_generator.ScriptGenerator._fetch_video_capabilities",
-        new=AsyncMock(return_value=None),
-    ):
-        with pytest.raises(ValueError, match="时长非法"):
-            await gen.build_prompt(episode=1)
+    gen = ScriptGenerator(reference_project, config_resolver=_stub_resolver(None))
+    with pytest.raises(ValueError, match="时长非法"):
+        await gen.build_prompt(episode=1)
 
 
 @pytest.mark.asyncio
@@ -949,36 +925,36 @@ async def test_promote_step2_draft_rejects_schema_breach_with_report(reference_p
     assert [v["code"] for v in refreshed["violations"]] == ["schema_invalid"]
 
 
-def _tiers_by_reference_state(with_refs: list[int], without_refs: list[int]):
-    """按 uses_reference_images 分流的 _resolve_supported_durations 替身。"""
-
-    def _resolve(_self, _caps=None, *, gen_mode, uses_reference_images=None):  # noqa: ANN001
-        return with_refs if uses_reference_images else without_refs
-
-    return _resolve
-
-
 @pytest.mark.asyncio
-async def test_step2_duration_off_tier_after_merge_quarantines(reference_project: Path):
+async def test_step2_duration_off_tier_after_merge_quarantines(wide_tier_reference_project: Path):
     """合并之后才判出的档位越界同样落待修复草稿——这份展开已经付过费了。
 
-    step2 可以给 unit 增删 `@` 引用，生效档位随之换一套：step1 那个 4 秒的带图 unit 在展开时
-    丢掉了引用，档位就从 [4] 变成 [8]。这一判在 `_add_metadata` 里、在保结构 diff 之后，
-    不接住的话产物只存在于内存里，错误却让调用方重新生成。
+    step2 可以给 unit 增删 `@` 引用，生效档位随之换一套：step1 那个 2 秒的无引用 unit 在展开时
+    加进了引用，档位就从 1–16 秒收窄到 3–16 秒。参考图约束只做收窄，故「展开后才越界」只可能
+    发生在增加引用的方向上。这一判在 `_add_metadata` 里、在保结构 diff 之后，不接住的话产物
+    只存在于内存里，错误却让调用方重新生成。
     """
-    no_reference_text = "镜头1：中景，平视。他推开门，侧身跨过门槛。"
-    gen = ScriptGenerator(reference_project, generator=_fake_step2_generator(no_reference_text))
+    project = wide_tier_reference_project
+    _write_step1(
+        project,
+        _json.dumps({"units": [{"unit_id": "E1U01", "text": "他推门", "duration_seconds": 2}]}, ensure_ascii=False),
+    )
+    with_reference_text = "镜头1：中景，平视。@[主角] 推开门，侧身跨过门槛。"
+    gen = ScriptGenerator(
+        project,
+        generator=_fake_step2_generator(with_reference_text),
+        config_resolver=_stub_resolver({}),
+    )
 
-    with patch.object(ScriptGenerator, "_resolve_supported_durations", _tiers_by_reference_state([4], [8])):
-        with pytest.raises(DraftViolation) as excinfo:
-            await gen.generate(episode=1)
+    with pytest.raises(DraftViolation) as excinfo:
+        await gen.generate(episode=1)
 
     assert "生效档位" in str(excinfo.value)
-    assert not _script_path(reference_project).exists()
-    envelope = _json.loads(_step2_quarantine(reference_project).read_text(encoding="utf-8"))
+    assert not _script_path(project).exists()
+    envelope = _json.loads(_step2_quarantine(project).read_text(encoding="utf-8"))
     assert [v["code"] for v in envelope["violations"]] == ["duration_off_tier"]
-    # 草稿装的仍是 Agent 要改的那一层正文，改回 `@` 引用即可重新晋升
-    assert envelope["content"]["units"][0]["text"] == no_reference_text
+    # 草稿装的仍是 Agent 要改的那一层正文，去掉 `@` 引用即可重新晋升
+    assert envelope["content"]["units"][0]["text"] == with_reference_text
 
 
 @pytest.mark.asyncio

--- a/tests/integration/lib/test_script_review_router.py
+++ b/tests/integration/lib/test_script_review_router.py
@@ -565,20 +565,12 @@ class TestReferenceVideoRouter:
         （收窄后的逐 unit 可选项）都要经 caps 解析出真实档位，否则这类项目的内容确认只能退回
         结构区间 clamp，读时迁移的收编对其整体失效。
         """
-        from server.agent_runtime.sdk_tools import _context
-        from server.services import script_review as mod
-
-        client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
-
-        async def _fake_caps(_project, _episode=None):
-            return {"provider_id": "custom-acme", "model": "acme-video", "supported_durations": [5, 10]}
-
-        monkeypatch.setattr(mod, "resolve_video_caps", _fake_caps)
-
-        async def _no_i2v(_project, *, capability=None):
-            raise ValueError("i2v bucket unresolvable in this test")
-
-        monkeypatch.setattr(_context, "resolve_video_caps", _no_i2v)
+        client, pm = _client(
+            monkeypatch,
+            tmp_path,
+            generation_mode="reference_video",
+            caps=_custom_provider_caps(durations=[5, 10], default_duration=None),
+        )
 
         with client:
             _write_rv_step1(pm, _rv_step1())

--- a/tests/integration/lib/test_script_review_router.py
+++ b/tests/integration/lib/test_script_review_router.py
@@ -3,17 +3,51 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from lib.config.resolver import ConfigResolver
 from lib.json_io import atomic_write_json
 from lib.project_manager import ProjectManager
 from server.auth import CurrentUserInfo, get_current_user
 from server.error_handlers import register_error_handlers
 from server.routers import script_review as router_mod
+from server.services.script_review import ScriptReviewService
 from tests.auth_deps import AUTH_DEPENDENCIES
-from tests.fakes import fake_reference_caps_fetcher
+
+
+class _StubConfigResolver:
+    """能力解析替身：两条 caps 取值路径最终都只经 ``video_capabilities_for_project`` 这一个读点。
+
+    经生产已有的 ``config_resolver`` 注入位下去，``_fetch_caps_with_fallback`` 与
+    ``_fetch_reference_caps_with_fallback`` 本体照常执行——档位收窄、空集软回退、默认时长的
+    成员性判定都仍在覆盖内；整体替换取值器会把这三段一起绕过去。
+
+    本文件现有断言都落在与时长无关的违约码上，注入档位买的是确定性而非断言支撑：不注入时
+    解析会去连真实数据库，用例的档位取决于「跑测试的机器上恰好没有库」这一环境事实。
+    """
+
+    def __init__(self, caps: dict) -> None:
+        self._caps = caps
+
+    async def video_capabilities_for_project(self, project: dict, *, capability: object = None) -> dict:
+        return self._caps
+
+
+def _custom_provider_caps(*, durations: list[int], default_duration: int | None = 4, max_refs: int = 3) -> dict:
+    """自定义供应商（``custom-`` 前缀）不在 ``PROVIDER_REGISTRY``，不声明任何时长联动约束。
+
+    caps 里的档位即最终生效档位，用例要什么档位就直接写什么，不必去挑一个恰好合适的真实型号。
+    """
+    return {
+        "provider_id": "custom-acme",
+        "model": "acme-video",
+        "supported_durations": list(durations),
+        "default_duration": default_duration,
+        "max_reference_images": max_refs,
+    }
 
 
 def _drama_step1() -> dict:
@@ -56,6 +90,7 @@ def _client(
     *,
     generation_mode: str | None = None,
     content_mode: str = "drama",
+    caps: dict | None = None,
 ) -> tuple[TestClient, ProjectManager]:
     pm = ProjectManager(tmp_path / "projects")
     pm.create_project("demo")
@@ -66,6 +101,13 @@ def _client(
         pm.update_project("demo", lambda p: p.__setitem__("generation_mode", generation_mode))
 
     monkeypatch.setattr(router_mod, "get_project_manager", lambda: pm)
+    if caps is not None:
+        resolver = cast(ConfigResolver, _StubConfigResolver(caps))
+        monkeypatch.setattr(
+            router_mod,
+            "ScriptReviewService",
+            lambda project_manager: ScriptReviewService(project_manager, config_resolver=resolver),
+        )
 
     app = FastAPI()
     register_error_handlers(app)
@@ -224,15 +266,14 @@ class TestReferenceVideoRouter:
         不信任草稿里上一轮的快照（这里把快照消息故意写成 "stale" 来验证）。"""
         from lib.draft_quarantine import QUARANTINE_KIND_STEP1, write_quarantine
         from lib.reference_video.draft_validation import DraftViolation
-        from server.agent_runtime.sdk_tools import text_generation as mod
 
-        client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
+        client, pm = _client(
+            monkeypatch, tmp_path, generation_mode="reference_video", caps=_custom_provider_caps(durations=[4, 6, 8])
+        )
         project_path = pm.get_project_path("demo")
         novel = "阿离站在屋檐下。"
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text(novel, encoding="utf-8")
-
-        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(max_duration=8))
 
         flat_units = [{"duration_seconds": 4, "source_text": novel, "text": "镜头1：门开了\n@[阿离]：｛我来了。｝"}]
         write_quarantine(
@@ -264,14 +305,13 @@ class TestReferenceVideoRouter:
         呈现层据此退回原始文本视图而非当作 units 列表遍历。"""
         from lib.draft_quarantine import QUARANTINE_KIND_STEP1, write_quarantine
         from lib.reference_video.draft_validation import DraftViolation
-        from server.agent_runtime.sdk_tools import text_generation as mod
 
-        client, pm = _client(monkeypatch, tmp_path, generation_mode="reference_video")
+        client, pm = _client(
+            monkeypatch, tmp_path, generation_mode="reference_video", caps=_custom_provider_caps(durations=[4, 6, 8])
+        )
         project_path = pm.get_project_path("demo")
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text("阿离站在屋檐下。", encoding="utf-8")
-
-        monkeypatch.setattr(mod, "_fetch_reference_caps_with_fallback", fake_reference_caps_fetcher(max_duration=8))
         write_quarantine(
             project_path,
             1,
@@ -319,18 +359,14 @@ class TestReferenceVideoRouter:
         """
         from lib.draft_quarantine import QUARANTINE_KIND_NARRATION_STEP1, write_quarantine
         from lib.draft_violation import DraftViolation
-        from server.agent_runtime.sdk_tools import text_generation as mod
 
-        client, pm = _client(monkeypatch, tmp_path, content_mode="narration")
+        client, pm = _client(
+            monkeypatch, tmp_path, content_mode="narration", caps=_custom_provider_caps(durations=[4, 6, 8])
+        )
         project_path = pm.get_project_path("demo")
         novel = "阿离站在屋檐下。"
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text(novel, encoding="utf-8")
-
-        async def fake_caps(_project, _episode=None):
-            return 4, [4, 6, 8]
-
-        monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
 
         segment = {
             "segment_id": "E1S01",
@@ -365,18 +401,12 @@ class TestReferenceVideoRouter:
         """drama 的待修复草稿（取回编辑工位）同样进 GET 响应：内容重判通过则违约为空、
         正文按现值收编回传，面板据此说明「等待晋升」而不是显示一片空白。"""
         from lib.draft_quarantine import QUARANTINE_KIND_DRAMA_STEP1, write_quarantine
-        from server.agent_runtime.sdk_tools import text_generation as mod
 
-        client, pm = _client(monkeypatch, tmp_path)
+        client, pm = _client(monkeypatch, tmp_path, caps=_custom_provider_caps(durations=[4, 6, 8]))
         project_path = pm.get_project_path("demo")
         novel = "阿离站在屋檐下。"
         (project_path / "source").mkdir(parents=True, exist_ok=True)
         (project_path / "source" / "episode_1.txt").write_text(novel, encoding="utf-8")
-
-        async def fake_caps(_project, _episode=None):
-            return 4, [4, 6, 8]
-
-        monkeypatch.setattr(mod, "_fetch_caps_with_fallback", fake_caps)
 
         scene = {
             "scene_id": "E1S01",

--- a/tests/integration/lib/test_task_terminal_events.py
+++ b/tests/integration/lib/test_task_terminal_events.py
@@ -4,9 +4,10 @@
 （成功 / 失败 / 取消 / 批量取消 / 级联失败）落库后是否把事件发上 batch 总线。
 """
 
+from contextlib import asynccontextmanager
+
 import pytest
 
-from lib.db.repositories.task_repo import TaskRepository
 from lib.generation_queue import GenerationQueue
 from lib.project_change_hints import register_project_change_batch_listener
 from lib.task_terminal_events import build_task_terminal_change
@@ -28,6 +29,30 @@ def captured_batches():
     unregister = register_project_change_batch_listener(listener)
     yield batches
     unregister()
+
+
+def _commit_failing_factory(factory):
+    """代理真实 session factory，只把 ``commit`` 换成抛错，其余读写照常落到真实库。
+
+    故障因此正好卡在「终态已收集、事务未提交」这一窗口；会话退出时真实事务照常回滚。
+    """
+
+    class _CommitFails:
+        def __init__(self, session):
+            self._session = session
+
+        def __getattr__(self, name):
+            return getattr(self._session, name)
+
+        async def commit(self):
+            raise RuntimeError("commit 炸了")
+
+    @asynccontextmanager
+    async def _open():
+        async with factory() as session:
+            yield _CommitFails(session)
+
+    return _open
 
 
 def _task_changes(batches):
@@ -156,28 +181,24 @@ class TestQueueEmitsTerminalEvents:
 
         assert _task_changes(captured_batches) == []
 
-    async def test_no_publish_when_body_raises_before_commit(self, queue, captured_batches, monkeypatch):
-        """终态已收集但会话未提交时不得发布——没有终态落库就没有终态可通告。
+    async def test_no_publish_when_commit_fails(self, queue, db_factory, captured_batches):
+        """终态已收集但会话提交失败时不得发布——没有终态落库就没有终态可通告。
 
         `_task_repo` 把发布放在 `async with` 之后正是为此；若发布挪进 repo 内部或提到
         提交之前，前端会收到一条对应状态并未落库的终态事件。
+
+        故障打在会话这个协作者的提交动作上，与生产上真实的提交失败同形：终态收集照常发生，
+        事务随即回滚，落库与通告因而必须一起没有。
         """
         task_id = await self._enqueue_running(queue)
         captured_batches.clear()
 
-        original_record = TaskRepository._record_terminal_event
-
-        def raise_after_collecting(self, **kwargs):
-            original_record(self, **kwargs)
-            assert self.terminal_events, "前置条件：终态已被 _record_terminal_event 收集"
-            raise RuntimeError("commit 前炸了")
-
-        monkeypatch.setattr(TaskRepository, "_record_terminal_event", raise_after_collecting)
-
-        with pytest.raises(RuntimeError, match="commit 前炸了"):
-            await queue.mark_task_succeeded(task_id, {"file_path": "videos/E1S01.mp4"})
+        failing_queue = GenerationQueue(session_factory=_commit_failing_factory(db_factory))
+        with pytest.raises(RuntimeError, match="commit 炸了"):
+            await failing_queue.mark_task_succeeded(task_id, {"file_path": "videos/E1S01.mp4"})
 
         assert _task_changes(captured_batches) == []
+        assert (await queue.get_task(task_id))["status"] == "running"
 
     async def test_cascade_failure_emits_event_for_dependent(self, queue, captured_batches):
         """级联失败的下游任务同样进事件——终态收口在 _record_terminal_event，一处覆盖全路径。"""

--- a/tests/integration/lib/test_workflow_state.py
+++ b/tests/integration/lib/test_workflow_state.py
@@ -681,35 +681,17 @@ def test_completed_first_episode_does_not_hide_later_incomplete_episode(
 
     original_load_project = pm.load_project_readonly
     load_calls = 0
-    source_inventory_calls = 0
-    asset_sheet_calls = 0
-    original_source_inventory = WorkflowStateService._source_inventory
-    original_asset_sheets = WorkflowStateService._asset_sheets
 
     def _counted_load_project(project_name: str) -> dict:
         nonlocal load_calls
         load_calls += 1
         return original_load_project(project_name)
 
-    def _counted_source_inventory(*args, **kwargs):
-        nonlocal source_inventory_calls
-        source_inventory_calls += 1
-        return original_source_inventory(*args, **kwargs)
-
-    def _counted_asset_sheets(*args, **kwargs):
-        nonlocal asset_sheet_calls
-        asset_sheet_calls += 1
-        return original_asset_sheets(*args, **kwargs)
-
     monkeypatch.setattr(pm, "load_project_readonly", _counted_load_project)
-    monkeypatch.setattr(WorkflowStateService, "_source_inventory", _counted_source_inventory)
-    monkeypatch.setattr(WorkflowStateService, "_asset_sheets", _counted_asset_sheets)
     source_reads = _count_source_reads(monkeypatch, project_path)
     status = WorkflowStateService(pm).get_status("demo")
 
     assert load_calls == 1
-    assert source_inventory_calls == 1
-    assert asset_sheet_calls == 1
     # 整本源文仍只读一次；分集原文是产物清单比对的输入（据其重建 step1 基线），
     # 由现势解析器按项目根与分集两层各读一次。
     assert source_reads == {"novel.txt": 1, "episode_1.txt": 2}

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -86,7 +86,7 @@ FIRST_IMPORT_MODULES = [
 
 @pytest.mark.parametrize("module_name", MODULES)
 def test_module_imports_cleanly(module_name: str) -> None:
-    """冒烟：模块能导入，且导进来的确实是它自己（而非同名的部分初始化占位）。"""
+    """冒烟：模块能按全名导入，import 期副作用（配置读取、循环 import）不抛错。"""
     assert importlib.import_module(module_name).__name__ == module_name
 
 

--- a/tests/integration/test_imports.py
+++ b/tests/integration/test_imports.py
@@ -86,7 +86,8 @@ FIRST_IMPORT_MODULES = [
 
 @pytest.mark.parametrize("module_name", MODULES)
 def test_module_imports_cleanly(module_name: str) -> None:
-    importlib.import_module(module_name)
+    """冒烟：模块能导入，且导进来的确实是它自己（而非同名的部分初始化占位）。"""
+    assert importlib.import_module(module_name).__name__ == module_name
 
 
 @pytest.mark.parametrize("module_name", FIRST_IMPORT_MODULES)

--- a/tests/unit/lib/agent_session_store/test_conformance.py
+++ b/tests/unit/lib/agent_session_store/test_conformance.py
@@ -69,7 +69,8 @@ async def test_db_session_store_passes_sdk_conformance():
         return DbSessionStore(factory, user_id="conformance")
 
     try:
-        await run_session_store_conformance(make_store)
+        # 一致性套件以抛异常报告失败；显式断言无返回，免得用例体被清空也没人发现。
+        assert await run_session_store_conformance(make_store) is None
     finally:
         # On PG, drop the per-store schemas before disposing the engines.
         if pg_url:

--- a/tests/unit/lib/config/test_anthropic_probe.py
+++ b/tests/unit/lib/config/test_anthropic_probe.py
@@ -1,13 +1,13 @@
-"""Anthropic probe 单元测试 (mock httpx，不打真实网络)。"""
+"""Anthropic probe 单元测试：respx 在 transport 层拦截，不打真实网络。"""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from collections.abc import AsyncIterator
 
 import httpx
 import pytest
 
-from lib.agent_provider_catalog import CUSTOM_SENTINEL_ID
+from lib.agent_provider_catalog import CUSTOM_SENTINEL_ID, get_preset
 from lib.config.anthropic_probe import (
     DiagnosisCode,
     ProbeResult,
@@ -16,91 +16,107 @@ from lib.config.anthropic_probe import (
     probe_messages,
     run_test,
 )
+from tests.http_capture import capture_http, only_request, request_json
+
+_ANTHROPIC_OK = {"id": "msg_1", "type": "message", "content": [{"type": "text", "text": "ok"}]}
 
 
-@pytest.mark.asyncio
-async def test_probe_messages_success() -> None:
-    fake_response = httpx.Response(
-        200,
-        json={"id": "msg_1", "type": "message", "content": [{"type": "text", "text": "ok"}]},
-    )
-    with patch(
-        "lib.config.anthropic_probe._post",
-        AsyncMock(return_value=fake_response),
-    ) as mocked:
+@pytest.fixture()
+async def probe_client() -> AsyncIterator[httpx.AsyncClient]:
+    """真实 httpx 客户端；出站流量由 respx 在 transport 层接管。
+
+    生产的共享单例要靠 lifespan 初始化，单测经 `http_client` seam 显式注入。
+    """
+    async with httpx.AsyncClient() as client:
+        yield client
+
+
+async def test_probe_messages_success(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        route = router.post("https://api.example.com/v1/messages").mock(
+            return_value=httpx.Response(200, json=_ANTHROPIC_OK)
+        )
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="sk-test",
             model="claude-3-5-sonnet-20241022",
+            http_client=probe_client,
         )
+
     assert result.success is True
     assert result.status_code == 200
     assert result.error is None
-    mocked.assert_awaited_once()
-    called_url = mocked.await_args.kwargs["url"]
-    assert called_url == "https://api.example.com/v1/messages"
+    request = only_request(route)
+    assert request.headers["x-api-key"] == "sk-test"
+    assert request.headers["anthropic-version"] == "2023-06-01"
+    assert request_json(request) == {
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
 
 
-@pytest.mark.asyncio
-async def test_probe_messages_401_marks_failure() -> None:
-    fake = httpx.Response(401, json={"error": {"type": "authentication_error"}})
-    with patch("lib.config.anthropic_probe._post", AsyncMock(return_value=fake)):
+async def test_probe_messages_401_marks_failure(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(
+            return_value=httpx.Response(401, json={"error": {"type": "authentication_error"}})
+        )
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="bad",
             model="claude-3-5-sonnet-20241022",
+            http_client=probe_client,
         )
+
     assert result.success is False
     assert result.status_code == 401
     assert "authentication_error" in (result.error or "")
 
 
-@pytest.mark.asyncio
-async def test_probe_messages_200_but_not_anthropic_marks_failure() -> None:
+async def test_probe_messages_200_but_not_anthropic_marks_failure(probe_client: httpx.AsyncClient) -> None:
     """OpenAI 兼容协议响应：200 但缺 type=message 应判失败。"""
-    fake = httpx.Response(
-        200,
-        json={"id": "chatcmpl-1", "object": "chat.completion", "choices": []},
-    )
-    with patch("lib.config.anthropic_probe._post", AsyncMock(return_value=fake)):
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(
+            return_value=httpx.Response(200, json={"id": "chatcmpl-1", "object": "chat.completion", "choices": []})
+        )
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="sk",
             model="x",
+            http_client=probe_client,
         )
+
     assert result.success is False
     assert result.status_code == 200
     assert "non-anthropic" in (result.error or "").lower()
 
 
-@pytest.mark.asyncio
-async def test_probe_messages_timeout() -> None:
-    with patch(
-        "lib.config.anthropic_probe._post",
-        AsyncMock(side_effect=httpx.TimeoutException("timeout")),
-    ):
+async def test_probe_messages_timeout(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(side_effect=httpx.TimeoutException("timeout"))
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="sk",
             model="x",
             timeout_s=0.5,
+            http_client=probe_client,
         )
+
     assert result.success is False
     assert result.status_code is None
     assert "timeout" in (result.error or "").lower()
 
 
-@pytest.mark.asyncio
-async def test_probe_messages_network_error() -> None:
-    with patch(
-        "lib.config.anthropic_probe._post",
-        AsyncMock(side_effect=httpx.ConnectError("connection refused")),
-    ):
+async def test_probe_messages_network_error(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(side_effect=httpx.ConnectError("connection refused"))
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="sk",
             model="x",
+            http_client=probe_client,
         )
+
     assert result.success is False
     assert result.status_code is None
     assert result.error is not None
@@ -147,78 +163,64 @@ def test_classify_probe_failure_unknown_404_no_model() -> None:
     assert classify_probe_failure(p) == DiagnosisCode.UNKNOWN
 
 
-@pytest.mark.asyncio
 async def test_probe_discovery_none_root_returns_none() -> None:
     assert await probe_discovery(discovery_root=None, api_key="sk") is None
 
 
-@pytest.mark.asyncio
-async def test_probe_discovery_success() -> None:
-    fake = httpx.Response(200, json={"data": [{"id": "m"}]})
-    with patch(
-        "lib.config.anthropic_probe._get",
-        AsyncMock(return_value=fake),
-    ) as mocked:
-        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk")
+async def test_probe_discovery_success(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        route = router.get("https://api.example.com/v1/models").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "m"}]})
+        )
+        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk", http_client=probe_client)
+
     assert result is not None
     assert result.success is True
     assert result.status_code == 200
-    called_url = mocked.await_args.kwargs["url"]
-    assert called_url == "https://api.example.com/v1/models"
+    assert only_request(route).headers["x-api-key"] == "sk"
 
 
-@pytest.mark.asyncio
-async def test_probe_discovery_non_2xx_marks_failure() -> None:
-    fake = httpx.Response(404, text="not found")
-    with patch("lib.config.anthropic_probe._get", AsyncMock(return_value=fake)):
-        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk")
+async def test_probe_discovery_non_2xx_marks_failure(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.get("https://api.example.com/v1/models").mock(return_value=httpx.Response(404, text="not found"))
+        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk", http_client=probe_client)
+
     assert result is not None
     assert result.success is False
     assert result.status_code == 404
     assert "not found" in (result.error or "")
 
 
-@pytest.mark.asyncio
-async def test_probe_discovery_network_error() -> None:
-    with patch(
-        "lib.config.anthropic_probe._get",
-        AsyncMock(side_effect=httpx.ConnectError("dns fail")),
-    ):
-        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk")
+async def test_probe_discovery_network_error(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.get("https://api.example.com/v1/models").mock(side_effect=httpx.ConnectError("dns fail"))
+        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk", http_client=probe_client)
+
     assert result is not None
     assert result.success is False
     assert result.status_code is None
     assert "dns fail" in (result.error or "").lower()
 
 
-@pytest.mark.asyncio
-async def test_run_test_custom_mode_self_heals_with_anthropic_suffix() -> None:
+async def test_run_test_custom_mode_self_heals_with_anthropic_suffix(probe_client: httpx.AsyncClient) -> None:
     """用户填 https://api.deepseek.com，messages probe 失败 (404)；
     自动重试 https://api.deepseek.com/anthropic 成功 → suggestion 给出修复值。
     """
-    post_seq = [
-        httpx.Response(404, text="not found"),  # 原 URL
-        httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []}),  # +/anthropic
-    ]
-    call_log: list[str] = []
+    with capture_http() as router:
+        plain = router.post("https://api.deepseek.com/v1/messages").mock(
+            return_value=httpx.Response(404, text="not found")
+        )
+        suffixed = router.post("https://api.deepseek.com/anthropic/v1/messages").mock(
+            return_value=httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []})
+        )
+        router.get("https://api.deepseek.com/v1/models").mock(return_value=httpx.Response(200, json={"data": []}))
 
-    async def fake_post(*, url, **_kw):
-        call_log.append(url)
-        return post_seq.pop(0)
-
-    async def fake_get(*, url, **_kw):
-        call_log.append(url)
-        return httpx.Response(200, json={"data": []})
-
-    with (
-        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
-        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
-    ):
         resp = await run_test(
             preset_id=CUSTOM_SENTINEL_ID,
             base_url="https://api.deepseek.com",
             api_key="sk",
             model=None,
+            http_client=probe_client,
         )
 
     assert resp.overall == "ok"
@@ -226,61 +228,51 @@ async def test_run_test_custom_mode_self_heals_with_anthropic_suffix() -> None:
     assert resp.suggestion is not None
     assert resp.suggestion.kind == "replace_base_url"
     assert resp.suggestion.suggested_value == "https://api.deepseek.com/anthropic"
-    posted = [u for u in call_log if "/v1/messages" in u]
-    assert posted == [
-        "https://api.deepseek.com/v1/messages",
-        "https://api.deepseek.com/anthropic/v1/messages",
-    ]
+    assert plain.call_count == 1
+    assert suffixed.call_count == 1
 
 
-@pytest.mark.asyncio
-async def test_run_test_preset_skips_self_heal() -> None:
+async def test_run_test_preset_skips_self_heal(probe_client: httpx.AsyncClient) -> None:
     """preset_id != __custom__ 时不做自愈尝试。"""
-    seq = [httpx.Response(404, text="not found")]
+    preset = get_preset("anthropic-official")
+    assert preset is not None
+    root = preset.messages_url
 
-    async def fake_post(*, url, **_kw):
-        return seq.pop(0)
+    with capture_http() as router:
+        router.post(f"{root}/v1/messages").mock(return_value=httpx.Response(404, text="not found"))
+        suffixed = router.post(f"{root}/anthropic/v1/messages").mock(
+            return_value=httpx.Response(200, json=_ANTHROPIC_OK)
+        )
+        router.get(f"{preset.discovery_url}/v1/models").mock(return_value=httpx.Response(200, json={"data": []}))
 
-    async def fake_get(**_kw):
-        return httpx.Response(200, json={"data": []})
-
-    with (
-        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
-        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
-    ):
         resp = await run_test(
             preset_id="anthropic-official",
             base_url=None,
             api_key="sk",
             model=None,
+            http_client=probe_client,
         )
+
     assert resp.overall == "fail"
     assert resp.suggestion is None
+    assert suffixed.call_count == 0
 
 
-@pytest.mark.asyncio
-async def test_run_test_self_heal_retry_also_fails_keeps_original_failure() -> None:
+async def test_run_test_self_heal_retry_also_fails_keeps_original_failure(probe_client: httpx.AsyncClient) -> None:
     """自愈重试也失败 (同 404) → suggestion=None，diagnosis=UNKNOWN。"""
-    post_seq = [
-        httpx.Response(404, text="not found"),
-        httpx.Response(404, text="still not found"),
-    ]
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(return_value=httpx.Response(404, text="not found"))
+        router.post("https://api.example.com/anthropic/v1/messages").mock(
+            return_value=httpx.Response(404, text="still not found")
+        )
+        router.get("https://api.example.com/v1/models").mock(return_value=httpx.Response(200, json={"data": []}))
 
-    async def fake_post(*, url, **_kw):
-        return post_seq.pop(0)
-
-    async def fake_get(**_kw):
-        return httpx.Response(200, json={"data": []})
-
-    with (
-        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
-        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
-    ):
         resp = await run_test(
             preset_id=CUSTOM_SENTINEL_ID,
             base_url="https://api.example.com",
             api_key="sk",
             model=None,
+            http_client=probe_client,
         )
 
     assert resp.overall == "fail"
@@ -288,29 +280,21 @@ async def test_run_test_self_heal_retry_also_fails_keeps_original_failure() -> N
     assert resp.diagnosis == DiagnosisCode.UNKNOWN
 
 
-@pytest.mark.asyncio
-async def test_run_test_self_heal_retry_promotes_specific_diagnosis() -> None:
+async def test_run_test_self_heal_retry_promotes_specific_diagnosis(probe_client: httpx.AsyncClient) -> None:
     """重试失败但二次诊断更具体 (401) → 采纳 retry，让用户看到 AUTH_FAILED 而非 UNKNOWN。"""
-    post_seq = [
-        httpx.Response(404, text="not found"),  # 首次：路径错
-        httpx.Response(401, json={"error": {"type": "authentication_error"}}),  # +/anthropic 后：key 错
-    ]
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(return_value=httpx.Response(404, text="not found"))
+        router.post("https://api.example.com/anthropic/v1/messages").mock(
+            return_value=httpx.Response(401, json={"error": {"type": "authentication_error"}})
+        )
+        router.get("https://api.example.com/v1/models").mock(return_value=httpx.Response(200, json={"data": []}))
 
-    async def fake_post(*, url, **_kw):
-        return post_seq.pop(0)
-
-    async def fake_get(**_kw):
-        return httpx.Response(200, json={"data": []})
-
-    with (
-        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
-        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
-    ):
         resp = await run_test(
             preset_id=CUSTOM_SENTINEL_ID,
             base_url="https://api.example.com",
             api_key="bad",
             model=None,
+            http_client=probe_client,
         )
 
     assert resp.overall == "fail"
@@ -320,44 +304,36 @@ async def test_run_test_self_heal_retry_promotes_specific_diagnosis() -> None:
     assert resp.suggestion is None
 
 
-@pytest.mark.asyncio
-async def test_run_test_preset_with_base_url_override_derives_discovery() -> None:
+async def test_run_test_preset_with_base_url_override_derives_discovery(probe_client: httpx.AsyncClient) -> None:
     """preset 凭证覆盖 base_url → discovery 也从 base_url 派生，与运行时一致。"""
-    captured: dict[str, str] = {}
+    with capture_http() as router:
+        messages = router.post("https://corp-proxy.example.com/anthropic/v1/messages").mock(
+            return_value=httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []})
+        )
+        # discovery 也从 base_url 派生（剥掉 /anthropic）
+        discovery = router.get("https://corp-proxy.example.com/v1/models").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
 
-    async def fake_post(*, url, **_kw):
-        captured["messages_url"] = url
-        return httpx.Response(200, json={"id": "msg_1", "type": "message", "content": []})
-
-    async def fake_get(*, url, **_kw):
-        captured["discovery_url"] = url
-        return httpx.Response(200, json={"data": []})
-
-    with (
-        patch("lib.config.anthropic_probe._post", AsyncMock(side_effect=fake_post)),
-        patch("lib.config.anthropic_probe._get", AsyncMock(side_effect=fake_get)),
-    ):
         resp = await run_test(
             preset_id="deepseek",
             base_url="https://corp-proxy.example.com/anthropic",
             api_key="sk",
             model=None,
+            http_client=probe_client,
         )
 
     assert resp.overall == "ok"
-    assert captured["messages_url"] == "https://corp-proxy.example.com/anthropic/v1/messages"
-    # discovery 也从 base_url 派生（剥掉 /anthropic）
-    assert captured["discovery_url"] == "https://corp-proxy.example.com/v1/models"
+    assert messages.call_count == 1
+    assert discovery.call_count == 1
     assert resp.derived_discovery_root == "https://corp-proxy.example.com"
 
 
-@pytest.mark.asyncio
 async def test_run_test_custom_mode_requires_base_url() -> None:
     with pytest.raises(ValueError, match="base_url required"):
         await run_test(preset_id=None, base_url=None, api_key="sk", model=None)
 
 
-@pytest.mark.asyncio
 async def test_run_test_unknown_preset_raises() -> None:
     with pytest.raises(ValueError, match="unknown preset"):
         await run_test(preset_id="bogus-preset", base_url=None, api_key="sk", model=None)

--- a/tests/unit/lib/config/test_anthropic_probe.py
+++ b/tests/unit/lib/config/test_anthropic_probe.py
@@ -261,8 +261,10 @@ async def test_run_test_preset_skips_self_heal(probe_client: httpx.AsyncClient) 
 async def test_run_test_self_heal_retry_also_fails_keeps_original_failure(probe_client: httpx.AsyncClient) -> None:
     """自愈重试也失败 (同 404) → suggestion=None，diagnosis=UNKNOWN。"""
     with capture_http() as router:
-        router.post("https://api.example.com/v1/messages").mock(return_value=httpx.Response(404, text="not found"))
-        router.post("https://api.example.com/anthropic/v1/messages").mock(
+        plain = router.post("https://api.example.com/v1/messages").mock(
+            return_value=httpx.Response(404, text="not found")
+        )
+        suffixed = router.post("https://api.example.com/anthropic/v1/messages").mock(
             return_value=httpx.Response(404, text="still not found")
         )
         router.get("https://api.example.com/v1/models").mock(return_value=httpx.Response(200, json={"data": []}))
@@ -278,6 +280,8 @@ async def test_run_test_self_heal_retry_also_fails_keeps_original_failure(probe_
     assert resp.overall == "fail"
     assert resp.suggestion is None
     assert resp.diagnosis == DiagnosisCode.UNKNOWN
+    assert plain.call_count == 1
+    assert suffixed.call_count == 1
 
 
 async def test_run_test_self_heal_retry_promotes_specific_diagnosis(probe_client: httpx.AsyncClient) -> None:

--- a/tests/unit/lib/config/test_config_migration.py
+++ b/tests/unit/lib/config/test_config_migration.py
@@ -87,8 +87,11 @@ async def test_migrate_aistudio_001_to_preview(db_session: AsyncSession, tmp_pat
 
 
 async def test_migrate_noop_if_no_file(db_session: AsyncSession, tmp_path: Path):
+    """源文件不存在：迁移直接返回，不抛错也不落任何配置行。"""
     nonexistent = tmp_path / ".system_config.json"
-    await migrate_json_to_db(db_session, nonexistent)  # should not raise
+
+    assert await migrate_json_to_db(db_session, nonexistent) is None
+    assert not nonexistent.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/config/test_config_migration.py
+++ b/tests/unit/lib/config/test_config_migration.py
@@ -92,6 +92,8 @@ async def test_migrate_noop_if_no_file(db_session: AsyncSession, tmp_path: Path)
 
     assert await migrate_json_to_db(db_session, nonexistent) is None
     assert not nonexistent.exists()
+    assert await ProviderConfigRepository(db_session).get_all_configs_bulk() == {}
+    assert await SystemSettingRepository(db_session).get_all() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/config/test_tts_resolver.py
+++ b/tests/unit/lib/config/test_tts_resolver.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
 from lib.config.resolver import ConfigResolver, ProviderModel
 from lib.config.service import ProviderStatus
-from lib.db.base import Base
 
 
 def _ready(name: str, media_types: list[str]) -> ProviderStatus:
@@ -98,192 +95,129 @@ class TestResolveDefaultAudioBackend:
         assert await resolver._resolve_default_audio_backend(svc, None) == ("dashscope", "qwen3-tts-flash")
 
 
-async def _make_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    return async_sessionmaker(engine, expire_on_commit=False), engine
-
-
 class TestResolveNarrationVoice:
-    async def test_project_override_wins(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_voice({"narration_voice": "Ethan"}) == "Ethan"
-        finally:
-            await engine.dispose()
+    async def test_project_override_wins(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_voice({"narration_voice": "Ethan"}) == "Ethan"
 
-    async def test_default_when_no_override(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_voice(None) == "Cherry"
-            assert await resolver.resolve_narration_voice({}) == "Cherry"
-            # 空白覆盖不算覆盖
-            assert await resolver.resolve_narration_voice({"narration_voice": "  "}) == "Cherry"
-        finally:
-            await engine.dispose()
+    async def test_default_when_no_override(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_voice(None) == "Cherry"
+        assert await resolver.resolve_narration_voice({}) == "Cherry"
+        # 空白覆盖不算覆盖
+        assert await resolver.resolve_narration_voice({"narration_voice": "  "}) == "Cherry"
 
 
 class TestResolveNarrationSpeed:
-    async def test_project_override_wins(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_speed({"narration_speed": 1.5}) == 1.5
-        finally:
-            await engine.dispose()
+    async def test_project_override_wins(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_speed({"narration_speed": 1.5}) == 1.5
 
-    async def test_global_setting_when_no_override(self):
+    async def test_global_setting_when_no_override(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("narration_speed", "1.2")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_speed(None) == 1.2
-            assert await resolver.resolve_narration_speed({}) == 1.2
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("narration_speed", "1.2")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_speed(None) == 1.2
+        assert await resolver.resolve_narration_speed({}) == 1.2
 
-    async def test_none_when_unset(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_speed(None) is None
-        finally:
-            await engine.dispose()
+    async def test_none_when_unset(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_speed(None) is None
 
-    async def test_numeric_string_override_accepted(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            # 项目级语速宽容解析：数字字符串与数字同样生效（口径与 default_duration 一致）
-            assert await resolver.resolve_narration_speed({"narration_speed": "1.2"}) == 1.2
-            assert await resolver.resolve_narration_speed({"narration_speed": " 0.8 "}) == 0.8
-            assert await resolver.resolve_narration_speed({"narration_speed": "2"}) == 2.0
-        finally:
-            await engine.dispose()
+    async def test_numeric_string_override_accepted(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        # 项目级语速宽容解析：数字字符串与数字同样生效（口径与 default_duration 一致）
+        assert await resolver.resolve_narration_speed({"narration_speed": "1.2"}) == 1.2
+        assert await resolver.resolve_narration_speed({"narration_speed": " 0.8 "}) == 0.8
+        assert await resolver.resolve_narration_speed({"narration_speed": "2"}) == 2.0
 
-    async def test_invalid_numeric_string_falls_back(self):
+    async def test_invalid_numeric_string_falls_back(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("narration_speed", "1.2")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            # 非正/非有限/空白的字符串覆盖按未设置处理，回退全局
-            for bad in ("0", "-1.5", "inf", "nan", "", "  "):
-                assert await resolver.resolve_narration_speed({"narration_speed": bad}) == 1.2
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("narration_speed", "1.2")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        # 非正/非有限/空白的字符串覆盖按未设置处理，回退全局
+        for bad in ("0", "-1.5", "inf", "nan", "", "  "):
+            assert await resolver.resolve_narration_speed({"narration_speed": bad}) == 1.2
 
-    async def test_invalid_values_treated_as_unset(self):
+    async def test_invalid_values_treated_as_unset(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("narration_speed", "not-a-number")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            assert await resolver.resolve_narration_speed(None) is None
-            # 项目级损坏值同样按未设置处理，回退全局/None
-            assert await resolver.resolve_narration_speed({"narration_speed": "fast"}) is None
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("narration_speed", "not-a-number")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.resolve_narration_speed(None) is None
+        # 项目级损坏值同样按未设置处理，回退全局/None
+        assert await resolver.resolve_narration_speed({"narration_speed": "fast"}) is None
 
-    async def test_invalid_project_value_falls_back_to_global(self):
+    async def test_invalid_project_value_falls_back_to_global(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("narration_speed", "1.2")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            # 项目级损坏值按未设置处理后回退到全局有效值，而非直接 None
-            assert await resolver.resolve_narration_speed({"narration_speed": "fast"}) == 1.2
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("narration_speed", "1.2")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        # 项目级损坏值按未设置处理后回退到全局有效值，而非直接 None
+        assert await resolver.resolve_narration_speed({"narration_speed": "fast"}) == 1.2
 
-    async def test_non_positive_and_non_finite_treated_as_unset(self):
+    async def test_non_positive_and_non_finite_treated_as_unset(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            # 项目级非正/非有限值不进 TTS 请求；超出 float 范围的巨大整数等同非有限值
-            for bad in (0, -1.5, float("nan"), float("inf"), 10**400):
-                assert await resolver.resolve_narration_speed({"narration_speed": bad}) is None
-            # 全局 setting 损坏成非有限值同样按未设置处理
-            async with factory() as session:
-                await ConfigService(session).set_setting("narration_speed", "inf")
-                await session.commit()
-            assert await resolver.resolve_narration_speed(None) is None
-        finally:
-            await engine.dispose()
+        resolver = ConfigResolver(db_factory)
+        # 项目级非正/非有限值不进 TTS 请求；超出 float 范围的巨大整数等同非有限值
+        for bad in (0, -1.5, float("nan"), float("inf"), 10**400):
+            assert await resolver.resolve_narration_speed({"narration_speed": bad}) is None
+        # 全局 setting 损坏成非有限值同样按未设置处理
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("narration_speed", "inf")
+            await session.commit()
+        assert await resolver.resolve_narration_speed(None) is None
 
 
 class TestPublicAudioResolverApi:
-    async def test_default_audio_backend_reads_global_setting(self):
+    async def test_default_audio_backend_reads_global_setting(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                await ConfigService(session).set_setting("default_audio_backend", "dashscope/qwen3-tts-flash")
-                await session.commit()
-            resolver = ConfigResolver(factory)
-            assert await resolver.default_audio_backend() == ("dashscope", "qwen3-tts-flash")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            await ConfigService(session).set_setting("default_audio_backend", "dashscope/qwen3-tts-flash")
+            await session.commit()
+        resolver = ConfigResolver(db_factory)
+        assert await resolver.default_audio_backend() == ("dashscope", "qwen3-tts-flash")
 
-    async def test_resolve_audio_backend_payload_short_circuit(self):
-        factory, engine = await _make_factory()
-        try:
-            resolver = ConfigResolver(factory)
-            result = await resolver.resolve_audio_backend(
-                None, {"audio_provider": "dashscope", "audio_model": "qwen3-tts-flash"}
-            )
-            assert result == ProviderModel("dashscope", "qwen3-tts-flash")
-        finally:
-            await engine.dispose()
+    async def test_resolve_audio_backend_payload_short_circuit(self, db_factory):
+        resolver = ConfigResolver(db_factory)
+        result = await resolver.resolve_audio_backend(
+            None, {"audio_provider": "dashscope", "audio_model": "qwen3-tts-flash"}
+        )
+        assert result == ProviderModel("dashscope", "qwen3-tts-flash")
 
 
 class TestServiceDefaultAudioBackend:
-    async def test_falls_back_to_builtin_default(self):
+    async def test_falls_back_to_builtin_default(self, db_factory):
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                svc = ConfigService(session)
-                assert await svc.get_default_audio_backend() == ("dashscope", "qwen3-tts-flash")
-        finally:
-            await engine.dispose()
+        async with db_factory() as session:
+            svc = ConfigService(session)
+            assert await svc.get_default_audio_backend() == ("dashscope", "qwen3-tts-flash")
 
 
 class TestServiceNarrationVoice:
-    async def test_blank_setting_falls_back_to_default(self):
+    async def test_blank_setting_falls_back_to_default(self, db_factory):
         # 全局 setting 被保存成空白时回退默认值，与项目级覆盖的 strip 语义一致
         from lib.config.service import ConfigService
 
-        factory, engine = await _make_factory()
-        try:
-            async with factory() as session:
-                svc = ConfigService(session)
-                await svc.set_setting("narration_voice", "  ")
-                await session.commit()
-                assert await svc.get_narration_voice() == "Cherry"
+        async with db_factory() as session:
+            svc = ConfigService(session)
+            await svc.set_setting("narration_voice", "  ")
+            await session.commit()
+            assert await svc.get_narration_voice() == "Cherry"
 
-                await svc.set_setting("narration_voice", "Ethan")
-                await session.commit()
-                assert await svc.get_narration_voice() == "Ethan"
-        finally:
-            await engine.dispose()
+            await svc.set_setting("narration_voice", "Ethan")
+            await session.commit()
+            assert await svc.get_narration_voice() == "Ethan"

--- a/tests/unit/lib/db/repositories/test_custom_provider_repo.py
+++ b/tests/unit/lib/db/repositories/test_custom_provider_repo.py
@@ -314,10 +314,22 @@ class TestModelManagement:
         assert remaining[0].model_id == "m2"
 
     async def test_delete_model_nonexistent(self, db_session: AsyncSession):
-        """删不存在的型号同样是 no-op。"""
+        """删不存在的型号同样是 no-op：既不抛错，也不波及在册型号。"""
         repo = CustomProviderRepository(db_session)
+        p = await repo.create_provider(
+            display_name="TestProvider",
+            discovery_format="openai",
+            base_url="https://example.com",
+            api_key="key",
+            models=[{"model_id": "m1", "display_name": "M1", "endpoint": "openai-chat"}],
+        )
+        await db_session.flush()
 
         assert await repo.delete_model(999) is None
+        await db_session.flush()
+
+        remaining = await repo.list_models(p.id)
+        assert [m.model_id for m in remaining] == ["m1"]
 
     async def test_list_enabled_models_by_media_type(self, db_session: AsyncSession):
         repo = CustomProviderRepository(db_session)

--- a/tests/unit/lib/db/repositories/test_custom_provider_repo.py
+++ b/tests/unit/lib/db/repositories/test_custom_provider_repo.py
@@ -151,9 +151,11 @@ class TestProviderCRUD:
         assert await repo.list_models(p.id) == []
 
     async def test_delete_provider_nonexistent(self, db_session: AsyncSession):
+        """删不存在的供应商是 no-op：不抛错，也不会凭空留下一行。"""
         repo = CustomProviderRepository(db_session)
-        # Should not raise
-        await repo.delete_provider(999)
+
+        assert await repo.delete_provider(999) is None
+        assert await repo.get_provider(999) is None
 
 
 class TestConcurrencyColumns:
@@ -312,9 +314,10 @@ class TestModelManagement:
         assert remaining[0].model_id == "m2"
 
     async def test_delete_model_nonexistent(self, db_session: AsyncSession):
+        """删不存在的型号同样是 no-op。"""
         repo = CustomProviderRepository(db_session)
-        # Should not raise
-        await repo.delete_model(999)
+
+        assert await repo.delete_model(999) is None
 
     async def test_list_enabled_models_by_media_type(self, db_session: AsyncSession):
         repo = CustomProviderRepository(db_session)

--- a/tests/unit/lib/project_migrations/test_project_migration_v0_v1.py
+++ b/tests/unit/lib/project_migrations/test_project_migration_v0_v1.py
@@ -100,18 +100,25 @@ def test_migrate_idempotent(tmp_path: Path):
     assert data["schema_version"] == 1
 
 
-def test_migrate_order_files_before_schema_bump(tmp_path: Path, monkeypatch):
-    """若剧本迁移中途崩溃，schema_version 必须仍为 0（防止下次启动因幂等跳过 → 永久丢图）。"""
+def test_migrate_order_files_before_schema_bump(tmp_path: Path):
+    """若剧本迁移中途崩溃，schema_version 必须仍为 0（防止下次启动因幂等跳过 → 永久丢图）。
+
+    崩溃点由畸形剧本真实触发：手改坏的 v0 剧本里 ``scenes`` 存的是字符串而非对象，级联改写
+    走到 ``pop`` 就 AttributeError。文件搬迁排在剧本级联之前，正好卡出「图已搬、剧本没改完、
+    版本没升」这一态。
+    """
     p = _make_v0_project(tmp_path)
-    original = mod._migrate_scripts
+    (p / "scripts" / "ep1.json").write_text(
+        json.dumps({"content_mode": "drama", "scenes": ["clues"]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
 
-    def fail(*args, **kwargs):
-        original(*args, **kwargs)
-        raise RuntimeError("boom mid-migration")
-
-    monkeypatch.setattr(mod, "_migrate_scripts", fail)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         mod.migrate_v0_to_v1(p)
+
+    # 第一步（搬图）确实先跑完了，崩溃卡在第二步
+    assert (p / "props" / "玉佩.png").exists()
+    assert (p / "scenes" / "庙宇.png").exists()
 
     data = json.loads((p / "project.json").read_text(encoding="utf-8"))
     assert data.get("schema_version", 0) == 0

--- a/tests/unit/lib/project_migrations/test_project_migration_v1_v2.py
+++ b/tests/unit/lib/project_migrations/test_project_migration_v1_v2.py
@@ -107,5 +107,9 @@ class TestMigrateV1ToV2File:
         assert data["image_backend"] == "seedance/x"
 
     def test_missing_project_json_is_noop(self, tmp_path: Path):
-        (tmp_path / "empty").mkdir()
-        migrate_v1_to_v2(tmp_path / "empty")  # 不抛错
+        """没有 project.json 的目录：迁移既不抛错，也不得凭空造出任何文件。"""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        assert migrate_v1_to_v2(empty) is None
+        assert list(empty.iterdir()) == []

--- a/tests/unit/lib/project_migrations/test_project_migration_v2_v3.py
+++ b/tests/unit/lib/project_migrations/test_project_migration_v2_v3.py
@@ -149,5 +149,9 @@ def test_remaining_file_preserved(tmp_path: Path):
 
 
 def test_missing_project_json_is_noop(tmp_path: Path):
-    (tmp_path / "empty").mkdir()
-    migrate_v2_to_v3(tmp_path / "empty")  # 不抛错
+    """没有 project.json 的目录：迁移既不抛错，也不得凭空造出任何文件。"""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    assert migrate_v2_to_v3(empty) is None
+    assert list(empty.iterdir()) == []

--- a/tests/unit/lib/reference_video/test_reference_video_draft_validation.py
+++ b/tests/unit/lib/reference_video/test_reference_video_draft_validation.py
@@ -29,17 +29,22 @@ _NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
 
 class TestSourceTextAnchor:
     def test_verbatim_substring_accepted(self):
-        validate_source_text_anchor("unit E1U01", "李明推开酒馆的门", "夜色深沉。李明推开酒馆的门，环视四周。")
+        assert (
+            validate_source_text_anchor("unit E1U01", "李明推开酒馆的门", "夜色深沉。李明推开酒馆的门，环视四周。")
+            is None
+        )
 
     def test_whitespace_differences_tolerated(self):
         """空白折叠后比对：换行 / 缩进的还原不可靠，但删字改字必须被抓住。"""
-        validate_source_text_anchor("unit E1U01", "李明推开\n  酒馆的门", "李明推开 酒馆的门，环视四周。")
+        assert (
+            validate_source_text_anchor("unit E1U01", "李明推开\n  酒馆的门", "李明推开 酒馆的门，环视四周。") is None
+        )
 
     def test_unicode_form_differences_tolerated(self):
         """源文以 NFD 落盘、模型回写 NFC（组合附加符语种常见）不算改写：两侧先归一到 NFC。"""
         novel = unicodedata.normalize("NFD", "Anh ấy mở cửa quán rượu.")
         anchor = unicodedata.normalize("NFC", "Anh ấy mở cửa")
-        validate_source_text_anchor("unit E1U01", anchor, novel)
+        assert validate_source_text_anchor("unit E1U01", anchor, novel) is None
 
     def test_rewritten_text_rejected(self):
         with pytest.raises(DraftViolation, match="不是小说原文的逐字片段"):
@@ -205,7 +210,7 @@ class TestUnitText:
 
 class TestDialogueLoad:
     def test_within_budget_accepted(self):
-        validate_dialogue_load("unit E1U01", "镜头1：门开了\n@[李明]：{我来了。}", 4, "zh")
+        assert validate_dialogue_load("unit E1U01", "镜头1：门开了\n@[李明]：{我来了。}", 4, "zh") is None
 
     def test_overload_rejected(self):
         long_line = "这是一段非常长的台词" * 6  # 60 字 ÷ 5 字/秒 ≈ 12 秒
@@ -216,7 +221,7 @@ class TestDialogueLoad:
         """宽容系数内放行：语速是统计估算，「刚好写满」的正常产出不该被判违约。"""
         # 21 字 ÷ 5 字/秒 = 4.2 秒，落在 4 秒 × 1.2 = 4.8 秒的宽容上限内
         line = "一二三四五六七八九十一二三四五六七八九十。"
-        validate_dialogue_load("unit E1U01", f"@[李明]：{{{line}}}", 4, "zh")
+        assert validate_dialogue_load("unit E1U01", f"@[李明]：{{{line}}}", 4, "zh") is None
 
     def test_voiceover_counts_toward_budget(self):
         long_line = "画外音很长很长的一段" * 6
@@ -232,13 +237,13 @@ class TestDialogueLoad:
 
     def test_non_string_language_falls_back_to_default_rate(self):
         """project.json 的 source_language 可能是脏数据：估算按默认语速走，不抛 AttributeError。"""
-        validate_dialogue_load("unit E1U01", "@[李明]：{我来了。}", 4, 123)  # pyright: ignore[reportArgumentType]
+        assert validate_dialogue_load("unit E1U01", "@[李明]：{我来了。}", 4, 123) is None  # pyright: ignore[reportArgumentType]
 
     def test_normalizes_unicode_before_estimating(self):
         """NFD 台词先归一再估：组合附加符会被词计数拆成多个单位，不归一会把念得完的 unit 判超载。"""
         line = "Anh ấy mở cửa quán rượu ngay lập tức"
         text = f"镜头1：@[李明] 推门\n@[李明]：{{{unicodedata.normalize('NFD', line)}}}"
-        validate_dialogue_load("unit E1U01", text, 4, "vi")
+        assert validate_dialogue_load("unit E1U01", text, 4, "vi") is None
 
 
 class TestNormativeLines:

--- a/tests/unit/lib/test_asset_fingerprints.py
+++ b/tests/unit/lib/test_asset_fingerprints.py
@@ -1,6 +1,10 @@
-import time
+import os
 
 from lib.asset_fingerprints import compute_asset_fingerprints
+
+#: 指纹用例里写死的两个 mtime，只要求「不同」，取值本身无意义。
+_MTIME_BEFORE = 1_700_000_000
+_MTIME_AFTER = _MTIME_BEFORE + 60
 
 
 class TestComputeAssetFingerprints:
@@ -53,14 +57,21 @@ class TestComputeAssetFingerprints:
         assert result == {}
 
     def test_fingerprint_changes_when_file_modified(self, tmp_path):
+        """改过的文件必须换指纹。
+
+        两次的 mtime 用 ``os.utime`` 写死而不是靠 sleep 等时钟走动：文件系统的 mtime 粒度
+        依平台而异，等多久都是猜，写死才既确定又不占时间。
+        """
         (tmp_path / "storyboards").mkdir()
         f = tmp_path / "storyboards" / "scene_E1S01.png"
         f.write_bytes(b"v1")
+        os.utime(f, (_MTIME_BEFORE, _MTIME_BEFORE))
         fp1 = compute_asset_fingerprints(tmp_path)["storyboards/scene_E1S01.png"]
 
-        time.sleep(0.1)
         f.write_bytes(b"v2")
+        os.utime(f, (_MTIME_AFTER, _MTIME_AFTER))
         fp2 = compute_asset_fingerprints(tmp_path)["storyboards/scene_E1S01.png"]
+
         assert fp2 != fp1
 
     def test_scans_characters_refs_subdirectory(self, tmp_path):

--- a/tests/unit/lib/test_drama_pipeline_split.py
+++ b/tests/unit/lib/test_drama_pipeline_split.py
@@ -186,7 +186,9 @@ class TestMergeDramaVisualIntoScenes:
 
     def test_merge_passes_full_episode_validation(self):
         merged = merge_drama_visual_into_scenes([_content_scene("E1S01")], [_visual_scene("E1S01")])
-        DramaEpisodeScript.model_validate({"title": "第一集", "scenes": merged})
+
+        episode = DramaEpisodeScript.model_validate({"title": "第一集", "scenes": merged})
+        assert len(episode.scenes) == 1
 
     def test_merge_missing_visual_raises(self):
         with pytest.raises(DramaVisualMergeError):

--- a/tests/unit/lib/test_generation_queue_client.py
+++ b/tests/unit/lib/test_generation_queue_client.py
@@ -569,15 +569,19 @@ class TestBatchEnqueueAndWaitSync:
             TaskSpec(task_type="character", media_type="image", resource_id="A"),
             TaskSpec(task_type="character", media_type="image", resource_id="B"),
         ]
-        batch_enqueue_and_wait_sync(
+        successes, failures = batch_enqueue_and_wait_sync(
             project_name="demo",
             specs=specs,
             on_success=on_success,
             on_failure=on_failure,
         )
 
-        assert len(success_ids) == 1
-        assert len(failure_ids) == 1
+        # 返回值与回调同口径：终态决定去向，两边都要认得出是哪个 resource
+        assert [r.resource_id for r in successes] == ["A"]
+        assert [r.resource_id for r in failures] == ["B"]
+        assert [r.status for r in failures] == ["failed"]
+        assert success_ids == ["A"]
+        assert failure_ids == ["B"]
 
     @patch("lib.generation_queue_client.wait_for_task", new_callable=AsyncMock)
     @patch("lib.generation_queue_client.enqueue_task_only", new_callable=AsyncMock)

--- a/tests/unit/lib/test_locked_episode_script_toctou.py
+++ b/tests/unit/lib/test_locked_episode_script_toctou.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -81,11 +80,15 @@ def test_locked_episode_script_holds_project_lock_until_write_done(tmp_path: Pat
     _seed(pm, name)
 
     inside = threading.Event()
+    attempting = threading.Event()
     other_done = threading.Event()
+    order: list[str] = []
 
     def _other() -> None:
         inside.wait(timeout=5)
+        attempting.set()  # 即将去抢项目锁
         pm.update_project(name, lambda p: p.setdefault("episodes", []))  # 需要 _project_lock
+        order.append("other")
         other_done.set()
 
     t = threading.Thread(target=_other)
@@ -93,11 +96,14 @@ def test_locked_episode_script_holds_project_lock_until_write_done(tmp_path: Pat
     try:
         with pm.locked_episode_script(name, lambda _proj: "episode_1.json", validate=False) as script:
             inside.set()  # 此刻已持脚本锁 + 项目锁
-            time.sleep(0.3)
+            # 等对方真的开始申请，而不是睡一段猜它到没到——到了仍未完成，才说明是被锁挡住的
+            assert attempting.wait(timeout=5), "另一线程应已开始申请项目锁"
             assert not other_done.is_set(), "持项目锁期间 update_project 不应完成"
+            order.append("critical-section")
             script["video_units"] = []
         t.join(timeout=5)
         assert other_done.is_set(), "退出临界区后 update_project 应能完成"
+        assert order == ["critical-section", "other"]
     finally:
         t.join(timeout=5)
 

--- a/tests/unit/lib/test_logging_utils.py
+++ b/tests/unit/lib/test_logging_utils.py
@@ -251,15 +251,18 @@ def test_fallback_returns_fixed_placeholder_not_raw_repr():
     assert out == "<unserializable>"
 
 
-def test_fallback_does_not_leak_sensitive_via_repr(monkeypatch):
-    """即使 _to_safe 抛错，也不应通过 repr 路径把 api_key 等字面量泄漏到日志。"""
-    from lib import logging_utils
+def test_fallback_does_not_leak_sensitive_via_repr():
+    """同一 payload 里既有敏感字面量、又有序列化会炸的对象：走兜底也不能把 api_key 带出来。
 
-    def boom(*args, **kwargs):
-        raise RuntimeError("simulated _to_safe failure")
+    炸点由真实对象触发（``__repr__`` 抛错），不替换脱敏函数——兜底一旦改回 repr(payload)，
+    整个 payload 连同未脱敏的 api_key 会一起进日志。
+    """
 
-    monkeypatch.setattr(logging_utils, "_to_safe", boom)
-    out = logging_utils.format_kwargs_for_log({"api_key": "sk-real-secret-1234"})
+    class Disaster:
+        def __repr__(self) -> str:
+            raise RuntimeError("repr exploded")
+
+    out = format_kwargs_for_log({"api_key": "sk-real-secret-1234", "detail": Disaster()})
     assert "sk-real-secret-1234" not in out
     assert out == "<unserializable>"
 

--- a/tests/unit/lib/test_retry.py
+++ b/tests/unit/lib/test_retry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -19,6 +19,8 @@ from lib.retry import (
 
 
 class _FakeClock:
+    """记录退避时长的时钟 seam 替身；sleep 不真等。"""
+
     def __init__(self) -> None:
         self.sleeps: list[float] = []
 
@@ -27,6 +29,10 @@ class _FakeClock:
 
     async def sleep(self, delay: float) -> None:
         self.sleeps.append(delay)
+
+
+def _no_jitter(_low: float, _high: float) -> float:
+    return 0.0
 
 
 class TestShouldRetry:
@@ -111,24 +117,26 @@ class TestWithRetryAsync:
 
     async def test_success_no_retry(self):
         mock_fn = AsyncMock(return_value="ok")
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
         result = await fn()
         assert result == "ok"
         assert mock_fn.call_count == 1
+        assert clock.sleeps == []
 
     async def test_retry_on_retryable_error(self):
         mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            result = await fn()
+        result = await fn()
 
         assert result == "ok"
         assert mock_fn.call_count == 2
@@ -136,27 +144,29 @@ class TestWithRetryAsync:
     async def test_retry_on_string_pattern(self):
         """错误信息中包含 429 时应重试。"""
         mock_fn = AsyncMock(side_effect=[RuntimeError("Error code: 429"), "ok"])
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            result = await fn()
+        result = await fn()
 
         assert result == "ok"
         assert mock_fn.call_count == 2
 
     async def test_no_retry_on_non_retryable(self):
         mock_fn = AsyncMock(side_effect=ValueError("bad input"))
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
         with pytest.raises(ValueError, match="bad input"):
             await fn()
         assert mock_fn.call_count == 1
+        assert clock.sleeps == []
 
     async def test_no_retry_on_non_retryable_despite_colliding_pattern(self):
         """NonRetryableError 消息即使包含 "500" 子串也只调用一次，不重试。"""
@@ -165,26 +175,28 @@ class TestWithRetryAsync:
             pass
 
         mock_fn = AsyncMock(side_effect=_Truncated("output_tokens=8500 处被截断"))
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
         with pytest.raises(_Truncated):
             await fn()
         assert mock_fn.call_count == 1
+        assert clock.sleeps == []
 
     async def test_exhausted_retries_raises_last_error(self):
         errors = [ConnectionError(f"attempt {i}") for i in range(3)]
         mock_fn = AsyncMock(side_effect=errors)
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0))
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            with pytest.raises(ConnectionError, match="attempt 2"):
-                await fn()
+        with pytest.raises(ConnectionError, match="attempt 2"):
+            await fn()
         assert mock_fn.call_count == 3
 
     async def test_custom_retryable_errors(self):
@@ -192,67 +204,54 @@ class TestWithRetryAsync:
             pass
 
         mock_fn = AsyncMock(side_effect=[CustomError("temp"), "ok"])
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retryable_errors=(CustomError,))
+        @with_retry_async(
+            max_attempts=3,
+            backoff_seconds=(0, 0, 0),
+            retryable_errors=(CustomError,),
+            clock=clock,
+            jitter=_no_jitter,
+        )
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            result = await fn()
+        result = await fn()
 
         assert result == "ok"
         assert mock_fn.call_count == 2
-
-    async def test_backoff_sleep_called(self):
-        mock_fn = AsyncMock(side_effect=[ConnectionError("err"), "ok"])
-
-        @with_retry_async(max_attempts=3, backoff_seconds=(5, 10, 20))
-        async def fn():
-            return await mock_fn()
-
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            with patch("lib.retry.random.uniform", return_value=0.5):
-                await fn()
-
-        mock_sleep.assert_called_once()
-        # base_wait=5 + jitter=0.5 = 5.5
-        assert mock_sleep.call_args[0][0] == 5.5
 
     async def test_backoff_index_clamped(self):
         """backoff_seconds 长度不足时，使用最后一个值。"""
         errors = [ConnectionError(f"e{i}") for i in range(4)]
         mock_fn = AsyncMock(side_effect=[*errors, "ok"])
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=5, backoff_seconds=(1, 2))
+        @with_retry_async(max_attempts=5, backoff_seconds=(1, 2), clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
-        sleep_values = []
-
-        async def capture_sleep(t):
-            sleep_values.append(t)
-
-        with patch("lib.retry.asyncio.sleep", side_effect=capture_sleep):
-            with patch("lib.retry.random.uniform", return_value=0):
-                await fn()
+        await fn()
 
         # attempt 0→backoff[0]=1, attempt 1→backoff[1]=2, attempt 2→backoff[1]=2 (clamped), attempt 3→backoff[1]=2
-        assert sleep_values == [1, 2, 2, 2]
+        assert clock.sleeps == [1, 2, 2, 2]
 
     async def test_retry_if_true_triggers_retry(self):
         """retry_if 返回 True 时应触发重试。"""
         mock_fn = AsyncMock(side_effect=[ValueError("transient"), "ok"])
+        clock = _FakeClock()
 
         @with_retry_async(
             max_attempts=3,
             backoff_seconds=(0, 0, 0),
             retry_if=lambda e: isinstance(e, ValueError),
+            clock=clock,
+            jitter=_no_jitter,
         )
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            result = await fn()
+        result = await fn()
 
         assert result == "ok"
         assert mock_fn.call_count == 2
@@ -260,11 +259,14 @@ class TestWithRetryAsync:
     async def test_retry_if_false_raises_immediately(self):
         """retry_if 返回 False 时应立即抛出，即使 _should_retry 会返回 True。"""
         mock_fn = AsyncMock(side_effect=ConnectionError("reset"))
+        clock = _FakeClock()
 
         @with_retry_async(
             max_attempts=3,
             backoff_seconds=(0, 0, 0),
             retry_if=lambda e: False,  # 始终不重试
+            clock=clock,
+            jitter=_no_jitter,
         )
         async def fn():
             return await mock_fn()
@@ -272,17 +274,18 @@ class TestWithRetryAsync:
         with pytest.raises(ConnectionError, match="reset"):
             await fn()
         assert mock_fn.call_count == 1
+        assert clock.sleeps == []
 
     async def test_retry_if_none_uses_default_should_retry(self):
         """retry_if=None（默认）应保持原有 _should_retry 行为。"""
         mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])
+        clock = _FakeClock()
 
-        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retry_if=None)
+        @with_retry_async(max_attempts=3, backoff_seconds=(0, 0, 0), retry_if=None, clock=clock, jitter=_no_jitter)
         async def fn():
             return await mock_fn()
 
-        with patch("lib.retry.asyncio.sleep", new_callable=AsyncMock):
-            result = await fn()
+        result = await fn()
 
         assert result == "ok"
         assert mock_fn.call_count == 2
@@ -299,11 +302,14 @@ class TestWithRetryAsync:
             pass
 
         mock_fn = AsyncMock(side_effect=_Truncated("boom"))
+        clock = _FakeClock()
 
         @with_retry_async(
             max_attempts=3,
             backoff_seconds=(0, 0, 0),
             retry_if=lambda e: True,
+            clock=clock,
+            jitter=_no_jitter,
         )
         async def fn():
             return await mock_fn()
@@ -311,6 +317,7 @@ class TestWithRetryAsync:
         with pytest.raises(_Truncated):
             await fn()
         assert mock_fn.call_count == 1
+        assert clock.sleeps == []
 
     async def test_waits_backoff_plus_injected_jitter_on_injected_clock(self):
         mock_fn = AsyncMock(side_effect=[ConnectionError("reset"), "ok"])

--- a/tests/unit/lib/test_script_models.py
+++ b/tests/unit/lib/test_script_models.py
@@ -794,15 +794,16 @@ class TestGeneratedAssetsTemplateContract:
         from lib.project_manager import ProjectManager
         from lib.script_models import GeneratedAssets
 
-        # 不抛即通过——template 任何 key 不在模型字段集时 extra="forbid" 会抛 ValidationError
-        GeneratedAssets.model_validate(ProjectManager.create_generated_assets())
-        GeneratedAssets.model_validate(ProjectManager.create_generated_assets("drama"))
+        # template 任何 key 不在模型字段集时 extra="forbid" 会抛；断验出来的对象带齐 template 的键
+        for template in (ProjectManager.create_generated_assets(), ProjectManager.create_generated_assets("drama")):
+            validated = GeneratedAssets.model_validate(template)
+            assert set(template) <= set(validated.model_dump())
 
     def test_video_thumbnail_runtime_write_passes_strict_validation(self):
         """reference_video_tasks 在视频生成后会写 ga['video_thumbnail'],模型必须接受。"""
         from lib.script_models import GeneratedAssets
 
-        GeneratedAssets.model_validate(
+        validated = GeneratedAssets.model_validate(
             {
                 "storyboard_image": "scenes/E1S01.png",
                 "video_clip": "videos/E1S01.mp4",
@@ -811,6 +812,8 @@ class TestGeneratedAssetsTemplateContract:
                 "status": "completed",
             }
         )
+
+        assert validated.video_thumbnail == "thumbnails/E1S01.jpg"
 
 
 class TestResolveContentMode:

--- a/tests/unit/lib/test_script_skeleton.py
+++ b/tests/unit/lib/test_script_skeleton.py
@@ -44,7 +44,8 @@ class TestRegistrySelfConsistency:
         assert SKELETONS["video_units"].chars_field is None
 
     def test_real_registry_passes_validation(self):
-        script_skeleton._validate_registry()  # 不抛即通过
+        """真实注册表自洽：校验器放行的契约就是「不抛且无返回」。"""
+        assert script_skeleton._validate_registry() is None
 
     def test_missing_kind_fails_fast(self, monkeypatch):
         broken = {k: v for k, v in SKELETONS.items() if k != "video_units"}

--- a/tests/unit/lib/test_thumbnail_fallback.py
+++ b/tests/unit/lib/test_thumbnail_fallback.py
@@ -242,7 +242,7 @@ async def test_last_frame_retries_precise_count_when_fast_extract_writes_nothing
 
 
 def test_ffprobe_available_is_cached():
-    """_ffprobe_available() 同样走 @functools.cache：独立于 ffmpeg 各缓存各的结论。"""
+    """_ffprobe_available() 走 @functools.cache：首次结论定死，之后 which 换答案也不再重探。"""
     thumbnail_module._reset_for_tests()
     with patch("lib.thumbnail.shutil.which", return_value=None):
         assert thumbnail_module._ffprobe_available() is False

--- a/tests/unit/lib/test_thumbnail_fallback.py
+++ b/tests/unit/lib/test_thumbnail_fallback.py
@@ -71,13 +71,17 @@ async def test_ffmpeg_available_attempts_extraction(tmp_path: Path):
 
 
 def test_ffmpeg_available_is_cached():
-    """_ffmpeg_available() 用 @functools.cache，多次调用 shutil.which 只一次。"""
+    """_ffmpeg_available() 用 @functools.cache：首次探测的结论此后固定，不随 PATH 再变。
+
+    断言落在「结论不变」而非探测次数上——调用方依赖的是这个稳定结论（进程内不会一会儿有
+    ffmpeg 一会儿没有），探测只调一次是它的副产物。
+    """
     thumbnail_module._reset_for_tests()
-    with patch("lib.thumbnail.shutil.which", return_value=None) as which:
-        thumbnail_module._ffmpeg_available()
-        thumbnail_module._ffmpeg_available()
-        thumbnail_module._ffmpeg_available()
-    assert which.call_count == 1
+    with patch("lib.thumbnail.shutil.which", return_value=None):
+        assert thumbnail_module._ffmpeg_available() is False
+    with patch("lib.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"):
+        assert thumbnail_module._ffmpeg_available() is False
+    thumbnail_module._reset_for_tests()
 
 
 @pytest.mark.asyncio
@@ -238,10 +242,10 @@ async def test_last_frame_retries_precise_count_when_fast_extract_writes_nothing
 
 
 def test_ffprobe_available_is_cached():
-    """_ffprobe_available() 同样走 @functools.cache。"""
+    """_ffprobe_available() 同样走 @functools.cache：独立于 ffmpeg 各缓存各的结论。"""
     thumbnail_module._reset_for_tests()
-    with patch("lib.thumbnail.shutil.which", return_value=None) as which:
-        thumbnail_module._ffprobe_available()
-        thumbnail_module._ffprobe_available()
-        thumbnail_module._ffprobe_available()
-    assert which.call_count == 1
+    with patch("lib.thumbnail.shutil.which", return_value=None):
+        assert thumbnail_module._ffprobe_available() is False
+    with patch("lib.thumbnail.shutil.which", return_value="/usr/bin/ffprobe"):
+        assert thumbnail_module._ffprobe_available() is False
+    thumbnail_module._reset_for_tests()

--- a/tests/unit/lib/test_thumbnail_fallback.py
+++ b/tests/unit/lib/test_thumbnail_fallback.py
@@ -76,12 +76,10 @@ def test_ffmpeg_available_is_cached():
     断言落在「结论不变」而非探测次数上——调用方依赖的是这个稳定结论（进程内不会一会儿有
     ffmpeg 一会儿没有），探测只调一次是它的副产物。
     """
-    thumbnail_module._reset_for_tests()
     with patch("lib.thumbnail.shutil.which", return_value=None):
         assert thumbnail_module._ffmpeg_available() is False
     with patch("lib.thumbnail.shutil.which", return_value="/usr/bin/ffmpeg"):
         assert thumbnail_module._ffmpeg_available() is False
-    thumbnail_module._reset_for_tests()
 
 
 @pytest.mark.asyncio
@@ -243,9 +241,7 @@ async def test_last_frame_retries_precise_count_when_fast_extract_writes_nothing
 
 def test_ffprobe_available_is_cached():
     """_ffprobe_available() 走 @functools.cache：首次结论定死，之后 which 换答案也不再重探。"""
-    thumbnail_module._reset_for_tests()
     with patch("lib.thumbnail.shutil.which", return_value=None):
         assert thumbnail_module._ffprobe_available() is False
     with patch("lib.thumbnail.shutil.which", return_value="/usr/bin/ffprobe"):
         assert thumbnail_module._ffprobe_available() is False
-    thumbnail_module._reset_for_tests()

--- a/tests/unit/lib/test_tts_skeleton.py
+++ b/tests/unit/lib/test_tts_skeleton.py
@@ -8,9 +8,11 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.audio_backends.base import AudioCapability, AudioSynthesisResult
 from lib.data_validator import DataValidator
+from lib.db.base import Base
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.generation_worker import CapacityTable, GenerationWorker, SlotTable
 from lib.media_generator import MediaGenerator
@@ -356,16 +358,24 @@ class TestGenerateAudioAsync:
 
 
 class TestUsageStatsAudioCount:
-    async def test_audio_count(self, db_session):
-        repo = UsageRepository(db_session)
-        call_id = await repo.start_call(
-            project_name="demo", call_type="audio", model="qwen3-tts-flash", provider="dashscope"
-        )
-        await repo.finish_call(call_id, status="success", settlement=SettlementInput(usage_tokens=1500))
-        stats = await repo.get_stats(project_name="demo")
-        assert stats["audio_count"] == 1
-        # audio 按字符冻结费用（非 0）
-        assert stats["cost_by_currency"].get("CNY", 0) > 0
+    async def test_audio_count(self):
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as session:
+                repo = UsageRepository(session)
+                call_id = await repo.start_call(
+                    project_name="demo", call_type="audio", model="qwen3-tts-flash", provider="dashscope"
+                )
+                await repo.finish_call(call_id, status="success", settlement=SettlementInput(usage_tokens=1500))
+                stats = await repo.get_stats(project_name="demo")
+                assert stats["audio_count"] == 1
+                # audio 按字符冻结费用（非 0）
+                assert stats["cost_by_currency"].get("CNY", 0) > 0
+        finally:
+            await engine.dispose()
 
 
 # ── worker audio lane ───────────────────────────────────────────────────────────
@@ -405,7 +415,9 @@ class TestWorkerAudioLane:
         w._slots.register("dashscope", "audio", "t", dummy)
         assert w._pool_full_providers("audio") == frozenset({"dashscope"})
 
-    async def test_claim_routes_audio_to_audio_lane(self):
+    async def test_claim_routes_audio_to_audio_lane(self, monkeypatch):
+        from lib import generation_worker as gw
+
         class _Q:
             def __init__(self):
                 self._given = False
@@ -417,9 +429,8 @@ class TestWorkerAudioLane:
                         "task_id": "T1",
                         "task_type": "tts",
                         "media_type": "audio",
-                        # 不带 project_name：payload 自报的 audio_provider 即可让真实
-                        # _extract_provider 短路解析出 dashscope，无需项目与 DB 在场。
-                        "payload": {"audio_provider": "dashscope", "audio_model": "qwen3-tts-flash"},
+                        "project_name": "demo",
+                        "payload": {},
                     }
                 return None
 
@@ -430,6 +441,11 @@ class TestWorkerAudioLane:
                 _defaults={"image": 5, "video": 3, "audio": 10},
             ),
         )
+
+        async def _fake_extract(task):
+            return "dashscope"
+
+        monkeypatch.setattr(gw, "_extract_provider", _fake_extract)
 
         async def _fake_process(task):
             await asyncio.sleep(0)

--- a/tests/unit/lib/test_tts_skeleton.py
+++ b/tests/unit/lib/test_tts_skeleton.py
@@ -8,11 +8,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from lib.audio_backends.base import AudioCapability, AudioSynthesisResult
 from lib.data_validator import DataValidator
-from lib.db.base import Base
 from lib.db.repositories.usage_repo import SettlementInput, UsageRepository
 from lib.generation_worker import CapacityTable, GenerationWorker, SlotTable
 from lib.media_generator import MediaGenerator
@@ -358,24 +356,16 @@ class TestGenerateAudioAsync:
 
 
 class TestUsageStatsAudioCount:
-    async def test_audio_count(self):
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        try:
-            factory = async_sessionmaker(engine, expire_on_commit=False)
-            async with factory() as session:
-                repo = UsageRepository(session)
-                call_id = await repo.start_call(
-                    project_name="demo", call_type="audio", model="qwen3-tts-flash", provider="dashscope"
-                )
-                await repo.finish_call(call_id, status="success", settlement=SettlementInput(usage_tokens=1500))
-                stats = await repo.get_stats(project_name="demo")
-                assert stats["audio_count"] == 1
-                # audio 按字符冻结费用（非 0）
-                assert stats["cost_by_currency"].get("CNY", 0) > 0
-        finally:
-            await engine.dispose()
+    async def test_audio_count(self, db_session):
+        repo = UsageRepository(db_session)
+        call_id = await repo.start_call(
+            project_name="demo", call_type="audio", model="qwen3-tts-flash", provider="dashscope"
+        )
+        await repo.finish_call(call_id, status="success", settlement=SettlementInput(usage_tokens=1500))
+        stats = await repo.get_stats(project_name="demo")
+        assert stats["audio_count"] == 1
+        # audio 按字符冻结费用（非 0）
+        assert stats["cost_by_currency"].get("CNY", 0) > 0
 
 
 # ── worker audio lane ───────────────────────────────────────────────────────────

--- a/tests/unit/lib/test_tts_skeleton.py
+++ b/tests/unit/lib/test_tts_skeleton.py
@@ -415,9 +415,7 @@ class TestWorkerAudioLane:
         w._slots.register("dashscope", "audio", "t", dummy)
         assert w._pool_full_providers("audio") == frozenset({"dashscope"})
 
-    async def test_claim_routes_audio_to_audio_lane(self, monkeypatch):
-        from lib import generation_worker as gw
-
+    async def test_claim_routes_audio_to_audio_lane(self):
         class _Q:
             def __init__(self):
                 self._given = False
@@ -429,8 +427,9 @@ class TestWorkerAudioLane:
                         "task_id": "T1",
                         "task_type": "tts",
                         "media_type": "audio",
-                        "project_name": "demo",
-                        "payload": {},
+                        # 不带 project_name：payload 自报的 audio_provider 即可让真实
+                        # _extract_provider 短路解析出 dashscope，无需项目与 DB 在场。
+                        "payload": {"audio_provider": "dashscope", "audio_model": "qwen3-tts-flash"},
                     }
                 return None
 
@@ -441,11 +440,6 @@ class TestWorkerAudioLane:
                 _defaults={"image": 5, "video": 3, "audio": 10},
             ),
         )
-
-        async def _fake_extract(task):
-            return "dashscope"
-
-        monkeypatch.setattr(gw, "_extract_provider", _fake_extract)
 
         async def _fake_process(task):
             await asyncio.sleep(0)

--- a/tests/unit/lib/test_video_frame_slots.py
+++ b/tests/unit/lib/test_video_frame_slots.py
@@ -33,7 +33,12 @@ CAPS_WITH_PROMPT_LIMIT = VideoCapabilities(first_frame=True, max_prompt_chars=10
 
 
 def _gate(caps: VideoCapabilities | None, **kwargs):
-    gate_video_request(caps=caps, provider="acme", model="acme-v1", **kwargs)
+    """跑一遍请求期校验并透出返回值。
+
+    校验器的放行契约就是「不抛且无返回」，放行用例据此断言 ``is None``——否则「通过」只能
+    靠「这个测试没炸」隐式表达，用例体一旦被清空也不会有人发现。
+    """
+    return gate_video_request(caps=caps, provider="acme", model="acme-v1", **kwargs)
 
 
 def _plan(caps: VideoCapabilities | None, **kwargs):
@@ -86,7 +91,7 @@ class TestLastFrameGating:
 
     def test_uncharted_caps_without_end_image_passes(self):
         """caps=None（调用方未查询能力）× 三条路径都不走：无需能力声明即可放行。"""
-        _gate(None)
+        assert _gate(None) is None
 
     def test_uncharted_caps_with_end_image_raises(self):
         """caps=None × 携带尾帧：未经能力核实的尾帧一律拒绝，不按"支持"放行。"""
@@ -173,7 +178,7 @@ class TestReferenceImageGating:
         assert exc.value.params == {"provider": "acme", "model": "acme-v1", "limit": 4, "count": 5}
 
     def test_reference_images_at_limit_pass(self):
-        _gate(CAPS_WITH_LAST_FRAME, reference_images=[Path(f"r{i}.png") for i in range(4)])
+        assert _gate(CAPS_WITH_LAST_FRAME, reference_images=[Path(f"r{i}.png") for i in range(4)]) is None
 
     def test_reference_images_on_zero_capacity_model_raise(self):
         with pytest.raises(VideoCapabilityError) as exc:
@@ -199,10 +204,10 @@ class TestReferenceAudioGating:
         assert exc.value.params == {"provider": "acme", "model": "acme-v1"}
 
     def test_audio_within_limit_passes(self):
-        _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path("a.mp3"), Path("b.wav")])
+        assert _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path("a.mp3"), Path("b.wav")]) is None
 
     def test_audio_at_limit_passes(self):
-        _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path(f"a{i}.mp3") for i in range(3)])
+        assert _gate(CAPS_WITH_AUDIO, reference_audio_files=[Path(f"a{i}.mp3") for i in range(3)]) is None
 
     def test_audio_beyond_limit_raises(self):
         with pytest.raises(VideoCapabilityError) as exc:
@@ -219,22 +224,28 @@ class TestReferenceAudioGating:
 
     def test_empty_audio_list_passes_on_incapable_model(self):
         """空列表与 None 同义：没有音频诉求就不该被音频能力挡住。"""
-        _gate(CAPS_WITH_LAST_FRAME, reference_audio_files=[])
+        assert _gate(CAPS_WITH_LAST_FRAME, reference_audio_files=[]) is None
 
 
 class TestReferenceAudioDurationGating:
     def test_total_within_limit_passes(self):
-        _gate(
-            CAPS_WITH_AUDIO_DURATION_LIMIT,
-            reference_audio_files=[Path("a.mp3"), Path("b.wav")],
-            reference_audio_total_seconds=14.9,
+        assert (
+            _gate(
+                CAPS_WITH_AUDIO_DURATION_LIMIT,
+                reference_audio_files=[Path("a.mp3"), Path("b.wav")],
+                reference_audio_total_seconds=14.9,
+            )
+            is None
         )
 
     def test_total_at_limit_passes(self):
-        _gate(
-            CAPS_WITH_AUDIO_DURATION_LIMIT,
-            reference_audio_files=[Path("a.mp3"), Path("b.wav")],
-            reference_audio_total_seconds=15.0,
+        assert (
+            _gate(
+                CAPS_WITH_AUDIO_DURATION_LIMIT,
+                reference_audio_files=[Path("a.mp3"), Path("b.wav")],
+                reference_audio_total_seconds=15.0,
+            )
+            is None
         )
 
     def test_total_beyond_limit_raises(self):
@@ -250,27 +261,33 @@ class TestReferenceAudioDurationGating:
 
     def test_unknown_total_skips_check_even_when_limit_declared(self):
         """探测失败（total=None）按仓库既有降级口径跳过校验，不当作超限拒绝。"""
-        _gate(
-            CAPS_WITH_AUDIO_DURATION_LIMIT,
-            reference_audio_files=[Path("a.mp3"), Path("b.wav")],
-            reference_audio_total_seconds=None,
+        assert (
+            _gate(
+                CAPS_WITH_AUDIO_DURATION_LIMIT,
+                reference_audio_files=[Path("a.mp3"), Path("b.wav")],
+                reference_audio_total_seconds=None,
+            )
+            is None
         )
 
     def test_no_declared_limit_skips_check_regardless_of_total(self):
         """caps 未声明总时长约束（None）：即便传了很大的 total 也不拦——该维度对这个后端不适用。"""
-        _gate(
-            CAPS_WITH_AUDIO,
-            reference_audio_files=[Path("a.mp3"), Path("b.wav")],
-            reference_audio_total_seconds=1000.0,
+        assert (
+            _gate(
+                CAPS_WITH_AUDIO,
+                reference_audio_files=[Path("a.mp3"), Path("b.wav")],
+                reference_audio_total_seconds=1000.0,
+            )
+            is None
         )
 
 
 class TestPromptLengthGating:
     def test_prompt_within_limit_passes(self):
-        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 99)
+        assert _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 99) is None
 
     def test_prompt_at_limit_passes(self):
-        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 100)
+        assert _gate(CAPS_WITH_PROMPT_LIMIT, prompt="x" * 100) is None
 
     def test_prompt_beyond_limit_raises(self):
         with pytest.raises(VideoCapabilityError) as exc:
@@ -281,15 +298,15 @@ class TestPromptLengthGating:
 
     def test_limit_counts_characters_not_bytes(self):
         """计量口径是字符数，中英文同权——按字节算会把中文 prompt 误拒。"""
-        _gate(CAPS_WITH_PROMPT_LIMIT, prompt="中" * 100)
+        assert _gate(CAPS_WITH_PROMPT_LIMIT, prompt="中" * 100) is None
 
     def test_no_declared_limit_skips_check(self):
         """caps 未声明上限：任意长度都放行，未声明不等于上限为 0。"""
-        _gate(CAPS_WITH_LAST_FRAME, prompt="x" * 100_000)
+        assert _gate(CAPS_WITH_LAST_FRAME, prompt="x" * 100_000) is None
 
     def test_none_caps_skips_check(self):
         """能力未查询（caps=None）时不拦 prompt——无从得知上限，拒绝反成误伤。"""
-        _gate(None, prompt="x" * 100_000)
+        assert _gate(None, prompt="x" * 100_000) is None
 
     def test_prompt_checked_before_optional_paths(self):
         """prompt 违约先于尾帧等可选路径报出，用户一次只看到最先命中的那条。"""

--- a/tests/unit/lib/test_vidu_shared.py
+++ b/tests/unit/lib/test_vidu_shared.py
@@ -76,8 +76,10 @@ class TestViduConnectionTestUrl:
         assert captured["url"].endswith("/tasks/0/creations")
 
     def test_404_is_success(self, monkeypatch: pytest.MonkeyPatch):
+        """404 表示凭证能用、只是那条探测路径不存在——连通性判定按成功收（不抛且无返回）。"""
         self._patched_client(monkeypatch, status_code=404)
-        vidu_shared.test_vidu_connection({"api_key": "vda_test"})  # 不抛错即成功
+
+        assert vidu_shared.test_vidu_connection({"api_key": "vda_test"}) is None
 
     def test_401_is_invalid_credential(self, monkeypatch: pytest.MonkeyPatch):
         self._patched_client(monkeypatch, status_code=401)

--- a/tests/unit/lib/test_vidu_shared.py
+++ b/tests/unit/lib/test_vidu_shared.py
@@ -76,10 +76,8 @@ class TestViduConnectionTestUrl:
         assert captured["url"].endswith("/tasks/0/creations")
 
     def test_404_is_success(self, monkeypatch: pytest.MonkeyPatch):
-        """404 表示凭证能用、只是那条探测路径不存在——连通性判定按成功收（不抛且无返回）。"""
         self._patched_client(monkeypatch, status_code=404)
-
-        assert vidu_shared.test_vidu_connection({"api_key": "vda_test"}) is None
+        vidu_shared.test_vidu_connection({"api_key": "vda_test"})  # 不抛错即成功
 
     def test_401_is_invalid_credential(self, monkeypatch: pytest.MonkeyPatch):
         self._patched_client(monkeypatch, status_code=401)


### PR DESCRIPTION
Closes #2000

## 做了什么

lib 域内其余测试文件的判据与替身处置（Spec #1989 的 B6 分票）：私有替身换生产已有注入位、零断言用例补真实判据、respx 迁移、测试体内自建 engine 收编 conftest fixture、域内两处真实 `time.sleep` 按 #1981 定案改造。

## 验收判据

审计脚本（`scripts/audit_tests.py`）三项不变量在本域清零：

| 指标 | 全仓余量 | 本域 | 域外分布 |
|---|---|---|---|
| `no_assertion_tests` | 14 | **0** | server 11、backends 2、vidu 1 |
| `private_patch_sites` | 251 | **0** | backends、generation_worker/media_generator/tts_skeleton、server |
| `integration_self_public_patch_sites` | 12 | **0** | generation_worker 1、server 11 |

全仓四值总量不在本票对账范围内（并行四票基线起点不同，终值由收尾票统一取）。

## 生产代码改动（一处）

`lib/artifact_activation.py::activate_artifact_target_state` 新增 `commit_schema` 关键字注入点，与既有的 `backup_file` 同形、带生产默认值。v7→v8 激活握手用例需要在「产物清单已换、schema 未提交」这一临界区窗口内暂停或注入故障，只能从该步骤落点；没有它就得退回 monkeypatch 私有 `_commit_schema_version`，那正是本票要清零的机械命中。

## 验证

在 `1c61f107d` 上完整复跑：

- `uv run python -m pytest`：10282 passed / 2 skipped（随机序，pytest-randomly 生效）
- `uv run ruff check .` 全过；`ruff format .` 无改动
- `uv run basedpyright`：0 errors
- `uv run lint-imports`：2 contracts kept, 0 broken

## 已知取舍

- `tests/integration/lib/config/test_config_resolver.py` 的自建 engine 收编选 `db_factory` / `file_db_factory` / `db_session` 而非 `session_factory`：前者与原地自建同方言且不注入 `uses_db`，postgres-compat 选集一字不变；换 `session_factory` 会把 59 条用例拉进 PG job，是本地无法验证的行为变更。
- `tests/unit/lib/test_locked_episode_script_toctou.py` 的互斥判据用事件握手 + 次序断言，而非 #1981 定案原文的「持锁期间非阻塞 acquire」。实测该探针可行，但需要测试直接引用 `.project.json.lock` 命名约定与 portalocker——`_project_lock` 刻意隐藏了这两者。现形态已消除 sleep，残留的单向否证（慢机漏检、不会误报）记为收尾候选。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 项目迁移流程支持更灵活的备份与版本提交控制，并提升并发一致性及失败后的可重试能力。
  * 异常情况下更可靠地保留原始项目数据，清理临时文件。
  * 强化视频、音频、图片及文本能力校验，完善时长、提示词、参考素材和计价限制处理。
  * 改善任务提交失败时的事务回滚，避免错误发布终态事件。
  * 增强敏感信息保护，防止异常日志泄露密钥等内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->