### PR TITLE
test(frontend): PresentationPlayer 字幕抑制用例去 flake

### DIFF
--- a/frontend/src/components/shared/PresentationPlayer.test.tsx
+++ b/frontend/src/components/shared/PresentationPlayer.test.tsx
@@ -360,28 +360,36 @@ describe("PresentationPlayer", () => {
       length: { configurable: true, value: 1 },
       0: { configurable: true, value: nativeTrack },
     });
-    const priorDescriptor = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, "textTracks");
-    Object.defineProperty(HTMLMediaElement.prototype, "textTracks", {
-      configurable: true,
-      get: () => textTracks,
-    });
+    let changeSubscriptions = 0;
+    const addEventListener = textTracks.addEventListener.bind(textTracks);
+    textTracks.addEventListener = (type, listener, options) => {
+      if (type === "change") changeSubscriptions += 1;
+      addEventListener(type, listener, options);
+    };
+    const createElement = document.createElement.bind(document);
+    const createElementSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+        const element = createElement(tagName, options);
+        if (element instanceof HTMLVideoElement) {
+          Object.defineProperty(element, "textTracks", { configurable: true, get: () => textTracks });
+        }
+        return element;
+      });
     try {
       render(
         <PresentationPlayer projectName="demo" resourceType="videos" resourceId="E1S01" />,
       );
       await screen.findByLabelText("E1S01 成片预览");
       expect(screen.getByText("机械字幕")).toBeInTheDocument();
+      await waitFor(() => expect(changeSubscriptions).toBeGreaterThan(0));
 
       nativeTrack.mode = "showing";
       act(() => textTracks.dispatchEvent(new Event("change")));
 
-      expect(screen.queryByText("机械字幕")).not.toBeInTheDocument();
+      await waitFor(() => expect(screen.queryByText("机械字幕")).not.toBeInTheDocument());
     } finally {
-      if (priorDescriptor) {
-        Object.defineProperty(HTMLMediaElement.prototype, "textTracks", priorDescriptor);
-      } else {
-        Reflect.deleteProperty(HTMLMediaElement.prototype, "textTracks");
-      }
+      createElementSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
Closes #2053

## 改动

`PresentationPlayer.test.tsx` 用例 `suppresses the custom cue while native captions are showing` 去 flake，仅改测试，不动生产代码：

- **替身作用域从原型收到实例**。原先 `Object.defineProperty(HTMLMediaElement.prototype, "textTracks", …)` 在改写窗口内与并发用例共享原型；现改为 `vi.spyOn(document, "createElement")` 透传真实实现，仅在 `element instanceof HTMLVideoElement` 时于该实例上装 `textTracks` getter，`HTMLMediaElement.prototype` 全程不被触碰。
- **时序依赖换成确定性握手**。`textTracks.addEventListener` 记录 `change` 订阅数；派发前 `waitFor` 等订阅计数 > 0，确认 `PresentationPlayer.tsx:245-250` 的订阅 effect 已挂上监听，再 `act()` 派发 change；抑制断言同样以 `waitFor` 包裹，不再依赖派发与渲染的相对时序。
- 断言语义不变：native captions 处于 showing 时自定义 cue 被抑制；派发前的正向断言 `getByText("机械字幕")` 保留，杜绝否定断言空洞通过。

选型备案：曾考虑「先挂载、装实例替身、再触发 presentation 重载让订阅 effect 重跑」，被否——重载路径经 loading spinner 卸载并重建 video 元素，装在旧实例上的替身随元素销毁，接不上订阅 effect。

## 验证

- 稳定性：`vitest --run` 对该文件重复运行，实现阶段 20 次 + 审查阶段 8 次，共 28 次全过。
- `pnpm lint` 通过；`pnpm check` 155 文件 / 1889 用例全过。
- `uv run python scripts/audit_tests.py --check` 0 处违规。
- base `origin/main` 全程停在 `2892f0f15`，未前进，无需 rebase。

## 审查中评估后不采纳的意见

- **把末尾否定断言的 `waitFor` 改回同步 `expect`**：不采纳。issue 验收标准明确要求「事件驱动改为确定性触发 + 确定性等待（`findBy*`/`waitFor` 围绕可观察的 DOM 结果，不依赖派发与渲染的相对时序）」，改回同步 `expect` 正是要靠 `act()` 同步 flush 的时序耦合——即本票要消除的东西。空洞通过风险已由前置正向断言与订阅握手覆盖。
- **删掉 `try/finally` + `mockRestore()`（`vitest.config.ts` 已配 `restoreMocks: true`）**：不采纳。该改动会作废已建立的 28 次稳定性证据链，收益仅为去噪，不值当。
- **首个等待用的是测试自建订阅计数器而非 DOM 结果**：保留。变异测试显示，替身未挂上时正是该断言先失败，它是「替身是否真的接上」的唯一显式护栏；去掉后该故障退化为终态否定断言超时，失败信息更差。终态等待仍围绕 DOM。
- **`createElement` spy 仍是全局钩子**：保留。生产 effect 在 `presentation` 到位时即读 `videoRef.current?.textTracks` 并订阅，渲染后打补丁会与订阅竞态；纯测试侧要抢在订阅前触达实例只能走工厂钩子。相比原先的 `HTMLMediaElement.prototype` 改写，作用面已收窄（透传实现 + `instanceof HTMLVideoElement` 守卫，不再波及 `<audio>`）。

## 断言非空洞性

变异验证两路：`nativeTrack.mode` 不置 `showing` → 用例失败；替身不挂载 → 用例失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 改进原生字幕显示相关测试，提升对字幕变化事件的验证覆盖。
  * 优化测试环境清理与媒体元素模拟，增强测试稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->