### PR TITLE
test: 测试替身与基建散件收口——_FakeConfigResolver 收编、失实断言与过程性注释清理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ frontend/.vite/
 htmlcov/
 .coverage
 coverage/
+coverage.xml
+coverage-pg.xml
 
 # File locks (project_manager 原子写产物)
 **/*.lock

--- a/frontend/src/components/assets/AddToLibraryButton.test.tsx
+++ b/frontend/src/components/assets/AddToLibraryButton.test.tsx
@@ -14,7 +14,7 @@ describe("AddToLibraryButton", () => {
     vi.restoreAllMocks();
   });
 
-  it("rejects submit if the resource becomes busy while the import modal is open (issue #1159 round-11 Codex finding)", async () => {
+  it("rejects submit if the resource becomes busy while the import modal is open", async () => {
     const addSpy = vi.spyOn(API, "addAssetFromProject").mockResolvedValue({} as never);
 
     const { rerender } = render(

--- a/frontend/src/components/pages/AssetLibraryPage.test.tsx
+++ b/frontend/src/components/pages/AssetLibraryPage.test.tsx
@@ -19,7 +19,7 @@ function renderPage(initialPath = "/app/assets") {
   };
 }
 
-describe("AssetLibraryPage tablist (issue #488)", () => {
+describe("AssetLibraryPage tablist", () => {
   beforeEach(() => {
     useAssetsStore.setState(useAssetsStore.getInitialState(), true);
     vi.spyOn(API, "listAssets").mockResolvedValue({ items: [] });

--- a/frontend/src/components/pages/settings/AboutSection.test.tsx
+++ b/frontend/src/components/pages/settings/AboutSection.test.tsx
@@ -16,7 +16,7 @@ const VERSION_RESPONSE: GetSystemVersionResponse = {
   update_check_error: null,
 };
 
-describe("AboutSection diagnostics download (issue #1040)", () => {
+describe("AboutSection diagnostics download", () => {
   beforeEach(() => {
     vi.spyOn(API, "getSystemVersion").mockResolvedValue(VERSION_RESPONSE);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-diagnostics");

--- a/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
+++ b/frontend/src/components/pages/settings/UsageStatsSection.test.tsx
@@ -28,7 +28,7 @@ const STATS_RESPONSE: UsageStatsResponse = {
   period: { start: "2026-07-01", end: "2026-07-16" },
 };
 
-describe("UsageStatsSection provider filter dropdown (issue #1179)", () => {
+describe("UsageStatsSection provider filter dropdown", () => {
   it("renders provider options by display_name while keeping provider id as value", async () => {
     vi.spyOn(API, "getUsageStatsGrouped").mockResolvedValue(STATS_RESPONSE);
 

--- a/frontend/src/components/task-hud/TaskHud.cascade.test.tsx
+++ b/frontend/src/components/task-hud/TaskHud.cascade.test.tsx
@@ -7,8 +7,8 @@ import { useTasksStore } from "@/stores/tasks-store";
 import { makeTask } from "@/test/factories";
 import i18n from "@/i18n";
 
-// 前端 finding #12 回归：cascade 取消的 task 在 HUD 渲染 cascade_label，
-// user 取消的不渲染。验证 SSE 携带的 cancelled_by 字段在前端被正确分流。
+// cascade 取消的 task 在 HUD 渲染 cascade_label，user 取消的不渲染。
+// 验证 SSE 携带的 cancelled_by 字段在前端被正确分流。
 
 function HostedTaskHud() {
   const anchorRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/task-hud/TaskHud.taskType.test.tsx
+++ b/frontend/src/components/task-hud/TaskHud.taskType.test.tsx
@@ -7,7 +7,7 @@ import { useTasksStore } from "@/stores/tasks-store";
 import { makeTask } from "@/test/factories";
 import i18n from "@/i18n";
 
-// issue #1218：任务 HUD 的 task_type 标签本地化。已知类型经 i18n key 映射显示；
+// 任务 HUD 的 task_type 标签本地化：已知类型经 i18n key 映射显示；
 // 词表外的未知类型机械兜底显示原始串（不做语义猜测映射）。
 
 function HostedTaskHud() {

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -352,7 +352,7 @@ describe("stores", () => {
     // store 层的 projectorSource 自愈检查若拿"即将写入的新数组"和"上一次
     // 记录值"比对，二者引用恒不相等（每次 append 都会重新构造数组），会
     // 导致每次追加都重建 projector、对全部历史条目重新深拷贝——退化为
-    // O(n²) 全量重放，正是本 PR 要消除的问题。
+    // O(n²) 全量重放。
     const assistant = useAssistantStore.getState();
     assistant.resetTimeline();
     const original = globalThis.structuredClone;

--- a/frontend/src/stores/stores.test.ts
+++ b/frontend/src/stores/stores.test.ts
@@ -73,7 +73,7 @@ describe("stores", () => {
     app.setAssistantToolActivitySuppressed(true);
     expect(useAppStore.getState().assistantToolActivitySuppressed).toBe(true);
 
-    // pushToast 只写 toast，不再副作用写入 workspaceNotifications（issue #351 根因回归）
+    // pushToast 只写 toast，不副作用写入 workspaceNotifications
     app.pushToast("hello");
     expect(useAppStore.getState().toast?.text).toBe("hello");
     expect(useAppStore.getState().toast?.tone).toBe("info");

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,7 +3,7 @@ import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import i18n, { i18nReady } from "@/i18n";
 
-// i18n 改为 lazy backend (issue #489) 后，测试运行前必须 await 资源加载完，
+// i18n 走 lazy backend，测试运行前必须 await 资源加载完，
 // 否则首次 t() 返回 key 字符串而不是中文，断言会失败。
 await i18nReady;
 await i18n.changeLanguage("zh");

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -537,7 +537,7 @@ def bounded_poll_clock(step: float = 30.0):
     ``SystemClock`` 落到这两个符号上，压缩等待无需触碰 ``_compute_wait`` 等私有符号。
 
     终态判定失灵时（把已就绪的任务当成"仍在跑"），真实时钟下 sleep 被 mock 掉的轮询会以近乎
-    为零的真实耗时空转到天荒地老——测试表现为挂起而不是失败。假表让这类回归在几十次轮询内
+    为零的真实耗时空转到天荒地老——测试表现为挂起而不是失败。假表让这类缺陷在几十次轮询内
     撞上 ``max_wait`` 抛 ``TimeoutError``，红得快且可读。
     """
     clock = itertools.count(0.0, step)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -19,7 +19,6 @@ from instructor.core import InstructorRetryException
 
 if TYPE_CHECKING:
     from lib.media_generator import MediaGenerator
-    from lib.reference_video.voice_settings import VoiceRenderSettings
     from lib.version_manager import PaidVersionCommit
 
 
@@ -370,49 +369,11 @@ def fake_reference_request_projector(
     return _project
 
 
-def fake_reference_caps_fetcher(
-    *,
-    default_duration: int | None = 4,
-    durations: tuple[int, ...] = (4, 6, 8),
-    reference_durations: tuple[int, ...] | None = None,
-    text_durations: tuple[int, ...] | None = None,
-    max_duration: int = 12,
-    max_refs: int | None = 3,
-    voice: VoiceRenderSettings | None = None,
-):
-    """假 ``_fetch_reference_caps_with_fallback``：返回一份 ``ReferenceSplitCaps`` 的 async 取值器。
-
-    ``reference_durations`` / ``text_durations`` 留 None 即与 ``durations`` 同集（该型号未声明
-    生效的「参考图↔时长」联动约束）；``voice`` 留 None 取 ``VoiceRenderSettings`` 的字段默认
-    （``soft`` 有声、无参考音频）。
-
-    被 monkeypatch 的目标签名带 episode 位，故取值器收两参——多数用例只关心返回值。
-    运行期用到的两个类型在函数体内导入：它们出自 lib / server 侧的业务模块，本模块的其余替身不
-    依赖这两个包，不为一个替身把依赖提到导入期（签名上的标注由 ``from __future__`` 延迟求值，
-    经 ``TYPE_CHECKING`` 供类型检查器读取）。
-    """
-    from lib.reference_video.voice_settings import VoiceRenderSettings
-    from server.agent_runtime.sdk_tools.text_generation import ReferenceSplitCaps
-
-    async def _fetch(_project, _episode=None) -> ReferenceSplitCaps:
-        return ReferenceSplitCaps(
-            default_duration=default_duration,
-            durations=list(durations),
-            reference_durations=list(durations if reference_durations is None else reference_durations),
-            text_durations=list(durations if text_durations is None else text_durations),
-            max_duration=max_duration,
-            max_refs=max_refs,
-            voice=VoiceRenderSettings() if voice is None else voice,
-        )
-
-    return _fetch
-
-
 class FakeConfigResolver:
     """能力解析器 seam 的手写替身：按桶回答视频能力，不触碰配置库。
 
-    生产侧凡接 ``config_resolver`` 关键字的入口（``ToolContext``、``resolve_video_caps`` /
-    ``fetch_video_caps`` 及 ``text_generation`` 的几个取值器）都可注入本类，替代对这些取值器
+    生产侧凡接 ``config_resolver`` 关键字的入口（``ToolContext``、``MediaGenerator``、
+    ``resolve_video_caps`` / ``fetch_video_caps`` 及 ``text_generation`` 的几个取值器）都可注入本类，替代对这些取值器
     本身的整体替换——被替换掉的取值器里有软回退、联动约束收窄与声音档派生，那些才是用例要
     保护的行为。
 
@@ -440,6 +401,7 @@ class FakeConfigResolver:
         generate_audio_error: BaseException | None = None,
         image_backend: tuple[str, str] = ("fake", "fake-image"),
         image_backend_error: BaseException | None = None,
+        reference_payload_limits: tuple[int, int] | None = None,
         **extra: Any,
     ) -> None:
         self._base: dict[str, Any] = {
@@ -463,10 +425,12 @@ class FakeConfigResolver:
         self._generate_audio_error = generate_audio_error
         self._image_backend = image_backend
         self._image_backend_error = image_backend_error
+        self._reference_payload_limits = reference_payload_limits
         self.capability_calls: list[str | None] = []
         self.project_names: list[str | None] = []
         self.image_capability_calls: list[str | None] = []
-        self.generate_audio_calls: list[dict[str, Any] | None] = []
+        self.generate_audio_calls: list[dict[str, Any] | str | None] = []
+        self.reference_limits_calls: list[str | None] = []
 
     def caps_for(self, capability: str | None = None) -> dict[str, Any]:
         """该桶的能力 dict（与生产返回同形），供用例直接对照期望。"""
@@ -510,6 +474,25 @@ class FakeConfigResolver:
         if self._generate_audio_error is not None:
             raise self._generate_audio_error
         return bool(self._base["requested_generate_audio"])
+
+    async def video_generate_audio(self, project_name: str | None = None) -> bool:
+        """生产同名读点（按项目名）：与 ``video_generate_audio_for_project`` 共享同一份配置值。"""
+        self.generate_audio_calls.append(project_name)
+        if self._generate_audio_error is not None:
+            raise self._generate_audio_error
+        return bool(self._base["requested_generate_audio"])
+
+    async def reference_payload_limits(self, provider_id: str | None = None) -> tuple[int, int]:
+        """参考图载荷限额（总量, 单张）；未显式配置时与生产同取 service 层保守默认。"""
+        self.reference_limits_calls.append(provider_id)
+        if self._reference_payload_limits is not None:
+            return self._reference_payload_limits
+        from lib.config.service import (
+            _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
+            _DEFAULT_REFERENCE_TOTAL_MAX_BYTES,
+        )
+
+        return _DEFAULT_REFERENCE_TOTAL_MAX_BYTES, _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
 
     def _resolve(self, capability: str | None) -> dict[str, Any]:
         self.capability_calls.append(capability)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -429,7 +429,8 @@ class FakeConfigResolver:
         self.capability_calls: list[str | None] = []
         self.project_names: list[str | None] = []
         self.image_capability_calls: list[str | None] = []
-        self.generate_audio_calls: list[dict[str, Any] | str | None] = []
+        self.generate_audio_calls: list[dict[str, Any] | None] = []
+        self.generate_audio_project_names: list[str | None] = []
         self.reference_limits_calls: list[str | None] = []
 
     def caps_for(self, capability: str | None = None) -> dict[str, Any]:
@@ -476,8 +477,12 @@ class FakeConfigResolver:
         return bool(self._base["requested_generate_audio"])
 
     async def video_generate_audio(self, project_name: str | None = None) -> bool:
-        """生产同名读点（按项目名）：与 ``video_generate_audio_for_project`` 共享同一份配置值。"""
-        self.generate_audio_calls.append(project_name)
+        """生产同名读点（按项目名）：与 ``video_generate_audio_for_project`` 共享同一份配置值。
+
+        两个读点各记各的入参（本读点收项目名、按 project 的那个收 project dict），
+        record 列表不合并，免得用例的等值断言被另一条路径的调用串味。
+        """
+        self.generate_audio_project_names.append(project_name)
         if self._generate_audio_error is not None:
             raise self._generate_audio_error
         return bool(self._base["requested_generate_audio"])

--- a/tests/integration/lib/test_media_generator_module.py
+++ b/tests/integration/lib/test_media_generator_module.py
@@ -14,7 +14,7 @@ from lib.media_generator import (
     task_video_staging_path,
 )
 from lib.version_manager import PaidVersionCommit
-from tests.fakes import select_formal_video
+from tests.fakes import FakeConfigResolver, select_formal_video
 
 
 class _FakeImageBackend:
@@ -131,25 +131,6 @@ class _FakeLedger:
             self.outcomes.append({"status": "success", "result": call.result})
 
 
-class _FakeConfigResolver:
-    """Fake ConfigResolver，返回可控的配置值。"""
-
-    def __init__(self, video_generate_audio: bool = False):
-        self._video_generate_audio = video_generate_audio
-
-    async def video_generate_audio(self, project_name=None):
-        return self._video_generate_audio
-
-    async def reference_payload_limits(self, provider_id=None):
-        # 与真实 resolver 同契约：provider_id 为 None 或未配置时返回 service 层保守默认。
-        from lib.config.service import (
-            _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
-            _DEFAULT_REFERENCE_TOTAL_MAX_BYTES,
-        )
-
-        return _DEFAULT_REFERENCE_TOTAL_MAX_BYTES, _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
-
-
 def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen = object.__new__(MediaGenerator)
     gen.project_path = tmp_path / "projects" / "demo"
@@ -159,7 +140,7 @@ def _build_generator(tmp_path: Path) -> MediaGenerator:
     gen._image_backend = _FakeImageBackend()
     gen._video_backend = _FakeVideoBackend()
     gen._user_id = "default"
-    gen._config = _FakeConfigResolver()
+    gen._config = FakeConfigResolver(requested_generate_audio=False)
     gen._image_provider_id = None
     gen._video_provider_id = None
     gen.versions = _FakeVersions()
@@ -968,7 +949,7 @@ class TestMediaGenerator:
     async def test_video_generate_audio_from_config_resolver(self, tmp_path):
         """验证 generate_video_async 通过 ConfigResolver 获取 audio 设置。"""
         gen = _build_generator(tmp_path)
-        gen._config = _FakeConfigResolver(video_generate_audio=False)
+        gen._config = FakeConfigResolver(requested_generate_audio=False)
 
         await gen.generate_video_async(
             prompt="p",
@@ -982,7 +963,7 @@ class TestMediaGenerator:
     async def test_video_generate_audio_respects_config_true(self, tmp_path):
         """验证 video_backend 尊重 ConfigResolver 返回的 True。"""
         gen = _build_generator(tmp_path)
-        gen._config = _FakeConfigResolver(video_generate_audio=True)
+        gen._config = FakeConfigResolver(requested_generate_audio=True)
 
         await gen.generate_video_async(
             prompt="p",

--- a/tests/integration/lib/test_media_generator_module.py
+++ b/tests/integration/lib/test_media_generator_module.py
@@ -975,7 +975,7 @@ class TestMediaGenerator:
     @pytest.mark.asyncio
     async def test_video_generate_audio_defaults_true_when_config_none(self, tmp_path):
         """当 self._config is None 时，fallback 默认 True，
-        与 ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO 对齐（PR7 §11）。"""
+        与 ConfigResolver._DEFAULT_VIDEO_GENERATE_AUDIO 对齐。"""
         gen = _build_generator(tmp_path)
         gen._config = None
 

--- a/tests/integration/lib/test_project_manager_concurrent_save.py
+++ b/tests/integration/lib/test_project_manager_concurrent_save.py
@@ -223,7 +223,7 @@ class TestSyncAfterConcurrentWrite:
 
 
 class TestConcurrentReadModifyWrite:
-    """并发 read-modify-write 不应丢更新（issue #334）。"""
+    """并发 read-modify-write 不应丢更新。"""
 
     def test_concurrent_update_scene_asset_preserves_all(self, tmp_path: Path) -> None:
         """并发对不同 segment 调用 update_scene_asset，所有写入都必须持久化。

--- a/tests/integration/lib/test_project_manager_concurrent_save.py
+++ b/tests/integration/lib/test_project_manager_concurrent_save.py
@@ -228,8 +228,8 @@ class TestConcurrentReadModifyWrite:
     def test_concurrent_update_scene_asset_preserves_all(self, tmp_path: Path) -> None:
         """并发对不同 segment 调用 update_scene_asset，所有写入都必须持久化。
 
-        修复前 load_script 在锁外、save_script 仅锁住写入，多个线程读到同一份快照后
-        互相覆盖，只有最后一个写者的更新存活。locked_script 把整段 RMW 收进单锁后应全部保留。
+        整段 read-modify-write 必须收进 locked_script 的单锁内：读在锁外时多个线程会拿到
+        同一份快照并互相覆盖，只有最后一个写者的更新存活。
         """
         pm = ProjectManager(tmp_path)
         name = "proj-rmw"
@@ -286,7 +286,7 @@ class TestConcurrentReadModifyWrite:
 
 
 def test_loaded_json_not_extra_data_after_save_script(tmp_path: Path) -> None:
-    """回归：save_script 后磁盘内容必须是单个 JSON 对象，不能有 Extra data。"""
+    """save_script 后磁盘内容必须是单个 JSON 对象，不能有 Extra data。"""
     pm = ProjectManager(tmp_path)
     name = "proj-regress"
     _seed_project(pm, name)

--- a/tests/integration/server/services/test_execute_reference_video_task.py
+++ b/tests/integration/server/services/test_execute_reference_video_task.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from lib.reference_video.request_projection import resolve_reference_assets
+from tests.fakes import FakeConfigResolver
 from tests.integration.server.services.reference_video_tasks_support import (
     _TINY_PNG,
     _register_asset_sheet,
@@ -1355,18 +1356,6 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
 
             yield _Call()
 
-    class _FakeConfigResolver:
-        async def video_generate_audio(self, _project_name=None):
-            return False
-
-        async def reference_payload_limits(self, _provider_id=None):
-            from lib.config.service import (
-                _DEFAULT_REFERENCE_SINGLE_MAX_BYTES,
-                _DEFAULT_REFERENCE_TOTAL_MAX_BYTES,
-            )
-
-            return _DEFAULT_REFERENCE_TOTAL_MAX_BYTES, _DEFAULT_REFERENCE_SINGLE_MAX_BYTES
-
     # object.__new__ 绕过 MediaGenerator.__init__（避开 __init__ 里的 Ledger 对 DB 的初始化）
     real_gen = object.__new__(MediaGenerator)
     real_gen.project_path = proj_dir
@@ -1375,7 +1364,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     real_gen._image_backend = None
     real_gen._video_backend = _FakeVideoBackend()
     real_gen._user_id = "u1"
-    real_gen._config = _FakeConfigResolver()
+    real_gen._config = FakeConfigResolver(requested_generate_audio=False)
     real_gen._image_provider_id = None
     real_gen._video_provider_id = None
     real_gen.versions = VersionManager(proj_dir)

--- a/tests/integration/server/services/test_execute_reference_video_task.py
+++ b/tests/integration/server/services/test_execute_reference_video_task.py
@@ -1443,7 +1443,7 @@ async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, m
         {"script_file": "scripts/episode_1.json"},
         user_id="u1",
     )
-    # 单次调用：R2V 层不再做二次压缩重试
+    # 单次调用：R2V 层不做二次压缩重试
     assert call_count["n"] == 1
     assert result["resource_id"] == "E1U1"
     # 传给咽喉层的恰是源 sheet 路径（项目目录内真实文件），而非临时压缩副本——

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -276,8 +276,8 @@ class TestResponseHandling:
         b64 = base64.b64encode(raw).decode("ascii")
         download = AsyncMock()
         out = tmp_path / "o.png"
-        # 不接管 download：base64 路径独立落盘
-        with _generation_route(_b64_response(b64)):
+        # download 接入路由，使末尾的 assert_not_called 真能证明 base64 路径独立落盘、不触下载
+        with _generation_route(_b64_response(b64), download):
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")

--- a/tests/unit/lib/test_accounting_characterization.py
+++ b/tests/unit/lib/test_accounting_characterization.py
@@ -14,7 +14,7 @@ CostCalculator → 定价策略）的落库行为逐字段锁定：链路内部�
 started_at / finished_at 可精确断言。SQLite 回读 DateTime(timezone=True) 为 naive
 datetime，跨 session 的 finish/finalize 中相减前按 UTC 补齐 naive 一侧 tzinfo 再与
 aware(finished_at) 相减，duration_ms 按真实步进（单次 start→finish 为 5000ms）回写
-（PostgreSQL 下同样为真实时长，不再分岔）。created_at / updated_at 由 ORM 列默认绑定
+（PostgreSQL 下同样为真实时长，不分岔）。created_at / updated_at 由 ORM 列默认绑定
 真实时钟、非记账语义字段，仅断言为 datetime。
 """
 

--- a/tests/unit/lib/test_accounting_characterization.py
+++ b/tests/unit/lib/test_accounting_characterization.py
@@ -49,6 +49,7 @@ from lib.video_backends.base import (
 from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession, SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
+from tests.fakes import FakeConfigResolver
 
 # ---------------------------------------------------------------------------
 # 冻结时钟：写入侧（usage_repo.utc_now）是 aware datetime，SQLite 回读为 naive。
@@ -353,16 +354,6 @@ class _FakeTextBackend:
         )
 
 
-class _FakeConfigResolver:
-    """generate/resume_video_async 仅消费 video_generate_audio 这一个配置读点。"""
-
-    def __init__(self, *, video_generate_audio: bool = True) -> None:
-        self._video_generate_audio = video_generate_audio
-
-    async def video_generate_audio(self, project_name: str | None = None) -> bool:
-        return self._video_generate_audio
-
-
 def _media_generator(
     tmp_path: Path,
     db: _AccountingDb,
@@ -384,7 +375,7 @@ def _media_generator(
         image_backend=image_backend,
         video_backend=video_backend,
         audio_backend=audio_backend,
-        config_resolver=cast(ConfigResolver, _FakeConfigResolver()),
+        config_resolver=cast(ConfigResolver, FakeConfigResolver()),
         image_provider_id=image_provider_id or (image_backend.name if image_backend else None),
         video_provider_id=video_provider_id or (video_backend.name if video_backend else None),
         audio_provider_id=audio_provider_id or (audio_backend.name if audio_backend else None),

--- a/tests/unit/lib/test_media_generator_resume.py
+++ b/tests/unit/lib/test_media_generator_resume.py
@@ -222,7 +222,7 @@ async def test_resume_expired_flips_pending_to_failed(tmp_path):
     call = gen.ledger.resumed[0]
     assert call["call_id"] == 42
     assert call["status"] == "failed"
-    # 零费用不重扣的语义已收进 ledger.resume_failed 内部（cost_amount=0.0），补账入参不再显式承载
+    # 零费用不重扣的语义收在 ledger.resume_failed 内部（cost_amount=0.0），补账入参不显式承载
 
 
 @pytest.mark.asyncio
@@ -262,7 +262,7 @@ async def test_resume_calls_add_version_after_download(tmp_path):
     # add_version 必须发生在下载之后：进入 resume_video 时 add_calls 还是 0
     assert probe.add_calls_at_resume == 0
     assert len(gen.versions.add_calls) == 1
-    # 不再在开头/末尾调 ensure_current_tracked（避免错位登记残留文件）
+    # 开头/末尾不调 ensure_current_tracked（避免错位登记残留文件）
     assert gen.versions.ensure_calls == []
 
 

--- a/tests/unit/lib/test_media_generator_resume.py
+++ b/tests/unit/lib/test_media_generator_resume.py
@@ -19,7 +19,7 @@ import pytest
 
 from lib.media_generator import MediaGenerator
 from lib.video_backends.base import ResumeExpiredError
-from tests.fakes import select_formal_video
+from tests.fakes import FakeConfigResolver, select_formal_video
 
 
 class _FakeVideoResult:
@@ -133,11 +133,6 @@ class _FakeLedger:
         return self._resume_affected
 
 
-class _FakeConfigResolver:
-    async def video_generate_audio(self, _project_name=None):
-        return True
-
-
 def _build_generator(tmp_path: Path, *, initial_version: int = 0) -> MediaGenerator:
     gen = object.__new__(MediaGenerator)
     gen.project_path = tmp_path / "projects" / "demo"
@@ -147,7 +142,7 @@ def _build_generator(tmp_path: Path, *, initial_version: int = 0) -> MediaGenera
     gen._image_backend = None
     gen._video_backend = _FakeVideoBackend()
     gen._user_id = "default"
-    gen._config = _FakeConfigResolver()
+    gen._config = FakeConfigResolver()
     gen.versions = _FakeVersions(initial_version=initial_version)
     gen.ledger = _FakeLedger()
     return gen

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -371,10 +371,10 @@ class TestOpenAIVideoBackend:
         assert result.video_path == output_path
 
     async def test_first_retrieve_completed_skips_polling_sleep(self, tmp_path: Path):
-        """首次 retrieve 即返回 completed 时走 fast-path：只查一次就下载，不进 poll_with_retry。
+        """首次 retrieve 即返回 completed 时只查一次、不等 poll_interval 就下载。
 
-        poll_with_retry 是「先查再等」，落进轮询循环必然多出一次 retrieve，记录的查询次数
-        足以判定 fast-path 有没有生效。
+        _poll_until_complete 无条件走 poll_with_retry；其循环「先查再等」，首查即终态
+        时直接返回、不落入 sleep。记录的查询次数足以判定该次序成立。
         """
         retrieved: list[str] = []
 
@@ -402,12 +402,12 @@ class TestOpenAIVideoBackend:
             )
             await backend.generate(request)
 
-        # fast-path：只查一次，不进入 poll_with_retry
+        # 首查即 completed：poll_with_retry 一次 retrieve 即返回，不再多查
         assert retrieved == ["vid_123"]
         assert output_path.read_bytes() == b"v"
 
     async def test_first_retrieve_failed_skips_polling(self, tmp_path: Path):
-        """首次 retrieve 即返回 failed 时应 fast-path 直接抛错，不进入 poll_with_retry 的 sleep。"""
+        """首次 retrieve 即返回 failed 时直接抛错：poll_with_retry 首查经 is_failed 判定即抛，不落入 sleep。"""
         err = MagicMock()
         err.message = "moderation rejected"
         failed = _make_mock_video(status="failed")
@@ -501,8 +501,7 @@ class TestOpenAIVideoBackend:
         assert output_path.read_bytes() == video_data
 
     async def test_poll_recognizes_expired_status(self, tmp_path: Path):
-        """fix #647 #5：retrieve 返回 status='expired' → 抛 ResumeExpiredError，
-        而不是白等 max_wait。"""
+        """retrieve 返回 status='expired' → 抛 ResumeExpiredError，而不是白等 max_wait。"""
         from lib.video_backends.base import ResumeExpiredError
 
         mock_client = AsyncMock()
@@ -525,7 +524,7 @@ class TestOpenAIVideoBackend:
             assert ei.value.provider == PROVIDER_OPENAI
 
     async def test_is_openai_not_found_no_loose_string_match(self):
-        """fix #647 #6：移除 "not found" / "expired" 子串兜底，避免业务字符串误判。"""
+        """不做 "not found" / "expired" 子串兜底，避免业务字符串误判；只认结构化 404。"""
         from lib.video_backends.openai import _is_openai_not_found
 
         assert _is_openai_not_found(RuntimeError("file not found in storage")) is False

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -406,7 +406,7 @@ class TestOpenAIVideoBackend:
         assert retrieved == ["vid_123"]
         assert output_path.read_bytes() == b"v"
 
-    async def test_first_retrieve_failed_skips_polling(self, tmp_path: Path):
+    async def test_first_retrieve_failed_raises_before_sleep(self, tmp_path: Path):
         """首次 retrieve 即返回 failed 时直接抛错：poll_with_retry 首查经 is_failed 判定即抛，不落入 sleep。"""
         err = MagicMock()
         err.message = "moderation rejected"

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -161,7 +161,7 @@ class TestOpenAIVideoBackend:
         mock_client.videos.download_content.assert_not_called()
 
     async def test_duration_passthrough(self, tmp_path: Path):
-        """所有 duration 值应原值透传到 SDK，不再被 _map_duration 篡改。"""
+        """所有 duration 值应原值透传到 SDK，不被 _map_duration 改写。"""
         mock_client = AsyncMock()
         _stub_client_completed(mock_client, seconds="6")
 
@@ -402,7 +402,7 @@ class TestOpenAIVideoBackend:
             )
             await backend.generate(request)
 
-        # 首查即 completed：poll_with_retry 一次 retrieve 即返回，不再多查
+        # 首查即 completed：poll_with_retry 一次 retrieve 即返回，不多查
         assert retrieved == ["vid_123"]
         assert output_path.read_bytes() == b"v"
 

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -333,8 +333,8 @@ class TestOpenAIVideoBackend:
     async def test_polls_until_completed_for_nonstandard_status(self, tmp_path: Path):
         """OpenAI 兼容网关返回非标 status（如 NOT_START / running）时，必须继续轮询直到 completed。
 
-        回归 issue：grok-imagine 走自定义供应商时，retrieve 返回 NOT_START，但 SDK 内置 poll
-        仅识别 4 种标准状态，会提前退出导致下载未就绪任务（400 Task is not completed yet）。
+        SDK 内置 poll 只识别 4 种标准状态，遇到非标状态会提前退出并下载未就绪任务
+        （400 Task is not completed yet），因此后端不得依赖它。
         """
         mock_client = AsyncMock()
         mock_client.videos.create = AsyncMock(return_value=_make_mock_video(status="queued"))

--- a/tests/unit/server/test_app_module.py
+++ b/tests/unit/server/test_app_module.py
@@ -54,7 +54,7 @@ class TestAppModule:
 
     @pytest.mark.asyncio
     async def test_lifespan_clears_callback_after_worker_stop(self, monkeypatch):
-        """fix #647 #7：lifespan 应先 worker.stop()（drain inflight + callback 仍可用），
+        """lifespan 应先 worker.stop()（drain inflight + callback 仍可用），
         再清掉 set_worker_cancel_callback(None)。
         """
         from lib.generation_queue import get_generation_queue

--- a/tests/unit/test_compose_video_filter_graph.py
+++ b/tests/unit/test_compose_video_filter_graph.py
@@ -185,9 +185,8 @@ class TestBuildXfadeFilterComplex:
     def test_no_semicolon_inside_audio_input_labels(self) -> None:
         """audio 输入标签之间不能出现 `;` 分隔。
 
-        旧实现用 `";".join([f"[{i}:a]"...])` 拼接成 `[0:a];[1:a];[2:a]concat=...`，
-        分号会被 ffmpeg 当作 filter chain 分隔符，导致 concat 输入参数不足报错。
-        新实现走 acrossfade 链，自然不会出现 `[N:a];[M:a]` 这种相邻片段。
+        `;` 是 ffmpeg 的 filter chain 分隔符，相邻 audio 输入标签之间出现它会切断
+        滤镜链、使下游输入参数不足而报错；音频走 acrossfade 链逐段串联即可避免。
         """
         result = compose_video._build_xfade_filter_complex([5.0, 5.0, 5.0], ["fade", "fade"], 0.5)
         assert result is not None

--- a/tests/unit/test_compose_video_filter_graph.py
+++ b/tests/unit/test_compose_video_filter_graph.py
@@ -1,6 +1,6 @@
 """compose_video.py 滤镜图构造与 fps 解析的纯函数单测。
 
-不依赖 ffmpeg / ffprobe，覆盖以下回归断言：
+不依赖 ffmpeg / ffprobe，覆盖以下断言：
 
 - `_resolve_fps`：avg_frame_rate `"0/0"`/`"0"`/`""` 显式回退到 r_frame_rate，
   而不是被 `or` 链当作真值通过
@@ -92,9 +92,8 @@ class TestResolveFps:
 class TestCoerceNumericDuration:
     """ffprobe duration 字段的容错解析。
 
-    ffprobe 对部分 webm / 流式封装会返回 `stream.duration="N/A"`，
-    这是真值字符串但不是数值；旧实现 `stream.duration or format.duration` 会
-    选中 "N/A" 然后 float() 抛错，导致正常视频被拒。这里覆盖该回归。
+    ffprobe 对部分 webm / 流式封装会返回 `stream.duration="N/A"`：这是真值字符串但不是
+    数值，`or` 链会选中它并让 float() 抛错。非数值真值必须在转换前被拒并回退到下一个来源。
     """
 
     def test_numeric_string_parses(self) -> None:

--- a/tests/unit/test_compose_video_filter_graph.py
+++ b/tests/unit/test_compose_video_filter_graph.py
@@ -3,13 +3,13 @@
 不依赖 ffmpeg / ffprobe，覆盖以下回归断言：
 
 - `_resolve_fps`：avg_frame_rate `"0/0"`/`"0"`/`""` 显式回退到 r_frame_rate，
-  而不是被 `or` 链当作真值通过（issue #562、#564 第 5 条）
+  而不是被 `or` 链当作真值通过
 - `_build_xfade_filter_complex`：
   - 全 cut → 返回 None（调用方 fallback 到 concatenate_final）
-  - 多片段 xfade chain + acrossfade chain 音画对齐（#564 第 3 条）
-  - cut+xfade 混用按 cut 分组、组内 offset 不跨 cut 累加（#564 评论补充）
+  - 多片段 xfade chain + acrossfade chain 音画对齐
+  - cut+xfade 混用按 cut 分组、组内 offset 不跨 cut 累加
   - 短片段边界自动降级为 cut（避免负 offset）
-  - audio 输入标签用空串连接而非 `;` 分隔（#564 第 1 条核心回归）
+  - audio 输入标签用空串连接而非 `;` 分隔
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ compose_video = _load_module()
 
 class TestResolveFps:
     def test_avg_0_over_0_falls_back_to_r(self) -> None:
-        """#562 核心场景：avg 为 '0/0' 时必须回退 r，不能直接被 `or` 当真值通过。"""
+        """avg 为 '0/0' 时必须回退 r，不能直接被 `or` 当真值通过。"""
         assert compose_video._resolve_fps("0/0", "24/1") == "24/1"
 
     def test_avg_0_falls_back_to_r(self) -> None:
@@ -183,7 +183,7 @@ class TestBuildXfadeFilterComplex:
         assert "[g0v1][2:v]xfade=transition=fade:duration=0.5:offset=9.000[g0v]" in result
 
     def test_no_semicolon_inside_audio_input_labels(self) -> None:
-        """#564 第 1 条核心回归：audio 输入标签之间不能出现 `;` 分隔。
+        """audio 输入标签之间不能出现 `;` 分隔。
 
         旧实现用 `";".join([f"[{i}:a]"...])` 拼接成 `[0:a];[1:a];[2:a]concat=...`，
         分号会被 ffmpeg 当作 filter chain 分隔符，导致 concat 输入参数不足报错。
@@ -196,7 +196,7 @@ class TestBuildXfadeFilterComplex:
         assert "[1:a];[2:a]" not in result
 
     def test_cut_xfade_mix_groups_by_cut(self) -> None:
-        """#564 评论补充：cut+xfade 混用按 cut 分组。
+        """cut+xfade 混用按 cut 分组。
 
         durations=[5,5,5,5], transitions=["fade","cut","fade"]
         → group A=[0,1], group B=[2,3]，组间 concat 串联
@@ -364,7 +364,7 @@ class TestConcatenateFinalSingleSegment:
     def test_single_clip_skips_concat_filter(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """单段输入应走 `-c copy + faststart` 直接 remux，不走 concat filter。
 
-        #564 第 2 条：concat=n=1 会让 ffmpeg 报参数错误。
+        concat=n=1 会让 ffmpeg 报参数错误。
         """
         captured: list[list[str]] = []
 


### PR DESCRIPTION
Closes #2052

Spec #1989 清尾轮收口票：收编批内评审与 follow-up 池中验证仍存在的机械性散件。纯测试与忽略清单改动，不触生产代码。

## 落地情况（issue 六项，全部落地、无留置）

1. `.gitignore` 的 `# Test coverage` 段补 `coverage.xml`、`coverage-pg.xml`（原 `coverage/` 尾斜杠仅匹配目录）。
2. 删除死代码替身 `tests/fakes.py:fake_reference_caps_fetcher`（全仓零消费方，grep 复核确认），连带清掉仅为其存在的 `VoiceRenderSettings` TYPE_CHECKING import。
3. 4 处手写 `_FakeConfigResolver` 全部收编共享 `tests.fakes.FakeConfigResolver`。共享替身原缺 `MediaGenerator` 消费的两个读点，为其新增生产同名 `video_generate_audio(project_name)` 与 `reference_payload_limits(provider_id)`（后者可配置、默认与生产 `provider_id is None` 分支同取 service 层保守默认）。逐处默认值比对无翻转：`test_media_generator_module` 原 False → 显式 `requested_generate_audio=False`；`test_accounting_characterization` 原 True → 默认 True；`test_media_generator_resume` 原 True → 默认 True；`test_execute_reference_video_task` 原 False → 显式 False。共享替身与被替换的 4 处手写一样不模拟项目层覆盖，相对原状零行为差异。
4. 清理测试内过程性追踪编号注释（CLAUDE.md：注释仅描述当前行为与约束，变更原因写 commit/PR）。**扩围**：除 issue 清单 13 处外，同文件 `tests/unit/test_compose_video_filter_graph.py` 的 :55/:186/:199/:367 及模块 docstring 块内其余编号引用一并清理——同一文件内留半数编号引用会让后续读者误以为剩下的有特殊含义，一次清干净。
5. 修复恒真断言：`test_minimax_image_backend.py::test_base64_response_decoded_and_saved` 的 `download` 接入 `_generation_route(resp, download)`，路由内 patch `download_image_to_path`，末尾 `download.assert_not_called()` 现真能证明 base64 路径独立落盘、不触下载。
6. 修正 `test_openai_video_backend.py` 两处失实 docstring：生产 `_poll_until_complete` 无条件走 `poll_with_retry`，并无 fast-path 绕过；单次 retrieve 来自 `poll_with_retry` 自身「先查 → is_failed 抛 → is_done 返回 → sleep」的次序。仅改注释。

## 本地审查追加修复

- `FakeConfigResolver` 的 `video_generate_audio` 与 `video_generate_audio_for_project` 原共用 `generate_audio_calls`，两读点入参类型不同（项目名 / project dict）挤进同一列表，用例等值断言会被另一条路径串味；改为各记各的 `generate_audio_project_names` / `generate_audio_calls`。
- `test_first_retrieve_failed_skips_polling` 名字与第 6 项澄清后的机制矛盾（并未跳过轮询，只是首查即抛、不落 sleep），改名 `test_first_retrieve_failed_raises_before_sleep`。

## 验证

本分支基于最新 `origin/main`（ccabe4393）rebase 后全量重跑：

- `uv run ruff check .` 通过；`ruff format --check` 1371 文件已格式化
- `uv run basedpyright` 0 errors
- `uv run lint-imports` 2 kept, 0 broken
- `uv run python scripts/audit_tests.py --check` 0 处违规
- `uv run python -m pytest` 10291 passed, 2 skipped
- `frontend: pnpm lint` 通过；`pnpm check` 155 test files / 1889 tests 全通过

追加修复后定向复跑受影响的 7 个测试文件：253 passed。

## 保留的判断题

`FakeConfigResolver` 新增的 `reference_payload_limits` 构造参数与 `reference_limits_calls` 记录器目前无用例消费。保留：该类既有形状即「每个读点一对 kwarg + 记录器」，新增读点遵循同一惯例，不为此单独破例。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试与质量**
  - 统一测试替身和配置解析测试支持，提升测试复用性与可维护性。
  - 完善媒体生成、参考载荷限制及视频轮询流程的测试覆盖。
  - 更新测试说明和命名，移除内部问题编号并明确行为描述。
- **工程维护**
  - 补充测试覆盖率报告的忽略规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->