### PR TITLE
chore(skills): squash stage integration fixes

### DIFF
--- a/.agents/skills/afk-team-workflow/SKILL.md
+++ b/.agents/skills/afk-team-workflow/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # AFK 团队执行流程
 
-你是 team-lead：把一个 Spec 的子 issue 或一组显式 issue 无人值守推进到全部合并或明确暂停。你负责计划、调度、集成与裁决；不实现 issue，只处理 stage 集成修复与 rebase 冲突。开工后持续运行到批次终态；中途不把调度问题升级给用户，真实业务取舍例外。
+你是 team-lead：把一个 Spec 的子 issue 或一组显式 issue 无人值守推进到全部合并或明确暂停。你负责计划、调度、集成与裁决，不写代码。开工后持续运行到批次终态；中途不把调度问题升级给用户，真实业务取舍例外。
 
 ## 1. 计划批次
 
@@ -22,14 +22,14 @@ disable-model-invocation: true
 
 严格串行执行各 stage：
 
-1. 从最新 `origin/main` 创建 `afk/<batch-id>/stage-<K>` 与专属 worktree，由 team-lead 独占并 push。
+1. 从最新 `origin/main` 创建 `afk/<batch-id>/stage-<K>` 与专属 worktree，并 push stage branch。
 2. 将依赖已满足且改动面可安全并发的 frontier 认领并委派。每个 issue 使用独立 worktree：implementer 按 [implementer.md](references/implementer.md) 交付后，由未参与实现的 local-reviewer 复用该 worktree，按 [local-reviewer.md](references/local-reviewer.md) 审查并交付一个 issue commit。不同 issue 的接力可自然重叠。
 3. team-lead 在 stage worktree 串行 cherry-pick 已审查的 issue commits 并 push。冲突时 abort，由原 local-reviewer 基于最新 stage branch 解决、验证并重新交付。带 `Refs #<N>` 的 commit 出现在远程 stage branch 后，该 issue 才算完成并可解锁新 frontier。
-4. 最后一个 stage 先聚合全批 handoff 的 follow-up：只处理经验证存在、属于批次范围且无需业务取舍的真缺陷；清尾 issue 创建后，Spec 批次按 [issue-tracker 约定](../../../docs/agents/issue-tracker.md) 挂接父 Spec，并沿用同一接力；其余转呈。全部 issues 集成后收敛 **green HEAD**：stage worktree 与 remote HEAD 一致、干净且累计质量门通过；质量门产生的改动提交为 integration-fix 并 push。持续、不可用或无法修复的质量门故障记为 `fault`，暂停并询问用户。达标后创建 ready PR，用 `Closes #<N>` 覆盖本 stage issues。Spec 批次另用 `Refs #<Spec>` 引用 Spec，不自动关闭它。将 stage worktree 与 branch 的独占写权交给新 agent，按 [review-looper.md](references/review-looper.md) 收敛整个 stage diff；交接期间 team-lead 不写该 worktree 或 branch。收回写权后核对达标 HEAD 等于当前 `headRefOid` 且 `mergeable=MERGEABLE`，以该 `headRefOid` 为 expected-head 执行 rebase merge；不匹配则重入审查循环。下一 stage 从最新 `origin/main` 开始。
+4. 最后一个 stage 先聚合全批 handoff 的 follow-up：只处理经验证存在、属于批次范围且无需业务取舍的真缺陷；清尾 issue 创建后，Spec 批次按 [issue-tracker 约定](../../../docs/agents/issue-tracker.md) 挂接父 Spec，并沿用同一接力；其余转呈。全部 issues 集成后创建 draft PR，用 `Closes #<N>` 覆盖本 stage issues；Spec 批次另用 `Refs #<Spec>` 引用 Spec，不自动关闭它。启动 review-looper 收敛 **green HEAD**、stage diff 与 commit history。agent 回报达标 HEAD 后，核对其等于当前 `headRefOid` 且 `mergeable=MERGEABLE`，以该 `headRefOid` 为 expected-head 执行 rebase merge；不匹配则重入审查循环。下一 stage 从最新 `origin/main` 开始。
 
 ## 3. 暂停边界
 
-实现或审查暴露真实业务取舍，或发现 Spec 要求没有 issue 覆盖时，暂停受影响事项及其下游并询问用户。**quiesce first**：停止受影响 agents 并废弃未集成 handoff；stage 写权已交出时，先停止 review-looper 写入并连同 worktree、branch、remote HEAD 与 handoff 收回。然后为已有 issue 移除 `ready-for-agent`、添加 `ready-for-human`，记录原因，并将暂停范围移出当前 stage。其余 frontier 继续执行。用户决定继续时：已有 issue 恢复标签；Spec gap 先创建并挂为 sub-issue，再重新编排。决定保留暂停时，仅当相关 commit 已进入 stage branch 才重建 stage，排除该 issue 及其下游；已有 PR 同步更新 `Closes` 清单。重建后重新运行累计质量门与审查循环。
+实现或审查暴露真实业务取舍，或发现 Spec 要求没有 issue 覆盖时，暂停受影响事项及其下游并询问用户。**quiesce first**：停止受影响 agents 并废弃未集成 handoff；review-looper 运行时，先停止它并核对 worktree、branch、remote HEAD 与 handoff。然后为已有 issue 移除 `ready-for-agent`、添加 `ready-for-human`，记录原因，并将暂停范围移出当前 stage。其余 frontier 继续执行。用户决定继续时：已有 issue 恢复标签；Spec gap 先创建并挂为 sub-issue，再重新编排。决定保留暂停时，仅当相关 commit 已进入 stage branch 才重建 stage，排除该 issue 及其下游；已有 PR 同步更新 `Closes` 清单。重建后重新运行累计质量门与审查循环。
 
 可吸收的运行故障、reviewer 重复噪声与无需业务选择的技术裁决由 team-lead 处理并记账；阻断 **green HEAD** 且无法自行恢复的故障按上文暂停。
 

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -1,11 +1,12 @@
 # Stage AI 审查循环契约
 
-你负责把一个 stage PR 推进到全部 AI reviewers 通过的可合并状态。
+你负责把一个 stage PR 推进到 **green HEAD**、全部 AI reviewers 通过且可合并。
 
 输入：PR、stage branch、stage worktree、本 stage issues、batch handoff 目录、stage handoff 绝对路径。
 
-1. 接受 team-lead 交出的 stage worktree 与 branch 独占写权；确认两者与远程最新提交一致，读 stage 内所有 issue 及其 handoff，以合并后的验收边界审查整个 stage diff。
-2. 运行 `/pr-ai-review-loop`，采用其评论、CI、pushback、等待与终核纪律；以目标状态全部达成为终点。轮数、边际收益与重复主题只是给 team-lead 的诊断信号，其软收敛出口与故障询问均先上报 team-lead。
-3. 普通审查修复以额外 conventional integration-fix commits 普通 push，保持 stage branch 追加式前进。`/pr-ai-review-loop` 需要 rebase 或 force-push 时停止写入并把独占写权交回 team-lead；team-lead 将 stage rebase 到最新 `origin/main`，解决冲突、运行累计质量门，把质量门产生的改动提交为 integration-fix，确认工作树干净后用 `--force-with-lease` 更新远程。保留每个 issue 的单个 conventional commit 与 `Refs #<N>`，按 [handoff.md](handoff.md) 记录新旧 HEAD 后重新交出写权，从新 HEAD 重启本循环。
-4. reviewer 意见超出批次范围时回复说明边界，并记为 follow-up。意见涉及真实业务取舍时请示 team-lead；team-lead 按主流程的暂停边界持久化 issue 状态并阻断当前 stage 合并，直到用户裁决并完成对应恢复或重建。
-5. 终核通过后按 [handoff.md](handoff.md) 追加「审查循环」段，把独占写权连同达标 HEAD 与轮数交回 team-lead，等待合并后退役。
+1. 确认 stage worktree、branch 与远程最新提交一致，读 stage 内所有 issue 及其 handoff，以合并后的验收边界审查整个 stage diff。
+2. 运行累计质量门，修复并以 conventional integration-fix commit push；持续失败时记为 `fault` 并上报 team-lead。达到 **green HEAD** 后将 PR 转为 ready。
+3. 运行 `/pr-ai-review-loop`，采用其评论、CI、pushback、等待与终核纪律；以目标状态全部达成为终点。普通修复以额外 integration-fix commits push。软收敛出口与故障询问均先上报 team-lead。
+4. 收到 rebase 指令时，rebase 到最新 `origin/main`，解决冲突、重跑累计质量门，以 `--force-with-lease` push，并按 [handoff.md](handoff.md) 记录新旧 HEAD。保留每个 issue 的单个 conventional commit 与 `Refs #<N>`。
+5. reviewer 意见超出批次范围时回复说明边界，并记为 follow-up。意见涉及真实业务取舍时请示 team-lead；team-lead 按主流程的暂停边界持久化 issue 状态并阻断当前 stage 合并，直到用户裁决并完成对应恢复或重建。
+6. 终核通过后，将本 stage 的所有非 issue commits 压成一个 conventional integration-fix commit。确认压缩前后 tree 一致后，以 `--force-with-lease` push；新 HEAD 的 required checks 通过后，按 [handoff.md](handoff.md) 追加「审查循环」段，回报达标 HEAD 与轮数并停止。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,7 +293,7 @@ AFK 团队流程的短期运行分支例外使用 `afk/<batch-id>/stage-<K>` 与
 
 每个 PR 压缩为 1 个 commit 合并回 `main`，commit message 遵循 conventional commits 规范（见下节）。GitHub 上选择 "Squash and merge"。
 
-`afk-team-workflow` 生成的 stage PR 是例外：它用 "Rebase and merge" 保留每个 issue 的 conventional commit，以及可追溯的清尾与 integration-fix commits。
+`afk-team-workflow` 生成的 stage PR 是例外：它用 "Rebase and merge" 保留每个 issue 的 conventional commit；清尾与 review loop 产生的非 issue commits 在合并前压成一个 conventional integration-fix commit。
 
 ## 提交规范
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/dev/contributing.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/dev/contributing.md
@@ -258,7 +258,7 @@ The time from creation to merge must be ≤3 days. If it runs longer, split it o
 
 Squash each PR into one commit when merging into `main`, with a conventional commit message (see the next section). Choose "Squash and merge" from the GitHub merge button.
 
-Stage PRs created by `afk-team-workflow` are the exception: rebase-merge them to preserve each issue's conventional commit plus cleanup and integration-fix commits.
+Stage PRs created by `afk-team-workflow` are the exception: rebase-merge them to preserve each issue's conventional commit; squash non-issue cleanup and review-loop commits into one conventional integration-fix commit before merging.
 
 ## Commit Conventions {#commit-convention}
 


### PR DESCRIPTION
## 范围

调整 `afk-team-workflow` 的 stage 收敛与提交历史约定，并同步中英文贡献文档。不改动产品代码。

## 变更

- 保留每个 issue commit，将清尾与 review loop 的非 issue commits 压成一个 conventional integration-fix commit
- squash 后验证 tree 未变并等待新 HEAD 的 required checks，不重复 AI review loop
- 删除不可执行的“写权”概念；review-looper 角色说明仅通过 spawn prompt 路由

## 验收清单

- [x] 本地已跑相关校验：`git diff --check`
- [x] 手动核对 team-lead 主流程与 review-looper 契约的职责边界
- [x] 中英文贡献文档已同步
- [x] 无新增 ESLint disable
- [ ] CODEOWNERS 要求的 review 已请求

`(cd website && pnpm check)` 未运行：独立 worktree 未安装 `node_modules`。

## 已知 defer

无。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新阶段工作流，明确负责人不直接编写代码，阶段分支不再由其独占。
  * 优化审查循环，补充质量检查、修复、变基、推送、故障上报及检查通过流程。
  * 集成后创建草稿 PR，并在暂停时停止审查循环，核对分支、工作区、远程状态及交接信息。
  * 调整合并规则：保留各问题的规范提交，并将清理与审查修复提交合并为一个集成修复提交。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->