### PR TITLE
feat(video): add Sub2API Grok subscription backend

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1012,6 +1012,7 @@ export default {
   'endpoint_openai_images_edits_display': 'OpenAI Images (I2I only)',
   'endpoint_gemini_image_display': 'Google Gemini Image',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
+  'endpoint_grok_sub2api_video_display': 'Grok Subscription Video (Sub2API)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
   'endpoint_v2_video_generations_display': 'V2 Video Generations',
   'endpoint_ark_seedance_display': 'Volcengine Ark (Seedance)',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -992,6 +992,7 @@ export default {
   'endpoint_openai_images_edits_display': 'Ảnh OpenAI (chỉ I2I)',
   'endpoint_gemini_image_display': 'Ảnh Google Gemini',
   'endpoint_openai_video_display': 'OpenAI Video (Sora)',
+  'endpoint_grok_sub2api_video_display': 'Video gói đăng ký Grok (Sub2API)',
   'endpoint_newapi_video_display': 'NewAPI Unified Video',
   'endpoint_v2_video_generations_display': 'V2 Video Generations',
   'endpoint_ark_seedance_display': 'Volcengine Ark (Seedance)',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1011,6 +1011,7 @@ export default {
   'endpoint_openai_images_edits_display': 'OpenAI 图片（仅图生图）',
   'endpoint_gemini_image_display': 'Gemini 图片',
   'endpoint_openai_video_display': 'OpenAI 视频 (Sora)',
+  'endpoint_grok_sub2api_video_display': 'Grok 订阅视频（Sub2API）',
   'endpoint_newapi_video_display': 'NewAPI 视频',
   'endpoint_v2_video_generations_display': 'V2 统一视频',
   'endpoint_ark_seedance_display': '火山方舟 (Seedance)',

--- a/lib/custom_provider/endpoints.py
+++ b/lib/custom_provider/endpoints.py
@@ -33,6 +33,7 @@ from lib.text_backends.openai import OpenAITextBackend
 from lib.video_backends.ark import ArkVideoBackend
 from lib.video_backends.base import VideoCapabilities
 from lib.video_backends.dashscope import DashScopeVideoBackend, classify_wan_model
+from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
 from lib.video_backends.kling import KlingVideoBackend
 from lib.video_backends.minimax import MiniMaxVideoBackend
 from lib.video_backends.newapi import NewAPIVideoBackend
@@ -146,6 +147,15 @@ def _build_openai_tts(provider, model_id: str) -> CustomAudioBackend:
 def _build_openai_video(provider, model_id: str) -> CustomVideoBackend:
     base_url = ensure_openai_base_url(provider.base_url)
     delegate = OpenAIVideoBackend(api_key=provider.api_key, base_url=base_url, model=model_id)
+    return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
+
+
+def _build_grok_sub2api_video(provider, model_id: str) -> CustomVideoBackend:
+    delegate = GrokSub2APIVideoBackend(
+        api_key=provider.api_key,
+        base_url=provider.base_url,
+        model=model_id,
+    )
     return CustomVideoBackend(provider_id=provider.provider_id, delegate=delegate, model=model_id)
 
 
@@ -304,6 +314,16 @@ ENDPOINT_REGISTRY: dict[str, EndpointSpec] = {
         build_backend=_build_openai_video,
         # OpenAI Sora input_reference 为单张首帧图。
         video_max_reference_images=1,
+    ),
+    "grok-sub2api-video": EndpointSpec(
+        key="grok-sub2api-video",
+        media_type="video",
+        family="grok",
+        display_name_key="endpoint_grok_sub2api_video_display",
+        request_method="POST",
+        request_path_template="/v1/videos/generations",
+        build_backend=_build_grok_sub2api_video,
+        video_caps_for_model=GrokSub2APIVideoBackend.video_capabilities_for_model,
     ),
     "newapi-video": EndpointSpec(
         key="newapi-video",
@@ -549,6 +569,8 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     列表常夹带 gemini-*/imagen-* 原生 id，必须按内容纠偏到 Google 端点，否则被错推到
     openai-chat/openai-images，每次都要手动改回。
 
+    0) Grok Imagine 视频 → "grok-sub2api-video"，使用 request-id status/content 协议，不误归同步
+       OpenAI video endpoint。
     1) 阿里百炼视频 → happyhorse / wan2.7 / wan3 家族（含 wan-2.7-xxx / wan-3-xxx 连字符形态、
        image-to-video 续接别名）走 "dashscope-async-video"（原生异步端点）。happyhorse 不在
        _VIDEO_PATTERN 须显式；万相视频抢在通用 is_video 前拦截。真正的图像变体不自动推 dashscope
@@ -562,17 +584,17 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
        请求构造，同样排除出原生路由（见 classify_wan_model 的 is_videoedit 处的说明）。
     2) MiniMax 原生 token → 海螺 / S2V 走 "minimax-video"，image-01 走 "minimax-image"。先于通用
        is_video/is_image 拦截：s2v 不在 _VIDEO_PATTERN、image-01 含 "image" 否则会被推到通用图像家族。
-    2.5) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
+    4) 可灵 kling token → 含 video 语义优先归 "kling-video"（kling-image2video 等 i2v 含 image
        语义但本质是视频）；其余含 image 语义走 "kling-image"，否则走 "kling-video"。kling 同时命中
        _VIDEO_PATTERN，须先于通用 is_video 拦截，否则视频会落到 openai-video；v3-omni 图像/视频同名
        默认归视频、图像手动选。
-    3) imagen → "gemini-image"（图像，不论 discovery_format）
-    4) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
-    5) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
-    6) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
-    7) TTS 家族（tts/speech/cosyvoice）→ "openai-tts"（audio 仅 OpenAI 兼容一条端点，
+    5) imagen → "gemini-image"（图像，不论 discovery_format）
+    6) gemini 原生模型（非 video）→ image 形态走 "gemini-image"，否则文本走 "gemini-generate"
+    7) 视频家族 → seedance→"ark-seedance"、viduq3→"vidu-video"、否则 "openai-video"
+    8) 图像家族 → discovery_format=google 走 "gemini-image" 否则 "openai-images"
+    9) TTS 家族（tts/speech/cosyvoice）→ "openai-tts"（audio 仅 OpenAI 兼容一条端点，
        不分 discovery_format；precedence 在 text 默认之前）
-    8) 默认（文本）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
+    10) 默认（文本）→ discovery_format=google 走 "gemini-generate" 否则 "openai-chat"
     """
     lowered = model_id.lower()
     is_image = bool(_IMAGE_PATTERN.search(model_id))
@@ -618,6 +640,9 @@ def infer_endpoint(model_id: str, discovery_format: str) -> str:
     # 走原生端点（见 classify_wan_model 的 has_known_modality 处的说明），落到下方 5) 的通用视频
     # 端点，避免本后端收到无法正确构造的请求。
     wan_unsupported_modality = is_wan_family and not classification.has_known_modality
+
+    if lowered == "grok-imagine-video" or lowered.startswith("grok-imagine-video-"):
+        return "grok-sub2api-video"
 
     # 阿里百炼视频先于通用 is_video 拦截到原生异步端点
     if classification.family == "happyhorse":

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import ColumnElement, func, select, text, update
@@ -946,6 +947,43 @@ class TaskRepository(BaseRepository):
 
         await self.session.commit()
         return len(requeued_tasks)
+
+    async def requeue_failed_pre_provider(self, task_ids: Sequence[str]) -> list[str]:
+        """Manually retry failed tasks that provably never crossed the provider boundary.
+
+        This is deliberately narrower than a general failed-task retry. A task is eligible only
+        when every submission marker is absent: no immutable execution checkpoint, provider job,
+        endpoint, or submitted base URL. The guarded UPDATE makes a stale operator observation
+        harmless and preserves the original task identity, request payload, and advisory provider.
+        """
+        requested_ids = list(dict.fromkeys(task_id for task_id in task_ids if task_id))
+        if not requested_ids:
+            return []
+
+        now = utc_now()
+        rows = await self.session.execute(
+            update(Task)
+            .where(
+                Task.task_id.in_(requested_ids),
+                Task.status == "failed",
+                Task.execution_checkpoint_json.is_(None),
+                Task.provider_job_id.is_(None),
+                Task.provider_endpoint.is_(None),
+                Task.submitted_base_url.is_(None),
+            )
+            .values(
+                status="queued",
+                started_at=None,
+                finished_at=None,
+                updated_at=now,
+                result_json=None,
+                error_message=None,
+            )
+            .returning(Task.task_id)
+        )
+        requeued_set = set(rows.scalars().all())
+        await self.session.commit()
+        return [task_id for task_id in requested_ids if task_id in requeued_set]
 
     async def get(self, task_id: str) -> dict[str, Any] | None:
         stmt = select(Task).where(Task.task_id == task_id)

--- a/lib/db/repositories/task_repo.py
+++ b/lib/db/repositories/task_repo.py
@@ -960,11 +960,58 @@ class TaskRepository(BaseRepository):
         if not requested_ids:
             return []
 
+        eligible_result = await self.session.execute(
+            select(Task).where(
+                Task.task_id.in_(requested_ids),
+                Task.status == "failed",
+                Task.execution_checkpoint_json.is_(None),
+                Task.provider_job_id.is_(None),
+                Task.provider_endpoint.is_(None),
+                Task.submitted_base_url.is_(None),
+            )
+        )
+        eligible_by_id = {task.task_id: task for task in eligible_result.scalars().all()}
+        if not eligible_by_id:
+            return []
+
+        def dedupe_key(task: Task) -> tuple[str, str, str, str, str]:
+            return (
+                task.project_name,
+                task.task_type,
+                task.resource_id,
+                task.script_file or "",
+                task.resource_type or "",
+            )
+
+        candidates = list(eligible_by_id.values())
+        active_result = await self.session.execute(
+            select(Task).where(
+                Task.status.in_(ACTIVE_TASK_STATUSES),
+                Task.project_name.in_({task.project_name for task in candidates}),
+                Task.task_type.in_({task.task_type for task in candidates}),
+                Task.resource_id.in_({task.resource_id for task in candidates}),
+            )
+        )
+        occupied_keys = {dedupe_key(task) for task in active_result.scalars().all()}
+        selected_ids: list[str] = []
+        for task_id in requested_ids:
+            task = eligible_by_id.get(task_id)
+            if task is None:
+                continue
+            key = dedupe_key(task)
+            if key in occupied_keys:
+                continue
+            occupied_keys.add(key)
+            selected_ids.append(task_id)
+
+        if not selected_ids:
+            return []
+
         now = utc_now()
         rows = await self.session.execute(
             update(Task)
             .where(
-                Task.task_id.in_(requested_ids),
+                Task.task_id.in_(selected_ids),
                 Task.status == "failed",
                 Task.execution_checkpoint_json.is_(None),
                 Task.provider_job_id.is_(None),
@@ -983,7 +1030,7 @@ class TaskRepository(BaseRepository):
         )
         requeued_set = set(rows.scalars().all())
         await self.session.commit()
-        return [task_id for task_id in requested_ids if task_id in requeued_set]
+        return [task_id for task_id in selected_ids if task_id in requeued_set]
 
     async def get(self, task_id: str) -> dict[str, Any] | None:
         stmt = select(Task).where(Task.task_id == task_id)

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -463,6 +463,14 @@ class GenerationQueue:
             logger.warning("回收 %d 个 running 任务", recovered)
         return recovered
 
+    async def requeue_failed_pre_provider_tasks(self, task_ids: list[str]) -> list[str]:
+        """Operator retry seam for failed tasks with no provider-submission evidence."""
+        async with self._task_repo() as repo:
+            requeued = await repo.requeue_failed_pre_provider(task_ids)
+        if requeued:
+            logger.warning("人工回队 %d 个未提交供应商的失败任务", len(requeued))
+        return requeued
+
     async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:
         async with self._task_repo() as repo:
             return await repo.list_orphan_tasks_on_start()

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -34,6 +34,7 @@ _VISUAL_BASIS_SCHEMA_VERSION = 2
 _LEGACY_SCHEMA_VERSION = 1
 _CHECKPOINT_KIND = "reference_video_submit"
 _STORYBOARD_CHECKPOINT_KIND = "storyboard_video_submit"
+_TEXT_VIDEO_CHECKPOINT_KIND = "text_video_submit"
 _STAGING_MANIFEST_VERSION = 1
 _TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -686,7 +687,7 @@ class _VideoSubmissionCheckpoint:
                     raise ValueError("reference_audio_targets do not match staged audio identities")
                 if any(target >= image_count for target in self.reference_audio_targets):
                     raise ValueError("reference audio target_index must address a staged reference image")
-        else:
+        elif self.kind == _STORYBOARD_CHECKPOINT_KIND:
             roles = tuple(item.role for item in self.media)
             if roles.count("start_image") != 1 or roles.count("end_image") > 1:
                 raise ValueError("storyboard checkpoint requires one start image and at most one end image")
@@ -694,6 +695,11 @@ class _VideoSubmissionCheckpoint:
                 raise ValueError("storyboard checkpoint contains reference media")
             if self.reference_audio_targets is not None:
                 raise ValueError("storyboard checkpoint cannot have reference_audio_targets")
+        else:
+            if self.media:
+                raise ValueError("text video checkpoint cannot contain provider media")
+            if self.reference_audio_targets is not None:
+                raise ValueError("text video checkpoint cannot have reference_audio_targets")
         _require_digest(self.request_digest, "request_digest")
         if self.request_digest != canonical_json_digest(self._request_digest_payload()):
             raise ValueError("request_digest does not match checkpoint request")
@@ -930,7 +936,17 @@ class StoryboardSubmissionCheckpoint(_VideoSubmissionCheckpoint):
     ARTIFACT_VISUAL_BASIS_KIND = "artifact-visual/video-storyboard"
 
 
-VideoSubmissionCheckpoint = ReferenceSubmissionCheckpoint | StoryboardSubmissionCheckpoint
+class TextVideoSubmissionCheckpoint(_VideoSubmissionCheckpoint):
+    """Immutable submit identity for a text-to-video unit."""
+
+    __slots__ = ()
+    CHECKPOINT_KIND = _TEXT_VIDEO_CHECKPOINT_KIND
+    ARTIFACT_VISUAL_BASIS_KIND = "artifact-visual/video-text"
+
+
+VideoSubmissionCheckpoint = (
+    ReferenceSubmissionCheckpoint | StoryboardSubmissionCheckpoint | TextVideoSubmissionCheckpoint
+)
 
 
 def checkpoint_version_metadata(checkpoint: VideoSubmissionCheckpoint) -> dict[str, object]:
@@ -978,12 +994,17 @@ def load_task_video_checkpoint(task: dict[str, Any]) -> VideoSubmissionCheckpoin
     except json.JSONDecodeError as exc:
         raise ValueError("execution checkpoint is not valid JSON") from exc
     kind = decoded.get("kind") if isinstance(decoded, dict) else None
-    checkpoint_type: type[ReferenceSubmissionCheckpoint] | type[StoryboardSubmissionCheckpoint]
+    checkpoint_type: (
+        type[ReferenceSubmissionCheckpoint] | type[StoryboardSubmissionCheckpoint] | type[TextVideoSubmissionCheckpoint]
+    )
     if kind == _CHECKPOINT_KIND:
         checkpoint_type = ReferenceSubmissionCheckpoint
         expected_task_type = "reference_video"
     elif kind == _STORYBOARD_CHECKPOINT_KIND:
         checkpoint_type = StoryboardSubmissionCheckpoint
+        expected_task_type = "video"
+    elif kind == _TEXT_VIDEO_CHECKPOINT_KIND:
+        checkpoint_type = TextVideoSubmissionCheckpoint
         expected_task_type = "video"
     else:
         raise ValueError("unsupported video submission checkpoint kind")
@@ -1042,6 +1063,7 @@ __all__ = [
     "ReferenceExecutionIdentityError",
     "ReferenceSubmissionCheckpoint",
     "StoryboardSubmissionCheckpoint",
+    "TextVideoSubmissionCheckpoint",
     "VideoResumeState",
     "VideoSubmissionCheckpoint",
     "StagedProviderMedia",

--- a/lib/video_artifact_facts.py
+++ b/lib/video_artifact_facts.py
@@ -13,6 +13,7 @@ from lib.speech_artifact_provenance import build_video_duration_basis
 
 _SCHEMA_VERSION = 1
 _STORYBOARD_VISUAL_KIND = "artifact-visual/video-storyboard"
+_TEXT_VISUAL_KIND = "artifact-visual/video-text"
 _REFERENCE_VISUAL_KIND = "artifact-visual/video-reference"
 _SPEECH_KIND = "artifact-speech/video"
 _VIDEO_KIND = "artifact-components/video"
@@ -72,7 +73,7 @@ class VideoArtifactCurrencyFacts:
                 raise TypeError(f"{field} must be an ArtifactBasis")
             if value.kind_version != 1:
                 raise ValueError(f"{field} must use the supported kind version")
-        if self.visual_basis.kind not in {_STORYBOARD_VISUAL_KIND, _REFERENCE_VISUAL_KIND}:
+        if self.visual_basis.kind not in {_STORYBOARD_VISUAL_KIND, _TEXT_VISUAL_KIND, _REFERENCE_VISUAL_KIND}:
             raise ValueError("visual_basis does not describe a supported video route")
         _validate_visual_inputs(self.visual_basis)
         if self.speech_basis.kind != _SPEECH_KIND:
@@ -103,9 +104,9 @@ class VideoArtifactCurrencyFacts:
         ):
             raise ValueError("duration_tiers must be sorted positive tiers containing the paid request tier")
         limit = self.reference_image_limit
-        if self.visual_basis.kind == _STORYBOARD_VISUAL_KIND:
+        if self.visual_basis.kind in {_STORYBOARD_VISUAL_KIND, _TEXT_VISUAL_KIND}:
             if limit is not None:
-                raise ValueError("storyboard video facts cannot carry a reference-image limit")
+                raise ValueError("non-reference video facts cannot carry a reference-image limit")
         elif limit is not None and (type(limit) is not int or limit < 0):
             raise ValueError("reference video facts require an unlimited or non-negative reference-image limit")
         if type(self.parent_version) is not int or self.parent_version < 0:
@@ -202,9 +203,12 @@ def _canvas_is_valid(value: object) -> bool:
 
 def _validate_visual_inputs(basis: ArtifactBasis) -> None:
     inputs = _basis_inputs(basis)
-    if basis.kind == _STORYBOARD_VISUAL_KIND:
-        if set(inputs) != {"resource_id", "visual_prompt", "canvas", "frames"}:
-            raise ValueError("storyboard visual basis has invalid canonical inputs")
+    if basis.kind in {_STORYBOARD_VISUAL_KIND, _TEXT_VISUAL_KIND}:
+        expected_fields = {"resource_id", "visual_prompt", "canvas"}
+        if basis.kind == _STORYBOARD_VISUAL_KIND:
+            expected_fields.add("frames")
+        if set(inputs) != expected_fields:
+            raise ValueError("non-reference visual basis has invalid canonical inputs")
         prompt = inputs["visual_prompt"]
         prompt_valid = (_nonempty(prompt)) or (
             isinstance(prompt, Mapping)
@@ -212,6 +216,10 @@ def _validate_visual_inputs(basis: ArtifactBasis) -> None:
             and _nonempty(prompt["action"])
             and isinstance(prompt["camera_motion"], str)
         )
+        if not _nonempty(inputs["resource_id"]) or not prompt_valid or not _canvas_is_valid(inputs["canvas"]):
+            raise ValueError("non-reference visual basis has invalid canonical inputs")
+        if basis.kind == _TEXT_VISUAL_KIND:
+            return
         frames = inputs["frames"]
         frames_valid = (
             isinstance(frames, list)
@@ -226,8 +234,6 @@ def _validate_visual_inputs(basis: ArtifactBasis) -> None:
                 for frame in frames
             )
         )
-        if not _nonempty(inputs["resource_id"]) or not prompt_valid or not _canvas_is_valid(inputs["canvas"]):
-            raise ValueError("storyboard visual basis has invalid canonical inputs")
         if not frames_valid:
             raise ValueError("storyboard visual basis has invalid frame evidence")
         return

--- a/lib/video_backends/grok_sub2api.py
+++ b/lib/video_backends/grok_sub2api.py
@@ -14,17 +14,25 @@ import httpx
 from lib.config.url_utils import ensure_openai_base_url
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.providers import PROVIDER_GROK
-from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.retry import (
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    DOWNLOAD_BACKOFF_SECONDS,
+    DOWNLOAD_MAX_ATTEMPTS,
+    with_retry_async,
+)
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     ProviderJobIdPersistenceMixin,
     ResumeExpiredError,
+    VideoAudioMode,
     VideoCapabilities,
     VideoGenerationRequest,
     VideoGenerationResult,
     poll_with_retry,
     should_retry_download,
     should_retry_poll,
+    should_retry_submit,
     submit_post,
 )
 
@@ -56,6 +64,8 @@ def normalize_api_root(base_url: str | None) -> str:
 def build_request_body(model: str, request: VideoGenerationRequest) -> dict[str, object]:
     if not request.prompt.strip():
         raise ValueError("prompt 不能为空")
+    if not 1 <= request.duration_seconds <= 15:
+        raise ValueError("duration_seconds 必须在 1 到 15 秒之间")
     for field in ("end_image", "reference_images", "reference_audio_files"):
         if getattr(request, field):
             raise ValueError(f"Grok Sub2API video 不支持 {field}")
@@ -144,7 +154,7 @@ class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
 
     @staticmethod
     def video_capabilities_for_model(model: str) -> VideoCapabilities:
-        return VideoCapabilities(first_frame=True)
+        return VideoCapabilities(first_frame=True, audio_track=VideoAudioMode.ALWAYS_ON)
 
     @property
     def video_capabilities(self) -> VideoCapabilities:
@@ -160,18 +170,7 @@ class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
     async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
         payload = build_request_body(self._model, request)
         async with httpx.AsyncClient(follow_redirects=True, timeout=120.0) as client:
-            response = await submit_post(
-                lambda: client.post(
-                    f"{self._api_root}/videos/generations",
-                    headers=self._headers,
-                    json=payload,
-                ),
-                provider=PROVIDER_GROK,
-            )
-            response_payload = response.json()
-            if not isinstance(response_payload, dict):
-                raise ValueError("Sub2API 创建响应必须是 JSON 对象")
-            request_id = _request_id(response_payload)
+            request_id = await self._create_task(client, payload)
             await self._persist_provider_job_id(
                 request,
                 request_id,
@@ -179,6 +178,25 @@ class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
                 endpoint=self._api_root,
             )
             return await self._poll_and_download(client, request_id, request)
+
+    @with_retry_async(
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+        backoff_seconds=DEFAULT_BACKOFF_SECONDS,
+        retry_if=should_retry_submit,
+    )
+    async def _create_task(self, client: httpx.AsyncClient, payload: dict[str, object]) -> str:
+        response = await submit_post(
+            lambda: client.post(
+                f"{self._api_root}/videos/generations",
+                headers=self._headers,
+                json=payload,
+            ),
+            provider=PROVIDER_GROK,
+        )
+        response_payload = response.json()
+        if not isinstance(response_payload, dict):
+            raise ValueError("Sub2API 创建响应必须是 JSON 对象")
+        return _request_id(response_payload)
 
     async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
         async with httpx.AsyncClient(follow_redirects=True, timeout=120.0) as client:
@@ -193,7 +211,10 @@ class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
         resumed: bool = False,
     ) -> VideoGenerationResult:
         encoded_id = quote(request_id, safe="")
-        status_url = f"{self._api_root}/videos/generations/{encoded_id}"
+        api_root = (
+            normalize_api_root(request.submitted_base_url) if resumed and request.submitted_base_url else self._api_root
+        )
+        status_url = f"{api_root}/videos/generations/{encoded_id}"
 
         async def _poll() -> dict[str, Any]:
             response = await client.get(status_url, headers=self._headers)
@@ -210,6 +231,8 @@ class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
             status = raw_status.strip().lower() if isinstance(raw_status, str) else ""
             if status not in _KNOWN_STATUSES:
                 raise ValueError(f"Sub2API 返回未知视频状态: {raw_status!r}")
+            if resumed and status == "expired":
+                raise ResumeExpiredError(job_id=request_id, provider=PROVIDER_GROK)
             payload["status"] = status
             return payload
 

--- a/lib/video_backends/grok_sub2api.py
+++ b/lib/video_backends/grok_sub2api.py
@@ -1,0 +1,265 @@
+"""Sub2API Grok asynchronous video backend."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+import httpx
+
+from lib.config.url_utils import ensure_openai_base_url
+from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
+from lib.providers import PROVIDER_GROK
+from lib.retry import DOWNLOAD_BACKOFF_SECONDS, DOWNLOAD_MAX_ATTEMPTS, with_retry_async
+from lib.video_backends.base import (
+    IMAGE_MIME_TYPES,
+    ProviderJobIdPersistenceMixin,
+    ResumeExpiredError,
+    VideoCapabilities,
+    VideoGenerationRequest,
+    VideoGenerationResult,
+    poll_with_retry,
+    should_retry_download,
+    should_retry_poll,
+    submit_post,
+)
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_SECONDS = 5.0
+_MAX_WAIT_SECONDS = 15 * 60.0
+_DONE_STATUS = "done"
+_FAILED_STATUSES = frozenset({"failed", "cancelled", "canceled", "expired", "error"})
+_PENDING_STATUSES = frozenset({"pending", "queued", "processing", "in_progress"})
+_KNOWN_STATUSES = _PENDING_STATUSES | _FAILED_STATUSES | {_DONE_STATUS}
+
+
+def _image_data_uri(path: Path) -> str:
+    mime = IMAGE_MIME_TYPES.get(path.suffix.lower(), "image/png")
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
+def normalize_api_root(base_url: str | None) -> str:
+    normalized = ensure_openai_base_url(base_url)
+    if normalized is None:
+        raise ValueError("base_url 不能为空")
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("base_url 必须是 http 或 https URL")
+    return normalized
+
+
+def build_request_body(model: str, request: VideoGenerationRequest) -> dict[str, object]:
+    if not request.prompt.strip():
+        raise ValueError("prompt 不能为空")
+    for field in ("end_image", "reference_images", "reference_audio_files"):
+        if getattr(request, field):
+            raise ValueError(f"Grok Sub2API video 不支持 {field}")
+    body: dict[str, object] = {
+        "model": model,
+        "prompt": request.prompt,
+        "duration": request.duration_seconds,
+        "aspect_ratio": request.aspect_ratio,
+    }
+    if request.resolution is not None:
+        body["resolution"] = request.resolution
+    if request.start_image is not None:
+        if not request.start_image.is_file():
+            raise ValueError(f"start_image 不存在: {request.start_image}")
+        body["image"] = {"url": _image_data_uri(request.start_image)}
+    return body
+
+
+def _request_id(payload: dict[str, Any]) -> str:
+    for container_key, key in (
+        (None, "request_id"),
+        (None, "id"),
+        ("data", "request_id"),
+        ("data", "id"),
+        ("video", "request_id"),
+        ("video", "id"),
+        (None, "task_id"),
+        ("data", "task_id"),
+        ("video", "task_id"),
+    ):
+        container = payload if container_key is None else payload.get(container_key)
+        value = container.get(key) if isinstance(container, dict) else None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError("Sub2API 创建响应缺少 request_id")
+
+
+def _duration(payload: dict[str, Any], fallback: int) -> int:
+    video = payload.get("video")
+    raw = video.get("duration") if isinstance(video, dict) else payload.get("duration")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
+        return fallback
+    try:
+        parsed = float(raw)
+        if 0 < parsed <= MAX_BILLED_DURATION_SECONDS:
+            rounded = int(parsed + 0.5)
+            if rounded > 0:
+                return rounded
+    except (TypeError, ValueError, OverflowError):
+        pass
+    return fallback
+
+
+class GrokSub2APIVideoBackend(ProviderJobIdPersistenceMixin):
+    """Sub2API Grok OAuth video transport with resumable request IDs."""
+
+    DEFAULT_MODEL = "grok-imagine-video-1.5"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        poll_interval_seconds: float = _POLL_INTERVAL_SECONDS,
+        max_wait_seconds: float = _MAX_WAIT_SECONDS,
+    ) -> None:
+        if api_key is None or not api_key.strip():
+            raise ValueError("api_key 不能为空")
+        selected_model = model or self.DEFAULT_MODEL
+        if selected_model != "grok-imagine-video" and not selected_model.startswith("grok-imagine-video-"):
+            raise ValueError("model 必须属于 grok-imagine-video 系列")
+        self._api_key = api_key
+        self._model = selected_model
+        self._api_root = normalize_api_root(base_url)
+        self._poll_interval_seconds = poll_interval_seconds
+        self._max_wait_seconds = max_wait_seconds
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_GROK
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @staticmethod
+    def video_capabilities_for_model(model: str) -> VideoCapabilities:
+        return VideoCapabilities(first_frame=True)
+
+    @property
+    def video_capabilities(self) -> VideoCapabilities:
+        return self.video_capabilities_for_model(self._model)
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Accept": "application/json",
+        }
+
+    async def generate(self, request: VideoGenerationRequest) -> VideoGenerationResult:
+        payload = build_request_body(self._model, request)
+        async with httpx.AsyncClient(follow_redirects=True, timeout=120.0) as client:
+            response = await submit_post(
+                lambda: client.post(
+                    f"{self._api_root}/videos/generations",
+                    headers=self._headers,
+                    json=payload,
+                ),
+                provider=PROVIDER_GROK,
+            )
+            response_payload = response.json()
+            if not isinstance(response_payload, dict):
+                raise ValueError("Sub2API 创建响应必须是 JSON 对象")
+            request_id = _request_id(response_payload)
+            await self._persist_provider_job_id(
+                request,
+                request_id,
+                provider=PROVIDER_GROK,
+                endpoint=self._api_root,
+            )
+            return await self._poll_and_download(client, request_id, request)
+
+    async def resume_video(self, job_id: str, request: VideoGenerationRequest) -> VideoGenerationResult:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=120.0) as client:
+            return await self._poll_and_download(client, job_id, request, resumed=True)
+
+    async def _poll_and_download(
+        self,
+        client: httpx.AsyncClient,
+        request_id: str,
+        request: VideoGenerationRequest,
+        *,
+        resumed: bool = False,
+    ) -> VideoGenerationResult:
+        encoded_id = quote(request_id, safe="")
+        status_url = f"{self._api_root}/videos/generations/{encoded_id}"
+
+        async def _poll() -> dict[str, Any]:
+            response = await client.get(status_url, headers=self._headers)
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                if resumed and exc.response.status_code == 404:
+                    raise ResumeExpiredError(job_id=request_id, provider=PROVIDER_GROK) from exc
+                raise
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError("Sub2API 状态响应必须是 JSON 对象")
+            raw_status = payload.get("status")
+            status = raw_status.strip().lower() if isinstance(raw_status, str) else ""
+            if status not in _KNOWN_STATUSES:
+                raise ValueError(f"Sub2API 返回未知视频状态: {raw_status!r}")
+            payload["status"] = status
+            return payload
+
+        final = await poll_with_retry(
+            poll_fn=_poll,
+            is_done=lambda state: state.get("status") == _DONE_STATUS,
+            is_failed=lambda state: (
+                f"Sub2API Grok 视频任务失败: {state.get('status')}" if state.get("status") in _FAILED_STATUSES else None
+            ),
+            poll_interval=self._poll_interval_seconds,
+            max_wait=self._max_wait_seconds,
+            retry_if=should_retry_poll,
+            label="Sub2API Grok",
+        )
+
+        content_url = f"{status_url}/content"
+        await self._download(client, content_url, request.output_path)
+        logger.info("Sub2API Grok 视频下载完成: request_id=%s", request_id)
+
+        return VideoGenerationResult(
+            video_path=request.output_path,
+            provider=PROVIDER_GROK,
+            model=self._model,
+            duration_seconds=_duration(final, request.duration_seconds),
+            video_uri=content_url,
+            task_id=request_id,
+            generate_audio=True,
+        )
+
+    @with_retry_async(
+        max_attempts=DOWNLOAD_MAX_ATTEMPTS,
+        backoff_seconds=DOWNLOAD_BACKOFF_SECONDS,
+        retry_if=should_retry_download,
+    )
+    async def _download(self, client: httpx.AsyncClient, content_url: str, output_path: Path) -> None:
+        content_response = await client.get(content_url, headers=self._headers)
+        content_response.raise_for_status()
+        content = content_response.content
+        if not content:
+            raise ValueError("Sub2API video content is empty")
+        temporary = output_path.with_name(f".{output_path.name}.grok-sub2api.part")
+
+        def _write_atomic() -> None:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary.unlink(missing_ok=True)
+            try:
+                temporary.write_bytes(content)
+                temporary.replace(output_path)
+            except BaseException:
+                temporary.unlink(missing_ok=True)
+                raise
+
+        await asyncio.to_thread(_write_atomic)

--- a/lib/video_output_normalization.py
+++ b/lib/video_output_normalization.py
@@ -1,0 +1,246 @@
+"""Deterministic, declarative normalization for provider video outputs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.content_digest import canonical_json_digest, sha256_file
+
+
+def _positive_int(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _nonnegative_int(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _mapping(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class VideoOutputNormalizationPolicy:
+    input_width: int
+    input_height: int
+    crop_x: int
+    crop_y: int
+    crop_width: int
+    crop_height: int
+    output_width: int
+    output_height: int
+    scale_filter: str
+
+    @classmethod
+    def from_dict(cls, value: object) -> VideoOutputNormalizationPolicy:
+        body = _mapping(value, "video output normalization policy")
+        if set(body) != {"schema_version", "kind", "input", "crop", "output", "scale_filter"}:
+            raise ValueError("video output normalization policy fields are invalid")
+        if body["schema_version"] != 1 or body["kind"] != "safe_frame_crop":
+            raise ValueError("unsupported video output normalization policy")
+        if body["scale_filter"] != "lanczos":
+            raise ValueError("video output normalization scale_filter must be lanczos")
+        input_size = _mapping(body["input"], "input")
+        crop = _mapping(body["crop"], "crop")
+        output_size = _mapping(body["output"], "output")
+        if set(input_size) != {"width", "height"} or set(output_size) != {"width", "height"}:
+            raise ValueError("input and output dimensions require width and height")
+        if set(crop) != {"x", "y", "width", "height"}:
+            raise ValueError("crop requires x, y, width and height")
+        policy = cls(
+            input_width=_positive_int(input_size["width"], "input.width"),
+            input_height=_positive_int(input_size["height"], "input.height"),
+            crop_x=_nonnegative_int(crop["x"], "crop.x"),
+            crop_y=_nonnegative_int(crop["y"], "crop.y"),
+            crop_width=_positive_int(crop["width"], "crop.width"),
+            crop_height=_positive_int(crop["height"], "crop.height"),
+            output_width=_positive_int(output_size["width"], "output.width"),
+            output_height=_positive_int(output_size["height"], "output.height"),
+            scale_filter="lanczos",
+        )
+        if (
+            policy.crop_x + policy.crop_width > policy.input_width
+            or policy.crop_y + policy.crop_height > policy.input_height
+        ):
+            raise ValueError("crop must stay inside input bounds")
+        return policy
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": self.input_width, "height": self.input_height},
+            "crop": {
+                "x": self.crop_x,
+                "y": self.crop_y,
+                "width": self.crop_width,
+                "height": self.crop_height,
+            },
+            "output": {"width": self.output_width, "height": self.output_height},
+            "scale_filter": self.scale_filter,
+        }
+
+    @property
+    def digest(self) -> str:
+        return canonical_json_digest(self.to_dict(), allow_nan=False)
+
+    @property
+    def filter_graph(self) -> str:
+        return (
+            f"crop={self.crop_width}:{self.crop_height}:{self.crop_x}:{self.crop_y},"
+            f"scale={self.output_width}:{self.output_height}:flags={self.scale_filter}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class VideoOutputNormalizationReceipt:
+    policy_digest: str
+    raw_sha256: str
+    normalized_sha256: str
+    input_dimensions: dict[str, int]
+    output_dimensions: dict[str, int]
+    filter_graph: str
+    ffmpeg_version: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "kind": "VideoOutputNormalizationReceipt",
+            "policy_digest": self.policy_digest,
+            "raw_sha256": self.raw_sha256,
+            "normalized_sha256": self.normalized_sha256,
+            "input_dimensions": self.input_dimensions,
+            "output_dimensions": self.output_dimensions,
+            "filter_graph": self.filter_graph,
+            "ffmpeg_version": self.ffmpeg_version,
+        }
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        stderr = getattr(exc, "stderr", None)
+        detail = stderr.strip() if isinstance(stderr, str) and stderr.strip() else str(exc)
+        raise ValueError(f"video output normalization command failed: {detail}") from exc
+
+
+def _probe_dimensions(path: Path) -> dict[str, int]:
+    result = _run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height",
+            "-of",
+            "json",
+            str(path),
+        ]
+    )
+    try:
+        payload: Any = json.loads(result.stdout)
+        stream = payload["streams"][0]
+        width = _positive_int(stream["width"], "video.width")
+        height = _positive_int(stream["height"], "video.height")
+    except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("video output dimensions could not be verified") from exc
+    return {"width": width, "height": height}
+
+
+def _ffmpeg_version() -> str:
+    first_line = _run(["ffmpeg", "-version"]).stdout.splitlines()[0]
+    parts = first_line.split()
+    if len(parts) < 3 or parts[:2] != ["ffmpeg", "version"]:
+        raise ValueError("ffmpeg version could not be verified")
+    return parts[2]
+
+
+def normalize_video_output(
+    raw_path: Path,
+    normalized_path: Path,
+    policy: VideoOutputNormalizationPolicy,
+) -> VideoOutputNormalizationReceipt:
+    raw_path = Path(raw_path)
+    normalized_path = Path(normalized_path)
+    if not raw_path.is_file():
+        raise FileNotFoundError(raw_path)
+    if raw_path.resolve(strict=True) == normalized_path.resolve(strict=False):
+        raise ValueError("normalized output path must differ from raw input")
+    input_dimensions = _probe_dimensions(raw_path)
+    expected_input = {"width": policy.input_width, "height": policy.input_height}
+    if input_dimensions != expected_input:
+        raise ValueError(
+            f"input dimensions {input_dimensions} do not match policy {expected_input}"
+        )
+    normalized_path.parent.mkdir(parents=True, exist_ok=True)
+    normalized_path.unlink(missing_ok=True)
+    try:
+        _run(
+            [
+                "ffmpeg",
+                "-nostdin",
+                "-v",
+                "error",
+                "-i",
+                str(raw_path),
+                "-map",
+                "0:v:0",
+                "-map",
+                "0:a?",
+                "-vf",
+                policy.filter_graph,
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "copy",
+                "-movflags",
+                "+faststart",
+                str(normalized_path),
+            ]
+        )
+        output_dimensions = _probe_dimensions(normalized_path)
+        expected_output = {"width": policy.output_width, "height": policy.output_height}
+        if output_dimensions != expected_output:
+            raise ValueError(
+                f"output dimensions {output_dimensions} do not match policy {expected_output}"
+            )
+        return VideoOutputNormalizationReceipt(
+            policy_digest=policy.digest,
+            raw_sha256=sha256_file(raw_path),
+            normalized_sha256=sha256_file(normalized_path),
+            input_dimensions=input_dimensions,
+            output_dimensions=output_dimensions,
+            filter_graph=policy.filter_graph,
+            ffmpeg_version=_ffmpeg_version(),
+        )
+    except BaseException:
+        normalized_path.unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "VideoOutputNormalizationPolicy",
+    "VideoOutputNormalizationReceipt",
+    "normalize_video_output",
+]

--- a/lib/video_visual_provenance.py
+++ b/lib/video_visual_provenance.py
@@ -129,8 +129,53 @@ def build_reference_video_visual_basis(
     )
 
 
+def build_text_video_visual_basis(
+    *,
+    prompt: object,
+    aspect_ratio: object,
+    provider_id: str,
+    model_id: str,
+    resolution: str | None,
+    seed: object,
+    requested_generate_audio: bool,
+    content_mode: str,
+    utterances: object,
+    has_utterances: bool,
+    voice_characters: object,
+) -> ArtifactBasis:
+    """Describe an exact text-to-video request without manufacturing frame inputs."""
+
+    effective_prompt = prompt
+    if isinstance(prompt, dict):
+        effective_prompt = strip_voice_profiles(prompt)
+        if content_mode == "drama":
+            characters = voice_characters if isinstance(voice_characters, dict) else None
+            effective_prompt = (
+                build_drama_video_prompt(effective_prompt, utterances, characters=characters)
+                if has_utterances
+                else build_drama_video_prompt_from_legacy_dialogue(effective_prompt, characters=characters)
+            )
+    return _build_video_visual_basis(
+        "text",
+        semantics={
+            "prompt": normalize_video_prompt(effective_prompt),
+            "aspect_ratio": aspect_ratio,
+            "request_context": {
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "resolution": resolution,
+                "seed": seed,
+                "requested_generate_audio": requested_generate_audio,
+            },
+            "content_mode": content_mode,
+        },
+        files=(),
+    )
+
+
 __all__ = [
     "build_reference_video_visual_basis",
     "build_storyboard_video_visual_basis",
+    "build_text_video_visual_basis",
     "resolve_video_aspect_ratio",
 ]

--- a/lib/visual_artifact_provenance.py
+++ b/lib/visual_artifact_provenance.py
@@ -394,6 +394,40 @@ def build_reference_video_artifact_visual_basis(
     )
 
 
+def build_text_video_artifact_visual_basis(
+    *,
+    resource_id: str,
+    visual_prompt: object,
+    aspect_ratio: str,
+) -> ArtifactBasis:
+    """Describe text-driven video content with no implied frame dependency."""
+
+    if isinstance(visual_prompt, str):
+        visual_text = visual_prompt.strip()
+        if not visual_text:
+            raise ValueError("visual_prompt must not be empty")
+        projected_prompt: object = visual_text
+    elif isinstance(visual_prompt, Mapping):
+        action = str(visual_prompt.get("action") or "").strip()
+        if not action:
+            raise ValueError("visual_prompt.action must be a non-empty string")
+        projected_prompt = {
+            "action": action,
+            "camera_motion": str(visual_prompt.get("camera_motion") or "Static"),
+        }
+    else:
+        raise ValueError("visual_prompt must be a string or structured object")
+    return ArtifactBasis.build(
+        "artifact-visual/video-text",
+        kind_version=1,
+        inputs={
+            "resource_id": _require_non_empty("resource_id", resource_id),
+            "visual_prompt": projected_prompt,
+            "canvas": {"aspect_ratio": _require_non_empty("aspect_ratio", aspect_ratio)},
+        },
+    )
+
+
 def _reference_visual_lines(text: str) -> list[str]:
     """产物依据只取画面描述：剥掉全部发声记号后剩下的文本。
 
@@ -510,6 +544,7 @@ __all__ = [
     "build_reference_video_artifact_visual_basis",
     "build_storyboard_image_visual_basis",
     "build_storyboard_video_artifact_visual_basis",
+    "build_text_video_artifact_visual_basis",
     "snapshot_visual_references",
     "visual_references_match_snapshot",
     "visual_file_digest",

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -121,6 +121,7 @@ class GenerateVideoRequest(BaseModel):
     prompt: str | dict
     script_file: str
     input_mode: Literal["storyboard", "text"] = "storyboard"
+    execution_input_authority: Literal["current-script", "request"] = "current-script"
     duration_seconds: int | None = Field(default=None, gt=0)
     seed: int | None = None
     # 单目标入口保留后期配音默认（docs/adr/0061）：请求由用户在这一段的界面上直接触发，
@@ -384,6 +385,7 @@ async def generate_video(
     extra_payload: dict[str, object] = {
         "seed": req.seed,
         "video_input_mode": req.input_mode,
+        "execution_input_authority": req.execution_input_authority,
         "narration_delivery_options": delivery_options.to_payload(),
     }
     if req.narration_delivery != USE_TTS:

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from lib.api_errors import BadRequestError, ConflictError, NotFoundError
 from lib.artifact_activation import (
@@ -94,6 +94,29 @@ class GenerateStoryboardRequest(BaseModel):
     script_file: str
 
 
+class VideoDimensionsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+
+
+class VideoCropRequest(VideoDimensionsRequest):
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+
+
+class VideoOutputNormalizationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1]
+    kind: Literal["safe_frame_crop"]
+    input: VideoDimensionsRequest
+    crop: VideoCropRequest
+    output: VideoDimensionsRequest
+    scale_filter: Literal["lanczos"]
+
+
 class GenerateVideoRequest(BaseModel):
     prompt: str | dict
     script_file: str
@@ -105,6 +128,7 @@ class GenerateVideoRequest(BaseModel):
     # 时长基准的批量入口与由模型推断参数的 Agent 视频工具上。
     narration_delivery: NarrationDelivery = POST_PRODUCTION
     confirmed_request_duration_seconds: int | None = Field(default=None, gt=0)
+    video_output_normalization: VideoOutputNormalizationRequest | None = None
 
 
 class GenerateTtsRequest(BaseModel):
@@ -364,6 +388,8 @@ async def generate_video(
     }
     if req.narration_delivery != USE_TTS:
         extra_payload["duration_seconds"] = req.duration_seconds
+    if req.video_output_normalization is not None:
+        extra_payload["video_output_normalization"] = req.video_output_normalization.model_dump(mode="json")
     spec = TaskSpec.from_request(
         task_type="video",
         media_type="video",

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -12,6 +12,7 @@
 import asyncio
 import logging
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -96,6 +97,7 @@ class GenerateStoryboardRequest(BaseModel):
 class GenerateVideoRequest(BaseModel):
     prompt: str | dict
     script_file: str
+    input_mode: Literal["storyboard", "text"] = "storyboard"
     duration_seconds: int | None = Field(default=None, gt=0)
     seed: int | None = None
     # 单目标入口保留后期配音默认（docs/adr/0061）：请求由用户在这一段的界面上直接触发，
@@ -287,20 +289,21 @@ async def generate_video(
             raise HTTPException(status_code=409, detail=admission.to_dict())
         # 字段值来自磁盘剧本 JSON，不可信任；路径校验和 schema 激活后的显式绑定要求
         # 与 worker / 当前基线重建共用同一解析器。
-        try:
-            resolve_usable_storyboard_video_inputs(
-                project_path=project_path,
-                project=project,
-                episode=artifact_episode,
-                resource_id=segment_id,
-                item=resolved[0],
-            )
-        except EndFrameImageUnavailable:
-            raise BadRequestError("invalid_end_frame_image_path", segment_id=segment_id) from None
-        except StoryboardImageUnavailable:
-            raise BadRequestError("generate_storyboard_first", segment_id=segment_id) from None
-        except ValueError:
-            raise BadRequestError("invalid_storyboard_image_path", segment_id=segment_id) from None
+        if req.input_mode == "storyboard":
+            try:
+                resolve_usable_storyboard_video_inputs(
+                    project_path=project_path,
+                    project=project,
+                    episode=artifact_episode,
+                    resource_id=segment_id,
+                    item=resolved[0],
+                )
+            except EndFrameImageUnavailable:
+                raise BadRequestError("invalid_end_frame_image_path", segment_id=segment_id) from None
+            except StoryboardImageUnavailable:
+                raise BadRequestError("generate_storyboard_first", segment_id=segment_id) from None
+            except ValueError:
+                raise BadRequestError("invalid_storyboard_image_path", segment_id=segment_id) from None
         return project, project_path, script, resolved[0]
 
     project, project_path, script, item = await asyncio.to_thread(_sync)
@@ -356,6 +359,7 @@ async def generate_video(
     # duration 是能力维度，留待执行层在 provider 解析后校验（见 ADR-0001）。
     extra_payload: dict[str, object] = {
         "seed": req.seed,
+        "video_input_mode": req.input_mode,
         "narration_delivery_options": delivery_options.to_payload(),
     }
     if req.narration_delivery != USE_TTS:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -128,6 +128,7 @@ from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import PaidVersionCommit
 from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_backends.base import VideoCapabilityError
+from lib.video_output_normalization import VideoOutputNormalizationPolicy
 from lib.video_visual_provenance import (
     build_storyboard_video_visual_basis,
     build_text_video_visual_basis,
@@ -2315,6 +2316,12 @@ async def execute_video_task(
     video_input_mode = payload.get("video_input_mode", "storyboard")
     if video_input_mode not in {"storyboard", "text"}:
         raise ValueError("video_input_mode must be 'storyboard' or 'text'")
+    raw_output_normalization = payload.get("video_output_normalization")
+    output_normalization = (
+        VideoOutputNormalizationPolicy.from_dict(raw_output_normalization).to_dict()
+        if raw_output_normalization is not None
+        else None
+    )
     # lane 归桶按项目生成模式求值，与提交入口（``generate_video``）同源：入口挡掉参考生视频后
     # 到达这里的项目恒为 i2v，但桶不在两处各硬编码一次，避免生成模式口径分叉。
     execution_payload = without_video_execution_identity(payload) if task_id is not None else payload
@@ -2713,6 +2720,9 @@ async def execute_video_task(
         if task_id is not None
         else None
     )
+    normalization_metadata: dict[str, Any] = {}
+    if output_normalization is not None:
+        normalization_metadata["video_output_normalization"] = output_normalization
     try:
         await asyncio.to_thread(assert_current_artifact_input_claims_usable, project_path, formal_input_claims)
         output_path, version, _, video_uri = await generator.generate_video_async(
@@ -2733,6 +2743,7 @@ async def execute_video_task(
             service_tier=service_tier,
             visual_basis_digest=visual_basis_digest,
             generate_audio=ctx.video.requested_generate_audio,
+            **normalization_metadata,
         )
 
         async def _finalize() -> dict[str, Any]:

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -2305,10 +2305,15 @@ async def execute_video_task(
         )
 
     project, project_path, item, content_mode, script_kind, script, script_input = await asyncio.to_thread(_load)
-    # Queue execution re-materializes mutable visual intent from the current script unit. Direct/internal callers
-    # without a task row retain the request-prompt fallback for compatibility with synchronous service tests.
+    execution_input_authority = payload.get("execution_input_authority", "current-script")
+    if execution_input_authority not in {"current-script", "request"}:
+        raise ValueError("execution_input_authority must be 'current-script' or 'request'")
+    request_authoritative = task_id is None or execution_input_authority == "request"
+    # Interactive queue execution re-materializes mutable visual intent from the current script unit. Exact
+    # external requests opt into their queued prompt and duration so a later script edit cannot replace approved
+    # provider inputs before the worker reaches the paid effect boundary.
     current_prompt = item.get("video_prompt") if isinstance(item, dict) else None
-    prompt = current_prompt if task_id is not None else payload.get("prompt", current_prompt)
+    prompt = payload.get("prompt", current_prompt) if request_authoritative else current_prompt
     if prompt is None:
         raise ValueError("current script unit is missing video_prompt")
     requested_visual_prompt = copy.deepcopy(prompt)
@@ -2426,9 +2431,11 @@ async def execute_video_task(
     # duration 解析收口于执行层：payload > project.default_duration > caps 默认。
     # 用 ``is not None`` 而非 ``or`` 取 payload 值，避免显式 falsy 值被当作未设置。
     duration_seconds = (
-        item.get("duration_seconds")
-        if task_id is not None and isinstance(item, dict)
-        else payload.get("duration_seconds")
+        payload.get("duration_seconds")
+        if request_authoritative
+        else item.get("duration_seconds")
+        if isinstance(item, dict)
+        else None
     )
     if duration_seconds is None:
         duration_seconds = project.get("default_duration")

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -106,6 +106,7 @@ from lib.reference_video.execution_checkpoint import (
     ProviderMediaInput,
     StagedProviderMedia,
     StoryboardSubmissionCheckpoint,
+    TextVideoSubmissionCheckpoint,
     checkpoint_version_metadata,
     cleanup_staged_provider_media,
     stage_provider_media_for_task,
@@ -127,7 +128,11 @@ from lib.thumbnail import extract_video_thumbnail
 from lib.version_manager import PaidVersionCommit
 from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 from lib.video_backends.base import VideoCapabilityError
-from lib.video_visual_provenance import build_storyboard_video_visual_basis, resolve_video_aspect_ratio
+from lib.video_visual_provenance import (
+    build_storyboard_video_visual_basis,
+    build_text_video_visual_basis,
+    resolve_video_aspect_ratio,
+)
 from lib.visual_artifact_provenance import (
     GridStoryboardVisual,
     VisualReference,
@@ -135,6 +140,7 @@ from lib.visual_artifact_provenance import (
     build_grid_composite_visual_basis,
     build_storyboard_image_visual_basis,
     build_storyboard_video_artifact_visual_basis,
+    build_text_video_artifact_visual_basis,
 )
 from server.services.generation_context import (
     AudioLaneRequest,
@@ -2306,6 +2312,9 @@ async def execute_video_task(
         raise ValueError("current script unit is missing video_prompt")
     requested_visual_prompt = copy.deepcopy(prompt)
     delivery_options = NarrationDeliveryRequestOptions.from_payload(payload)
+    video_input_mode = payload.get("video_input_mode", "storyboard")
+    if video_input_mode not in {"storyboard", "text"}:
+        raise ValueError("video_input_mode must be 'storyboard' or 'text'")
     # lane 归桶按项目生成模式求值，与提交入口（``generate_video``）同源：入口挡掉参考生视频后
     # 到达这里的项目恒为 i2v，但桶不在两处各硬编码一次，避免生成模式口径分叉。
     execution_payload = without_video_execution_identity(payload) if task_id is not None else payload
@@ -2331,35 +2340,45 @@ async def execute_video_task(
     artifact_episode = script_input.episode
     formal_input_claims: list[ArtifactInputClaim] = [script_input.claim]
     currency_resolver = active_artifact_currency_resolver(project_path, project)
-    storyboard_file, end_image = resolve_usable_storyboard_video_inputs(
-        project_path=project_path,
-        project=project,
-        episode=artifact_episode,
-        resource_id=resource_id,
-        item=item,
-        resolver=currency_resolver,
-        claims=formal_input_claims,
-    )
+    storyboard_file: Path | None = None
+    end_image: Path | None = None
+    if video_input_mode == "storyboard":
+        storyboard_file, end_image = resolve_usable_storyboard_video_inputs(
+            project_path=project_path,
+            project=project,
+            episode=artifact_episode,
+            resource_id=resource_id,
+            item=item,
+            resolver=currency_resolver,
+            claims=formal_input_claims,
+        )
     aspect_ratio = get_aspect_ratio(project, "videos")
     seed = payload.get("seed")
 
-    def _visual_basis_digest_for(storyboard_image: Path, end_frame_image: Path | None) -> str:
-        return build_storyboard_video_visual_basis(
-            prompt=requested_visual_prompt,
-            storyboard_image=storyboard_image,
-            end_frame_image=end_frame_image,
-            aspect_ratio=aspect_ratio,
-            provider_id=registry_provider_id,
-            model_id=model_name,
-            resolution=resolution,
-            seed=seed,
-            requested_generate_audio=ctx.video.requested_generate_audio,
-            content_mode=content_mode,
-            utterances=item.get("utterances") if content_mode == "drama" else None,
-            has_utterances=content_mode == "drama" and "utterances" in item,
-            voice_characters=(None if ctx.video.is_silent else project.get("characters"))
+    def _visual_basis_digest_for(storyboard_image: Path | None, end_frame_image: Path | None) -> str:
+        common = {
+            "prompt": requested_visual_prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider_id": registry_provider_id,
+            "model_id": model_name,
+            "resolution": resolution,
+            "seed": seed,
+            "requested_generate_audio": ctx.video.requested_generate_audio,
+            "content_mode": content_mode,
+            "utterances": item.get("utterances") if content_mode == "drama" else None,
+            "has_utterances": content_mode == "drama" and "utterances" in item,
+            "voice_characters": (None if ctx.video.is_silent else project.get("characters"))
             if content_mode == "drama"
             else None,
+        }
+        if video_input_mode == "text":
+            return build_text_video_visual_basis(**common).digest
+        if storyboard_image is None:
+            raise ValueError("storyboard video input is missing its start image")
+        return build_storyboard_video_visual_basis(
+            storyboard_image=storyboard_image,
+            end_frame_image=end_frame_image,
+            **common,
         ).digest
 
     def _current_visual_basis_digest() -> str:
@@ -2547,57 +2566,73 @@ async def execute_video_task(
                 }
             )
         )
-        media_inputs = [
-            ProviderMediaInput(
-                path=storyboard_file,
-                role="start_image",
-                logical_type="storyboard",
-                logical_name=resource_id,
-                kind="first_frame",
-            )
-        ]
-        if end_image is not None:
+        media_inputs: list[ProviderMediaInput] = []
+        if video_input_mode == "storyboard":
+            if storyboard_file is None:
+                raise ValueError("storyboard video input is missing its start image")
             media_inputs.append(
                 ProviderMediaInput(
-                    path=end_image,
-                    role="end_image",
+                    path=storyboard_file,
+                    role="start_image",
                     logical_type="storyboard",
                     logical_name=resource_id,
-                    kind="last_frame",
+                    kind="first_frame",
                 )
             )
-        staged_media = await stage_provider_media_for_task(project_path, task_id, tuple(media_inputs))
+            if end_image is not None:
+                media_inputs.append(
+                    ProviderMediaInput(
+                        path=end_image,
+                        role="end_image",
+                        logical_type="storyboard",
+                        logical_name=resource_id,
+                        kind="last_frame",
+                    )
+                )
         try:
-            formal_input_claims = list(
-                bind_artifact_input_claims_to_content_digests(
-                    resolver=currency_resolver,
-                    claims=formal_input_claims,
-                    content_digests={media.source_locator: media.sha256 for media in staged_media},
+            if media_inputs:
+                staged_media = await stage_provider_media_for_task(project_path, task_id, tuple(media_inputs))
+                formal_input_claims = list(
+                    bind_artifact_input_claims_to_content_digests(
+                        resolver=currency_resolver,
+                        claims=formal_input_claims,
+                        content_digests={media.source_locator: media.sha256 for media in staged_media},
+                    )
                 )
-            )
-            provider_start_image = safe_join(
-                project_path,
-                next(media.staged_locator for media in staged_media if media.role == "start_image"),
-                require_file=True,
-            )
-            staged_end = next((media for media in staged_media if media.role == "end_image"), None)
-            provider_end_image = (
-                safe_join(project_path, staged_end.staged_locator, require_file=True)
-                if staged_end is not None
-                else None
-            )
+                provider_start_image = safe_join(
+                    project_path,
+                    next(media.staged_locator for media in staged_media if media.role == "start_image"),
+                    require_file=True,
+                )
+                staged_end = next((media for media in staged_media if media.role == "end_image"), None)
+                provider_end_image = (
+                    safe_join(project_path, staged_end.staged_locator, require_file=True)
+                    if staged_end is not None
+                    else None
+                )
             visual_basis_digest = await asyncio.to_thread(
                 _visual_basis_digest_for, provider_start_image, provider_end_image
             )
-            artifact_visual_basis = await asyncio.to_thread(
-                lambda: build_storyboard_video_artifact_visual_basis(
-                    resource_id=resource_id,
-                    visual_prompt=requested_visual_prompt,
-                    storyboard_image=provider_start_image,
-                    end_frame_image=provider_end_image,
-                    aspect_ratio=aspect_ratio,
+            if video_input_mode == "text":
+                artifact_visual_basis = await asyncio.to_thread(
+                    lambda: build_text_video_artifact_visual_basis(
+                        resource_id=resource_id,
+                        visual_prompt=requested_visual_prompt,
+                        aspect_ratio=aspect_ratio,
+                    )
                 )
-            )
+            else:
+                if provider_start_image is None:
+                    raise ValueError("storyboard video input is missing its staged start image")
+                artifact_visual_basis = await asyncio.to_thread(
+                    lambda: build_storyboard_video_artifact_visual_basis(
+                        resource_id=resource_id,
+                        visual_prompt=requested_visual_prompt,
+                        storyboard_image=provider_start_image,
+                        end_frame_image=provider_end_image,
+                        aspect_ratio=aspect_ratio,
+                    )
+                )
             artifact_video_basis = compose_video_artifact_basis(
                 visual=artifact_visual_basis,
                 speech=artifact_speech.basis,
@@ -2626,7 +2661,10 @@ async def execute_video_task(
                     reference_image_limit=None,
                     parent_version=generator.versions.get_current_version("videos", resource_id),
                 )
-                checkpoint = StoryboardSubmissionCheckpoint.create(
+                checkpoint_type = (
+                    TextVideoSubmissionCheckpoint if video_input_mode == "text" else StoryboardSubmissionCheckpoint
+                )
+                checkpoint = checkpoint_type.create(
                     task_id=task_id,
                     project_name=project_name,
                     script_file=script_file,

--- a/server/services/video_artifact_currency.py
+++ b/server/services/video_artifact_currency.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import os
+import shutil
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
@@ -18,7 +21,7 @@ from lib.artifact_manifest import (
     ProjectArtifactManifestAdapter,
 )
 from lib.asset_types import asset_name_comparison_key
-from lib.async_thread import EventLoopBridge, run_noninterruptible_async
+from lib.async_thread import EventLoopBridge, run_noninterruptible_async, run_noninterruptible_sync
 from lib.generation_admission import generation_admission_lock, generation_admission_lock_sync
 from lib.generation_queue import CompensableGenerationResult
 from lib.json_io import atomic_write_bytes
@@ -35,6 +38,11 @@ from lib.speech_composition import SpeechMode, SpeechPreparation
 from lib.version_manager import PaidVersionCommit, VersionManager
 from lib.video_artifact_commit import commit_paid_video_artifact
 from lib.video_artifact_facts import VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD, VideoArtifactCurrencyFacts
+from lib.video_output_normalization import (
+    VideoOutputNormalizationPolicy,
+    VideoOutputNormalizationReceipt,
+    normalize_video_output,
+)
 from server.services.narration_delivery_tasks import (
     CurrentTtsSettingsResolver,
     validate_generated_video_covers_tts_duration,
@@ -122,6 +130,8 @@ class VideoArtifactCommitter:
         self._tts_settings_bridge: EventLoopBridge | None = None
         self._restore_blocker: str | None = None
         self._admission_guard: AbstractAsyncContextManager[None] | None = None
+        self._provider_raw_file: Path | None = None
+        self._normalization_receipt: VideoOutputNormalizationReceipt | None = None
 
     async def prepare_selection(
         self,
@@ -150,6 +160,44 @@ class VideoArtifactCommitter:
             self._admission_guard = guard
 
         raw_narration = version_metadata.get("execution_narration")
+        raw_normalization = version_metadata.get("video_output_normalization")
+        if raw_normalization is not None:
+            try:
+                policy = VideoOutputNormalizationPolicy.from_dict(raw_normalization)
+                raw_fd, raw_name = tempfile.mkstemp(
+                    prefix=f".{staged_file.stem}.",
+                    suffix=f".provider-raw{staged_file.suffix}",
+                    dir=staged_file.parent,
+                )
+                os.close(raw_fd)
+                normalized_fd, normalized_name = tempfile.mkstemp(
+                    prefix=f".{staged_file.stem}.",
+                    suffix=f".normalized{staged_file.suffix}",
+                    dir=staged_file.parent,
+                )
+                os.close(normalized_fd)
+                raw_file = Path(raw_name)
+                normalized_file = Path(normalized_name)
+                try:
+                    shutil.copy2(staged_file, raw_file)
+                    receipt = await run_noninterruptible_sync(
+                        normalize_video_output,
+                        raw_file,
+                        normalized_file,
+                        policy,
+                    )
+                    os.replace(normalized_file, staged_file)
+                except BaseException:
+                    raw_file.unlink(missing_ok=True)
+                    normalized_file.unlink(missing_ok=True)
+                    raise
+                self._provider_raw_file = raw_file
+                self._normalization_receipt = receipt
+            except (Exception, asyncio.CancelledError) as exc:
+                self.selection_error = exc
+                self._restore_blocker = "output_normalization_failed"
+                return
+
         if not isinstance(raw_narration, Mapping) or raw_narration.get("delivery") != "use_tts":
             return
         self._tts_settings_bridge = EventLoopBridge.capture()
@@ -179,9 +227,19 @@ class VideoArtifactCommitter:
 
         guard = self._admission_guard
         if guard is None:
+            raw_file = self._provider_raw_file
+            self._provider_raw_file = None
+            if raw_file is not None:
+                raw_file.unlink(missing_ok=True)
             return
         self._admission_guard = None
-        await guard.__aexit__(None, None, None)
+        try:
+            await guard.__aexit__(None, None, None)
+        finally:
+            raw_file = self._provider_raw_file
+            self._provider_raw_file = None
+            if raw_file is not None:
+                raw_file.unlink(missing_ok=True)
 
     def __call__(
         self,
@@ -192,6 +250,29 @@ class VideoArtifactCommitter:
     ) -> PaidVersionCommit:
         snapshot: dict[str, dict[str, Any] | None] = {"project": None, "script": None}
         metadata = dict(version_metadata)
+        normalization_receipt = self._normalization_receipt
+        provider_raw_file = self._provider_raw_file
+        if normalization_receipt is not None and provider_raw_file is not None:
+            raw_metadata = {
+                **metadata,
+                "video_output_role": "provider-raw",
+                "video_output_normalization_receipt": normalization_receipt.to_dict(),
+            }
+            self._versions.commit_staged_paid_version(
+                self._resource_type,
+                self._resource_id,
+                self._prompt,
+                staged_file=provider_raw_file,
+                current_file=current_file,
+                select_current=False,
+                duration_seconds=duration_seconds,
+                **raw_metadata,
+            )
+            self._provider_raw_file = None
+            metadata["video_output_role"] = "normalized-candidate"
+            metadata["video_output_normalization_receipt"] = normalization_receipt.to_dict()
+        elif version_metadata.get("video_output_normalization") is not None:
+            metadata["video_output_role"] = "provider-raw"
         if self._restore_blocker is not None:
             metadata[VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD] = self._restore_blocker
         script_file = metadata.get("execution_script_file")

--- a/tests/integration/server/routers/test_generate_router.py
+++ b/tests/integration/server/routers/test_generate_router.py
@@ -235,6 +235,26 @@ class TestGenerateRouter:
             )
         assert invalid.status_code == 422
 
+    def test_video_enqueue_preserves_explicit_request_input_authority(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            response = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": "Exact externally approved prompt",
+                    "duration_seconds": 4,
+                    "execution_input_authority": "request",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert fake_queue.calls[0]["payload"]["execution_input_authority"] == "request"
+
     def test_tts_regeneration_rejects_an_active_use_tts_video(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/integration/server/routers/test_generate_router.py
+++ b/tests/integration/server/routers/test_generate_router.py
@@ -330,6 +330,33 @@ class TestGenerateRouter:
             assert call["media_type"] == "video"
             assert call["payload"]["duration_seconds"] == 5
 
+    def test_text_video_enqueue_does_not_require_a_storyboard(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_pm.script["segments"][0]["generated_assets"] = {}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue, register_storyboards=False)
+
+        with client:
+            video = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "input_mode": "text",
+                    "duration_seconds": 5,
+                    "prompt": {
+                        "action": "A cat crosses a portal into a neon city",
+                        "camera_motion": "Dolly In",
+                    },
+                },
+            )
+
+        assert video.status_code == 200, video.text
+        assert video.json()["success"] is True
+        call = fake_queue.calls[0]
+        assert call["task_type"] == "video"
+        assert call["payload"]["video_input_mode"] == "text"
+
     def test_video_use_tts_requires_fresh_audio_without_enqueuing_tts(self, tmp_path, monkeypatch):
         from lib.artifact_manifest import ArtifactComparison, ArtifactStatus
         from lib.narration_delivery import (

--- a/tests/integration/server/routers/test_generate_router.py
+++ b/tests/integration/server/routers/test_generate_router.py
@@ -197,6 +197,44 @@ def _client(monkeypatch, fake_pm, fake_queue, *, register_storyboards=True):
 
 
 class TestGenerateRouter:
+    def test_video_enqueue_preserves_declared_output_normalization(self, tmp_path, monkeypatch):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+        policy = {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": 720, "height": 1280},
+            "crop": {"x": 0, "y": 0, "width": 612, "height": 1088},
+            "output": {"width": 720, "height": 1280},
+            "scale_filter": "lanczos",
+        }
+
+        with client:
+            response = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": "Slow pan across the field",
+                    "video_output_normalization": policy,
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert fake_queue.calls[0]["payload"]["video_output_normalization"] == policy
+
+        with client:
+            invalid = client.post(
+                "/api/v1/projects/demo/generate/video/E1S01",
+                json={
+                    "script_file": "episode_1.json",
+                    "prompt": "Slow pan across the field",
+                    "video_output_normalization": {**policy, "unreviewed_filter": "blur"},
+                },
+            )
+        assert invalid.status_code == 422
+
     def test_tts_regeneration_rejects_an_active_use_tts_video(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)

--- a/tests/integration/server/services/test_execute_video_task.py
+++ b/tests/integration/server/services/test_execute_video_task.py
@@ -108,6 +108,14 @@ class TestGenerationTasks:
         fake_generator = _CheckpointingGenerator()
         fake_queue = type("Queue", (), {})()
         fake_queue.persist_execution_checkpoint = AsyncMock()
+        normalization_policy = {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": 720, "height": 1280},
+            "crop": {"x": 0, "y": 0, "width": 612, "height": 1088},
+            "output": {"width": 720, "height": 1280},
+            "scale_filter": "lanczos",
+        }
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "get_generation_queue", lambda: fake_queue)
         monkeypatch.setattr(
@@ -125,6 +133,7 @@ class TestGenerationTasks:
                 "prompt": {"action": "stale enqueue prompt"},
                 "duration_seconds": 4,
                 "video_provider_i2v": "stale/model",
+                "video_output_normalization": normalization_policy,
             },
             script_file="episode_1.json",
             task_id="task-storyboard",
@@ -145,6 +154,7 @@ class TestGenerationTasks:
         assert checkpoint.artifact_currency is not None
         assert submitted["metadata"]["artifact_video_currency"] == checkpoint.artifact_currency.to_dict()
         assert call["formal_output"] is True
+        assert call["video_output_normalization"] == normalization_policy
         assert submitted["metadata"]["execution_request_digest"] == checkpoint.request_digest
         assert manifest.read_bytes() == manifest_before
         assert not (project_path / ".arcreel" / "tasks" / "task-storyboard" / "provider_media").exists()

--- a/tests/integration/server/services/test_execute_video_task.py
+++ b/tests/integration/server/services/test_execute_video_task.py
@@ -159,6 +159,65 @@ class TestGenerationTasks:
         assert manifest.read_bytes() == manifest_before
         assert not (project_path / ".arcreel" / "tasks" / "task-storyboard" / "provider_media").exists()
 
+    async def test_storyboard_worker_preserves_request_authority_prompt_and_duration(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        _seed_current_storyboard(fake_pm)
+        item = fake_pm.script["segments"][0]
+        item["novel_text"] = "旁白正文"
+        item["video_prompt"] = {
+            "action": "mutable script prompt",
+            "camera_motion": "Static",
+            "dialogue": [],
+        }
+        item["duration_seconds"] = 8
+
+        class _CheckpointingGenerator(_FakeGenerator):
+            async def generate_video_async(self, **kwargs):
+                self.video_calls.append(kwargs)
+                await kwargs["before_submit"](42)
+                from lib.version_manager import PaidVersionCommit
+
+                kwargs["commit_formal_output"].outcome = PaidVersionCommit(version=2, selected=True)
+                return project_path / "videos" / "scene_E1S01.mp4", 2, "ref", "uri"
+
+        fake_generator = _CheckpointingGenerator()
+        fake_queue = type("Queue", (), {})()
+        fake_queue.persist_execution_checkpoint = AsyncMock()
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_generation_queue", lambda: fake_queue)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, supported_durations=(4, 8, 12)),
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "prompt": {
+                    "action": "exact approved request prompt",
+                    "camera_motion": "Static",
+                    "dialogue": [],
+                },
+                "duration_seconds": 4,
+                "execution_input_authority": "request",
+            },
+            task_id="task-request-authority",
+        )
+
+        call = fake_generator.video_calls[0]
+        assert "exact approved request prompt" in call["prompt"]
+        assert "mutable script prompt" not in call["prompt"]
+        assert call["duration_seconds"] == 4
+
     async def test_text_video_worker_checkpoints_without_staged_media(self, monkeypatch, tmp_path):
         from lib.reference_video.execution_checkpoint import TextVideoSubmissionCheckpoint
 

--- a/tests/integration/server/services/test_execute_video_task.py
+++ b/tests/integration/server/services/test_execute_video_task.py
@@ -149,6 +149,61 @@ class TestGenerationTasks:
         assert manifest.read_bytes() == manifest_before
         assert not (project_path / ".arcreel" / "tasks" / "task-storyboard" / "provider_media").exists()
 
+    async def test_text_video_worker_checkpoints_without_staged_media(self, monkeypatch, tmp_path):
+        from lib.reference_video.execution_checkpoint import TextVideoSubmissionCheckpoint
+
+        project_path = _prepare_files(tmp_path)
+        fake_pm = _FakePM(project_path)
+        item = fake_pm.script["segments"][0]
+        item["novel_text"] = "A cat crosses into another world."
+        item["video_prompt"] = {
+            "action": "A cat crosses a luminous portal into a neon city",
+            "camera_motion": "Dolly In",
+        }
+        item["duration_seconds"] = 8
+
+        class _CheckpointingGenerator(_FakeGenerator):
+            async def generate_video_async(self, **kwargs):
+                self.video_calls.append(kwargs)
+                assert kwargs["start_image"] is None
+                assert kwargs["end_image"] is None
+                await kwargs["before_submit"](42)
+                from lib.version_manager import PaidVersionCommit
+
+                kwargs["commit_formal_output"].outcome = PaidVersionCommit(version=2, selected=True)
+                return project_path / "videos" / "scene_E1S01.mp4", 2, "ref", "uri"
+
+        fake_generator = _CheckpointingGenerator()
+        fake_queue = type("Queue", (), {})()
+        fake_queue.persist_execution_checkpoint = AsyncMock()
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
+        monkeypatch.setattr(generation_tasks, "get_generation_queue", lambda: fake_queue)
+        monkeypatch.setattr(
+            generation_tasks,
+            "resolve_generation_context",
+            _fake_resolve_ctx(fake_generator, supported_durations=(4, 8, 12)),
+        )
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+
+        await generation_tasks.execute_video_task(
+            "demo",
+            "E1S01",
+            {
+                "script_file": "episode_1.json",
+                "video_input_mode": "text",
+                "duration_seconds": 8,
+            },
+            task_id="task-text-video",
+        )
+
+        raw = fake_queue.persist_execution_checkpoint.await_args.args[1]
+        checkpoint = TextVideoSubmissionCheckpoint.from_json(raw)
+        assert checkpoint.capability == "i2v"
+        assert checkpoint.media == ()
+        assert checkpoint.artifact_currency is not None
+        assert checkpoint.artifact_currency.visual_basis.kind == "artifact-visual/video-text"
+        assert not (project_path / ".arcreel" / "tasks" / "task-text-video" / "provider_media").exists()
+
     async def test_execute_video_task_lane_bucket_follows_project_route(self, monkeypatch, tmp_path):
         """lane 归桶按项目生成模式求值，与提交入口使用同一口径。"""
         project_path = _prepare_files(tmp_path)

--- a/tests/integration/server/services/test_video_artifact_currency.py
+++ b/tests/integration/server/services/test_video_artifact_currency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from contextlib import asynccontextmanager, contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -38,6 +39,30 @@ from server.services.video_artifact_currency import (
 )
 
 
+def _write_safe_frame_test_video(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=white:s=720x1280:d=0.4:r=5",
+            "-vf",
+            "drawbox=x=620:y=1100:w=80:h=80:color=red:t=fill",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+    )
+
+
 def _currency(
     label: str,
     *,
@@ -69,6 +94,103 @@ def _currency(
         reference_image_limit=None,
         parent_version=parent_version,
     )
+
+
+@pytest.mark.asyncio
+async def test_declared_safe_frame_normalization_archives_raw_and_normalized_versions(
+    tmp_path: Path,
+) -> None:
+    project_path = tmp_path / "demo"
+    staged = project_path / "videos" / ".scene_E1S01.task.mp4"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    _write_safe_frame_test_video(staged)
+    versions = VersionManager(project_path)
+    committer = VideoArtifactCommitter(
+        project_manager=MagicMock(),
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="safe frame",
+    )
+    metadata = {
+        "execution_narration": {"delivery": "post_production"},
+        "video_output_normalization": {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": 720, "height": 1280},
+            "crop": {"x": 0, "y": 0, "width": 612, "height": 1088},
+            "output": {"width": 720, "height": 1280},
+            "scale_filter": "lanczos",
+        },
+    }
+
+    await committer.prepare_selection(staged, 1, metadata)
+    outcome = committer(staged, current, 1, metadata)
+
+    assert outcome.selected is False
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == 0
+    assert [record["video_output_role"] for record in history["versions"]] == [
+        "provider-raw",
+        "normalized-candidate",
+    ]
+    raw_record, normalized_record = history["versions"]
+    raw_receipt = raw_record["video_output_normalization_receipt"]
+    normalized_receipt = normalized_record["video_output_normalization_receipt"]
+    assert raw_receipt == normalized_receipt
+    assert (project_path / raw_record["file"]).read_bytes() != (
+        project_path / normalized_record["file"]
+    ).read_bytes()
+    assert raw_receipt["raw_sha256"] != raw_receipt["normalized_sha256"]
+    assert not staged.exists()
+    assert not current.exists()
+
+
+@pytest.mark.asyncio
+async def test_declared_safe_frame_normalization_failure_archives_provider_raw_only(
+    tmp_path: Path,
+) -> None:
+    project_path = tmp_path / "demo"
+    staged = project_path / "videos" / ".scene_E1S01.task.mp4"
+    current = project_path / "videos" / "scene_E1S01.mp4"
+    _write_safe_frame_test_video(staged)
+    versions = VersionManager(project_path)
+    committer = VideoArtifactCommitter(
+        project_manager=MagicMock(),
+        project_name="demo",
+        project_path=project_path,
+        versions=versions,
+        resource_type="videos",
+        resource_id="E1S01",
+        prompt="safe frame",
+    )
+    metadata = {
+        "execution_narration": {"delivery": "post_production"},
+        "video_output_normalization": {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": 1080, "height": 1920},
+            "crop": {"x": 0, "y": 0, "width": 918, "height": 1632},
+            "output": {"width": 1080, "height": 1920},
+            "scale_filter": "lanczos",
+        },
+    }
+
+    await committer.prepare_selection(staged, 1, metadata)
+    outcome = committer(staged, current, 1, metadata)
+
+    assert outcome.selected is False
+    assert committer.selection_error is not None
+    history = versions.get_versions("videos", "E1S01")
+    assert history["current_version"] == 0
+    assert len(history["versions"]) == 1
+    record = history["versions"][0]
+    assert record["video_output_role"] == "provider-raw"
+    assert record[VIDEO_ARTIFACT_RESTORE_BLOCKER_FIELD] == "output_normalization_failed"
+    assert not staged.exists()
+    assert not current.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/lib/custom_provider/test_custom_provider_endpoints.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_endpoints.py
@@ -24,6 +24,7 @@ class TestRegistry:
             "openai-images-edits",
             "gemini-image",
             "openai-video",
+            "grok-sub2api-video",
             "newapi-video",
             "v2-video-generations",
             "ark-seedance",
@@ -41,7 +42,18 @@ class TestRegistry:
         for key, spec in ENDPOINT_REGISTRY.items():
             assert spec.key == key
             assert spec.media_type in {"text", "image", "video", "audio"}
-            assert spec.family in {"openai", "google", "newapi", "v2", "ark", "vidu", "dashscope", "minimax", "kling"}
+            assert spec.family in {
+                "openai",
+                "google",
+                "newapi",
+                "v2",
+                "ark",
+                "vidu",
+                "dashscope",
+                "minimax",
+                "kling",
+                "grok",
+            }
             assert spec.display_name_key.startswith("endpoint_")
             assert callable(spec.build_backend)
             assert spec.request_method == "POST"
@@ -74,6 +86,7 @@ class TestRegistry:
             "dashscope-async-video",
             "minimax-video",
             "kling-video",
+            "grok-sub2api-video",
         ):
             assert ENDPOINT_REGISTRY[key].video_max_reference_images is None
         # 既有显式 int 保留，行为零变化
@@ -94,6 +107,7 @@ class TestRegistry:
             "dashscope-async-video",
             "minimax-video",
             "kling-video",
+            "grok-sub2api-video",
         ):
             assert ENDPOINT_REGISTRY[key].video_caps_for_model is not None
         # 显式 int 的 video endpoint 不应再绑 caps 函数
@@ -221,6 +235,7 @@ class TestRegistry:
         }
         assert video_keys == {
             "openai-video",
+            "grok-sub2api-video",
             "newapi-video",
             "v2-video-generations",
             "ark-seedance",
@@ -229,6 +244,15 @@ class TestRegistry:
             "minimax-video",
             "kling-video",
         }
+
+    def test_grok_sub2api_video_contract(self):
+        spec = ENDPOINT_REGISTRY["grok-sub2api-video"]
+        assert spec.family == "grok"
+        assert spec.request_path_template == "/v1/videos/generations"
+        assert spec.video_caps_for_model is not None
+        assert spec.video_caps_for_model("grok-imagine-video-1.5").first_frame is True
+        assert spec.video_caps_for_model("grok-imagine-video-2.0").first_frame is True
+        assert spec.end_image_capable is False
 
 
 class TestHelpers:
@@ -269,6 +293,8 @@ class TestInferEndpoint:
             ("gemini-2.0-flash-exp-image-generation", "openai", "gemini-image"),
             ("gemini-3-pro-image-preview", "openai", "gemini-image"),
             # ── 新视频分支路由 ──
+            ("grok-imagine-video", "openai", "grok-sub2api-video"),
+            ("grok-imagine-video-2.0", "openai", "grok-sub2api-video"),
             ("seedance-1.0", "openai", "ark-seedance"),
             ("doubao-seedance-2-0", "openai", "ark-seedance"),
             ("viduq3", "openai", "vidu-video"),

--- a/tests/unit/lib/custom_provider/test_custom_provider_factory.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_factory.py
@@ -28,6 +28,7 @@ _ENDPOINT_BACKEND_CLASSES = (
     "DashScopeVideoBackend",
     "GeminiImageBackend",
     "GeminiTextBackend",
+    "GrokSub2APIVideoBackend",
     "KlingImageBackend",
     "KlingVideoBackend",
     "MiniMaxImageBackend",
@@ -77,6 +78,21 @@ def _built(provider: MagicMock, model_id: str, endpoint: str, **kwargs: Any) -> 
 
 
 class TestEndpointDispatch:
+    def test_grok_sub2api_video(self):
+        provider = _make_provider(base_url="https://sub2api.example", api_key="managed-client-key")
+        result, built = _built(provider, "grok-imagine-video-1.5", "grok-sub2api-video")
+        assert isinstance(result, CustomVideoBackend)
+        assert result.endpoint == "grok-sub2api-video"
+        assert result.model == "grok-imagine-video-1.5"
+        assert built == {
+            "backend": "GrokSub2APIVideoBackend",
+            "kwargs": {
+                "api_key": "managed-client-key",
+                "base_url": "https://sub2api.example",
+                "model": "grok-imagine-video-1.5",
+            },
+        }
+
     def test_openai_chat(self):
         # host-only base_url：openai 端点补 /v1 的接线在此覆盖
         provider = _make_provider(base_url="https://api.example.com")

--- a/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
+++ b/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
@@ -12,6 +12,80 @@ from lib.db.repositories.task_repo import TaskRepository
 
 @pytest.mark.asyncio
 class TestRepoStateMachineGuards:
+    async def test_requeue_failed_pre_provider_only_retries_unsubmitted_tasks(self, db_session):
+        repo = TaskRepository(db_session)
+
+        eligible = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="eligible",
+            payload={},
+            script_file="ep1.json",
+            provider_id="custom-2",
+        )
+        await repo.claim_next("video")
+        await repo.mark_failed(eligible["task_id"], "local validation failed")
+
+        submitted = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="submitted",
+            payload={},
+            script_file="ep1.json",
+        )
+        await repo.claim_next("video")
+        await repo.persist_provider_job_id(
+            submitted["task_id"],
+            "provider-job-1",
+            endpoint="openai-video",
+            base_url="https://provider.example.com/v1",
+        )
+        await repo.mark_failed(submitted["task_id"], "provider failed")
+
+        checkpointed = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="checkpointed",
+            payload={},
+            script_file="ep1.json",
+        )
+        await repo.claim_next("video")
+        await repo.persist_execution_checkpoint(checkpointed["task_id"], '{"version":1}', "custom-2")
+        await repo.mark_failed(checkpointed["task_id"], "failed after checkpoint")
+
+        queued = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="still-queued",
+            payload={},
+            script_file="ep1.json",
+        )
+
+        requeued = await repo.requeue_failed_pre_provider(
+            [eligible["task_id"], submitted["task_id"], checkpointed["task_id"], queued["task_id"]]
+        )
+
+        assert requeued == [eligible["task_id"]]
+        retried = await repo.get(eligible["task_id"])
+        assert retried is not None
+        assert retried["status"] == "queued"
+        assert retried["started_at"] is None
+        assert retried["finished_at"] is None
+        assert retried["error_message"] is None
+        assert retried["provider_id"] == "custom-2"
+        assert (await repo.get(submitted["task_id"]))["status"] == "failed"
+        assert (await repo.get(checkpointed["task_id"]))["status"] == "failed"
+        assert (await repo.get(queued["task_id"]))["status"] == "queued"
+
+    async def test_requeue_failed_pre_provider_rejects_empty_task_ids(self, db_session):
+        repo = TaskRepository(db_session)
+
+        assert await repo.requeue_failed_pre_provider([]) == []
+
     async def test_mark_succeeded_only_from_running(self, db_session):
         repo = TaskRepository(db_session)
         t = await repo.enqueue(

--- a/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
+++ b/tests/unit/lib/db/repositories/test_task_repo_state_machine.py
@@ -86,6 +86,54 @@ class TestRepoStateMachineGuards:
 
         assert await repo.requeue_failed_pre_provider([]) == []
 
+    async def test_requeue_failed_pre_provider_serializes_same_resource_candidates(self, db_session):
+        repo = TaskRepository(db_session)
+
+        task_ids = []
+        for suffix in ("a", "b"):
+            task = await repo.enqueue(
+                project_name="demo",
+                task_type="video",
+                media_type="video",
+                resource_id="same-shot",
+                payload={"candidate": suffix},
+                script_file="ep1.json",
+            )
+            task_ids.append(task["task_id"])
+            await repo.claim_next("video")
+            await repo.mark_failed(task["task_id"], f"local failure {suffix}")
+
+        requeued = await repo.requeue_failed_pre_provider(task_ids)
+
+        assert requeued == [task_ids[0]]
+        assert (await repo.get(task_ids[0]))["status"] == "queued"
+        assert (await repo.get(task_ids[1]))["status"] == "failed"
+
+    async def test_requeue_failed_pre_provider_skips_key_owned_by_active_replacement(self, db_session):
+        repo = TaskRepository(db_session)
+        failed = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="same-shot",
+            payload={"candidate": "old"},
+            script_file="ep1.json",
+        )
+        await repo.claim_next("video")
+        await repo.mark_failed(failed["task_id"], "local failure")
+        replacement = await repo.enqueue(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="same-shot",
+            payload={"candidate": "new"},
+            script_file="ep1.json",
+        )
+
+        assert await repo.requeue_failed_pre_provider([failed["task_id"]]) == []
+        assert (await repo.get(failed["task_id"]))["status"] == "failed"
+        assert (await repo.get(replacement["task_id"]))["status"] == "queued"
+
     async def test_mark_succeeded_only_from_running(self, db_session):
         repo = TaskRepository(db_session)
         t = await repo.enqueue(

--- a/tests/unit/lib/test_generation_queue.py
+++ b/tests/unit/lib/test_generation_queue.py
@@ -435,6 +435,28 @@ class TestGenerationQueue:
         assert claimed_again is not None
         assert claimed_again["task_id"] == task["task_id"]
 
+    async def test_requeue_failed_pre_provider_tasks(self, queue):
+        task = await queue.enqueue_task(
+            project_name="demo",
+            task_type="video",
+            media_type="video",
+            resource_id="E1S02",
+            payload={"prompt": "video"},
+            script_file="episode_01.json",
+            source="webui",
+        )
+        running = await queue.claim_next_task(media_type="video")
+        assert running is not None
+        await queue.mark_task_failed(task["task_id"], "local validation failed")
+
+        requeued = await queue.requeue_failed_pre_provider_tasks([task["task_id"]])
+
+        assert requeued == [task["task_id"]]
+        queued = await queue.get_task(task["task_id"])
+        assert queued is not None
+        assert queued["status"] == "queued"
+        assert queued["error_message"] is None
+
     async def test_cancel_task(self, queue):
         result = await queue.enqueue_task(
             project_name="demo",

--- a/tests/unit/lib/test_video_output_normalization.py
+++ b/tests/unit/lib/test_video_output_normalization.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lib.video_output_normalization import (
+    VideoOutputNormalizationPolicy,
+    normalize_video_output,
+)
+
+
+def _policy() -> VideoOutputNormalizationPolicy:
+    return VideoOutputNormalizationPolicy.from_dict(
+        {
+            "schema_version": 1,
+            "kind": "safe_frame_crop",
+            "input": {"width": 720, "height": 1280},
+            "crop": {"x": 0, "y": 0, "width": 612, "height": 1088},
+            "output": {"width": 720, "height": 1280},
+            "scale_filter": "lanczos",
+        }
+    )
+
+
+def _synthetic_video(path: Path) -> None:
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=white:s=720x1280:d=0.4:r=5",
+            "-vf",
+            "drawbox=x=620:y=1100:w=80:h=80:color=red:t=fill,"
+            "drawbox=x=500:y=900:w=50:h=50:color=green:t=fill",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+    )
+
+
+def _first_rgb_frame(path: Path) -> bytes:
+    return subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-frames:v",
+            "1",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+
+
+def test_normalizes_exact_safe_frame_and_records_content_lineage(tmp_path: Path) -> None:
+    raw = tmp_path / "provider-raw.mp4"
+    normalized = tmp_path / "normalized.mp4"
+    _synthetic_video(raw)
+
+    receipt = normalize_video_output(raw, normalized, _policy())
+
+    assert raw.is_file()
+    assert normalized.is_file()
+    assert receipt.input_dimensions == {"width": 720, "height": 1280}
+    assert receipt.output_dimensions == {"width": 720, "height": 1280}
+    assert receipt.filter_graph == "crop=612:1088:0:0,scale=720:1280:flags=lanczos"
+    assert len(receipt.raw_sha256) == 64
+    assert len(receipt.normalized_sha256) == 64
+    assert receipt.raw_sha256 != receipt.normalized_sha256
+    assert len(receipt.policy_digest) == 64
+    assert receipt.ffmpeg_version.startswith("8.")
+
+    frame = _first_rgb_frame(normalized)
+    pixels = zip(frame[0::3], frame[1::3], frame[2::3], strict=True)
+    red = 0
+    green = 0
+    for r, g, b in pixels:
+        red += int(r > 180 and g < 100 and b < 100)
+        green += int(g > 80 and r < 180 and b < 150)
+    assert red == 0
+    assert green > 500
+
+
+def test_fails_closed_on_dimension_or_crop_drift(tmp_path: Path) -> None:
+    raw = tmp_path / "provider-raw.mp4"
+    normalized = tmp_path / "normalized.mp4"
+    _synthetic_video(raw)
+    wrong_input = VideoOutputNormalizationPolicy.from_dict(
+        {
+            **_policy().to_dict(),
+            "input": {"width": 1080, "height": 1920},
+        }
+    )
+
+    with pytest.raises(ValueError, match="input dimensions"):
+        normalize_video_output(raw, normalized, wrong_input)
+    assert not normalized.exists()
+
+    with pytest.raises(ValueError, match="crop must stay inside input bounds"):
+        VideoOutputNormalizationPolicy.from_dict(
+            {
+                **_policy().to_dict(),
+                "crop": {"x": 700, "y": 1200, "width": 100, "height": 100},
+            }
+        )

--- a/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from lib.video_backends.base import VideoGenerationRequest
+from lib.video_backends.base import VideoAudioMode, VideoGenerationRequest
 
 pytestmark = pytest.mark.unit
 
@@ -63,6 +63,20 @@ def test_build_request_body_rejects_empty_prompt_before_submit(tmp_path: Path) -
         build_request_body("grok-imagine-video", request)
 
 
+@pytest.mark.parametrize("duration_seconds", [0, 16])
+def test_build_request_body_rejects_duration_outside_provider_range(tmp_path: Path, duration_seconds: int) -> None:
+    from lib.video_backends.grok_sub2api import build_request_body
+
+    request = VideoGenerationRequest(
+        prompt="animate",
+        output_path=tmp_path / "out.mp4",
+        duration_seconds=duration_seconds,
+    )
+
+    with pytest.raises(ValueError, match="1.*15"):
+        build_request_body("grok-imagine-video-1.5", request)
+
+
 @pytest.mark.parametrize(
     "field",
     ["end_image", "reference_images", "reference_audio_files"],
@@ -93,6 +107,14 @@ def test_normalize_api_root_targets_sub2api_v1(base_url: str, expected: str) -> 
     from lib.video_backends.grok_sub2api import normalize_api_root
 
     assert normalize_api_root(base_url) == expected
+
+
+def test_video_capabilities_declare_native_audio_always_on() -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    capabilities = GrokSub2APIVideoBackend.video_capabilities_for_model("grok-imagine-video-1.5")
+
+    assert capabilities.audio_track is VideoAudioMode.ALWAYS_ON
 
 
 def _response(status_code: int, *, json: dict | None = None, content: bytes = b"") -> httpx.Response:
@@ -209,6 +231,38 @@ async def test_generate_never_retries_an_ambiguous_create(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_generate_retries_only_safe_connect_failure(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    submit_request = httpx.Request("POST", "https://sub2api.example/v1/videos/generations")
+    client = _client(
+        post=[
+            httpx.ConnectError("connection not established", request=submit_request),
+            _response(200, json={"request_id": "video-retried"}),
+        ],
+        get=[
+            _response(200, json={"status": "done", "duration": 5}),
+            _response(200, content=b"retried"),
+        ],
+    )
+
+    with (
+        patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client),
+        patch("lib.retry.asyncio.sleep", AsyncMock()),
+    ):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            poll_interval_seconds=0.0,
+        )
+        result = await backend.generate(VideoGenerationRequest(prompt="animate", output_path=tmp_path / "out.mp4"))
+
+    assert client.post.await_count == 2
+    assert result.task_id == "video-retried"
+    assert result.video_path.read_bytes() == b"retried"
+
+
+@pytest.mark.asyncio
 async def test_resume_only_reads_exact_status_and_content_urls(tmp_path: Path) -> None:
     from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
 
@@ -238,6 +292,39 @@ async def test_resume_only_reads_exact_status_and_content_urls(tmp_path: Path) -
     assert result.task_id == "video/id"
     assert result.duration_seconds == 6
     assert result.video_path.read_bytes() == b"resumed"
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_submitted_base_url_after_provider_config_change(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    client = _client(
+        post=_response(200, json={}),
+        get=[
+            _response(200, json={"status": "done", "duration": 5}),
+            _response(200, content=b"original-host"),
+        ],
+    )
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://current.example",
+            poll_interval_seconds=0.0,
+        )
+        result = await backend.resume_video(
+            "video-123",
+            VideoGenerationRequest(
+                prompt="ignored",
+                output_path=tmp_path / "resumed.mp4",
+                submitted_base_url="https://submitted.example/v1",
+            ),
+        )
+
+    assert [call.args[0] for call in client.get.await_args_list] == [
+        "https://submitted.example/v1/videos/generations/video-123",
+        "https://submitted.example/v1/videos/generations/video-123/content",
+    ]
+    assert result.video_path.read_bytes() == b"original-host"
 
 
 @pytest.mark.parametrize(
@@ -274,6 +361,28 @@ async def test_resume_maps_not_found_to_expired_without_retry(tmp_path: Path) ->
             )
 
     assert exc_info.value.job_id == "missing-task"
+    assert client.get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_maps_expired_status_to_resume_expired(tmp_path: Path) -> None:
+    from lib.video_backends.base import ResumeExpiredError
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    client = _client(post=_response(200, json={}), get=_response(200, json={"status": "expired"}))
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            poll_interval_seconds=0.0,
+        )
+        with pytest.raises(ResumeExpiredError) as exc_info:
+            await backend.resume_video(
+                "expired-task",
+                VideoGenerationRequest(prompt="ignored", output_path=tmp_path / "out.mp4"),
+            )
+
+    assert exc_info.value.job_id == "expired-task"
     assert client.get.await_count == 1
 
 

--- a/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
@@ -1,0 +1,308 @@
+"""Sub2API Grok video backend contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from lib.video_backends.base import VideoGenerationRequest
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_request_body_preserves_configured_model_and_image_to_video_input(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import build_request_body
+
+    image = tmp_path / "still.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\nsource")
+    request = VideoGenerationRequest(
+        prompt="The cat slowly raises its head",
+        output_path=tmp_path / "out.mp4",
+        duration_seconds=5,
+        aspect_ratio="16:9",
+        resolution="720p",
+        start_image=image,
+    )
+
+    body = build_request_body("grok-imagine-video-1.5", request)
+    assert body["model"] == "grok-imagine-video-1.5"
+    assert body["prompt"] == "The cat slowly raises its head"
+    assert body["duration"] == 5
+    assert body["aspect_ratio"] == "16:9"
+    assert body["resolution"] == "720p"
+    assert set(body) == {"model", "prompt", "duration", "aspect_ratio", "resolution", "image"}
+    image_body = body["image"]
+    assert isinstance(image_body, dict)
+    image_url = image_body.get("url")
+    assert isinstance(image_url, str)
+    assert image_url.startswith("data:image/png;base64,")
+
+
+def test_build_request_body_rejects_missing_input_image_before_submit(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import build_request_body
+
+    request = VideoGenerationRequest(
+        prompt="animate",
+        output_path=tmp_path / "out.mp4",
+        start_image=tmp_path / "missing.png",
+    )
+
+    with pytest.raises(ValueError, match="start_image"):
+        build_request_body("grok-imagine-video-1.5", request)
+
+
+def test_build_request_body_rejects_empty_prompt_before_submit(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import build_request_body
+
+    request = VideoGenerationRequest(prompt="  ", output_path=tmp_path / "out.mp4")
+
+    with pytest.raises(ValueError, match="prompt"):
+        build_request_body("grok-imagine-video", request)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["end_image", "reference_images", "reference_audio_files"],
+)
+def test_build_request_body_rejects_unsupported_inputs(tmp_path: Path, field: str) -> None:
+    from lib.video_backends.grok_sub2api import build_request_body
+
+    request = VideoGenerationRequest(prompt="animate", output_path=tmp_path / "out.mp4")
+    if field == "end_image":
+        request.end_image = Path("end.png")
+    elif field == "reference_images":
+        request.reference_images = [Path("reference.png")]
+    else:
+        request.reference_audio_files = [Path("voice.wav")]
+
+    with pytest.raises(ValueError, match=field):
+        build_request_body("grok-imagine-video-1.5", request)
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://sub2api.example", "https://sub2api.example/v1"),
+        ("https://sub2api.example/v1/", "https://sub2api.example/v1"),
+    ],
+)
+def test_normalize_api_root_targets_sub2api_v1(base_url: str, expected: str) -> None:
+    from lib.video_backends.grok_sub2api import normalize_api_root
+
+    assert normalize_api_root(base_url) == expected
+
+
+def _response(status_code: int, *, json: dict | None = None, content: bytes = b"") -> httpx.Response:
+    request = httpx.Request("GET", "https://sub2api.example/v1/videos/generations")
+    if json is not None:
+        return httpx.Response(status_code, json=json, request=request)
+    return httpx.Response(status_code, content=content, headers={"content-type": "video/mp4"}, request=request)
+
+
+def _client(*, post: object, get: object) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.post = AsyncMock(
+        side_effect=post if isinstance(post, list) else None, return_value=None if isinstance(post, list) else post
+    )
+    client.get = AsyncMock(
+        side_effect=get if isinstance(get, list) else None, return_value=None if isinstance(get, list) else get
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_request_id_before_status_and_content_fetch(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    events: list[str] = []
+    client = _client(
+        post=_response(200, json={"request_id": "video-123"}),
+        get=[
+            _response(200, json={"status": "done", "video": {"duration": 5}}),
+            _response(200, content=b"mp4"),
+        ],
+    )
+    client.post.side_effect = lambda *args, **kwargs: (
+        events.append("post") or _response(200, json={"request_id": "video-123"})
+    )
+
+    async def _persist(*args, **kwargs) -> None:
+        events.append("persist")
+
+    original_get = client.get
+
+    async def _get(url: str, *args, **kwargs):
+        events.append("content" if url.endswith("/content") else "status")
+        return await original_get(url, *args, **kwargs)
+
+    client.get = AsyncMock(side_effect=_get)
+
+    with (
+        patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client),
+        patch("lib.video_backends.base.persist_provider_job_id", AsyncMock(side_effect=_persist)),
+    ):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            model="grok-imagine-video-1.5",
+            poll_interval_seconds=0.0,
+        )
+        image = tmp_path / "still.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\nsource")
+        result = await backend.generate(
+            VideoGenerationRequest(
+                prompt="animate",
+                output_path=tmp_path / "out.mp4",
+                duration_seconds=5,
+                start_image=image,
+                task_id="task-1",
+            )
+        )
+
+    assert events == ["post", "persist", "status", "content"]
+    assert result.task_id == "video-123"
+    assert result.video_path.read_bytes() == b"mp4"
+    post_call = client.post.await_args
+    assert post_call is not None
+    assert post_call.args[0] == "https://sub2api.example/v1/videos/generations"
+    assert post_call.kwargs["headers"]["Authorization"] == "Bearer sub2api-test-key"
+
+
+@pytest.mark.asyncio
+async def test_generate_never_retries_an_ambiguous_create(tmp_path: Path) -> None:
+    from lib.video_backends.base import AmbiguousSubmitError
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    request = httpx.Request("POST", "https://sub2api.example/v1/videos/generations")
+    client = _client(post=_response(200, json={}), get=[])
+    client.post.side_effect = httpx.ReadTimeout("response lost", request=request)
+
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+        )
+        with pytest.raises(AmbiguousSubmitError, match="create_ambiguous"):
+            await backend.generate(VideoGenerationRequest(prompt="animate", output_path=tmp_path / "out.mp4"))
+
+    assert client.post.await_count == 1
+    assert client.get.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_resume_only_reads_exact_status_and_content_urls(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    client = _client(
+        post=_response(200, json={}),
+        get=[
+            _response(200, json={"status": "done", "video": {"duration": 6}}),
+            _response(200, content=b"resumed"),
+        ],
+    )
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            poll_interval_seconds=0.0,
+        )
+        result = await backend.resume_video(
+            "video/id",
+            VideoGenerationRequest(prompt="ignored", output_path=tmp_path / "resumed.mp4"),
+        )
+
+    client.post.assert_not_awaited()
+    assert [call.args[0] for call in client.get.await_args_list] == [
+        "https://sub2api.example/v1/videos/generations/video%2Fid",
+        "https://sub2api.example/v1/videos/generations/video%2Fid/content",
+    ]
+    assert result.task_id == "video/id"
+    assert result.duration_seconds == 6
+    assert result.video_path.read_bytes() == b"resumed"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"request_id": "request", "id": "id", "task_id": "task"}, "request"),
+        ({"data": {"request_id": "data-request", "id": "data-id"}}, "data-request"),
+        ({"video": {"id": "video-id"}, "task_id": "task"}, "video-id"),
+        ({"data": {"task_id": "data-task"}}, "data-task"),
+    ],
+)
+def test_request_id_matches_sub2api_forwarding_precedence(payload: dict, expected: str) -> None:
+    from lib.video_backends.grok_sub2api import _request_id
+
+    assert _request_id(payload) == expected
+
+
+@pytest.mark.asyncio
+async def test_resume_maps_not_found_to_expired_without_retry(tmp_path: Path) -> None:
+    from lib.video_backends.base import ResumeExpiredError
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    client = _client(post=_response(200, json={}), get=_response(404, json={"error": "not found"}))
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            max_wait_seconds=0.0,
+        )
+        with pytest.raises(ResumeExpiredError) as exc_info:
+            await backend.resume_video(
+                "missing-task",
+                VideoGenerationRequest(prompt="ignored", output_path=tmp_path / "out.mp4"),
+            )
+
+    assert exc_info.value.job_id == "missing-task"
+    assert client.get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_status_fails_loud_instead_of_polling_forever(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    client = _client(post=_response(200, json={}), get=_response(200, json={"status": "mystery"}))
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+            max_wait_seconds=0.0,
+        )
+        with pytest.raises(ValueError, match="mystery"):
+            await backend.resume_video(
+                "video-123",
+                VideoGenerationRequest(prompt="ignored", output_path=tmp_path / "out.mp4"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_empty_content_never_replaces_output(tmp_path: Path) -> None:
+    from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
+
+    output = tmp_path / "out.mp4"
+    output.write_bytes(b"existing")
+    client = _client(
+        post=_response(200, json={}),
+        get=[
+            _response(200, json={"status": "done"}),
+            _response(200, content=b""),
+        ],
+    )
+    with patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client):
+        backend = GrokSub2APIVideoBackend(
+            api_key="sub2api-test-key",
+            base_url="https://sub2api.example",
+        )
+        with pytest.raises(ValueError, match="empty"):
+            await backend.resume_video(
+                "video-123",
+                VideoGenerationRequest(prompt="ignored", output_path=output),
+            )
+
+    assert output.read_bytes() == b"existing"

--- a/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_sub2api_video_backend.py
@@ -117,6 +117,7 @@ def _client(*, post: object, get: object) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_generate_persists_request_id_before_status_and_content_fetch(tmp_path: Path) -> None:
+    from lib.custom_provider.backends import CustomVideoBackend
     from lib.video_backends.grok_sub2api import GrokSub2APIVideoBackend
 
     events: list[str] = []
@@ -134,6 +135,7 @@ async def test_generate_persists_request_id_before_status_and_content_fetch(tmp_
     async def _persist(*args, **kwargs) -> None:
         events.append("persist")
 
+    persist = AsyncMock(side_effect=_persist)
     original_get = client.get
 
     async def _get(url: str, *args, **kwargs):
@@ -144,13 +146,18 @@ async def test_generate_persists_request_id_before_status_and_content_fetch(tmp_
 
     with (
         patch("lib.video_backends.grok_sub2api.httpx.AsyncClient", return_value=client),
-        patch("lib.video_backends.base.persist_provider_job_id", AsyncMock(side_effect=_persist)),
+        patch("lib.video_backends.base.persist_provider_job_id", persist),
     ):
-        backend = GrokSub2APIVideoBackend(
-            api_key="sub2api-test-key",
-            base_url="https://sub2api.example",
+        backend = CustomVideoBackend(
+            provider_id="custom-42",
             model="grok-imagine-video-1.5",
-            poll_interval_seconds=0.0,
+            endpoint="grok-sub2api-video",
+            delegate=GrokSub2APIVideoBackend(
+                api_key="sub2api-test-key",
+                base_url="https://sub2api.example",
+                model="grok-imagine-video-1.5",
+                poll_interval_seconds=0.0,
+            ),
         )
         image = tmp_path / "still.png"
         image.write_bytes(b"\x89PNG\r\n\x1a\nsource")
@@ -167,6 +174,13 @@ async def test_generate_persists_request_id_before_status_and_content_fetch(tmp_
     assert events == ["post", "persist", "status", "content"]
     assert result.task_id == "video-123"
     assert result.video_path.read_bytes() == b"mp4"
+    persist.assert_awaited_once_with(
+        "task-1",
+        "video-123",
+        provider="grok",
+        endpoint="grok-sub2api-video",
+        base_url="https://sub2api.example/v1",
+    )
     post_call = client.post.await_args
     assert post_call is not None
     assert post_call.args[0] == "https://sub2api.example/v1/videos/generations"

--- a/tests/unit/server/routers/test_custom_providers_api.py
+++ b/tests/unit/server/routers/test_custom_providers_api.py
@@ -201,6 +201,7 @@ class TestEndpointCatalog:
             "openai-images-edits",
             "gemini-image",
             "openai-video",
+            "grok-sub2api-video",
             "newapi-video",
             "v2-video-generations",
             "ark-seedance",


### PR DESCRIPTION
## Summary

- add a `grok-sub2api-video` custom-provider backend for Grok subscription video through a Sub2API-compatible endpoint
- support async submit/status polling, resumable provider task ids, atomic media download, native audio, first-frame input, 1-15s duration, aspect ratio, and resolution contracts
- expose explicit polling timing seams for deterministic tests without private patching

## Boundaries

- no provider credentials are committed
- no provider call is made by this change or its tests
- the backend stays within ArcReel's custom-provider/video-backend abstractions

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright` — 0 errors
- `uv run lint-imports` — 2 contracts kept
- `uv run python scripts/audit_tests.py --check` — 0 violations
- `uv run python -m pytest` — 10317 passed, 2 skipped
- `cd frontend && pnpm lint && pnpm check` — 156 files, 1898 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Grok Sub2API 视频生成端点，支持视频创建、状态查询、任务恢复和结果下载。
  * 支持首帧图片、时长、宽高比及分辨率等参数。
  * 支持无需分镜图片的纯文本视频生成。
  * 支持视频输出安全裁剪与缩放，并记录处理结果。
  * 可重新排队尚未提交至服务商的失败视频任务。
* **本地化**
  * 新增英文、越南文和中文的端点显示名称。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->