### PR TITLE
test: harden durable polling contracts [Spec #2062]

### DIFF
--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -552,6 +552,7 @@ class GenerationWorker:
         try:
             await asyncio.wait_for(self._wake_event.wait(), timeout=timeout)
         except TimeoutError:
+            # No local wake is normal; cross-process work is discovered on the polling timeout.
             pass
         self._wake_event.clear()
 

--- a/lib/generation_worker.py
+++ b/lib/generation_worker.py
@@ -495,6 +495,7 @@ class GenerationWorker:
 
         self._main_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
+        self._wake_event = asyncio.Event()
         self._owns_lease = False
         # Orphan dispatcher 句柄持久化：shutdown 时 await 它跑完；lease 切换重夺时
         # 第二次进 _handle_orphan_tasks_on_start，旧句柄未 done 不能直接覆盖。
@@ -533,13 +534,26 @@ class GenerationWorker:
         if self._main_task and not self._main_task.done():
             return
         self._stop_event.clear()
+        self._wake_event.clear()
         self._main_task = asyncio.create_task(self._run_loop(), name="generation-worker")
 
     async def stop(self) -> None:
         self._stop_event.set()
+        self.wake()
         if self._main_task:
             await self._main_task
             self._main_task = None
+
+    def wake(self) -> None:
+        """Wake the local worker without changing cross-process polling."""
+        self._wake_event.set()
+
+    async def _wait_for_wake(self, timeout: float) -> None:
+        try:
+            await asyncio.wait_for(self._wake_event.wait(), timeout=timeout)
+        except TimeoutError:
+            pass
+        self._wake_event.clear()
 
     # ------------------------------------------------------------------
     # Main loop
@@ -585,7 +599,7 @@ class GenerationWorker:
                     self._orphan_handled_once = True
 
                 if not self._owns_lease:
-                    await asyncio.sleep(self.heartbeat_interval)
+                    await self._wait_for_wake(self.heartbeat_interval)
                     continue
 
                 claimed_any = await self._claim_tasks()
@@ -593,7 +607,7 @@ class GenerationWorker:
                 if claimed_any:
                     await asyncio.sleep(0.05)
                 else:
-                    await asyncio.sleep(self.poll_interval)
+                    await self._wait_for_wake(self.poll_interval)
 
             await self._wait_inflight_completion()
         finally:

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -926,6 +926,50 @@ class TestCapacityTable:
 
 class TestGenerationWorker:
     @pytest.mark.asyncio
+    async def test_wake_claims_task_without_waiting_for_poll_interval(self):
+        task = {"task_id": "wake-task", "media_type": "text", "provider_id": "text"}
+        queue = _FakeQueue()
+        idle = asyncio.Event()
+        completed = asyncio.Event()
+
+        async def claim_next_task(media_type, **_kwargs):
+            assert media_type == "text"
+            if idle.is_set():
+                return task
+            idle.set()
+            return None
+
+        queue.claim_next_task = claim_next_task
+
+        async def mark_task_succeeded(task_id, result):
+            queue.succeeded.append((task_id, result))
+            completed.set()
+            return 1
+
+        queue.mark_task_succeeded = mark_task_succeeded
+
+        async def execute(_task, *, claimed_provider_id):
+            assert claimed_provider_id == "text"
+            return {"ok": True}
+
+        worker = GenerationWorker(
+            queue=queue,
+            capacity=CapacityTable(_limits={}, _defaults={"text": 1}),
+            provider_projection=lambda _task: asyncio.sleep(0, result="text"),
+            executor=execute,
+            lanes=("text",),
+        )
+        worker.poll_interval = 60
+        await worker.start()
+        try:
+            await asyncio.wait_for(idle.wait(), timeout=1)
+            worker.wake()
+            await asyncio.wait_for(completed.wait(), timeout=1)
+            assert queue.succeeded == [("wake-task", {"ok": True})]
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
     async def test_process_task_success_and_failure(self, monkeypatch):
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -926,50 +926,6 @@ class TestCapacityTable:
 
 class TestGenerationWorker:
     @pytest.mark.asyncio
-    async def test_wake_claims_task_without_waiting_for_poll_interval(self):
-        task = {"task_id": "wake-task", "media_type": "text", "provider_id": "text"}
-        queue = _FakeQueue()
-        idle = asyncio.Event()
-        completed = asyncio.Event()
-
-        async def claim_next_task(media_type, **_kwargs):
-            assert media_type == "text"
-            if idle.is_set():
-                return task
-            idle.set()
-            return None
-
-        queue.claim_next_task = claim_next_task
-
-        async def mark_task_succeeded(task_id, result):
-            queue.succeeded.append((task_id, result))
-            completed.set()
-            return 1
-
-        queue.mark_task_succeeded = mark_task_succeeded
-
-        async def execute(_task, *, claimed_provider_id):
-            assert claimed_provider_id == "text"
-            return {"ok": True}
-
-        worker = GenerationWorker(
-            queue=queue,
-            capacity=CapacityTable(_limits={}, _defaults={"text": 1}),
-            provider_projection=lambda _task: asyncio.sleep(0, result="text"),
-            executor=execute,
-            lanes=("text",),
-        )
-        worker.poll_interval = 60
-        await worker.start()
-        try:
-            await asyncio.wait_for(idle.wait(), timeout=1)
-            worker.wake()
-            await asyncio.wait_for(completed.wait(), timeout=1)
-            assert queue.succeeded == [("wake-task", {"ok": True})]
-        finally:
-            await worker.stop()
-
-    @pytest.mark.asyncio
     async def test_process_task_success_and_failure(self, monkeypatch):
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)

--- a/tests/integration/server/conftest.py
+++ b/tests/integration/server/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -7,7 +8,9 @@ from typing import Any
 import pytest
 
 from lib.generation_queue import GenerationQueue
+from lib.generation_queue_client import wait_for_task
 from lib.generation_worker import CapacityTable, GenerationWorker
+from lib.project_change_hints import register_project_change_batch_listener
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import _fake_caps_resolver, _FakePM
 
@@ -57,8 +60,28 @@ async def fake_ctx(
         provider_projection=text_provider,
         lanes=("text",),
     )
-    worker.poll_interval = 0.01
-    worker.heartbeat_interval = 0.01
+    worker.poll_interval = 60
+    worker.heartbeat_interval = 60
+    terminal_events: dict[str, asyncio.Event] = {}
+
+    def record_terminal_events(_project_name, _source, changes) -> None:
+        for change in changes:
+            if change.get("entity_type") == "task":
+                terminal_events.setdefault(str(change["entity_id"]), asyncio.Event()).set()
+
+    async def wait_for_worker_task(task_id: str, *, queue: GenerationQueue) -> dict[str, Any]:
+        terminal = terminal_events.setdefault(task_id, asyncio.Event())
+        worker.wake()
+        await asyncio.wait_for(terminal.wait(), timeout=5)
+        return await wait_for_task(task_id, queue=queue)
+
+    unregister = register_project_change_batch_listener(record_terminal_events)
+    monkeypatch.setattr("server.tool_runtime.wait_for_task", wait_for_worker_task)
+    assert await queue.acquire_or_renew_worker_lease(
+        name=worker.lease_name,
+        owner_id=worker.owner_id,
+        ttl_seconds=worker.lease_ttl,
+    )
     queue.set_worker_cancel_callback(worker.request_cancel)
     await worker.start()
     try:
@@ -66,3 +89,4 @@ async def fake_ctx(
     finally:
         await worker.stop()
         queue.set_worker_cancel_callback(None)
+        unregister()

--- a/tests/integration/server/test_remote_mcp.py
+++ b/tests/integration/server/test_remote_mcp.py
@@ -389,6 +389,7 @@ async def test_remote_mcp_returns_typed_workflow_plan_and_rejects_bad_project(
     assert "remote MCP" in narration_description
     assert "get_generation_batch" in narration_description
     assert "poll_after_seconds" in narration_description
+    assert "done=true" in narration_description
     assert result.structuredContent is not None
     assert result.structuredContent["workflow_plan"]["status"]["target"]["episode"] == 1
     assert capabilities.structuredContent == {

--- a/tests/unit/lib/test_generation_worker_wake.py
+++ b/tests/unit/lib/test_generation_worker_wake.py
@@ -1,0 +1,62 @@
+import asyncio
+from typing import Any
+
+from lib.generation_worker import CapacityTable, GenerationWorker
+
+
+class _WakeQueue:
+    def __init__(self) -> None:
+        self.idle = asyncio.Event()
+        self.completed = asyncio.Event()
+        self.claimed = False
+        self.succeeded: list[tuple[str, dict[str, Any]]] = []
+
+    async def acquire_or_renew_worker_lease(self, **_kwargs: Any) -> bool:
+        return True
+
+    async def release_worker_lease(self, **_kwargs: Any) -> None:
+        return None
+
+    async def list_orphan_tasks_on_start(self) -> list[dict[str, Any]]:
+        return []
+
+    async def claim_next_task(self, media_type: str, **_kwargs: Any) -> dict[str, str] | None:
+        assert media_type == "text"
+        if self.idle.is_set() and not self.claimed:
+            self.claimed = True
+            return {"task_id": "wake-task", "media_type": "text", "provider_id": "text"}
+        self.idle.set()
+        return None
+
+    async def mark_task_succeeded(self, task_id: str, result: dict[str, Any]) -> int:
+        self.succeeded.append((task_id, result))
+        self.completed.set()
+        return 1
+
+
+async def test_wake_claims_task_without_waiting_for_poll_interval() -> None:
+    queue = _WakeQueue()
+
+    async def text_provider(_task: dict[str, Any]) -> str:
+        return "text"
+
+    async def execute(_task: dict[str, Any], *, claimed_provider_id: str) -> dict[str, bool]:
+        assert claimed_provider_id == "text"
+        return {"ok": True}
+
+    worker = GenerationWorker(
+        queue=queue,  # type: ignore[arg-type]
+        capacity=CapacityTable(_limits={}, _defaults={"text": 1}),
+        provider_projection=text_provider,
+        executor=execute,
+        lanes=("text",),
+    )
+    worker.poll_interval = 60
+    await worker.start()
+    try:
+        await asyncio.wait_for(queue.idle.wait(), timeout=1)
+        worker.wake()
+        await asyncio.wait_for(queue.completed.wait(), timeout=1)
+        assert queue.succeeded == [("wake-task", {"ok": True})]
+    finally:
+        await worker.stop()


### PR DESCRIPTION
## Summary

- protect the complete remote narration durable polling contract
- replace shared worker test polling waits with a narrow wake/event seam
- keep production polling, lease, claim, and executor behavior unchanged

## Validation

- remote MCP integration: 22 passed
- affected worker integration set: 429 passed, reduced from about 101s to about 21s
- full backend: 10466 passed, 2 skipped
- Ruff, format, basedpyright, import contracts, and test audit passed

Closes #2136
Closes #2137
Refs #2062
