### PR TITLE
fix(i18n): translate "Pacing Estimate" section title for zh/en/vi

### DIFF
--- a/frontend/src/components/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/components/pages/ProjectSettingsPage.tsx
@@ -888,7 +888,7 @@ export function ProjectSettingsPage() {
 
               {/* 口播语速估算：驱动时长建议、说话量提示与字幕定时，与配音（TTS）无关，
                   故独立成卡、不与 Audio Channel 同栏，避免两个「语速」被读成一个设置 */}
-              <SectionCard kicker="Pacing Estimate">
+              <SectionCard kicker={t("pacing_estimate")}>
                 <SpeechRateField
                   value={speechRate}
                   onChange={setSpeechRate}

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -330,6 +330,7 @@ export default {
   'speech_rate_hint_language_pending': 'The project language is not set yet: Chinese projects count characters per second, English and Vietnamese projects count words per second. You can adjust this in project settings once the language is known.',
   'speech_rate_hint': 'Estimates how long dialogue and voiceover take to read aloud, affecting duration suggestions, dialogue-load notices and subtitle pacing. Leave empty to estimate at the default pace for the project language. Does not change the actual voice speed.',
   'speech_rate_out_of_range': 'Enter a value between {{min}} and {{max}}',
+  'pacing_estimate': 'Pacing Estimate',
   'episode_target_duration_label': 'Episode target length (optional)',
   'episode_target_duration_unit': 'sec',
   'episode_target_duration_hint': 'The intended length of the finished episode. The AI uses it to decide how many shots or video units to split the episode into. It is a soft target: fewer units when there is not enough material, and it may run over when the content calls for it. Leave empty to let the AI judge from the content.',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -333,6 +333,7 @@ export default {
   'speech_rate_hint_language_pending': 'Ngôn ngữ dự án chưa được xác định: dự án tiếng Trung tính ký tự mỗi giây, dự án tiếng Anh và tiếng Việt tính từ mỗi giây. Bạn có thể điều chỉnh trong cài đặt dự án sau khi ngôn ngữ được xác định.',
   'speech_rate_hint': 'Ước tính thời lượng đọc lời thoại và lời dẫn, ảnh hưởng đến gợi ý thời lượng, cảnh báo lượng thoại và nhịp phụ đề. Để trống để ước tính theo nhịp mặc định của ngôn ngữ dự án. Không thay đổi tốc độ giọng đọc thực tế.',
   'speech_rate_out_of_range': 'Vui lòng nhập giá trị từ {{min}} đến {{max}}',
+  'pacing_estimate': 'Ước tính tốc độ nói',
   'episode_target_duration_label': 'Thời lượng mục tiêu mỗi tập (tùy chọn)',
   'episode_target_duration_unit': 'giây',
   'episode_target_duration_hint': 'Độ dài mong muốn của tập hoàn chỉnh. AI dựa vào đó để quyết định chia tập thành bao nhiêu cảnh quay hoặc đơn vị video. Đây là mục tiêu mềm: chia ít hơn khi nội dung không đủ, và có thể vượt khi nội dung cần. Để trống để AI tự cân nhắc theo nội dung.',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -330,6 +330,7 @@ export default {
   'speech_rate_hint_language_pending': '项目语言还未确定：中文项目按「字/秒」计，英文、越南语项目按「词/秒」计。语言确定后可在项目设置里调整。',
   'speech_rate_hint': '用于估算台词和旁白的朗读时长，影响时长建议、台词量提示和字幕节奏。留空时按项目语言的默认语速估算。不改变实际配音速度。',
   'speech_rate_out_of_range': '请输入 {{min}} 到 {{max}} 之间的数值',
+  'pacing_estimate': '语速估算',
   'episode_target_duration_label': '单集目标时长（可选）',
   'episode_target_duration_unit': '秒',
   'episode_target_duration_hint': '整集成片的期望长度，AI 据此决定本集拆多少个分镜或视频单元。软目标：内容不够时会少拆，内容需要时可以超出。留空则由 AI 按内容自行把握。',


### PR DESCRIPTION
Closes #1823

## 变更

The project settings "Pacing Estimate" section used a hardcoded English kicker (`<SectionCard kicker="Pacing Estimate">`). When the UI language is switched to Chinese or Vietnamese, the title stayed English, producing a mixed-language page.

- Added the `pacing_estimate` key to the dashboard i18n namespace for `en`, `zh`, and `vi`:
  - en: `Pacing Estimate`
  - zh: `语速估算`
  - vi: `Ước tính tốc độ nói`
- `frontend/src/components/pages/ProjectSettingsPage.tsx`: render the section title via `t("pacing_estimate")` instead of a hardcoded string.

The three locale resource key sets remain in sync, enforced by the existing `satisfies Record<keyof typeof enDashboard, string>` guard in `zh/dashboard.ts` and `vi/dashboard.ts`.

## 验证

- Confirmed the `pacing_estimate` key is present in `en`, `zh`, and `vi` dashboard resources and referenced exactly once in `ProjectSettingsPage.tsx` (static parity check against the `satisfies` guard).
- Scope is a single user-visible string; no behavior, logic, or dependencies changed.
- The full frontend i18n consistency check and `vitest` run are executed by CI on this PR (the local toolchain install was not reachable from this environment due to network instability, so it was not run locally).

## 风险与遗留

无。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 语速估算区块现已支持国际化显示。
  * 新增英文、越南文和中文界面文案，提升多语言使用体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->