### PR TITLE
fix(i18n): 导入提示按 Spec 命名改为「定义 JSON 文件」 [Spec #2150]

### DIFF
--- a/frontend/src/components/pages/settings/endpoints/endpoint-definition-draft.ts
+++ b/frontend/src/components/pages/settings/endpoints/endpoint-definition-draft.ts
@@ -164,7 +164,7 @@ export function isRenderableDefinition(value: unknown): value is EndpointDefinit
   );
 }
 
-/** 导出为不含凭证的定义文件；文件名取 meta.name，落到 ASCII 安全的形态。 */
+/** 导出为不含凭证的定义 JSON；文件名取 meta.name，落到 ASCII 安全的形态。 */
 export function definitionFileName(definition: EndpointDefinition): string {
   const raw = definition.meta?.name?.trim() || "endpoint";
   const slug = raw.replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "");

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1777,7 +1777,7 @@ export default {
   'ce_reference_count': '{{n}} models in use',
   'ce_manage_entry': 'Manage endpoints…',
   'ce_import': 'Import',
-  'ce_import_hint': 'Import a definition file (.json)',
+  'ce_import_hint': 'Import a definition JSON file',
   'ce_import_title': 'Import endpoint definition',
   'ce_import_read_failed': 'This file is not a valid definition. Choose a definition JSON file exported from an endpoint.',
   'ce_import_failed': 'The definition could not be imported.',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1775,7 +1775,7 @@ export default {
   'ce_reference_count': '{{n}} mô hình đang dùng',
   'ce_manage_entry': 'Quản lý điểm gọi…',
   'ce_import': 'Nhập',
-  'ce_import_hint': 'Nhập tệp định nghĩa (.json)',
+  'ce_import_hint': 'Nhập tệp JSON định nghĩa',
   'ce_import_title': 'Nhập định nghĩa điểm gọi',
   'ce_import_read_failed': 'Tệp này không phải định nghĩa hợp lệ. Hãy chọn tệp JSON định nghĩa được xuất từ một điểm gọi.',
   'ce_import_failed': 'Không nhập được định nghĩa.',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1776,7 +1776,7 @@ export default {
   'ce_reference_count': '{{n}} 个模型正在使用',
   'ce_manage_entry': '管理调用端点…',
   'ce_import': '导入',
-  'ce_import_hint': '导入定义文件（.json）',
+  'ce_import_hint': '导入定义 JSON 文件',
   'ce_import_title': '导入端点定义',
   'ce_import_read_failed': '该文件不是有效的定义，请选择从端点导出的定义 JSON 文件。',
   'ce_import_failed': '导入定义失败。',


### PR DESCRIPTION
用户校对 #2161 文案时指出「导入定义文件（.json）」不符合在案命名。Spec #2150 与 #2161 验收标准的确认表述为「定义 JSON」（「导入定义 JSON 文件走确认流」「导出的定义 JSON 不含凭证」），据此三语同改：zh「导入定义 JSON 文件」/ en 'Import a definition JSON file' / vi 'Nhập tệp JSON định nghĩa'，顺带同一措辞的一处代码注释。前端 lint + check（1933 tests）全绿。

Refs #2161
Refs #2150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 明确端点定义导出文件为不含凭证的 JSON 文件。
* **界面文案**
  * 更新英文、越南语和中文的导入提示，明确提示用户导入定义 JSON 文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->