### PR TITLE
chore(skills): 收紧 afk-team-workflow 角色契约的执行纪律

### DIFF
--- a/.agents/skills/afk-team-workflow/references/herdr-teammate.md
+++ b/.agents/skills/afk-team-workflow/references/herdr-teammate.md
@@ -1,6 +1,6 @@
 # Herdr 跨 harness 委派
 
-仅在 `HERDR_ENV=1` 时读本页，并先调用已安装的 `herdr` skill。同 harness teammate 使用 harness 原生团队能力；跨 harness teammate 使用 Herdr。
+仅在 `HERDR_ENV=1` 时读本页，并先使用 Skill 工具调用 `herdr`。同 harness teammate 使用 harness 原生团队能力；跨 harness teammate 使用 Herdr。
 
 ## Workspace
 

--- a/.agents/skills/afk-team-workflow/references/implementer.md
+++ b/.agents/skills/afk-team-workflow/references/implementer.md
@@ -5,6 +5,6 @@
 输入：issue、repo root、stage branch、issue branch、handoff 绝对路径。
 
 1. 通读 issue 正文与评论。验收标准是范围边界；与代码现实冲突或涉及业务取舍时请示 team-lead。
-2. fetch 远程，从 stage branch 最新提交创建 `issue/<N>` 与专属 worktree，向 team-lead 回报路径与起始 SHA。所有代码读写都在该 worktree；服务端口与数据目录与其他 worktree 隔离。
-3. 按 issue 实现，可行时使用 `/tdd`。运行改动范围对应的项目质量门，将 formatter 等产生的改动一并 commit。
+2. fetch 远程，从 stage branch 最新提交创建 `issue/<N>` 与专属 worktree，向 team-lead 回报路径与起始 SHA。此后所有代码读写都在该 worktree，git 命令一律写 `git -C <worktree 绝对路径>`；服务端口与数据目录与其他 worktree 隔离。
+3. 按 issue 实现；可行处按 TDD 推进，使用 Skill 工具调用 `tdd`。运行改动范围对应的项目质量门，将 formatter 等产生的改动一并 commit。
 4. 工作树干净且所有改动已 commit 后，按 [handoff.md](handoff.md) 追加「实现」段，向 team-lead 回报 branch、worktree、起始 SHA 与验证结果。保留现场给 local-reviewer，不 push，不建 PR。

--- a/.agents/skills/afk-team-workflow/references/local-reviewer.md
+++ b/.agents/skills/afk-team-workflow/references/local-reviewer.md
@@ -4,7 +4,7 @@
 
 输入：issue、worktree、issue branch、stage branch、起始 SHA、handoff 绝对路径。
 
-1. 读 issue 正文与评论、实现 handoff，然后运行 `/code-review <起始 SHA>`；以实际 diff 和验收标准为边界，修复 findings 并重跑对应质量门。接近重做或涉及业务取舍时请示 team-lead。
-2. 将起始 SHA 之后的改动整理为一个 conventional commit；标题描述用户可感知变化，commit body 带 `Refs #<N>`。工作树必须干净。
+1. 读 issue 正文与评论、实现方的 handoff，然后使用 Skill 工具调用 `code-review`；以实际 diff 和验收标准为边界，修复 findings 并亲自复跑改动范围的质量门；断言行为缺陷前，按生产调用方的真实用法复现。接近重做或涉及业务取舍时请示 team-lead。
+2. 将起始 SHA 之后的改动整理为一个 conventional commit；标题描述用户可感知变化，commit body 带 `Refs #<N>`。工作树必须干净。git 命令一律写 `git -C <worktree 绝对路径>`。
 3. 按 [handoff.md](handoff.md) 追加「本地审查」段，向 team-lead 回报 commit SHA 与验证结果；保留 worktree，不 push、不建 PR。
 4. team-lead 回报 cherry-pick 冲突时，fetch 远程并将 issue branch rebase 到最新 stage branch，按功能意图解决冲突、重跑受影响的质量门，把质量门产生的改动纳入该 issue commit并确认工作树干净，再次交付。team-lead 确认集成后退役，由 team-lead 清理 worktree 与本地 issue branch。

--- a/.agents/skills/afk-team-workflow/references/review-looper.md
+++ b/.agents/skills/afk-team-workflow/references/review-looper.md
@@ -4,9 +4,9 @@
 
 输入：PR、stage branch、stage worktree、本 stage issues、batch handoff 目录、stage handoff 绝对路径。
 
-1. 确认 stage worktree、branch 与远程最新提交一致，读 stage 内所有 issue 及其 handoff，以合并后的验收边界审查整个 stage diff。
+1. 确认 stage worktree、branch 与远程最新提交一致，读 stage 内所有 issue 及其 handoff，以合并后的验收边界审查整个 stage diff，含并行 issue 间的重复实现与接缝收敛。git 命令一律写 `git -C <stage worktree 绝对路径>`。
 2. 运行累计质量门，修复并以 conventional integration-fix commit push；持续失败时记为 `fault` 并上报 team-lead。达到 **green HEAD** 后将 PR 转为 ready。
-3. 运行 `/pr-ai-review-loop`，采用其评论、CI、pushback、等待与终核纪律；以目标状态全部达成为终点。普通修复以额外 integration-fix commits push。软收敛出口与故障询问均先上报 team-lead。
+3. 使用 Skill 工具调用 `pr-ai-review-loop`，采用其评论、CI、pushback、等待与终核纪律；以目标状态全部达成为终点。wait.sh 与质量门等长任务前台阻塞执行。断言行为缺陷前，按生产调用方的真实用法复现。普通修复以额外 integration-fix commits push；integration-fix commits 累计达 6 个后停手，按 [handoff.md](handoff.md) 交接换人。软收敛出口与故障询问均先上报 team-lead。
 4. 收到 rebase 指令时，rebase 到最新 `origin/main`，解决冲突、重跑累计质量门，以 `--force-with-lease` push，并按 [handoff.md](handoff.md) 记录新旧 HEAD。保留每个 issue 的单个 conventional commit 与 `Refs #<N>`。
-5. reviewer 意见超出批次范围时回复说明边界，并记为 follow-up。意见涉及真实业务取舍时请示 team-lead；team-lead 按主流程的暂停边界持久化 issue 状态并阻断当前 stage 合并，直到用户裁决并完成对应恢复或重建。
+5. reviewer 意见超出批次范围时回复说明边界，并记为 follow-up。意见涉及真实业务取舍时请示 team-lead，收到裁决后回执确认；team-lead 按主流程的暂停边界持久化 issue 状态并阻断当前 stage 合并，直到用户裁决并完成对应恢复或重建。
 6. 终核通过后，将本 stage 的所有非 issue commits 压成一个 conventional integration-fix commit。确认压缩前后 tree 一致后，以 `--force-with-lease` push；新 HEAD 的 required checks 通过后，按 [handoff.md](handoff.md) 追加「审查循环」段，回报达标 HEAD 与轮数并停止。

--- a/.agents/skills/afk-team-workflow/references/spawn-prompts.md
+++ b/.agents/skills/afk-team-workflow/references/spawn-prompts.md
@@ -7,6 +7,7 @@
 ```text
 你是 afk-team-workflow 批次中 issue #<N> 的 implementer。读 <skill 目录绝对路径>/references/implementer.md 并按契约工作。
 输入：repo-root=<path>；stage-branch=<branch>；issue-branch=issue/<N>；handoff=<repo-root>/.afk/<batch-id>/handoff-<N>.md。
+补充：<必要背景信息；无则省略>
 ```
 
 改动面大时可附加：`开工先委派独立探索 agent 勘察。`
@@ -16,6 +17,7 @@
 ```text
 你是 afk-team-workflow 批次中 issue #<N> 的 local-reviewer，未参与该 issue 实现。读 <skill 目录绝对路径>/references/local-reviewer.md 并按契约工作。
 输入：worktree=<path>；issue-branch=issue/<N>；stage-branch=<branch>；start-sha=<implementer handoff 中的起始 SHA>；handoff=<repo-root>/.afk/<batch-id>/handoff-<N>.md。
+补充：<必要背景信息；无则省略>
 ```
 
 ## Review looper
@@ -23,6 +25,9 @@
 ```text
 你负责 afk-team-workflow 批次 stage <K> 的 AI review loop。读 <skill 目录绝对路径>/references/review-looper.md 并按契约工作。
 输入：PR=#<M>；stage-branch=<branch>；worktree=<path>；issues=<N,...>；handoffs=<repo-root>/.afk/<batch-id>/；stage-handoff=<repo-root>/.afk/<batch-id>/handoff-stage-<K>.md。
+补充：<必要背景信息；无则省略>
 ```
 
 任一 issue 在远程 stage branch 留下 commit 前失效，即丢弃现场与该未集成 handoff 文件，并从 stage branch 最新提交重新委派；不传递半成品接管 prompt。
+
+换人接力前确认前任进程已终止。


### PR DESCRIPTION
Refs #2150

Spec #2150 批次（spec-2150-20260827）全流程复盘产出的 skill 契约收紧，对应账本中的 fault/retrospective 记录。

## 变更

**review-looper.md**
- 长任务（wait.sh、质量门）前台阻塞执行（三次后台唤醒丢失致静默停摆）
- 断言行为缺陷前按生产调用方的真实用法复现（Stage 2 探针误判致裁决撤销）
- integration-fix commits 累计达 6 个后停手交接换人（批中新增规则固化）
- stage diff 审查含并行 issue 间重复实现与接缝收敛
- 收到 team-lead 裁决后回执确认（多次消息丢投）

**local-reviewer.md**
- 亲自复跑改动范围质量门（实现方自报门失真）；同复现要求
- git 命令一律写 `git -C <worktree 绝对路径>`（裸 amend 落错分支事故）

**implementer.md**
- 同款 git -C 纪律

**spawn-prompts.md**
- 三个模板增 `补充：<必要背景信息；无则省略>` 占位行
- 换人接力前确认前任进程已终止（并发写入事故）

**全部文件**
- 调用其他 skill 的措辞统一为「使用 Skill 工具调用 `xxx`」

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新协作工作流说明，统一 Git 操作、工具调用及分支与工作区管理规范。
  * 强化代码审查流程，包括真实生产用法复现、质量门复跑及并行改动检查。
  * 完善审查接力、裁决确认和任务委派所需的背景信息与交接要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->