### PR TITLE
test: 清理批次 nonspec-2164 暴露的无意义测试

### DIFF
--- a/frontend/src/components/canvas/reference/VoiceLegacyBanner.test.ts
+++ b/frontend/src/components/canvas/reference/VoiceLegacyBanner.test.ts
@@ -144,13 +144,6 @@ describe("computeVoiceLegacyNotice", () => {
     const units = [unit("E1U1", "王", ga({ video_generated_at: "2026-01-01T00:00:00Z" }))];
     const characters = { 王: character({ voice_updated_at: "2026-01-02T00:00:00Z" }) };
 
-    it("参考音频绑定档下照常报出", () => {
-      expect(computeVoiceLegacyNotice(units, characters, "reference_audio")).toEqual({
-        count: 1,
-        characterNames: ["王"],
-      });
-    });
-
     it("提示词软约束档下恒为空——该档不挂参考音频，换了也不改变已生成视频的声音", () => {
       expect(computeVoiceLegacyNotice(units, characters, "prompt")).toEqual({ count: 0, characterNames: [] });
     });

--- a/frontend/src/components/pages/ProviderSection.test.tsx
+++ b/frontend/src/components/pages/ProviderSection.test.tsx
@@ -1,19 +1,23 @@
 import { render, screen, waitFor, within, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
 import i18n from "@/i18n";
 import { API } from "@/api";
 import { ProviderSection } from "./ProviderSection";
 import type { ProviderInfo, CustomProviderInfo } from "@/types";
 
-let search = "provider=gemini-aistudio";
-const navigateMock = vi.fn((to: string) => {
-  search = to.includes("?") ? to.slice(to.indexOf("?") + 1) : "";
-});
-
-vi.mock("wouter", () => ({
-  useLocation: () => ["/app/settings", navigateMock],
-  useSearch: () => search,
-}));
+function renderAt(path = "/app/settings?provider=gemini-aistudio") {
+  const location = memoryLocation({ path, record: true });
+  return {
+    ...render(
+      <Router hook={location.hook} searchHook={location.searchHook}>
+        <ProviderSection />
+      </Router>,
+    ),
+    location,
+  };
+}
 
 // 后端按 Accept-Language 成文供应商与模型名，这里用替身按当前语言返回对应译名。
 function providersFor(lang: string): { providers: ProviderInfo[] } {
@@ -57,8 +61,6 @@ function customFor(lang: string): { providers: CustomProviderInfo[] } {
 
 describe("ProviderSection", () => {
   beforeEach(() => {
-    search = "provider=gemini-aistudio";
-    navigateMock.mockClear();
     vi.spyOn(API, "getProviders").mockImplementation(() =>
       Promise.resolve(providersFor(i18n.language)),
     );
@@ -75,7 +77,7 @@ describe("ProviderSection", () => {
   });
 
   it("refetches the provider catalog when the interface language changes", async () => {
-    render(<ProviderSection />);
+    renderAt();
 
     const nav = () => screen.getByRole("navigation");
     await screen.findByRole("navigation");
@@ -104,7 +106,7 @@ describe("ProviderSection", () => {
       });
     });
 
-    render(<ProviderSection />);
+    renderAt();
     await screen.findByRole("navigation");
 
     await act(async () => {
@@ -135,7 +137,7 @@ describe("ProviderSection", () => {
       return Promise.reject(new Error("network down"));
     });
 
-    render(<ProviderSection />);
+    renderAt();
     await screen.findByRole("navigation");
 
     await act(async () => {
@@ -158,7 +160,7 @@ describe("ProviderSection", () => {
       return Promise.reject(new Error("network down"));
     });
 
-    render(<ProviderSection />);
+    renderAt();
 
     // 首次拉取尚未返回就切语言：没有可留的目录，失败必须走错误面板而非留下空列表
     await act(async () => {
@@ -170,15 +172,14 @@ describe("ProviderSection", () => {
   });
 
   it("selects the first preset provider when the URL names no selection", async () => {
-    search = "";
+    const { location } = renderAt("/app/settings");
+    const nav = await screen.findByRole("navigation");
 
-    render(<ProviderSection />);
-    await screen.findByRole("navigation");
-
+    // 兜底选中以 replace 写回 URL，并在目录里点亮首个 preset
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith("/app/settings?provider=gemini-aistudio", {
-        replace: true,
-      }),
+      expect(within(nav).getByText("Gemini AI Studio（中文）").closest('[aria-current="page"]')).not.toBeNull(),
     );
+    // replace 写回：历史里只剩替换后的一条，不追加
+    expect(location.history).toEqual(["/app/settings?provider=gemini-aistudio"]);
   });
 });

--- a/frontend/src/components/shared/TaskElapsedReadout.test.tsx
+++ b/frontend/src/components/shared/TaskElapsedReadout.test.tsx
@@ -13,6 +13,8 @@ describe("TaskElapsedReadout", () => {
   });
 
   afterEach(() => {
+    // 先还原 spy 再切回真实定时器：反过来会把 spy 捕获的假 setInterval 重新装回全局
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/frontend/src/utils/task-elapsed.test.ts
+++ b/frontend/src/utils/task-elapsed.test.ts
@@ -19,7 +19,7 @@ describe("taskElapsed", () => {
     expect(taskElapsed(timing({}), NOW)).toEqual({ kind: "queued", ms: 600_000 });
   });
 
-  it("执行中任务按 started_at 计运行时长", () => {
+  it("执行中任务按 started_at 计运行时长，无时区后缀的时间戳按 UTC 解析", () => {
     const task = timing({ status: "running", started_at: "2026-01-01T00:09:00" });
     expect(taskElapsed(task, NOW)).toEqual({ kind: "running", ms: 60_000 });
   });
@@ -58,11 +58,6 @@ describe("taskElapsed", () => {
   it("时钟回拨导致的负值收敛为 0，不产生负数时长", () => {
     const task = timing({ status: "running", started_at: "2026-01-01T00:20:00" });
     expect(taskElapsed(task, NOW)).toEqual({ kind: "running", ms: 0 });
-  });
-
-  it("无时区后缀的时间戳按 UTC 解析", () => {
-    const task = timing({ status: "running", started_at: "2026-01-01T00:09:00Z" });
-    expect(taskElapsed(task, NOW)).toEqual({ kind: "running", ms: 60_000 });
   });
 });
 

--- a/tests/integration/lib/test_visual_artifact_provenance.py
+++ b/tests/integration/lib/test_visual_artifact_provenance.py
@@ -696,3 +696,40 @@ def test_video_component_composition_names_absent_future_components() -> None:
 
     assert explicit_none.digest == visual_only.digest
     assert with_speech.digest != visual_only.digest
+
+
+class TestTextFormArtifactCurrency:
+    """文本形态提示词照常进产物依据（ADR 0062）：改动它即让对应产物判 stale。"""
+
+    def test_text_form_image_prompt_participates_in_basis(self):
+        def _digest(image_prompt: object) -> str:
+            return build_storyboard_image_visual_basis(
+                resource_id="E1S02",
+                image_prompt=image_prompt,
+                style="Anime",
+                style_description="cinematic",
+                aspect_ratio="9:16",
+                references=(),
+            ).digest
+
+        assert _digest("初版文本提示词") == _digest("初版文本提示词")
+        assert _digest("初版文本提示词") != _digest("改过的文本提示词")
+        assert _digest("初版文本提示词") != _digest(
+            {"scene": "在雨夜街道", "composition": {"shot_type": "Medium Shot"}}
+        )
+
+    def test_text_form_video_prompt_participates_in_basis(self, tmp_path):
+        storyboard = tmp_path / "scene.png"
+        storyboard.write_bytes(b"png")
+
+        def _digest(visual_prompt: object) -> str:
+            return build_storyboard_video_artifact_visual_basis(
+                resource_id="E1S02",
+                visual_prompt=visual_prompt,
+                storyboard_image=storyboard,
+                end_frame_image=None,
+                aspect_ratio="9:16",
+            ).digest
+
+        assert _digest("初版视频文本提示词") == _digest("初版视频文本提示词")
+        assert _digest("初版视频文本提示词") != _digest("改过的视频文本提示词")

--- a/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
@@ -623,18 +623,6 @@ async def test_promote_draft_report_silent_when_every_unit_references_a_scene(
     assert "未引用场景" not in out["content"][0]["text"]
 
 
-async def test_promote_draft_report_silent_without_scene_assets(fake_ctx: ToolContext, monkeypatch) -> None:
-    """项目一张场景资产都没登记时报告不发场景提示：无处可引用，提示指不出任何动作。"""
-    _rv_source(fake_ctx)
-    _rv_scenes(fake_ctx, {})
-    await _rv_draft_with(fake_ctx, monkeypatch, ["@[不存在的人] 出场"])
-
-    out = await _promote(fake_ctx)
-
-    assert out.get("is_error") is True
-    assert "未引用场景" not in out["content"][0]["text"]
-
-
 async def test_promote_receipt_names_units_without_scene_reference(fake_ctx: ToolContext, monkeypatch) -> None:
     """晋升回执带软违约段，与拆分回执同口径——软违约不阻断晋升，正式文件照常落盘。"""
     _rv_source(fake_ctx)
@@ -657,18 +645,6 @@ async def test_promote_receipt_silent_when_every_unit_references_a_scene(fake_ct
     _rv_source(fake_ctx)
     _rv_scenes(fake_ctx, {"村口": {"description": "黄昏的村口"}})
     await _rv_draft_with(fake_ctx, monkeypatch, ["@[村口] 黄昏，@[张三] 推门"])
-
-    out = await _promote(fake_ctx)
-
-    assert out.get("is_error") is not True, out
-    assert "未引用场景" not in json.loads(out["content"][0]["text"])["draft"]["message"]
-
-
-async def test_promote_receipt_silent_without_scene_assets(fake_ctx: ToolContext, monkeypatch) -> None:
-    """项目无场景资产时回执不发场景提示。"""
-    _rv_source(fake_ctx)
-    _rv_scenes(fake_ctx, {})
-    await _rv_draft_with(fake_ctx, monkeypatch, ["@[张三] 起身"])
 
     out = await _promote(fake_ctx)
 

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -475,18 +475,6 @@ async def test_split_reference_video_units_names_units_without_scene_reference(
     assert "未引用场景" in text
 
 
-async def test_split_reference_video_units_silent_on_scene_warning_without_scene_assets(
-    fake_ctx: ToolContext, monkeypatch
-) -> None:
-    """项目一张场景资产都没登记时不发场景提示——无处可引用，提示指不出任何动作。"""
-    _rv_source(fake_ctx)
-    fake_ctx.pm.project_payload["scenes"] = {}  # pyright: ignore[reportAttributeAccessIssue]
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身。")])
-
-    assert out.get("is_error") is not True, out
-    assert "未引用场景" not in out["content"][0]["text"]
-
-
 async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_backend(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:

--- a/tests/integration/server/routers/test_files_router.py
+++ b/tests/integration/server/routers/test_files_router.py
@@ -208,7 +208,7 @@ class TestFilesRouter:
             assert get_draft.status_code == 200
             assert "draft content" in get_draft.text
 
-            bad_stage = client.get("/api/v1/projects/demo/drafts/1/unknown_stage")
+            bad_stage = client.get("/api/v1/projects/demo/drafts/1/prompt_authoring")
             assert bad_stage.status_code == 400
 
             delete_draft = client.delete("/api/v1/projects/demo/drafts/1/script_plan")

--- a/tests/integration/server/services/test_prompt_preview.py
+++ b/tests/integration/server/services/test_prompt_preview.py
@@ -276,45 +276,6 @@ class TestPreviewUnavailableSides:
             await prompt_preview.preview_item_prompts("demo", "episode_1.json", "E9S99")
 
 
-class TestTextFormArtifactCurrency:
-    """文本形态提示词照常进产物依据（ADR 0062）：改动它即让对应产物判 stale。"""
-
-    def test_text_form_image_prompt_participates_in_basis(self, tmp_path):
-        from lib.visual_artifact_provenance import build_storyboard_image_visual_basis
-
-        def _digest(image_prompt: object) -> str:
-            return build_storyboard_image_visual_basis(
-                resource_id=ITEM_ID,
-                image_prompt=image_prompt,
-                style="Anime",
-                style_description="cinematic",
-                aspect_ratio="9:16",
-                references=(),
-            ).digest
-
-        assert _digest("初版文本提示词") == _digest("初版文本提示词")
-        assert _digest("初版文本提示词") != _digest("改过的文本提示词")
-        assert _digest("初版文本提示词") != _digest(STRUCTURED_IMAGE_PROMPT)
-
-    def test_text_form_video_prompt_participates_in_basis(self, tmp_path):
-        from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
-
-        storyboard = tmp_path / "scene.png"
-        storyboard.write_bytes(b"png")
-
-        def _digest(visual_prompt: object) -> str:
-            return build_storyboard_video_artifact_visual_basis(
-                resource_id=ITEM_ID,
-                visual_prompt=visual_prompt,
-                storyboard_image=storyboard,
-                end_frame_image=None,
-                aspect_ratio="9:16",
-            ).digest
-
-        assert _digest("初版视频文本提示词") == _digest("初版视频文本提示词")
-        assert _digest("初版视频文本提示词") != _digest("改过的视频文本提示词")
-
-
 class TestPromptPreviewTool:
     """MCP 工具层是服务层的薄包装：同一份预览，两个 host 同一入口。"""
 

--- a/tests/unit/lib/prompt_rules/test_subagent_md_sync.py
+++ b/tests/unit/lib/prompt_rules/test_subagent_md_sync.py
@@ -1,7 +1,4 @@
-"""漂移防御：lib.prompt_rules.episode_pacing 的常量与项目字段名必须出现在对应 subagent .md 中。
-
-用首尾 60 字符锚点做 substring 断言，避免空白差异误报。
-"""
+"""漂移防御：lib.prompt_rules 的规则常量与项目字段名必须逐字出现在对应 subagent .md 中。"""
 
 from pathlib import Path
 
@@ -16,12 +13,6 @@ from lib.reference_video.writing_syntax import SCENE_REFERENCE_RULES
 
 REPO = Path(__file__).resolve().parents[4]
 
-SCRIPT_PLAN_DRAFT_AGENTS = (
-    "agent_runtime_profile/.claude/agents/create-episode-script.md",
-    "agent_runtime_profile/.claude/agents/normalize-drama-script.md",
-    "agent_runtime_profile/.claude/agents/split-reference-video-units.md",
-)
-
 
 def _normalize(text: str) -> str:
     return "".join(text.split())
@@ -31,27 +22,7 @@ def test_drama_pacing_in_normalize_drama_md() -> None:
     md = (REPO / "agent_runtime_profile/.claude/agents/normalize-drama-script.md").read_text(encoding="utf-8")
     md_norm = _normalize(md)
     rules_norm = _normalize(DRAMA_PACING_RULES)
-    assert rules_norm[:60] in md_norm, "DRAMA_PACING_RULES 首段未在 normalize-drama-script.md 中找到（漂移）"
-    assert rules_norm[-60:] in md_norm, "DRAMA_PACING_RULES 末段未在 normalize-drama-script.md 中找到（漂移）"
-
-
-def test_drama_repair_scope_covers_entire_draft_content() -> None:
-    md = (REPO / "agent_runtime_profile/.claude/agents/normalize-drama-script.md").read_text(encoding="utf-8")
-
-    assert "修复草稿 `content` 中对应字段" in md
-    assert "只修改草稿的 `content.scenes[i]`" not in md
-
-
-@pytest.mark.parametrize("relative_path", SCRIPT_PLAN_DRAFT_AGENTS)
-def test_script_plan_draft_repair_combines_user_intent_with_violation_repair(relative_path: str) -> None:
-    md = (REPO / relative_path).read_text(encoding="utf-8")
-
-    assert (
-        "保留草稿中已有修改；如主 Agent 本轮传入用户修改意见，先应用该意见；`violations[]` 非空时，在上述修改基础上"
-    ) in md
-    assert "为空时保留已有修改" not in md
-    assert "为空时按用户修改意见定位" not in md
-    assert "不得因为没有违约就原样晋升" not in md
+    assert rules_norm in md_norm, "DRAMA_PACING_RULES 未完整同步到 normalize-drama-script.md（漂移）"
 
 
 def test_scene_reference_rules_in_split_reference_video_units_md() -> None:

--- a/tests/unit/lib/reference_video/test_reference_video_script_preview.py
+++ b/tests/unit/lib/reference_video/test_reference_video_script_preview.py
@@ -42,9 +42,6 @@ PROJECT = {
 #: 语法 / 声音用例据此保持单一关注点。
 PROJECT_WITHOUT_SCENES = {**PROJECT, "scenes": {}}
 
-#: 商品为主体的广告项目：登记商品与角色、不登记场景，是 ad 参考路线的典型资产形状。
-PROJECT_AD = {**PROJECT_WITHOUT_SCENES, "products": {"保温杯": {"description": "x"}}}
-
 #: 带组合附加符的角色名（越南语），两种编码屏幕显示相同、字节不同——资产名比对的坐标系用例。
 _NAME_NFC = unicodedata.normalize("NFC", "Hiếu")
 _NAME_NFD = unicodedata.normalize("NFD", "Hiếu")
@@ -217,12 +214,6 @@ def test_no_scene_warning_when_unit_references_a_scene():
 
 def test_no_scene_warning_when_project_registers_no_scene():
     preview = build_script_preview("中景，@[张三] 推门。", PROJECT_WITHOUT_SCENES, _SOFT)
-    assert keys(preview) == []
-
-
-def test_no_scene_warning_for_ad_project_without_scene_assets():
-    """商品为主体的广告项目常一张场景资产都没有：无处可引用时提示指不出任何动作。"""
-    preview = build_script_preview("中景，@[保温杯] 静置在桌面上。", PROJECT_AD, _SOFT)
     assert keys(preview) == []
 
 

--- a/tests/unit/lib/test_prompt_builders_reference.py
+++ b/tests/unit/lib/test_prompt_builders_reference.py
@@ -7,7 +7,10 @@ from lib.prompt_builders_reference import (
     build_reference_video_prompt,
     render_reference_units_for_prompt_authoring,
 )
-from lib.prompt_rules.episode_target_duration import render_episode_target_duration_rule
+from lib.prompt_rules.episode_target_duration import (
+    EPISODE_TARGET_DURATION_RULE_TEMPLATE,
+    render_episode_target_duration_rule,
+)
 from lib.reference_video.writing_syntax import SCENE_REFERENCE_RULES, WRITING_SYNTAX_SPEC
 
 
@@ -295,8 +298,8 @@ class TestEpisodeTargetDurationInjection:
         prompt = _split_prompt(episode_target_duration=120)
         assert render_episode_target_duration_rule(120) in prompt
 
-    def test_split_prompt_is_unchanged_without_a_target(self):
-        assert _split_prompt(episode_target_duration=None) == _split_prompt()
+    def test_split_prompt_omits_the_rule_without_a_target(self):
+        assert EPISODE_TARGET_DURATION_RULE_TEMPLATE.split("{seconds}")[0] not in _split_prompt()
 
     def test_packing_no_longer_pushes_units_toward_the_per_call_ceiling(self):
         assert "使 unit 时长贴近 8 秒" in _split_prompt()

--- a/tests/unit/lib/test_prompt_builders_script_duration.py
+++ b/tests/unit/lib/test_prompt_builders_script_duration.py
@@ -9,7 +9,13 @@ from lib.prompt_builders_script import (
     build_narration_split_prompt,
     build_normalize_prompt,
 )
-from lib.prompt_rules.episode_target_duration import render_episode_target_duration_rule
+from lib.prompt_rules.episode_target_duration import (
+    EPISODE_TARGET_DURATION_RULE_TEMPLATE,
+    render_episode_target_duration_rule,
+)
+
+#: 规则句的固定开头：未设目标时整段不注入，该开头不应出现在提示词中。
+_RULE_HEAD = EPISODE_TARGET_DURATION_RULE_TEMPLATE.split("{seconds}")[0]
 
 
 class TestFormatDurationConstraint:
@@ -91,11 +97,11 @@ class TestEpisodeTargetDurationInjection:
         prompt = _narration_prompt(episode_target_duration=120)
         assert render_episode_target_duration_rule(120) in prompt
 
-    def test_drama_prompt_is_unchanged_without_a_target(self):
-        assert _drama_prompt(episode_target_duration=None) == _drama_prompt()
+    def test_drama_prompt_omits_the_rule_without_a_target(self):
+        assert _RULE_HEAD not in _drama_prompt()
 
-    def test_narration_prompt_is_unchanged_without_a_target(self):
-        assert _narration_prompt(episode_target_duration=None) == _narration_prompt()
+    def test_narration_prompt_omits_the_rule_without_a_target(self):
+        assert _RULE_HEAD not in _narration_prompt()
 
     def test_the_rule_coexists_with_the_default_duration_preference(self):
         """两条约束尺度不同（整集体量 vs 单场秒数），须同时呈现而非互相取代。"""

--- a/tests/unit/test_public_contract.py
+++ b/tests/unit/test_public_contract.py
@@ -25,10 +25,8 @@ class TestAgentInstallationGuide:
         assert "arc-" in self.guide
         assert "npx skills add ArcReel/skills" in self.guide
         assert "/setup-arcreel-skills" in self.guide
-        assert "setup-arcreel-skills" in self.guide
         assert "video-workflow" in self.guide
         assert "{{BASE_URL}}/mcp" in self.guide
-        assert "完成判据" in self.guide
         assert "tool_timeout_sec" in self.guide
 
     def test_excludes_rest_workflow_reference(self):


### PR DESCRIPTION
## 背景
对 PR #2192 / #2193 / #2200 新增或改写的约 245 个用例按 CONTRIBUTING「无意义测试判据」做了一次专项审计，命中 11 条（≈4.5%），另带出 `test_subagent_md_sync.py` / `test_public_contract.py` 两处既有债务。无一命中闸门 2（patch 被测单元自身）。

## 处置
| 类别 | 用例 | 处置 |
|---|---|---|
| 恒真断言 | `test_*_prompt_is_unchanged_without_a_target` ×3 | 改为断言规则句开头不在提示词中 |
| 重复弱化 | script_preview「无场景资产」同一 early-return 的 4 条 | 删除（保留直接覆盖它的 `test_no_scene_warning_when_project_registers_no_scene`） |
| 名实不符 | `task-elapsed` 「无时区后缀」用例（输入带 Z） | 删除，真正无后缀的用例改名 |
| 重复弱化 | `VoiceLegacyBanner` 门控组「参考音频档照常报出」 | 删除（与默认档用例逐字相同） |
| 替身断言 | `ProviderSection` 兜底选中用例只断言 `navigateMock` | 改用真实 wouter Router + `memoryLocation`，断言 `aria-current` 与 `location.history` |
| 恒真 + 过度表征 | `test_subagent_md_sync.py` 两条钉旧措辞的用例 | 删除；`DRAMA_PACING_RULES` 锚点改为全文包含 |
| 死断言 / 过度表征 | `test_public_contract.py` 两行 | 删除 |

顺带：`test_files_router` 非法 stage 名恢复一处 `prompt_authoring`（回归护栏）；`TestTextFormArtifactCurrency` 迁到 `test_visual_artifact_provenance.py`；`TaskElapsedReadout` 测试补 `restoreAllMocks`。

审计中经核实为误报、未动：`test_project_migration_v9_v10.py::test_migrating_twice_is_a_no_op`（删掉版本闸会把 schema 写回 10，用例会红）。

## 验证
后端 ruff / format / `audit_tests.py --check` / 相关测试文件通过，全量 pytest 与 CI 见 checks；前端 `pnpm lint` 与 `pnpm check`（166 文件 1989 例）通过。

https://claude.ai/code/session_01WCRs6B389srt2nNjTUZHBz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 调整路由、时间戳、提示词规则及安装指引相关测试断言。
  * 增强文本提示词参与视觉产物摘要一致性的验证。
  * 改进测试隔离，避免模拟对象在测试间相互影响。
  * 清理过时或不再适用的场景资产、草稿晋升及引用视频测试用例。
  * 更新非法阶段读取、提示词构建及公共指引相关断言，使其更贴合当前行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->