### PR TITLE
perf(tests): 缩短本地与 CI 测试耗时

### DIFF
--- a/.github/actions/domain-filter/action.yml
+++ b/.github/actions/domain-filter/action.yml
@@ -50,6 +50,11 @@ runs:
             - 'agent_runtime_profile/**'
             - 'pyproject.toml'
             - 'uv.lock'
+            # 后端契约测试直接读取这些前端源文件；它们同时命中 frontend 域。
+            - 'frontend/src/i18n/*/dashboard.ts'
+            - 'frontend/src/i18n/*/events.ts'
+            - 'frontend/src/types/workflow.ts'
+            - 'frontend/src/data/example-templates/**'
           frontend:
             - 'frontend/**'
           # public/ 目录与根目录 README.md 是 Dockerfile 的 COPY 源且不属于

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Classification marker gate (collect-only)
+        # 必须不带 -n：xdist 的收集发生在各 worker 内，conftest 的 UsageError 会撞上
+        # dsession 断言并丢失违规清单。-qq 保留收集错误且避免输出上万条 nodeid。
+        run: uv run python -m pytest --collect-only -qq
+
       - name: Lint & format check
         run: uv run ruff check . && uv run ruff format --check .
 
@@ -96,10 +101,19 @@ jobs:
         run: python scripts/audit_tests.py --check
 
   backend-tests:
+    name: Backend tests (${{ matrix.suite }})
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            path: tests/unit
+          - suite: integration
+            path: tests/integration
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -114,32 +128,28 @@ jobs:
           python-version: "3.12"
 
       - name: Install system dependencies
+        if: matrix.suite == 'integration'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg mediainfo bubblewrap socat
 
       - name: Install dependencies
         run: uv sync
-
-      - name: Classification marker gate (collect-only)
-        # 必须在并行步骤之前、且不带 -n：xdist 的收集发生在各 worker 内，conftest
-        # 的 UsageError 会撞上 dsession 的断言退化成 INTERNALERROR，违规清单一个字
-        # 都不剩。--collect-only 由 controller 本地收集，清单完整、全量约 2s。
-        # -qq 而非 -q：-q 会把上万条 nodeid 打进日志，淹掉这一步唯一有消费方的输出。
-        # -qq 只列各文件用例数，违规清单（stderr）与 import 失败的 traceback（stdout）
-        # 都不受影响；不能改成丢弃 stdout，那会连收集期 import 错误一起吞掉。
-        run: uv run python -m pytest --collect-only -qq
 
       - name: Run tests with coverage
         # -n 固定 4 而非 auto：-n auto 优先取 psutil 的物理核数，一旦某传递依赖带进
         # psutil，CI worker 数会静默减半。loadfile 而非默认 load：仓库根共享路径
         # （PROJECT_ROOT 下 mkdir/rmdir、module 级 autouse fixture）要求同文件用例
         # 留在同一 worker。
-        run: uv run python -m pytest -m "not e2e" -n 4 --dist loadfile --cov=lib --cov=server --cov-report=term-missing --cov-report=xml
+        run: >-
+          uv run python -m pytest ${{ matrix.path }} -n 4 --dist loadfile
+          --cov=lib --cov=server --cov-report=term-missing
+          --cov-report=xml:coverage-${{ matrix.suite }}.xml
 
       - name: Upload backend coverage
+        # unit/integration 使用同一 flag；Codecov 按 commit 合并，无需本地聚合作业。
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          files: coverage-${{ matrix.suite }}.xml
           flags: backend
           fail_ci_if_error: false
 
@@ -193,12 +203,12 @@ jobs:
           uv run alembic upgrade head           # 4. 再次正向，验证 downgrade 真清掉了
 
       - name: Run dialect-sensitive tests against Postgres
-        # 保持单进程：92 个用例约 2m44s，可省时间小于并行风险——其中
-        # tests/integration/lib/db/repositories/test_agent_credential_repo.py 的用例
-        # 共用 alembic 建出的 public schema，两 worker 写同一主键会互相阻塞。
+        # 4 worker + loadfile：独立 schema 用例可并行，共用 public schema 的 async_session
+        # 用例留在同一文件/worker，避免主键与锁冲突。
         run: |
           uv run python -m pytest -v \
             -m "uses_db and not sqlite_only" \
+            -n 4 --dist loadfile \
             --cov=lib --cov=server --cov-report=xml:coverage-pg.xml
 
       - name: Upload PG coverage
@@ -209,7 +219,7 @@ jobs:
           flags: postgres
           fail_ci_if_error: false
 
-  frontend-tests:
+  frontend-static:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -240,6 +250,30 @@ jobs:
       - name: Build
         working-directory: frontend
         run: pnpm build
+
+  frontend-tests:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests with coverage
         working-directory: frontend
@@ -453,6 +487,7 @@ jobs:
         test-lint,
         backend-tests,
         postgres-compat,
+        frontend-static,
         frontend-tests,
         docker-verify,
         website-checks,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@ AI 视频创作平台，将小说、剧本或创作构想转化为短视频。�
 
 ## 工具链与校验
 
-后端使用 `uv`，前端与文档站使用 `pnpm`。push 前按改动范围执行对应校验：
+后端使用 `uv`，前端与文档站使用 `pnpm`。修改代码或测试时，先按 `CONTRIBUTING.md`「测试选择」运行相关测试；任务完成和 push 前执行受影响域的全量闸门：
 
 ```bash
-uv run ruff check . && uv run ruff format . && uv run basedpyright && uv run lint-imports && uv run python -m pytest
+uv run ruff check . && uv run ruff format . && uv run basedpyright && uv run lint-imports && uv run python -m pytest -n 4 --dist loadfile
 uv run python scripts/audit_tests.py --check   # 改动测试文件时；同时扫后端 tests/ 与前端 *.test.*
-(cd frontend && pnpm lint && pnpm check)
+(cd frontend && pnpm check)
 (cd website && pnpm check)
 ```
 
-启动开发服务器、数据库迁移、测试规范（分层/替身/判据/闸门）、分支与提交规范、依赖管理、注释规范见 `CONTRIBUTING.md`。
+相关测试必须实际运行且通过；若选择结果为 0 个测试，须扩大范围。启动开发服务器、数据库迁移、测试选择与规范（分层/替身/判据/闸门）、分支与提交规范、依赖管理、注释规范见 `CONTRIBUTING.md`。
 
 ## 通用规范
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,14 +59,24 @@ pnpm check-consistency
 ## 测试
 
 ```bash
-# 后端测试；单文件：uv run python -m pytest path/to/test.py，-k 关键字筛选，-v 详细输出
-uv run python -m pytest
+# 后端完整测试；单文件可直接替换 tests/ 路径，-k 仅用于人工按名称筛选
+uv run python -m pytest -n 4 --dist loadfile
 
 # 前端 typecheck + lint + 测试
 cd frontend && pnpm check
 ```
 
 pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
+
+### 测试选择
+
+开发循环先跑与改动相关的最小测试集，任务完成和 push 前再跑受影响域的完整闸门。选择结果为 0 个测试时扩大到对应目录或完整测试集，不把 0 个测试视为验证通过。
+
+- 后端测试文件变更：直接运行这些文件；源码变更：优先运行 `tests/unit|integration/` 下镜像路径及已知消费方。路径能缩小收集范围，`unit` / `integration` / `uses_db` marker 只用于跨路径筛选，`-k` 只用于人工定位。
+- 后端完整测试：改动 `pyproject.toml`、`uv.lock`、根 `tests/conftest.py`、含行为的包初始化、测试选择规则，或涉及 Alembic、profile、DB、i18n、共享测试设施时执行。无法可靠判断影响范围时也执行完整测试。
+- 前端测试文件变更：直接传文件给 Vitest；普通源码变更：在 `frontend/` 运行 `pnpm exec vitest related --run <source files>`；分支级检查运行 `pnpm exec vitest run --changed <base>`。TypeScript 源码变更同时运行完整 typecheck。
+- 前端完整测试：改动 `package.json`、`pnpm-lock.yaml`、`vitest.config.*`、测试 setup、i18n 或 branding 时执行 `pnpm check`。相关测试选择为 0 时先扩大到所在功能目录，仍无法确定时执行 `pnpm check`。
+- 任一测试文件变更后运行 `uv run python scripts/audit_tests.py --check`。
 
 ### 分层与目录
 
@@ -180,7 +190,7 @@ cd frontend && pnpm lint:fix      # 自动修复可修复的问题
 - 配置：`frontend/eslint.config.js`（flat config）
 - 规则集：`typescript-eslint/recommendedTypeChecked` + `react/recommended` + `react-hooks/recommended` + `jsx-a11y/recommended`
 - typed linting 启用 `projectService: true`，可检查 `no-floating-promises`、`no-misused-promises` 等 async 相关问题
-- CI 中强制检查：`frontend-tests` job 的 `Lint` step
+- CI 中强制检查：`frontend-static` job 的 `Lint` step
 
 **Lint & Format（文档站 ESLint + prettier）：**
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,26 +69,22 @@ def _stub_sandbox_check(monkeypatch, request):
     monkeypatch.setattr("server.app.check_sandbox_available", lambda: True)
 
 
-@pytest.fixture(autouse=True)
-def _profile_env(monkeypatch, tmp_path):
-    """Pin ``agent_profile_dir()`` to a per-test ``tmp_path/agent_runtime_profile``
-    so tests that build a fake profile under tmp_path are exercised against the
-    env-driven contract instead of the repo-level default.
+@pytest.fixture(scope="session", autouse=True)
+def _profile_env(tmp_path_factory):
+    """Provide one minimal runtime profile per pytest worker.
 
-    Also seed the profile with a minimal ``.claude/`` + ``CLAUDE.md`` so unrelated
-    tests that go through ``ProjectManager.create_project`` (which triggers
-    profile sync) don't trip the ``ProfileMissingError`` / ``ProfileEmptyError``
-    入口防御 — those guards are deployment-correctness contracts, not test fixtures.
-    Tests that explicitly need profile-missing / empty scenarios still work because
-    they ``setenv`` to a different path under tmp_path.
+    Tests exercising another profile location set ``ARCREEL_PROFILE_DIR`` explicitly.
     """
-    profile_dir = tmp_path / "agent_runtime_profile"
-    profile_dir.mkdir(parents=True, exist_ok=True)
-    # 仅 touch 顶层 CLAUDE.md（最少 1 个可物化文件以避开 ProfileEmptyError）。
-    # 不预创建 ``.claude/`` —— 让需要自己 mkdir(".claude", parents=True) 的下游测试
-    # 不撞 FileExistsError；那些测试自己会构造完整 profile 内容。
-    (profile_dir / "CLAUDE.md").write_text("")
-    monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_dir))
+    profile_dir = tmp_path_factory.mktemp("agent-runtime-profile")
+    (profile_dir / "CLAUDE.md").write_text("", encoding="utf-8")
+
+    previous = os.environ.get("ARCREEL_PROFILE_DIR")
+    os.environ["ARCREEL_PROFILE_DIR"] = str(profile_dir)
+    yield
+    if previous is None:
+        os.environ.pop("ARCREEL_PROFILE_DIR", None)
+    else:
+        os.environ["ARCREEL_PROFILE_DIR"] = previous
 
 
 @pytest.fixture()

--- a/tests/unit/server/agent_runtime/test_assistant_service.py
+++ b/tests/unit/server/agent_runtime/test_assistant_service.py
@@ -679,7 +679,9 @@ class TestAssistantService:
         service = AssistantService(project_root=tmp_path)
         service.pm = _FakePM(valid_project="demo")
 
-        agent_skill = tmp_path / "agent_runtime_profile" / ".claude" / "skills" / "s1"
+        profile_root = tmp_path / "agent_runtime_profile"
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        agent_skill = profile_root / ".claude" / "skills" / "s1"
         agent_skill.mkdir(parents=True)
         (agent_skill / "SKILL.md").write_text(
             "---\nname: project-skill\ndescription: from frontmatter\n---\n# body\n",
@@ -687,7 +689,7 @@ class TestAssistantService:
         )
 
         # Create a fallback skill for metadata parsing test
-        fallback_skill_dir = tmp_path / "agent_runtime_profile" / ".claude" / "skills" / "s2"
+        fallback_skill_dir = profile_root / ".claude" / "skills" / "s2"
         fallback_skill_dir.mkdir(parents=True)
         (fallback_skill_dir / "SKILL.md").write_text(
             "first non heading line\n# heading\n",

--- a/tests/unit/server/agent_runtime/test_assistant_service_skills.py
+++ b/tests/unit/server/agent_runtime/test_assistant_service_skills.py
@@ -8,9 +8,11 @@ from server.agent_runtime.service import AssistantService
 
 
 class TestListAvailableSkills:
-    def test_lists_skills_from_agent_runtime_profile(self, tmp_path):
+    def test_lists_skills_from_agent_runtime_profile(self, tmp_path, monkeypatch):
         """Should scan agent_runtime_profile/.claude/skills/ instead of .claude/skills/."""
-        skill_dir = tmp_path / "agent_runtime_profile" / ".claude" / "skills" / "test-skill"
+        profile_root = tmp_path / "agent_runtime_profile"
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_root))
+        skill_dir = profile_root / ".claude" / "skills" / "test-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
             "---\nname: test-skill\ndescription: A test skill\n---\n",
@@ -37,8 +39,9 @@ class TestListAvailableSkills:
         assert "test-skill" in names
         assert "dev-tool" not in names
 
-    def test_returns_empty_when_no_profile(self, tmp_path):
+    def test_returns_empty_when_no_profile(self, tmp_path, monkeypatch):
         """Should return empty list when agent_runtime_profile doesn't exist."""
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(tmp_path / "missing-profile"))
         with patch.object(AssistantService, "__init__", lambda self, *a, **kw: None):
             service = AssistantService.__new__(AssistantService)
             service.project_root = tmp_path

--- a/tests/unit/server/agent_runtime/test_session_manager.py
+++ b/tests/unit/server/agent_runtime/test_session_manager.py
@@ -615,13 +615,12 @@ class TestSessionManager:
         assert result.get("continue_") is True
 
     @pytest.mark.asyncio
-    async def test_file_access_hook_allows_read_agent_profile(self, tmp_path, meta_store):
+    async def test_file_access_hook_allows_read_agent_profile(self, tmp_path, meta_store, monkeypatch):
         """Hook allows Read for agent_runtime_profile/ files."""
         own_project = tmp_path / "projects" / "alpha"
         own_project.mkdir(parents=True)
         profile_md = tmp_path / "agent_runtime_profile" / "CLAUDE.md"
-        # conftest 的 _profile_env autouse fixture 已预创建 profile dir，
-        # 这里用 exist_ok=True 容忍。CLAUDE.md 内容会被本测试覆写为有意义文本。
+        monkeypatch.setenv("ARCREEL_PROFILE_DIR", str(profile_md.parent))
         profile_md.parent.mkdir(parents=True, exist_ok=True)
         profile_md.write_text("# Agent instructions")
 

--- a/website/scripts/sync-contributing.mjs
+++ b/website/scripts/sync-contributing.mjs
@@ -20,6 +20,7 @@ const ANCHORS = new Map([
   ["## 本地开发环境", "local-development"],
   ["### 文档站", "docs-site"],
   ["## 测试", "testing"],
+  ["### 测试选择", "test-selection"],
   ["### 分层与目录", "test-tiers"],
   ["### 体量与命名", "test-file-size"],
   ["### 测试替身", "test-doubles"],


### PR DESCRIPTION
## 概要

- 本地后端完整测试固定使用 4 个 worker 与 loadfile，并移除前端重复 lint
- 将运行时 profile fixture 从每用例临时目录改为每 worker 复用，依赖独立 profile 的用例显式隔离
- CI 后端按 unit/integration、前端按 static/tests 并行，PostgreSQL 兼容测试采用 4 worker
- 补齐后端测试直接读取前端源文件时的跨域 CI 触发
- 在 AGENTS.md 内联两阶段验证流程，在 CONTRIBUTING.md 集中维护测试选择规则

## 基准

PostgreSQL 501 个用例，含覆盖率开销，各运行 3 次：

| workers | 中位耗时 |
|---|---:|
| 1 | 329.9s |
| 2 | 87.0s |
| 4 | 65.5s |

4 worker 已将整段压至约 65 秒，因此未实施风险更高的 per-worker schema 复用。

## 验证

- 后端完整测试连续三次：每次 11,151 passed / 3 skipped
- PostgreSQL n=1/2/4 各三次：每次 501 passed，无 deadlock 或 schema 泄漏
- 前端：166 files / 1,991 tests passed
- ruff、basedpyright（0 errors）、import-linter、test audit、actionlint 全部通过
- website typecheck、lint、format check 全部通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试与质量**
  - 后端单元测试与集成测试分离并行运行，优化覆盖率收集与上传。
  - 前端静态检查、构建与测试流程分离执行。
  - 更新测试选择规范，要求相关测试实际运行并通过。

- **持续集成**
  - 改进前后端变更路径识别，确保相关检查正确触发。

- **测试稳定性**
  - 优化测试配置目录隔离与环境变量管理，提升并行测试可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->