### PR TITLE
fix(frontend): 列表分隔符随语言输出、轮询超时输入口径统一 [Spec #2150]

### DIFF
--- a/frontend/src/components/pages/SystemConfigPage.tsx
+++ b/frontend/src/components/pages/SystemConfigPage.tsx
@@ -71,8 +71,8 @@ const SECTION_GROUPS: SectionGroup[] = [
     kicker: "Configuration",
     items: [
       { id: "providers", labelKey: "dashboard:providers", Icon: Plug },
-      { id: "endpoints", labelKey: "dashboard:ce_section_title", Icon: Waypoints },
       { id: "agent", labelKey: "dashboard:agents", Icon: Bot },
+      { id: "endpoints", labelKey: "dashboard:ce_section_title", Icon: Waypoints },
       { id: "media", labelKey: "dashboard:models", Icon: Film },
     ],
   },

--- a/frontend/src/components/pages/settings/CustomProviderForm.tsx
+++ b/frontend/src/components/pages/settings/CustomProviderForm.tsx
@@ -45,6 +45,7 @@ import {
   INPUT_CLS,
 } from "@/components/ui/darkroom-tokens";
 import { FieldLabel } from "@/components/ui/FieldLabel";
+import { formatNameList } from "@/utils/list-format";
 
 // ---------------------------------------------------------------------------
 // Style constants
@@ -307,7 +308,7 @@ export function CustomProviderForm({
   onSaved,
   onCancel,
 }: CustomProviderFormProps) {
-  const { t } = useTranslation("dashboard");
+  const { t, i18n } = useTranslation("dashboard");
   const isEdit = !!existing;
 
   // Endpoint catalog（后端单一真相源）：mediaType 推断、price/default 互斥分组都从这里读。
@@ -704,7 +705,7 @@ export function CustomProviderForm({
           </label>
           {noApiKey && keyRequiringModels.length > 0 && (
             <p className="mt-1.5 text-[12px] leading-[1.55] text-warm-bright">
-              {t("cp_no_api_key_conflict", { models: keyRequiringModels.join("、") })}
+              {t("cp_no_api_key_conflict", { models: formatNameList(keyRequiringModels, i18n.language) })}
             </p>
           )}
         </div>

--- a/frontend/src/components/pages/settings/MediaModelSection.test.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.test.tsx
@@ -76,12 +76,46 @@ describe("MediaModelSection", () => {
     const patch = vi.spyOn(API, "updateSystemConfig").mockResolvedValue(CONFIG as never);
     render(<MediaModelSection />);
 
-    const timeout = await screen.findByRole("spinbutton", { name: "视频轮询超时（秒）" });
+    const timeout = await screen.findByRole("textbox", { name: "视频轮询超时（秒）" });
     await user.clear(timeout);
     await user.type(timeout, "7200");
     await user.click(screen.getByRole("button", { name: "保存" }));
 
     await waitFor(() => expect(patch).toHaveBeenCalledWith({ video_poll_timeout_seconds: 7200 }));
+  });
+
+  it("rounds a fractional polling timeout to an integer on blur before saving", async () => {
+    const user = userEvent.setup();
+    const patch = vi.spyOn(API, "updateSystemConfig").mockResolvedValue(CONFIG as never);
+    render(<MediaModelSection />);
+
+    const timeout = await screen.findByRole("textbox", { name: "视频轮询超时（秒）" });
+    await user.clear(timeout);
+    await user.type(timeout, "60.5");
+    // 编辑期间保留原始字符串，小数点等中间态不被吞掉
+    expect(timeout).toHaveValue("60.5");
+    await user.tab();
+    expect(timeout).toHaveValue("61");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalledWith({ video_poll_timeout_seconds: 61 }));
+  });
+
+  it("discards the polling timeout edit, including typed intermediates, when the field is left empty", async () => {
+    const user = userEvent.setup();
+    render(<MediaModelSection />);
+
+    const timeout = await screen.findByRole("textbox", { name: "视频轮询超时（秒）" });
+    // 先键入有效值（键入过程会把中间值写进草稿），再清空离开
+    await user.clear(timeout);
+    await user.type(timeout, "7200");
+    await user.clear(timeout);
+    expect(timeout).toHaveValue("");
+    await user.tab();
+
+    // 空输入撤销该字段的未保存编辑：回显已保存值，键入过的 7200 不残留在草稿里
+    expect(timeout).toHaveValue("3600");
+    expect(screen.queryByRole("button", { name: "保存" })).not.toBeInTheDocument();
   });
 
   it("keeps configured global sub-fields visible when the candidate fetch fails", async () => {
@@ -395,7 +429,7 @@ describe("MediaModelSection – 语言切换", () => {
     const trigger = await screen.findByRole("combobox", { name: "默认视频模型" });
     await waitFor(() => expect(trigger).toHaveTextContent("谷歌 · 维奥 3"));
 
-    const timeout = screen.getByRole("spinbutton", { name: "视频轮询超时（秒）" });
+    const timeout = screen.getByRole("textbox", { name: "视频轮询超时（秒）" });
     await user.clear(timeout);
     await user.type(timeout, "7200");
 
@@ -405,7 +439,7 @@ describe("MediaModelSection – 语言切换", () => {
 
     await waitFor(() => expect(trigger).toHaveTextContent("Gemini · Veo 3"));
     // 语言切换只重取候选，不重取整页配置——后者会 setDraft({}) 丢掉这里未保存的输入
-    expect(timeout).toHaveValue(7200);
+    expect(timeout).toHaveValue("7200");
 
     await user.click(trigger);
     // 选项行主行为译名，model id 仍在行内可辨识

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -383,9 +383,18 @@ export function MediaModelSection() {
             value={currentPollTimeout}
             onChange={(e) => {
               const next = Number(e.target.value);
-              if (Number.isInteger(next)) {
+              // 仅过滤非有限数，与 narration_speed 同口径：小数等中间态允许暂存，键入内容
+              // 与草稿不再静默分叉；失焦时归一为整数，下限由保存时后端校验兜底。
+              if (Number.isFinite(next)) {
                 setDraft((prev) => ({ ...prev, video_poll_timeout_seconds: next }));
               }
+            }}
+            onBlur={() => {
+              setDraft((prev) => {
+                const raw = prev.video_poll_timeout_seconds;
+                if (raw === undefined || Number.isInteger(raw)) return prev;
+                return { ...prev, video_poll_timeout_seconds: Math.round(raw) };
+              });
             }}
             className="w-full rounded-[8px] border border-hairline bg-bg-grad-a/55 px-3 py-2 text-[12.5px] text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           />

--- a/frontend/src/components/pages/settings/MediaModelSection.tsx
+++ b/frontend/src/components/pages/settings/MediaModelSection.tsx
@@ -81,6 +81,9 @@ export function MediaModelSection() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [customProviders, setCustomProviders] = useState<CustomProviderInfo[]>([]);
   const [draft, setDraft] = useState<SystemConfigPatch>({});
+  // 轮询超时编辑期的原始字符串（null = 未在编辑）：受控 value 若直接取数字，
+  // 「60.」等中间态与清空会被数字化吞掉；失焦时统一解析写回草稿。
+  const [pollTimeoutInput, setPollTimeoutInput] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const isDirty = Object.keys(draft).length > 0;
@@ -377,24 +380,34 @@ export function MediaModelSection() {
           </label>
           <input
             id="video-poll-timeout-input"
-            type="number"
-            min={60}
-            step={1}
-            value={currentPollTimeout}
+            type="text"
+            inputMode="decimal"
+            value={pollTimeoutInput ?? String(currentPollTimeout)}
             onChange={(e) => {
-              const next = Number(e.target.value);
-              // 仅过滤非有限数，与 narration_speed 同口径：小数等中间态允许暂存，键入内容
-              // 与草稿不再静默分叉；失焦时归一为整数，下限由保存时后端校验兜底。
-              if (Number.isFinite(next)) {
+              const raw = e.target.value;
+              setPollTimeoutInput(raw);
+              const next = Number(raw);
+              // 显示以原始字符串为准（「60.」等中间态与清空保真）；有效数值同步进草稿，
+              // 空串或非数值不写入——清空不会产生 0 这类假值。
+              if (raw.trim() !== "" && Number.isFinite(next)) {
                 setDraft((prev) => ({ ...prev, video_poll_timeout_seconds: next }));
               }
             }}
             onBlur={() => {
-              setDraft((prev) => {
-                const raw = prev.video_poll_timeout_seconds;
-                if (raw === undefined || Number.isInteger(raw)) return prev;
-                return { ...prev, video_poll_timeout_seconds: Math.round(raw) };
-              });
+              if (pollTimeoutInput === null) return;
+              const next = Number(pollTimeoutInput);
+              // 失焦归一：有效数值取整写入草稿；空串或非数值撤销该字段的未保存编辑
+              // （连同键入过程写入的中间值），回显已保存值。下限由保存时后端校验兜底。
+              if (pollTimeoutInput.trim() !== "" && Number.isFinite(next)) {
+                setDraft((prev) => ({ ...prev, video_poll_timeout_seconds: Math.round(next) }));
+              } else {
+                setDraft((prev) => {
+                  if (!("video_poll_timeout_seconds" in prev)) return prev;
+                  const { video_poll_timeout_seconds: _dropped, ...rest } = prev;
+                  return rest;
+                });
+              }
+              setPollTimeoutInput(null);
             }}
             className="w-full rounded-[8px] border border-hairline bg-bg-grad-a/55 px-3 py-2 text-[12.5px] text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           />

--- a/frontend/src/components/pages/settings/endpoints/EndpointImportDialog.tsx
+++ b/frontend/src/components/pages/settings/endpoints/EndpointImportDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { GlassModal } from "@/components/ui/GlassModal";
 import { ACCENT_BTN_SM_CLS, ACCENT_BUTTON_STYLE, GHOST_BTN_CLS } from "@/components/ui/darkroom-tokens";
 import type { EndpointDefinition, EndpointValidateResponse } from "@/types";
+import { formatNameList } from "@/utils/list-format";
 
 /** 导入确认：先看校验结果与重复血统，再决定新建副本、覆盖既有，还是取消。 */
 export function EndpointImportDialog({
@@ -25,7 +26,7 @@ export function EndpointImportDialog({
   onOverwrite: (id: number) => void;
   onCancel: () => void;
 }) {
-  const { t } = useTranslation(["dashboard", "common"]);
+  const { t, i18n } = useTranslation(["dashboard", "common"]);
   const titleId = useId();
 
   const hasErrors = (validation?.errors.length ?? 0) > 0;
@@ -90,7 +91,10 @@ export function EndpointImportDialog({
         {validation?.hints?.suggested_models && validation.hints.suggested_models.length > 0 && (
           <p className="mt-1 text-[12px] text-text-3">
             {t("ce_import_hint_models", {
-              models: validation.hints.suggested_models.map((m) => m.label ?? m.id).join("、"),
+              models: formatNameList(
+                validation.hints.suggested_models.map((m) => m.label ?? m.id),
+                i18n.language,
+              ),
             })}
           </p>
         )}

--- a/frontend/src/utils/list-format.test.ts
+++ b/frontend/src/utils/list-format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatNameList } from "./list-format";
+
+describe("formatNameList", () => {
+  it("中文用顿号分隔", () => {
+    expect(formatNameList(["甲", "乙", "丙"], "zh")).toBe("甲、乙、丙");
+  });
+
+  it("英文用逗号分隔", () => {
+    expect(formatNameList(["a", "b", "c"], "en")).toBe("a, b, c");
+  });
+
+  it("单元素原样返回", () => {
+    expect(formatNameList(["only"], "vi")).toBe("only");
+  });
+
+  it("非法语言标签回退默认 locale 而不抛错", () => {
+    expect(formatNameList(["a", "b"], "not a locale")).toContain("a");
+  });
+});

--- a/frontend/src/utils/list-format.ts
+++ b/frontend/src/utils/list-format.ts
@@ -1,0 +1,21 @@
+const cache = new Map<string, Intl.ListFormat>();
+
+function getFormatter(lang: string | undefined): Intl.ListFormat {
+  const key = lang ?? "";
+  let fmt = cache.get(key);
+  if (!fmt) {
+    try {
+      fmt = new Intl.ListFormat(lang, { style: "narrow", type: "conjunction" });
+    } catch {
+      fmt = new Intl.ListFormat(undefined, { style: "narrow", type: "conjunction" });
+    }
+    cache.set(key, fmt);
+  }
+  return fmt;
+}
+
+// 名词列表按界面语言出分隔符（zh「、」/ en「, 」）；narrow-conjunction 不加连接词，
+// 适合嵌进句子里的名称枚举。
+export function formatNameList(items: string[], lang: string): string {
+  return getFormatter(lang).format(items);
+}


### PR DESCRIPTION
## Summary

Spec #2150 AFK 批次复盘 follow-up FU-06 / FU-08（Refs #2150）：

- **FU-06**：`CustomProviderForm`「无需密钥冲突提示」与 `EndpointImportDialog` 建议模型列表原来 `join("、")` 硬编码顿号，en/vi 界面出现中文标点。新增 `utils/list-format.ts`（`Intl.ListFormat`，narrow-conjunction：zh「甲、乙、丙」/ en「a, b, c」/ vi「a, b, c」），两处改为按界面语言输出分隔符。
- **FU-08**：`MediaModelSection` 轮询超时输入原来 `Number.isInteger` 静默忽略小数——DOM 显示所键内容、draft 不更新。改为 `Number.isFinite` 接收 + 失焦 `Math.round` 归一整数，与同卡片 `narration_speed` 口径一致；`≥60` 下限仍由后端保存校验兜底（`ConfigService.set_video_poll_timeout_seconds`），未放宽整型约束。
- **附带**：设置页侧栏「调用端点」栏位移到 Agent 下方（Configuration 组排序：供应商 → Agent → 调用端点 → 模型）。

## 测试

- 新增 `utils/list-format.test.ts`（zh 顿号 / en 逗号 / 单元素 / 非法 locale 回退）。
- `pnpm check` 全绿（169 文件 / 2006 测试）；`scripts/audit_tests.py --check` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 设置页面中的模型名称列表会根据当前界面语言自动调整分隔格式。
  * 视频轮询超时输入支持更自然地编辑小数等中间值，并在失焦时自动取整。
  * 优化相关提示和导入建议的本地化显示，非法语言设置也能稳定回退。
  * 调整设置侧栏顺序，将“Agent”移至“Endpoints”之前。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->