### PR TITLE
chore(custom-provider): 修正过时 FK 注释、schema 规约注解与计费时长负例 [Spec #2150]

### DIFF
--- a/lib/custom_provider/endpoint_definition/schema.json
+++ b/lib/custom_provider/endpoint_definition/schema.json
@@ -64,7 +64,7 @@
   "$defs": {
     "semver": {
       "type": "string",
-      "$comment": "这份 schema 前后端共用，pattern 只写两个运行时都成立的构造：用 [0-9] 而非 \\d（Python 的 \\d 含 Unicode 十进制数字），另加禁换行的 not（Python 的 $ 还匹配末尾换行前的位置，而 ECMA-262 没有 \\Z）。",
+      "$comment": "这份 schema 前后端共用，pattern 只写两个运行时都成立的构造：用 [0-9] 而非 \\d（Python 的 \\d 含 Unicode 十进制数字），另加禁换行的 not（Python 的 $ 还匹配末尾换行前的位置，而 ECMA-262 没有 \\Z）。另外 format 在 jsonschema 里默认只是注解、本仓也未装格式检查器，写 format 只当文档，约束力必须由同字段的 pattern 提供。",
       "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
       "not": { "pattern": "\\n" }
     },

--- a/lib/db/repositories/custom_endpoint_repo.py
+++ b/lib/db/repositories/custom_endpoint_repo.py
@@ -89,8 +89,8 @@ class CustomEndpointRepository(BaseRepository):
     async def list_references(self, endpoint_key: str) -> list[EndpointReference]:
         """按 ``endpoint`` 键字面量列出引用它的模型行，供 409 响应说明「谁还在用」。
 
-        引用完整性靠本查询而非 FK：SQLite 默认关闭 foreign_keys pragma，加 FK 列既拦不住写入，
-        又成了第二真相源；而删除路径本就要把引用清单回给客户端，约束只能抛一个 IntegrityError。
+        引用完整性靠本查询而非 FK：409 要回引用清单，FK 约束只能抛一个 IntegrityError，
+        而删除路径本就要先查引用（docs/adr/0067）。
         """
         stmt = (
             select(

--- a/lib/db/repositories/custom_provider_repo.py
+++ b/lib/db/repositories/custom_provider_repo.py
@@ -104,7 +104,8 @@ class CustomProviderRepository(BaseRepository):
     async def delete_provider(self, provider_id: int) -> None:
         """删除供应商及其所有模型。
 
-        显式删除模型而非依赖 FK CASCADE，因为 SQLite 默认不启用 foreign_keys pragma。
+        显式删除模型而非依赖 FK CASCADE：级联只在开启 foreign_keys pragma 的连接上生效，
+        应用引擎虽统一开启（engine.py），脚本或外部工具直连时不保证；显式删除不依赖连接配置。
         """
         await self.session.execute(delete(CustomProviderModel).where(CustomProviderModel.provider_id == provider_id))
         await self.session.execute(delete(CustomProvider).where(CustomProvider.id == provider_id))

--- a/tests/unit/lib/custom_provider/test_declarative_video_backend.py
+++ b/tests/unit/lib/custom_provider/test_declarative_video_backend.py
@@ -6,8 +6,13 @@ from pathlib import Path
 import httpx
 import pytest
 
-from lib.custom_provider.declarative_backend import DeclarativeRuntimeError, DeclarativeVideoBackend
+from lib.custom_provider.declarative_backend import (
+    DeclarativeRuntimeError,
+    DeclarativeVideoBackend,
+    extract_duration,
+)
 from lib.custom_provider.endpoint_definition import validate_definition
+from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.video_backends.base import (
     VIDEO_POLL_MAX_CONSECUTIVE_FAILURES,
     ResumeExpiredError,
@@ -1129,3 +1134,27 @@ class TestDeclarativeVideoBackend:
         )
         assert "声明式视频请求" in logged
         assert "sk-super-secret" not in logged
+
+
+class TestExtractDuration:
+    """``extract_duration`` 直接决定计费时长：越界与不可解析一律回 ``None`` 走缺省计价。"""
+
+    SPEC = {"paths": ["$.usage.duration"], "accept": "scalar"}
+
+    @pytest.mark.parametrize(
+        "raw",
+        [0, -3, MAX_BILLED_DURATION_SECONDS + 1, "not-a-number"],
+        ids=["zero", "negative", "over-max", "non-numeric"],
+    )
+    def test_out_of_range_or_unparsable_values_fall_back_to_none(self, raw):
+        assert extract_duration(self.SPEC, {"usage": {"duration": raw}}) is None
+
+    def test_half_up_rounding_can_push_the_value_out_of_range(self):
+        boundary = MAX_BILLED_DURATION_SECONDS + 0.5
+        assert extract_duration(self.SPEC, {"usage": {"duration": boundary}}) is None
+
+    def test_boundary_values_inside_the_range_are_kept(self):
+        assert extract_duration(self.SPEC, {"usage": {"duration": 1}}) == 1
+        assert extract_duration(self.SPEC, {"usage": {"duration": MAX_BILLED_DURATION_SECONDS}}) == (
+            MAX_BILLED_DURATION_SECONDS
+        )


### PR DESCRIPTION
## Summary

Spec #2150 AFK 批次复盘 follow-up FU-05 / FU-07 / INST-01（Refs #2150），零生产行为变更：

- **FU-07**：`custom_provider_repo.py` 与 `custom_endpoint_repo.py` 的「SQLite 默认不启用 foreign_keys pragma」依据已与 `engine.py` 的 `PRAGMA foreign_keys=ON` 矛盾。注释改为表述当前真实约束：provider 删除的显式级联不依赖连接层 pragma 配置；endpoint 拒删靠服务层引用计数（与 ADR 0067 口径一致）。
- **INST-01**：`schema.json` 编写规约 `$comment` 补「format 只是注解、本仓未装格式检查器，约束力必须由同字段 pattern 提供」——跨运行时正则规约已就地承载，这半条此前无文字承载，schema 扩字段时易重踩空校验。
- **FU-05**：`extract_duration` 直接决定计费时长口径，此前 tests/ 下零直接用例。补负例（0 / 负值 / 超上限 / 非数值 / half-up 舍入越界）与区间边界正例，断言越界一律回 `None` 走缺省计价。

## 测试

全量闸门通过：ruff / basedpyright / lint-imports / audit_tests / pytest 11154 passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 澄清版本格式校验规则及其实际约束方式。
  * 更新自定义端点引用完整性和提供方删除机制的说明。
* **测试**
  * 补充视频计费时长提取的边界测试，覆盖负数、零值、无法解析、四舍五入越界及有效范围边界。
* **影响**
  * 本次变更不改变现有模式结构或运行时行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->