### PR TITLE
feat(custom-provider): validate 对 auth 值中疑似字面凭证给出 warning [Spec #2150]

### DIFF
--- a/lib/custom_provider/endpoint_definition/errors.py
+++ b/lib/custom_provider/endpoint_definition/errors.py
@@ -91,6 +91,7 @@ class DefinitionErrorCode(StrEnum):
     # ---- warning ----
     POLL_WITHOUT_TASK_ID = "poll_without_task_id"
     JSONPATH_WILDCARD_ORDER = "jsonpath_wildcard_order"
+    AUTH_LITERAL_CREDENTIAL = "auth_literal_credential"
 
 
 def message_key(code: DefinitionErrorCode) -> str:

--- a/lib/custom_provider/endpoint_definition/validator.py
+++ b/lib/custom_provider/endpoint_definition/validator.py
@@ -325,7 +325,10 @@ class _SemanticChecker:
         scope = _Scope(section="auth")
         for group, values in (("headers", headers), ("query", query)):
             for name, template in values.items():
-                self._scan_template(template, join_path(join_path("auth", group), name), scope)
+                path = join_path(join_path("auth", group), name)
+                self._scan_template(template, path, scope)
+                if _looks_like_literal_credential(str(template)):
+                    self._warn(path, DefinitionErrorCode.AUTH_LITERAL_CREDENTIAL)
         self._check_header_names(join_path("auth", "headers"), headers)
         if not headers and not query:
             return
@@ -620,6 +623,21 @@ def _capability_is_on(capability: str, value: object) -> bool:
 
 def _placeholder_names(text: str) -> list[str]:
     return _PLACEHOLDER.findall(text)
+
+
+#: 凭证长相：20+ 位含数字的 token 串（API key / JWT / base64 的公共形态）。版本号、固定
+#: 字段这类短静态值不命中；误报的代价只是一条不拦保存的 warning。
+_CREDENTIAL_TOKEN = re.compile(r"[A-Za-z0-9+/_=-]{20,}")
+
+
+def _looks_like_literal_credential(template: str) -> bool:
+    """auth 值剔除占位符后，剩余字面部分是否形似直接写入的凭证。
+
+    凭证以 api_key 占位符形态出现是导出剥凭证的前提；字面凭证会随导出与「复制为我的」
+    原样外流，只能靠形态识别提示。
+    """
+    literal = _PLACEHOLDER.sub(" ", template)
+    return any(any(ch.isdigit() for ch in token) for token in _CREDENTIAL_TOKEN.findall(literal))
 
 
 def _malformed_placeholders(text: str) -> list[str]:

--- a/lib/i18n/en/validation.py
+++ b/lib/i18n/en/validation.py
@@ -316,6 +316,10 @@ MESSAGES = {
     ),
     "val_ce_jsonpath_syntax": "Extraction path syntax error (at character {position}): {path_expression}",
     "val_ce_template_render_failed": "Could not render the request template: {detail}",
+    "val_ce_auth_literal_credential": (
+        "This value appears to contain an actual secret key: reference the credential with the api_key "
+        "placeholder instead, or the key will be exposed when the definition is exported or shared"
+    ),
     "val_ce_poll_without_task_id": "The polling request never references task_id; confirm that this is intended",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} uses a wildcard: an object wildcard takes the first member only, "

--- a/lib/i18n/vi/validation.py
+++ b/lib/i18n/vi/validation.py
@@ -324,6 +324,10 @@ MESSAGES = {
     ),
     "val_ce_jsonpath_syntax": "Lỗi cú pháp đường dẫn trích xuất (tại ký tự {position}): {path_expression}",
     "val_ce_template_render_failed": "Không dựng được mẫu yêu cầu: {detail}",
+    "val_ce_auth_literal_credential": (
+        "Giá trị này có vẻ chứa khóa bí mật thật: hãy tham chiếu thông tin xác thực qua placeholder api_key, "
+        "nếu không khóa sẽ bị lộ khi định nghĩa được xuất hoặc chia sẻ"
+    ),
     "val_ce_poll_without_task_id": "Yêu cầu hỏi trạng thái không tham chiếu task_id; hãy xác nhận đây là chủ ý",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} dùng ký tự đại diện: với đối tượng chỉ lấy thành viên đầu tiên, "

--- a/lib/i18n/zh/validation.py
+++ b/lib/i18n/zh/validation.py
@@ -237,6 +237,7 @@ MESSAGES = {
     "val_ce_jsonpath_regex_operator": "取值路径禁用正则匹配运算符（第 {position} 个字符）：{path_expression}",
     "val_ce_jsonpath_syntax": "取值路径语法错误（第 {position} 个字符）：{path_expression}",
     "val_ce_template_render_failed": "请求模板渲染失败：{detail}",
+    "val_ce_auth_literal_credential": "该值疑似直接填写了真实密钥：请改用 api_key 占位符引用凭证，否则导出或分享定义时会泄露该密钥",
     "val_ce_poll_without_task_id": "轮询请求没有引用 task_id，请确认这是有意的",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} 含通配：对象通配只取首个，键序在前端预览与后端执行之间可能不同"

--- a/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_validator.py
+++ b/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_validator.py
@@ -563,6 +563,25 @@ class TestWarnings:
         assert diagnostics.valid
         assert [issue.code for issue in diagnostics.warnings] == [DefinitionErrorCode.POLL_WITHOUT_TASK_ID]
 
+    def test_a_literal_credential_beside_the_placeholder_is_only_a_warning(self):
+        definition = custom_endpoint_definition()
+        definition["auth"] = {
+            "headers": {
+                "Authorization": "Bearer {{ api_key }}",
+                "X-Backup-Key": "sk-live-9f8e7d6c5b4a39281706",
+            }
+        }
+        diagnostics = validate_definition(definition)
+        assert diagnostics.valid
+        assert [issue.code for issue in diagnostics.warnings] == [DefinitionErrorCode.AUTH_LITERAL_CREDENTIAL]
+        assert diagnostics.warnings[0].path == "auth.headers.X-Backup-Key"
+
+    def test_placeholder_and_short_static_auth_values_do_not_look_like_credentials(self):
+        definition = custom_endpoint_definition()
+        definition["auth"]["headers"]["X-Api-Version"] = "2024-06-01"
+        definition["auth"]["headers"]["X-Client"] = "arcreel-desktop-production-build"
+        assert not validate_definition(definition).warnings
+
     def test_wildcard_ordering_is_only_a_warning(self):
         definition = custom_endpoint_definition()
         definition["poll"]["extract"]["video_url"] = ["$.outputs[*].url"]


### PR DESCRIPTION
## Summary

Spec #2150 AFK 批次复盘 follow-up FU-04（Refs #2150）。

导出剥凭证依赖「凭证以 `api_key` 占位符形态出现」的模板语义；纯字面凭证替代占位符的形态已被 `auth_without_api_key` 错误拦下，但**占位符之外再写字面 key**（如备用 header、query 里的第二把钥匙）此前保存、导出、复制为我的各入口均无提示，导出文件即带真实密钥外流。

- 新增 warning 码 `auth_literal_credential`（warning 不拦保存）：`auth.headers` / `auth.query` 的值剔除占位符后，字面部分含 20+ 位带数字的 token 串（API key / JWT / base64 公共形态）即按条目路径提示。
- 判定收在共享校验器 `_check_auth_section` 一处，经 `to_payload` 既有 warnings 通道下发，各入口自动一致。
- 三语文案 `val_ce_auth_literal_credential`（zh/en/vi，`test_every_code_reads_as_prose_in_every_locale` 自动校验齐全）。**文案为内容性表述，请校对。**

## 误报边界

版本号（`2024-06-01`）、无数字长串（`arcreel-desktop-production-build`）不命中，测试固化；误报代价止于一条不阻断的提示。

## 测试

新增 warning 正反例两条；全量闸门通过：ruff / basedpyright / lint-imports / audit_tests / pytest 11150 passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增认证配置检查，可识别疑似直接写入的长凭证，并提供安全替代建议。
* **改进**
  * 检测结果仅以警告提示，不会阻止配置保存。
  * 支持英文、中文和越南语提示，建议使用 `api_key` 占位符引用凭证。
* **测试**
  * 增加对真实凭证格式及普通短文本误报场景的验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->