### PR TITLE
fix(mcp): 远程 MCP 外部接入零配置 [#2221]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,16 +38,18 @@ AUTH_TOKEN_SECRET=
 # LISTEN_PORT=1241
 # Comma-separated CORS origins; "*" or unset → permissive (credentials disabled
 # by CORS spec). Set an explicit whitelist (e.g. "http://localhost:5173") to
-# enable credentialed cross-origin requests.
+# enable credentialed cross-origin requests. The remote MCP endpoint shares this
+# allowlist for browser clients, so it needs no separate MCP origin variable.
 # 逗号分隔的 CORS 允许 origin；"*" 或不设 → 通配（credentials 因 CORS spec 强制关闭）。
-# 设为白名单（如 "http://localhost:5173"）才会开启 credentials 跨域。
+# 设为白名单（如 "http://localhost:5173"）才会开启 credentials 跨域。远程 MCP 端点
+# 对浏览器型客户端共用这份白名单，无需另设 MCP 专用 origin 变量。
 # CORS_ORIGINS=*
-# Remote MCP public URL and DNS-rebinding allowlists. Localhost is allowed by default;
-# external deployments must list their exact host/origin here.
-# 远程 MCP 公网地址与 DNS 重绑定防护白名单。默认只允许 localhost；外部部署须填写实际 host/origin。
+# Remote MCP needs no configuration for external access. This optional variable only
+# fills the OAuth protected-resource metadata that discovery-based clients read;
+# clients connecting with an arc- API Key as a Bearer token never use it.
+# 远程 MCP 外部接入无需配置。此可选变量仅用于填写 OAuth 受保护资源元数据，
+# 供做发现流程的客户端读取；用 arc- API Key 以 Bearer 直连的客户端不会用到。
 # MCP_PUBLIC_URL=https://arcreel.example.com/mcp
-# MCP_ALLOWED_HOSTS=arcreel.example.com
-# MCP_ALLOWED_ORIGINS=https://arcreel.example.com
 
 # ============================================================
 # Application Data Root / 应用数据根目录

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -11,10 +11,9 @@ AUTH_PASSWORD=
 # JWT 签名密钥（留空则自动生成，但重启后 token 失效需重新登录）
 AUTH_TOKEN_SECRET=
 
-# 远程 MCP（外部部署须填写实际 HTTPS 端点及 DNS 重绑定防护白名单）
+# 远程 MCP 外部接入无需配置。以下可选变量仅填 OAuth 受保护资源元数据，
+# 供做发现流程的客户端读取；用 arc- API Key 以 Bearer 直连的客户端不会用到
 # MCP_PUBLIC_URL=https://arcreel.example.com/mcp
-# MCP_ALLOWED_HOSTS=arcreel.example.com
-# MCP_ALLOWED_ORIGINS=https://arcreel.example.com
 
 # ============================================================
 # 日志配置 (Logging)

--- a/deploy/production/.env.example
+++ b/deploy/production/.env.example
@@ -11,10 +11,9 @@ AUTH_PASSWORD=
 # JWT 签名密钥（留空则自动生成，但重启后 token 失效需重新登录）
 AUTH_TOKEN_SECRET=
 
-# 远程 MCP（外部部署须填写实际 HTTPS 端点及 DNS 重绑定防护白名单）
+# 远程 MCP 外部接入无需配置。以下可选变量仅填 OAuth 受保护资源元数据，
+# 供做发现流程的客户端读取；用 arc- API Key 以 Bearer 直连的客户端不会用到
 # MCP_PUBLIC_URL=https://arcreel.example.com/mcp
-# MCP_ALLOWED_HOSTS=arcreel.example.com
-# MCP_ALLOWED_ORIGINS=https://arcreel.example.com
 
 # ============================================================
 # PostgreSQL 配置

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -272,9 +272,17 @@ ADR 0069.
 
 ### 9.7 CORS and logging
 
-When `CORS_ORIGINS` is absent, empty, or contains `*`, ArcReel uses wildcard origins with credentials disabled. This does not independently bypass bearer authentication because an attacker-controlled origin does not know the token.
+When `CORS_ORIGINS` is absent, empty, or contains `*`, ArcReel uses wildcard origins with credentials disabled. This does not independently bypass bearer authentication because an attacker-controlled origin does not know the token. The allowlist is parsed once in `server/cors_config.py` and applied by a single application-level `CORSMiddleware` that also wraps the `/mcp` mount; there is no MCP-specific origin list.
 
 Application request logging records URL paths rather than complete query strings. Reverse proxies, ingress controllers, monitoring systems, and diagnostic middleware may still record query parameters.
+
+### 9.8 Remote MCP transport
+
+The remote MCP endpoint is mounted at `/mcp` and enforces an `arc-` API key on every request through `ArcApiKeyVerifier`. `AUTH_ENABLED=false` does not grant it anonymous access, and login JWTs and download tokens are rejected.
+
+The MCP SDK's DNS-rebinding protection is disabled (`TransportSecuritySettings(enable_dns_rebinding_protection=False)`), so ArcReel validates neither the `Host` nor the `Origin` header inside the MCP mount. A rebound request reaches the endpoint but carries no credential, because the API key is never held in a browser cookie or session, and receives 401. Host ownership is delegated to the reverse proxy and deployment topology. Cross-origin protection for browser MCP clients rests entirely on the application-level CORS allowlist described in 9.7. Disabling the flag does not affect the SDK's `Content-Type` validation for POST requests.
+
+`MCP_PUBLIC_URL` populates only the RFC 9728 protected-resource metadata and the 401 challenge. The `AccessToken` returned by `ArcApiKeyVerifier` carries no resource, so neither the issuer nor the resource URL participates in token validation.
 
 ## 10. Attack surfaces and abuse cases
 

--- a/server/app.py
+++ b/server/app.py
@@ -43,6 +43,7 @@ from lib.path_safety import try_safe_join
 from lib.project_migrations import cleanup_stale_backups, run_project_migrations
 from lib.source_loader.migration import migrate_project_source_encoding
 from server.auth import ensure_auth_password, get_current_user
+from server.cors_config import resolve_cors_policy
 from server.dependencies import require_project_migration_ok
 from server.error_handlers import register_error_handlers
 from server.remote_mcp import remote_mcp_host
@@ -497,21 +498,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS 配置（env 驱动）：
-#   - CORS_ORIGINS 未设置 / 空 / 包含 "*" → 通配 origins，credentials 强制关闭
-#     （CORS spec 不允许通配 + credentials 组合；Starlette 在初始化时会 RuntimeError）
-#   - 否则按逗号分隔解析为白名单，credentials 打开供前端附带 cookie / Authorization 跨域
-#
+# CORS 配置（env 驱动，解析见 server/cors_config.py；远程 MCP 挂载共用同一份白名单）。
 # 须在 register_error_handlers(app) 之前算出：未预期异常的 500 由
 # ServerErrorMiddleware 兜底发送，绕过 CORSMiddleware（见
 # server/error_handlers.py::_cors_headers_for），handler 需要这份配置手工补 CORS 头。
-_cors_raw = os.environ.get("CORS_ORIGINS", "*").strip()
-_allow_origins: list[str] = [o.strip() for o in _cors_raw.split(",") if o.strip()]
-if not _allow_origins or "*" in _allow_origins:
-    _allow_origins = ["*"]
-    _allow_credentials = False
-else:
-    _allow_credentials = True
+_allow_origins, _allow_credentials = resolve_cors_policy()
 
 # app 级异常处理器：异常→状态码→detail 映射的单点（见 server/error_handlers.py）
 register_error_handlers(app, cors_allow_origins=_allow_origins, cors_allow_credentials=_allow_credentials)

--- a/server/cors_config.py
+++ b/server/cors_config.py
@@ -1,0 +1,24 @@
+"""Env-driven CORS origin policy, shared by the app middleware and the remote MCP mount."""
+
+from __future__ import annotations
+
+import os
+
+WILDCARD = "*"
+
+
+def resolve_cors_policy(raw: str | None = None) -> tuple[list[str], bool]:
+    """Parse ``CORS_ORIGINS`` into ``(allow_origins, allow_credentials)``.
+
+    未设置 / 空 / 含 ``*`` → 通配 origins 且 credentials 强制关闭（CORS spec 不允许通配 +
+    credentials 组合，Starlette 在初始化时会 RuntimeError）；否则按逗号分隔解析为白名单，
+    credentials 打开供前端附带 cookie / Authorization 跨域。
+    """
+    raw = os.environ.get("CORS_ORIGINS", WILDCARD) if raw is None else raw
+    origins = [origin.strip() for origin in raw.strip().split(",") if origin.strip()]
+    if not origins or WILDCARD in origins:
+        return [WILDCARD], False
+    return origins, True
+
+
+__all__ = ["WILDCARD", "resolve_cors_policy"]

--- a/server/remote_mcp.py
+++ b/server/remote_mcp.py
@@ -105,15 +105,6 @@ from server.tool_runtime import (
     upload_source,
 )
 
-_LOCAL_HOSTS = ["127.0.0.1", "127.0.0.1:*", "localhost", "localhost:*", "[::1]", "[::1]:*"]
-_LOCAL_ORIGINS = [
-    "http://127.0.0.1",
-    "http://127.0.0.1:*",
-    "http://localhost",
-    "http://localhost:*",
-    "http://[::1]",
-    "http://[::1]:*",
-]
 # One decoded control byte may occupy six JSON bytes (``\u00XX``); leave 1 MiB for the MCP envelope.
 _MAX_REQUEST_BODY_BYTES = SourceLoader.DEFAULT_MAX_BYTES * 6 + 1024 * 1024
 _REMOTE_DURABLE_BATCH_MEDIA_TOOLS = frozenset(
@@ -142,11 +133,6 @@ class ArcApiKeyVerifier(TokenVerifier):
         if payload is None:
             return None
         return AccessToken(token=token, client_id=payload["sub"], scopes=["arcreel"])
-
-
-def _csv_env(name: str, default: list[str]) -> list[str]:
-    configured = [value.strip() for value in os.environ.get(name, "").split(",") if value.strip()]
-    return configured or default
 
 
 def _authenticated_caller() -> CallerContext:
@@ -362,6 +348,9 @@ def build_remote_mcp_server(
         definition = definition_factory(schema_context)
         media_tools.append(_remote_media_tool(definition, definition_factory, invoke_media))
 
+    # MCP_PUBLIC_URL 只喂 RFC 9728 protected-resource metadata 与 401 challenge：ArcReel 只认
+    # 静态 arc- API Key，ArcApiKeyVerifier 返回的 AccessToken 不带 resource，不参与任何校验。
+    # Bearer 直连的客户端不读这两处，故该变量对常规接入可缺省。
     public_url = AnyHttpUrl(os.environ.get("MCP_PUBLIC_URL", "http://localhost:1241/mcp"))
     server = FastMCP(
         "arcreel",
@@ -376,11 +365,12 @@ def build_remote_mcp_server(
         streamable_http_path="/",
         json_response=False,
         max_request_body_size=_MAX_REQUEST_BODY_BYTES,
-        transport_security=TransportSecuritySettings(
-            enable_dns_rebinding_protection=True,
-            allowed_hosts=_csv_env("MCP_ALLOWED_HOSTS", _LOCAL_HOSTS),
-            allowed_origins=_csv_env("MCP_ALLOWED_ORIGINS", _LOCAL_ORIGINS),
-        ),
+        # 端点每请求强制 arc- API Key，且该 Key 从不以 cookie / session 形式存在于浏览器，
+        # 重绑定到本端点的请求拿不到凭证、只能收 401——Host 白名单在此不构成安全边界，
+        # 只会拦下合法部署；Host 归属由反向代理与部署形态承担。浏览器型客户端的跨源防护由
+        # 应用级 CORSMiddleware（CORS_ORIGINS，见 server/cors_config.py）单点承担。
+        # 关闭该开关不影响 SDK 对 POST 的 Content-Type 校验。
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
 
     @server.tool(name="list_projects", structured_output=False)
@@ -951,4 +941,9 @@ class RemoteMCPHost:
 remote_mcp_host = RemoteMCPHost()
 
 
-__all__ = ["ArcApiKeyVerifier", "RemoteMCPHost", "build_remote_mcp_server", "remote_mcp_host"]
+__all__ = [
+    "ArcApiKeyVerifier",
+    "RemoteMCPHost",
+    "build_remote_mcp_server",
+    "remote_mcp_host",
+]

--- a/tests/integration/server/test_remote_mcp.py
+++ b/tests/integration/server/test_remote_mcp.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import httpx
 import pytest
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
@@ -26,6 +27,7 @@ from lib.workflow_state import WorkflowStatus
 from server.agent_runtime.sdk_tools import ARCREEL_MCP_TOOL_IDS
 from server.agent_runtime.sdk_tools.text_generation import generate_episode_script_tool
 from server.auth import create_download_token, create_token
+from server.cors_config import resolve_cors_policy
 from server.media_tools.assets import generate_assets_tool, list_pending_assets_tool
 from server.media_tools.context import ToolContext
 from server.media_tools.grid import generate_grid_tool
@@ -203,6 +205,82 @@ async def test_remote_mcp_always_rejects_anonymous(remote_server, monkeypatch, a
     response = await _post_initialize(_mounted(remote_server))
 
     assert response.status_code == 401
+
+
+_INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"},
+    },
+}
+
+
+async def test_remote_mcp_accepts_non_loopback_host_header(remote_server) -> None:
+    """任意 Host 都能到达端点：边界由每请求强制的 arc- API Key 承担，不由 Host 白名单承担。"""
+    app = _mounted(remote_server)
+    async with remote_server.session_manager.run():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="https://arcreel.example.com",
+            follow_redirects=True,
+        ) as client:
+            response = await client.post(
+                "/mcp",
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": "Bearer arc-valid",
+                },
+                json=_INITIALIZE_REQUEST,
+            )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("origin", "allowed"),
+    [("https://evil.example.com", False), ("https://arcreel.example.com", True)],
+)
+async def test_remote_mcp_mount_inherits_app_cors_allowlist(
+    remote_server, monkeypatch, origin: str, allowed: bool
+) -> None:
+    """浏览器型客户端的跨源防护由应用级 CORSMiddleware 单点承担，``/mcp`` 挂载被一并覆盖。
+
+    MCP 的 POST 带 Authorization 与 JSON body，浏览器必先发预检；不在 ``CORS_ORIGINS`` 里的
+    Origin 在预检阶段即被拒，实际请求不会发出。
+    """
+    monkeypatch.setenv("CORS_ORIGINS", "https://arcreel.example.com")
+    host = RemoteMCPHost(server_factory=lambda: remote_server)
+    app = FastAPI()
+    allow_origins, allow_credentials = resolve_cors_policy()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allow_origins,
+        allow_credentials=allow_credentials,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.mount("/mcp", host)
+
+    async with host.run():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="https://arcreel.example.com",
+        ) as client:
+            preflight = await client.options(
+                "/mcp",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "authorization,content-type",
+                },
+            )
+
+    assert (preflight.headers.get("access-control-allow-origin") == origin) is allowed
+    assert (preflight.status_code == 200) is allowed
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/test_app_module.py
+++ b/tests/unit/server/test_app_module.py
@@ -99,3 +99,25 @@ class TestAppModule:
         # 退出后 callback 已清
         assert queue._worker_cancel_callback is None
         assert worker.stopped
+
+
+class TestListenEnvVars:
+    """``LISTEN_HOST`` / ``LISTEN_PORT`` 的解析仅在 ``__main__`` 块被 uvicorn 消费，
+    导入 ``server.app`` 不会触发；通过共用的模块级 ``_resolve_listen_addr()`` 函数
+    测试同一份生产解析逻辑，避免测试 / 生产代码漂移。"""
+
+    def test_defaults_match_existing_behavior(self, monkeypatch):
+        monkeypatch.delenv("LISTEN_HOST", raising=False)
+        monkeypatch.delenv("LISTEN_PORT", raising=False)
+        assert app_module._resolve_listen_addr() == ("0.0.0.0", 1241)
+
+    def test_env_overrides_take_effect(self, monkeypatch):
+        monkeypatch.setenv("LISTEN_HOST", "127.0.0.1")
+        monkeypatch.setenv("LISTEN_PORT", "18080")
+        assert app_module._resolve_listen_addr() == ("127.0.0.1", 18080)
+
+    def test_empty_listen_port_falls_back_to_default(self, monkeypatch):
+        """`.env` 误写 `LISTEN_PORT=`（空值）不应让 `int("")` 抛 ValueError。"""
+        monkeypatch.setenv("LISTEN_HOST", "")
+        monkeypatch.setenv("LISTEN_PORT", "")
+        assert app_module._resolve_listen_addr() == ("0.0.0.0", 1241)

--- a/tests/unit/server/test_cors_config.py
+++ b/tests/unit/server/test_cors_config.py
@@ -1,109 +1,36 @@
-"""Tests for env-driven CORS / network binding configuration."""
+"""``CORS_ORIGINS`` 的解析规则；应用中间件与远程 MCP 挂载共用这一份结果。"""
 
 from __future__ import annotations
 
-import importlib
 import os
 from unittest.mock import patch
 
-import pytest
-
-
-@pytest.fixture()
-def reload_app_with_env(monkeypatch: pytest.MonkeyPatch):
-    """Reload server.app under controlled env so module-level CORS config rebuilds."""
-
-    def _reload(env_overrides: dict[str, str | None]):
-        env = os.environ.copy()
-        for k, v in env_overrides.items():
-            if v is None:
-                env.pop(k, None)
-            else:
-                env[k] = v
-        with patch.dict(os.environ, env, clear=True):
-            import server.app as module
-
-            return importlib.reload(module)
-
-    return _reload
+from server.cors_config import resolve_cors_policy
 
 
 class TestCorsOriginsParsing:
-    """The CORS middleware values come from CORS_ORIGINS at module import time."""
+    def test_unset_defaults_to_wildcard_no_credentials(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_cors_policy() == (["*"], False)
 
-    def test_unset_defaults_to_wildcard_no_credentials(self, reload_app_with_env):
-        mod = reload_app_with_env({"CORS_ORIGINS": None})
-        assert mod._allow_origins == ["*"]
-        assert mod._allow_credentials is False
+    def test_explicit_wildcard_keeps_credentials_off(self):
+        assert resolve_cors_policy("*") == (["*"], False)
 
-    def test_explicit_wildcard_keeps_credentials_off(self, reload_app_with_env):
-        mod = reload_app_with_env({"CORS_ORIGINS": "*"})
-        assert mod._allow_origins == ["*"]
-        assert mod._allow_credentials is False
+    def test_empty_string_falls_back_to_wildcard(self):
+        assert resolve_cors_policy("   ") == (["*"], False)
 
-    def test_empty_string_falls_back_to_wildcard(self, reload_app_with_env):
-        mod = reload_app_with_env({"CORS_ORIGINS": "   "})
-        assert mod._allow_origins == ["*"]
-        assert mod._allow_credentials is False
+    def test_single_origin_enables_credentials(self):
+        assert resolve_cors_policy("http://localhost:5173") == (["http://localhost:5173"], True)
 
-    def test_single_origin_enables_credentials(self, reload_app_with_env):
-        mod = reload_app_with_env({"CORS_ORIGINS": "http://localhost:5173"})
-        assert mod._allow_origins == ["http://localhost:5173"]
-        assert mod._allow_credentials is True
+    def test_multiple_origins_parsed_and_stripped(self):
+        origins, credentials = resolve_cors_policy(" http://a.example.com , http://b.example.com,http://c.example.com ")
+        assert origins == ["http://a.example.com", "http://b.example.com", "http://c.example.com"]
+        assert credentials is True
 
-    def test_multiple_origins_parsed_and_stripped(self, reload_app_with_env):
-        mod = reload_app_with_env(
-            {"CORS_ORIGINS": " http://a.example.com , http://b.example.com,http://c.example.com "}
-        )
-        assert mod._allow_origins == [
-            "http://a.example.com",
-            "http://b.example.com",
-            "http://c.example.com",
-        ]
-        assert mod._allow_credentials is True
+    def test_empty_segments_dropped(self):
+        assert resolve_cors_policy("http://a,,http://b,") == (["http://a", "http://b"], True)
 
-    def test_empty_segments_dropped(self, reload_app_with_env):
-        mod = reload_app_with_env({"CORS_ORIGINS": "http://a,,http://b,"})
-        assert mod._allow_origins == ["http://a", "http://b"]
-        assert mod._allow_credentials is True
-
-    def test_mixed_wildcard_with_specific_origin_collapses_to_wildcard(self, reload_app_with_env):
+    def test_mixed_wildcard_with_specific_origin_collapses_to_wildcard(self):
         """`*` 出现在白名单里时，整体降级为通配 + credentials=False，
         避免 Starlette `RuntimeError` (CORS spec 禁止通配 + credentials 共存)。"""
-        mod = reload_app_with_env({"CORS_ORIGINS": "http://localhost:5173, *"})
-        assert mod._allow_origins == ["*"]
-        assert mod._allow_credentials is False
-
-
-class TestListenEnvVars:
-    """``LISTEN_HOST`` / ``LISTEN_PORT`` 的解析仅在 ``__main__`` 块被 uvicorn 消费，
-    导入 ``server.app`` 不会触发；通过共用的模块级 ``_resolve_listen_addr()`` 函数
-    测试同一份生产解析逻辑，避免测试 / 生产代码漂移。"""
-
-    @staticmethod
-    def _resolve() -> tuple[str, int]:
-        import server.app as module
-
-        return module._resolve_listen_addr()
-
-    def test_defaults_match_existing_behavior(self):
-        env = os.environ.copy()
-        env.pop("LISTEN_HOST", None)
-        env.pop("LISTEN_PORT", None)
-        with patch.dict(os.environ, env, clear=True):
-            host, port = self._resolve()
-        assert host == "0.0.0.0"
-        assert port == 1241
-
-    def test_env_overrides_take_effect(self):
-        with patch.dict(os.environ, {"LISTEN_HOST": "127.0.0.1", "LISTEN_PORT": "18080"}):
-            host, port = self._resolve()
-        assert host == "127.0.0.1"
-        assert port == 18080
-
-    def test_empty_listen_port_falls_back_to_default(self):
-        """`.env` 误写 `LISTEN_PORT=`（空值）不应让 `int("")` 抛 ValueError。"""
-        with patch.dict(os.environ, {"LISTEN_HOST": "", "LISTEN_PORT": ""}):
-            host, port = self._resolve()
-        assert host == "0.0.0.0"
-        assert port == 1241
+        assert resolve_cors_policy("http://localhost:5173, *") == (["*"], False)

--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -161,10 +161,8 @@ ArcReel 在应用启动时运行 Alembic 迁移，将数据库结构升级到当
 | `TZ` | `Asia/Shanghai` | 可在 Compose 环境中覆盖 |
 | `DATABASE_URL` | SQLite 默认路径 | 生产 Compose 自动设置 PostgreSQL URL |
 | `ARCREEL_DATA_DIR` | `projects` | 需要自定义应用数据根目录时使用 |
-| `CORS_ORIGINS` | 常用本地前端 Origin | 浏览器型 MCP 客户端跨源访问时也须加入其 Origin |
-| `MCP_PUBLIC_URL` | `http://localhost:1241/mcp` | 外部接入时填写实际 HTTPS MCP 端点 |
-| `MCP_ALLOWED_HOSTS` | 仅 loopback host | 外部接入时填写逗号分隔的实际 Host 白名单 |
-| `MCP_ALLOWED_ORIGINS` | 仅 loopback origin | 浏览器型 MCP 客户端跨源访问时填写逗号分隔的 Origin 白名单 |
+| `CORS_ORIGINS` | 通配 | 设为白名单时，浏览器型 MCP 客户端的 Origin 也须列入 |
+| `MCP_PUBLIC_URL` | `http://localhost:1241/mcp` | 可选；仅 OAuth 发现型 MCP 客户端需要 |
 
 注意：
 
@@ -173,7 +171,11 @@ ArcReel 在应用启动时运行 Alembic 迁移，将数据库结构升级到当
 - Vertex 凭据文件应只授予运行 ArcReel 的用户读取权限。
 - 第三方模型 API Key 通常在 ArcReel 设置页中管理，不要写入公开文档。
 
-远程 MCP 端点为 `/mcp`，始终要求 `arc-` 前缀 API Key；即使 `AUTH_ENABLED=false` 也不会匿名放行。外部接入须同时配置上述三个 `MCP_*` 变量，并通过保留 SSE 长连接的 HTTPS 反向代理、VPN 或安全隧道访问。浏览器型 MCP 客户端的 Origin 必须同时出现在 `MCP_ALLOWED_ORIGINS` 和应用级 `CORS_ORIGINS` 中，否则预检会先被应用的 CORS 中间件拒绝。
+远程 MCP 端点为 `/mcp`，始终要求 `arc-` 前缀 API Key；即使 `AUTH_ENABLED=false` 也不会匿名放行。外部接入不需要额外的 `MCP_*` 配置：把设置页「外部智能体接入」弹窗给出的端点地址与 API Key 填进客户端即可，通过保留 SSE 长连接的 HTTPS 反向代理、VPN 或安全隧道访问。
+
+服务端不校验请求的 `Host` 头，端点边界由每请求强制的 API Key 承担；域名归属交给部署形态，请在反向代理上限定 `server_name`（Nginx）或等价规则，只把预期域名的请求转发给 ArcReel。
+
+`CORS_ORIGINS` 保持默认通配时，浏览器型 MCP 客户端同样无需配置；一旦收紧为白名单，就要把该客户端的 Origin 也列进去——这一个白名单同时约束应用 API 与 MCP 端点，不存在第二份 MCP 专用清单。`MCP_PUBLIC_URL` 只用于填写 OAuth 受保护资源元数据（RFC 9728）与 401 challenge，供做发现流程的客户端读取；以 Bearer 直连的 Claude Code、codex 等客户端不会用到，可以不设。
 
 ArcReel 的沙箱要求父进程环境中不保留供应商密钥。以下凭据环境变量存在非空值时，服务会拒绝启动并提示迁移到 WebUI 设置页：
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -160,10 +160,8 @@ The default deployment examples currently include these core variables:
 | `TZ` | `Asia/Shanghai` | Can be overridden in the Compose environment |
 | `DATABASE_URL` | Default SQLite path | Production Compose sets the PostgreSQL URL automatically |
 | `ARCREEL_DATA_DIR` | `projects` | Use this to customize the application's root data directory |
-| `CORS_ORIGINS` | Common local frontend origins | Cross-origin browser MCP clients must also add their Origin here |
-| `MCP_PUBLIC_URL` | `http://localhost:1241/mcp` | Set this to the actual HTTPS MCP endpoint for remote access |
-| `MCP_ALLOWED_HOSTS` | Loopback hosts only | For remote access, set a comma-separated allowlist of actual Host values |
-| `MCP_ALLOWED_ORIGINS` | Loopback origins only | For cross-origin browser MCP clients, set a comma-separated Origin allowlist |
+| `CORS_ORIGINS` | Wildcard | When narrowed to an allowlist, browser MCP client origins must be listed too |
+| `MCP_PUBLIC_URL` | `http://localhost:1241/mcp` | Optional; only OAuth discovery-based MCP clients need it |
 
 Notes:
 
@@ -172,7 +170,11 @@ Notes:
 - Vertex credential files should be readable only by the user who runs ArcReel.
 - Third-party model API keys are normally managed on the ArcReel Settings page. Do not include them in public documentation.
 
-The remote MCP endpoint is `/mcp` and always requires an API Key with an `arc-` prefix; it never permits anonymous access, even when `AUTH_ENABLED=false`. For remote access, configure all three `MCP_*` variables above and connect through an HTTPS reverse proxy, VPN, or secure tunnel that preserves long-lived SSE connections. For browser MCP clients, add the client Origin to both `MCP_ALLOWED_ORIGINS` and the application-level `CORS_ORIGINS`; otherwise the application CORS middleware rejects the preflight first.
+The remote MCP endpoint is `/mcp` and always requires an API Key with an `arc-` prefix; it never permits anonymous access, even when `AUTH_ENABLED=false`. Remote access needs no extra `MCP_*` configuration: paste the endpoint URL and API Key shown in the Settings page's "External agent access" dialog into your client, and connect through an HTTPS reverse proxy, VPN, or secure tunnel that preserves long-lived SSE connections.
+
+The server does not validate the request `Host` header; the endpoint boundary rests on the API Key enforced on every request. Host ownership belongs to the deployment: restrict `server_name` (Nginx) or the equivalent rule on your reverse proxy so only requests for the expected domain reach ArcReel.
+
+Browser MCP clients need no configuration either while `CORS_ORIGINS` stays at its permissive default; once you narrow it to an allowlist, add the client Origin to it as well. That single allowlist governs both the application API and the MCP endpoint; there is no second MCP-specific list. `MCP_PUBLIC_URL` only fills the OAuth protected-resource metadata (RFC 9728) and the 401 challenge that discovery-based clients read; clients that connect with a Bearer token, such as Claude Code and codex, never use it and can leave it unset.
 
 ArcReel's sandbox requires provider secrets to be absent from the parent process environment. If any of the following credential environment variables has a non-empty value, the service refuses to start and prompts you to move the credential to the Web UI Settings page:
 


### PR DESCRIPTION
## 背景

自部署实例接外部 agent 时，codex / Claude Code 连 `/mcp` 会被 SDK 的 DNS 重绑定防护拦成 `421 Invalid Host header`，文档要求同时配置三个 `MCP_*` 变量。三者中只有 `MCP_ALLOWED_HOSTS` 真的参与拦截：`MCP_ALLOWED_ORIGINS` 在 Origin 缺失时直接放行，对非浏览器客户端完全无效；`MCP_PUBLIC_URL` 只喂 RFC 9728 metadata 与 401 challenge，对 Bearer 直连路径纯装饰。

根因是 Host 白名单在此不构成安全边界：`/mcp` 每请求强制 `arc-` API Key，该 Key 从不以 cookie / session 形式存在于浏览器，重绑定到本端点的请求拿不到凭证只能收 401。

## 改动

- 关闭 `enable_dns_rebinding_protection`，`MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` 退场；Host 归属交给反向代理。
- 浏览器型客户端的跨源防护由应用级 `CORSMiddleware` 单点承担——它本就包住 `app.mount("/mcp", ...)`，MCP 的 POST 带 Authorization 与 JSON body 必先发预检，不在白名单的 Origin 在预检阶段即被拒。挂载层不另设 Origin 守卫。
- `CORS_ORIGINS` 的解析从 `server/app.py` 提取为 `server/cors_config.py`，成为单一白名单来源。
- `MCP_PUBLIC_URL` 降为可选。
- 文档：`.env.example` ×3、中英 `ops/deployment.md`（顺带修正 `CORS_ORIGINS` 默认值记载，并补 Host 归属说明）；按 `docs/security/threat-model.md` §14 的 network policy / MCP capabilities 触发条件，§9.7 补 CORS 覆盖 `/mcp` 挂载，新增 §9.8 记录远程 MCP 传输层现状。

## 效果

`MCP_*` 从「必填三件套」变为「零必填 + 一个可选」；白名单从两份收敛为一份。鉴权边界不变：端点仍始终要求 `arc-` 前缀 API Key，`AUTH_ENABLED=false` 不匿名放行。

## 验证

ruff / basedpyright（0 errors）/ lint-imports / `pytest -n 4 --dist loadfile`（11151 passed）/ `audit_tests.py --check` / `website pnpm check` 全通过。

https://claude.ai/code/session_01Skfit58CsCGHUe2jZmb8uj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 统一应用 API 与远程 MCP 端点的 CORS 来源配置，支持通过单一白名单控制浏览器访问。
  - 远程 MCP 接入无需额外配置主机或来源白名单，访问安全性由每次请求的 API Key 认证保障。
  - OAuth 客户端可通过可选的公开地址发现受保护资源元数据。

- **文档**
  - 更新部署指南、环境变量示例及安全威胁模型，明确远程 MCP、CORS 与 OAuth 的配置方式和适用场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->