### PR TITLE
fix(custom-endpoints): 完善端点诊断与响应留痕

### DIFF
--- a/frontend/src/components/pages/settings/endpoints/EndpointTestSection.test.tsx
+++ b/frontend/src/components/pages/settings/endpoints/EndpointTestSection.test.tsx
@@ -41,6 +41,7 @@ const RUNNING: TrialRunInfo = {
   api_call_id: null,
   request: null,
   submit_response: null,
+  result_response: null,
   poll_responses: [],
   extractions: {},
   video_url: null,

--- a/frontend/src/types/custom-endpoint.ts
+++ b/frontend/src/types/custom-endpoint.ts
@@ -254,6 +254,7 @@ export interface TrialRunInfo {
   request: PreviewedRequest | null;
   submit_response: unknown;
   poll_responses: unknown[];
+  result_response: unknown;
   extractions: Partial<Record<EndpointTestStage, EndpointStageReport>>;
   video_url: string | null;
   duration_seconds: number | null;

--- a/lib/custom_provider/declarative_backend.py
+++ b/lib/custom_provider/declarative_backend.py
@@ -38,6 +38,7 @@ from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     ProviderJobIdPersistenceMixin,
     ProviderJobStatus,
+    ProviderResponseStage,
     ResumeExpiredError,
     VideoCapabilities,
     VideoGenerationRequest,
@@ -403,7 +404,7 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
             async def post() -> httpx.Response:
                 response = await self._send_without_status(client, section, context)
                 if response.status_code >= 400:
-                    await self._record_response(response, request)
+                    await self._record_response(response, request, "submit")
                 return response
 
             return await submit_post(
@@ -412,7 +413,7 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
             )
 
         response = await retry_async(operation, retry_if=should_retry_submit)
-        body = await self._response_body(response, request)
+        body = await self._response_body(response, request, "submit")
         try:
             job_id = extract_value(section["extract"]["task_id"], body)
             error = extract_text(section["extract"].get("error"), body)
@@ -479,6 +480,7 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
             section: Mapping[str, Any],
             section_context: Mapping[str, object],
             *,
+            stage: ProviderResponseStage,
             expire_on_404: bool,
         ) -> object:
             """取件一次，失败响应一律留痕。
@@ -490,12 +492,12 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
             try:
                 response = await self._send(client, section, section_context)
             except httpx.HTTPStatusError as exc:
-                await self._record_response(exc.response, request)
+                await self._record_response(exc.response, request, stage)
                 if expire_on_404 and is_resume and exc.response.status_code == 404:
                     raise ResumeExpiredError(job_id=job_id, provider=self._provider) from exc
                 raise
             trusted_origins.add(self._endpoint_origin(section, section_context))
-            return await self._response_body(response, request)
+            return await self._response_body(response, request, stage)
 
         async def poll_once() -> ProviderState:
             return self._extract_state(
@@ -504,6 +506,7 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
                 await fetch(
                     self._definition["poll"],
                     poll_context,
+                    stage="poll",
                     expire_on_404=bool(self._definition["poll"].get("expire_on_404", True)),
                 ),
                 self._definition["poll"]["extract"],
@@ -527,7 +530,7 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
             result_context = {**poll_context, "result_id": final.result_id}
 
             async def fetch_result() -> object:
-                return await fetch(self._definition["result"], result_context, expire_on_404=False)
+                return await fetch(self._definition["result"], result_context, stage="result", expire_on_404=False)
 
             # 走到这里供应商任务已经成功、钱已经花了，二次取件与产物下载同属「任务已建成后的
             # 幂等取件」：共用同一份预算，别让一次 429 / 5xx / 尚未收敛的 404 直接废掉成片。
@@ -585,27 +588,31 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
         return extract_provider_state(body, extract, status_map=self._definition.get("status_map"), status=status)
 
     @staticmethod
-    async def _response_body(response: httpx.Response, request: VideoGenerationRequest) -> object:
+    async def _response_body(
+        response: httpx.Response, request: VideoGenerationRequest, stage: ProviderResponseStage
+    ) -> object:
         try:
             body = response.json()
         except ValueError as exc:
             # 2xx 但不是 JSON（网关的 HTML 错误页、被截断的响应）：原文先留痕再抛。诊断字段
             # 若停在上一次轮询的响应上，正好在最需要看到这次响应的场合给出误导。
-            await notify_provider_response(request, response.text)
+            await notify_provider_response(request, stage, response.text)
             raise DeclarativeRuntimeError(
                 "declarative_response_extract_failed", detail="provider response was not valid JSON"
             ) from exc
-        await notify_provider_response(request, body)
+        await notify_provider_response(request, stage, body)
         return body
 
     @staticmethod
-    async def _record_response(response: httpx.Response, request: VideoGenerationRequest) -> None:
+    async def _record_response(
+        response: httpx.Response, request: VideoGenerationRequest, stage: ProviderResponseStage
+    ) -> None:
         """留痕失败响应；非 JSON 体存截断后的原文，不因此让任务多失败一种方式。"""
         try:
             body: object = response.json()
         except ValueError:
             body = response.text
-        await notify_provider_response(request, body)
+        await notify_provider_response(request, stage, body)
 
     async def _download(
         self,

--- a/lib/custom_provider/declarative_backend.py
+++ b/lib/custom_provider/declarative_backend.py
@@ -33,6 +33,7 @@ from lib.custom_provider.endpoint_definition import (
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.logging_utils import format_kwargs_for_log
 from lib.retry import retry_async
+from lib.validation_messages import ValidationMessage
 from lib.video_backends.base import (
     IMAGE_MIME_TYPES,
     ProviderJobIdPersistenceMixin,
@@ -162,10 +163,14 @@ def normalize_declarative_base_url(base_url: str, definition: Mapping[str, Any])
 class DeclarativeRuntimeError(RuntimeError):
     """声明式定义执行失败，携带可持久化、本地化的稳定错误码。"""
 
-    def __init__(self, code: str, *, detail: str) -> None:
+    def __init__(self, code: str, *, detail: str | ValidationMessage) -> None:
         self.code = code
-        self.params = {"detail": detail}
-        super().__init__(detail)
+        self.params = {
+            "detail": {"key": detail.key, "params": dict(detail.params)}
+            if isinstance(detail, ValidationMessage)
+            else detail
+        }
+        super().__init__(detail.key if isinstance(detail, ValidationMessage) else detail)
 
 
 @dataclass(frozen=True)
@@ -330,7 +335,9 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
                 encoded,
                 self._definition.get("defaults"),
             )
-        except (OSError, TemplateRenderError) as exc:
+        except TemplateRenderError as exc:
+            raise DeclarativeRuntimeError("declarative_template_render_failed", detail=exc.message) from exc
+        except OSError as exc:
             raise DeclarativeRuntimeError("declarative_template_render_failed", detail=str(exc)) from exc
 
     @staticmethod
@@ -356,7 +363,9 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
                 enum_maps=self._definition.get("enum_maps"),
                 auth=self._definition.get("auth"),
             )
-        except (KeyError, TypeError, ValueError, TemplateRenderError) as exc:
+        except TemplateRenderError as exc:
+            raise DeclarativeRuntimeError("declarative_template_render_failed", detail=exc.message) from exc
+        except (KeyError, TypeError, ValueError) as exc:
             raise DeclarativeRuntimeError("declarative_template_render_failed", detail=str(exc)) from exc
 
     def _endpoint_origin(

--- a/lib/custom_provider/declarative_backend.py
+++ b/lib/custom_provider/declarative_backend.py
@@ -22,6 +22,7 @@ import httpx
 
 from lib.custom_provider.endpoint_definition import (
     AssetData,
+    JsonPathEvaluationError,
     RenderedRequest,
     TemplateRenderError,
     build_context,
@@ -171,7 +172,7 @@ class DeclarativeRuntimeError(RuntimeError):
             if isinstance(detail, ValidationMessage)
             else detail
         }
-        super().__init__(detail.key if isinstance(detail, ValidationMessage) else detail)
+        super().__init__(detail.render() if isinstance(detail, ValidationMessage) else detail)
 
 
 @dataclass(frozen=True)
@@ -212,6 +213,8 @@ def extract_provider_state(
             result_id=extract_text(extract.get("result_id"), body),
             duration_seconds=extract_duration((extract.get("usage") or {}).get("duration_seconds"), body),
         )
+    except JsonPathEvaluationError as exc:
+        raise DeclarativeRuntimeError("declarative_response_extract_failed", detail=exc.message) from exc
     except (KeyError, TypeError, ValueError) as exc:
         raise DeclarativeRuntimeError("declarative_response_extract_failed", detail=str(exc)) from exc
 
@@ -237,6 +240,8 @@ def extract_duration(spec: object | None, body: object) -> int | None:
     raw = extract_value(spec, body)
     try:
         value = int(Decimal(str(raw)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    except JsonPathEvaluationError:
+        raise
     except (InvalidOperation, TypeError, ValueError):
         return None
     return value if 0 < value <= MAX_BILLED_DURATION_SECONDS else None
@@ -417,6 +422,8 @@ class DeclarativeVideoBackend(ProviderJobIdPersistenceMixin):
         try:
             job_id = extract_value(section["extract"]["task_id"], body)
             error = extract_text(section["extract"].get("error"), body)
+        except JsonPathEvaluationError as exc:
+            raise DeclarativeRuntimeError("declarative_response_extract_failed", detail=exc.message) from exc
         except (TypeError, ValueError) as exc:
             raise DeclarativeRuntimeError("declarative_response_extract_failed", detail=str(exc)) from exc
         # accept="scalar" 的定义可以命中数字或布尔，格式说明的口径是「按字符串化交给下游」；

--- a/lib/custom_provider/endpoint_definition/__init__.py
+++ b/lib/custom_provider/endpoint_definition/__init__.py
@@ -14,7 +14,7 @@ from .errors import (
     message_key,
 )
 from .jsonpath_subset import JsonPathSubsetError, ParsedJsonPath, parse_json_path
-from .response_extractor import extract_value, map_status, normalize_extract_spec
+from .response_extractor import JsonPathEvaluationError, extract_value, map_status, normalize_extract_spec
 from .template_engine import (
     AssetData,
     RenderedRequest,
@@ -48,6 +48,7 @@ __all__ = [
     "DefinitionIssue",
     "AssetData",
     "JsonPathSubsetError",
+    "JsonPathEvaluationError",
     "ParsedJsonPath",
     "RenderedRequest",
     "SchemaVersionLevel",

--- a/lib/custom_provider/endpoint_definition/errors.py
+++ b/lib/custom_provider/endpoint_definition/errors.py
@@ -84,6 +84,7 @@ class DefinitionErrorCode(StrEnum):
     JSONPATH_FILTER_NON_SINGULAR = "jsonpath_filter_non_singular"
     JSONPATH_REGEX_OPERATOR = "jsonpath_regex_operator"
     JSONPATH_SYNTAX = "jsonpath_syntax"
+    JSONPATH_EVALUATION_FAILED = "jsonpath_evaluation_failed"
 
     # ---- 渲染期（端点测试按同一份诊断结构下发）----
     TEMPLATE_RENDER_FAILED = "template_render_failed"

--- a/lib/custom_provider/endpoint_definition/errors.py
+++ b/lib/custom_provider/endpoint_definition/errors.py
@@ -87,6 +87,11 @@ class DefinitionErrorCode(StrEnum):
 
     # ---- 渲染期（端点测试按同一份诊断结构下发）----
     TEMPLATE_RENDER_FAILED = "template_render_failed"
+    TEMPLATE_URL_NOT_STRING = "template_url_not_string"
+    UNKNOWN_ASSET_ENCODING = "unknown_asset_encoding"
+    ENUM_MAP_VALUE_MISSING = "enum_map_value_missing"
+    TEMPLATE_TEXT_VARIABLE_NULL = "template_text_variable_null"
+    EACH_VALUE_NOT_LIST = "each_value_not_list"
 
     # ---- warning ----
     POLL_WITHOUT_TASK_ID = "poll_without_task_id"

--- a/lib/custom_provider/endpoint_definition/response_extractor.py
+++ b/lib/custom_provider/endpoint_definition/response_extractor.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from jsonpath_rfc9535 import find
+from jsonpath_rfc9535 import JSONPathError, find
 
 from lib.video_backends.base import ProviderJobStatus, normalize_provider_status
 
@@ -20,6 +20,13 @@ _DECLARATIVE_STATUSES = frozenset(
         ProviderJobStatus.FAILED,
     }
 )
+
+
+class JsonPathEvaluationError(ValueError):
+    """运行时 JSONPath 实现无法对已通过子集闸门的路径求值。"""
+
+    def __init__(self, path: str, cause: Exception) -> None:
+        super().__init__(f"JSONPath 求值失败：{path}: {cause}")
 
 
 def extract_value(spec: object, response_body: object) -> object | None:
@@ -77,9 +84,12 @@ def normalize_extract_spec(spec: object) -> tuple[Sequence[object], str]:
 
 def _first_acceptable(path: str, target: Any, accept: str) -> object | None:
     parse_json_path(path)
-    for node in find(path, target):
-        if _acceptable(node.value, accept):
-            return node.value
+    try:
+        for node in find(path, target):
+            if _acceptable(node.value, accept):
+                return node.value
+    except (ArithmeticError, JSONPathError) as exc:
+        raise JsonPathEvaluationError(path, exc) from exc
     return None
 
 

--- a/lib/custom_provider/endpoint_definition/response_extractor.py
+++ b/lib/custom_provider/endpoint_definition/response_extractor.py
@@ -8,8 +8,10 @@ from typing import Any
 
 from jsonpath_rfc9535 import JSONPathError, find
 
+from lib.validation_messages import ValidationMessage
 from lib.video_backends.base import ProviderJobStatus, normalize_provider_status
 
+from .errors import DefinitionErrorCode, message_key
 from .jsonpath_subset import parse_json_path
 
 _DECLARATIVE_STATUSES = frozenset(
@@ -26,7 +28,9 @@ class JsonPathEvaluationError(ValueError):
     """运行时 JSONPath 实现无法对已通过子集闸门的路径求值。"""
 
     def __init__(self, path: str, cause: Exception) -> None:
-        super().__init__(f"JSONPath 求值失败：{path}: {cause}")
+        self.code = DefinitionErrorCode.JSONPATH_EVALUATION_FAILED
+        self.message = ValidationMessage(message_key(self.code), {"path_expression": path})
+        super().__init__(self.message.render())
 
 
 def extract_value(spec: object, response_body: object) -> object | None:

--- a/lib/custom_provider/endpoint_definition/template_engine.py
+++ b/lib/custom_provider/endpoint_definition/template_engine.py
@@ -11,6 +11,9 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, urlsplit, urlunsplit
 
 from lib.aspect_size import VIDEO_TIER_SHORT_EDGE, aspect_size, resolution_to_short_edge
+from lib.validation_messages import ValidationMessage
+
+from .errors import DefinitionErrorCode, message_key
 
 _PLACEHOLDER = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*}}")
 _WHOLE_PLACEHOLDER = re.compile(r"^\s*{{\s*([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*}}\s*$")
@@ -19,6 +22,11 @@ _DROP = object()
 
 class TemplateRenderError(ValueError):
     """模板无法在给定上下文中安全渲染。"""
+
+    def __init__(self, code: DefinitionErrorCode, **params: object) -> None:
+        self.code = code
+        self.message = ValidationMessage(message_key(code), params)
+        super().__init__(code.value)
 
 
 @dataclass(frozen=True)
@@ -99,7 +107,7 @@ def render_request(
     maps = enum_maps or {}
     url = _render_string(request["url"], context, maps)
     if not isinstance(url, str):
-        raise TemplateRenderError("URL 模板必须渲染为字符串")
+        raise TemplateRenderError(DefinitionErrorCode.TEMPLATE_URL_NOT_STRING)
 
     auth = auth or {}
     auth_header_names = {name.lower() for name in auth.get("headers", {})}
@@ -131,14 +139,14 @@ def _encode_asset(asset: AssetData, encoding: str) -> str:
         return payload
     if encoding == "data_uri":
         return f"data:{asset.mime_type};base64,{payload}"
-    raise TemplateRenderError(f"未知素材编码：{encoding}")
+    raise TemplateRenderError(DefinitionErrorCode.UNKNOWN_ASSET_ENCODING, encoding=encoding)
 
 
 def _lookup(context: Mapping[str, object], name: str) -> object:
     current: object = context
     for part in name.split("."):
         if not isinstance(current, Mapping) or part not in current:
-            raise TemplateRenderError(f"占位符引用了未声明的变量：{name}")
+            raise TemplateRenderError(DefinitionErrorCode.UNDECLARED_VARIABLE, name=name)
         current = current[part]
     return current
 
@@ -159,7 +167,7 @@ def _resolve(
     mapping = enum_maps[name]
     key = enum_map_key(value)
     if key not in mapping:
-        raise TemplateRenderError(f"enum_maps.{name} 缺少 {key!r}")
+        raise TemplateRenderError(DefinitionErrorCode.ENUM_MAP_VALUE_MISSING, name=name, value=key)
     return mapping[key]
 
 
@@ -186,7 +194,7 @@ def _render_string(
     def replace(match: re.Match[str]) -> str:
         value = _resolve(match.group(1), context, enum_maps)
         if value is None:
-            raise TemplateRenderError(f"混合文本中的变量为空：{match.group(1)}")
+            raise TemplateRenderError(DefinitionErrorCode.TEMPLATE_TEXT_VARIABLE_NULL, name=match.group(1))
         return _stringify(value)
 
     return _PLACEHOLDER.sub(replace, template)
@@ -254,7 +262,7 @@ def _each_values(directive: Mapping[str, Any], context: Mapping[str, object]) ->
     if values is None:
         return ()
     if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
-        raise TemplateRenderError(f"$each.in 不是列表：{directive['in']}")
+        raise TemplateRenderError(DefinitionErrorCode.EACH_VALUE_NOT_LIST, name=directive["in"])
     return values
 
 
@@ -285,7 +293,7 @@ def _append_auth_query(url: str, auth_query: Mapping[str, str]) -> str:
     existing = {name for name, _ in parse_qsl(parts.query, keep_blank_values=True)}
     overlap = existing & auth_query.keys()
     if overlap:
-        raise TemplateRenderError(f"URL 与 auth.query 重复参数：{sorted(overlap)[0]}")
+        raise TemplateRenderError(DefinitionErrorCode.AUTH_QUERY_CONFLICT, param=sorted(overlap)[0])
     appended = [f"{quote(name, safe='')}={quote(value, safe='')}" for name, value in auth_query.items()]
     query = "&".join([parts.query, *appended]) if parts.query else "&".join(appended)
     return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))

--- a/lib/custom_provider/endpoint_definition/validator.py
+++ b/lib/custom_provider/endpoint_definition/validator.py
@@ -21,7 +21,7 @@ from urllib.parse import parse_qsl
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
 
-from lib.validation_messages import MessageRef
+from lib.validation_messages import MessageRef, ValidationMessage
 from lib.video_backends.base import ProviderJobStatus, ReferenceAudioMode, audio_capability_pair_is_coherent
 
 from .errors import ROOT_PATH, DefinitionDiagnostics, DefinitionErrorCode, DefinitionIssue, join_path
@@ -149,6 +149,10 @@ _VALUE_SHAPE_KEYWORDS = frozenset(
     {"pattern", "format", "minLength", "maxLength", "minimum", "maximum", "minItems", "minProperties", "propertyNames"}
 )
 
+_MINIMUM_KEYWORDS = frozenset({"minLength", "minimum", "minItems", "minProperties"})
+_MAXIMUM_KEYWORDS = frozenset({"maxLength", "maximum"})
+_FORMAT_KEYWORDS = frozenset({"pattern", "format", "propertyNames"})
+
 
 @cache
 def load_schema() -> dict[str, Any]:
@@ -230,9 +234,31 @@ def _translate_schema_error(error: ValidationError) -> Iterator[DefinitionIssue]
         )
         return
     if keyword in _VALUE_SHAPE_KEYWORDS:
-        yield DefinitionIssue(path, DefinitionErrorCode.INVALID_VALUE, {"detail": error.message})
+        yield DefinitionIssue(
+            path,
+            DefinitionErrorCode.INVALID_VALUE,
+            {"detail": _schema_detail(error)},
+        )
         return
-    yield DefinitionIssue(path, DefinitionErrorCode.SCHEMA_VIOLATION, {"detail": error.message})
+    yield DefinitionIssue(
+        path,
+        DefinitionErrorCode.SCHEMA_VIOLATION,
+        {"detail": _schema_detail(error)},
+    )
+
+
+def _schema_detail(error: ValidationError) -> ValidationMessage:
+    """把 jsonschema 的英文散文收成少量 locale-neutral 约束模板。"""
+    keyword = str(error.validator)
+    if keyword in _MINIMUM_KEYWORDS:
+        return ValidationMessage("val_ce_schema_minimum_constraint", {"limit": error.validator_value})
+    if keyword in _MAXIMUM_KEYWORDS:
+        return ValidationMessage("val_ce_schema_maximum_constraint", {"limit": error.validator_value})
+    if keyword in _FORMAT_KEYWORDS:
+        return ValidationMessage("val_ce_schema_format_constraint", {"constraint": error.validator_value})
+    if keyword == "not":
+        return ValidationMessage("val_ce_schema_forbidden_constraint")
+    return ValidationMessage("val_ce_schema_generic_constraint", {"keyword": keyword})
 
 
 def _missing_field_issues(error: ValidationError, path: str) -> Iterator[DefinitionIssue]:

--- a/lib/custom_provider/endpoint_test/check.py
+++ b/lib/custom_provider/endpoint_test/check.py
@@ -18,7 +18,7 @@ from lib.custom_provider.declarative_backend import (
     extract_provider_state,
     text_or_none,
 )
-from lib.custom_provider.endpoint_definition import extract_value, normalize_extract_spec
+from lib.custom_provider.endpoint_definition import JsonPathEvaluationError, extract_value, normalize_extract_spec
 from lib.video_backends.base import ProviderJobStatus
 
 from .errors import EndpointTestDefinitionError
@@ -172,6 +172,8 @@ def _field_report(key: str, spec: object, body: object) -> FieldExtraction:
         try:
             # 逐条走同一个 extract_value：优先级语义、json_decode 后缀与 accept 过滤都只有一份实现。
             hit = extract_value({"paths": [item], "accept": accept}, body)
+        except JsonPathEvaluationError as exc:
+            raise EndpointTestDefinitionError.from_render_failure(key, exc) from exc
         except (TypeError, ValueError) as exc:
             raise EndpointTestDefinitionError.from_render_failure(key, str(exc)) from exc
         attempts.append(

--- a/lib/custom_provider/endpoint_test/errors.py
+++ b/lib/custom_provider/endpoint_test/errors.py
@@ -11,6 +11,7 @@ from lib.custom_provider.endpoint_definition import (
     DefinitionDiagnostics,
     DefinitionErrorCode,
     DefinitionIssue,
+    JsonPathEvaluationError,
     TemplateRenderError,
 )
 
@@ -23,9 +24,11 @@ class EndpointTestDefinitionError(Exception):
         super().__init__("endpoint definition cannot be executed")
 
     @classmethod
-    def from_render_failure(cls, path: str, detail: str | TemplateRenderError) -> EndpointTestDefinitionError:
-        """把一次模板渲染失败（占位符缺值、混合文本遇 null、enum 缺项）包成单条诊断。"""
-        if isinstance(detail, TemplateRenderError):
+    def from_render_failure(
+        cls, path: str, detail: str | TemplateRenderError | JsonPathEvaluationError
+    ) -> EndpointTestDefinitionError:
+        """把模板渲染或 JSONPath 求值失败包成单条结构化诊断。"""
+        if isinstance(detail, TemplateRenderError | JsonPathEvaluationError):
             issue = DefinitionIssue(path=path, code=detail.code, params=detail.message.params)
         else:
             issue = DefinitionIssue(

--- a/lib/custom_provider/endpoint_test/errors.py
+++ b/lib/custom_provider/endpoint_test/errors.py
@@ -11,6 +11,7 @@ from lib.custom_provider.endpoint_definition import (
     DefinitionDiagnostics,
     DefinitionErrorCode,
     DefinitionIssue,
+    TemplateRenderError,
 )
 
 
@@ -22,7 +23,14 @@ class EndpointTestDefinitionError(Exception):
         super().__init__("endpoint definition cannot be executed")
 
     @classmethod
-    def from_render_failure(cls, path: str, detail: str) -> EndpointTestDefinitionError:
+    def from_render_failure(cls, path: str, detail: str | TemplateRenderError) -> EndpointTestDefinitionError:
         """把一次模板渲染失败（占位符缺值、混合文本遇 null、enum 缺项）包成单条诊断。"""
-        issue = DefinitionIssue(path=path, code=DefinitionErrorCode.TEMPLATE_RENDER_FAILED, params={"detail": detail})
+        if isinstance(detail, TemplateRenderError):
+            issue = DefinitionIssue(path=path, code=detail.code, params=detail.message.params)
+        else:
+            issue = DefinitionIssue(
+                path=path,
+                code=DefinitionErrorCode.TEMPLATE_RENDER_FAILED,
+                params={"detail": detail},
+            )
         return cls(DefinitionDiagnostics(errors=(issue,)))

--- a/lib/custom_provider/endpoint_test/preview.py
+++ b/lib/custom_provider/endpoint_test/preview.py
@@ -186,7 +186,9 @@ def _render(definition: Mapping[str, Any], section: str, context: Mapping[str, o
             enum_maps=definition.get("enum_maps"),
             auth=definition.get("auth"),
         )
-    except (KeyError, TypeError, ValueError, TemplateRenderError) as exc:
+    except TemplateRenderError as exc:
+        raise EndpointTestDefinitionError.from_render_failure(section, exc) from exc
+    except (KeyError, TypeError, ValueError) as exc:
         raise EndpointTestDefinitionError.from_render_failure(section, str(exc)) from exc
 
 

--- a/lib/custom_provider/endpoint_test/trial_run.py
+++ b/lib/custom_provider/endpoint_test/trial_run.py
@@ -34,7 +34,7 @@ from lib.custom_provider.declarative_backend import DeclarativeVideoBackend
 from lib.db.base import DEFAULT_USER_ID
 from lib.db.repositories.usage_repo import bound_provider_response
 from lib.ledger import Ledger
-from lib.video_backends.base import VideoGenerationRequest
+from lib.video_backends.base import ProviderResponseStage, VideoGenerationRequest
 from lib.video_frame_slots import resolve_first_frame_aspect_ratio
 
 from .check import STAGES, check_response, stage_report_payload
@@ -168,24 +168,21 @@ class TrialRun:
 
 
 class _ResponseCapture:
-    """按运行时的固定次序收供应商响应：提交一次，其后是轮询与可选的二次取件。
-
-    每条按与账本诊断列同一个 64 KiB 上限收口。提交经重试才成功时，首条留痕是失败的那次尝试，
-    成功的那次会落进轮询序列——两者都是提交阶段的真实响应，不额外猜。
-    """
+    """按运行时标记的阶段收供应商响应，每条按账本诊断列的 64 KiB 上限收口。"""
 
     def __init__(self) -> None:
         self.submit: object | None = None
         self.polls: deque[object] = deque(maxlen=MAX_POLL_RESPONSES)
-        self._seen_submit = False
+        self.result: object | None = None
 
-    def add(self, body: object) -> None:
+    def add(self, stage: ProviderResponseStage, body: object) -> None:
         bounded = bound_provider_response(body)
-        if not self._seen_submit:
-            self._seen_submit = True
+        if stage == "submit":
             self.submit = bounded
-            return
-        self.polls.append(bounded)
+        elif stage == "poll":
+            self.polls.append(bounded)
+        else:
+            self.result = bounded
 
 
 class TrialRunManager:
@@ -416,8 +413,8 @@ class TrialRunManager:
         *,
         aspect_ratio: str,
     ) -> VideoGenerationRequest:
-        async def on_provider_response(body: object) -> None:
-            capture.add(body)
+        async def on_provider_response(stage: ProviderResponseStage, body: object) -> None:
+            capture.add(stage, body)
             # 用户随时可能取消，而取消可能正落在这次写入中间。诊断留痕的写入被拦腰截断会留下
             # 一个半开的事务，随后的失败结算就得在一条坏掉的连接上做——shield 让这次写入自己跑完，
             # 取消照常传给调用它的那一层。写入任务登记在 run 名下：shield 只保护协程不被取消，
@@ -463,7 +460,7 @@ class TrialRunManager:
         run.finished_at = time.time()
         run.submit_response = capture.submit
         run.poll_responses = list(capture.polls)
-        run.extractions = _stage_reports(target.definition, capture, succeeded=status is TrialRunStatus.SUCCEEDED)
+        run.extractions = _stage_reports(target.definition, capture)
         try:
             self._result_file(run.id).write_text(
                 json.dumps(run.to_payload(), ensure_ascii=False, default=str), encoding="utf-8"
@@ -604,26 +601,18 @@ def _single(value: Path | list[Path] | None) -> Path | None:
     return value if isinstance(value, Path) else None
 
 
-def _stage_reports(
-    definition: Mapping[str, Any] | None, capture: _ResponseCapture, *, succeeded: bool
-) -> dict[str, Any]:
-    """按运行时的固定次序把留痕对回三节。没有定义可读（Python 实现的端点）返回空。
-
-    只在能确定对应关系时才出报告：成功且定义声明了二次取件节时，最后一条留痕必然是取件响应，
-    其前一条是最后一次轮询；其余情形最后一条就是最后一次轮询。对不上就不报，不猜。
-    """
+def _stage_reports(definition: Mapping[str, Any] | None, capture: _ResponseCapture) -> dict[str, Any]:
+    """按运行时阶段生成逐节提取报告。没有定义可读（Python 实现的端点）返回空。"""
     if definition is None:
         return {}
-    has_result = "result" in definition
     polls = list(capture.polls)
     bodies: dict[str, object] = {}
     if capture.submit is not None:
         bodies["submit"] = capture.submit
-    if succeeded and has_result and len(polls) >= 2:
-        bodies["poll"] = polls[-2]
-        bodies["result"] = polls[-1]
-    elif polls:
+    if polls:
         bodies["poll"] = polls[-1]
+    if capture.result is not None:
+        bodies["result"] = capture.result
     reports: dict[str, Any] = {}
     for stage in STAGES:
         body = bodies.get(stage)

--- a/lib/custom_provider/endpoint_test/trial_run.py
+++ b/lib/custom_provider/endpoint_test/trial_run.py
@@ -30,10 +30,11 @@ from urllib.parse import urlsplit
 
 from lib.app_data_dir import app_data_dir
 from lib.config.resolver import ConfigResolver
-from lib.custom_provider.declarative_backend import DeclarativeVideoBackend
+from lib.custom_provider.declarative_backend import DeclarativeRuntimeError, DeclarativeVideoBackend
 from lib.db.base import DEFAULT_USER_ID
 from lib.db.repositories.usage_repo import bound_provider_response
 from lib.ledger import Ledger
+from lib.task_failure import encode_failure
 from lib.video_backends.base import ProviderResponseStage, VideoGenerationRequest
 from lib.video_frame_slots import resolve_first_frame_aspect_ratio
 
@@ -120,6 +121,7 @@ class TrialRun:
     request: dict[str, Any] | None = None
     submit_response: object | None = None
     poll_responses: list[object] = field(default_factory=list)
+    result_response: object | None = None
     #: 逐阶段提取，键取自 :data:`check.STAGES`；无定义可读（Python 实现的端点）为空。
     extractions: dict[str, Any] = field(default_factory=dict)
     video_url: str | None = None
@@ -139,6 +141,7 @@ class TrialRun:
             "request": self.request,
             "submit_response": self.submit_response,
             "poll_responses": self.poll_responses,
+            "result_response": self.result_response,
             "extractions": self.extractions,
             "video_url": self.video_url,
             "duration_seconds": self.duration_seconds,
@@ -159,6 +162,7 @@ class TrialRun:
             request=payload.get("request"),
             submit_response=payload.get("submit_response"),
             poll_responses=list(payload.get("poll_responses") or []),
+            result_response=payload.get("result_response"),
             extractions=dict(payload.get("extractions") or {}),
             video_url=_as_str(payload.get("video_url")),
             duration_seconds=_as_int(payload.get("duration_seconds")),
@@ -399,7 +403,7 @@ class TrialRunManager:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            run.error = str(exc)
+            run.error = encode_failure(exc.code, **exc.params) if isinstance(exc, DeclarativeRuntimeError) else str(exc)
             self._finish(run, target, capture, TrialRunStatus.FAILED)
 
     def _request(
@@ -460,6 +464,7 @@ class TrialRunManager:
         run.finished_at = time.time()
         run.submit_response = capture.submit
         run.poll_responses = list(capture.polls)
+        run.result_response = capture.result
         run.extractions = _stage_reports(target.definition, capture)
         try:
             self._result_file(run.id).write_text(

--- a/lib/i18n/en/validation.py
+++ b/lib/i18n/en/validation.py
@@ -320,6 +320,7 @@ MESSAGES = {
         "The regex match operator is not allowed in extraction paths (at character {position}): {path_expression}"
     ),
     "val_ce_jsonpath_syntax": "Extraction path syntax error (at character {position}): {path_expression}",
+    "val_ce_jsonpath_evaluation_failed": "Could not evaluate extraction path: {path_expression}",
     "val_ce_template_render_failed": "Could not render the request template: {detail}",
     "val_ce_auth_literal_credential": (
         "This value appears to contain an actual secret key: reference the credential with the api_key "

--- a/lib/i18n/en/validation.py
+++ b/lib/i18n/en/validation.py
@@ -218,6 +218,11 @@ MESSAGES = {
     "val_ce_invalid_enum_value": "Value is not allowed here; allowed: {allowed}",
     "val_ce_invalid_value": "Value does not match the format: {detail}",
     "val_ce_schema_violation": "Does not match the definition format: {detail}",
+    "val_ce_schema_minimum_constraint": "Minimum allowed: {limit}",
+    "val_ce_schema_maximum_constraint": "Maximum allowed: {limit}",
+    "val_ce_schema_format_constraint": "Required format not matched: {constraint}",
+    "val_ce_schema_forbidden_constraint": "The value matches a forbidden constraint",
+    "val_ce_schema_generic_constraint": "Definition constraint not satisfied ({keyword})",
     "val_ce_removed_reason_request_query": (
         "static and dynamic query parameters belong in the url template, credential query in auth.query"
     ),
@@ -320,6 +325,11 @@ MESSAGES = {
         "This value appears to contain an actual secret key: reference the credential with the api_key "
         "placeholder instead, or the key will be exposed when the definition is exported or shared"
     ),
+    "val_ce_template_url_not_string": "The URL template must render to a string",
+    "val_ce_unknown_asset_encoding": "Unknown asset encoding: {encoding}",
+    "val_ce_enum_map_value_missing": "enum_maps.{name} has no entry for '{value}'",
+    "val_ce_template_text_variable_null": "Variable {name} is null and cannot be embedded in text",
+    "val_ce_each_value_not_list": "$each.in points at {name}, whose runtime value is not a list",
     "val_ce_poll_without_task_id": "The polling request never references task_id; confirm that this is intended",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} uses a wildcard: an object wildcard takes the first member only, "

--- a/lib/i18n/vi/validation.py
+++ b/lib/i18n/vi/validation.py
@@ -328,6 +328,7 @@ MESSAGES = {
         "Đường dẫn trích xuất không cho phép toán tử khớp biểu thức chính quy (tại ký tự {position}): {path_expression}"
     ),
     "val_ce_jsonpath_syntax": "Lỗi cú pháp đường dẫn trích xuất (tại ký tự {position}): {path_expression}",
+    "val_ce_jsonpath_evaluation_failed": "Không thể đánh giá đường dẫn trích xuất: {path_expression}",
     "val_ce_template_render_failed": "Không dựng được mẫu yêu cầu: {detail}",
     "val_ce_auth_literal_credential": (
         "Giá trị này có vẻ chứa khóa bí mật thật: hãy tham chiếu thông tin xác thực qua placeholder api_key, "

--- a/lib/i18n/vi/validation.py
+++ b/lib/i18n/vi/validation.py
@@ -216,6 +216,11 @@ MESSAGES = {
     "val_ce_invalid_enum_value": "Giá trị không được phép, các giá trị hợp lệ: {allowed}",
     "val_ce_invalid_value": "Giá trị không đúng định dạng: {detail}",
     "val_ce_schema_violation": "Không khớp định dạng định nghĩa: {detail}",
+    "val_ce_schema_minimum_constraint": "Giá trị hoặc số lượng tối thiểu được phép: {limit}",
+    "val_ce_schema_maximum_constraint": "Giá trị hoặc số lượng tối đa được phép: {limit}",
+    "val_ce_schema_format_constraint": "Không khớp định dạng bắt buộc: {constraint}",
+    "val_ce_schema_forbidden_constraint": "Giá trị thuộc phạm vi bị cấm",
+    "val_ce_schema_generic_constraint": "Chưa thỏa mãn ràng buộc định nghĩa ({keyword})",
     "val_ce_removed_reason_request_query": (
         "tham số query tĩnh và động đều viết trong mẫu url, query chứa thông tin xác thực thuộc về auth.query"
     ),
@@ -328,6 +333,11 @@ MESSAGES = {
         "Giá trị này có vẻ chứa khóa bí mật thật: hãy tham chiếu thông tin xác thực qua placeholder api_key, "
         "nếu không khóa sẽ bị lộ khi định nghĩa được xuất hoặc chia sẻ"
     ),
+    "val_ce_template_url_not_string": "Mẫu URL phải được dựng thành chuỗi",
+    "val_ce_unknown_asset_encoding": "Kiểu mã hóa tư liệu không xác định: {encoding}",
+    "val_ce_enum_map_value_missing": "enum_maps.{name} không có ánh xạ cho '{value}'",
+    "val_ce_template_text_variable_null": "Biến {name} rỗng nên không thể chèn vào văn bản",
+    "val_ce_each_value_not_list": "$each.in trỏ tới {name}, có giá trị khi chạy không phải danh sách",
     "val_ce_poll_without_task_id": "Yêu cầu hỏi trạng thái không tham chiếu task_id; hãy xác nhận đây là chủ ý",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} dùng ký tự đại diện: với đối tượng chỉ lấy thành viên đầu tiên, "

--- a/lib/i18n/zh/validation.py
+++ b/lib/i18n/zh/validation.py
@@ -185,6 +185,11 @@ MESSAGES = {
     "val_ce_invalid_enum_value": "取值不在允许范围内，可选：{allowed}",
     "val_ce_invalid_value": "取值不符合格式约定：{detail}",
     "val_ce_schema_violation": "不符合定义格式：{detail}",
+    "val_ce_schema_minimum_constraint": "允许的最小值或数量：{limit}",
+    "val_ce_schema_maximum_constraint": "允许的最大值或数量：{limit}",
+    "val_ce_schema_format_constraint": "不符合要求的格式：{constraint}",
+    "val_ce_schema_forbidden_constraint": "取值落入了禁止范围",
+    "val_ce_schema_generic_constraint": "未满足定义约束（{keyword}）",
     "val_ce_removed_reason_request_query": "静态与动态 query 都写进 url 模板，凭证 query 归 auth.query",
     "val_ce_removed_reason_status_codes": "HTTP 码策略归运行时：2xx 成功、429 与 5xx 重试、其余失败",
     "val_ce_removed_reason_polling_policy": "轮询间隔与超时是运行时策略，不进定义",
@@ -238,6 +243,11 @@ MESSAGES = {
     "val_ce_jsonpath_syntax": "取值路径语法错误（第 {position} 个字符）：{path_expression}",
     "val_ce_template_render_failed": "请求模板渲染失败：{detail}",
     "val_ce_auth_literal_credential": "该值疑似直接填写了真实密钥：请改用 api_key 占位符引用凭证，否则导出或分享定义时会泄露该密钥",
+    "val_ce_template_url_not_string": "URL 模板必须渲染为字符串",
+    "val_ce_unknown_asset_encoding": "未知素材编码：{encoding}",
+    "val_ce_enum_map_value_missing": "enum_maps.{name} 缺少 '{value}' 的映射",
+    "val_ce_template_text_variable_null": "变量 {name} 为空，不能嵌入混合文本",
+    "val_ce_each_value_not_list": "$each.in 指向的 {name} 在运行时不是列表",
     "val_ce_poll_without_task_id": "轮询请求没有引用 task_id，请确认这是有意的",
     "val_ce_jsonpath_wildcard_order": (
         "{path_expression} 含通配：对象通配只取首个，键序在前端预览与后端执行之间可能不同"

--- a/lib/i18n/zh/validation.py
+++ b/lib/i18n/zh/validation.py
@@ -241,6 +241,7 @@ MESSAGES = {
     "val_ce_jsonpath_filter_non_singular": "过滤器内只允许单值查询（第 {position} 个字符）：{path_expression}",
     "val_ce_jsonpath_regex_operator": "取值路径禁用正则匹配运算符（第 {position} 个字符）：{path_expression}",
     "val_ce_jsonpath_syntax": "取值路径语法错误（第 {position} 个字符）：{path_expression}",
+    "val_ce_jsonpath_evaluation_failed": "取值路径求值失败：{path_expression}",
     "val_ce_template_render_failed": "请求模板渲染失败：{detail}",
     "val_ce_auth_literal_credential": "该值疑似直接填写了真实密钥：请改用 api_key 占位符引用凭证，否则导出或分享定义时会泄露该密钥",
     "val_ce_template_url_not_string": "URL 模板必须渲染为字符串",

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -1059,7 +1059,7 @@ class MediaGenerator:
                         project_name=self.project_name,
                         task_id=task_id,
                         on_provider_resubmit_unsafe=_mark_provider_resubmit_unsafe,
-                        on_provider_response=lambda body: self.ledger.record_provider_response(
+                        on_provider_response=lambda _stage, body: self.ledger.record_provider_response(
                             call_id=call.call_id, body=body
                         ),
                         service_tier=version_metadata.get("service_tier", "default"),
@@ -1190,7 +1190,7 @@ class MediaGenerator:
             project_name=self.project_name,
             task_id=task_id,
             on_provider_response=(
-                (lambda body: self.ledger.record_provider_response(call_id=api_call_id, body=body))
+                (lambda _stage, body: self.ledger.record_provider_response(call_id=api_call_id, body=body))
                 if api_call_id is not None
                 else None
             ),

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -286,6 +286,15 @@ def render_failure(error_message: str | None, translate: Callable[..., str]) -> 
         nested_reason = params.get("reason")
         if isinstance(nested_reason, str):
             params = {**params, "reason": render_failure(nested_reason, translate)}
+    if code == "declarative_template_render_failed":
+        detail = params.get("detail")
+        if (
+            isinstance(detail, dict)
+            and set(detail) == {"key", "params"}
+            and isinstance(detail.get("key"), str)
+            and isinstance(detail.get("params"), dict)
+        ):
+            params = {**params, "detail": translate(detail["key"], **detail["params"])}
     return translate(FAILURE_CODE_KEYS[code], **params)
 
 

--- a/lib/task_failure.py
+++ b/lib/task_failure.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeGuard
 
 # Backend capability rejections (``ImageCapabilityError`` / ``VideoCapabilityError`` /
 # ``ReferencePayloadFloorError``). Their ``.code`` is already an ``errors`` catalog key,
@@ -179,6 +179,16 @@ def _as_shrinkable(value: Any) -> Any:
         return "…"
 
 
+def _is_validation_message(value: Any) -> TypeGuard[dict[str, Any]]:
+    """Return whether ``value`` is the locale-neutral nested diagnostic envelope."""
+    return (
+        isinstance(value, dict)
+        and set(value) == {"key", "params"}
+        and isinstance(value.get("key"), str)
+        and isinstance(value.get("params"), dict)
+    )
+
+
 def collapse_cascade_reason(reason: str) -> str:
     """把嵌套的级联原因折叠成最内层的根本原因，供级联编码前调用。
 
@@ -242,14 +252,29 @@ def bound_reason(reason: str, limit: int) -> str:
     if not isinstance(parsed, dict):
         return reason[:limit]
     params: dict[str, Any] = {key: _as_shrinkable(value) for key, value in parsed.items()}
-    string_keys = [k for k, v in params.items() if isinstance(v, str)]
-    if not string_keys:
+    detail = parsed.get("detail")
+    if _is_validation_message(detail):
+        # ``detail`` 必须保持机器结构，读侧才能按请求 locale 渲染。只把它的 params 中可能
+        # 过大的容器降级成可裁剪文本，并把字符串叶子加入与顶层参数相同的预算竞争。
+        params["detail"] = {
+            "key": detail["key"],
+            "params": {key: _as_shrinkable(value) for key, value in detail["params"].items()},
+        }
+
+    shrinkable: list[tuple[dict[str, Any], str]] = [
+        (params, key) for key, value in params.items() if isinstance(value, str)
+    ]
+    nested_detail = params.get("detail")
+    if _is_validation_message(nested_detail):
+        nested_params = nested_detail["params"]
+        shrinkable.extend((nested_params, key) for key, value in nested_params.items() if isinstance(value, str))
+    if not shrinkable:
         return reason[:limit]
 
     encoded = encode_failure(code, **params)
     while len(encoded) > limit:
-        longest_key = max(string_keys, key=lambda k: len(params[k]))
-        current: str = params[longest_key]
+        owner, longest_key = max(shrinkable, key=lambda item: len(item[0][item[1]]))
+        current: str = owner[longest_key]
         if not current:
             # 字符串参数全被削空仍超限，说明预算连信封骨架都装不下，只能退回按字符裁剪。
             return reason[:limit]
@@ -259,7 +284,7 @@ def bound_reason(reason: str, limit: int) -> str:
         # 可保留的诊断内容全丢掉。至少砍一个字符保证收敛。
         deficit = len(encoded) - limit
         drop = deficit if deficit < len(current) else max(1, len(current) // 2)
-        params[longest_key] = current[: len(current) - drop]
+        owner[longest_key] = current[: len(current) - drop]
         encoded = encode_failure(code, **params)
     return encoded
 
@@ -286,14 +311,9 @@ def render_failure(error_message: str | None, translate: Callable[..., str]) -> 
         nested_reason = params.get("reason")
         if isinstance(nested_reason, str):
             params = {**params, "reason": render_failure(nested_reason, translate)}
-    if code == "declarative_template_render_failed":
+    if code in {"declarative_template_render_failed", "declarative_response_extract_failed"}:
         detail = params.get("detail")
-        if (
-            isinstance(detail, dict)
-            and set(detail) == {"key", "params"}
-            and isinstance(detail.get("key"), str)
-            and isinstance(detail.get("params"), dict)
-        ):
+        if _is_validation_message(detail):
             params = {**params, "detail": translate(detail["key"], **detail["params"])}
     return translate(FAILURE_CODE_KEYS[code], **params)
 

--- a/lib/validation_messages.py
+++ b/lib/validation_messages.py
@@ -6,7 +6,8 @@
 的 ``{"key", "params"}`` 同构（见 ``lib.reference_video.duration_slots.DurationSlot.warning``）。
 
 ``params`` 里的值默认按 ``str.format`` 直出；需要跟随语言变化的词（资产类别、生成模式、骨架
-名词）用 ``MessageRef`` 包一层，渲染时先按其自身的 key 翻译再代入。
+名词）用 ``MessageRef`` 包一层，完整的嵌套句子用 ``ValidationMessage``，渲染时都先按同一语言
+翻译再代入。
 """
 
 from __future__ import annotations
@@ -106,6 +107,8 @@ class ValidationResult:
 
 def _resolve_param(value: Any, translate: Callable[..., str]) -> Any:
     """把参数值里的嵌套翻译标记解析成当前语言的文本，其余值原样返回。"""
+    if isinstance(value, ValidationMessage):
+        return value.render(translate)
     if isinstance(value, MessageRef):
         return translate(value.key)
     if isinstance(value, MessageJoin):

--- a/lib/video_backends/agnes.py
+++ b/lib/video_backends/agnes.py
@@ -463,7 +463,7 @@ class AgnesVideoBackend(ProviderJobIdPersistenceMixin):
             resp.raise_for_status()
             return resp.json()
 
-        return await recording_poll(fetch, request)()
+        return await recording_poll(fetch, request, stage="result")()
 
     async def _resolve_video_url(
         self, client: httpx.AsyncClient, final: dict, request: VideoGenerationRequest

--- a/lib/video_backends/base.py
+++ b/lib/video_backends/base.py
@@ -30,6 +30,8 @@ VIDEO_POLL_INTERVAL_SECONDS = 5.0
 VIDEO_POLL_MAX_CONSECUTIVE_FAILURES = 10
 VIDEO_POLL_MAX_BACKOFF_SECONDS = 60.0
 
+ProviderResponseStage = Literal["submit", "poll", "result"]
+
 
 # DB 瞬态错误集合：sqlite "database is locked"、pg "could not connect" / 连接已关闭。
 # 故意不收 DBAPIError 父类——会兜住 IntegrityError/DataError/ProgrammingError 等非瞬态
@@ -361,7 +363,7 @@ async def submit_post(
             raise
         raise AmbiguousSubmitError(provider=provider) from exc
     if request is not None:
-        await notify_provider_response(request, _response_body_or_text(resp))
+        await notify_provider_response(request, "submit", _response_body_or_text(resp))
     if resp.status_code >= 400:
         logger.warning("%s create 返回 %s: %s", provider, resp.status_code, resp.text[:500])
         try:
@@ -1076,8 +1078,8 @@ class VideoGenerationRequest:
     # call whose failure cannot prove that the provider rejected the request before accepting a paid job.
     on_provider_resubmit_unsafe: Callable[[], None] | None = None
 
-    # 收到供应商 JSON 响应时覆盖写入当前 ApiCall 的诊断留痕。非账本调用保持 None。
-    on_provider_response: Callable[[object], Awaitable[None]] | None = None
+    # 收到供应商 JSON 响应时携阶段写入诊断留痕。非账本调用保持 None。
+    on_provider_response: Callable[[ProviderResponseStage, object], Awaitable[None]] | None = None
 
     # 自定义供应商包装层（`CustomVideoBackend`）在转发给协议 backend 前注入的协议标识，与 job_id
     # 一并持久化到 `tasks.provider_endpoint`，记录本笔供应商任务的协议归属。内置供应商无此维度，
@@ -1110,8 +1112,8 @@ class VideoGenerationResult:
     generate_audio: bool | None = None
 
 
-async def notify_provider_response(request: VideoGenerationRequest, body: object) -> None:
-    """把 HTTP 式调用通道最后一次供应商响应送到可选账本回调。
+async def notify_provider_response(request: VideoGenerationRequest, stage: ProviderResponseStage, body: object) -> None:
+    """把 HTTP 式调用通道的供应商响应及其阶段送到可选诊断回调。
 
     留痕是诊断数据，不参与业务解析：写入失败只记日志，不让一笔已被供应商受理（多半已计费）
     的生成因为诊断列写不进去而失败。
@@ -1119,15 +1121,18 @@ async def notify_provider_response(request: VideoGenerationRequest, body: object
     if request.on_provider_response is None:
         return
     try:
-        await request.on_provider_response(body)
+        await request.on_provider_response(stage, body)
     except Exception:
         logger.warning("供应商响应留痕写入失败 task_id=%s", request.task_id, exc_info=True)
 
 
 def recording_poll[T](
-    poll_fn: Callable[[], Awaitable[T]], request: VideoGenerationRequest
+    poll_fn: Callable[[], Awaitable[T]],
+    request: VideoGenerationRequest,
+    *,
+    stage: ProviderResponseStage = "poll",
 ) -> Callable[[], Awaitable[T]]:
-    """包一层轮询取件：每收到一次供应商响应就留痕，早于状态与错误解读。
+    """包一层轮询或二次取件：每收到一次供应商响应就留痕，早于状态与错误解读。
 
     终态失败由 ``is_failed`` 谓词在 :func:`poll_with_retry` 内部抛出、HTTP 错误响应则从
     ``poll_fn`` 自己抛出，两者都发生在 ``poll_with_retry`` 返回之前。留痕若放在轮询之后，
@@ -1138,9 +1143,9 @@ def recording_poll[T](
         try:
             body = await poll_fn()
         except httpx.HTTPStatusError as exc:
-            await notify_provider_response(request, _response_body_or_text(exc.response))
+            await notify_provider_response(request, stage, _response_body_or_text(exc.response))
             raise
-        await notify_provider_response(request, body)
+        await notify_provider_response(request, stage, body)
         return body
 
     return once

--- a/server/routers/endpoint_tests.py
+++ b/server/routers/endpoint_tests.py
@@ -61,6 +61,7 @@ from lib.db.models.custom_provider import CustomProvider
 from lib.db.repositories.custom_endpoint_repo import CustomEndpointRepository
 from lib.db.repositories.custom_provider_repo import CustomProviderRepository
 from lib.i18n import Translator
+from lib.task_failure import render_failure
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +169,7 @@ class TrialRunResponse(BaseModel):
     request: dict[str, Any] | None = None
     submit_response: Any = None
     poll_responses: list[Any] = []
+    result_response: Any = None
     extractions: dict[str, Any] = {}
     video_url: str | None = None
     duration_seconds: int | None = None
@@ -414,19 +416,20 @@ async def start_trial_run(
         # manager 接手前失败（落素材、建结果目录）时临时目录还没有主人，留在盘上没人会回来删。
         shutil.rmtree(staging, ignore_errors=True)
         raise
-    return _run_response(run)
+    return _run_response(run, _t)
 
 
 @router.get("/trial-runs/{run_id}")
 async def get_trial_run(
     run_id: str,
+    _t: Translator,
     manager: TrialRunManager = Depends(get_trial_run_manager),
 ) -> TrialRunResponse:
     """读一次测试连接。运行中读内存、终态读盘；取消或被重启打断的 run 不留结果。"""
     run = manager.get(run_id)
     if run is None:
         raise NotFoundError("trial_run_not_found")
-    return _run_response(run)
+    return _run_response(run, _t)
 
 
 @router.post("/trial-runs/{run_id}/cancel", status_code=204)
@@ -461,8 +464,10 @@ def _previewed(section: Any) -> PreviewedRequestResponse:
     return PreviewedRequestResponse(method=section.method, url=section.url, headers=section.headers, body=section.body)
 
 
-def _run_response(run: TrialRun) -> TrialRunResponse:
-    return TrialRunResponse(**run.to_payload())
+def _run_response(run: TrialRun, translate: Translator) -> TrialRunResponse:
+    payload = run.to_payload()
+    payload["error"] = render_failure(run.error, translate)
+    return TrialRunResponse(**payload)
 
 
 def _has_usable_credentials(meta: ProviderMeta, config: Mapping[str, str]) -> bool:

--- a/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_response_extractor.py
+++ b/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_response_extractor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from lib.custom_provider.endpoint_definition import JsonPathEvaluationError, extract_value, map_status
+from lib.i18n import _
 from lib.video_backends.base import ProviderJobStatus
 
 COMFYUI_STATUS = {"paths": ["$.code"], "accept": "scalar"}
@@ -75,6 +76,9 @@ def test_jsonpath_evaluation_errors_are_normalized():
         extract_value(["$[?@.a == 1e400]"], {"a": 1})
 
     assert isinstance(caught.value.__cause__, OverflowError)
+    assert caught.value.message.render(lambda key, **params: _(key, locale="en", **params)) == (
+        "Could not evaluate extraction path: $[?@.a == 1e400]"
+    )
 
 
 def test_unknown_and_expired_statuses_do_not_escape_declarative_four_tiers():

--- a/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_response_extractor.py
+++ b/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_response_extractor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from lib.custom_provider.endpoint_definition import extract_value, map_status
+import pytest
+
+from lib.custom_provider.endpoint_definition import JsonPathEvaluationError, extract_value, map_status
 from lib.video_backends.base import ProviderJobStatus
 
 COMFYUI_STATUS = {"paths": ["$.code"], "accept": "scalar"}
@@ -66,6 +68,13 @@ def test_all_paths_missing_yields_none():
     assert extract_value(["$.a", "$.b.c"], {"other": "x"}) is None
     assert extract_value({"paths": ["$.a"], "accept": "scalar"}, {"other": "x"}) is None
     assert extract_value([{"path": "$.blob", "json_decode": True, "then": ["$.url"]}], {"blob": "{}"}) is None
+
+
+def test_jsonpath_evaluation_errors_are_normalized():
+    with pytest.raises(JsonPathEvaluationError) as caught:
+        extract_value(["$[?@.a == 1e400]"], {"a": 1})
+
+    assert isinstance(caught.value.__cause__, OverflowError)
 
 
 def test_unknown_and_expired_statuses_do_not_escape_declarative_four_tiers():

--- a/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_template_engine.py
+++ b/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_template_engine.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from lib.custom_provider.endpoint_definition import AssetData, build_context, encode_inputs, render_request
+from lib.custom_provider.endpoint_definition import (
+    AssetData,
+    DefinitionErrorCode,
+    build_context,
+    encode_inputs,
+    render_request,
+)
 from lib.custom_provider.endpoint_definition.template_engine import TemplateRenderError
 
 
@@ -77,20 +83,63 @@ def test_mixed_text_stringifies_and_missing_value_fails_loud():
 
     assert request.body == {"mix": "seed=hi-5"}
 
-    with pytest.raises(TemplateRenderError):
+    with pytest.raises(TemplateRenderError) as exc_info:
         render_request(
             {"method": "POST", "url": "{{ base_url }}", "body": {"mix": "seed={{ seed }}"}},
             context,
         )
+    assert exc_info.value.code is DefinitionErrorCode.TEMPLATE_TEXT_VARIABLE_NULL
 
 
 def test_enum_map_miss_fails_loud():
-    with pytest.raises(TemplateRenderError):
+    with pytest.raises(TemplateRenderError) as exc_info:
         render_request(
             {"method": "POST", "url": "{{ base_url }}", "body": {"d": "{{ duration }}"}},
             _context(duration=7),
             enum_maps={"duration": {"5": "5s"}},
         )
+    assert exc_info.value.code is DefinitionErrorCode.ENUM_MAP_VALUE_MISSING
+
+
+def test_undeclared_variable_has_a_specific_failure_code():
+    with pytest.raises(TemplateRenderError) as exc_info:
+        render_request(
+            {"method": "POST", "url": "{{ base_url }}", "body": {"value": "{{ missing }}"}},
+            _context(),
+        )
+
+    assert exc_info.value.code is DefinitionErrorCode.UNDECLARED_VARIABLE
+
+
+def test_non_string_rendered_url_has_a_specific_failure_code():
+    with pytest.raises(TemplateRenderError) as exc_info:
+        render_request({"method": "POST", "url": "{{ port }}"}, _context(port=443))
+
+    assert exc_info.value.code is DefinitionErrorCode.TEMPLATE_URL_NOT_STRING
+
+
+def test_unknown_asset_encoding_has_a_specific_failure_code():
+    with pytest.raises(TemplateRenderError) as exc_info:
+        encode_inputs(
+            {"first": {"source": "start_image", "encoding": "hex"}},
+            {"start_image": AssetData("image/png", b"image")},
+        )
+
+    assert exc_info.value.code is DefinitionErrorCode.UNKNOWN_ASSET_ENCODING
+
+
+def test_each_runtime_value_that_is_not_a_list_has_a_specific_failure_code():
+    with pytest.raises(TemplateRenderError) as exc_info:
+        render_request(
+            {
+                "method": "POST",
+                "url": "{{ base_url }}",
+                "body": [{"$each": {"in": "refs", "as": "ref", "item": "{{ ref }}"}}],
+            },
+            _context(refs=1),
+        )
+
+    assert exc_info.value.code is DefinitionErrorCode.EACH_VALUE_NOT_LIST
 
 
 def test_enum_maps_apply_to_url_headers_and_auth_query_alike():
@@ -122,12 +171,13 @@ def test_auth_query_appends_without_reencoding_existing_url_query():
 
 
 def test_auth_query_rejects_parameter_already_present_in_url():
-    with pytest.raises(TemplateRenderError):
+    with pytest.raises(TemplateRenderError) as exc_info:
         render_request(
             {"method": "GET", "url": "{{ base_url }}/v?key=static"},
             _context(),
             auth={"query": {"key": "{{ api_key }}"}},
         )
+    assert exc_info.value.code is DefinitionErrorCode.AUTH_QUERY_CONFLICT
 
 
 def test_auth_header_overrides_request_header_case_insensitively():

--- a/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_validator.py
+++ b/tests/unit/lib/custom_provider/endpoint_definition/test_endpoint_definition_validator.py
@@ -605,6 +605,39 @@ class TestDiagnosticPayload:
         payload = validate_definition(definition).to_payload(make_translator("zh"))
         assert "运行时策略" in payload["errors"][0]["message"]
 
+    @pytest.mark.parametrize(
+        ("locale", "expected"),
+        [
+            ("zh", "取值不符合格式约定：不符合要求的格式：\\S"),
+            ("en", "Value does not match the format: Required format not matched: \\S"),
+            ("vi", "Giá trị không đúng định dạng: Không khớp định dạng bắt buộc: \\S"),
+        ],
+    )
+    def test_jsonschema_detail_is_rendered_in_the_requested_locale(self, locale: str, expected: str):
+        definition = custom_endpoint_definition()
+        definition["submit"]["url"] = " "
+
+        payload = validate_definition(definition).to_payload(make_translator(locale))
+
+        assert payload["errors"][0]["message"] == expected
+
+    @pytest.mark.parametrize(
+        ("locale", "expected"),
+        [
+            ("zh", "不符合定义格式：取值落入了禁止范围"),
+            ("en", "Does not match the definition format: The value matches a forbidden constraint"),
+            ("vi", "Không khớp định dạng định nghĩa: Giá trị thuộc phạm vi bị cấm"),
+        ],
+    )
+    def test_jsonschema_fallback_detail_is_rendered_in_the_requested_locale(self, locale: str, expected: str):
+        definition = custom_endpoint_definition()
+        definition["schema_version"] = "1.0.0\n"
+
+        payload = validate_definition(definition).to_payload(make_translator(locale))
+
+        assert payload["errors"][0]["code"] == "schema_violation"
+        assert payload["errors"][0]["message"] == expected
+
     def test_every_code_reads_as_prose_in_every_locale(self):
         keys = {message_key(code) for code in DefinitionErrorCode} | set(REMOVED_FIELD_REASONS.values())
         for key in sorted(keys):

--- a/tests/unit/lib/custom_provider/test_declarative_video_backend.py
+++ b/tests/unit/lib/custom_provider/test_declarative_video_backend.py
@@ -709,6 +709,27 @@ class TestDeclarativeVideoBackend:
         assert caught.value.code == "declarative_template_render_failed"
         assert submit.call_count == 0
 
+    async def test_template_failure_keeps_its_detail_locale_neutral(self, tmp_path: Path):
+        definition = _definition()
+        definition["enum_maps"] = {"duration": {"10": 10}}
+
+        with capture_http() as router:
+            submit = router.post("https://relay.test/v1/video/create")
+            with pytest.raises(DeclarativeRuntimeError) as caught:
+                await DeclarativeVideoBackend(
+                    api_key="secret",
+                    base_url="https://relay.test",
+                    model="video-x",
+                    definition=definition,
+                    provider="custom-1",
+                ).generate(_request(tmp_path))
+
+        assert caught.value.params["detail"] == {
+            "key": "val_ce_enum_map_value_missing",
+            "params": {"name": "duration", "value": "5"},
+        }
+        assert submit.call_count == 0
+
     async def test_non_json_success_response_is_recorded(self, tmp_path: Path):
         """2xx 却不是 JSON（网关 HTML 错误页、被截断的响应）时，原文也要留痕。"""
         recorded: list[object] = []

--- a/tests/unit/lib/custom_provider/test_declarative_video_backend.py
+++ b/tests/unit/lib/custom_provider/test_declarative_video_backend.py
@@ -10,11 +10,13 @@ from lib.custom_provider.declarative_backend import (
     DeclarativeRuntimeError,
     DeclarativeVideoBackend,
     extract_duration,
+    extract_provider_state,
 )
 from lib.custom_provider.endpoint_definition import validate_definition
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.video_backends.base import (
     VIDEO_POLL_MAX_CONSECUTIVE_FAILURES,
+    ProviderJobStatus,
     ProviderResponseStage,
     ResumeExpiredError,
     VideoGenerationRequest,
@@ -729,6 +731,7 @@ class TestDeclarativeVideoBackend:
             "key": "val_ce_enum_map_value_missing",
             "params": {"name": "duration", "value": "5"},
         }
+        assert str(caught.value) == "enum_maps.duration 缺少 '5' 的映射"
         assert submit.call_count == 0
 
     async def test_non_json_success_response_is_recorded(self, tmp_path: Path):
@@ -754,6 +757,28 @@ class TestDeclarativeVideoBackend:
 
         assert caught.value.code == "declarative_response_extract_failed"
         assert recorded[-1] == ("submit", "<html>gateway timeout</html>")
+
+    async def test_jsonpath_evaluation_failure_keeps_its_detail_locale_neutral(self, tmp_path: Path):
+        definition = _definition()
+        definition["submit"]["extract"]["task_id"] = ["$[?@.a == 1e400]"]
+
+        with capture_http() as router:
+            router.post("https://relay.test/v1/video/create").mock(return_value=httpx.Response(200, json={"a": 1}))
+
+            with pytest.raises(DeclarativeRuntimeError) as caught:
+                await DeclarativeVideoBackend(
+                    api_key="secret",
+                    base_url="https://relay.test",
+                    model="video-x",
+                    definition=definition,
+                    provider="custom-1",
+                ).generate(_request(tmp_path))
+
+        assert caught.value.code == "declarative_response_extract_failed"
+        assert caught.value.params["detail"] == {
+            "key": "val_ce_jsonpath_evaluation_failed",
+            "params": {"path_expression": "$[?@.a == 1e400]"},
+        }
 
     async def test_missing_required_input_fails_before_submitting(self, tmp_path: Path):
         """声明为必需的素材缺席时不许发请求：模板会把该键整个删掉，供应商照样建任务照常计费。"""
@@ -1180,3 +1205,21 @@ class TestExtractDuration:
         assert extract_duration(self.SPEC, {"usage": {"duration": MAX_BILLED_DURATION_SECONDS}}) == (
             MAX_BILLED_DURATION_SECONDS
         )
+
+    def test_jsonpath_evaluation_failure_reaches_the_shared_runtime_diagnostic(self):
+        extract = {
+            "usage": {
+                "duration_seconds": {"paths": ["$[?@.a == 1e400]"], "accept": "scalar"},
+            }
+        }
+
+        with pytest.raises(DeclarativeRuntimeError) as caught:
+            extract_provider_state({"a": 1}, extract, status=ProviderJobStatus.SUCCEEDED)
+
+        assert caught.value.code == "declarative_response_extract_failed"
+        assert caught.value.params == {
+            "detail": {
+                "key": "val_ce_jsonpath_evaluation_failed",
+                "params": {"path_expression": "$[?@.a == 1e400]"},
+            }
+        }

--- a/tests/unit/lib/custom_provider/test_declarative_video_backend.py
+++ b/tests/unit/lib/custom_provider/test_declarative_video_backend.py
@@ -15,6 +15,7 @@ from lib.custom_provider.endpoint_definition import validate_definition
 from lib.db.repositories.usage_repo import MAX_BILLED_DURATION_SECONDS
 from lib.video_backends.base import (
     VIDEO_POLL_MAX_CONSECUTIVE_FAILURES,
+    ProviderResponseStage,
     ResumeExpiredError,
     VideoGenerationRequest,
 )
@@ -568,10 +569,10 @@ class TestDeclarativeVideoBackend:
         assert download.call_count == 3
 
     async def test_failed_submit_body_is_recorded(self, tmp_path: Path):
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
 
-        async def record(body: object) -> None:
-            recorded.append(body)
+        async def record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
 
         with capture_http() as router:
             router.post("https://relay.test/v1/video/create").mock(
@@ -586,7 +587,7 @@ class TestDeclarativeVideoBackend:
                     provider="custom-1",
                 ).generate(_request(tmp_path, on_provider_response=record))
 
-        assert recorded == [{"error": "bad prompt"}]
+        assert recorded == [("submit", {"error": "bad prompt"})]
 
     async def test_download_exhausts_shared_ten_failure_budget(self, tmp_path: Path):
         with capture_http() as router, bounded_poll_clock():
@@ -732,10 +733,10 @@ class TestDeclarativeVideoBackend:
 
     async def test_non_json_success_response_is_recorded(self, tmp_path: Path):
         """2xx 却不是 JSON（网关 HTML 错误页、被截断的响应）时，原文也要留痕。"""
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
 
-        async def _record(body: object) -> None:
-            recorded.append(body)
+        async def _record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
 
         with capture_http() as router, bounded_poll_clock():
             router.post("https://relay.test/v1/video/create").mock(
@@ -752,7 +753,7 @@ class TestDeclarativeVideoBackend:
                 ).generate(_request(tmp_path, on_provider_response=_record))
 
         assert caught.value.code == "declarative_response_extract_failed"
-        assert recorded[-1] == "<html>gateway timeout</html>"
+        assert recorded[-1] == ("submit", "<html>gateway timeout</html>")
 
     async def test_missing_required_input_fails_before_submitting(self, tmp_path: Path):
         """声明为必需的素材缺席时不许发请求：模板会把该键整个删掉，供应商照样建任务照常计费。"""
@@ -957,10 +958,10 @@ class TestDeclarativeVideoBackend:
             "extract": {"video_url": ["$.video_url"]},
         }
         assert validate_definition(definition).valid
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
 
-        async def _record(body: object) -> None:
-            recorded.append(body)
+        async def _record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
 
         with capture_http() as router, bounded_poll_clock():
             router.post("https://relay.test/v1/video/create").mock(
@@ -986,7 +987,7 @@ class TestDeclarativeVideoBackend:
 
         assert caught.value.code == "artifact_download_failed"
         assert result.call_count == VIDEO_POLL_MAX_CONSECUTIVE_FAILURES
-        assert recorded[-1] == {"error": "result exploded"}
+        assert recorded[-1] == ("result", {"error": "result exploded"})
 
     async def test_request_log_drops_auth_query_credentials(self, tmp_path: Path, caplog):
         """请求日志按键名遮蔽，遮不到拼进 URL 查询串里的 ``auth.query`` 凭证。"""

--- a/tests/unit/lib/custom_provider/test_endpoint_test_preview.py
+++ b/tests/unit/lib/custom_provider/test_endpoint_test_preview.py
@@ -14,6 +14,7 @@ from lib.custom_provider.endpoint_test import (
     parse_response_body,
     preview_request,
 )
+from lib.i18n import _
 from tests.factories import custom_endpoint_definition
 from tests.http_capture import capture_http
 
@@ -141,7 +142,10 @@ class TestPreviewRequest:
 
         issue = exc_info.value.diagnostics.errors[0]
         assert issue.path == "submit"
-        assert issue.code.value == "template_render_failed"
+        assert issue.code.value == "enum_map_value_missing"
+        assert issue.to_payload(lambda key, **params: _(key, locale="en", **params))["message"] == (
+            "enum_maps.duration has no entry for '5'"
+        )
 
 
 class TestCheckResponse:

--- a/tests/unit/lib/custom_provider/test_endpoint_test_preview.py
+++ b/tests/unit/lib/custom_provider/test_endpoint_test_preview.py
@@ -194,3 +194,16 @@ class TestCheckResponse:
         report = check_response(custom_endpoint_definition(), "poll", parse_response_body('{"status": "completed"}'))
 
         assert report.status == "succeeded"
+
+    def test_jsonpath_evaluation_failure_is_rendered_in_the_requested_locale(self):
+        definition = custom_endpoint_definition()
+        definition["poll"]["extract"]["status"] = ["$[?@.a == 1e400]"]
+
+        with pytest.raises(EndpointTestDefinitionError) as exc_info:
+            check_response(definition, "poll", {"a": 1})
+
+        issue = exc_info.value.diagnostics.errors[0]
+        assert issue.code.value == "jsonpath_evaluation_failed"
+        assert issue.to_payload(lambda key, **params: _(key, locale="en", **params))["message"] == (
+            "Could not evaluate extraction path: $[?@.a == 1e400]"
+        )

--- a/tests/unit/lib/custom_provider/test_endpoint_test_trial_run.py
+++ b/tests/unit/lib/custom_provider/test_endpoint_test_trial_run.py
@@ -133,6 +133,67 @@ class TestTrialRun:
         assert run.extractions["submit"]["task_id"] == "job-42"
         assert run.extractions["poll"]["status"] == "succeeded"
 
+    async def test_submit_retry_keeps_the_successful_submit_response(self, trial_runs: TrialRunManager):
+        with capture_http() as router, bounded_poll_clock():
+            router.post("https://relay.test/v1/video/create").mock(
+                side_effect=[
+                    httpx.Response(429, json={"error": "busy"}),
+                    httpx.Response(200, json={"task_id": "job-42"}),
+                ]
+            )
+            router.get("https://relay.test/v1/video/fetch/job-42").mock(
+                side_effect=[
+                    httpx.Response(200, json={"status": "processing"}),
+                    httpx.Response(
+                        200,
+                        json={"status": "completed", "video_url": "https://relay.test/files/job-42.mp4"},
+                    ),
+                ]
+            )
+            router.get("https://relay.test/files/job-42.mp4").mock(return_value=httpx.Response(200, content=b"video"))
+
+            started = await trial_runs.start(_target(), PARAMETERS)
+            run = await _await_terminal(trial_runs, started.id)
+
+        assert run.status is TrialRunStatus.SUCCEEDED, run.error
+        assert run.submit_response == {"task_id": "job-42"}
+        assert run.poll_responses == [
+            {"status": "processing"},
+            {"status": "completed", "video_url": "https://relay.test/files/job-42.mp4"},
+        ]
+
+    async def test_result_response_is_not_counted_as_polling(self, trial_runs: TrialRunManager):
+        definition = custom_endpoint_definition()
+        definition["poll"]["extract"] = {"status": ["$.status"], "result_id": ["$.result_id"]}
+        definition["result"] = {
+            "method": "GET",
+            "url": "{{ base_url }}/v1/video/result/{{ result_id }}",
+            "extract": {"video_url": ["$.video_url"]},
+        }
+        poll_body = {"status": "completed", "result_id": "result-9"}
+        result_body = {"video_url": "https://relay.test/files/job-42.mp4"}
+
+        with capture_http() as router, bounded_poll_clock(step=1.0):
+            router.post("https://relay.test/v1/video/create").mock(
+                return_value=httpx.Response(200, json={"task_id": "job-42"})
+            )
+            router.get("https://relay.test/v1/video/fetch/job-42").mock(
+                return_value=httpx.Response(200, json=poll_body)
+            )
+            router.get("https://relay.test/v1/video/result/result-9").mock(
+                return_value=httpx.Response(200, json=result_body)
+            )
+            router.get("https://relay.test/files/job-42.mp4").mock(return_value=httpx.Response(200, content=b"video"))
+
+            target = declarative_target(definition, CREDENTIALS, PARAMETERS)
+            started = await trial_runs.start(target, PARAMETERS)
+            run = await _await_terminal(trial_runs, started.id)
+
+        assert run.status is TrialRunStatus.SUCCEEDED, run.error
+        assert run.poll_responses == [poll_body]
+        assert run.extractions["poll"]["status"] == "succeeded"
+        assert run.extractions["result"]["video_url"] == result_body["video_url"]
+
     async def test_terminal_result_is_read_from_disk(self, trial_runs: TrialRunManager):
         with capture_http() as router, bounded_poll_clock():
             _mock_successful_run(router)

--- a/tests/unit/lib/custom_provider/test_endpoint_test_trial_run.py
+++ b/tests/unit/lib/custom_provider/test_endpoint_test_trial_run.py
@@ -191,6 +191,7 @@ class TestTrialRun:
 
         assert run.status is TrialRunStatus.SUCCEEDED, run.error
         assert run.poll_responses == [poll_body]
+        assert run.result_response == result_body
         assert run.extractions["poll"]["status"] == "succeeded"
         assert run.extractions["result"]["video_url"] == result_body["video_url"]
 

--- a/tests/unit/lib/test_task_failure.py
+++ b/tests/unit/lib/test_task_failure.py
@@ -86,6 +86,16 @@ class TestRenderKnownCodes:
             "Không thể kết xuất yêu cầu endpoint: enum_maps.duration không có ánh xạ cho '5'"
         )
 
+    def test_jsonpath_evaluation_detail_is_rendered_with_the_outer_failure_locale(self):
+        encoded = encode_failure(
+            "declarative_response_extract_failed",
+            detail={"key": "val_ce_jsonpath_evaluation_failed", "params": {"path_expression": "$[?@.a == 1e400]"}},
+        )
+
+        assert render_failure(encoded, _translator("en")) == (
+            "Endpoint response extraction failed: Could not evaluate extraction path: $[?@.a == 1e400]"
+        )
+
 
 class TestCascadeBlockedDependency:
     def test_renders_nested_structured_reason(self):
@@ -146,6 +156,30 @@ class TestBoundReason:
         assert rendered is not None
         assert "[" not in rendered
         assert "resume_expired_detail" not in rendered
+
+    @pytest.mark.parametrize("locale", ["zh", "en", "vi"])
+    def test_preserves_oversized_nested_diagnostic_for_locale_rendering(self, locale):
+        path_expression = f"$.{'member' * 500}[?@.a == 1e400]"
+        reason = encode_failure(
+            "declarative_response_extract_failed",
+            detail={
+                "key": "val_ce_jsonpath_evaluation_failed",
+                "params": {"path_expression": path_expression},
+            },
+        )
+
+        bounded = bound_reason(reason, 2000)
+
+        assert len(bounded) <= 2000
+        parsed = parse_failure(bounded)
+        assert parsed is not None
+        detail = parsed[1]["detail"]
+        assert detail["key"] == "val_ce_jsonpath_evaluation_failed"
+        assert detail["params"]["path_expression"]
+        rendered = render_failure(bounded, _translator(locale))
+        assert rendered is not None
+        assert "val_ce_jsonpath_evaluation_failed" not in rendered
+        assert '"key"' not in rendered
 
 
 class TestPassthrough:

--- a/tests/unit/lib/test_task_failure.py
+++ b/tests/unit/lib/test_task_failure.py
@@ -70,6 +70,22 @@ class TestRenderKnownCodes:
         assert "HTTP 404 job gone" in zh
         assert "HTTP 404 job gone" in en
 
+    def test_locale_neutral_detail_is_rendered_with_the_outer_failure_locale(self):
+        encoded = encode_failure(
+            "declarative_template_render_failed",
+            detail={"key": "val_ce_enum_map_value_missing", "params": {"name": "duration", "value": "5"}},
+        )
+
+        assert render_failure(encoded, _translator("en")) == (
+            "Endpoint request rendering failed: enum_maps.duration has no entry for '5'"
+        )
+        assert render_failure(encoded, _translator("zh")) == (
+            "调用端点请求渲染失败：enum_maps.duration 缺少 '5' 的映射"
+        )
+        assert render_failure(encoded, _translator("vi")) == (
+            "Không thể kết xuất yêu cầu endpoint: enum_maps.duration không có ánh xạ cho '5'"
+        )
+
 
 class TestCascadeBlockedDependency:
     def test_renders_nested_structured_reason(self):

--- a/tests/unit/lib/test_validation_messages.py
+++ b/tests/unit/lib/test_validation_messages.py
@@ -33,6 +33,13 @@ class TestValidationMessage:
         assert "角色" in message.render()
         assert "角色" not in message.render(_translator("en"))
 
+    def test_validation_message_param_is_rendered_in_the_same_locale(self):
+        detail = ValidationMessage("val_ce_schema_minimum_constraint", {"limit": 1})
+        message = ValidationMessage("val_ce_invalid_value", {"detail": detail})
+
+        assert message.render(_translator("en")) == "Value does not match the format: Minimum allowed: 1"
+        assert message.render(_translator("zh")) == "取值不符合格式约定：允许的最小值或数量：1"
+
     def test_message_join_renders_fragments_with_separator(self):
         message = ValidationMessage(
             "val_missing_field",

--- a/tests/unit/lib/video_backends/test_agnes_video_backend.py
+++ b/tests/unit/lib/video_backends/test_agnes_video_backend.py
@@ -18,6 +18,7 @@ from lib.video_backends.agnes import AgnesVideoBackend
 from lib.video_backends.base import (
     AmbiguousSubmitError,
     ArtifactDownloadError,
+    ProviderResponseStage,
     ResumeExpiredError,
     VideoCapabilityError,
     VideoGenerationRequest,
@@ -425,6 +426,11 @@ class TestFailureAndTimeout:
     async def test_completed_with_null_remixed_from_video_id_uses_video_id_query(self, tmp_path: Path):
         """普通图生/文生视频完成态 remixed_from_video_id 恒为 null，成片地址须按 video_id
         二次查询取得。"""
+        recorded: list[tuple[ProviderResponseStage, object]] = []
+
+        async def _record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
+
         with _agnes_api(base_url=_GATEWAY_BASE_URL) as routes:
             routes.submit.mock(return_value=_queued("t-null-remix"))
             routes.poll.mock(
@@ -442,7 +448,7 @@ class TestFailureAndTimeout:
             routes.download.mock(return_value=httpx.Response(200, content=b"queried-bytes"))
 
             backend = AgnesVideoBackend(api_key="k", base_url=_GATEWAY_BASE_URL)
-            result = await backend.generate(_request(tmp_path))
+            result = await backend.generate(_request(tmp_path, on_provider_response=_record))
 
             # 二次查询打网关根下的 /agnesapi，按 video_id 传参（不带 /v1，也不用 task_id）
             assert str(only_request(routes.query).url) == "https://apihub.agnes-ai.com/agnesapi?video_id=vid-123"
@@ -450,6 +456,7 @@ class TestFailureAndTimeout:
         assert result.video_uri == "https://cdn.agnes/queried.mp4"
         assert result.duration_seconds == 8
         assert result.video_path.read_bytes() == b"queried-bytes"
+        assert [stage for stage, _body in recorded] == ["submit", "poll", "result"]
 
     async def test_completed_with_direct_url_field_skips_video_id_query(self, tmp_path: Path):
         """完成态直接带 url 字段时直接下载，不发起 video_id 二次查询。"""

--- a/tests/unit/lib/video_backends/test_video_backend_base.py
+++ b/tests/unit/lib/video_backends/test_video_backend_base.py
@@ -14,6 +14,7 @@ from lib.video_backends.base import (
     AmbiguousSubmitError,
     ProviderJobIdPersistenceMixin,
     ProviderJobStatus,
+    ProviderResponseStage,
     ResumeExpiredError,
     VideoGenerationRequest,
     VideoGenerationResult,
@@ -658,11 +659,18 @@ class TestSubmitPost:
 
     async def test_returns_response_on_success(self):
         resp = httpx.Response(200, request=httpx.Request("POST", "https://x/v2"), json={"id": "ok"})
+        recorded: list[tuple[str, object]] = []
 
         async def _post() -> httpx.Response:
             return resp
 
-        assert await submit_post(_post, provider="v2") is resp
+        async def _record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
+
+        request = VideoGenerationRequest(prompt="p", output_path=Path("out.mp4"), on_provider_response=_record)
+
+        assert await submit_post(_post, provider="v2", request=request) is resp
+        assert recorded == [("submit", {"id": "ok"})]
 
     async def test_not_sent_error_propagates_for_retry(self):
         # 连接建立失败 / 代理握手失败原样抛出，交 should_retry_submit 重试（不包成终态）。
@@ -1081,9 +1089,9 @@ class TestRecordingPoll:
     """轮询留痕：每收到一次响应即写入，早于状态与错误解读。"""
 
     @staticmethod
-    def _request(recorded: list[object]) -> VideoGenerationRequest:
-        async def _record(body: object) -> None:
-            recorded.append(body)
+    def _request(recorded: list[tuple[str, object]]) -> VideoGenerationRequest:
+        async def _record(stage: ProviderResponseStage, body: object) -> None:
+            recorded.append((stage, body))
 
         return VideoGenerationRequest(
             prompt="p",
@@ -1094,7 +1102,7 @@ class TestRecordingPoll:
 
     async def test_terminal_failure_body_is_recorded_before_it_raises(self):
         """终态失败由 is_failed 在 poll_with_retry 内抛出，留痕仍须拿到该响应体。"""
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
         body = {"status": "failed", "error": "provider said no"}
 
         with pytest.raises(RuntimeError, match="provider said no"):
@@ -1107,28 +1115,39 @@ class TestRecordingPoll:
                 clock=_FakeClock(),
             )
 
-        assert recorded == [body]
+        assert recorded == [("poll", body)]
 
     async def test_http_error_response_body_is_recorded(self):
         """4xx/5xx 响应从 poll_fn 自己抛出，同样是需要诊断的那次调用。"""
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
         response = httpx.Response(500, json={"detail": "boom"}, request=httpx.Request("GET", "https://x/t"))
         error = httpx.HTTPStatusError("500", request=response.request, response=response)
 
         with pytest.raises(httpx.HTTPStatusError):
             await recording_poll(AsyncMock(side_effect=error), self._request(recorded))()
 
-        assert recorded == [{"detail": "boom"}]
+        assert recorded == [("poll", {"detail": "boom"})]
 
     async def test_non_json_http_error_body_is_recorded_as_text(self):
-        recorded: list[object] = []
+        recorded: list[tuple[str, object]] = []
         response = httpx.Response(502, text="<html>gateway</html>", request=httpx.Request("GET", "https://x/t"))
         error = httpx.HTTPStatusError("502", request=response.request, response=response)
 
         with pytest.raises(httpx.HTTPStatusError):
             await recording_poll(AsyncMock(side_effect=error), self._request(recorded))()
 
-        assert recorded == ["<html>gateway</html>"]
+        assert recorded == [("poll", "<html>gateway</html>")]
+
+    async def test_result_response_uses_requested_stage(self):
+        recorded: list[tuple[str, object]] = []
+
+        await recording_poll(
+            AsyncMock(return_value={"video_url": "https://cdn.test/video.mp4"}),
+            self._request(recorded),
+            stage="result",
+        )()
+
+        assert recorded == [("result", {"video_url": "https://cdn.test/video.mp4"})]
 
     async def test_diagnostic_write_failure_does_not_fail_the_generation(self):
         """留痕列写不进去时任务照常推进——供应商已受理的生成不因诊断数据失败。"""

--- a/tests/unit/server/routers/test_endpoint_tests_api.py
+++ b/tests/unit/server/routers/test_endpoint_tests_api.py
@@ -303,6 +303,35 @@ class TestTrialRuns:
         assert artifact.status_code == 200
         assert artifact.content == b"video"
 
+    def test_failed_run_diagnostic_is_rendered_in_the_read_request_locale(
+        self, client: TestClient, trial_runs: TrialRunManager
+    ):
+        definition = custom_endpoint_definition()
+        definition["submit"]["extract"]["task_id"] = ["$[?@.a == 1e400]"]
+        with capture_http() as router:
+            router.post("https://relay.test/v1/video/create").mock(return_value=httpx.Response(200, json={"a": 1}))
+            created = _post(
+                client,
+                "trial-runs",
+                {
+                    "definition": definition,
+                    "parameters": PARAMETERS,
+                    "credentials": INLINE_CREDENTIALS,
+                },
+            )
+            assert created.status_code == 201, created.text
+            run_id = created.json()["id"]
+            _drain(client, trial_runs, run_id)
+
+        en = client.get(f"/api/v1/custom-endpoints/trial-runs/{run_id}", headers={"Accept-Language": "en"}).json()
+        vi = client.get(f"/api/v1/custom-endpoints/trial-runs/{run_id}", headers={"Accept-Language": "vi"}).json()
+        assert en["error"] == (
+            "Endpoint response extraction failed: Could not evaluate extraction path: $[?@.a == 1e400]"
+        )
+        assert vi["error"] == (
+            "Không thể trích xuất phản hồi endpoint: Không thể đánh giá đường dẫn trích xuất: $[?@.a == 1e400]"
+        )
+
     def test_a_second_concurrent_run_is_refused(self, client: TestClient, trial_runs: TrialRunManager):
         with capture_http() as router, bounded_poll_clock():
             router.post("https://relay.test/v1/video/create").mock(

--- a/tests/unit/server/routers/test_endpoint_tests_api.py
+++ b/tests/unit/server/routers/test_endpoint_tests_api.py
@@ -265,14 +265,18 @@ class TestSharedValidation:
         definition = custom_endpoint_definition()
         definition["enum_maps"] = {"duration": {"10": 10}}
 
-        resp = _post(
-            client,
-            "preview-request",
-            {"definition": definition, "parameters": PARAMETERS, "credentials": INLINE_CREDENTIALS},
+        resp = client.post(
+            "/api/v1/custom-endpoints/preview-request",
+            json={"definition": definition, "parameters": PARAMETERS, "credentials": INLINE_CREDENTIALS},
+            headers={"Accept-Language": "en"},
         )
 
         assert resp.status_code == 422
-        assert resp.json()["diagnostic"]["errors"][0]["code"] == "template_render_failed"
+        assert resp.json()["diagnostic"]["errors"][0] == {
+            "path": "submit",
+            "code": "enum_map_value_missing",
+            "message": "enum_maps.duration has no entry for '5'",
+        }
 
 
 class TestTrialRuns:


### PR DESCRIPTION
## Summary

- record provider responses by submit, poll, and result stage so retried submissions show the successful response
- localize template-render and schema-validation diagnostics in all supported languages
- normalize JSONPath evaluation failures into the existing stable extraction-error path

## Validation

- issue-level related tests and backend full suite passed in each reviewed handoff
- cumulative stage gates and AI review loop run before marking the PR ready

Closes #2186
Closes #2187
Closes #2188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增自定义端点结构化错误诊断，覆盖模板渲染、参数校验和 JSONPath 提取。
  * 支持中文、英文和越南语本地化错误消息。
  * 视频生成流程区分提交、轮询和结果阶段，并保存最终结果响应供查看。
  * 支持成片下载失败后恢复下载，无需重新提交任务。

* **问题修复**
  * 改进模板渲染及响应提取失败时的错误反馈。
  * 修复重试后各阶段响应记录不准确的问题。
  * 优化长错误详情的裁剪与本地化展示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->