### PR TITLE
fix(agent):  隔离继承的 Claude 认证令牌

### DIFF
--- a/lib/config/env_keys.py
+++ b/lib/config/env_keys.py
@@ -18,6 +18,10 @@ ANTHROPIC_ENV_KEYS: tuple[str, ...] = (
 
 # —— 其他 provider env keys（options.env 用空值覆盖兜底）——
 OTHER_PROVIDER_ENV_KEYS: tuple[str, ...] = (
+    # Claude CLI / SDK 会优先读取这些旁路认证变量。它们不属于 ArcReel 的
+    # provider 凭证模型，但必须在 Agent 会话中显式置空，避免继承宿主环境。
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
     "ARK_API_KEY",
     "XAI_API_KEY",
     "GEMINI_API_KEY",
@@ -48,6 +52,7 @@ OTHER_PROVIDER_ENV_KEYS: tuple[str, ...] = (
 PROVIDER_SECRET_KEYS: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
         "ARK_API_KEY",
         "XAI_API_KEY",
         "GEMINI_API_KEY",

--- a/tests/unit/lib/config/test_env_keys.py
+++ b/tests/unit/lib/config/test_env_keys.py
@@ -6,6 +6,7 @@ from lib.config.env_keys import (
     ANTHROPIC_ENV_KEYS,
     OTHER_PROVIDER_ENV_KEYS,
     PROVIDER_SECRET_KEYS,
+    is_provider_env_key,
 )
 
 
@@ -48,3 +49,13 @@ def test_anthropic_keys_complete():
         "CLAUDE_CODE_SUBAGENT_MODEL",
     }
     assert required <= set(ANTHROPIC_ENV_KEYS)
+
+
+def test_claude_auth_tokens_are_isolated_with_correct_secret_scope():
+    """Claude 旁路认证令牌必须隔离；仅 Anthropic token 触发启动拒绝。"""
+    for key in ("ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        assert key in OTHER_PROVIDER_ENV_KEYS
+        assert is_provider_env_key(key)
+
+    assert "ANTHROPIC_AUTH_TOKEN" in PROVIDER_SECRET_KEYS
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in PROVIDER_SECRET_KEYS

--- a/tests/unit/server/agent_runtime/test_options_assembler.py
+++ b/tests/unit/server/agent_runtime/test_options_assembler.py
@@ -72,6 +72,8 @@ async def test_load_provider_env_overrides_injects_anthropic_and_empties() -> No
 
     assert env["ANTHROPIC_API_KEY"] == "sk-from-db"
     assert env["ANTHROPIC_BASE_URL"] == "https://anthropic.example.com"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == ""
     # 其他 provider 空值覆盖
     assert env["ARK_API_KEY"] == ""
     assert env["XAI_API_KEY"] == ""

--- a/tests/unit/server/test_startup_assertions.py
+++ b/tests/unit/server/test_startup_assertions.py
@@ -72,6 +72,13 @@ def test_empty_string_value_not_treated_as_leak(monkeypatch: pytest.MonkeyPatch)
     assert_no_provider_secrets_in_environ()  # 空值不 raise
 
 
+def test_claude_code_oauth_token_does_not_trigger_startup_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Claude 登录态会在会话环境中清空，但不属于启动期 provider 密钥。"""
+    _clear_secret_envs(monkeypatch)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "user-login-token")
+    assert_no_provider_secrets_in_environ()
+
+
 def test_sandbox_available_macos(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/sandbox-exec" if name == "sandbox-exec" else None)

--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -177,7 +177,7 @@ ArcReel 在应用启动时运行 Alembic 迁移，将数据库结构升级到当
 
 ArcReel 的沙箱要求父进程环境中不保留供应商密钥。以下凭据环境变量存在非空值时，服务会拒绝启动并提示迁移到 WebUI 设置页：
 
-- `ANTHROPIC_API_KEY`
+- `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`
 - `ARK_API_KEY` / `XAI_API_KEY` / `GEMINI_API_KEY` / `VIDU_API_KEY`
 - `DASHSCOPE_API_KEY` / `MINIMAX_API_KEY` / `AGNES_API_KEY` / `OPENAI_API_KEY`
 - `GOOGLE_APPLICATION_CREDENTIALS`（Vertex 凭据继续放在 `vertex_keys/` 目录）

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -176,7 +176,7 @@ The remote MCP endpoint is `/mcp` and always requires an API Key with an `arc-` 
 
 ArcReel's sandbox requires provider secrets to be absent from the parent process environment. If any of the following credential environment variables has a non-empty value, the service refuses to start and prompts you to move the credential to the Web UI Settings page:
 
-- `ANTHROPIC_API_KEY`
+- `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`
 - `ARK_API_KEY` / `XAI_API_KEY` / `GEMINI_API_KEY` / `VIDU_API_KEY`
 - `DASHSCOPE_API_KEY` / `MINIMAX_API_KEY` / `AGNES_API_KEY` / `OPENAI_API_KEY`
 - `GOOGLE_APPLICATION_CREDENTIALS` (continue storing Vertex credentials in the `vertex_keys/` directory)


### PR DESCRIPTION
Closes #2141

## 变更

- 防止 Agent 会话继承宿主进程中的 `ANTHROPIC_AUTH_TOKEN` 和 `CLAUDE_CODE_OAUTH_TOKEN`，避免其覆盖 ArcReel 配置的认证信息。
- 将非空的 `ANTHROPIC_AUTH_TOKEN` 纳入启动期密钥检查；检测到时服务拒绝启动。
- `CLAUDE_CODE_OAUTH_TOKEN` 仅在 Agent 子进程环境中清空，不会阻止服务启动。
- 补充相关单元测试，并更新中英文部署文档。
- 不修改 `CLAUDE_CONFIG_DIR`、用户配置文件、连接测试流程或 Agent 运行架构。

## 验证

- `pytest`：相关配置、Agent 运行时与启动断言测试共 `41 passed`。
- `ruff check`：通过。
- `ruff format --check`：通过。
- `basedpyright`：`0 errors, 0 warnings`。
- 本机为 Windows；2 个既有 Linux `bwrap` 沙箱诊断用例依赖 Linux 系统配置，未纳入本次本地验证。

## 风险与遗留

- 无数据库迁移、接口变更或配置迁移。
- 本次改动仅影响 Agent 子进程环境变量隔离；如需回滚，回退本提交即可。