### PR TITLE
ci: 发布镜像同步推送 Docker Hub

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,8 +1,8 @@
 name: Docker Release
 
 # v* tag 触发的正式发布：双架构漏洞闸门 → 多架构构建 → semver + latest 标签，
-# 附带 SBOM 与 provenance attestation。GitHub Release 由 release-please 创建，
-# 此处不再重复生成。
+# 同一次构建推送 ghcr 与 Docker Hub，附带 SBOM 与 provenance attestation。
+# GitHub Release 由 release-please 创建，此处不再重复生成。
 
 on:
   push:
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
+  DOCKERHUB_IMAGE: arcreel/arcreel
 
 jobs:
   build-and-release:
@@ -45,6 +46,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # 闸门逐架构构建并扫描：架构间基础镜像层与二进制包可能不同，
       # 只扫 amd64 会放过仅存在于 arm64 变体的可修复漏洞。构建层进
@@ -119,7 +125,9 @@ jobs:
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+            ${{ env.DOCKERHUB_IMAGE }}
           # latest 交由 metadata-action 默认 flavor（latest=auto）：仅稳定
           # semver tag 生成，预发布 tag（如 v1.2.3-rc.1）只推版本标签
           tags: |
@@ -128,6 +136,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build & push multi-arch image with SBOM and provenance
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -140,3 +149,23 @@ jobs:
           cache-from: |
             type=gha,scope=release-amd64
             type=gha,scope=release-arm64
+
+      # 双推是同一次构建的产物，digest 理论上必然相同；这一步是「同步确实发生了」
+      # 的唯一凭证，Docker Hub 侧静默失配时立即让发布失败而不是等用户报障
+      - name: Assert both registries carry the same digest
+        env:
+          GHCR_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          DOCKERHUB_REF: ${{ env.DOCKERHUB_IMAGE }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          ghcr_digest=$(docker buildx imagetools inspect "${GHCR_REF}:${VERSION}" --format '{{.Manifest.Digest}}')
+          hub_digest=$(docker buildx imagetools inspect "${DOCKERHUB_REF}:${VERSION}" --format '{{.Manifest.Digest}}')
+          echo "build:      ${BUILD_DIGEST}"
+          echo "ghcr:       ${ghcr_digest}"
+          echo "docker hub: ${hub_digest}"
+          if [ "$ghcr_digest" != "$BUILD_DIGEST" ] || [ "$hub_digest" != "$BUILD_DIGEST" ]; then
+            echo "::error::registry digests diverge from the build output"
+            exit 1
+          fi

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,7 +18,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  DOCKERHUB_IMAGE: arcreel/arcreel
 
 jobs:
   build-and-release:
@@ -32,6 +31,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Docker Hub 命名空间与 GitHub 组织同名，两个 registry 共用这一份小写仓库名；
+      # fork 因此自动指向自己的命名空间，不会继承上游的推送目标
       - name: Compute lowercase image name
         run: echo "IMAGE_NAME_LC=${REPO,,}" >> "$GITHUB_ENV"
         env:
@@ -41,13 +42,15 @@ jobs:
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -127,7 +130,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
-            ${{ env.DOCKERHUB_IMAGE }}
+            docker.io/${{ env.IMAGE_NAME_LC }}
           # latest 交由 metadata-action 默认 flavor（latest=auto）：仅稳定
           # semver tag 生成，预发布 tag（如 v1.2.3-rc.1）只推版本标签
           tags: |
@@ -151,21 +154,27 @@ jobs:
             type=gha,scope=release-arm64
 
       # 双推是同一次构建的产物，digest 理论上必然相同；这一步是「同步确实发生了」
-      # 的唯一凭证，Docker Hub 侧静默失配时立即让发布失败而不是等用户报障
-      - name: Assert both registries carry the same digest
+      # 的唯一凭证，逐一核对 metadata-action 产出的每个标签——只验版本标签会放过
+      # latest / {{major}} 在某个 registry 未落地的情况，而 latest 正是默认拉取入口
+      - name: Assert every pushed tag resolves to the build digest
         env:
-          GHCR_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
-          DOCKERHUB_REF: ${{ env.DOCKERHUB_IMAGE }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          TAGS: ${{ steps.meta.outputs.tags }}
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          ghcr_digest=$(docker buildx imagetools inspect "${GHCR_REF}:${VERSION}" --format '{{.Manifest.Digest}}')
-          hub_digest=$(docker buildx imagetools inspect "${DOCKERHUB_REF}:${VERSION}" --format '{{.Manifest.Digest}}')
-          echo "build:      ${BUILD_DIGEST}"
-          echo "ghcr:       ${ghcr_digest}"
-          echo "docker hub: ${hub_digest}"
-          if [ "$ghcr_digest" != "$BUILD_DIGEST" ] || [ "$hub_digest" != "$BUILD_DIGEST" ]; then
-            echo "::error::registry digests diverge from the build output"
+          echo "build digest: ${BUILD_DIGEST}"
+          failed=0
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+            if [ "$digest" = "$BUILD_DIGEST" ]; then
+              printf '  ok   %s\n' "$tag"
+            else
+              printf '  FAIL %s -> %s\n' "$tag" "$digest"
+              failed=1
+            fi
+          done <<< "$TAGS"
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::pushed tags diverge from the build digest"
             exit 1
           fi

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -5,8 +5,7 @@ name: Docker Hub Description
 # 还给发布多一个可能失败的点。
 #
 # 该 action 调用 Docker Hub 的仓库元数据接口，要求 PAT 具备 read/write/delete
-# 作用域，比发布用的 DOCKERHUB_TOKEN（read/write）更宽，故用独立 secret 承载：
-# 发布管线不持有 delete 权限。
+# 作用域；DOCKERHUB_TOKEN 按这里的要求取该作用域，发布流程共用同一份。
 
 on:
   push:
@@ -41,7 +40,7 @@ jobs:
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.IMAGE_NAME_LC }}
           readme-filepath: ./docs/dockerhub-README.md
           short-description: "Open-source, self-hosted AI video production workspace — novels and scripts to editable videos"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,39 @@
+name: Docker Hub Description
+
+# 把 docs/dockerhub-README.md 同步为 Docker Hub 仓库页的描述。描述是低频改动，
+# 不挂在发布流程上：绑在 release 里等于每次发布都做一次无意义的 API 写入，
+# 还给发布多一个可能失败的点。
+#
+# 该 action 调用 Docker Hub 的仓库元数据接口，要求 PAT 具备 read/write/delete
+# 作用域，比发布用的 DOCKERHUB_TOKEN（read/write）更宽，故用独立 secret 承载。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/dockerhub-README.md"
+      - ".github/workflows/dockerhub-description.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: dockerhub-description
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN }}
+          repository: arcreel/arcreel
+          readme-filepath: ./docs/dockerhub-README.md
+          short-description: "Open-source, self-hosted AI video production workspace — novels and scripts to editable videos"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -5,7 +5,8 @@ name: Docker Hub Description
 # 还给发布多一个可能失败的点。
 #
 # 该 action 调用 Docker Hub 的仓库元数据接口，要求 PAT 具备 read/write/delete
-# 作用域，比发布用的 DOCKERHUB_TOKEN（read/write）更宽，故用独立 secret 承载。
+# 作用域，比发布用的 DOCKERHUB_TOKEN（read/write）更宽，故用独立 secret 承载：
+# 发布管线不持有 delete 权限。
 
 on:
   push:
@@ -30,10 +31,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+      # 与 docker-release.yml 同一份坐标来源：Docker Hub 命名空间与 GitHub 组织同名
+      - name: Compute lowercase image name
+        run: echo "IMAGE_NAME_LC=${REPO,,}" >> "$GITHUB_ENV"
+        env:
+          REPO: ${{ github.repository }}
+
+      - name: Sync repository description to Docker Hub
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DESCRIPTION_TOKEN }}
-          repository: arcreel/arcreel
+          repository: ${{ env.IMAGE_NAME_LC }}
           readme-filepath: ./docs/dockerhub-README.md
           short-description: "Open-source, self-hosted AI video production workspace — novels and scripts to editable videos"

--- a/README.en.md
+++ b/README.en.md
@@ -25,7 +25,7 @@
   <a href="https://github.com/ArcReel/ArcReel/releases/latest"><img src="https://img.shields.io/github/v/release/ArcReel/ArcReel?style=flat-square&label=release" alt="Release"></a>
   <a href="https://github.com/ArcReel/ArcReel/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/test.yml?style=flat-square&label=tests" alt="Tests"></a>
   <a href="https://codecov.io/gh/ArcReel/ArcReel"><img src="https://img.shields.io/codecov/c/github/ArcReel/ArcReel?style=flat-square&label=coverage" alt="Coverage"></a>
-  <a href="https://github.com/ArcReel/ArcReel/pkgs/container/arcreel"><img src="https://img.shields.io/badge/Docker-ghcr.io-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker"></a>
+  <a href="https://hub.docker.com/r/arcreel/arcreel"><img src="https://img.shields.io/docker/pulls/arcreel/arcreel?style=flat-square&logo=docker&logoColor=white&label=docker%20pulls" alt="Docker"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-2ea44f?style=flat-square" alt="License"></a>
   <a href="https://github.com/ArcReel/ArcReel"><img src="https://img.shields.io/github/stars/ArcReel/ArcReel?style=flat-square" alt="Stars"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://github.com/ArcReel/ArcReel/releases/latest"><img src="https://img.shields.io/github/v/release/ArcReel/ArcReel?style=flat-square&label=release" alt="Release"></a>
   <a href="https://github.com/ArcReel/ArcReel/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/ArcReel/ArcReel/test.yml?style=flat-square&label=tests" alt="Tests"></a>
   <a href="https://codecov.io/gh/ArcReel/ArcReel"><img src="https://img.shields.io/codecov/c/github/ArcReel/ArcReel?style=flat-square&label=coverage" alt="Coverage"></a>
-  <a href="https://github.com/ArcReel/ArcReel/pkgs/container/arcreel"><img src="https://img.shields.io/badge/Docker-ghcr.io-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker"></a>
+  <a href="https://hub.docker.com/r/arcreel/arcreel"><img src="https://img.shields.io/docker/pulls/arcreel/arcreel?style=flat-square&logo=docker&logoColor=white&label=docker%20pulls" alt="Docker"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-2ea44f?style=flat-square" alt="License"></a>
   <a href="https://github.com/ArcReel/ArcReel"><img src="https://img.shields.io/github/stars/ArcReel/ArcReel?style=flat-square" alt="Stars"></a>
 </p>

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   arcreel:
-    image: ghcr.io/arcreel/arcreel:latest
+    image: arcreel/arcreel:latest
     # build: ../  # 本地构建时取消注释，注释掉 image 行
     ports:
       - "1241:1241"

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   arcreel:
-    image: ghcr.io/arcreel/arcreel:latest
+    image: arcreel/arcreel:latest
     ports:
       - "1241:1241"
     env_file: .env

--- a/docs/dockerhub-README.md
+++ b/docs/dockerhub-README.md
@@ -13,7 +13,7 @@ An open-source, self-hosted AI video production workspace. Turn novels, finished
 | Tag | Meaning |
 |---|---|
 | `latest` | The most recent stable release |
-| `X.Y.Z` | An exact release, e.g. `0.28.0` |
+| `X.Y.Z` | An exact release |
 | `X.Y` | The latest patch of that minor line |
 | `X` | The latest release of that major line |
 

--- a/docs/dockerhub-README.md
+++ b/docs/dockerhub-README.md
@@ -1,0 +1,49 @@
+# ArcReel
+
+> 中文说明见[项目文档](https://docs.arc-reel.com/)与 [GitHub 仓库](https://github.com/ArcReel/ArcReel)。
+
+An open-source, self-hosted AI video production workspace. Turn novels, finished screenplays, or product assets into character-consistent, controllable, cost-trackable short videos that remain editable.
+
+- **Source**: https://github.com/ArcReel/ArcReel
+- **Documentation**: https://docs.arc-reel.com/en/
+- **License**: AGPL-3.0
+
+## Supported tags
+
+| Tag | Meaning |
+|---|---|
+| `latest` | The most recent stable release |
+| `X.Y.Z` | An exact release, e.g. `0.28.0` |
+| `X.Y` | The latest patch of that minor line |
+| `X` | The latest release of that major line |
+
+Images are published for `linux/amd64` and `linux/arm64`, with SBOM and provenance attestations attached.
+
+## Quick start
+
+Compose is the supported way to run ArcReel — the application needs a database, a data volume, and specific kernel capabilities for its sandbox:
+
+```bash
+git clone https://github.com/ArcReel/ArcReel.git
+cd ArcReel/deploy
+
+cp .env.example .env
+docker compose up -d
+```
+
+Open <http://localhost:1241>. The default username is `admin`. If `AUTH_PASSWORD` is empty, ArcReel generates a password on first startup and writes it back to `deploy/.env`.
+
+> Default Compose publishes port `1241` on all host interfaces. Do not expose ArcReel directly to the public Internet; before enabling remote access, configure authentication and use HTTPS, a VPN, or a secure tunnel.
+
+For the complete first-run walkthrough see [Getting Started](https://docs.arc-reel.com/en/guide/getting-started); for production deployment, upgrades, backups, and reverse proxies see [Deployment and Operations](https://docs.arc-reel.com/en/ops/deployment).
+
+## What you get
+
+- **One production workflow**: turn novels, finished screenplays, or product assets into characters, scenes, props, storyboards, video clips, and final videos step by step.
+- **Visual continuity with human control**: reuse reference assets across shots, review key stages, regenerate individual assets, and roll back to earlier versions.
+- **Manageable models and costs**: configure text, image, video, and TTS capabilities in one place, then review estimated costs and actual usage.
+- **Editable delivery**: render final videos directly or export Jianying drafts to refine subtitles, voice-over, pacing, and transitions.
+
+## Support
+
+Reproducible bugs and focused feature requests are welcome in [GitHub Issues](https://github.com/ArcReel/ArcReel/issues).

--- a/website/docs/ops/deployment.md
+++ b/website/docs/ops/deployment.md
@@ -291,7 +291,7 @@ curl -f http://localhost:1241/health
 将 Compose 中的镜像改为：
 
 ```yaml
-image: ghcr.io/arcreel/arcreel:vX.Y.Z
+image: arcreel/arcreel:X.Y.Z
 ```
 
 升级时显式修改版本，可以降低无意中拉取新版本的风险。

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/ops/deployment.md
@@ -290,7 +290,7 @@ If a project migration fails, preserve the files and inspect the startup logs. D
 Change the image in Compose to:
 
 ```yaml
-image: ghcr.io/arcreel/arcreel:vX.Y.Z
+image: arcreel/arcreel:X.Y.Z
 ```
 
 Explicitly changing the version when upgrading reduces the risk of unintentionally pulling a new version.


### PR DESCRIPTION
## 变更

正式发布（`v*` tag）在同一次构建中推送 ghcr 与 Docker Hub：

- `metadata-action` 增加 Docker Hub 坐标，新增 Docker Hub 登录步骤
- 两个 registry 共用已算好的小写仓库名，不硬编码字面量——fork 自动指向自身命名空间
- SBOM 与 provenance 两边都带
- 末尾逐一核对 `metadata-action` 产出的**每个**标签，digest 与构建输出不符则发布失败
- `docker-edge.yml` 不动，edge 镜像仍只推 ghcr

面向用户的镜像坐标统一为 `arcreel/arcreel`：README / README.en 徽章、`deploy/docker-compose.yml`、`deploy/production/docker-compose.yml`、`website/docs/ops/deployment.md` 及 en 翻译。

顺带修正：部署文档「固定版本」示例原为 `:vX.Y.Z`，但 `metadata-action` 的 `{{version}}` 产出的是无 `v` 前缀的 `X.Y.Z`，原示例拉不到镜像。

新增 `docs/dockerhub-README.md`（英文为主，顶部一行中文指引，全绝对链接）与仅在该文件变更时触发的同步 workflow。

## 失败语义

Docker Hub 推送失败会让整个 release job 标红——发布产物两边不一致应当被看见，不用 `continue-on-error` 吞掉。重跑幂等，代价是一次构建时间。

## 合并前需要配置的 secret

| Secret | 值 |
|---|---|
| `DOCKERHUB_USERNAME` | Docker Hub 用户名 |
| `DOCKERHUB_TOKEN` | PAT，作用域 read/write/delete |

两个 workflow 共用这一份。delete 作用域是描述同步 action 的硬要求（它写仓库元数据）；发布流程因此也持有该权限，取舍为可接受：fork PR 拿不到 secret，`docker-release.yml` 只在 `v*` tag 推送时运行。

`dockerhub-description.yml` 在本 PR 合入后会立即触发（它的 `paths` 命中本 PR 新增的描述文件），secret 未配置则该次运行会失败。

## 配套的一次性人工操作

清理 Docker Hub `arcreel` 命名空间下的历史遗留镜像，并从 ghcr 按 digest 回填 0.24–0.28 的版本标签及 `0` / `latest`。**须在合入前完成**——compose 已指向 `arcreel/arcreel:latest`，回填是它在下一次发版前存在的前提。脚本不入库。

Closes #2239

https://claude.ai/code/session_01E1YiXTYkeNfe9DkK9BgUaH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新特性**
  * Docker 镜像现已发布至 Docker Hub，并支持多种版本标签。
  * 新增 Docker Hub 项目说明，涵盖快速启动、平台支持与安全提示。

* **改进**
  * Docker Compose 和部署文档已切换为使用 Docker Hub 镜像。
  * README 徽章现显示 Docker Hub 链接及实时拉取次数。
  * 发布流程会校验所有镜像标签对应的构建摘要。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->