### PR TITLE
ci: basedpyright warning 全面阻断，unused/unreachable/deprecated 进闸门并清零存量

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         run: uv run ruff check . && uv run ruff format --check .
 
       - name: Type check (basedpyright)
-        run: uv run basedpyright
+        run: uv run basedpyright --warnings
 
       - name: Import layering (import-linter)
         run: uv run lint-imports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
       - id: basedpyright
         name: basedpyright (full project type check)
-        entry: uv run basedpyright
+        entry: uv run basedpyright --warnings
         language: system
         pass_filenames: false
         always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ AI 视频创作平台，将小说、剧本或创作构想转化为短视频。�
 后端使用 `uv`，前端与文档站使用 `pnpm`。修改代码或测试时，先按 `CONTRIBUTING.md`「测试选择」运行相关测试；任务完成和 push 前执行受影响域的全量闸门：
 
 ```bash
-uv run ruff check . && uv run ruff format . && uv run basedpyright && uv run lint-imports && uv run deptry lib server alembic scripts tests && uv run python -m pytest -n 4 --dist loadfile
+uv run ruff check . && uv run ruff format . && uv run basedpyright --warnings && uv run lint-imports && uv run deptry lib server alembic scripts tests && uv run python -m pytest -n 4 --dist loadfile
 uv run python scripts/audit_tests.py --check   # 改动测试文件时；同时扫后端 tests/ 与前端 *.test.*
 uv run pre-commit run --all-files actionlint && uv run pre-commit run --all-files zizmor   # 改动 .github/ 时
 (cd frontend && pnpm check)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 ## 代码质量
 
-工具报出的问题一律改代码，不加 baseline 或计数阈值。抑制注释只用于工具已确认的误报，且必须行内带理由：ruff 写 `# noqa: X -- 理由`，basedpyright 写 `# pyright: ignore[X]  # 理由`（典型场景是第三方 untyped 库；同一注册块内成批重复的同一条误报例外，理由写在块开头一条注释里，见下方「类型检查」节的 `reportUnusedFunction`），zizmor 写 `# zizmor: ignore[X] 理由`（放在被报告的 YAML 键所在行），actionlint 见下方「Workflow 语法与安全」，deptry 见下方「依赖卫生」，knip 写导出上方的 `/** @public 理由 */`，ESLint 见下方「ESLint disable 使用规范」。策略阈值类 finding（如 Dependabot 冷却期天数）按工具要求调整配置，不用豁免绕过。
+工具报出的问题一律改代码，不加 baseline 或计数阈值。抑制注释只用于工具已确认的误报，且必须行内带理由：ruff 写 `# noqa: X -- 理由`，basedpyright 写 `# pyright: ignore[X]  # 理由`（典型场景是第三方 untyped 库；装饰器注册块内重复的同一条误报例外——无论块内是一条还是数十条，理由统一写在块开头一条注释里，不在每行重复，见下方「类型检查」节的 `reportUnusedFunction`），zizmor 写 `# zizmor: ignore[X] 理由`（放在被报告的 YAML 键所在行），actionlint 见下方「Workflow 语法与安全」，deptry 见下方「依赖卫生」，knip 写导出上方的 `/** @public 理由 */`，ESLint 见下方「ESLint disable 使用规范」。策略阈值类 finding（如 Dependabot 冷却期天数）按工具要求调整配置，不用豁免绕过。
 
 **Lint & Format（ruff）：**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 - **优先级**：真实对象（内存 SQLite、`tmp_path`）＞ `tests/fakes.py` 手写替身（收录边界见其模块 docstring）＞ 带 `spec`/`autospec` 的 Mock ＞ 裸 `MagicMock`/`AsyncMock`。Mock 只替换仓库边界（第三方 SDK、网络传输、子进程、文件系统、时钟）；仓库内协作者用真实对象或手写 fake。
 - **禁止 patch 生产代码私有符号**（闸门，无豁免）：`patch("lib.x._y")`、`monkeypatch.setattr(mod, "_y")`、`patch.object(Cls, "_y")` 三种形式一律禁止。需要控制内部行为时走 seam。
 - **seam 即显式参数注入**：构造参数或关键字参数，带生产默认值，不改变生产行为，如 `retry_async(operation, *, clock=..., jitter=...)`；不引入模块级可替换全局。适用范围：轮询时钟/间隔/退避、能力解析器、HTTP 探测客户端、文件系统与子进程。
+- **进程级缓存的重置钩子取公开名**：生产模块用 `functools.cache` 之类的进程级缓存时，为测试暴露的重置入口写成公开的 `reset_*_for_tests()`（如 `lib.app_data_dir.reset_for_tests`），不写下划线私有名——测试 import 私有符号既撞上上一条禁令，也会被 basedpyright 的 `reportUnusedFunction` 判成死代码。钩子只清缓存、不改生产行为。它是过渡形态，新代码优先按上一条做参数注入。
 - **出站 HTTP 断言用 respx**：保留真实 httpx 客户端，在 transport 层拦截（`AsyncOpenAI` 流量同样被捕获），断言真实序列化后的请求。
 - **patch 收编**（闸门）：同一 patch 目标字符串出现在 ≥3 个测试文件时收编为共享 fixture / helper，各文件不再各自定义；FastAPI 路由依赖优先 `app.dependency_overrides` 而非 patch。
 
@@ -151,7 +152,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 ## 代码质量
 
-工具报出的问题一律改代码，不加 baseline 或计数阈值。抑制注释只用于工具已确认的误报，且必须行内带理由：ruff 写 `# noqa: X -- 理由`，basedpyright 写 `# pyright: ignore[X]  # 理由`（典型场景是第三方 untyped 库），zizmor 写 `# zizmor: ignore[X] 理由`（放在被报告的 YAML 键所在行），actionlint 见下方「Workflow 语法与安全」，deptry 见下方「依赖卫生」，knip 写导出上方的 `/** @public 理由 */`，ESLint 见下方「ESLint disable 使用规范」。策略阈值类 finding（如 Dependabot 冷却期天数）按工具要求调整配置，不用豁免绕过。
+工具报出的问题一律改代码，不加 baseline 或计数阈值。抑制注释只用于工具已确认的误报，且必须行内带理由：ruff 写 `# noqa: X -- 理由`，basedpyright 写 `# pyright: ignore[X]  # 理由`（典型场景是第三方 untyped 库；同一注册块内成批重复的同一条误报例外，理由写在块开头一条注释里，见下方「类型检查」节的 `reportUnusedFunction`），zizmor 写 `# zizmor: ignore[X] 理由`（放在被报告的 YAML 键所在行），actionlint 见下方「Workflow 语法与安全」，deptry 见下方「依赖卫生」，knip 写导出上方的 `/** @public 理由 */`，ESLint 见下方「ESLint disable 使用规范」。策略阈值类 finding（如 Dependabot 冷却期天数）按工具要求调整配置，不用豁免绕过。
 
 **Lint & Format（ruff）：**
 
@@ -171,7 +172,9 @@ uv run basedpyright --warnings
 ```
 
 - standard 模式 + `reportMissingTypeStubs = false`；`--warnings` 让 warning 也返回非 0，CI 与 pre-push hook 均以此执行全量扫描，闸门判据是 error 与 warning 双零
-- 额外开启 `reportUnnecessaryIsInstance` / `reportUnnecessaryComparison` / `reportUnnecessaryTypeIgnoreComment` / `reportUnusedImport` / `reportUnusedVariable` / `reportUnusedClass` / `reportDeprecated`，级别 warning
+- 额外开启 `reportUnnecessaryIsInstance` / `reportUnnecessaryComparison` / `reportUnnecessaryTypeIgnoreComment` / `reportUnusedImport` / `reportUnusedVariable` / `reportUnusedClass` / `reportUnusedFunction` / `reportUnreachable` / `reportDeprecated`，级别 warning
+- `reportUnreachable` 不用忽略注释绕过：穷尽分支后的防御性兜底改 `assert_never(x)`，真正的死分支删除；回调里产出、外层消费的结果用单元素列表当信箱，别写 `x: T | None = None` + `nonlocal`（basedpyright 不跟踪回调里的赋值，会把外层的空值判定当成恒真）
+- `reportUnusedFunction` 把函数作用域内的任何符号一律判为私有，装饰器就地注册的处理器（`@app.exception_handler`、`@router.*`、`@server.tool`、`@event.listens_for`）因此被误报：逐个挂 `# pyright: ignore[reportUnusedFunction]`，并在注册块开头写一条注释说明理由。模块级的 `_` 前缀函数若被别的模块 import，改公开名而不是加豁免；模块级 pytest fixture 同理取公开名（由 pytest 按名收集、无人 import，本规则一律判它未被访问）
 - tests/ 内 `reportOptional*`、`reportArgumentType`、`reportAttributeAccessIssue` 等设为 `none`（不做闸门）：测试的断言式访问与 mock 返回值 narrow 噪声大。scripts/ 与 alembic/ 的 `reportMissingImports` 同理，两处都用 `sys.path` 注入或运行期注入符号，静态不可解析
 - 标注表达期望、判定负责实际：从磁盘 JSON 重建的数据类，其构造期形状校验走 `lib/schema_guards.py`（谓词以 `object` 收参），不要写成对自身标注的同义反复；只校验外层容器类型的访问器把元素标注写成 `Any`，别写成 `dict[str, Any]`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,18 +159,21 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 uv run ruff check . && uv run ruff format .
 ```
 
-- 规则集：`E`/`F`/`I`/`UP`，忽略 `E402` 和 `E501`
+- 规则集：`E`/`F`/`I`/`UP`/`B`/`C4`/`PIE`/`PT`/`RET`/`PERF`/`RUF`/`SIM`/`ASYNC`；忽略 `E402`、`E501` 与 `RUF001`-`RUF003`（中文全角标点被判「易混淆 unicode」，对中文仓库是噪音）
+- FastAPI 的 `Depends`/`Query` 等在参数默认值处调用属惯用法，已登记进 `flake8-bugbear.extend-immutable-calls`，无需逐处 `noqa: B008`
 - line-length：120
 - CI 中强制检查：`ruff check . && ruff format --check .`
 
 **类型检查（basedpyright）：**
 
 ```bash
-uv run basedpyright
+uv run basedpyright --warnings
 ```
 
-- standard 模式 + `reportMissingTypeStubs = false`，CI 强制 0 error，pre-push hook 执行全量扫描
-- tests/ 内 `reportOptional*` 和 `unknown*` 系列降级为 warning，避免大量使用 mock 的测试产生噪声
+- standard 模式 + `reportMissingTypeStubs = false`；`--warnings` 让 warning 也返回非 0，CI 与 pre-push hook 均以此执行全量扫描，闸门判据是 error 与 warning 双零
+- 额外开启 `reportUnnecessaryIsInstance` / `reportUnnecessaryComparison` / `reportUnnecessaryTypeIgnoreComment` / `reportUnusedImport` / `reportUnusedVariable` / `reportUnusedClass` / `reportDeprecated`，级别 warning
+- tests/ 内 `reportOptional*`、`reportArgumentType`、`reportAttributeAccessIssue` 等设为 `none`（不做闸门）：测试的断言式访问与 mock 返回值 narrow 噪声大。scripts/ 与 alembic/ 的 `reportMissingImports` 同理，两处都用 `sys.path` 注入或运行期注入符号，静态不可解析
+- 标注表达期望、判定负责实际：从磁盘 JSON 重建的数据类，其构造期形状校验走 `lib/schema_guards.py`（谓词以 `object` 收参），不要写成对自身标注的同义反复；只校验外层容器类型的访问器把元素标注写成 `Any`，别写成 `dict[str, Any]`
 
 **Import 分层契约（import-linter）：**
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,13 +11,15 @@ from logging.config import fileConfig
 from sqlalchemy import DateTime, String, pool
 from sqlalchemy.ext.asyncio import create_async_engine
 
-import lib.agent_session_store.models  # 副作用导入：注册 agent_session 表
-
-# Import all models so their tables are included in metadata
-import lib.db.models  # noqa: F401
 from alembic import context
+from lib.agent_session_store.models import register_models as register_agent_session_models
 from lib.db.base import Base
 from lib.db.engine import get_database_url
+from lib.db.models import register_models as register_db_models
+
+# 把全部 ORM 模型登记到 Base.metadata，否则 autogenerate 的对比范围取决于 import 链
+register_agent_session_models()
+register_db_models()
 
 # Alembic Config object
 config = context.config

--- a/lib/agent_session_store/models.py
+++ b/lib/agent_session_store/models.py
@@ -52,3 +52,11 @@ class AgentSessionSummary(TimestampMixin, UserOwnedMixin, Base):
     session_id: Mapped[str] = mapped_column(String, primary_key=True)
     mtime_ms: Mapped[int] = mapped_column(BigInteger, nullable=False)
     data: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+
+def register_models() -> None:
+    """把 agent_session 相关 ORM 模型登记到 ``Base.metadata``。
+
+    登记发生在 import 本模块时（模型类定义即注册），本函数不做额外工作；
+    调用它是为了让「因副作用而 import」在调用点显式可见。
+    """

--- a/lib/app_data_dir.py
+++ b/lib/app_data_dir.py
@@ -42,6 +42,6 @@ def app_data_dir() -> Path:
     return default
 
 
-def _reset_for_tests() -> None:
+def reset_for_tests() -> None:
     """Clear the cached value so tests can monkeypatch env between cases."""
     app_data_dir.cache_clear()

--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -349,10 +349,7 @@ def prepare_episode_script_manifest_commit(
     remaining_ids = frozenset(resource_ids)
     removed_ids = frozenset(removed_resource_ids)
     replaced_ids = frozenset(replaced_resource_ids)
-    if any(
-        not isinstance(resource_id, str) or not resource_id
-        for resource_id in (*remaining_ids, *removed_ids, *replaced_ids)
-    ):
+    if any(not resource_id for resource_id in (*remaining_ids, *removed_ids, *replaced_ids)):
         raise ValueError("script resource identities must be non-empty strings")
 
     storage = adapter or ProjectArtifactManifestAdapter(project_dir)

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -18,7 +18,7 @@ import tempfile
 import threading
 import time
 import unicodedata
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
@@ -36,6 +36,7 @@ from lib.content_digest import (
     digest_stream,
     prefixed,
 )
+from lib.schema_guards import is_str
 
 _KEY_PREFIX = "artifact-key-v1:"
 MANIFEST_FILENAME = ".arcreel_artifacts.json"
@@ -241,8 +242,6 @@ class ArtifactManifest:
         self._adapter = adapter
 
     def register(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> bool:
-        if not isinstance(basis, ArtifactBasis):
-            raise TypeError("basis must be an ArtifactBasis")
         return self.register_descriptor(
             key,
             artifact_path=artifact_path,
@@ -263,8 +262,6 @@ class ArtifactManifest:
         guessing the original input payload during resume and restore.
         """
 
-        if not isinstance(basis, ArtifactBasisDescriptor):
-            raise TypeError("basis must be an ArtifactBasisDescriptor")
         observation = self._adapter.inspect_artifact(artifact_path)
         if observation.blocker is not None:
             raise ArtifactRegistrationError(observation.blocker.detail)
@@ -287,8 +284,6 @@ class ArtifactManifest:
     ) -> bool:
         """Register a descriptor while restoring the exact prior entry on error."""
 
-        if not isinstance(basis, ArtifactBasisDescriptor):
-            raise TypeError("basis must be an ArtifactBasisDescriptor")
         previous = self._adapter.get_entry(key)
         expected = ArtifactManifestEntry(
             artifact_path=normalize_artifact_path(artifact_path),
@@ -433,8 +428,6 @@ class ArtifactManifest:
         )
 
     def compare(self, key: ArtifactKey, *, artifact_path: str, basis: ArtifactBasis) -> ArtifactComparison:
-        if not isinstance(basis, ArtifactBasis):
-            raise TypeError("basis must be an ArtifactBasis")
         return self.compare_entry(
             key,
             artifact_path=artifact_path,
@@ -1237,7 +1230,7 @@ class ProjectArtifactManifestAdapter:
             return True
 
     @contextmanager
-    def _locked(self) -> Iterator[int | None]:
+    def _locked(self) -> Generator[int | None]:
         lock_path = self._project_dir / LOCK_FILENAME
         with contextlib.ExitStack() as root_stack:
             root_fd: int | None = None
@@ -1307,7 +1300,7 @@ class ProjectArtifactManifestAdapter:
                     os.close(root_fd)
 
     @contextmanager
-    def _guard_portable_project_root(self) -> Iterator[None]:
+    def _guard_portable_project_root(self) -> Generator[None]:
         windows_handle = _open_windows_directory_handle(self._project_dir) if os.name == "nt" else None
         try:
             self._assert_portable_project_root_identity()
@@ -1519,17 +1512,15 @@ class ArtifactBasisDescriptor:
     digest: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.kind, str) or not self.kind:
+        if not is_str(self.kind) or not self.kind:
             raise ValueError("artifact basis descriptor kind must be a non-empty string")
         if type(self.kind_version) is not int or self.kind_version < 1:
             raise ValueError("artifact basis descriptor kind_version must be a positive integer")
-        if not isinstance(self.digest, str) or PREFIXED_DIGEST_RE.fullmatch(self.digest) is None:
+        if not is_str(self.digest) or PREFIXED_DIGEST_RE.fullmatch(self.digest) is None:
             raise ValueError("artifact basis descriptor digest must be a canonical sha256-v1 digest")
 
     @classmethod
     def from_basis(cls, basis: ArtifactBasis) -> Self:
-        if not isinstance(basis, ArtifactBasis):
-            raise TypeError("basis must be an ArtifactBasis")
         return cls(kind=basis.kind, kind_version=basis.kind_version, digest=basis.digest)
 
     @classmethod
@@ -1587,9 +1578,7 @@ def _coerce_artifact_basis_descriptor(
 ) -> ArtifactBasisDescriptor:
     if isinstance(value, ArtifactBasis):
         return ArtifactBasisDescriptor.from_basis(value)
-    if isinstance(value, ArtifactBasisDescriptor):
-        return value
-    raise TypeError(f"{field} must be an ArtifactBasis or ArtifactBasisDescriptor")
+    return value
 
 
 def _coerce_optional_artifact_basis_descriptor(
@@ -1887,10 +1876,6 @@ def _encode_target_entries(
 ) -> dict[str, ArtifactManifestEntry]:
     encoded: dict[str, ArtifactManifestEntry] = {}
     for key, entry in entries.items():
-        if not isinstance(key, ArtifactKey):
-            raise TypeError("manifest target keys must be ArtifactKey values")
-        if not isinstance(entry, ArtifactManifestEntry):
-            raise TypeError("manifest target entries must be ArtifactManifestEntry values")
         normalized_path = normalize_artifact_path(entry.artifact_path)
         if normalized_path != entry.artifact_path:
             raise ValueError("manifest target artifact path must be canonical")
@@ -1912,8 +1897,6 @@ def _encode_optional_entries(
     encoded_present = _encode_target_entries(present)
     encoded: dict[str, ArtifactManifestEntry | None] = {}
     for key, entry in entries.items():
-        if not isinstance(key, ArtifactKey):
-            raise TypeError("manifest compare-and-swap keys must be ArtifactKey values")
         encoded[key.encode()] = encoded_present.get(key.encode()) if entry is not None else None
     return encoded
 
@@ -1963,9 +1946,7 @@ def encode_artifact_manifest_payload(
     encoded = _encode_target_entries(snapshot.entries)
     content_digests: dict[str, str] = {}
     for key, digest in snapshot.content_digests.items():
-        if not isinstance(key, ArtifactKey):
-            raise TypeError("archive artifact content digest keys must be ArtifactKey values")
-        if not isinstance(digest, str) or CONTENT_DIGEST_RE.fullmatch(digest) is None:
+        if CONTENT_DIGEST_RE.fullmatch(digest) is None:
             raise ValueError("archive artifact content digest must be a lowercase SHA-256 digest")
         content_digests[key.encode()] = digest
     if set(content_digests) != set(encoded):

--- a/lib/artifact_planner.py
+++ b/lib/artifact_planner.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -289,7 +289,7 @@ class TargetStatePlanner:
         self._episodes_loaded = True
 
     @contextmanager
-    def _episode_context(self, binding: _EpisodeBinding) -> Iterator[None]:
+    def _episode_context(self, binding: _EpisodeBinding) -> Generator[None]:
         """Name the episode and script a preflight rejection came from.
 
         Only active while planning a target state: the runtime resolve paths

--- a/lib/asset_inventory.py
+++ b/lib/asset_inventory.py
@@ -63,11 +63,10 @@ def complete_asset_inventory(
 
     prepared = _prepare_entries(entries)
 
-    result: AssetInventoryCompletion | None = None
+    completed: list[AssetInventoryCompletion] = []
     project_path = pm.get_project_path(project_name)
 
     def _mutate(project: dict[str, Any]) -> None:
-        nonlocal result
         revision = compute_source_revision(project_path, project, scope)
         if revision.blockers:
             raise AssetInventorySourceBlocked(revision.blockers)
@@ -109,20 +108,22 @@ def complete_asset_inventory(
             "source_revision": revision.revision,
             "completed_at": datetime.now(UTC).isoformat(),
         }
-        result = AssetInventoryCompletion(
-            scope=completed_scope,
-            source_revision=revision.revision,
-            counts={
-                "characters": _bucket_count(project.get("characters")),
-                "scenes": _bucket_count(project.get("scenes")),
-                "props": _bucket_count(project.get("props")),
-            },
+        completed.append(
+            AssetInventoryCompletion(
+                scope=completed_scope,
+                source_revision=revision.revision,
+                counts={
+                    "characters": _bucket_count(project.get("characters")),
+                    "scenes": _bucket_count(project.get("scenes")),
+                    "props": _bucket_count(project.get("props")),
+                },
+            )
         )
 
     pm.update_project(project_name, _mutate)
-    if result is None:  # pragma: no cover - update_project always invokes the callback or raises
+    if not completed:  # pragma: no cover - update_project always invokes the callback or raises
         raise RuntimeError("asset inventory completion did not run")
-    return result
+    return completed[0]
 
 
 def _prepare_entries(entries: object) -> dict[str, dict[str, dict[str, Any]]]:

--- a/lib/asset_types.py
+++ b/lib/asset_types.py
@@ -289,7 +289,7 @@ def normalize_asset_bucket(bucket: object) -> dict[str, Any]:
     """
     if not isinstance(bucket, dict):
         return {}
-    return {normalize_asset_name(str(name)): item for name, item in bucket.items()}  # pyright: ignore[reportUnknownVariableType]
+    return {normalize_asset_name(str(name)): item for name, item in bucket.items()}
 
 
 def resolve_asset_key(bucket: object, name: str) -> str | None:

--- a/lib/audio_utils.py
+++ b/lib/audio_utils.py
@@ -94,7 +94,7 @@ def _ffprobe_available() -> bool:
     return shutil.which("ffprobe") is not None
 
 
-def _reset_for_tests() -> None:
+def reset_for_tests() -> None:
     """test helper —— 清缓存让 monkeypatch shutil.which 立刻生效。"""
     _ffprobe_available.cache_clear()
 

--- a/lib/config/resolver.py
+++ b/lib/config/resolver.py
@@ -14,11 +14,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, get_args
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
     from lib.db.models.custom_provider import CustomProviderModel
+
+from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -729,7 +729,7 @@ class ConfigResolver:
     # ── Session 管理 ──
 
     @asynccontextmanager
-    async def session(self) -> AsyncIterator[ConfigResolver]:
+    async def session(self) -> AsyncGenerator[ConfigResolver]:
         """打开共享 session，返回绑定到该 session 的 ConfigResolver。"""
         if self._bound_session is not None:
             yield self
@@ -738,7 +738,7 @@ class ConfigResolver:
                 yield ConfigResolver(self._session_factory, _bound_session=sess)
 
     @asynccontextmanager
-    async def _open_session(self) -> AsyncIterator[tuple[AsyncSession, ConfigService]]:
+    async def _open_session(self) -> AsyncGenerator[tuple[AsyncSession, ConfigService]]:
         """获取 (session, ConfigService)，优先复用 bound session。"""
         if self._bound_session is not None:
             yield self._bound_session, ConfigService(self._bound_session)

--- a/lib/config/service.py
+++ b/lib/config/service.py
@@ -11,6 +11,7 @@ from lib.config.env_keys import ANTHROPIC_ENV_KEYS
 from lib.config.registry import PROVIDER_REGISTRY
 from lib.config.repository import ProviderConfigRepository, SystemSettingRepository
 from lib.db.repositories.credential_repository import CredentialRepository
+from lib.schema_guards import is_int
 
 _DEFAULT_VIDEO_BACKEND = "gemini-aistudio/veo-3.1-lite-generate-preview"
 _DEFAULT_IMAGE_BACKEND = "gemini-aistudio/gemini-3.1-flash-image-preview"
@@ -221,7 +222,7 @@ class ConfigService:
         return value if value >= MIN_VIDEO_POLL_TIMEOUT_SECONDS else DEFAULT_VIDEO_POLL_TIMEOUT_SECONDS
 
     async def set_video_poll_timeout_seconds(self, value: int) -> None:
-        if not isinstance(value, int) or isinstance(value, bool) or value < MIN_VIDEO_POLL_TIMEOUT_SECONDS:
+        if not is_int(value, minimum=MIN_VIDEO_POLL_TIMEOUT_SECONDS):
             raise ValueError(
                 f"video poll timeout must be an integer of at least {MIN_VIDEO_POLL_TIMEOUT_SECONDS} seconds"
             )

--- a/lib/custom_provider/endpoint_test/inputs.py
+++ b/lib/custom_provider/endpoint_test/inputs.py
@@ -51,10 +51,10 @@ class EndpointTestAssets:
         return self.by_source.get(source)
 
     def items(self, source: str) -> list[AssetData]:
-        """列表型来源的素材；缺席、单值或非素材内容一律空列表。"""
+        """列表型来源的素材；缺席或单值来源取空列表。"""
         value = self.by_source.get(source)
         if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-            return [item for item in value if isinstance(item, AssetData)]
+            return list(value)
         return []
 
     def single(self, source: str) -> AssetData | None:

--- a/lib/data_validator.py
+++ b/lib/data_validator.py
@@ -788,7 +788,7 @@ class DataValidator:
 
     def _validate_segments(
         self,
-        segments: list[dict[str, Any]] | Any,
+        segments: Any,
         project_characters: set[str],
         project_scenes: set[str],
         project_props: set[str],
@@ -879,7 +879,7 @@ class DataValidator:
 
     def _validate_scenes(
         self,
-        scenes: list[dict[str, Any]] | Any,
+        scenes: Any,
         project_characters: set[str],
         project_scenes: set[str],
         project_props: set[str],
@@ -1067,7 +1067,7 @@ class DataValidator:
 
     def _validate_shots(
         self,
-        shots: list[dict[str, Any]] | Any,
+        shots: Any,
         project_characters: set[str],
         project_scenes: set[str],
         project_props: set[str],
@@ -1214,7 +1214,7 @@ class DataValidator:
 
     def _validate_reference_video_script(
         self,
-        video_units: list[dict[str, Any]] | Any,
+        video_units: Any,
         errors: list[ValidationMessage],
         warnings: list[ValidationMessage],
         *,

--- a/lib/db/engine.py
+++ b/lib/db/engine.py
@@ -60,9 +60,10 @@ def _create_engine():
     )
 
     if _is_sqlite:
-
+        # 由 SQLAlchemy 的 event.listens_for 注册，模块内无其它引用；basedpyright 把函数作用域内的
+        # 符号一律判为私有，本处的 reportUnusedFunction 是工具误报。
         @event.listens_for(engine.sync_engine, "connect")
-        def _set_sqlite_pragma(dbapi_conn, connection_record):
+        def _set_sqlite_pragma(dbapi_conn, connection_record):  # pyright: ignore[reportUnusedFunction]
             cursor = dbapi_conn.cursor()
             cursor.execute("PRAGMA journal_mode=WAL")
             cursor.execute("PRAGMA busy_timeout=30000")

--- a/lib/db/migration_helpers.py
+++ b/lib/db/migration_helpers.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 
 import sqlalchemy as sa
@@ -30,7 +30,7 @@ def _index_ddl(bind: Connection, table_name: str) -> dict[str, str]:
 
 
 @contextmanager
-def preserve_sqlite_indexes(table_name: str) -> Iterator[None]:
+def preserve_sqlite_indexes(table_name: str) -> Generator[None]:
     """在 SQLite 重建表期间保住反射不出的索引。
 
     SQLite 上 ``batch_alter_table`` 的增删列走重建表路径，而 SQLAlchemy 反射不出表达式型索引

--- a/lib/db/models/__init__.py
+++ b/lib/db/models/__init__.py
@@ -33,4 +33,13 @@ __all__ = [
     "Task",
     "User",
     "WorkerLease",
+    "register_models",
 ]
+
+
+def register_models() -> None:
+    """把本包内全部 ORM 模型登记到 ``Base.metadata``。
+
+    登记发生在 import 本模块时（模型类定义即注册），本函数不做额外工作；
+    调用它是为了让「因副作用而 import」在调用点显式可见。
+    """

--- a/lib/db/repositories/usage_repo.py
+++ b/lib/db/repositories/usage_repo.py
@@ -278,7 +278,7 @@ class UsageRepository(BaseRepository):
             )
 
             params = PricingParams(
-                call_type=row.call_type,  # pyright: ignore[reportArgumentType]
+                call_type=row.call_type,
                 model=row.model,
                 resolution=row.resolution,
                 aspect_ratio=row.aspect_ratio,

--- a/lib/episode_reset.py
+++ b/lib/episode_reset.py
@@ -468,7 +468,7 @@ def reset_episode_planning(
         )
 
     # 结果只能在锁内（按锁内复扫的实际处置）拼出，用闭包变量带回锁外
-    committed: EpisodeResetResult | None = None
+    committed: list[EpisodeResetResult] = []
     commit_plan: _ResetPlan | None = None
     manifest_expected: dict[ArtifactKey, ArtifactManifestEntry | None] = {}
     manifest_removals: dict[ArtifactKey, ArtifactManifestEntry | None] = {}
@@ -514,7 +514,6 @@ def reset_episode_planning(
         commit_plan = current
 
     def _commit_side_effects(_project_file: Path) -> None:
-        nonlocal committed
         if commit_plan is None:  # pragma: no cover - update_project calls mutate before on_commit
             raise EpisodeResetError("重置未执行：文件处置计划未生成")
         _assert_source_directory_safe(project_dir)
@@ -540,25 +539,28 @@ def reset_episode_planning(
                 )
             elif recover_unreadable_manifest:
                 ProjectArtifactManifestAdapter(project_dir).replace_unreadable_entries_atomically({})
-        committed = EpisodeResetResult(
-            removed_episodes=commit_plan.episode_nums,
-            deleted_files=deleted,
-            archived_files=archived,
-            consumed_episodes=commit_plan.consumed,
+        committed.append(
+            EpisodeResetResult(
+                removed_episodes=commit_plan.episode_nums,
+                deleted_files=deleted,
+                archived_files=archived,
+                consumed_episodes=commit_plan.consumed,
+            )
         )
 
     pm.update_project(project_name, _commit, on_commit=_commit_side_effects)
-    if committed is None:  # pragma: no cover - update_project 必然调用 mutate_fn
+    if not committed:  # pragma: no cover - update_project 必然调用 mutate_fn
         raise EpisodeResetError("重置未执行：账本更新回调未被调用")
+    result = committed[0]
     logger.info(
         "分集规划已%s重置：项目 %s，清空 %d 集，删除派生文件 %d 个，留底 %d 个",
         "全量" if from_episode == 1 else f"部分（从第 {from_episode} 集起）",
         project_name,
-        len(committed.removed_episodes),
-        len(committed.deleted_files),
-        len(committed.archived_files),
+        len(result.removed_episodes),
+        len(result.deleted_files),
+        len(result.archived_files),
     )
-    return committed
+    return result
 
 
 __all__ = [

--- a/lib/formal_write.py
+++ b/lib/formal_write.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -78,7 +78,7 @@ def _restore_snapshots(snapshots: tuple[_FileSnapshot, ...]) -> None:
 
 
 @contextmanager
-def project_metadata_lock(project_dir: Path) -> Iterator[None]:
+def project_metadata_lock(project_dir: Path) -> Generator[None]:
     """Serialize project metadata and formal-artifact transactions across processes."""
 
     lock_path = Path(project_dir) / ".project.json.lock"
@@ -91,7 +91,7 @@ def project_metadata_lock(project_dir: Path) -> Iterator[None]:
 def formal_write_transaction(
     *paths: Path,
     cancellation_receipts: list[FormalWriteReceipt] | None = None,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Restore exact pre-write bytes when a formal multi-file commit fails.
 
     Callers must hold the domain locks that serialize writes to ``paths`` for

--- a/lib/gemini_shared.py
+++ b/lib/gemini_shared.py
@@ -238,9 +238,6 @@ def get_shared_rate_limiter(
     - request_gap：最小请求间隔（None 时从环境变量 GEMINI_REQUEST_GAP 读取，默认 3.1）
     """
     global _shared_rate_limiter
-    if _shared_rate_limiter is not None:
-        return _shared_rate_limiter
-
     with _shared_rate_limiter_lock:
         if _shared_rate_limiter is not None:
             return _shared_rate_limiter

--- a/lib/gemini_shared.py
+++ b/lib/gemini_shared.py
@@ -63,8 +63,8 @@ try:
 
     RETRYABLE_ERRORS = (
         *RETRYABLE_ERRORS,
-        genai.errors.ClientError,  # pyright: ignore[reportAttributeAccessIssue]
-        genai.errors.ServerError,  # pyright: ignore[reportAttributeAccessIssue]
+        genai.errors.ClientError,
+        genai.errors.ServerError,
     )
 except ImportError:
     logger.debug("google.genai 未安装，跳过对应可重试错误，沿用基础集合")

--- a/lib/generation_admission.py
+++ b/lib/generation_admission.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 
@@ -28,7 +28,7 @@ async def generation_admission_lock(
     project_name: str,
     script_file: str,
     resource_id: str,
-) -> AsyncIterator[None]:
+) -> AsyncGenerator[None]:
     """Serialize task admission with guarded media selection for one unit.
 
     Non-blocking lock attempts keep the event loop responsive and cancellation
@@ -63,7 +63,7 @@ def generation_admission_lock_sync(
     project_name: str,
     script_file: str,
     resource_id: str,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Blocking counterpart for synchronous compensation after the async guard is released."""
 
     path = _lock_path(project_name=project_name, resource_id=resource_id)

--- a/lib/generation_queue.py
+++ b/lib/generation_queue.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import threading
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -367,7 +367,7 @@ class GenerationQueue:
         await asyncio.to_thread(assert_project_migration_ok, project_name, self._project_manager)
 
     @asynccontextmanager
-    async def _task_repo(self) -> AsyncIterator[TaskRepository]:
+    async def _task_repo(self) -> AsyncGenerator[TaskRepository]:
         """打开一条 TaskRepository 会话，退出时把落地的任务终态发上项目事件总线。
 
         发布放在会话退出之后而非 repo 内部：repo 内直接发会让前端读到尚未提交的状态。

--- a/lib/grid_manager.py
+++ b/lib/grid_manager.py
@@ -35,7 +35,7 @@ class GridManager:
         位置，``grid_xxxxxxxxxxxx\\n`` 这类带尾随换行的输入能骗过 ``match()``，让换行符
         混入最终文件名。
         """
-        if not isinstance(grid_id, str) or _GRID_ID_RE.fullmatch(grid_id) is None:
+        if _GRID_ID_RE.fullmatch(grid_id) is None:
             raise ValueError(f"非法宫格 ID: {grid_id!r}")
         return safe_join(self._dir, f"{grid_id}{suffix}")
 

--- a/lib/image_backends/grok.py
+++ b/lib/image_backends/grok.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -87,11 +88,14 @@ class GrokImageBackend:
 
         # I2I：将所有参考图转为 base64 data URI 列表
         if request.reference_images:
-            data_uris = []
-            for ref in request.reference_images:
-                ref_path = Path(ref.path)
-                if ref_path.exists():  # noqa: ASYNC240 -- 参考图存在性检查，本地元数据
-                    data_uris.append(image_to_base64_data_uri(ref_path))
+            # exists() 只读本地文件元数据，不阻塞；读整张图做 base64 编码才是阻塞 I/O，
+            # 逐张卸载到线程后并发等待，避免堵住事件循环
+            existing_paths = [ref_path for ref in request.reference_images if (ref_path := Path(ref.path)).exists()]
+            data_uris = list(
+                await asyncio.gather(
+                    *[asyncio.to_thread(image_to_base64_data_uri, ref_path) for ref_path in existing_paths]
+                )
+            )
             if data_uris:
                 generate_kwargs["image_urls"] = data_uris
                 logger.info("Grok I2I 模式: %d 张参考图", len(data_uris))

--- a/lib/json_io.py
+++ b/lib/json_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
@@ -22,7 +22,7 @@ def domain_error_on_value_error(
     factory: Callable[[ValueError], BaseException],
     *,
     extra_passthrough: tuple[type[BaseException], ...] = (),
-) -> Iterator[None]:
+) -> Generator[None]:
     """把业务解析调用抛出的 ``ValueError`` 转换为调用方指定的领域错误。
 
     ``json.JSONDecodeError`` 是 ``ValueError`` 子类，须先于通用 ``ValueError`` 分支放行——

--- a/lib/ledger.py
+++ b/lib/ledger.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
@@ -108,7 +108,7 @@ class Ledger:
         segment_id: str | None = None,
         service_tier: str = "default",
         output_path: str | None = None,
-    ) -> AsyncIterator[LedgerCall]:
+    ) -> AsyncGenerator[LedgerCall]:
         """记账括号：进入落 pending，块内 ``call.success(result)`` 声明成功。
 
         退出语义：``CancelledError`` 穿透留 pending；``Exception`` 翻 failed 后原样重抛；正常

--- a/lib/ledger.py
+++ b/lib/ledger.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Any, Literal
+from typing import Any, Literal, assert_never
 
 from lib.db import safe_session_factory
 from lib.db.base import DEFAULT_USER_ID
@@ -70,7 +70,7 @@ def _settlement_from_result(call_type: CallType, result: Any, *, service_tier: s
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
         )
-    raise ValueError(f"unknown ledger channel: {call_type!r}")
+    assert_never(call_type)
 
 
 class LedgerCall:

--- a/lib/media_generator.py
+++ b/lib/media_generator.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 def task_media_staging_path(output_path: Path, task_id: str) -> Path:
     """Return the bounded, deterministic formal-output path owned by one task."""
 
-    if not isinstance(task_id, str) or not task_id:
+    if not task_id:
         raise ValueError("formal media output requires a task_id")
     token = hashlib.sha256(task_id.encode("utf-8")).hexdigest()
     return output_path.with_name(f".{token}.task-output{output_path.suffix}")
@@ -938,9 +938,7 @@ class MediaGenerator:
         # （如 wan2.7）不必为每个请求多付一轮 ffprobe 子进程开销。
         reference_audio_total_seconds = (
             await probe_reference_audio_total_seconds(reference_audio_files)
-            if reference_audio_files
-            and video_caps is not None
-            and video_caps.max_reference_audio_total_seconds is not None
+            if reference_audio_files and video_caps.max_reference_audio_total_seconds is not None
             else None
         )
         slot_plan = plan_frame_slots(

--- a/lib/narration_delivery.py
+++ b/lib/narration_delivery.py
@@ -28,6 +28,7 @@ from lib.audio_utils import probe_existing_audio_duration_seconds
 from lib.path_safety import safe_join
 from lib.reference_video.duration_slots import Adjustment, resolve_duration_slot
 from lib.resource_paths import resource_relative_path
+from lib.schema_guards import is_int
 from lib.speech_composition import (
     SpeechFieldLocation,
     SpeechMode,
@@ -51,7 +52,7 @@ class NarrationDeliveryRequestOptions:
         if self.narration_delivery not in (POST_PRODUCTION, USE_TTS):
             raise ValueError(f"unsupported narration delivery: {self.narration_delivery!r}")
         confirmed = self.confirmed_request_duration_seconds
-        if confirmed is not None and (not isinstance(confirmed, int) or isinstance(confirmed, bool) or confirmed <= 0):
+        if confirmed is not None and not is_int(confirmed, minimum=1):
             raise ValueError("confirmed_request_duration_seconds must be a positive integer or null")
 
     def to_payload(self) -> dict[str, object]:

--- a/lib/narration_delivery.py
+++ b/lib/narration_delivery.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Literal, Protocol, assert_never
 
 from lib.artifact_manifest import (
     ArtifactBasis,
@@ -388,7 +388,7 @@ def prepare_narration_delivery(
     """Project current TTS currency into one non-persistent delivery request."""
 
     if delivery not in (POST_PRODUCTION, USE_TTS):
-        raise ValueError(f"unsupported narration delivery: {delivery!r}")
+        assert_never(delivery)
 
     problems = _speech_problems(preparation)
     basis_digest: str | None = None

--- a/lib/profile_manifest.py
+++ b/lib/profile_manifest.py
@@ -222,7 +222,7 @@ def _ensure_dest_within(project_dir: Path, rel: str) -> Path:
         raise ValueError(f"dest path escapes project_dir: {rel!r}") from exc
 
 
-def _normalize_profile_rel_path(rel: str) -> str:
+def _normalize_profile_rel_path(rel: object) -> str:
     """force_resync 的 ``paths`` 来自 UI / 外部输入，必须拒掉绝对路径和 ``..``，
     否则 ``profile_dir / rel`` 和 ``project_dir / rel`` 会逃逸到 profile / 项目
     根目录之外，读写任意可写文件。

--- a/lib/project_change_hints.py
+++ b/lib/project_change_hints.py
@@ -102,7 +102,7 @@ def emit_project_change_batch(
 ) -> None:
     """Notify listeners with a ready-to-broadcast project change batch."""
     resolved_source = source or get_project_change_source()
-    payload = tuple(dict(change) for change in changes if isinstance(change, dict))
+    payload = tuple(dict(change) for change in changes)
     if not payload:
         return
 

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -3656,9 +3656,3 @@ def get_project_manager() -> ProjectManager:
     if _project_manager is None:
         _project_manager = ProjectManager(app_data_dir())
     return _project_manager
-
-
-def _reset_project_manager_for_tests() -> None:
-    """清空缓存的单例，供测试在不同 app_data_dir 场景间重置。"""
-    global _project_manager
-    _project_manager = None

--- a/lib/project_manager.py
+++ b/lib/project_manager.py
@@ -17,7 +17,7 @@ import secrets
 import shutil
 import time
 import unicodedata
-from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, Callable, Generator, Mapping, Sequence
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -83,6 +83,7 @@ from lib.profile_manifest import (
 from lib.project_change_hints import emit_project_change_hint
 from lib.project_schema import parse_project_schema_version
 from lib.reference_video.duration_migration import migrate_script_unit_durations
+from lib.schema_guards import is_int, is_shape, is_str
 from lib.script_editor import ScriptEditError, resolve_items
 from lib.script_models import get_generated_assets
 from lib.script_plan_entries import ScriptPlanKind, backfill_entry_revisions
@@ -204,7 +205,7 @@ def resolve_source_kind(project: Mapping[str, Any]) -> SourceKind:
     return DEFAULT_SOURCE_KIND
 
 
-def _resolve_items_or_warn(script: dict, *, script_filename: str | None = None) -> list[dict]:
+def _resolve_items_or_warn(script: dict, *, script_filename: str | None = None) -> list[Any]:
     """读取路径的脏数据降级：基于 `resolve_items` 判别三种剧本结构，
     脏数据（键存在但值非 list）下 log warning + 返回 []。
 
@@ -1927,7 +1928,7 @@ class ProjectManager:
             yield
 
     @contextmanager
-    def locked_source_mutation(self, project_name: str) -> Iterator[Path]:
+    def locked_source_mutation(self, project_name: str) -> Generator[Path]:
         """Serialize source-file mutations with project transactions.
 
         Workflow facts such as asset-inventory completion compute source revisions while
@@ -1946,7 +1947,7 @@ class ProjectManager:
     async def async_file_lock(
         self,
         path: Path,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None]:
         """Cancellation-safe async counterpart of :meth:`file_lock`."""
         path.parent.mkdir(parents=True, exist_ok=True)
         lock_path = path.parent / f".{path.name}.lock"
@@ -2409,11 +2410,9 @@ class ProjectManager:
                 raise ValueError("广告/短片项目不持有 default_duration（分镜时长按 target_duration 预算逐个分镜规划）")
             if episode_target_duration is not None:
                 raise ValueError("广告/短片项目不持有 episode_target_duration（整集体量按 target_duration 预算规划）")
-            if target_duration is not None and (
-                not isinstance(target_duration, int) or isinstance(target_duration, bool) or target_duration <= 0
-            ):
+            if target_duration is not None and not is_int(target_duration, minimum=1):
                 raise ValueError(f"target_duration 必须为正整数秒，当前为 {target_duration!r}")
-            if brief is not None and not isinstance(brief, str):
+            if brief is not None and not is_str(brief):
                 raise ValueError(f"brief 必须是字符串，当前为 {brief!r}")
         else:
             if target_duration is not None:
@@ -2647,7 +2646,7 @@ class ProjectManager:
 
         asset_type = self._resolve_asset_type(table)
         # entries 类型错误与空对象需要不同提示，便于 Agent 精确修正输入。
-        if not isinstance(entries, dict):
+        if not is_shape(entries, dict):
             raise ValueError(f"entries 必须是对象（dict），当前为 {type(entries).__name__}")
         if not entries:
             raise ValueError("entries 不能为空（至少需要一个 name → attrs 条目）")
@@ -2663,7 +2662,7 @@ class ProjectManager:
                 name = validate_asset_name(raw_name)
             except ValueError as exc:
                 raise ValueError(f"{table}: {exc}") from None
-            if not isinstance(attrs, dict):
+            if not is_shape(attrs, dict):
                 raise ValueError(f"{table} '{name}' 的内容必须是对象")
             if name in normalized_entries:
                 raise ValueError(

--- a/lib/project_migrations/v8_to_v9_reference_unit_text.py
+++ b/lib/project_migrations/v8_to_v9_reference_unit_text.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import copy
 import shutil
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -174,7 +174,7 @@ def _ensure_backup(path: Path) -> None:
 
 
 @contextmanager
-def _located(episode: int, file: str) -> Iterator[None]:
+def _located(episode: int, file: str) -> Generator[None]:
     """把预检抛出的结构违约补成带定位事实的迁移错误。
 
     「需要修复」裁决按 ``(episode, file)`` 给用户与 Agent 导航，仅凭消息文本无法定位到集与文件。

--- a/lib/prompt_builders.py
+++ b/lib/prompt_builders.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from lib.prompt_utils import image_prompt_to_yaml, project_storyboard_image_prompt
+from lib.schema_guards import is_str
 
 # ---------------------------------------------------------------------------
 # 内部常量：防崩 / 反向 / 布局 / 风格前缀
@@ -146,7 +147,7 @@ def build_storyboard_prompt(
 ) -> str:
     """Render canonical storyboard semantics into the exact provider prompt."""
 
-    if not isinstance(style_description, str):
+    if not is_str(style_description):
         raise TypeError("style_description must be a string")
     projected, normalized_style = project_storyboard_image_prompt(image_prompt, style)
 

--- a/lib/prompt_builders_ad.py
+++ b/lib/prompt_builders_ad.py
@@ -22,6 +22,7 @@ from lib.prompt_builders_script import (
     _format_names,
 )
 from lib.reference_video.writing_syntax import writing_syntax_spec
+from lib.schema_guards import is_int
 from lib.script_models import REFERENCE_UNIT_DURATION_RANGE
 from lib.speech_rate import speech_rate_units_per_second
 from lib.text_metrics import reading_unit_noun
@@ -193,7 +194,7 @@ def build_ad_prompt(
     （无带货框架，不设显式子模式开关）。``speech_rate_override`` 是项目级语速覆盖
     （由调用方经 ``project_speech_rate_override`` 解析），None 即回退语言默认。
     """
-    if not isinstance(target_duration, int) or isinstance(target_duration, bool) or target_duration <= 0:
+    if not is_int(target_duration, minimum=1):
         raise ValueError(f"target_duration 必须为正整数秒，当前为 {target_duration!r}")
 
     duration_constraint = _shot_duration_constraint(generation_mode, supported_durations)
@@ -359,7 +360,7 @@ def build_ad_reference_prompt(
     target_language: str = "中文",
 ) -> str:
     """广告/短片的参考生视频单阶段生成 prompt；直接输出含引用语法正文的扁平 unit。"""
-    if not isinstance(target_duration, int) or isinstance(target_duration, bool) or target_duration <= 0:
+    if not is_int(target_duration, minimum=1):
         raise ValueError(f"target_duration 必须为正整数秒，当前为 {target_duration!r}")
     min_unit_duration, max_unit_duration = REFERENCE_UNIT_DURATION_RANGE
     product_context = _format_products(products) if products else "（无商品，按通用短片创作）"

--- a/lib/prompt_builders_ad.py
+++ b/lib/prompt_builders_ad.py
@@ -18,8 +18,8 @@ from lib.prompt_builders_script import (
     _LIGHTING_WRITING_GUIDE,
     _SCENE_WRITING_GUIDE,
     _format_aspect_ratio_desc,
-    _format_duration_constraint,
     _format_names,
+    format_duration_constraint,
 )
 from lib.reference_video.writing_syntax import writing_syntax_spec
 from lib.schema_guards import is_int
@@ -163,7 +163,7 @@ def _shot_duration_constraint(generation_mode: str | None, supported_durations: 
         raise ValueError("reference_video 路径须使用 build_ad_reference_prompt")
     if not supported_durations:
         raise ValueError("storyboard 路径必须提供 supported_durations（视频模型的合法时长集合）")
-    return _format_duration_constraint(supported_durations, None)
+    return format_duration_constraint(supported_durations, None)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/prompt_builders_script.py
+++ b/lib/prompt_builders_script.py
@@ -57,7 +57,7 @@ def _format_assets_with_desc(items: dict) -> str:
 _ASSET_APPEARANCE_NOTE = "资产外观以上述描述为准：视觉字段写到出场资产的服装 / 材质 / 陈设细节时从中取材，不自行发明。"
 
 
-def _format_duration_constraint(supported_durations: list[int], default_duration: int | None) -> str:
+def format_duration_constraint(supported_durations: list[int], default_duration: int | None) -> str:
     """生成时长约束描述。连续整数集 ≥5 用区间表达，否则枚举。"""
     if not supported_durations:
         raise ValueError("supported_durations 不能为空：调用方必须提供 model 的合法时长列表")

--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -309,7 +309,7 @@ def _attach_voice_profiles(
     return prompt
 
 
-def _build_voice_profiles(dialogue: list[dict[str, str]], characters: dict[str, Any]) -> list[dict[str, str]]:
+def _build_voice_profiles(dialogue: list[Any], characters: dict[str, Any]) -> list[dict[str, str]]:
     """从 dialogue speakers 与角色资产派生 Voice_Profiles 声明段。
 
     仅收录角色资产存在且 ``voice_style`` 非空者，一个 speaker 一条（按 dialogue 中首次

--- a/lib/reference_compression.py
+++ b/lib/reference_compression.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import contextlib
 import shutil
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Generator
 from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
@@ -218,7 +218,7 @@ def compressed_reference_payload(
     *,
     limits: PayloadLimits,
     start_step: int = 0,
-) -> Iterator[tuple[int, list[CompressedRef]]]:
+) -> Generator[tuple[int, list[CompressedRef]]]:
     """压缩参考图为临时文件，yield (landed_step, refs)，退出时清理临时文件。
 
     非本地 / 不可解码源（理论上不会发生——各 backend 本就对 reference 调 read_bytes()，

--- a/lib/reference_video/draft_validation.py
+++ b/lib/reference_video/draft_validation.py
@@ -269,7 +269,7 @@ def validate_dialogue_load(
     label: str,
     text: str,
     duration_seconds: int,
-    language: str | None,
+    language: object,
     speech_rate_override: float | None = None,
 ) -> None:
     """校验该 unit 的台词量念得完：口播估算超出 unit 时长（含宽容系数）即违约。

--- a/lib/reference_video/execution_checkpoint.py
+++ b/lib/reference_video/execution_checkpoint.py
@@ -8,7 +8,6 @@ import errno
 import hashlib
 import json
 import logging
-import math
 import os
 import re
 import shutil
@@ -23,6 +22,7 @@ from lib.artifact_manifest import ArtifactBasisDescriptor
 from lib.content_digest import canonical_json, canonical_json_digest, sha256_file_with_size
 from lib.json_io import atomic_write_json, load_json
 from lib.path_safety import safe_join
+from lib.schema_guards import is_bool, is_finite_number, is_int, is_shape, is_str
 from lib.video_artifact_facts import VideoArtifactCurrencyFacts
 
 logger = logging.getLogger(__name__)
@@ -64,8 +64,8 @@ def _sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _require_task_id(task_id: str) -> None:
-    if not isinstance(task_id, str) or not _TASK_ID_RE.fullmatch(task_id):
+def _require_task_id(task_id: object) -> None:
+    if not is_str(task_id) or not _TASK_ID_RE.fullmatch(str(task_id)):
         raise ValueError("task_id contains unsafe path characters")
 
 
@@ -138,9 +138,7 @@ class ProviderMediaInput:
         _require_nonempty_string(self.logical_type, "logical_type")
         _require_nonempty_string(self.logical_name, "logical_name")
         _require_nonempty_string(self.kind, "kind")
-        if self.target_index is not None and (
-            not isinstance(self.target_index, int) or isinstance(self.target_index, bool) or self.target_index < 0
-        ):
+        if self.target_index is not None and not is_int(self.target_index, minimum=0):
             raise ValueError("target_index must be a non-negative integer or null")
         if self.role != "reference_audio" and self.target_index is not None:
             raise ValueError(f"{self.role} cannot have target_index")
@@ -177,7 +175,7 @@ class StagedProviderMedia:
     )
 
     def __post_init__(self) -> None:
-        if not isinstance(self.index, int) or isinstance(self.index, bool) or self.index < 0:
+        if not is_int(self.index, minimum=0):
             raise ValueError("media index must be a non-negative integer")
         if self.role not in ("reference_image", "reference_audio", "start_image", "end_image"):
             raise ValueError(f"unsupported provider media role: {self.role!r}")
@@ -187,11 +185,9 @@ class StagedProviderMedia:
         _require_relative_locator(self.source_locator, "source_locator")
         _require_relative_locator(self.staged_locator, "staged_locator")
         _require_digest(self.sha256, "sha256")
-        if not isinstance(self.size_bytes, int) or isinstance(self.size_bytes, bool) or self.size_bytes < 0:
+        if not is_int(self.size_bytes, minimum=0):
             raise ValueError("size_bytes must be a non-negative integer")
-        if self.target_index is not None and (
-            not isinstance(self.target_index, int) or isinstance(self.target_index, bool) or self.target_index < 0
-        ):
+        if self.target_index is not None and not is_int(self.target_index, minimum=0):
             raise ValueError("target_index must be a non-negative integer or null")
         if self.role != "reference_audio" and self.target_index is not None:
             raise ValueError(f"{self.role} cannot have target_index")
@@ -310,7 +306,7 @@ def stage_provider_media(
     """Atomically publish task-local copies of exactly the provider-bound media."""
 
     _require_task_id(task_id)
-    if not isinstance(inputs, tuple):
+    if not is_shape(inputs, tuple):
         raise TypeError("provider media inputs must be a tuple")
     planned = _media_plan(project_path, task_id, inputs)
     if not planned:
@@ -457,10 +453,7 @@ class NarrationExecutionFacts:
         _require_relative_locator(self.artifact_path, "artifact_path", allow_empty=True)
         _require_basis_digest(self.basis_digest, "basis_digest", optional=True)
         if self.actual_duration_seconds is not None and (
-            not isinstance(self.actual_duration_seconds, (int, float))
-            or isinstance(self.actual_duration_seconds, bool)
-            or not math.isfinite(self.actual_duration_seconds)
-            or self.actual_duration_seconds <= 0
+            not is_finite_number(self.actual_duration_seconds) or self.actual_duration_seconds <= 0
         ):
             raise ValueError("actual_duration_seconds must be positive and finite or null")
         if self.delivery == "post_production":
@@ -606,8 +599,7 @@ class _VideoSubmissionCheckpoint:
 
     def __post_init__(self) -> None:
         if (
-            not isinstance(self.schema_version, int)
-            or isinstance(self.schema_version, bool)
+            not is_int(self.schema_version)
             or self.schema_version not in {_LEGACY_SCHEMA_VERSION, _VISUAL_BASIS_SCHEMA_VERSION, _SCHEMA_VERSION}
             or self.kind != self.CHECKPOINT_KIND
         ):
@@ -622,24 +614,20 @@ class _VideoSubmissionCheckpoint:
         _require_nonempty_string(self.provider_model_id, "provider_model_id")
         _require_nonempty_string(self.backend_model_id, "backend_model_id")
         _require_optional_string(self.endpoint_guard, "endpoint_guard")
-        if not isinstance(self.api_call_id, int) or isinstance(self.api_call_id, bool) or self.api_call_id <= 0:
+        if not is_int(self.api_call_id, minimum=1):
             raise ValueError("api_call_id must be a positive integer")
         _require_nonempty_string(self.prompt, "prompt")
         _require_digest(self.prompt_sha256, "prompt_sha256")
         if self.prompt_sha256 != _sha256_bytes(self.prompt.encode("utf-8")):
             raise ValueError("prompt_sha256 does not match prompt")
-        if (
-            not isinstance(self.duration_seconds, int)
-            or isinstance(self.duration_seconds, bool)
-            or self.duration_seconds <= 0
-        ):
+        if not is_int(self.duration_seconds, minimum=1):
             raise ValueError("duration_seconds must be a positive integer")
         _require_nonempty_string(self.aspect_ratio, "aspect_ratio")
         _require_optional_string(self.resolution, "resolution")
-        if not isinstance(self.generate_audio, bool):
+        if not is_bool(self.generate_audio):
             raise ValueError("generate_audio must be a boolean")
         _require_nonempty_string(self.service_tier, "service_tier")
-        if self.seed is not None and (not isinstance(self.seed, int) or isinstance(self.seed, bool)):
+        if self.seed is not None and not is_int(self.seed):
             raise ValueError("seed must be an integer or null")
         _require_basis_digest(self.visual_basis_digest, "visual_basis_digest")
         if self.schema_version == _VISUAL_BASIS_SCHEMA_VERSION:
@@ -672,10 +660,7 @@ class _VideoSubmissionCheckpoint:
                 if any(item.target_index is not None for item in audio):
                     raise ValueError("media target_index requires reference_audio_targets")
             else:
-                if any(
-                    not isinstance(target, int) or isinstance(target, bool) or target < 0
-                    for target in self.reference_audio_targets
-                ):
+                if any(not is_int(target, minimum=0) for target in self.reference_audio_targets):
                     raise ValueError("reference_audio_targets must contain non-negative integers")
                 if tuple(item.target_index for item in audio) != self.reference_audio_targets:
                     raise ValueError("reference_audio_targets do not match staged audio identities")

--- a/lib/reference_video/request_projection.py
+++ b/lib/reference_video/request_projection.py
@@ -41,6 +41,7 @@ from lib.narration_delivery import (
 from lib.path_safety import PathTraversalError, safe_join
 from lib.reference_video.duration_slots import DurationSlot, resolve_duration_slot
 from lib.reference_video.text_parser import derive_references_from_text
+from lib.schema_guards import is_int
 from lib.script_models import ReferenceResource
 from lib.speech_composition import admit_script_unit
 
@@ -67,16 +68,10 @@ class ReferenceRequestOptions(NarrationDeliveryRequestOptions):
         if floor is not None and (not math.isfinite(floor) or floor <= 0):
             raise ValueError("current_tts_duration_seconds must be positive and finite or null")
         visual_duration = self.current_visual_duration_seconds
-        if visual_duration is not None and (
-            not isinstance(visual_duration, int) or isinstance(visual_duration, bool) or visual_duration <= 0
-        ):
+        if visual_duration is not None and not is_int(visual_duration, minimum=1):
             raise ValueError("current_visual_duration_seconds must be a positive integer or null")
         reusable_visual_duration = self.current_reusable_visual_duration_seconds
-        if reusable_visual_duration is not None and (
-            not isinstance(reusable_visual_duration, int)
-            or isinstance(reusable_visual_duration, bool)
-            or reusable_visual_duration <= 0
-        ):
+        if reusable_visual_duration is not None and not is_int(reusable_visual_duration, minimum=1):
             raise ValueError("current_reusable_visual_duration_seconds must be a positive integer or null")
         preparation = self.narration_preparation
         if preparation is not None and preparation.delivery != self.narration_delivery:

--- a/lib/schema_guards.py
+++ b/lib/schema_guards.py
@@ -1,0 +1,50 @@
+"""持久化 schema 的运行期形状判定。
+
+数据类的字段标注描述的是**期望** schema；实例既由本仓库的类型化代码构造，也由
+``from_dict`` 之类的入口从磁盘 JSON 重建，故构造期仍须校验真实形状。这些判定函数
+以 ``object`` 收参，把「标注表达期望、判定负责实际」的分工落到类型上，构造期校验
+因此不会退化成对自身标注的同义反复。
+"""
+
+from collections.abc import Mapping
+from math import isfinite
+
+__all__ = [
+    "is_bool",
+    "is_finite_number",
+    "is_int",
+    "is_mapping",
+    "is_shape",
+    "is_str",
+]
+
+
+def is_int(value: object, *, minimum: int | None = None) -> bool:
+    """严格整数判定：``bool`` 是 ``int`` 的子类，此处按非整数处理。"""
+    if not isinstance(value, int) or isinstance(value, bool):
+        return False
+    return minimum is None or value >= minimum
+
+
+def is_finite_number(value: object) -> bool:
+    """有限实数判定，同样排除 ``bool``。"""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    return isfinite(value)
+
+
+def is_bool(value: object) -> bool:
+    return isinstance(value, bool)
+
+
+def is_str(value: object) -> bool:
+    return isinstance(value, str)
+
+
+def is_mapping(value: object) -> bool:
+    return isinstance(value, Mapping)
+
+
+def is_shape(value: object, expected: type | tuple[type, ...]) -> bool:
+    """任意类型的形状判定，供无专用谓词的持久化字段使用。"""
+    return isinstance(value, expected)

--- a/lib/script_batch_edit.py
+++ b/lib/script_batch_edit.py
@@ -571,7 +571,7 @@ def _filename_episode(script_file: str) -> int | None:
     return int(match.group(1)) if match is not None else None
 
 
-def _find_index(items: list[dict[str, Any]], id_field: str, item_id: str) -> int:
+def _find_index(items: list[Any], id_field: str, item_id: str) -> int:
     for index, item in enumerate(items):
         if isinstance(item, dict) and str(item.get(id_field)) == item_id:
             return index

--- a/lib/script_editor.py
+++ b/lib/script_editor.py
@@ -39,7 +39,7 @@ class ScriptEditError(ValueError):
         self.params = params
 
 
-def resolve_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[list[dict[str, Any]], str, str]:
+def resolve_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[list[Any], str, str]:
     """按剧本骨架选出当前剧本的条目数组、其 id 字段名与种类。
 
     返回 ``(items, id_field, kind)``：``kind`` ∈ {"segments", "scenes", "shots", "video_units"}。
@@ -64,14 +64,14 @@ def resolve_items(script: dict[str, Any], *, kind: str | None = None) -> tuple[l
     return raw_items, id_field, kind
 
 
-def _find_index(items: list[dict[str, Any]], id_field: str, item_id: str) -> int:
+def _find_index(items: list[Any], id_field: str, item_id: str) -> int:
     for idx, item in enumerate(items):
         if isinstance(item, dict) and str(item.get(id_field)) == str(item_id):
             return idx
     raise ScriptEditError(f"未找到 id={item_id!r} 的分镜（{id_field}）")
 
 
-def _existing_ids(items: list[dict[str, Any]], id_field: str) -> set[str]:
+def _existing_ids(items: list[Any], id_field: str) -> set[str]:
     return {str(item.get(id_field)) for item in items if isinstance(item, dict)}
 
 
@@ -154,8 +154,6 @@ def insert_segment(script: dict[str, Any], after_id: str, new_item: dict[str, An
     新分镜的 id 字段被强制改写为 ``{after_id}_{k}``（唯一），``generated_assets`` 与
     ``end_frame_image`` 清空。其余字段由 Agent 提供，结构是否合法由写盘统一入口校验。
     """
-    if not isinstance(new_item, dict):
-        raise ScriptEditError("new_item 必须是对象")
     items, id_field, _ = resolve_items(script)
     idx = _find_index(items, id_field, after_id)
     item = deepcopy(new_item)
@@ -188,10 +186,8 @@ def split_segment(script: dict[str, Any], item_id: str, parts: list[dict[str, An
     新 unit（各带自己的 ``shots``），不是把原 unit 内的 ``shots`` 拆细。``duration_seconds`` 是
     unit 独立字段、不由 ``shots`` 派生，故各新 part 须自行给出，本函数不代算。
     """
-    if not isinstance(parts, list) or len(parts) < 2:
+    if len(parts) < 2:
         raise ScriptEditError("split 至少需要 2 个部分")
-    if any(not isinstance(p, dict) for p in parts):
-        raise ScriptEditError("split 的每个部分必须是对象")
     items, id_field, _ = resolve_items(script)
     idx = _find_index(items, id_field, item_id)
     anchor_assets = items[idx].get("generated_assets")

--- a/lib/script_generator.py
+++ b/lib/script_generator.py
@@ -158,7 +158,7 @@ _KIND_PARSE_SCHEMA: dict[str, type[BaseModel]] = {
 }
 
 
-def _units_use_references(units: list[dict] | None) -> bool | None:
+def _units_use_references(units: list[Any] | None) -> bool | None:
     """本集 script_plan 是否存在带 ``@[名称]`` 提及的 unit；``units`` 为 None（非参考生视频路径）时返回 None。
 
     None 的语义是「交给下游按生成模式近似判定」，与「确定不带参考图」的 False 区分开。

--- a/lib/script_review.py
+++ b/lib/script_review.py
@@ -24,7 +24,7 @@ import enum
 import hashlib
 import json
 import logging
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -278,7 +278,7 @@ def official_reference_script_plan_path(project_path: Path, episode: int) -> Pat
 
 
 @contextmanager
-def formal_script_plan_lock(project_path: Path, episode: int, path: Path) -> Iterator[Path]:
+def formal_script_plan_lock(project_path: Path, episode: int, path: Path) -> Generator[Path]:
     """任一变体正式 script_plan 的写临界区：建目录 + per-path 排他锁，yield 该正式文件路径。
 
     与迁移读改写、Web 端保存、重拆分 / 晋升共用同一把 ``ProjectManager.file_lock``（per-path，
@@ -295,7 +295,7 @@ def formal_script_plan_lock(project_path: Path, episode: int, path: Path) -> Ite
 
 
 @contextmanager
-def script_plan_write_lock(project_path: Path, episode: int) -> Iterator[Path]:
+def script_plan_write_lock(project_path: Path, episode: int) -> Generator[Path]:
     """参考生视频正式 script_plan 的写临界区（``formal_script_plan_lock`` 绑定该变体路径的具名入口）。"""
     with formal_script_plan_lock(
         project_path, episode, official_reference_script_plan_path(project_path, episode)
@@ -309,7 +309,7 @@ def formal_script_plan_write_transaction(
     episode: int,
     *paths: Path,
     basis: ArtifactBasis | None = None,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Commit formal script_plan files and their active Manifest claim as one unit.
 
     Callers own the canonical per-path lock.  Every Python write path for a

--- a/lib/source_loader/epub.py
+++ b/lib/source_loader/epub.py
@@ -6,6 +6,8 @@ import ebooklib
 from bs4 import BeautifulSoup
 from ebooklib import epub
 
+from lib.schema_guards import is_shape
+
 from .base import ExtractedText
 from .errors import CorruptFileError
 
@@ -24,9 +26,10 @@ def _resolve_titles(book: epub.EpubBook, doc_items: list) -> list[str]:
             elif hasattr(entry, "href") and entry.href:
                 by_href[entry.href.split("#")[0]] = entry.title
 
-    if book.toc:
-        toc = book.toc if isinstance(book.toc, list | tuple) else [book.toc]
-        _walk(toc)
+    # ebooklib 的 toc 未做类型声明，运行期可能是单个 Link 而非序列
+    toc = book.toc
+    if toc:
+        _walk(list(toc) if is_shape(toc, (list, tuple)) else [toc])
 
     titles: list[str] = []
     for idx, item in enumerate(doc_items, start=1):

--- a/lib/source_loader/txt.py
+++ b/lib/source_loader/txt.py
@@ -34,7 +34,7 @@ def decode_txt(raw: bytes) -> tuple[str, str]:
 
     best = charset_normalizer.from_bytes(raw).best()
     detected_enc: str | None = None
-    if best is not None and best.chaos is not None and best.chaos < 0.5 and best.encoding:
+    if best is not None and best.chaos < 0.5 and best.encoding:
         detected_enc = best.encoding
         try:
             return raw.decode(best.encoding), best.encoding

--- a/lib/speech_artifact_provenance.py
+++ b/lib/speech_artifact_provenance.py
@@ -7,7 +7,6 @@ own a second stale store beside :mod:`lib.artifact_manifest`.
 
 from __future__ import annotations
 
-import math
 import unicodedata
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -18,6 +17,7 @@ from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor
 from lib.asset_types import asset_name_comparison_key, normalize_asset_bucket
 from lib.content_digest import PREFIXED_DIGEST_RE, prefixed_sha256_file
 from lib.narration_delivery import POST_PRODUCTION, USE_TTS
+from lib.schema_guards import is_finite_number, is_str
 from lib.speech_composition import SpeechMode, SpeechOwner, SpeechPreparation
 
 RenditionVariant = Literal["post_production", "use_tts"]
@@ -42,12 +42,8 @@ class CharacterVoiceEvidence:
     reference_audio: Path | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.speaker, str) or not self.speaker.strip():
+        if not self.speaker.strip():
             raise ValueError("speaker must be a non-empty string")
-        if not isinstance(self.voice_style, str):
-            raise ValueError("voice_style must be a string")
-        if self.reference_audio is not None and not isinstance(self.reference_audio, Path):
-            raise TypeError("reference_audio must be a Path or null")
         object.__setattr__(self, "speaker", asset_name_comparison_key(self.speaker))
         object.__setattr__(self, "voice_style", _canonical_text(self.voice_style))
 
@@ -70,12 +66,10 @@ class SelectedMediaEvidence:
     actual_duration_seconds: float
 
     def __post_init__(self) -> None:
-        if not isinstance(self.basis, ArtifactBasisDescriptor):
-            raise TypeError("basis must be an ArtifactBasisDescriptor")
-        if not isinstance(self.content_digest, str) or PREFIXED_DIGEST_RE.fullmatch(self.content_digest) is None:
+        if not is_str(self.content_digest) or PREFIXED_DIGEST_RE.fullmatch(self.content_digest) is None:
             raise ValueError("content_digest must be a canonical sha256-v1 digest")
         duration = self.actual_duration_seconds
-        if isinstance(duration, bool) or not isinstance(duration, (int, float)) or not math.isfinite(duration):
+        if not is_finite_number(duration):
             raise ValueError("actual_duration_seconds must be positive and finite")
         if duration <= 0:
             raise ValueError("actual_duration_seconds must be positive and finite")
@@ -90,7 +84,7 @@ class SelectedMediaEvidence:
         actual_duration_seconds: float,
     ) -> SelectedMediaEvidence:
         return cls(
-            basis=_basis_descriptor("basis", basis),
+            basis=_basis_descriptor(basis),
             content_digest=media_content_digest(path),
             actual_duration_seconds=actual_duration_seconds,
         )
@@ -112,8 +106,6 @@ class SubtitleUtteranceEvidence:
     speaker: str | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.owner, SpeechOwner):
-            raise TypeError("owner must be a SpeechOwner")
         normalized_text = _canonical_text(self.text)
         if not normalized_text:
             raise ValueError("subtitle utterance text must be non-empty")
@@ -155,8 +147,6 @@ def project_character_voice_evidence(
         return ()
     style_names = {asset_name_comparison_key(name) for name in voice_style_speakers}
     audio_paths = {asset_name_comparison_key(name): path for name, path in (reference_audio_paths or {}).items()}
-    if any(not isinstance(path, Path) for path in audio_paths.values()):
-        raise TypeError("reference_audio_paths values must be Paths")
     character_bucket = normalize_asset_bucket(characters)
     ordered_speakers = list(
         dict.fromkeys(
@@ -197,8 +187,6 @@ def build_video_speech_basis(
     """
 
     mode = _require_prepared_speech(preparation)
-    if any(not isinstance(voice, CharacterVoiceEvidence) for voice in voices):
-        raise TypeError("voices must contain CharacterVoiceEvidence values")
     profiles: dict[str, CharacterVoiceEvidence] = {}
     for voice in voices:
         if voice.speaker in profiles:
@@ -269,12 +257,6 @@ def build_mechanical_subtitle_basis(
 
     mode = _require_prepared_speech(preparation)
     normalized_variant = _variant(variant)
-    if not isinstance(video, SelectedMediaEvidence):
-        raise TypeError("video must be SelectedMediaEvidence")
-    if narration_audio is not None and not isinstance(narration_audio, SelectedMediaEvidence):
-        raise TypeError("narration_audio must be SelectedMediaEvidence or null")
-    if not isinstance(timing_policy, Mapping):
-        raise TypeError("timing_policy must be a mapping")
 
     narrator_uses_tts = mode is SpeechMode.NARRATOR_VOICEOVER and normalized_variant == USE_TTS
     if narrator_uses_tts and narration_audio is None:
@@ -308,17 +290,7 @@ def build_presentation_basis(
     """Describe a final-presentation variant without performing media mixing."""
 
     normalized_variant = _variant(variant)
-    if not isinstance(video, SelectedMediaEvidence):
-        raise TypeError("video must be SelectedMediaEvidence")
-    subtitle_descriptor = _basis_descriptor("subtitle", subtitle)
-    if narration_audio is not None and not isinstance(narration_audio, SelectedMediaEvidence):
-        raise TypeError("narration_audio must be SelectedMediaEvidence or null")
-    if not isinstance(provider_audio_enabled, bool):
-        raise TypeError("provider_audio_enabled must be a boolean")
-    if not isinstance(transition_to_next, str):
-        raise TypeError("transition_to_next must be a string")
-    if not isinstance(mix_policy, Mapping):
-        raise TypeError("mix_policy must be a mapping")
+    subtitle_descriptor = _basis_descriptor(subtitle)
     if normalized_variant == USE_TTS and narration_audio is None:
         raise ValueError("use_tts presentation basis requires narration audio")
     if normalized_variant == POST_PRODUCTION and narration_audio is not None:
@@ -361,25 +333,21 @@ def project_subtitle_utterances(preparation: SpeechPreparation) -> tuple[Subtitl
 
 
 def _require_prepared_speech(preparation: SpeechPreparation) -> SpeechMode:
-    if not isinstance(preparation, SpeechPreparation):
-        raise TypeError("preparation must be a SpeechPreparation")
     if preparation.problems or preparation.mode is None:
         raise ValueError("cannot build artifact basis from blocked speech preparation")
     return preparation.mode
 
 
-def _basis_descriptor(field: str, value: ArtifactBasis | ArtifactBasisDescriptor) -> ArtifactBasisDescriptor:
+def _basis_descriptor(value: ArtifactBasis | ArtifactBasisDescriptor) -> ArtifactBasisDescriptor:
     if isinstance(value, ArtifactBasis):
         return ArtifactBasisDescriptor.from_basis(value)
-    if isinstance(value, ArtifactBasisDescriptor):
-        return value
-    raise TypeError(f"{field} must be an ArtifactBasis or ArtifactBasisDescriptor")
+    return value
 
 
 def _variant(value: object) -> RenditionVariant:
     if value not in (POST_PRODUCTION, USE_TTS):
         raise ValueError(f"unsupported rendition variant: {value!r}")
-    return value  # type: ignore[return-value]
+    return value
 
 
 def _canonical_text(value: object) -> str:

--- a/lib/speech_presentation.py
+++ b/lib/speech_presentation.py
@@ -40,7 +40,7 @@ def presentation_artifact_paths(episode: int, resource_id: str, variant: Renditi
 
     if type(episode) is not int or episode <= 0:
         raise ValueError("episode must be a positive integer")
-    if not isinstance(resource_id, str) or not resource_id:
+    if not resource_id:
         raise ValueError("resource_id must be a non-empty string")
     if variant not in {POST_PRODUCTION, USE_TTS}:
         raise ValueError(f"unsupported rendition variant: {variant!r}")
@@ -62,7 +62,7 @@ class PresentationMedia:
     evidence: SelectedMediaEvidence
 
     def __post_init__(self) -> None:
-        if not isinstance(self.artifact_path, str) or not self.artifact_path:
+        if not self.artifact_path:
             raise ValueError("artifact_path must be a non-empty string")
         if type(self.version) is not int or self.version <= 0:
             raise ValueError("version must be a positive integer")
@@ -70,8 +70,6 @@ class PresentationMedia:
             raise ValueError("selection must be current or history")
         if self.currency not in {"current", "stale"}:
             raise ValueError("currency must be current or stale")
-        if not isinstance(self.evidence, SelectedMediaEvidence):
-            raise TypeError("evidence must be SelectedMediaEvidence")
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,10 +81,6 @@ class SubtitleCue:
     text: str
     owner: SpeechOwner
     speaker: str | None
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.owner, SpeechOwner):
-            raise TypeError("owner must be a SpeechOwner")
 
     @property
     def end_microseconds(self) -> int:
@@ -267,16 +261,16 @@ class RawPresentationMedia:
     actual_duration_seconds: float
 
     def __post_init__(self) -> None:
-        if not isinstance(self.artifact_path, str) or not self.artifact_path:
+        if not self.artifact_path:
             raise ValueError("artifact_path must be a non-empty string")
         if type(self.version) is not int or self.version <= 0:
             raise ValueError("version must be a positive integer")
         if self.selection not in {"current", "history"}:
             raise ValueError("selection must be current or history")
-        if not isinstance(self.content_digest, str) or PREFIXED_DIGEST_RE.fullmatch(self.content_digest) is None:
+        if PREFIXED_DIGEST_RE.fullmatch(self.content_digest) is None:
             raise ValueError("content_digest must be a canonical sha256-v1 digest")
         duration = self.actual_duration_seconds
-        if isinstance(duration, bool) or not isinstance(duration, (int, float)) or not math.isfinite(duration):
+        if not math.isfinite(duration):
             raise ValueError("actual_duration_seconds must be positive and finite")
         if duration <= 0:
             raise ValueError("actual_duration_seconds must be positive and finite")
@@ -366,10 +360,8 @@ def materialize_raw_video_presentation(
 ) -> RawVideoPresentation:
     """Represent an observed manual upload without inventing generation provenance."""
 
-    if not isinstance(unit_id, str) or not unit_id:
+    if not unit_id:
         raise ValueError("unit_id must be a non-empty string")
-    if not isinstance(video, RawPresentationMedia):
-        raise TypeError("video must be RawPresentationMedia")
     return RawVideoPresentation(
         unit_id=unit_id,
         selection=video.selection,
@@ -393,18 +385,10 @@ def materialize_speech_presentation(
 ) -> SpeechPresentation:
     """Materialize one validated presentation from selected real media."""
 
-    if not isinstance(preparation, SpeechPreparation) or preparation.problems or preparation.mode is None:
+    if preparation.problems or preparation.mode is None:
         raise ValueError("presentation requires an admitted speech preparation")
     if variant not in {POST_PRODUCTION, USE_TTS}:
         raise ValueError(f"unsupported rendition variant: {variant!r}")
-    if not isinstance(video, PresentationMedia):
-        raise TypeError("video must be PresentationMedia")
-    if not isinstance(provider_audio_enabled, bool):
-        raise TypeError("provider_audio_enabled must be a boolean")
-    if not isinstance(transition_to_next, str):
-        raise TypeError("transition_to_next must be a string")
-    if narration_audio is not None and not isinstance(narration_audio, PresentationMedia):
-        raise TypeError("narration_audio must be PresentationMedia or null")
     if variant == USE_TTS and preparation.mode is not SpeechMode.NARRATOR_VOICEOVER:
         raise ValueError("use_tts presentation requires narrator voiceover")
     if variant == USE_TTS and narration_audio is None:
@@ -474,7 +458,7 @@ def materialize_speech_presentation(
 
 
 def _duration_microseconds(seconds: float) -> int:
-    if isinstance(seconds, bool) or not isinstance(seconds, (int, float)) or not math.isfinite(seconds) or seconds <= 0:
+    if not math.isfinite(seconds) or seconds <= 0:
         raise ValueError("media duration must be positive and finite")
     duration = round(float(seconds) * MICROSECONDS_PER_SECOND)
     if duration <= 0:

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -77,7 +77,8 @@ def find_storyboard_item(
     resource_id: str,
 ) -> tuple[Any, int] | None:
     for index, item in enumerate(items):
-        if str(item.get(id_field)) == str(resource_id):
+        # 条目来自磁盘剧本 JSON，只有外层 list 被校验过：非映射条目跳过而不是抛 AttributeError。
+        if isinstance(item, dict) and str(item.get(id_field)) == str(resource_id):
             return item, index
     return None
 
@@ -165,7 +166,7 @@ def resolve_storyboard_video_inputs(
 
 def resolve_previous_storyboard_path(
     project_path: Path,
-    items: Sequence[dict],
+    items: Sequence[Any],
     id_field: str,
     resource_id: str,
 ) -> Path | None:
@@ -178,6 +179,8 @@ def resolve_previous_storyboard_path(
         return None
 
     previous_item = items[index - 1]
+    if not isinstance(previous_item, dict):
+        return None
     previous_id = str(previous_item.get(id_field) or "").strip()
     if not previous_id:
         return None

--- a/lib/storyboard_sequence.py
+++ b/lib/storyboard_sequence.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from lib.path_safety import safe_join, try_safe_join
 from lib.resource_paths import END_FRAME_RESOURCE_TYPE, resource_relative_path
@@ -42,7 +43,7 @@ PREVIOUS_STORYBOARD_REFERENCE_DESCRIPTION = (
 )
 
 
-def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str, str]:
+def get_storyboard_items(script: dict) -> tuple[list[Any], str, str | None, str, str]:
     """返回 旁白/解说、剧情演绎与广告/短片剧本的分镜列表 + 各引用字段名。
 
     ``video_units`` 骨架没有 storyboard 一说（视频按 unit 直出，见
@@ -71,10 +72,10 @@ def get_storyboard_items(script: dict) -> tuple[list[dict], str, str | None, str
 
 
 def find_storyboard_item(
-    items: Sequence[dict],
+    items: Sequence[Any],
     id_field: str,
     resource_id: str,
-) -> tuple[dict, int] | None:
+) -> tuple[Any, int] | None:
     for index, item in enumerate(items):
         if str(item.get(id_field)) == str(resource_id):
             return item, index

--- a/lib/system_config.py
+++ b/lib/system_config.py
@@ -90,14 +90,6 @@ def _iso_now_millis() -> str:
     return datetime.now(UTC).isoformat(timespec="milliseconds")
 
 
-def _safe_str(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return value
-    return str(value)
-
-
 def _is_blank(value: Any) -> bool:
     if value is None:
         return True
@@ -119,42 +111,6 @@ def parse_bool_env(value: Any, default: bool) -> bool:
         if normalized in {"0", "false", "f", "no", "n", "off"}:
             return False
     return default
-
-
-def _read_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str):
-        if not value.strip():
-            return None
-        try:
-            return int(value)
-        except ValueError:
-            return None
-    return None
-
-
-def _read_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return float(int(value))
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        if not value.strip():
-            return None
-        try:
-            return float(value)
-        except ValueError:
-            return None
-    return None
 
 
 @dataclass(frozen=True)

--- a/lib/text_backends/base.py
+++ b/lib/text_backends/base.py
@@ -238,8 +238,6 @@ def resolve_schema(schema: dict | type[BaseModel]) -> dict:
     - dict: 直接内联 $ref（如果有）
     """
     if isinstance(schema, type):
-        if not issubclass(schema, BaseModel):
-            raise TypeError(f"resolve_schema 仅接受 dict 或 Pydantic BaseModel 子类，得到 {schema!r}")
         schema_dict: dict = schema.model_json_schema()
     else:
         schema_dict = schema

--- a/lib/text_backends/instructor_support.py
+++ b/lib/text_backends/instructor_support.py
@@ -233,11 +233,6 @@ def generate_structured_via_instructor(
     与原生结构化通道的截断行为同口径（见 docs/adr/0044）。
     """
     patched = instructor.from_openai(client, mode=mode)
-    if patched is None:
-        raise TypeError(
-            f"instructor.from_openai() 返回 None — client 类型 {type(client).__name__} 不受支持，"
-            "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
-        )
     extra: dict = {token_param: max_tokens} if max_tokens is not None else {}
     try:
         result, completion = patched.chat.completions.create_with_completion(
@@ -281,11 +276,6 @@ async def generate_structured_via_instructor_async(
     与原生结构化通道的截断行为同口径（见 docs/adr/0044）。
     """
     patched = instructor.from_openai(client, mode=mode)
-    if patched is None:
-        raise TypeError(
-            f"instructor.from_openai() 返回 None — client 类型 {type(client).__name__} 不受支持，"
-            "请传入 openai.OpenAI 或 openai.AsyncOpenAI 实例"
-        )
     extra: dict = {token_param: max_tokens} if max_tokens is not None else {}
     try:
         result, completion = await patched.chat.completions.create_with_completion(  # type: ignore[misc]

--- a/lib/thumbnail.py
+++ b/lib/thumbnail.py
@@ -21,7 +21,7 @@ def _ffprobe_available() -> bool:
     return shutil.which("ffprobe") is not None
 
 
-def _reset_for_tests() -> None:
+def reset_for_tests() -> None:
     """test helper — 清缓存让 monkeypatch shutil.which 立刻生效。"""
     _ffmpeg_available.cache_clear()
     _ffprobe_available.cache_clear()

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
-from typing import Any, ClassVar
+from typing import Any, ClassVar, assert_never
 
 from lib.api_errors import BadRequestError, NotFoundError
 from lib.artifact_manifest import ArtifactManifestError, ProjectArtifactManifestAdapter
@@ -645,7 +645,7 @@ class VersionManager:
         if resource_type not in self.RESOURCE_TYPES:
             raise ValueError(f"不支持的资源类型: {resource_type}")
         if not isinstance(select_current, bool) and not callable(select_current):
-            raise TypeError("select_current must be a boolean or a callable returning one")
+            assert_never(select_current)
         if expected_current_version is not None and (
             type(expected_current_version) is not int or expected_current_version < 0
         ):

--- a/lib/version_manager.py
+++ b/lib/version_manager.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 import tempfile
 import threading
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -25,6 +25,7 @@ from lib.formal_write import formal_write_transaction
 from lib.json_io import atomic_write_bytes, atomic_write_json
 from lib.resource_paths import RESOURCE_TYPES as _RESOURCE_TYPES
 from lib.resource_paths import resource_extension, resource_relative_path
+from lib.schema_guards import is_bool
 
 _LOCKS_GUARD = threading.Lock()
 _LOCKS_BY_VERSIONS_FILE: dict[str, threading.RLock] = {}
@@ -220,7 +221,7 @@ class VersionManager:
         return info["current_version"]
 
     @contextmanager
-    def locked_version_snapshot(self, resource_type: str, resource_id: str) -> Iterator[dict[str, Any]]:
+    def locked_version_snapshot(self, resource_type: str, resource_id: str) -> Generator[dict[str, Any]]:
         """Keep one resource selection stable while a dependent read-model commit runs."""
 
         with self._lock:
@@ -732,7 +733,7 @@ class VersionManager:
                     if callable(select_current)
                     else select_current
                 )
-                if not isinstance(should_select, bool):
+                if not is_bool(should_select):
                     raise TypeError("select_current callback must return a boolean")
             except BaseException as failure:
                 _report_cleanup_failures(_unlink_paths(staged_file), active_failure=failure)

--- a/lib/video_artifact_facts.py
+++ b/lib/video_artifact_facts.py
@@ -9,6 +9,7 @@ from typing import Any, Self, cast
 from lib.artifact_manifest import ArtifactBasis, ArtifactBasisDescriptor, compose_video_artifact_basis
 from lib.asset_types import asset_name_comparison_key
 from lib.content_digest import CONTENT_DIGEST_RE, PREFIXED_DIGEST_RE, prefixed_canonical_json_digest
+from lib.schema_guards import is_str
 from lib.speech_artifact_provenance import build_video_duration_basis
 
 _SCHEMA_VERSION = 1
@@ -68,8 +69,6 @@ class VideoArtifactCurrencyFacts:
             ("duration_basis", self.duration_basis),
             ("video_basis", self.video_basis),
         ):
-            if not isinstance(value, ArtifactBasis):
-                raise TypeError(f"{field} must be an ArtifactBasis")
             if value.kind_version != 1:
                 raise ValueError(f"{field} must use the supported kind version")
         if self.visual_basis.kind not in {_STORYBOARD_VISUAL_KIND, _REFERENCE_VISUAL_KIND}:
@@ -89,7 +88,7 @@ class VideoArtifactCurrencyFacts:
         if self.video_basis != expected_video or self.video_basis.kind != _VIDEO_KIND:
             raise ValueError("video_basis does not compose the frozen video components")
         if any(
-            not isinstance(speaker, str) or not speaker or asset_name_comparison_key(speaker) != speaker
+            not is_str(speaker) or not speaker or asset_name_comparison_key(speaker) != speaker
             for speaker in self.voice_style_speakers
         ):
             raise ValueError("voice_style_speakers must contain canonical non-empty names")
@@ -152,7 +151,7 @@ class VideoArtifactCurrencyFacts:
 
     @classmethod
     def from_dict(cls, value: object) -> Self:
-        if not isinstance(value, Mapping) or set(value) != cls._FIELDS:
+        if not isinstance(value, Mapping) or frozenset(value) != cls._FIELDS:
             raise ValueError("video artifact currency facts have an invalid schema")
         raw = cast(Mapping[str, Any], value)
         if raw["schema_version"] != _SCHEMA_VERSION:

--- a/lib/video_backends/ark.py
+++ b/lib/video_backends/ark.py
@@ -312,7 +312,7 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
         if request.start_image:
             from lib.image_backends.base import image_to_base64_data_uri
 
-            data_uri = image_to_base64_data_uri(request.start_image)
+            data_uri = await asyncio.to_thread(image_to_base64_data_uri, request.start_image)
             content.append(
                 {
                     "type": "image_url",
@@ -331,7 +331,7 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
                 raise VideoCapabilityError(
                     "video_end_image_unreadable", model=self._model, name=end_path.name or str(end_path)
                 )
-            data_uri = image_to_base64_data_uri(request.end_image)
+            data_uri = await asyncio.to_thread(image_to_base64_data_uri, request.end_image)
             content.append(
                 {
                     "type": "image_url",
@@ -351,32 +351,42 @@ class ArkVideoBackend(ProviderJobIdPersistenceMixin):
                     model=self._model,
                     names=", ".join(p.name or str(p) for p in missing),
                 )
-            for ref_path in request.reference_images:
-                data_uri = image_to_base64_data_uri(Path(ref_path))
-                content.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": data_uri},
-                        "role": "reference_image",
-                    }
-                )
+            ref_data_uris = await asyncio.gather(
+                *[asyncio.to_thread(image_to_base64_data_uri, Path(ref_path)) for ref_path in request.reference_images]
+            )
+            content.extend(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": data_uri},
+                    "role": "reference_image",
+                }
+                for data_uri in ref_data_uris
+            )
 
         if request.reference_audio_files:
             # 音频条目与图片条目同列 content 数组，各自按类型独立编号：prompt 里的「音频N」
             # 指的是第 N 个 type="audio_url" 条目（官方《快速入门》提示词规则）。故这里必须
             # 保持 reference_audio_files 的原始顺序、不跳过任何一段——跳过会让编排层拼好的
-            # 指认文本整体错位，把 A 角色的音色安到 B 角色头上。
+            # 指认文本整体错位，把 A 角色的音色安到 B 角色头上。gather 按入参顺序返回，
+            # 并发不影响该编号。读整段音频做 base64 编码是阻塞 I/O，逐段卸载到线程。
+            audio_data_uris = await asyncio.gather(
+                *[
+                    asyncio.to_thread(
+                        reference_audio_to_data_uri,
+                        Path(audio_path),
+                        model=self._model,
+                        mime_types=_REFERENCE_AUDIO_MIME_TYPES,
+                    )
+                    for audio_path in request.reference_audio_files
+                ]
+            )
             content.extend(
                 {
                     "type": "audio_url",
-                    "audio_url": {
-                        "url": reference_audio_to_data_uri(
-                            Path(audio_path), model=self._model, mime_types=_REFERENCE_AUDIO_MIME_TYPES
-                        )
-                    },
+                    "audio_url": {"url": data_uri},
                     "role": "reference_audio",
                 }
-                for audio_path in request.reference_audio_files
+                for data_uri in audio_data_uris
             )
 
         # 2. Build API params

--- a/lib/video_backends/gemini.py
+++ b/lib/video_backends/gemini.py
@@ -353,12 +353,10 @@ class GeminiVideoBackend(ProviderJobIdPersistenceMixin):
             }
             mime_type = mime_types.get(suffix, mime_type_png)
             return self._types.Image(image_bytes=image_bytes, mime_type=mime_type)
-        if isinstance(image, Image.Image):
-            buffer = io.BytesIO()
-            image.save(buffer, format="PNG")
-            image_bytes = buffer.getvalue()
-            return self._types.Image(image_bytes=image_bytes, mime_type=mime_type_png)
-        return image
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        image_bytes = buffer.getvalue()
+        return self._types.Image(image_bytes=image_bytes, mime_type=mime_type_png)
 
     async def _download_video_with_retry(self, video_ref, output_path: Path) -> None:
         """下载视频，重试走共用的产物下载预算。
@@ -401,7 +399,7 @@ def _is_gemini_not_found(exc: BaseException) -> bool:
     与 NOT_FOUND（资源不存在）语义不同；归过期会把客户端 bug 当成幽灵任务静默吞掉。
     """
     try:
-        from google.genai import errors as _genai_errors  # pyright: ignore[reportMissingImports]
+        from google.genai import errors as _genai_errors
     except ImportError:
         _genai_errors = None
 

--- a/lib/video_backends/grok.py
+++ b/lib/video_backends/grok.py
@@ -127,7 +127,7 @@ class GrokVideoBackend:
             generate_kwargs["image_url"] = await asyncio.to_thread(image_to_data_uri, image_path, IMAGE_MIME_TYPES)
 
         if request.reference_images:
-            ref_paths = [Path(p) if not isinstance(p, Path) else p for p in request.reference_images]
+            ref_paths = list(request.reference_images)
             existing_paths = [p for p in ref_paths if p.exists()]
             if existing_paths:
                 ref_urls = await asyncio.gather(

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -167,14 +167,13 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
         kwargs["size"] = _resolve_size(self._model, request.resolution, request.aspect_ratio)
 
         # 收集所有参考图：start_image + reference_images
-        refs = []
+        ref_paths: list[Path] = []
         if request.start_image and Path(request.start_image).exists():  # noqa: ASYNC240 -- 首帧存在性检查，本地元数据
-            refs.append(_encode_start_image(Path(request.start_image)))
+            ref_paths.append(Path(request.start_image))
         if request.reference_images:
-            for ref_path in request.reference_images:
-                p = ref_path
-                if p.exists():
-                    refs.append(_encode_start_image(p))
+            ref_paths.extend(p for p in request.reference_images if p.exists())
+        # 读整张图取上传字节是阻塞 I/O，逐张卸载到线程后并发等待，避免堵住事件循环
+        refs = list(await asyncio.gather(*[asyncio.to_thread(_encode_start_image, p) for p in ref_paths]))
         if refs:
             # 单张图时保持 tuple 格式（API 兼容），多张时用 list
             kwargs["input_reference"] = refs[0] if len(refs) == 1 else refs

--- a/lib/video_backends/openai.py
+++ b/lib/video_backends/openai.py
@@ -172,7 +172,7 @@ class OpenAIVideoBackend(ProviderJobIdPersistenceMixin):
             refs.append(_encode_start_image(Path(request.start_image)))
         if request.reference_images:
             for ref_path in request.reference_images:
-                p = Path(ref_path) if not isinstance(ref_path, Path) else ref_path
+                p = ref_path
                 if p.exists():
                     refs.append(_encode_start_image(p))
         if refs:
@@ -298,7 +298,7 @@ def _is_openai_not_found(exc: BaseException) -> bool:
     宽泛字串会把诸如 ``"file not found in storage"`` 等业务错误误判为幽灵任务。
     """
     try:
-        from openai import NotFoundError  # pyright: ignore[reportMissingImports]
+        from openai import NotFoundError
     except ImportError:
         NotFoundError = None
 

--- a/lib/visual_artifact_provenance.py
+++ b/lib/visual_artifact_provenance.py
@@ -37,8 +37,6 @@ class VisualReference:
     content_digest: str | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.path, Path):
-            raise TypeError("visual reference path must be a Path")
         _require_non_empty("visual reference role", self.role)
         if (self.logical_type is None) != (self.logical_id is None):
             raise ValueError("visual reference logical_type and logical_id must be provided together")
@@ -101,7 +99,7 @@ def visual_references_match_snapshot(references: Sequence[VisualReference]) -> b
     """Verify that every selected reference still has its frozen content digest."""
 
     for reference in references:
-        if not isinstance(reference, VisualReference) or reference.content_digest is None:
+        if reference.content_digest is None:
             raise ValueError("visual reference comparison requires frozen snapshots")
         try:
             current_digest = visual_file_digest(reference.path)
@@ -368,19 +366,16 @@ def build_reference_video_artifact_visual_basis(
     if not isinstance(raw_text, str):
         raise ValueError("unit.text must be a string")
     visual_lines = _reference_visual_lines(raw_text)
-    references: list[VisualReference] = []
-    for asset in request_assets:
-        if not isinstance(asset, ResolvedReferenceAsset):
-            raise TypeError("request_assets must contain ResolvedReferenceAsset values")
-        references.append(
-            VisualReference(
-                path=asset.path,
-                role="reference_image",
-                logical_type=asset.reference.type,
-                logical_id=asset.reference.name,
-                kind=asset.kind,
-            )
+    references = [
+        VisualReference(
+            path=asset.path,
+            role="reference_image",
+            logical_type=asset.reference.type,
+            logical_id=asset.reference.name,
+            kind=asset.kind,
         )
+        for asset in request_assets
+    ]
     return ArtifactBasis.build(
         "artifact-visual/video-reference",
         kind_version=1,
@@ -421,8 +416,6 @@ def _validate_grid_members(
         raise ValueError("grid must contain at least one member")
     if len(member_tuple) > rows * columns:
         raise ValueError("grid members exceed the declared layout capacity")
-    if any(not isinstance(member, GridStoryboardVisual) for member in member_tuple):
-        raise TypeError("grid members must be GridStoryboardVisual values")
     identities = [member.resource_id for member in member_tuple]
     if len(set(identities)) != len(identities):
         raise ValueError("grid member resource_id values must be unique")
@@ -457,8 +450,6 @@ def _project_grid_action(video_prompt: object) -> str:
 
 
 def _reference_evidence(references: Sequence[VisualReference]) -> list[dict[str, object]]:
-    if any(not isinstance(reference, VisualReference) for reference in references):
-        raise TypeError("visual references must be VisualReference values")
     return [reference.evidence() for reference in references]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,10 @@ reportImportCycles = false
 reportUnnecessaryIsInstance = "warning"
 reportUnnecessaryComparison = "warning"
 reportUnnecessaryTypeIgnoreComment = "warning"
+reportUnusedImport = "warning"
+reportUnusedVariable = "warning"
+reportUnusedClass = "warning"
+reportDeprecated = "warning"
 
 reportGeneralTypeIssues = "error"
 reportOptionalSubscript = "error"
@@ -268,18 +272,21 @@ reportPrivateUsage = "none"
 reportUnknownMemberType = "none"
 reportUnknownArgumentType = "none"
 reportUnknownVariableType = "none"
-reportArgumentType = "warning"
-reportAttributeAccessIssue = "warning"
-# 测试里 repo/manager 调用通常断言式访问，narrow 噪声大；mock 返回也常被 subscript
-reportOptionalSubscript = "warning"
-reportOptionalMemberAccess = "warning"
-reportOptionalIterable = "warning"
-reportOperatorIssue = "warning"
-reportOptionalCall = "warning"
+# 以下规则在测试域不做闸门：测试里 repo/manager 调用通常断言式访问，narrow 噪声大；
+# mock 返回也常被 subscript。闸门跑 `basedpyright --warnings` 后 warning 即阻断，
+# 故这批降级写成 none 才是「测试域不做闸门」这一既有决策的诚实表达。
+reportArgumentType = "none"
+reportAttributeAccessIssue = "none"
+reportOptionalSubscript = "none"
+reportOptionalMemberAccess = "none"
+reportOptionalIterable = "none"
+reportOperatorIssue = "none"
+reportOptionalCall = "none"
 
 [[tool.basedpyright.executionEnvironments]]
 root = "alembic"
-reportMissingImports = "warning"
+# alembic 模板里的 `from alembic import context` 等运行期注入符号静态不可解析，此域不做闸门
+reportMissingImports = "none"
 
 # scripts/ 是一次性辅助脚本（迁移、生成 fixture、烟雾测试），
 # 不值得花大力气做类型，但 tests/scripts/ 会 import 它们，所以必须可解析
@@ -299,4 +306,5 @@ reportPossiblyUnboundVariable = "none"
 reportGeneralTypeIssues = "none"
 reportCallIssue = "none"
 reportIndexIssue = "none"
-reportMissingImports = "warning"
+# 脚本用 sys.path 注入后再 import，静态不可解析，此域不做闸门
+reportMissingImports = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,8 @@ reportUnnecessaryTypeIgnoreComment = "warning"
 reportUnusedImport = "warning"
 reportUnusedVariable = "warning"
 reportUnusedClass = "warning"
+reportUnusedFunction = "warning"
+reportUnreachable = "warning"
 reportDeprecated = "warning"
 
 reportGeneralTypeIssues = "error"

--- a/scripts/generate_style_thumbnails.py
+++ b/scripts/generate_style_thumbnails.py
@@ -15,7 +15,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from lib import config  # noqa: F401 -- 副作用导入：先初始化 config 以打破 db.repositories 的循环导入
 from lib.db import async_session_factory
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.image_backends.base import ImageGenerationRequest

--- a/server/agent_runtime/entry_pipeline.py
+++ b/server/agent_runtime/entry_pipeline.py
@@ -255,12 +255,10 @@ class SessionEntryPipeline:
             logger.exception(
                 "事件日志写入点处理失败 session_id=%s msg_type=%s",
                 self._session_id_provider(),
-                msg_dict.get("type") if isinstance(msg_dict, dict) else type(msg_dict),
+                msg_dict.get("type"),
             )
 
     async def _handle(self, msg_dict: dict[str, Any]) -> None:
-        if not isinstance(msg_dict, dict):
-            return
         session_id = self._session_id_provider()
         if not session_id:
             return

--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -212,7 +212,7 @@ class OptionsAssembler:
         ``session_id`` 以预先指定的 id 开一个全新会话（无历史可 resume），
         与 ``resume_id`` 互斥——SDK 只在 ``fork_session`` 下才允许两者并存。
         """
-        if not SDK_AVAILABLE or ClaudeAgentOptions is None:
+        if not SDK_AVAILABLE:
             raise RuntimeError("claude_agent_sdk is not installed")
         if resume_id is not None and session_id is not None:
             raise ValueError("resume_id and session_id are mutually exclusive")
@@ -226,42 +226,41 @@ class OptionsAssembler:
         # permission chain) before reaching can_use_tool (step 5).  Hooks
         # (step 1) fire for ALL tool calls and can override allow rules.
         hooks = None
-        if HookMatcher is not None:
-            hook_callbacks: list[Any] = [
-                self._build_file_access_hook(project_cwd),
-            ]
-            if can_use_tool is not None:
-                # Official Python SDK guidance: keep stream open when using
-                # can_use_tool.
-                hook_callbacks.insert(0, self._keep_stream_open_hook)
+        hook_callbacks: list[Any] = [
+            self._build_file_access_hook(project_cwd),
+        ]
+        if can_use_tool is not None:
+            # Official Python SDK guidance: keep stream open when using
+            # can_use_tool.
+            hook_callbacks.insert(0, self._keep_stream_open_hook)
 
-            # Shared dict: PreToolUse saves file backup, PostToolUse restores
-            # on corruption.  Keyed by tool_use_id.
-            json_backups: dict[str, tuple[Path, str]] = {}
+        # Shared dict: PreToolUse saves file backup, PostToolUse restores
+        # on corruption.  Keyed by tool_use_id.
+        json_backups: dict[str, tuple[Path, str]] = {}
 
-            hooks = {
-                "PreToolUse": [
-                    HookMatcher(matcher=None, hooks=hook_callbacks),
-                    HookMatcher(
-                        matcher="Bash",
-                        hooks=[self._bash_env_scrub_hook],  # type: ignore[list-item]
-                    ),
-                    HookMatcher(
-                        matcher="Write|Edit",
-                        hooks=[
-                            self._build_json_validation_hook(project_cwd, json_backups),
-                        ],
-                    ),
-                ],
-                "PostToolUse": [
-                    HookMatcher(
-                        matcher="Write|Edit",
-                        hooks=[
-                            self._build_json_post_validation_hook(project_cwd, json_backups),
-                        ],
-                    ),
-                ],
-            }
+        hooks = {
+            "PreToolUse": [
+                HookMatcher(matcher=None, hooks=hook_callbacks),
+                HookMatcher(
+                    matcher="Bash",
+                    hooks=[self._bash_env_scrub_hook],  # type: ignore[list-item]
+                ),
+                HookMatcher(
+                    matcher="Write|Edit",
+                    hooks=[
+                        self._build_json_validation_hook(project_cwd, json_backups),
+                    ],
+                ),
+            ],
+            "PostToolUse": [
+                HookMatcher(
+                    matcher="Write|Edit",
+                    hooks=[
+                        self._build_json_post_validation_hook(project_cwd, json_backups),
+                    ],
+                ),
+            ],
+        }
 
         provider_env = await self.build_provider_env_overrides()
         provider_env.update(

--- a/server/agent_runtime/options_assembler.py
+++ b/server/agent_runtime/options_assembler.py
@@ -10,6 +10,7 @@ policy，装配天职是开会话时现场读 DB / 扫盘则允许 I/O 归本类
 ``configure_sandbox_runtime`` 整体换新 policy 后对后续所有会话立即生效。
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -481,7 +482,7 @@ class OptionsAssembler:
                 p = Path(file_path)
                 resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()  # noqa: ASYNC240 -- 仅路径解析（resolve），不读文件内容
                 try:
-                    current = resolved.read_text(encoding="utf-8")
+                    current = await asyncio.to_thread(resolved.read_text, encoding="utf-8")
                 except OSError as read_err:
                     logger.info(
                         "JSON 校验 hook: tool=Edit file=%s skip=读取失败 error=%s",
@@ -604,7 +605,7 @@ class OptionsAssembler:
             resolved = (project_cwd / p).resolve() if not p.is_absolute() else p.resolve()  # noqa: ASYNC240 -- 仅路径解析（resolve），不读文件内容
 
             try:
-                actual = resolved.read_text(encoding="utf-8")
+                actual = await asyncio.to_thread(resolved.read_text, encoding="utf-8")
             except OSError:
                 return {}
 

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import time
-from collections.abc import AsyncIterable, AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, ClassVar, Optional
@@ -509,8 +509,6 @@ class SessionManager:
             if managed is None:
                 return
             msg_dict = message_to_dict(raw_msg)
-            if not isinstance(msg_dict, dict):
-                return
             echo = match_user_echo(managed.pending_user_echoes, msg_dict)
             if echo is not None:
                 # SDK 回放的用户消息副本：POST 受理时已写日志分配身份，
@@ -573,7 +571,7 @@ class SessionManager:
         sdk_session_id 就绪后由 inbox 任务先写日志（seq 0）再放行等待，权威
         条目落在 ``managed.initial_user_log_entry`` 供受理响应回传。
         """
-        if not SDK_AVAILABLE or ClaudeSDKClient is None:
+        if not SDK_AVAILABLE:
             exc = RuntimeError("claude_agent_sdk is not installed")
             raise _make_agent_startup_error(exc, project_name=project_name, session_id=None) from exc
 
@@ -665,8 +663,7 @@ class SessionManager:
                     "send_disconnect on error path 超时，走 cancel 兜底 session_id=%s",
                     temp_id,
                 )
-                if managed.actor is not None:
-                    await managed.actor.cancel_and_wait()
+                await managed.actor.cancel_and_wait()
             except Exception:
                 logger.exception(
                     "send_disconnect on error path failed session_id=%s",
@@ -908,7 +905,7 @@ class SessionManager:
                 if meta is None:
                     raise FileNotFoundError(f"session not found: {session_id}")
 
-            if not SDK_AVAILABLE or ClaudeSDKClient is None:
+            if not SDK_AVAILABLE:
                 exc = RuntimeError("claude_agent_sdk is not installed")
                 raise _make_agent_startup_error(exc, project_name=meta.project_name, session_id=session_id) from exc
 
@@ -1294,8 +1291,7 @@ class SessionManager:
                     "actor disconnect 超时，走 cancel 兜底 session_id=%s",
                     session_id,
                 )
-                if managed.actor is not None:
-                    await managed.actor.cancel_and_wait()
+                await managed.actor.cancel_and_wait()
                 managed.status = "interrupted"
             except Exception:
                 logger.exception("actor 关停异常 session_id=%s", session_id)
@@ -1361,7 +1357,7 @@ class SessionManager:
     async def _ensure_capacity(self) -> None:
         """确保有空余并发槽位，必要时淘汰最久未活跃的非 running 会话。"""
         max_concurrent = await self._get_max_concurrent()
-        active = [s for s in self.sessions.values() if s.actor is not None and s.session_id not in self._disconnecting]
+        active = [s for s in self.sessions.values() if s.session_id not in self._disconnecting]
 
         if len(active) < max_concurrent:
             return
@@ -1462,12 +1458,10 @@ class SessionManager:
         try:
             answers = await pending.answer_future
         except Exception as exc:
-            if PermissionResultDeny is not None:
-                return PermissionResultDeny(
-                    message=str(exc) or "session interrupted by user",
-                    interrupt=True,
-                )
-            raise
+            return PermissionResultDeny(
+                message=str(exc) or "session interrupted by user",
+                interrupt=True,
+            )
         merged_input = dict(input_data or {})
         merged_input["answers"] = answers
         return PermissionResultAllow(updated_input=merged_input)
@@ -1503,9 +1497,6 @@ class SessionManager:
             input_data: dict[str, Any],
             _context: Any,
         ) -> Any:
-            if PermissionResultAllow is None:
-                raise RuntimeError("claude_agent_sdk is not installed")
-
             normalized_tool = str(tool_name or "").strip().lower()
 
             if normalized_tool == "askuserquestion":
@@ -1522,27 +1513,25 @@ class SessionManager:
                 cmd = str((input_data or {}).get("command") or "").strip()
                 if self.access_policy.is_bash_command_whitelisted(cmd):
                     return PermissionResultAllow(updated_input=input_data)
-                if PermissionResultDeny is not None:
-                    return PermissionResultDeny(
-                        message=self.access_policy.format_bash_whitelist_deny_message(cmd),
-                    )
+                return PermissionResultDeny(
+                    message=self.access_policy.format_bash_whitelist_deny_message(cmd),
+                )
             # BashOutput / KillBash 是 Bash 管理类工具，回退模式直接放行。
             if not self.access_policy.sandbox_enabled and tool_name in ("BashOutput", "KillBash"):
                 return PermissionResultAllow(updated_input=input_data)
 
             # Whitelist fallback: deny any tool that was not pre-approved
             # by allowed_tools or settings.json allow rules.
-            if PermissionResultDeny is not None:
-                reason = getattr(_context, "decision_reason", None)  # SDK 0.1.74+
-                reason_line = f"上游决策原因: {reason}\n" if reason else ""
-                hint = (
-                    f"未授权的工具调用: {tool_name}"
-                    f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
-                    f"{reason_line}"
-                    "请检查工具名是否正确，以及 file_path / 命令是否触发了 "
-                    "settings.json 的 deny 规则或 PreToolUse hook（跨项目/cwd 外写/代码扩展名）。"
-                )
-                return PermissionResultDeny(message=hint)
+            reason = getattr(_context, "decision_reason", None)  # SDK 0.1.74+
+            reason_line = f"上游决策原因: {reason}\n" if reason else ""
+            hint = (
+                f"未授权的工具调用: {tool_name}"
+                f"({json.dumps(input_data, ensure_ascii=False)[:200]})\n"
+                f"{reason_line}"
+                "请检查工具名是否正确，以及 file_path / 命令是否触发了 "
+                "settings.json 的 deny 规则或 PreToolUse hook（跨项目/cwd 外写/代码扩展名）。"
+            )
+            return PermissionResultDeny(message=hint)
             return PermissionResultAllow(updated_input=input_data)
 
         return _can_use_tool
@@ -1613,9 +1602,7 @@ class SessionManager:
     @staticmethod
     def _extract_sdk_session_id(message: Any, msg_dict: dict[str, Any]) -> str | None:
         """Extract SDK session id from either serialized payload or raw object."""
-        sdk_id = None
-        if isinstance(msg_dict, dict):
-            sdk_id = msg_dict.get("session_id") or msg_dict.get("sessionId")
+        sdk_id = msg_dict.get("session_id") or msg_dict.get("sessionId")
         if sdk_id:
             return str(sdk_id)
         raw_sdk_id = getattr(message, "session_id", None) or getattr(message, "sessionId", None)
@@ -1679,7 +1666,7 @@ class SessionManager:
     @contextlib.asynccontextmanager
     async def stream_messages(
         self, session_id: str, *, idle_timeout: float = 20.0, locale: str = DEFAULT_LOCALE
-    ) -> AsyncIterator[AsyncIterator[SessionStreamEvent]]:
+    ) -> AsyncGenerator[AsyncIterator[SessionStreamEvent]]:
         """Subscribe to a session's messages as a self-cleaning async iterator.
 
         Yields an async iterator producing semantic events, in order:

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -1532,7 +1532,6 @@ class SessionManager:
                 "settings.json 的 deny 规则或 PreToolUse hook（跨项目/cwd 外写/代码扩展名）。"
             )
             return PermissionResultDeny(message=hint)
-            return PermissionResultAllow(updated_input=input_data)
 
         return _can_use_tool
 

--- a/server/agent_runtime/turn_schema.py
+++ b/server/agent_runtime/turn_schema.py
@@ -108,10 +108,5 @@ def normalize_content(content: Any) -> list[dict[str, Any]]:
             return []
         return [{"type": "text", "text": content}]
     if isinstance(content, list):
-        normalized_blocks: list[dict[str, Any]] = []
-        for block in content:
-            normalized = normalize_block(block)
-            if isinstance(normalized, dict):
-                normalized_blocks.append(normalized)
-        return normalized_blocks
+        return [normalize_block(block) for block in content]
     return []

--- a/server/error_handlers.py
+++ b/server/error_handlers.py
@@ -84,8 +84,10 @@ def register_error_handlers(
     ``server/app.py`` 调用处），默认值对应「未配置 CORS」的保守场景。
     """
 
+    # 以下处理器全部由 @app.exception_handler 就地注册，模块内无其它引用；basedpyright 把函数
+    # 作用域内的符号一律判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @app.exception_handler(ApiError)
-    async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
+    async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         _t = get_translator(request)
         content: dict[str, object] = {"detail": _t(exc.key, **exc.params)}
         if exc.diagnostic is not None:
@@ -93,7 +95,7 @@ def register_error_handlers(
         return JSONResponse(status_code=exc.status_code, content=content)
 
     @app.exception_handler(RequestValidationError)
-    async def _handle_request_validation(request: Request, exc: RequestValidationError) -> JSONResponse:
+    async def _handle_request_validation(request: Request, exc: RequestValidationError) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         _t = get_translator(request)
         error_types = {error["type"] for error in exc.errors()}
         if "assistant_image_too_large" in error_types:
@@ -103,12 +105,12 @@ def register_error_handlers(
         return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})
 
     @app.exception_handler(TaskSpecValidationError)
-    async def _handle_task_spec_error(request: Request, exc: TaskSpecValidationError) -> JSONResponse:
+    async def _handle_task_spec_error(request: Request, exc: TaskSpecValidationError) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         _t = get_translator(request)
         return JSONResponse(status_code=400, content={"detail": _t(exc.code, **exc.params)})
 
     @app.exception_handler(ActiveTaskRequestConflict)
-    async def _handle_active_task_request_conflict(
+    async def _handle_active_task_request_conflict(  # pyright: ignore[reportUnusedFunction]
         request: Request,
         exc: ActiveTaskRequestConflict,
     ) -> JSONResponse:
@@ -124,20 +126,20 @@ def register_error_handlers(
         )
 
     @app.exception_handler(ScriptEditError)
-    async def _handle_script_edit_error(request: Request, exc: ScriptEditError) -> JSONResponse:
+    async def _handle_script_edit_error(request: Request, exc: ScriptEditError) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         # 脏脚本（分镜数组键损坏等）→ 4xx 客户端错误
         _t = get_translator(request)
         return JSONResponse(status_code=400, content={"detail": script_edit_detail(exc, _t)})
 
     @app.exception_handler(FileNotFoundError)
-    async def _handle_file_not_found(request: Request, exc: FileNotFoundError) -> JSONResponse:
+    async def _handle_file_not_found(request: Request, exc: FileNotFoundError) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         # 不回传 str(exc)：load_script 等异常消息含服务器绝对路径，只进日志
         logger.warning("资源不存在: %s %s (%s)", request.method, request.url.path, exc)
         _t = get_translator(request)
         return JSONResponse(status_code=404, content={"detail": _t("resource_not_found")})
 
     @app.exception_handler(Exception)
-    async def _handle_unexpected(request: Request, exc: Exception) -> JSONResponse:
+    async def _handle_unexpected(request: Request, exc: Exception) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
         # 未预期异常的消息可能含服务器路径等内部细节，一律通用 500。
         # Starlette 发送本响应后会 re-raise，堆栈由 request_logging_middleware /
         # uvicorn 记录，此处不重复打印。

--- a/server/media_tools/context.py
+++ b/server/media_tools/context.py
@@ -21,6 +21,7 @@ from lib.narration_delivery import TtsSettingsResolver
 from lib.project_manager import ProjectManager
 from lib.project_migration_failure import MigrationFailureRecord
 from lib.project_migration_guard import project_migration_failure
+from lib.schema_guards import is_str
 from server.services import workflow_planner
 from server.services.video_caps import (
     constrained_caps_durations,
@@ -237,7 +238,7 @@ def validate_script_filename(value: str) -> str:
     is fixed inside ``ProjectManager.load_script``. Any path separator —
     including a ``scripts/`` prefix or ``..`` segments — is rejected.
     """
-    if not isinstance(value, str) or not value:
+    if not is_str(value) or not value:
         raise ValueError("script 文件名不能为空")
     if "/" in value or "\\" in value or value in (".", ".."):
         raise ValueError(f"script 必须是纯文件名，禁止路径分隔符: {value!r}")

--- a/server/media_tools/grid.py
+++ b/server/media_tools/grid.py
@@ -43,7 +43,7 @@ from lib.grid.layout import GridLayout, plan_grid_chunks, video_aspect_ratio_of
 from lib.grid.models import GridGeneration, build_grid_task_payload
 from lib.grid.prompt_builder import build_grid_prompt
 from lib.grid_manager import GridManager
-from lib.project_manager import ProjectManager, grid_storyboard_enabled
+from lib.project_manager import grid_storyboard_enabled
 from lib.resource_paths import resource_relative_path
 from lib.script_models import get_generated_assets, resolve_content_mode
 from lib.script_skeleton import ensure_route_skeleton
@@ -191,8 +191,6 @@ async def handle_generate_grid(
             script=script,
             script_filename=script_filename,
         )
-        if episode is None:
-            episode = ProjectManager.resolve_episode_from_script(script, script_filename)
         project_path = ctx.project_path
         items, id_field, _, _, _ = get_storyboard_items(script)
         aspect_ratio = video_aspect_ratio_of(project)

--- a/server/media_tools/videos.py
+++ b/server/media_tools/videos.py
@@ -755,14 +755,11 @@ async def _generate_reference_units(
 def _reference_episode(project: dict[str, Any], script: dict[str, Any], script_filename: str) -> int:
     """参考生视频的集号：绑定身份优先，取不到时回落到剧本 / 文件名推断。"""
 
-    episode = resolve_artifact_episode(
+    return resolve_artifact_episode(
         project=project,
         script=script,
         script_filename=script_filename,
     )
-    if episode is None:
-        episode = ProjectManager.resolve_episode_from_script(script, script_filename)
-    return episode
 
 
 async def _run_reference_batch(

--- a/server/remote_mcp.py
+++ b/server/remote_mcp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 from typing import Annotated, Any, Literal
@@ -925,7 +925,7 @@ class RemoteMCPHost:
         await self._app(scope, receive, send)
 
     @asynccontextmanager
-    async def run(self) -> AsyncIterator[None]:
+    async def run(self) -> AsyncGenerator[None]:
         server = self._server_factory()
         child_app = server.streamable_http_app()
         async with server.session_manager.run():

--- a/server/remote_mcp.py
+++ b/server/remote_mcp.py
@@ -371,13 +371,15 @@ def build_remote_mcp_server(
         transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
 
+    # 以下工具全部由 @server.tool 就地注册（闭包捕获 services），模块内无其它引用；basedpyright
+    # 把函数作用域内的符号一律判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @server.tool(name="list_projects", structured_output=False)
-    async def remote_list_projects() -> CallToolResult:
+    async def remote_list_projects() -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """List ArcReel projects that can be addressed by subsequent tools."""
         return _to_mcp_result("projects", await list_projects(ToolRequest(None), _authenticated_caller(), services))
 
     @server.tool(name="create_project", structured_output=False)
-    async def remote_create_project(
+    async def remote_create_project(  # pyright: ignore[reportUnusedFunction]
         name: str,
         title: str = "",
         content_mode: Literal["narration", "drama", "ad"] = "narration",
@@ -408,7 +410,7 @@ def build_remote_mcp_server(
         return _to_mcp_result("project", await create_project(ToolRequest(request), _authenticated_caller(), services))
 
     @server.tool(name="upload_source", structured_output=False)
-    async def remote_upload_source(
+    async def remote_upload_source(  # pyright: ignore[reportUnusedFunction]
         project: str,
         filename: str,
         content: str,
@@ -425,7 +427,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="open_draft", structured_output=False)
-    async def remote_open_draft(
+    async def remote_open_draft(  # pyright: ignore[reportUnusedFunction]
         project: str,
         episode: PositiveEpisode,
         doc_type: DraftDocType,
@@ -442,7 +444,7 @@ def build_remote_mcp_server(
         return _to_mcp_result("draft", await open_draft(ToolRequest(request), scope, _authenticated_caller(), services))
 
     @server.tool(name="patch_draft", structured_output=False)
-    async def remote_patch_draft(
+    async def remote_patch_draft(  # pyright: ignore[reportUnusedFunction]
         project: str,
         episode: PositiveEpisode,
         doc_type: DraftDocType,
@@ -475,7 +477,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="promote_draft", structured_output=False)
-    async def remote_promote_draft(
+    async def remote_promote_draft(  # pyright: ignore[reportUnusedFunction]
         project: str, episode: PositiveEpisode, doc_type: DraftDocType, base_revision: str
     ) -> CallToolResult:
         """Validate and promote one editing draft into its formal document."""
@@ -491,7 +493,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="discard_draft", structured_output=False)
-    async def remote_discard_draft(
+    async def remote_discard_draft(  # pyright: ignore[reportUnusedFunction]
         project: str, episode: PositiveEpisode, doc_type: DraftDocType, base_revision: str
     ) -> CallToolResult:
         """Discard one editing draft without changing its formal document."""
@@ -513,7 +515,7 @@ def build_remote_mcp_server(
         ),
         structured_output=False,
     )
-    async def remote_generate_episode_script(
+    async def remote_generate_episode_script(  # pyright: ignore[reportUnusedFunction]
         project: str,
         episode: PositiveEpisode,
         context: Context,
@@ -559,7 +561,7 @@ def build_remote_mcp_server(
         ),
         structured_output=False,
     )
-    async def remote_generate_script_plan(
+    async def remote_generate_script_plan(  # pyright: ignore[reportUnusedFunction]
         project: str,
         episode: PositiveEpisode,
         context: Context,
@@ -590,7 +592,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="confirm_script_review", structured_output=False)
-    async def remote_confirm_script_review(project: str, episode: int) -> CallToolResult:
+    async def remote_confirm_script_review(project: str, episode: int) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Confirm one episode's script_plan review before visual generation."""
         try:
             scope = _project_scope(project, projects)
@@ -604,7 +606,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="patch_episode_script", structured_output=False)
-    async def remote_patch_episode_script(
+    async def remote_patch_episode_script(  # pyright: ignore[reportUnusedFunction]
         project: str,
         script: str,
         base_revision: str,
@@ -626,7 +628,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_workflow_plan", structured_output=False)
-    async def remote_workflow_plan(
+    async def remote_workflow_plan(  # pyright: ignore[reportUnusedFunction]
         project: str,
         episode: int | None = None,
         narration_delivery: NarrationDelivery | None = None,
@@ -650,7 +652,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_generation_batch", structured_output=False)
-    async def remote_get_generation_batch(project: str, batch_id: str) -> CallToolResult:
+    async def remote_get_generation_batch(project: str, batch_id: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Read durable member states, counts, polling guidance and the terminal generation result."""
         try:
             scope = _project_scope(project, projects)
@@ -663,7 +665,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="cancel_generation_batch", structured_output=False)
-    async def remote_cancel_generation_batch(project: str, batch_id: str) -> CallToolResult:
+    async def remote_cancel_generation_batch(project: str, batch_id: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Cancel every non-terminal member through the normal queue cancellation path."""
         try:
             scope = _project_scope(project, projects)
@@ -679,7 +681,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_video_capabilities", structured_output=False)
-    async def remote_video_capabilities(project: str) -> CallToolResult:
+    async def remote_video_capabilities(project: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Return video capabilities for one explicit ArcReel project."""
         try:
             scope = _project_scope(project, projects)
@@ -695,7 +697,7 @@ def build_remote_mcp_server(
         description="Plan the next source window for one explicit project." + _REMOTE_DURABLE_BATCH_DESCRIPTION,
         structured_output=False,
     )
-    async def remote_plan_episodes(project: str, instructions: str | None = None) -> CallToolResult:
+    async def remote_plan_episodes(project: str, instructions: str | None = None) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Plan the next source window for one explicit project."""
         try:
             scope = _project_scope(project, projects)
@@ -707,7 +709,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="reset_episode_planning", structured_output=False)
-    async def remote_reset_episode_planning(
+    async def remote_reset_episode_planning(  # pyright: ignore[reportUnusedFunction]
         project: str, from_episode: int, confirm_consumed: bool = False
     ) -> CallToolResult:
         """Reset episode planning from one episode while preserving transactional safeguards."""
@@ -722,7 +724,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="patch_project", structured_output=False)
-    async def remote_patch_project(
+    async def remote_patch_project(  # pyright: ignore[reportUnusedFunction]
         project: str,
         table: str | None = None,
         entries: dict[str, Any] | None = None,
@@ -740,7 +742,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="patch_episode_meta", structured_output=False)
-    async def remote_patch_episode_meta(
+    async def remote_patch_episode_meta(  # pyright: ignore[reportUnusedFunction]
         project: str, script: str, field: Literal["title"], value: str
     ) -> CallToolResult:
         """Atomically patch episode-level metadata for one explicit project."""
@@ -755,7 +757,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="rename_asset", structured_output=False)
-    async def remote_rename_asset(project: str, table: str, old_name: str, new_name: str) -> CallToolResult:
+    async def remote_rename_asset(project: str, table: str, old_name: str, new_name: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Transactionally rename an asset and all project-local references."""
         try:
             scope = _project_scope(project, projects)
@@ -767,7 +769,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="retry_project_migration", structured_output=False)
-    async def remote_retry_project_migration(project: str) -> CallToolResult:
+    async def remote_retry_project_migration(project: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Retry the project migration chain and return the current workflow plan."""
         try:
             scope = _project_scope(project, projects)
@@ -779,7 +781,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="complete_asset_inventory", structured_output=False)
-    async def remote_complete_asset_inventory(
+    async def remote_complete_asset_inventory(  # pyright: ignore[reportUnusedFunction]
         project: str,
         scope: SourceScope,
         expected_source_revision: str,
@@ -801,7 +803,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="complete_script_plan_rebuild", structured_output=False)
-    async def remote_complete_script_plan_rebuild(
+    async def remote_complete_script_plan_rebuild(  # pyright: ignore[reportUnusedFunction]
         project: str, episode: int, expected_stale_script_plan_revision: str | None
     ) -> CallToolResult:
         """Record completion of a stale script_plan rebuild using its expected revision."""
@@ -818,7 +820,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_project_content", structured_output=False)
-    async def remote_project_content(project: str) -> CallToolResult:
+    async def remote_project_content(project: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Return project creative content and its canonical revision."""
         try:
             scope = _project_scope(project, projects)
@@ -829,7 +831,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_prompt_preview", structured_output=False)
-    async def remote_prompt_preview(project: str, script: str, item_id: str) -> CallToolResult:
+    async def remote_prompt_preview(project: str, script: str, item_id: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Return one shot's final image and video prompts, verbatim as generation would send them."""
         try:
             scope = _project_scope(project, projects)
@@ -842,7 +844,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="list_source_files", structured_output=False)
-    async def remote_source_files(project: str) -> CallToolResult:
+    async def remote_source_files(project: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """List source text files with revision and etags."""
         try:
             scope = _project_scope(project, projects)
@@ -853,7 +855,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_source_text", structured_output=False)
-    async def remote_source_text(project: str, path: str) -> CallToolResult:
+    async def remote_source_text(project: str, path: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Read one UTF-8 source text file and its revision."""
         try:
             scope = _project_scope(project, projects)
@@ -864,7 +866,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_episode_script", structured_output=False)
-    async def remote_episode_script(project: str, script: str) -> CallToolResult:
+    async def remote_episode_script(project: str, script: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Read an episode script body and the canonical revision used for patching."""
         try:
             scope = _project_scope(project, projects)
@@ -875,7 +877,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="get_script_plan_content", structured_output=False)
-    async def remote_script_plan_content(project: str, episode: int) -> CallToolResult:
+    async def remote_script_plan_content(project: str, episode: int) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Read the current formal script_plan body and its canonical revision."""
         try:
             scope = _project_scope(project, projects)
@@ -887,7 +889,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="list_project_files", structured_output=False)
-    async def remote_project_files(project: str) -> CallToolResult:
+    async def remote_project_files(project: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """List the allowlisted project business files available for diagnostics."""
         try:
             scope = _project_scope(project, projects)
@@ -898,7 +900,7 @@ def build_remote_mcp_server(
         )
 
     @server.tool(name="read_project_file", structured_output=False)
-    async def remote_project_file(project: str, path: str) -> CallToolResult:
+    async def remote_project_file(project: str, path: str) -> CallToolResult:  # pyright: ignore[reportUnusedFunction]
         """Read one allowlisted project business file and its revision/etag."""
         try:
             scope = _project_scope(project, projects)

--- a/server/routers/_asset_router_factory.py
+++ b/server/routers/_asset_router_factory.py
@@ -137,8 +137,10 @@ def build_asset_router(
 
     router = APIRouter()
 
+    # 以下四个处理器由 @router.* 就地注册，模块内无其它引用；basedpyright 把函数作用域内的符号
+    # 一律判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @router.post(f"/projects/{{project_name}}/{spec.subdir}")
-    async def add_entry(
+    async def add_entry(  # pyright: ignore[reportUnusedFunction]
         project_name: str,
         req: _CreateRequest,
         _t: Translator,
@@ -206,7 +208,7 @@ def build_asset_router(
             raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc
 
     @router.patch(f"/projects/{{project_name}}/{spec.subdir}/{{entry_name}}")
-    async def update_entry(
+    async def update_entry(  # pyright: ignore[reportUnusedFunction]
         project_name: str,
         entry_name: str,
         req: dict[str, Any],
@@ -268,7 +270,7 @@ def build_asset_router(
             raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc
 
     @router.post(f"/projects/{{project_name}}/{spec.subdir}/{{entry_name}}/rename")
-    async def rename_entry(
+    async def rename_entry(  # pyright: ignore[reportUnusedFunction]
         project_name: str,
         entry_name: str,
         req: _RenameRequest,
@@ -325,7 +327,7 @@ def build_asset_router(
             raise HTTPException(status_code=500, detail=_t("internal_server_error")) from exc
 
     @router.delete(f"/projects/{{project_name}}/{spec.subdir}/{{entry_name}}")
-    async def delete_entry(project_name: str, entry_name: str, _t: Translator):
+    async def delete_entry(project_name: str, entry_name: str, _t: Translator):  # pyright: ignore[reportUnusedFunction]
         try:
 
             def _sync():

--- a/server/routers/assets.py
+++ b/server/routers/assets.py
@@ -349,6 +349,8 @@ async def from_project(
     # 两次拷贝共用一个失败边界：任一失败都清理已落盘的另一个文件，不留孤儿。
     new_image_path: str | None = None
     new_audio_path: str | None = None
+    # 已落盘的拷贝按发生顺序登记，失败路径统一按这张清单回删，不重复逐个变量判空。
+    copied_paths: list[str] = []
     try:
         if source_sheet_path is not None:
             ext = source_sheet_path.suffix.lower() or ".png"
@@ -357,6 +359,7 @@ async def from_project(
             target = root / f"{uid}{ext}"
             await asyncio.to_thread(shutil.copyfile, source_sheet_path, target)
             new_image_path = f"_global_assets/{req.resource_type}/{uid}{ext}"
+            copied_paths.append(new_image_path)
 
         if source_audio_path is not None:
             ext = source_audio_path.suffix.lower() or ".wav"
@@ -365,11 +368,10 @@ async def from_project(
             target = root / f"{uid}{ext}"
             await asyncio.to_thread(shutil.copyfile, source_audio_path, target)
             new_audio_path = f"_global_assets/{req.resource_type}/{uid}{ext}"
+            copied_paths.append(new_audio_path)
     except Exception:
-        if new_image_path:
-            _delete_global_asset_file(new_image_path)
-        if new_audio_path:
-            _delete_global_asset_file(new_audio_path)
+        for copied in copied_paths:
+            _delete_global_asset_file(copied)
         raise
 
     # 6) 写 DB：失败路径清理拷贝文件
@@ -413,10 +415,8 @@ async def from_project(
                     await s.refresh(a)
                 except IntegrityError as exc:
                     await s.rollback()
-                    if new_image_path:
-                        _delete_global_asset_file(new_image_path)
-                    if new_audio_path:
-                        _delete_global_asset_file(new_audio_path)
+                    for copied in copied_paths:
+                        _delete_global_asset_file(copied)
                     raise HTTPException(
                         status_code=409,
                         detail=_t("asset_already_exists", name=asset_name),
@@ -424,10 +424,8 @@ async def from_project(
     except HTTPException:
         raise
     except Exception:
-        if new_image_path:
-            _delete_global_asset_file(new_image_path)
-        if new_audio_path:
-            _delete_global_asset_file(new_audio_path)
+        for copied in copied_paths:
+            _delete_global_asset_file(copied)
         raise
 
     return {"asset": _serialize(a)}

--- a/server/routers/end_frames.py
+++ b/server/routers/end_frames.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
@@ -44,7 +44,7 @@ class SelectEndFrameRequest(BaseModel):
 
 
 @contextmanager
-def _translated_errors(script_file: str, _t: Translator) -> Iterator[None]:
+def _translated_errors(script_file: str, _t: Translator) -> Generator[None]:
     """三个端点共用的领域错误 → HTTP 映射。"""
     try:
         yield

--- a/server/services/artifact_version_restore.py
+++ b/server/services/artifact_version_restore.py
@@ -94,7 +94,7 @@ def restore_typed_media_version(
         resource_id=resource_id,
         version=version,
     )
-    restored: dict[str, Any] | None = None
+    restored: list[dict[str, Any]] = []
 
     def _same_script(project: dict[str, Any]) -> str:
         current_binding = resolve_episode_script_binding(project, target.episode, target.script_file)
@@ -103,8 +103,6 @@ def restore_typed_media_version(
         return current_binding
 
     def _restore_and_register(_script_path: Path) -> None:
-        nonlocal restored
-
         def _register(record: dict[str, Any]) -> None:
             committed_target = parse_typed_media_version_record(resource_type, record)
             if committed_target != target:
@@ -116,12 +114,14 @@ def restore_typed_media_version(
                 basis=target.basis,
             )
 
-        restored = versions.restore_version(
-            resource_type,
-            resource_id,
-            version,
-            current_file,
-            on_restore=_register,
+        restored.append(
+            versions.restore_version(
+                resource_type,
+                resource_id,
+                version,
+                current_file,
+                on_restore=_register,
+            )
         )
 
     with project_manager.locked_episode_script(
@@ -139,9 +139,9 @@ def restore_typed_media_version(
             created_at=target.created_at,
         )
 
-    if restored is None:
+    if not restored:
         raise RuntimeError("typed artifact restore completed without selecting a version")
-    return restored
+    return restored[0]
 
 
 def parse_typed_media_version_record(

--- a/server/services/cost_estimation.py
+++ b/server/services/cost_estimation.py
@@ -221,39 +221,6 @@ def _split_cost_across(cost: CostBreakdown, parts: int) -> list[CostBreakdown]:
     return split
 
 
-def _estimate_unit_video_cost(
-    *,
-    unit_id: str,
-    duration_seconds: int,
-    video: _VideoPricing,
-) -> CostBreakdown:
-    """一个视频单元取档后秒数的视频估值。计价失败返回空 breakdown（该 unit 不计费）。
-
-    两条参考生视频估算路径（ad 按分镜摊回、narration/drama 按视频单元展示）的展示颗粒度不同，
-    但「按取档后秒数向 provider 询价」这一步与颗粒度无关，共用同一实现避免两处漂移。
-    """
-    est_video: CostBreakdown = {}
-    try:
-        amount, currency = cost_calculator.calculate_cost(
-            video.provider,
-            PricingParams(
-                call_type="video",
-                model=video.model,
-                resolution=video.resolution,
-                duration_seconds=duration_seconds,
-                generate_audio=video.generate_audio,
-            ),
-            custom_price_input=video.price.price_input,
-            custom_price_output=video.price.price_output,
-            custom_currency=video.price.currency,
-            estimate_only=True,
-        )
-        _add_cost(est_video, amount, currency)
-    except Exception:
-        logger.debug("无法计算 video 预估 for %s", unit_id, exc_info=True)
-    return est_video
-
-
 class _AssumeResolvedAssetsAvailable:
     def is_available(self, asset: ResolvedReferenceAsset) -> bool:
         del asset

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -104,6 +104,7 @@ from lib.reference_video.execution_checkpoint import (
     stage_provider_media_for_task,
 )
 from lib.resource_paths import resource_relative_path
+from lib.schema_guards import is_int
 from lib.script_editor import resolve_items
 from lib.script_models import resolve_content_mode
 from lib.script_skeleton import SKELETON_ENTITY_TYPES, SKELETON_ITEM_LABEL_KEYS, resolve_script_kind
@@ -641,7 +642,7 @@ def collect_shot_product_references(
 def collect_product_references_for_names(
     project: dict,
     project_path: Path,
-    names: Sequence[str],
+    names: Sequence[Any],
     *,
     currency_resolver: ArtifactCurrencyResolver,
     formal_claims: list[ArtifactInputClaim] | None = None,
@@ -1737,7 +1738,7 @@ def _resolve_tts_task_items(
     script: dict[str, Any],
     *,
     reference_video_route: bool,
-) -> tuple[list[dict[str, Any]], str, str]:
+) -> tuple[list[Any], str, str]:
     """Resolve TTS units from the generation route fixed at task start."""
 
     if not reference_video_route:
@@ -2028,8 +2029,6 @@ async def execute_tts_task(
                     failure.add_note(f"paid TTS history archival also failed: {archive_failure}")
             raise
 
-        if committed_outcome is None:
-            raise RuntimeError("TTS commit completed without a version")
         selected_current = committed_outcome.selected
         return committed_outcome
 
@@ -2320,7 +2319,7 @@ async def execute_video_task(
             _script_input,
         )
 
-    project, project_path, item, content_mode, script_kind, script, script_input = await asyncio.to_thread(_load)
+    project, project_path, item, content_mode, script_kind, _script, script_input = await asyncio.to_thread(_load)
     # Queue execution re-materializes mutable visual intent from the current script unit. Direct/internal callers
     # without a task row retain the request-prompt fallback for compatibility with synchronous service tests.
     current_prompt = item.get("video_prompt") if isinstance(item, dict) else None
@@ -2432,8 +2431,6 @@ async def execute_video_task(
     delivery_projection = None
     if delivery_options.narration_delivery == USE_TTS:
         episode = artifact_episode
-        if episode is None:
-            episode = ProjectManager.resolve_episode_from_script(script, str(script_file))
         current_planned_duration = item.get("duration_seconds") if isinstance(item, dict) else None
         if (
             not isinstance(current_planned_duration, int)
@@ -2512,7 +2509,7 @@ async def execute_video_task(
     duration_seconds = int(float(duration_seconds))
 
     if delivery_projection is not None:
-        if not isinstance(duration_seconds, int) or isinstance(duration_seconds, bool):
+        if not is_int(duration_seconds):
             raise RuntimeError("allowed TTS video projection produced a non-integer request duration")
         narration_actual_duration = delivery_projection.narration.actual_duration_seconds
         if narration_actual_duration is None:
@@ -3245,7 +3242,7 @@ async def execute_grid_task(
         # d) Generate grid image
         _needs_i2i = bool(reference_images)
         items, id_field, _char_field, _scene_field, _prop_field = get_storyboard_items(script)
-        item_by_id = {str(item.get(id_field)): item for item in items if isinstance(item, Mapping)}
+        item_by_id = {str(item.get(id_field)): item for item in items if isinstance(item, dict)}
         if len(set(grid.scene_ids)) != len(grid.scene_ids):
             raise ValueError("grid scene identities must be unique")
         missing_members = [scene_id for scene_id in grid.scene_ids if scene_id not in item_by_id]

--- a/server/services/generation_tasks.py
+++ b/server/services/generation_tasks.py
@@ -114,7 +114,6 @@ from lib.storyboard_sequence import (
     build_previous_storyboard_reference,
     find_storyboard_item,
     get_storyboard_items,
-    group_scenes_by_segment_break,
     resolve_previous_storyboard_path,
 )
 from lib.thumbnail import extract_video_thumbnail
@@ -1847,7 +1846,8 @@ async def execute_tts_task(
 
     audio_rel = resource_relative_path("audio", resource_id)
     duration_seconds: float | None = None
-    tts_selection_error: BaseException | None = None
+    # 选片依据的解析失败在回调里发生、在外层消费，用单元素信箱传递而非 nonlocal 哨兵。
+    tts_selection_errors: list[BaseException] = []
     tts_settings_bridge = EventLoopBridge.capture()
     selected_current = True
     missing_narration_audio = object()
@@ -1859,19 +1859,19 @@ async def execute_tts_task(
         pass
 
     async def _measure_staged(staged_path: Path) -> None:
-        nonlocal duration_seconds, tts_selection_error
+        nonlocal duration_seconds
         try:
             measured_duration = await probe_existing_audio_duration_seconds(staged_path)
         except (Exception, asyncio.CancelledError) as exc:
-            tts_selection_error = exc
+            tts_selection_errors.append(exc)
             return
         if measured_duration is None or not math.isfinite(measured_duration) or measured_duration <= 0:
-            tts_selection_error = RuntimeError("generated narration audio duration is unavailable")
+            tts_selection_errors.append(RuntimeError("generated narration audio duration is unavailable"))
             return
         duration_seconds = float(measured_duration)
 
     def _commit_staged(staged_path: Path, output_path: Path) -> int | PaidVersionCommit:
-        nonlocal prior_narration_audio, selected_current, tts_selection_error
+        nonlocal prior_narration_audio, selected_current
         if script_file is None or preparation is None or episode is None or basis is None:
             selected_current = False
             return generator.versions.commit_staged_paid_version(
@@ -1893,9 +1893,9 @@ async def execute_tts_task(
         committed_episode = episode
         committed_basis = basis
         pm = get_project_manager()
-        committed_outcome: PaidVersionCommit | None = None
+        committed_outcome: list[PaidVersionCommit] = []
         should_select = False
-        guarded_project: dict[str, Any] | None = None
+        guarded_project: list[dict[str, Any]] = []
 
         version_metadata = {
             "tts_provider_id": settings.provider_id,
@@ -1920,10 +1920,10 @@ async def execute_tts_task(
                 **version_metadata,
             )
 
-        if tts_selection_error is not None:
-            committed_outcome = _archive_paid_history()
+        if tts_selection_errors:
+            committed_outcome.append(_archive_paid_history())
             selected_current = False
-            return committed_outcome
+            return committed_outcome[-1]
 
         def _register_basis() -> None:
             register_narration_audio_transactionally(
@@ -1934,27 +1934,28 @@ async def execute_tts_task(
             )
 
         def _activate(_script_path: Path) -> None:
-            nonlocal committed_outcome, prior_manifest_captured, prior_manifest_entry
+            nonlocal prior_manifest_captured, prior_manifest_entry
             if should_select:
                 manifest_adapter = ProjectArtifactManifestAdapter(project_path)
                 prior_manifest_entry = manifest_adapter.get_entry(
                     ArtifactKey.episode_audio(committed_episode, resource_id)
                 )
                 prior_manifest_captured = True
-            committed_outcome = generator.versions.commit_staged_paid_version(
-                resource_type="audio",
-                resource_id=resource_id,
-                prompt=text,
-                staged_file=staged_path,
-                current_file=output_path,
-                select_current=lambda: should_select,
-                on_select=_register_basis,
-                **version_metadata,
+            committed_outcome.append(
+                generator.versions.commit_staged_paid_version(
+                    resource_type="audio",
+                    resource_id=resource_id,
+                    prompt=text,
+                    staged_file=staged_path,
+                    current_file=output_path,
+                    select_current=lambda: should_select,
+                    on_select=_register_basis,
+                    **version_metadata,
+                )
             )
 
         def _same_script(_project: dict) -> str:
-            nonlocal guarded_project
-            guarded_project = _project
+            guarded_project.append(_project)
             current_binding = resolve_episode_script_binding(_project, committed_episode, str(script_file))
             if current_binding is None:
                 raise EpisodeScriptReboundError(f"episode {committed_episode} script binding changed before TTS commit")
@@ -1967,7 +1968,7 @@ async def execute_tts_task(
                 validate=False,
                 on_commit=_activate,
             ) as current_script:
-                if guarded_project is None:
+                if not guarded_project:
                     raise RuntimeError("TTS commit guard did not expose the current project")
                 try:
                     current_commit_settings = tts_settings_bridge.run(
@@ -1976,10 +1977,10 @@ async def execute_tts_task(
                             user_id=user_id,
                             project_path=project_path,
                             context_resolver=resolve_generation_context,
-                        ).resolve_tts_synthesis_settings(guarded_project)
+                        ).resolve_tts_synthesis_settings(guarded_project[-1])
                     )
                 except (Exception, asyncio.CancelledError) as exc:
-                    tts_selection_error = exc
+                    tts_selection_errors.append(exc)
                     raise _TtsSelectionResolutionFailed from exc
                 items, id_field, current_kind = _resolve_tts_task_items(
                     current_script,
@@ -1994,7 +1995,7 @@ async def execute_tts_task(
                     None,
                 )
                 current_basis = None
-                if tts_selection_error is None and item is not None:
+                if not tts_selection_errors and item is not None:
                     current_admission = admit_script_unit(current_kind, item)
                     try:
                         current_basis = build_narration_audio_basis(
@@ -2020,7 +2021,7 @@ async def execute_tts_task(
                     assets["narration_audio"] = audio_rel
                     pm.update_scene_status(item)
         except (EpisodeScriptReboundError, _TtsSelectionResolutionFailed):
-            committed_outcome = _archive_paid_history()
+            committed_outcome.append(_archive_paid_history())
         except BaseException as failure:
             if staged_path.is_file():
                 try:
@@ -2029,8 +2030,10 @@ async def execute_tts_task(
                     failure.add_note(f"paid TTS history archival also failed: {archive_failure}")
             raise
 
-        selected_current = committed_outcome.selected
-        return committed_outcome
+        if not committed_outcome:
+            raise RuntimeError("paid TTS commit produced no version record")
+        selected_current = committed_outcome[-1].selected
+        return committed_outcome[-1]
 
     async def _before_submit() -> None:
         await asyncio.to_thread(
@@ -2054,8 +2057,8 @@ async def execute_tts_task(
         tts_basis_digest=basis.digest if basis is not None else None,
     )
 
-    if tts_selection_error is not None:
-        raise tts_selection_error
+    if tts_selection_errors:
+        raise tts_selection_errors[-1]
 
     version_record: dict[str, Any] | None = None
     try:
@@ -2996,14 +2999,6 @@ async def execute_product_task(
     task_id: str | None = None,
 ) -> dict[str, Any]:
     return await execute_design_task("product", project_name, resource_id, payload, user_id=user_id, task_id=task_id)
-
-
-def _group_scenes_by_segment_break(items: list[dict], id_field: str) -> list[list[dict]]:
-    """Groups consecutive scene dicts, breaking at segment_break=True.
-
-    Delegates to :func:`lib.storyboard_sequence.group_scenes_by_segment_break`.
-    """
-    return group_scenes_by_segment_break(items, id_field)
 
 
 def _collect_grid_reference_images(

--- a/server/services/grid_split.py
+++ b/server/services/grid_split.py
@@ -362,7 +362,7 @@ async def apply_grid_split(
                 for metadata in version_metadata_by_resource.values():
                     metadata.pop(IMAGE_ARTIFACT_BASIS_FIELD, None)
 
-                if source_status is ArtifactStatus.STALE and source_entry is not None:
+                if source_status is ArtifactStatus.STALE:
                     for cell_index, resource_id, cell_rel in cell_assignments:
                         try:
                             basis = build_stale_grid_member_storyboard_visual_basis(

--- a/server/services/narration_delivery_tasks.py
+++ b/server/services/narration_delivery_tasks.py
@@ -56,6 +56,7 @@ from lib.reference_video.request_projection import (
 )
 from lib.reference_video.voice_settings import VoiceRenderSettings
 from lib.resource_paths import resource_relative_path
+from lib.schema_guards import is_finite_number
 from lib.script_editor import resolve_items
 from lib.script_models import resolve_content_mode
 from lib.script_skeleton import resolve_script_kind
@@ -216,12 +217,7 @@ async def _selected_current_video_covering_duration(
 ) -> tuple[str, Path, dict[str, Any], int] | None:
     """Read one trusted selected visual whose measured media covers current TTS."""
 
-    if (
-        isinstance(minimum_actual_duration_seconds, bool)
-        or not isinstance(minimum_actual_duration_seconds, (int, float))
-        or not math.isfinite(minimum_actual_duration_seconds)
-        or minimum_actual_duration_seconds <= 0
-    ):
+    if not is_finite_number(minimum_actual_duration_seconds) or minimum_actual_duration_seconds <= 0:
         raise ValueError("minimum_actual_duration_seconds must be positive")
     selected = await asyncio.to_thread(
         _selected_current_video_record,

--- a/server/services/project_events.py
+++ b/server/services/project_events.py
@@ -10,7 +10,7 @@ import hashlib
 import logging
 import uuid
 from collections import Counter
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -228,7 +228,7 @@ class ProjectEventService:
     @contextlib.asynccontextmanager
     async def stream_events(
         self, project_name: str, *, idle_timeout: float = 1.0
-    ) -> AsyncIterator[AsyncIterator[tuple[str, Any] | dict[str, Any]]]:
+    ) -> AsyncGenerator[AsyncIterator[tuple[str, Any] | dict[str, Any]]]:
         """Subscribe to a project's events as a self-cleaning async iterator.
 
         Yields an async iterator producing, in order:

--- a/server/services/reference_video_tasks.py
+++ b/server/services/reference_video_tasks.py
@@ -52,7 +52,6 @@ from lib.reference_video.request_projection import (
     ReferenceRequestOptions,
     ReferenceUnitRequestProjector,
     ResolvedReferenceAsset,
-    clamp_reference_assets,
     hydrate_reference_assets,
     reference_audio_model_facts,
     resolve_reference_assets,
@@ -139,25 +138,6 @@ def _reference_limit_warning(*, provider: str, model: str | None, count: int, ma
         "key": "ref_too_many_images",
         "params": {"count": count, "model": model or provider, "max_count": max_refs},
     }
-
-
-def _clamp_resolved_reference_images(
-    entries: list[ResolvedReferenceImage],
-    max_refs: int | None,
-    *,
-    provider: str,
-    model: str | None,
-) -> tuple[list[ResolvedReferenceImage], list[dict[str, Any]]]:
-    """按请求上限裁图片，并让所有商品资产图优先于商品原图及其它资产。
-
-    未超限时保留原始稳定顺序；只有必须裁剪时才重排，避免在容量足够时无谓改变同一商品
-    sheet 与原图的邻接顺序。``max_refs == 0`` 表示模型不支持参考图，返回空集。
-    """
-    clamped = list(clamp_reference_assets(entries, max_refs))
-    if len(clamped) == len(entries):
-        return clamped, []
-    assert max_refs is not None
-    return clamped, [_reference_limit_warning(provider=provider, model=model, count=len(entries), max_refs=max_refs)]
 
 
 #: unit 时长缺值时的兼容兜底秒数，也作为能力暂不可解析时的新建 unit 默认值。

--- a/server/services/upload_finalize.py
+++ b/server/services/upload_finalize.py
@@ -229,11 +229,9 @@ async def commit_manual_video_upload(
         selected_thumbnail = thumbnail_rel if extracted is not None and staged_thumbnail.is_file() else None
 
         def _commit() -> int:
-            committed_version: int | None = None
+            committed_version: list[int] = []
 
             def _activate(_script_path: Path) -> None:
-                nonlocal committed_version
-
                 def _forget_claim() -> None:
                     # Manual uploads have no self-verifying paid-request facts, so an older
                     # current-basis claim cannot survive their formal replacement.
@@ -254,20 +252,22 @@ async def commit_manual_video_upload(
                     metadata: dict[str, str] = {"source": UPLOAD_VERSION_SOURCE}
                     if original_filename:
                         metadata["original_filename"] = original_filename
-                    committed_version = versions.commit_staged_version(
-                        resource_type,
-                        resource_id,
-                        "",
-                        staged_file=staged_video,
-                        current_file=current_video,
-                        on_commit=_forget_claim,
-                        **metadata,
+                    committed_version.append(
+                        versions.commit_staged_version(
+                            resource_type,
+                            resource_id,
+                            "",
+                            staged_file=staged_video,
+                            current_file=current_video,
+                            on_commit=_forget_claim,
+                            **metadata,
+                        )
                     )
 
             commit_metadata(selected_thumbnail, _activate)
-            if committed_version is None:
+            if not committed_version:
                 raise RuntimeError("manual video metadata commit skipped staged activation")
-            return committed_version
+            return committed_version[0]
 
         return await run_noninterruptible_sync(_commit)
     finally:

--- a/server/text_generation.py
+++ b/server/text_generation.py
@@ -74,6 +74,7 @@ from lib.reference_video.script_preview import (
 )
 from lib.reference_video.text_parser import extract_mentions
 from lib.reference_video.voice_settings import VoiceRenderSettings
+from lib.schema_guards import is_int, is_str
 from lib.script_generator import ScriptGenerator
 from lib.script_models import (
     NarrationScriptPlanDraft,
@@ -110,14 +111,14 @@ class TextGenerationRequest:
     entry_ids: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if isinstance(self.episode, bool) or not isinstance(self.episode, int) or self.episode < 1:
+        if not is_int(self.episode, minimum=1):
             raise ValueError("episode must be a positive integer")
         if self.scope not in {SCOPE_ALL, SCOPE_STALE}:
             raise ValueError(f"scope must be {SCOPE_ALL!r} or {SCOPE_STALE!r}")
         # 队列 payload 经 JSON 往返后 entry_ids 是 list：在此归一为 tuple，让「从工具入口构造」
         # 与「从 payload 还原」两条路径得到同一个值，任务事实比对才不会因容器类型分叉。
         entry_ids = tuple(self.entry_ids)
-        if any(not isinstance(entry_id, str) or not entry_id for entry_id in entry_ids):
+        if any(not is_str(entry_id) or not entry_id for entry_id in entry_ids):
             raise ValueError("entry_ids must be non-empty strings")
         if entry_ids and self.scope == SCOPE_ALL:
             raise ValueError("entry_ids 与 scope='all' 互斥：要么整集重写，要么只重写指定条目")
@@ -504,7 +505,7 @@ def _load_novel_source(project_path: Path, source: str | None) -> str:
     的调用方一律只接 ValueError，放行 TypeError 会在内容确认的读时重算里变成未处理的
     500，而不是「无法重算」这个本该有的降级态。
     """
-    if source is not None and not isinstance(source, str):
+    if source is not None and not is_str(source):
         raise ValueError(f"meta.source 类型非法，须为字符串或 null：{source!r}")
     if source:
         try:

--- a/server/tool_runtime.py
+++ b/server/tool_runtime.py
@@ -928,7 +928,9 @@ async def get_source_text(
 ) -> ToolOutcome[SourceTextContent]:
     try:
         project_dir = services.projects.get_project_path(scope.project_name)
-        if not request.value.startswith("source/"):
+        # path 是模型给的原始 JSON 入参，运行期不受 @tool schema 约束；非 str 在 startswith 上会抛
+        # AttributeError，越过本函数的降级口径变成 internal_error，故先判形状。
+        if not is_str(request.value) or not request.value.startswith("source/"):
             raise ValueError("path 必须指向 source/ 下的文本文件")
         content, revision, etag, _size = await asyncio.to_thread(_decode_business_file, project_dir, request.value)
         if not isinstance(content, str):

--- a/server/tool_runtime.py
+++ b/server/tool_runtime.py
@@ -103,6 +103,7 @@ from lib.project_migration_failure import (
 )
 from lib.project_migration_guard import project_migration_failure
 from lib.project_migrations import migrate_project_with_verdict
+from lib.schema_guards import is_int, is_str
 from lib.script_batch_edit import (
     ScriptBatchEditCommand,
     ScriptBatchEditLocation,
@@ -685,7 +686,7 @@ _SCRIPT_PLAN_BUSINESS_FILENAMES = frozenset(
 
 
 def _business_path_parts(value: str) -> tuple[str, ...]:
-    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+    if not is_str(value) or not value or "\\" in value or "\x00" in value:
         raise ValueError("path 必须是项目内业务文件的 POSIX 相对路径")
     pure = PurePosixPath(value)
     parts = pure.parts
@@ -842,7 +843,7 @@ async def get_episode_script(
     services: Services,
 ) -> ToolOutcome[EpisodeScriptContent]:
     filename = request.value
-    if not isinstance(filename, str) or not filename or "/" in filename or "\\" in filename or filename in {".", ".."}:
+    if not is_str(filename) or not filename or "/" in filename or "\\" in filename or filename in {".", ".."}:
         return ToolOutcome(problem=ToolProblem("invalid_request", "script 必须是纯文件名"))
     try:
         failure = await asyncio.to_thread(project_migration_failure, scope.project_name, services.projects)
@@ -967,7 +968,7 @@ async def get_script_plan_content(
     services: Services,
 ) -> ToolOutcome[ScriptPlanContent]:
     episode = request.value
-    if not isinstance(episode, int) or isinstance(episode, bool) or episode < 1:
+    if not is_int(episode, minimum=1):
         return ToolOutcome(problem=ToolProblem("invalid_request", "episode 必须是正整数"))
     try:
         result = await asyncio.to_thread(_get_script_plan_content_sync, scope.project_name, episode, services.projects)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 # 所以覆写必须发生在下方任何会传染到该模块的 import 之前。未显式指定时它落在仓库根的
 # `projects/.arcreel.db`：一份文件被 xdist 的多个 worker 共用，且 schema 只由某个先跑到
 # 的用例顺带建出——用例间因此存在隐式顺序依赖。钉到本进程独占的临时库上，schema 由
-# `_shared_db_schema` 显式建立。DATABASE_URL 已由外部给定（postgres-compat job、
+# `shared_db_schema` 显式建立。DATABASE_URL 已由外部给定（postgres-compat job、
 # 逐个用例 monkeypatch 的 alembic 用例）时不介入。
 #
 # xdist 的 worker 从 controller 继承 environ，会连这里写下的 URL 一起带过去；
@@ -44,19 +44,19 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(autouse=True)
-def _reset_app_data_dir_cache():
+def reset_app_data_dir_cache():
     """``app_data_dir()`` uses ``functools.cache`` for production; reset it between
     tests so per-test monkeypatching of ARCREEL_DATA_DIR / AI_ANIME_PROJECTS takes
     effect immediately."""
-    from lib.app_data_dir import _reset_for_tests
+    from lib.app_data_dir import reset_for_tests
 
-    _reset_for_tests()
+    reset_for_tests()
     yield
-    _reset_for_tests()
+    reset_for_tests()
 
 
 @pytest.fixture(autouse=True)
-def _stub_sandbox_check(monkeypatch, request):
+def stub_sandbox_check(monkeypatch, request):
     """Mock ``check_sandbox_available`` 返回 True，避免测试机不满足真实 bwrap probe。
 
     GitHub Actions Ubuntu 24.04 runner 上 ``apparmor_restrict_unprivileged_userns=1``
@@ -72,7 +72,7 @@ def _stub_sandbox_check(monkeypatch, request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _profile_env(tmp_path_factory):
+def profile_env(tmp_path_factory):
     """Provide one minimal runtime profile per pytest worker.
 
     Tests exercising another profile location set ``ARCREEL_PROFILE_DIR`` explicitly.
@@ -119,7 +119,7 @@ def fd_count():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _shared_db_schema():
+def shared_db_schema():
     """把模块级 engine 所指的库迁到 head，使任何用例都能直接用它。
 
     只对本 conftest 自建的临时库执行：外部给定 DATABASE_URL 时（postgres-compat job）
@@ -218,8 +218,10 @@ async def make_test_engine(*, dialect_aware: bool = True, file_path: Path | None
     else:
         engine = create_async_engine(f"sqlite+aiosqlite:///{file_path}", poolclass=pool.NullPool)
 
+        # 由 SQLAlchemy 的 event.listens_for 注册，模块内无其它引用；basedpyright 把函数作用域内的
+        # 符号一律判为私有，本处的 reportUnusedFunction 是工具误报。
         @event.listens_for(engine.sync_engine, "connect")
-        def _set_sqlite_pragma(dbapi_conn, _record):
+        def _set_sqlite_pragma(dbapi_conn, _record):  # pyright: ignore[reportUnusedFunction]
             cursor = dbapi_conn.cursor()
             cursor.execute("PRAGMA journal_mode=WAL")
             cursor.execute("PRAGMA busy_timeout=30000")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import uuid as _uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -172,12 +172,15 @@ def _register_models() -> None:
     不这么做时建表范围取决于被测模块的 import 链，同一 fixture 在不同文件下建出的
     schema 不同。
     """
-    import lib.agent_session_store.models
-    import lib.db.models  # noqa: F401  (users / agent_sessions / config etc.)
+    from lib.agent_session_store.models import register_models as register_agent_session_models
+    from lib.db.models import register_models as register_db_models
+
+    register_agent_session_models()
+    register_db_models()
 
 
 @asynccontextmanager
-async def make_test_engine(*, dialect_aware: bool = True, file_path: Path | None = None) -> AsyncIterator[AsyncEngine]:
+async def make_test_engine(*, dialect_aware: bool = True, file_path: Path | None = None) -> AsyncGenerator[AsyncEngine]:
     """DB fixture 的 engine 构造点，唯一例外是 `async_session` 的 PG 分支。
 
     那条分支绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import AsyncIterator, Callable, Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -20,6 +20,19 @@ from instructor.core import InstructorRetryException
 if TYPE_CHECKING:
     from lib.media_generator import MediaGenerator
     from lib.version_manager import PaidVersionCommit
+
+
+_NO_SDK_MESSAGES: tuple[dict[str, Any], ...] = ()
+
+
+async def empty_sdk_response_stream() -> AsyncIterator[dict[str, Any]]:
+    """不产出任何消息即结束的 SDK 响应流。
+
+    fake client 需要「空响应流」时返回本函数的结果；直接写 ``if False: yield`` 会留下
+    静态不可达的分支。
+    """
+    for message in _NO_SDK_MESSAGES:
+        yield message
 
 
 class FakeProjectAssetMutationMixin:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -234,7 +234,7 @@ async def build_managed_with_actor(
     managed = ManagedSession(
         session_id=session_id,
         actor=actor,
-        status=status,  # type: ignore[arg-type]
+        status=status,
         project_name=project_name,
     )
     managed_ref[0] = managed
@@ -565,7 +565,7 @@ def bounded_poll_clock(step: float = 30.0):
 
 
 @contextmanager
-def captured_provider_job_ids() -> Iterator[list[dict[str, Any]]]:
+def captured_provider_job_ids() -> Generator[list[dict[str, Any]]]:
     """provider_job_id 写回的手写替身：收下写回参数，不落 DB。
 
     ``persist_provider_job_id`` 是 backend 的 DB 边界，各提交-轮询型 backend 的测试只关心
@@ -597,7 +597,7 @@ def captured_provider_job_ids() -> Iterator[list[dict[str, Any]]]:
 
 
 @contextmanager
-def captured_ark_clients(module: str, client: Any = None) -> Iterator[list[dict[str, Any]]]:
+def captured_ark_clients(module: str, client: Any = None) -> Generator[list[dict[str, Any]]]:
     """create_ark_client 的记录器：收下建客户端的参数，回给定（或空）客户端替身。
 
     Ark 系三个后端（文本 / 图像 / 视频）各自从自己的模块引用这个工厂，模块路径由调用方给出。
@@ -617,7 +617,7 @@ def captured_ark_clients(module: str, client: Any = None) -> Iterator[list[dict[
 
 
 @contextmanager
-def captured_openai_clients(client: Any = None) -> Iterator[list[dict[str, Any]]]:
+def captured_openai_clients(client: Any = None) -> Generator[list[dict[str, Any]]]:
     """AsyncOpenAI 构造的记录器：收下建客户端的参数，回给定（或空）客户端替身。
 
     OpenAI 兼容族（openai / agnes 文本、openai 图像与视频、openai TTS、dashscope 与 minimax
@@ -638,7 +638,7 @@ def captured_openai_clients(client: Any = None) -> Iterator[list[dict[str, Any]]
 
 
 @contextmanager
-def captured_backend_construction() -> Iterator[list[dict[str, Any]]]:
+def captured_backend_construction() -> Generator[list[dict[str, Any]]]:
     """四个后端 registry 的构造记录器：工厂换成只记参数的哑后端，不建 SDK 客户端。
 
     装配层（``ProviderSpec.build_backend``、``lib.text_backends.factory``）的产出就是

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
+import threading
 from collections.abc import AsyncIterator, Callable, Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
@@ -689,3 +690,67 @@ def captured_backend_construction() -> Generator[list[dict[str, Any]]]:
         for media, table in factories.items():
             table.clear()
             table.update(saved[media])
+
+
+class BlockingFileReadGate:
+    """把某个路径的同步读挡在闸门后，观测 async 生产路径是否把该读卸载到线程。
+
+    读若仍在事件循环线程上跑，循环就停在闸门里，测试协程推进不到 ``release()``，闸门
+    等放行超时后记下 ``event_loop_blocked`` 并照常读完（不抛异常，理由见 ``enter_read``）；
+    读卸载到线程后循环照常推进，放行即读完。裁决由 ``assert_read_was_offloaded()`` 给出，
+    断言的是循环的可推进性，不看调用记录。
+    """
+
+    TIMEOUT_SECONDS = 5.0
+
+    def __init__(self, path: Path, method: str) -> None:
+        self.path = path
+        self.method = method
+        self.event_loop_blocked = False
+        self._started = threading.Event()
+        self._release = threading.Event()
+
+    def enter_read(self) -> None:
+        """在闸门内被调用：登记读已开始，等待测试放行。
+
+        放行等不到只记 ``event_loop_blocked`` 后照常读完，不抛异常——被测路径多带重试
+        装饰器，抛出来会被重试吞掉、第二次穿过已放行的闸门，把红测变绿。
+        """
+        self._started.set()
+        if not self._release.wait(self.TIMEOUT_SECONDS):
+            self.event_loop_blocked = True
+
+    async def wait_until_read_started(self) -> None:
+        """等到闸门内的读开始。读没卸载时事件循环被堵住，本 await 无法返回。"""
+        started = await asyncio.to_thread(self._started.wait, self.TIMEOUT_SECONDS)
+        assert started, f"{self.path.name} 的 {self.method} 未在 {self.TIMEOUT_SECONDS} 秒内开始"
+
+    def release(self) -> None:
+        self._release.set()
+
+    def assert_read_was_offloaded(self) -> None:
+        assert not self.event_loop_blocked, f"{self.path.name} 的 {self.method} 卡在事件循环线程上：该读未卸载到线程"
+
+
+@contextmanager
+def blocking_file_read_gate(
+    monkeypatch: Any,
+    path: Path,
+    *,
+    method: str = "read_bytes",
+) -> Generator[BlockingFileReadGate]:
+    """在文件系统边界上给 *path* 的 ``Path.<method>`` 读装一道闸门。"""
+    gate = BlockingFileReadGate(path, method)
+    original = getattr(Path, method)
+    target = path.resolve()
+
+    def gated(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self.resolve() == target:
+            gate.enter_read()
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, gated)
+    try:
+        yield gate
+    finally:
+        gate.release()

--- a/tests/http_capture.py
+++ b/tests/http_capture.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 
@@ -17,7 +17,7 @@ import respx
 
 
 @contextmanager
-def capture_http(*, assert_all_called: bool = False) -> Iterator[respx.MockRouter]:
+def capture_http(*, assert_all_called: bool = False) -> Generator[respx.MockRouter]:
     """拦截全部出站 httpx 流量；未声明路由的请求直接抛错，不会静默放行到真实网络。
 
     `assert_all_called` 缺省关闭：多数用例只关心其中一条路由是否收到预期请求，声明了

--- a/tests/integration/lib/db/migrations/test_alembic_collapse_image_backend_buckets.py
+++ b/tests/integration/lib/db/migrations/test_alembic_collapse_image_backend_buckets.py
@@ -190,7 +190,7 @@ async def test_resolution_after_upgrade(name, before, after):
             assert not any("/" in after.get(key, "") for key in (f"default_image_backend_{capability}", _KEYS[0]))
             continue
         resolved = await resolver._resolve_layered_backend(
-            _Settings(),  # pyright: ignore[reportArgumentType]
+            _Settings(),
             None,
             None,
             _IMAGE_LAYERED_KEYS[capability],

--- a/tests/integration/lib/db/repositories/test_usage_repo.py
+++ b/tests/integration/lib/db/repositories/test_usage_repo.py
@@ -239,7 +239,7 @@ class TestFinalizePendingByCallId:
         """provider 成功响应但漏报 usage（``usage_tokens`` 为 None）时，实付结算必须如实按
         0 计费，不能借费用预估侧的 token 近似换算兜底把估算近似值当成真实支出记录——
         该兜底只应在 ``CostCalculator.calculate_cost(estimate_only=True)`` 时生效
-        （见 ``server/services/cost_estimation.py::_estimate_unit_video_cost``），
+        （见 ``server/services/cost_estimation.py`` 的视频预估分支），
         ``UsageRepository._settle`` 走真实结算，不传 ``estimate_only``。"""
         repo = UsageRepository(db_session)
         call_id = await repo.start_call(

--- a/tests/integration/lib/project_migrations/test_project_migration_v7_v8.py
+++ b/tests/integration/lib/project_migrations/test_project_migration_v7_v8.py
@@ -1020,7 +1020,7 @@ def test_script_save_rechecks_manifest_activation_inside_the_project_lock(
     def _commit_after_activation(*args: object, **kwargs: object) -> Path:
         commit_reached.set()
         release_save.wait()
-        return original_commit(*args, **kwargs)  # type: ignore[arg-type]
+        return original_commit(*args, **kwargs)
 
     def _save() -> None:
         try:

--- a/tests/integration/lib/reference_video/test_reference_request_projection_consumers.py
+++ b/tests/integration/lib/reference_video/test_reference_request_projection_consumers.py
@@ -178,7 +178,7 @@ async def test_reference_projection_contract_stays_aligned_across_public_consume
             )
 
         agent_outcome = await videos.generate_videos_tool(
-            ToolContext(project_name="demo", projects_root=tmp_path, pm=pm)  # type: ignore[arg-type]
+            ToolContext(project_name="demo", projects_root=tmp_path, pm=pm)
         ).invoke(
             {
                 "script": "ep1.json",

--- a/tests/integration/lib/test_audio_utils.py
+++ b/tests/integration/lib/test_audio_utils.py
@@ -16,10 +16,10 @@ from tests.factories import make_test_video_with_audio_tail, wav_bytes
 
 
 @pytest.fixture(autouse=True)
-def _reset_ffprobe_cache():
-    audio_utils_module._reset_for_tests()
+def reset_ffprobe_cache():
+    audio_utils_module.reset_for_tests()
     yield
-    audio_utils_module._reset_for_tests()
+    audio_utils_module.reset_for_tests()
 
 
 def _video_only_mp4_bytes(duration_seconds: float = 1.0) -> bytes:

--- a/tests/integration/lib/test_episode_planner.py
+++ b/tests/integration/lib/test_episode_planner.py
@@ -140,7 +140,7 @@ class TestParseDraft:
     def test_accepts_wrapped_episodes(self):
         raw = _plan_response([{"title": "山村少年", "hook": "h", "end_anchor": ANCHOR_EP1}])
         draft = EpisodePlanner._parse_draft(raw, NarrationPlanDraft)
-        assert [ep.end_anchor for ep in draft.episodes] == [ANCHOR_EP1]  # pyright: ignore[reportAttributeAccessIssue]
+        assert [ep.end_anchor for ep in draft.episodes] == [ANCHOR_EP1]
 
 
 class TestPlan:

--- a/tests/integration/lib/test_episode_planner.py
+++ b/tests/integration/lib/test_episode_planner.py
@@ -1337,29 +1337,6 @@ SOURCE2 = "第二部 上界风云。李恒踏入上界，灵气扑面而来。�
 ANCHOR2_MID = "云岚宗弟子苏沐。"
 
 
-def _planned_two_files(
-    tmp_path: Path, *, statuses: tuple[str, str, str, str] = ("planned", "planned", "planned", "planned")
-) -> Path:
-    """已规划 4 集横跨两个源文件的项目：1-2 集在 novel.txt、3-4 集在 novel2.txt，cursor 在第二个文件末尾。"""
-    a = _end_of(ANCHOR_EP1)
-    c = _end_of(ANCHOR2_MID, SOURCE2)
-    project_dir = _write_project(
-        tmp_path,
-        episodes=[
-            _entry(1, 0, a, status=statuses[0]),
-            _entry(2, a, len(SOURCE), status=statuses[1]),
-            _entry(3, 0, c, status=statuses[2], source_file="source/novel2.txt"),
-            _entry(4, c, len(SOURCE2), status=statuses[3], source_file="source/novel2.txt"),
-        ],
-        planning_cursor={"source_file": "source/novel2.txt", "offset": len(SOURCE2)},
-    )
-    (project_dir / "source" / "novel2.txt").write_text(SOURCE2, encoding="utf-8")
-    ranges = [(SOURCE, 0, a), (SOURCE, a, len(SOURCE)), (SOURCE2, 0, c), (SOURCE2, c, len(SOURCE2))]
-    for num, (text, s, e) in enumerate(ranges, start=1):
-        (project_dir / "source" / f"episode_{num}.txt").write_text(text[s:e], encoding="utf-8")
-    return project_dir
-
-
 class TestSourceFingerprintGate:
     """plan 提交路径记录源文指纹、入口比对拒绝已改动的源文。"""
 

--- a/tests/integration/lib/test_generation_queue_batches.py
+++ b/tests/integration/lib/test_generation_queue_batches.py
@@ -308,7 +308,7 @@ async def test_terminal_batch_reobserves_artifact_currency_instead_of_echoing_ad
     with_resolver = await batch_queue.get_generation_batch(
         project_name="demo",
         batch_id=batch_id,
-        resolver=_Resolver(),  # type: ignore[arg-type]
+        resolver=_Resolver(),
     )
 
     assert without_resolver.generation_result is not None

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -1311,7 +1311,7 @@ class TestGenerationWorker:
         """drain 端兜底 mark_cancelled 自身抛错时只 warning，不冒泡（不挂掉主循环）。"""
 
         class _RaisingQueue(_FakeQueue):
-            async def mark_task_cancelled(self, task_id, *, cancelled_by="user"):  # type: ignore[override]
+            async def mark_task_cancelled(self, task_id, *, cancelled_by="user"):
                 raise RuntimeError("db down")
 
         queue = _RaisingQueue()
@@ -2732,7 +2732,7 @@ class TestOrphanOnceAndLeaseFlap:
             scan_count.append(1)
 
         # 替换 _handle_orphan_tasks_on_start 为 spy，便于精确断言扫描次数
-        worker._handle_orphan_tasks_on_start = _spy_scan  # type: ignore[assignment]
+        worker._handle_orphan_tasks_on_start = _spy_scan
         return worker, queue, scan_count
 
     @pytest.mark.asyncio

--- a/tests/integration/lib/test_generation_worker_module.py
+++ b/tests/integration/lib/test_generation_worker_module.py
@@ -1128,12 +1128,8 @@ class TestGenerationWorker:
 
     @pytest.mark.asyncio
     async def test_requeue_single_task_reports_database_failure(self, monkeypatch):
-        from contextlib import asynccontextmanager
-
-        @asynccontextmanager
-        async def _session_factory():
+        def _session_factory() -> contextlib.AbstractAsyncContextManager[object]:
             raise RuntimeError("database unavailable")
-            yield  # pragma: no cover
 
         monkeypatch.setattr("lib.db.safe_session_factory", _session_factory)
 
@@ -2186,13 +2182,10 @@ class TestGenerationWorker:
         """分镜视频只有 checkpoint + job 齐备才续跑；enqueue payload 不再承担身份锁定。"""
         queue = _FakeQueue()
         worker = GenerationWorker(queue=queue)
-        captured_task: dict | None = None
-        captured_job_id: str | None = None
+        captured: list[tuple[dict, str]] = []
 
         async def _fake_resume(task, *, job_id):
-            nonlocal captured_task, captured_job_id
-            captured_task = task
-            captured_job_id = job_id
+            captured.append((task, job_id))
             return {"ok": True}
 
         monkeypatch.setattr("server.services.resume_executor.execute_resume_video_task", _fake_resume)
@@ -2200,7 +2193,8 @@ class TestGenerationWorker:
         task = _storyboard_resume_task("resume-locked", provider_id="openai", job_id="openai-job")
         task["payload"] = {"video_provider_i2v": "gemini-aistudio/veo-3.1-fast-generate-preview"}
         await worker._process_resume_task(task)
-        assert captured_task is not None
+        assert len(captured) == 1
+        captured_task, captured_job_id = captured[0]
         # Resume executor receives the row unchanged and loads its immutable checkpoint itself.
         assert captured_task["payload"] == {"video_provider_i2v": "gemini-aistudio/veo-3.1-fast-generate-preview"}
         assert captured_job_id == "openai-job"

--- a/tests/integration/lib/test_project_manager.py
+++ b/tests/integration/lib/test_project_manager.py
@@ -15,10 +15,6 @@ def _write(path: Path, text: str):
     path.write_text(text, encoding="utf-8")
 
 
-def _read_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
 def _narration_script(resource_id: str) -> dict:
     return {
         "episode": 1,

--- a/tests/integration/lib/test_project_migration_blocking.py
+++ b/tests/integration/lib/test_project_migration_blocking.py
@@ -495,16 +495,18 @@ def _guarded_app() -> FastAPI:
     register_error_handlers(app)
     router = APIRouter(dependencies=[Depends(require_project_migration_ok)])
 
+    # 以下路由桩由装饰器就地注册，函数体内无其它引用；basedpyright 把函数作用域内的符号一律
+    # 判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @router.post("/projects/{project_name}/generate/thing")
-    async def _generate(project_name: str) -> dict[str, str]:
+    async def _generate(project_name: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
         return {"generated": project_name}
 
     @router.get("/projects/{project_name}/thing")
-    async def _read(project_name: str) -> dict[str, str]:
+    async def _read(project_name: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
         return {"read": project_name}
 
     @router.post("/no-project-param")
-    async def _unparametrized() -> dict[str, str]:
+    async def _unparametrized() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
         return {"ok": "yes"}
 
     app.include_router(router)

--- a/tests/integration/lib/test_project_migration_blocking.py
+++ b/tests/integration/lib/test_project_migration_blocking.py
@@ -253,7 +253,7 @@ async def test_retry_success_uses_caller_scoped_queue_and_capabilities(tmp_path:
     services = Services(
         projects=projects,
         workflow_planner=planner,
-        capabilities=capabilities,  # type: ignore[arg-type]
+        capabilities=capabilities,
         queue=queue,
     )
 
@@ -358,7 +358,7 @@ async def test_mcp_generation_tools_report_the_same_problem_without_running(tmp_
         ran = True
         return {"content": []}
 
-    guarded = sdk_tools._refuse_while_migration_failed(_inner, ctx)  # pyright: ignore[reportPrivateUsage]
+    guarded = sdk_tools._refuse_while_migration_failed(_inner, ctx)
     blocked = await guarded.handler({"segment_ids": ["E1S01"]})
 
     assert ran is False
@@ -401,7 +401,7 @@ async def test_script_edit_mcp_tools_refuse_at_registration_on_a_migration_block
 
     sdk_tool = tool_factory(ctx)
     assert sdk_tool.name in sdk_tools.MIGRATION_BLOCKED_TOOL_IDS
-    guarded = sdk_tools._refuse_while_migration_failed(sdk_tool, ctx)  # pyright: ignore[reportPrivateUsage]
+    guarded = sdk_tools._refuse_while_migration_failed(sdk_tool, ctx)
     blocked = await guarded.handler({})
 
     assert blocked["is_error"] is True
@@ -438,7 +438,7 @@ async def test_mcp_guard_reads_the_session_projects_root_not_the_global_one(tmp_
         ran = True
         return {"content": []}
 
-    guarded = sdk_tools._refuse_while_migration_failed(_inner, ctx)  # pyright: ignore[reportPrivateUsage]
+    guarded = sdk_tools._refuse_while_migration_failed(_inner, ctx)
     result = await guarded.handler({})
 
     assert ran is True

--- a/tests/integration/lib/test_project_summary.py
+++ b/tests/integration/lib/test_project_summary.py
@@ -307,7 +307,7 @@ def test_summary_never_reads_the_source_corpus(tmp_path: Path, monkeypatch: pyte
 
     def _spy(project_path: Path, *args: object, **kwargs: object) -> SourceRevisionResult:
         revision_calls.append(project_path)
-        return compute_source_revision(project_path, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+        return compute_source_revision(project_path, *args, **kwargs)
 
     monkeypatch.setattr("lib.workflow_state.compute_source_revision", _spy)
     source_reads = _count_source_reads(monkeypatch, project_path)

--- a/tests/integration/lib/test_video_artifact_commit.py
+++ b/tests/integration/lib/test_video_artifact_commit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -73,7 +73,7 @@ def test_matching_typed_basis_selects_and_registers_inside_the_shared_guard(tmp_
     events: list[str] = []
 
     @contextmanager
-    def _guard() -> Iterator[object]:
+    def _guard() -> Generator[object]:
         events.append("guard-enter")
         yield object()
         events.append("guard-exit")
@@ -284,7 +284,7 @@ def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -
     basis = currency.video_descriptor
 
     @contextmanager
-    def _failed_guard() -> Iterator[object]:
+    def _failed_guard() -> Generator[object]:
         raise OSError("project snapshot unavailable")
         yield object()
 

--- a/tests/integration/lib/test_video_artifact_commit.py
+++ b/tests/integration/lib/test_video_artifact_commit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 
 import pytest
@@ -283,10 +283,8 @@ def test_selection_guard_failure_still_archives_the_paid_video(tmp_path: Path) -
     currency = _currency("submitted", parent_version=old_version)
     basis = currency.video_descriptor
 
-    @contextmanager
-    def _failed_guard() -> Generator[object]:
+    def _failed_guard() -> AbstractContextManager[object]:
         raise OSError("project snapshot unavailable")
-        yield object()
 
     with pytest.raises(OSError, match="project snapshot unavailable"):
         commit_paid_video_artifact(

--- a/tests/integration/lib/test_workflow_state.py
+++ b/tests/integration/lib/test_workflow_state.py
@@ -627,7 +627,7 @@ def _count_source_reads(monkeypatch: pytest.MonkeyPatch, project_path: Path) -> 
 
     def _counted_read_text(self: Path, *args: object, **kwargs: object) -> str:
         _record(self)
-        return original_read_text(self, *args, **kwargs)  # pyright: ignore[reportArgumentType, reportCallIssue]
+        return original_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_bytes", _counted_read_bytes)
     monkeypatch.setattr(Path, "read_text", _counted_read_text)

--- a/tests/integration/lib/video_backends/test_kling_video_backend.py
+++ b/tests/integration/lib/video_backends/test_kling_video_backend.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import NamedTuple
@@ -43,7 +43,7 @@ class _KlingRoutes(NamedTuple):
 
 
 @contextmanager
-def _kling_api() -> Iterator[_KlingRoutes]:
+def _kling_api() -> Generator[_KlingRoutes]:
     videos = re.escape(f"{_BASE_URL}/videos")
     with capture_http() as router:
         yield _KlingRoutes(
@@ -664,7 +664,7 @@ class TestResume:
 class TestAudioGatingResult:
     @staticmethod
     @contextmanager
-    def _succeeding(task_id: str) -> Iterator[_KlingRoutes]:
+    def _succeeding(task_id: str) -> Generator[_KlingRoutes]:
         """submit 成功 → 一次轮询直接终态 → 下载空片，只留有声决策作观察点。"""
         with _kling_api() as routes:
             routes.submit.mock(return_value=_resp(_submit(task_id)))

--- a/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
@@ -96,7 +96,7 @@ def _videos_tool_for_scope(ctx: ToolContext, scope: str):
 _CLAIMED_BASIS_DIGEST = "sha256-v1:" + "a" * 64
 
 
-class _FakePM:
+class FakePM:
     def __init__(self, project_name: str, project_dir: Path):
         self._project_name = project_name
         self._project_dir = project_dir
@@ -372,7 +372,7 @@ async def _call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _activate_unbound_project(fake_ctx: ToolContext, *, generation_mode: str = "storyboard") -> None:
-    project = fake_ctx.pm.project_payload  # type: ignore[attr-defined]
+    project = fake_ctx.pm.project_payload
     project.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
@@ -402,7 +402,7 @@ def _reference_video_script(**overrides: Any) -> dict[str, Any]:
 
 def _use_reference_route(fake_ctx: ToolContext) -> None:
     """把 fake 项目切到参考生视频——生成模式是项目级事实，剧本不携带戳。"""
-    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
 
 
 def _rv_generator_returning(units: list[dict], captured: dict[str, Any] | None = None):
@@ -435,10 +435,10 @@ def _rv_project(fake_ctx: ToolContext, generation_mode: str = "reference_video")
 
     盘上的 project.json 与 pm 的内存视图同步：生成入口从盘上读，晋升工具经 ``pm.load_project`` 读。
     """
-    fake_ctx.pm.project_payload["content_mode"] = "narration"  # pyright: ignore[reportAttributeAccessIssue]
-    fake_ctx.pm.project_payload["generation_mode"] = generation_mode  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["content_mode"] = "narration"
+    fake_ctx.pm.project_payload["generation_mode"] = generation_mode
     (fake_ctx.project_path / "project.json").write_text(
-        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),  # pyright: ignore[reportAttributeAccessIssue]
+        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),
         encoding="utf-8",
     )
 
@@ -580,8 +580,8 @@ def _drama_project(fake_ctx: ToolContext) -> None:
         json.dumps({"content_mode": "drama", "generation_mode": "storyboard"}, ensure_ascii=False),
         encoding="utf-8",
     )
-    fake_ctx.pm.project_payload["content_mode"] = "drama"  # pyright: ignore[reportAttributeAccessIssue]
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["content_mode"] = "drama"
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True, exist_ok=True)
     (src / "episode_1.txt").write_text(_DRAMA_NOVEL, encoding="utf-8")

--- a/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/sdk_tools_support.py
@@ -37,7 +37,7 @@ from tests.fakes import FakeConfigResolver
 # ---------------------------------------------------------------------------
 
 
-async def _fake_scene_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
+async def fake_scene_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
     """Stand in for the queue: every scene spec lands its canonical mp4."""
 
     from lib.generation_queue_client import BatchTaskResult
@@ -53,7 +53,7 @@ async def _fake_scene_batch(*, project_name, specs, on_success=None, on_failure=
     ], []
 
 
-def _generation_result(out: dict[str, Any] | ToolOutcome[Any]) -> GenerationBatchResult:
+def read_generation_result(out: dict[str, Any] | ToolOutcome[Any]) -> GenerationBatchResult:
     """Read the structured contract out of a tool response, never its text."""
 
     if isinstance(out, ToolOutcome):
@@ -62,7 +62,7 @@ def _generation_result(out: dict[str, Any] | ToolOutcome[Any]) -> GenerationBatc
     return GenerationBatchResult.model_validate(out["generation_result"])
 
 
-def _videos_tool_for_scope(ctx: ToolContext, scope: str):
+def videos_tool_for_scope(ctx: ToolContext, scope: str):
     """Exercise one unified video scope while keeping legacy-behavior test setup compact."""
 
     from server.media_tools.videos import generate_videos_tool
@@ -269,7 +269,7 @@ class FakePM:
         return [{"name": "保温杯", "description": "不锈钢保温杯"}]
 
 
-def _fake_reference_projection(
+def fake_reference_projection(
     slot_for=None,
     calls: list[str] | None = None,
     *,
@@ -332,7 +332,7 @@ def _fake_reference_projection(
     return _project
 
 
-def _fake_caps_resolver(**kwargs: Any) -> Any:
+def fake_caps_resolver(**kwargs: Any) -> Any:
     """构造假能力解析器（见 ``tests.fakes.FakeConfigResolver``）。
 
     返回值按 ``Any`` 交出：注入点标注的是生产的 ``ConfigResolver``，替身只实现被调到的那几个
@@ -341,19 +341,19 @@ def _fake_caps_resolver(**kwargs: Any) -> Any:
     return FakeConfigResolver(**kwargs)
 
 
-def _use_fake_caps(fake_ctx: ToolContext, **kwargs: Any) -> Any:
+def use_fake_caps(fake_ctx: ToolContext, **kwargs: Any) -> Any:
     """给这个会话装上假能力解析器并返回它。
 
     工具经 ``ToolContext.config_resolver`` 把解析器透传给能力取值器，注入后取值器里的软回退、
     时长联动约束收窄与声音档派生照常执行——那些正是用例要保护的行为，整体替换取值器会把它们
     一并旁路掉。
     """
-    resolver = _fake_caps_resolver(**kwargs)
+    resolver = fake_caps_resolver(**kwargs)
     fake_ctx.config_resolver = resolver
     return resolver
 
 
-async def _call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
+async def call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
     """调工具处理器；工具声明为必填的交付方式在未点名时补成后期配音。
 
     绝大多数视频用例的主题不是旁白交付，逐个写死这一项只会让它们看起来在断言交付方式。
@@ -371,7 +371,7 @@ async def _call(tool_obj, args: dict[str, Any]) -> dict[str, Any]:
     return outcome
 
 
-def _activate_unbound_project(fake_ctx: ToolContext, *, generation_mode: str = "storyboard") -> None:
+def activate_unbound_project(fake_ctx: ToolContext, *, generation_mode: str = "storyboard") -> None:
     project = fake_ctx.pm.project_payload
     project.update(
         {
@@ -384,7 +384,7 @@ def _activate_unbound_project(fake_ctx: ToolContext, *, generation_mode: str = "
     (fake_ctx.project_path / "project.json").write_text(json.dumps(project), encoding="utf-8")
 
 
-def _reference_video_script(**overrides: Any) -> dict[str, Any]:
+def reference_video_script(**overrides: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "content_mode": "narration",
         "episode": 1,
@@ -400,12 +400,12 @@ def _reference_video_script(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
-def _use_reference_route(fake_ctx: ToolContext) -> None:
+def use_reference_route(fake_ctx: ToolContext) -> None:
     """把 fake 项目切到参考生视频——生成模式是项目级事实，剧本不携带戳。"""
     fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
 
 
-def _rv_generator_returning(units: list[dict], captured: dict[str, Any] | None = None):
+def rv_generator_returning(units: list[dict], captured: dict[str, Any] | None = None):
     """构造返回指定扁平 units JSON 的假 TextGenerator.create（可选捕获 task_type / project_name）。"""
 
     class _FakeGenerator:
@@ -430,7 +430,7 @@ def _rv_generator_returning(units: list[dict], captured: dict[str, Any] | None =
 _RV_NOVEL = "张三在村口等人"
 
 
-def _rv_project(fake_ctx: ToolContext, generation_mode: str = "reference_video") -> None:
+def rv_project(fake_ctx: ToolContext, generation_mode: str = "reference_video") -> None:
     """把项目声明成参考生视频路径——草稿的拆分 / 晋升 / 阻塞判定都以此为前提。
 
     盘上的 project.json 与 pm 的内存视图同步：生成入口从盘上读，晋升工具经 ``pm.load_project`` 读。
@@ -443,19 +443,19 @@ def _rv_project(fake_ctx: ToolContext, generation_mode: str = "reference_video")
     )
 
 
-def _rv_source(fake_ctx: ToolContext) -> None:
-    _rv_project(fake_ctx)
+def rv_source(fake_ctx: ToolContext) -> None:
+    rv_project(fake_ctx)
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
     (src / "episode_1.txt").write_text(_RV_NOVEL, encoding="utf-8")
 
 
-def _rv_unit(text: str, *, duration: int = 8, source_text: str = _RV_NOVEL) -> dict:
+def rv_unit(text: str, *, duration: int = 8, source_text: str = _RV_NOVEL) -> dict:
     """script_plan 的 LLM 产出形状：一层扁平（时长 + 原文锚 + 引用语法正文）。"""
     return {"duration_seconds": duration, "source_text": source_text, "text": text}
 
 
-def _derived_reference_names(fake_ctx: ToolContext, text: str) -> list[str]:
+def derived_reference_names(fake_ctx: ToolContext, text: str) -> list[str]:
     """正文 → 参考图名称：读侧的唯一派生入口，落盘不带 references。"""
     from lib.reference_video.text_parser import derive_references_from_text
 
@@ -464,51 +464,51 @@ def _derived_reference_names(fake_ctx: ToolContext, text: str) -> list[str]:
     return [reference.name for reference in references]
 
 
-def _rv_script_plan_path(fake_ctx: ToolContext):
+def rv_script_plan_path(fake_ctx: ToolContext):
     return fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_reference_units.json"
 
 
-async def _run_rv_split(fake_ctx: ToolContext, monkeypatch, units: list[dict], **caps_kwargs) -> dict:
+async def run_rv_split(fake_ctx: ToolContext, monkeypatch, units: list[dict], **caps_kwargs) -> dict:
     from server import text_generation as mod
 
-    _use_fake_caps(fake_ctx, **caps_kwargs)
-    monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units))
-    return await _call(generate_script_plan_tool(fake_ctx), {"episode": 1})
+    use_fake_caps(fake_ctx, **caps_kwargs)
+    monkeypatch.setattr(mod.TextGenerator, "create", rv_generator_returning(units))
+    return await call(generate_script_plan_tool(fake_ctx), {"episode": 1})
 
 
-def _rv_quarantine_path(fake_ctx: ToolContext):
+def rv_quarantine_path(fake_ctx: ToolContext):
     return quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
 
 
-def _read_rv_quarantine(fake_ctx: ToolContext) -> dict:
-    return json.loads(_rv_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
+def read_rv_quarantine(fake_ctx: ToolContext) -> dict:
+    return json.loads(rv_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
 
 
-async def _promote(fake_ctx: ToolContext, **caps_kwargs) -> dict:
+async def promote_reference_draft(fake_ctx: ToolContext, **caps_kwargs) -> dict:
     if not (fake_ctx.project_path / "project.json").exists():
-        _rv_project(fake_ctx)
-    _use_fake_caps(fake_ctx, **caps_kwargs)
-    if _rv_quarantine_path(fake_ctx).exists():
+        rv_project(fake_ctx)
+    use_fake_caps(fake_ctx, **caps_kwargs)
+    if rv_quarantine_path(fake_ctx).exists():
         doc_type = "reference_script_plan"
     elif quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING).exists():
         doc_type = "reference_prompt_authoring"
     else:
         doc_type = "reference_script_plan"
     args = {"episode": 1, "doc_type": doc_type}
-    opened = await _call(open_draft_tool(fake_ctx), args)
+    opened = await call(open_draft_tool(fake_ctx), args)
     payload = json.loads(opened["content"][0]["text"])
     revision = payload.get("draft", {}).get("revision", "")
-    return await _call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})
+    return await call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})
 
 
-def _write_rv_script_plan(fake_ctx: ToolContext, units: list[dict]) -> None:
+def write_rv_script_plan(fake_ctx: ToolContext, units: list[dict]) -> None:
     """直接铺一份正式 script_plan（模拟上一轮拆分的落盘产物）。"""
-    path = _rv_script_plan_path(fake_ctx)
+    path = rv_script_plan_path(fake_ctx)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"units": units}, ensure_ascii=False), encoding="utf-8")
 
 
-def _rv_saved_unit(text: str, *, unit_id: str = "E1U01", duration: int = 8) -> dict:
+def rv_saved_unit(text: str, *, unit_id: str = "E1U01", duration: int = 8) -> dict:
     """正式 script_plan 的落盘形状（正文 + 机器派生的 unit_id）。"""
     return {
         "unit_id": unit_id,
@@ -518,24 +518,24 @@ def _rv_saved_unit(text: str, *, unit_id: str = "E1U01", duration: int = 8) -> d
     }
 
 
-async def _open_for_edit(fake_ctx: ToolContext, **args) -> dict:
+async def open_for_edit(fake_ctx: ToolContext, **args) -> dict:
     if not (fake_ctx.project_path / "project.json").exists():
-        _rv_project(fake_ctx)
-    return await _call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "reference_script_plan", **args})
+        rv_project(fake_ctx)
+    return await call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "reference_script_plan", **args})
 
 
-def _nr_project(fake_ctx: ToolContext) -> None:
-    _rv_project(fake_ctx, generation_mode="storyboard")
+def nr_project(fake_ctx: ToolContext) -> None:
+    rv_project(fake_ctx, generation_mode="storyboard")
 
 
-def _nr_source(fake_ctx: ToolContext) -> None:
-    _nr_project(fake_ctx)
+def nr_source(fake_ctx: ToolContext) -> None:
+    nr_project(fake_ctx)
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
     (src / "episode_1.txt").write_text(_RV_NOVEL, encoding="utf-8")
 
 
-def _nr_generator_returning(segments: list[dict], captured: dict[str, Any] | None = None):
+def nr_generator_returning(segments: list[dict], captured: dict[str, Any] | None = None):
     """构造返回指定 segments JSON 的假 TextGenerator.create（可选捕获 task_type / project_name）。"""
 
     class _FakeGenerator:
@@ -557,7 +557,7 @@ def _nr_generator_returning(segments: list[dict], captured: dict[str, Any] | Non
     return fake_create
 
 
-def _nr_segment(segment_id="E1S01", duration=4, novel_text="张三走向村口。", **extra):
+def nr_segment(segment_id="E1S01", duration=4, novel_text="张三走向村口。", **extra):
     seg = {
         "segment_id": segment_id,
         "novel_text": novel_text,
@@ -574,7 +574,7 @@ def _nr_segment(segment_id="E1S01", duration=4, novel_text="张三走向村口�
 _DRAMA_NOVEL = "三年后，阿离回到山门。"
 
 
-def _drama_project(fake_ctx: ToolContext) -> None:
+def drama_project(fake_ctx: ToolContext) -> None:
     """把项目声明成 drama + 分镜图生视频，并铺好源文——正式 script_plan 的写禁与草稿通道以此为前提。"""
     (fake_ctx.project_path / "project.json").write_text(
         json.dumps({"content_mode": "drama", "generation_mode": "storyboard"}, ensure_ascii=False),
@@ -587,7 +587,7 @@ def _drama_project(fake_ctx: ToolContext) -> None:
     (src / "episode_1.txt").write_text(_DRAMA_NOVEL, encoding="utf-8")
 
 
-def _drama_scene(**overrides) -> dict:
+def drama_scene(**overrides) -> dict:
     scene = {
         "scene_id": "E1S01",
         "duration_seconds": 4,
@@ -603,61 +603,61 @@ def _drama_scene(**overrides) -> dict:
     return scene
 
 
-def _drama_script_plan_path(fake_ctx: ToolContext) -> Path:
+def drama_script_plan_path(fake_ctx: ToolContext) -> Path:
     return fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_normalized_script.json"
 
 
-def _drama_quarantine_path(fake_ctx: ToolContext) -> Path:
+def drama_quarantine_path(fake_ctx: ToolContext) -> Path:
     return quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_DRAMA_SCRIPT_PLAN)
 
 
-def _write_drama_script_plan(fake_ctx: ToolContext, scenes: list[dict]) -> None:
-    path = _drama_script_plan_path(fake_ctx)
+def write_drama_script_plan(fake_ctx: ToolContext, scenes: list[dict]) -> None:
+    path = drama_script_plan_path(fake_ctx)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"title": "第一集", "scenes": scenes}, ensure_ascii=False), encoding="utf-8")
 
 
-def _read_drama_quarantine(fake_ctx: ToolContext) -> dict:
-    return json.loads(_drama_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
+def read_drama_quarantine(fake_ctx: ToolContext) -> dict:
+    return json.loads(drama_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
 
 
-async def _open_drama_for_edit(fake_ctx: ToolContext, **args) -> dict:
-    return await _call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "drama_script_plan", **args})
+async def open_drama_for_edit(fake_ctx: ToolContext, **args) -> dict:
+    return await call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "drama_script_plan", **args})
 
 
-async def _promote_drama(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
-    _use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
+async def promote_drama(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
+    use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
     args = {"episode": 1, "doc_type": "drama_script_plan"}
-    opened = await _call(open_draft_tool(fake_ctx), args)
+    opened = await call(open_draft_tool(fake_ctx), args)
     revision = json.loads(opened["content"][0]["text"])["draft"]["revision"]
-    return await _call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})
+    return await call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})
 
 
-def _nr_script_plan_path(fake_ctx: ToolContext) -> Path:
+def nr_script_plan_path(fake_ctx: ToolContext) -> Path:
     return fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json"
 
 
-def _nr_quarantine_path(fake_ctx: ToolContext) -> Path:
+def nr_quarantine_path(fake_ctx: ToolContext) -> Path:
     return quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_NARRATION_SCRIPT_PLAN)
 
 
-def _read_nr_quarantine(fake_ctx: ToolContext) -> dict:
-    return json.loads(_nr_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
+def read_nr_quarantine(fake_ctx: ToolContext) -> dict:
+    return json.loads(nr_quarantine_path(fake_ctx).read_text(encoding="utf-8"))
 
 
-def _write_nr_script_plan(fake_ctx: ToolContext, segments: list[dict]) -> None:
-    path = _nr_script_plan_path(fake_ctx)
+def write_nr_script_plan(fake_ctx: ToolContext, segments: list[dict]) -> None:
+    path = nr_script_plan_path(fake_ctx)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"segments": segments}, ensure_ascii=False), encoding="utf-8")
 
 
-async def _open_nr_for_edit(fake_ctx: ToolContext, **args) -> dict:
-    return await _call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "narration_script_plan", **args})
+async def open_nr_for_edit(fake_ctx: ToolContext, **args) -> dict:
+    return await call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "narration_script_plan", **args})
 
 
-async def _promote_nr(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
-    _use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
+async def promote_nr(fake_ctx: ToolContext, durations=(4, 6, 8)) -> dict:
+    use_fake_caps(fake_ctx, supported_durations=durations, default_duration=durations[0])
     args = {"episode": 1, "doc_type": "narration_script_plan"}
-    opened = await _call(open_draft_tool(fake_ctx), args)
+    opened = await call(open_draft_tool(fake_ctx), args)
     revision = json.loads(opened["content"][0]["text"])["draft"]["revision"]
-    return await _call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})
+    return await call(promote_draft_tool(fake_ctx), {**args, "base_revision": revision})

--- a/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
@@ -81,7 +81,7 @@ def test_draft_tools_share_strict_locator_schema(fake_ctx: ToolContext, factory)
 
 
 def _write_reference_prompt_authoring(fake_ctx: ToolContext, script: dict) -> None:
-    fake_ctx.pm.script_payload = script  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.script_payload = script
     scripts = fake_ctx.project_path / "scripts"
     scripts.mkdir(exist_ok=True)
     (scripts / "episode_1.json").write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
@@ -382,8 +382,8 @@ async def test_open_draft_rejects_variant_without_draft_channel(fake_ctx: ToolCo
         json.dumps({"content_mode": "ad", "generation_mode": "storyboard"}, ensure_ascii=False),
         encoding="utf-8",
     )
-    fake_ctx.pm.project_payload["content_mode"] = "ad"  # pyright: ignore[reportAttributeAccessIssue]
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["content_mode"] = "ad"
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
 
     out = await _open_for_edit(fake_ctx)
 

--- a/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
@@ -32,35 +32,35 @@ from server.draft_workflow import DraftContext, DraftWorkflow, DraftWorkflowErro
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _RV_NOVEL,
-    _call,
-    _derived_reference_names,
-    _drama_project,
-    _drama_quarantine_path,
-    _drama_scene,
-    _drama_script_plan_path,
-    _nr_quarantine_path,
-    _nr_script_plan_path,
-    _nr_segment,
-    _nr_source,
-    _open_drama_for_edit,
-    _open_for_edit,
-    _open_nr_for_edit,
-    _promote,
-    _promote_drama,
-    _promote_nr,
-    _read_drama_quarantine,
-    _read_nr_quarantine,
-    _read_rv_quarantine,
-    _run_rv_split,
-    _rv_project,
-    _rv_quarantine_path,
-    _rv_saved_unit,
-    _rv_script_plan_path,
-    _rv_source,
-    _rv_unit,
-    _write_drama_script_plan,
-    _write_nr_script_plan,
-    _write_rv_script_plan,
+    call,
+    derived_reference_names,
+    drama_project,
+    drama_quarantine_path,
+    drama_scene,
+    drama_script_plan_path,
+    nr_quarantine_path,
+    nr_script_plan_path,
+    nr_segment,
+    nr_source,
+    open_drama_for_edit,
+    open_for_edit,
+    open_nr_for_edit,
+    promote_drama,
+    promote_nr,
+    promote_reference_draft,
+    read_drama_quarantine,
+    read_nr_quarantine,
+    read_rv_quarantine,
+    run_rv_split,
+    rv_project,
+    rv_quarantine_path,
+    rv_saved_unit,
+    rv_script_plan_path,
+    rv_source,
+    rv_unit,
+    write_drama_script_plan,
+    write_nr_script_plan,
+    write_rv_script_plan,
 )
 
 
@@ -95,13 +95,13 @@ def _write_reference_prompt_authoring(fake_ctx: ToolContext, script: dict) -> No
 async def test_open_draft_returns_flat_draft_structure(fake_ctx: ToolContext) -> None:
     """取回的是扁平草稿结构，不装派生物：Agent 改的是引用语法正文 / 原文锚 / 时长，
     unit_id 由晋升时按数组序号重新派生，放进草稿等于给漂移开口子。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身\n@[张三] 走向 @[村口]")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身\n@[张三] 走向 @[村口]")])
 
-    out = await _open_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await open_for_edit(fake_ctx, source="source/episode_1.txt")
 
     assert out.get("is_error") is not True, out
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     assert envelope["kind"] == QUARANTINE_KIND_SCRIPT_PLAN
     assert envelope["violations"] == []
     assert envelope["meta"]["source"] == "source/episode_1.txt"
@@ -114,89 +114,89 @@ async def test_open_draft_returns_flat_draft_structure(fake_ctx: ToolContext) ->
 
 async def test_open_draft_leaves_official_file_untouched(fake_ctx: ToolContext) -> None:
     """取回只是开编辑工位，正式文件一步不动——改动落回正式文件只发生在持锁的晋升侧。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    before = _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    before = rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    await _open_for_edit(fake_ctx)
+    await open_for_edit(fake_ctx)
 
-    assert _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
 async def test_open_draft_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """情况 B 的完整闭环：取回 → 改草稿 → 晋升。改动经晋升侧的持锁写盘落回正式文件。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
 
-    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_rv_quarantine(fake_ctx)
+    await open_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 在 @[村口] 出场"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert not rv_quarantine_path(fake_ctx).exists()
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["units"][0]["text"] == "@[张三] 在 @[村口] 出场"
-    assert _derived_reference_names(fake_ctx, saved["units"][0]["text"]) == ["张三", "村口"]
+    assert derived_reference_names(fake_ctx, saved["units"][0]["text"]) == ["张三", "村口"]
 
 
 async def test_open_draft_returns_existing_draft_without_clobbering(fake_ctx: ToolContext, monkeypatch) -> None:
     """已有草稿在场时不覆盖：那份草稿可能已含 Agent 未晋升的修改（或本就是待修复草稿），
     拿正式文件盖过去等于抹掉它手上的工作。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
-    before = _rv_quarantine_path(fake_ctx).read_text(encoding="utf-8")
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
+    before = rv_quarantine_path(fake_ctx).read_text(encoding="utf-8")
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is not True
-    assert _rv_quarantine_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert rv_quarantine_path(fake_ctx).read_text(encoding="utf-8") == before
     assert "reference_script_plan" in out["content"][0]["text"]
 
 
 async def test_open_draft_without_official_file(fake_ctx: ToolContext) -> None:
     """没有正式 script_plan 时指回首次拆分工具，而不是开一份空草稿让 Agent 手写整集。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is True
     assert "generate_script_plan" in out["content"][0]["text"]
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_open_draft_keeps_malformed_duration_verbatim(fake_ctx: ToolContext) -> None:
     """盘上 unit 的字段类型不符时原样带进草稿，不归一化成合法值：``8.0`` 被改写成 ``0``
     后，Agent 从草稿里看到的是一个它没写过的时长，晋升报告说「时长不在档位内」也对不上
     盘上的原值。原样带过则由晋升侧 schema 逐条报告，Agent 看得见错在哪。"""
-    _rv_source(fake_ctx)
-    unit = _rv_saved_unit("@[张三] 起身")
+    rv_source(fake_ctx)
+    unit = rv_saved_unit("@[张三] 起身")
     unit["duration_seconds"] = 8.0
-    _write_rv_script_plan(fake_ctx, [unit])
+    write_rv_script_plan(fake_ctx, [unit])
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert _read_rv_quarantine(fake_ctx)["content"]["units"][0]["duration_seconds"] == 8.0
+    assert read_rv_quarantine(fake_ctx)["content"]["units"][0]["duration_seconds"] == 8.0
 
 
 async def test_open_draft_keeps_malformed_non_dict_unit_slot(fake_ctx: ToolContext) -> None:
     """盘上 units 混入非 dict 元素时不能直接丢弃：跳过会让草稿数组比正式文件短一个，若剩余
     unit 都能过校验，晋升会悄悄覆盖正式文件、丢失这个 unit 而无人知晓。留空占位在原数组
     位置，让晋升侧 schema 判它结构非法、逐条报出。"""
-    _rv_source(fake_ctx)
-    good_unit = _rv_saved_unit("@[张三] 起身")
-    path = _rv_script_plan_path(fake_ctx)
+    rv_source(fake_ctx)
+    good_unit = rv_saved_unit("@[张三] 起身")
+    path = rv_script_plan_path(fake_ctx)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"units": [good_unit, "不是对象"]}, ensure_ascii=False), encoding="utf-8")
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    units = _read_rv_quarantine(fake_ctx)["content"]["units"]
+    units = read_rv_quarantine(fake_ctx)["content"]["units"]
     assert len(units) == 2
     assert units[1] == {"duration_seconds": None, "source_text": "", "text": ""}
 
@@ -207,8 +207,8 @@ async def test_open_draft_rejects_missing_source_without_side_effect(
     """`source` 指向不存在的文件时不落盘草稿：草稿一旦创建就把这个坏路径记进 meta.source，
     晋升时 `_load_novel_source` 会反复报错，而草稿在场又挡住重新取回改正 source，Agent
     会卡在一个自己改不动的死角。校验失败时不产生持久副作用，Agent 改对参数重试即可。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
     workflow = DraftWorkflow(
         DraftContext(
             project_name=fake_ctx.project_name,
@@ -226,12 +226,12 @@ async def test_open_draft_rejects_missing_source_without_side_effect(
         )
 
     assert excinfo.value.code == "draft_open_failed"
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_script_plan_write_cannot_race_a_prompt_authoring_draft_patch(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
     _write_reference_prompt_authoring(
         fake_ctx,
         {
@@ -241,7 +241,7 @@ async def test_script_plan_write_cannot_race_a_prompt_authoring_draft_patch(fake
             "video_units": [{"unit_id": "E1U01", "text": "@[张三] 起身", "duration_seconds": 4}],
         },
     )
-    opened = _draft_result(await _open_for_edit(fake_ctx, doc_type="reference_prompt_authoring"))
+    opened = _draft_result(await open_for_edit(fake_ctx, doc_type="reference_prompt_authoring"))
     changed = copy.deepcopy(opened["content"])
     changed["units"][0]["text"] = "并发编辑"
     target = quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING)
@@ -276,7 +276,7 @@ async def test_script_plan_write_cannot_race_a_prompt_authoring_draft_patch(fake
         script_review.write_script_plan(
             fake_ctx.project_path,
             1,
-            {"units": [_rv_saved_unit("@[张三] 修改 script_plan")]},
+            {"units": [rv_saved_unit("@[张三] 修改 script_plan")]},
             before_lock=writer_attempted_draft_lock.set,
         )
 
@@ -299,38 +299,38 @@ async def test_script_plan_write_cannot_race_a_prompt_authoring_draft_patch(fake
 
 async def test_open_draft_rejects_non_reference_episode(fake_ctx: ToolContext) -> None:
     """切走参考路径的集不给编辑：盘上的 script_plan 与该集此刻的生成路径无关。与晋升工具同一判据。"""
-    _rv_source(fake_ctx)
-    _rv_project(fake_ctx, generation_mode="image_to_video")
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    rv_project(fake_ctx, generation_mode="image_to_video")
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is True
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_open_draft_records_base_fingerprint(fake_ctx: ToolContext) -> None:
     """取回时把正式文件此刻的内容指纹记进 meta.base_fingerprint，供晋升前基线比对。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    meta = _read_rv_quarantine(fake_ctx)["meta"]
-    assert meta["base_fingerprint"] == script_review.content_fingerprint(_rv_script_plan_path(fake_ctx))
+    meta = read_rv_quarantine(fake_ctx)["meta"]
+    assert meta["base_fingerprint"] == script_review.content_fingerprint(rv_script_plan_path(fake_ctx))
 
 
 async def test_open_draft_returns_drama_scenes(fake_ctx: ToolContext) -> None:
     """drama 取回的草稿装分镜内容表，正式文件一步不动——写盘只发生在持锁的晋升侧。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene(needs_replan=True)])
-    before = _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene(needs_replan=True)])
+    before = drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
 
     assert out.get("is_error") is not True, out
-    envelope = _read_drama_quarantine(fake_ctx)
+    envelope = read_drama_quarantine(fake_ctx)
     assert envelope["kind"] == QUARANTINE_KIND_DRAMA_SCRIPT_PLAN
     assert envelope["violations"] == []
     assert envelope["meta"]["source"] == "source/episode_1.txt"
@@ -340,40 +340,40 @@ async def test_open_draft_returns_drama_scenes(fake_ctx: ToolContext) -> None:
     # 而晋升侧无论如何都按现值重派生，两者不一致只会误导。
     assert "needs_replan" not in scene
     assert scene["scene_description"] == "阿离站在山门前。"
-    assert _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
 async def test_open_draft_drama_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """完整闭环：取回 → 改草稿 → 晋升。改动经持锁写盘落回正式文件，派生字段按新内容重算。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
 
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_drama_quarantine(fake_ctx)
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_drama_quarantine(fake_ctx)
     envelope["content"]["scenes"][0]["scene_description"] = "阿离推开山门。"
-    _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx)
+    out = await promote_drama(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _drama_quarantine_path(fake_ctx).exists()
-    saved = json.loads(_drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert not drama_quarantine_path(fake_ctx).exists()
+    saved = json.loads(drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["scenes"][0]["scene_description"] == "阿离推开山门。"
 
 
 async def test_open_draft_returns_existing_drama_draft(fake_ctx: ToolContext) -> None:
     """已有草稿在场时不覆盖：那份草稿可能已含未晋升的修改，出路是继续改它再晋升。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_drama_quarantine(fake_ctx)
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_drama_quarantine(fake_ctx)
     envelope["content"]["scenes"][0]["scene_description"] = "未晋升的修改。"
-    _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
 
     assert out.get("is_error") is not True
-    assert _read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "未晋升的修改。"
+    assert read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "未晋升的修改。"
 
 
 async def test_open_draft_rejects_variant_without_draft_channel(fake_ctx: ToolContext) -> None:
@@ -385,7 +385,7 @@ async def test_open_draft_rejects_variant_without_draft_channel(fake_ctx: ToolCo
     fake_ctx.pm.project_payload["content_mode"] = "ad"
     fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
 
-    out = await _open_for_edit(fake_ctx)
+    out = await open_for_edit(fake_ctx)
 
     assert out.get("is_error") is True
     assert "doc_type_not_applicable" in out["content"][0]["text"]
@@ -393,67 +393,67 @@ async def test_open_draft_rejects_variant_without_draft_channel(fake_ctx: ToolCo
 
 async def test_open_draft_returns_narration_segments(fake_ctx: ToolContext) -> None:
     """narration 取回的草稿装分镜表，正式文件一步不动——写盘只发生在持锁的晋升侧。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    before = _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    before = nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
 
     assert out.get("is_error") is not True, out
-    envelope = _read_nr_quarantine(fake_ctx)
+    envelope = read_nr_quarantine(fake_ctx)
     assert envelope["kind"] == QUARANTINE_KIND_NARRATION_SCRIPT_PLAN
     assert envelope["content"]["segments"][0]["novel_text"] == _RV_NOVEL
     assert envelope["violations"] == [], "取回是编辑工位，不是待修复草稿"
     assert envelope["meta"]["source"] == "source/episode_1.txt"
     assert envelope["meta"]["base_fingerprint"] is not None
-    assert _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
 async def test_open_draft_narration_round_trips_through_promote(fake_ctx: ToolContext) -> None:
     """取回 → 改草稿 → 晋升写回正式文件、草稿清除：与 drama / 参考生视频同一条晋升通道。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
 
-    envelope = _read_nr_quarantine(fake_ctx)
+    envelope = read_nr_quarantine(fake_ctx)
     envelope["content"]["segments"][0]["duration_seconds"] = 8
-    _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _nr_quarantine_path(fake_ctx).exists()
-    saved = json.loads(_nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert not nr_quarantine_path(fake_ctx).exists()
+    saved = json.loads(nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["segments"][0]["duration_seconds"] == 8
     assert saved["segments"][0]["novel_text"] == _RV_NOVEL
 
 
 async def test_open_draft_returns_existing_narration_draft(fake_ctx: ToolContext) -> None:
     """已有草稿在场时不覆盖：那份草稿可能已含未晋升的修改，拿正式文件盖过去等于抹掉它的工作。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
     write_quarantine(
         fake_ctx.project_path,
         1,
         QUARANTINE_KIND_NARRATION_SCRIPT_PLAN,
-        content={"segments": [_nr_segment("E1S01", 8, "改到一半的正文")]},
+        content={"segments": [nr_segment("E1S01", 8, "改到一半的正文")]},
         violations=[],
     )
 
-    out = await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
 
     assert out.get("is_error") is not True
-    assert _read_nr_quarantine(fake_ctx)["content"]["segments"][0]["novel_text"] == "改到一半的正文"
+    assert read_nr_quarantine(fake_ctx)["content"]["segments"][0]["novel_text"] == "改到一半的正文"
 
 
 async def test_patch_draft_supports_multiple_rounds_and_rejects_stale_revision(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    opened = _draft_result(await _open_for_edit(fake_ctx, source="source/episode_1.txt"))
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    opened = _draft_result(await open_for_edit(fake_ctx, source="source/episode_1.txt"))
 
     first_content = opened["content"]
     first_content["units"][0]["text"] = "@[张三] 走向 @[村口]"
-    first = await _call(
+    first = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -465,7 +465,7 @@ async def test_patch_draft_supports_multiple_rounds_and_rejects_stale_revision(f
     first_result = _draft_result(first)
     assert first_result["revision"] != opened["revision"]
 
-    stale = await _call(
+    stale = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -479,7 +479,7 @@ async def test_patch_draft_supports_multiple_rounds_and_rejects_stale_revision(f
 
     second_content = first_result["content"]
     second_content["units"][0]["text"] = "@[张三] 在 @[村口] 停下"
-    second = await _call(
+    second = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -499,16 +499,16 @@ async def test_each_doc_type_completes_multi_patch_then_promote_or_discard(
     fake_ctx: ToolContext, doc_type: str
 ) -> None:
     if doc_type == "drama_script_plan":
-        _drama_project(fake_ctx)
-        _write_drama_script_plan(fake_ctx, [_drama_scene()])
+        drama_project(fake_ctx)
+        write_drama_script_plan(fake_ctx, [drama_scene()])
     elif doc_type == "narration_script_plan":
-        _nr_source(fake_ctx)
-        _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
+        nr_source(fake_ctx)
+        write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
     elif doc_type == "reference_script_plan":
-        _rv_source(fake_ctx)
-        _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+        rv_source(fake_ctx)
+        write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
     else:
-        _rv_project(fake_ctx)
+        rv_project(fake_ctx)
         _write_reference_prompt_authoring(
             fake_ctx,
             {
@@ -520,7 +520,7 @@ async def test_each_doc_type_completes_multi_patch_then_promote_or_discard(
         )
 
     args = {"episode": 1, "doc_type": doc_type}
-    opened = _draft_result(await _call(open_draft_tool(fake_ctx), args))
+    opened = _draft_result(await call(open_draft_tool(fake_ctx), args))
 
     def edit(content: dict, marker: str) -> None:
         if doc_type == "drama_script_plan":
@@ -535,7 +535,7 @@ async def test_each_doc_type_completes_multi_patch_then_promote_or_discard(
     first_content = opened["content"]
     edit(first_content, "first")
     first = _draft_result(
-        await _call(
+        await call(
             patch_draft_tool(fake_ctx),
             {**args, "content": first_content, "base_revision": opened["revision"]},
         )
@@ -543,7 +543,7 @@ async def test_each_doc_type_completes_multi_patch_then_promote_or_discard(
     second_content = first["content"]
     edit(second_content, "second")
     second = _draft_result(
-        await _call(
+        await call(
             patch_draft_tool(fake_ctx),
             {**args, "content": second_content, "base_revision": first["revision"]},
         )
@@ -552,29 +552,29 @@ async def test_each_doc_type_completes_multi_patch_then_promote_or_discard(
 
     if doc_type == "reference_prompt_authoring":
         discarded = _draft_result(
-            await _call(discard_draft_tool(fake_ctx), {**args, "base_revision": second["revision"]})
+            await call(discard_draft_tool(fake_ctx), {**args, "base_revision": second["revision"]})
         )
         assert discarded["discarded"] is True
     else:
         if doc_type == "drama_script_plan":
-            result = await _promote_drama(fake_ctx)
+            result = await promote_drama(fake_ctx)
         elif doc_type == "narration_script_plan":
-            result = await _promote_nr(fake_ctx)
+            result = await promote_nr(fake_ctx)
         else:
-            result = await _promote(fake_ctx)
+            result = await promote_reference_draft(fake_ctx)
         assert result.get("is_error") is not True, result
 
 
 async def test_patch_draft_can_accept_a_merged_formal_revision(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    opened = _draft_result(await _open_for_edit(fake_ctx, source="source/episode_1.txt"))
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    opened = _draft_result(await open_for_edit(fake_ctx, source="source/episode_1.txt"))
 
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 走向 @[村口]")])
-    refreshed = _draft_result(await _open_for_edit(fake_ctx))
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 走向 @[村口]")])
+    refreshed = _draft_result(await open_for_edit(fake_ctx))
     merged = refreshed["content"]
     merged["units"][0]["text"] = "@[张三] 在 @[村口] 停下"
-    patched = await _call(
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -586,8 +586,8 @@ async def test_patch_draft_can_accept_a_merged_formal_revision(fake_ctx: ToolCon
     )
 
     assert patched.get("is_error") is not True, patched
-    assert _read_rv_quarantine(fake_ctx)["meta"]["base_fingerprint"] == refreshed["formal_revision"]
-    promoted = await _promote(fake_ctx)
+    assert read_rv_quarantine(fake_ctx)["meta"]["base_fingerprint"] == refreshed["formal_revision"]
+    promoted = await promote_reference_draft(fake_ctx)
     assert promoted.get("is_error") is not True, promoted
 
 
@@ -595,17 +595,17 @@ async def test_patch_draft_can_accept_a_merged_formal_revision(fake_ctx: ToolCon
 async def test_patch_draft_revision_covers_source_metadata_without_blocking_event_loop(
     fake_ctx: ToolContext,
 ) -> None:
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     (fake_ctx.project_path / "source" / "episode_2.txt").write_text(_RV_NOVEL, encoding="utf-8")
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    opened = _draft_result(await _open_for_edit(fake_ctx, source="source/episode_1.txt"))
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    opened = _draft_result(await open_for_edit(fake_ctx, source="source/episode_1.txt"))
     args = {
         "episode": 1,
         "doc_type": "reference_script_plan",
         "content": opened["content"],
         "base_revision": opened["revision"],
     }
-    path = _rv_quarantine_path(fake_ctx)
+    path = rv_quarantine_path(fake_ctx)
     snapshot = path.read_text(encoding="utf-8")
     path.unlink()
     os.mkfifo(path)
@@ -641,7 +641,7 @@ with open(sys.argv[1], "w", encoding="utf-8") as fifo:
             # The child may close stdin after its FIFO write completes.
             pass
 
-    patching = asyncio.create_task(_call(patch_draft_tool(fake_ctx), {**args, "source": "source/episode_2.txt"}))
+    patching = asyncio.create_task(call(patch_draft_tool(fake_ctx), {**args, "source": "source/episode_2.txt"}))
     try:
         started = await asyncio.wait_for(asyncio.to_thread(snapshot_writer.stdout.readline), timeout=20)
         assert started == "snapshot_started\n"
@@ -661,23 +661,23 @@ with open(sys.argv[1], "w", encoding="utf-8") as fifo:
             patching.cancel()
         await asyncio.gather(patching, return_exceptions=True)
 
-    stale = await _call(patch_draft_tool(fake_ctx), {**args, "source": "source/episode_1.txt"})
+    stale = await call(patch_draft_tool(fake_ctx), {**args, "source": "source/episode_1.txt"})
 
     assert "event_loop_blocked" not in writer_output
     assert first["revision"] != opened["revision"]
-    assert _read_rv_quarantine(fake_ctx)["meta"]["source"] == "source/episode_2.txt"
+    assert read_rv_quarantine(fake_ctx)["meta"]["source"] == "source/episode_2.txt"
     assert stale.get("is_error") is True
     assert "revision_conflict" in stale["content"][0]["text"]
 
 
 async def test_discard_draft_rejects_stale_revision(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    opened = _draft_result(await _open_for_edit(fake_ctx))
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    opened = _draft_result(await open_for_edit(fake_ctx))
     changed = copy.deepcopy(opened["content"])
     changed["units"][0]["text"] = "@[张三] 走向 @[村口]"
     patched = _draft_result(
-        await _call(
+        await call(
             patch_draft_tool(fake_ctx),
             {
                 "episode": 1,
@@ -688,16 +688,16 @@ async def test_discard_draft_rejects_stale_revision(fake_ctx: ToolContext) -> No
         )
     )
 
-    stale = await _call(
+    stale = await call(
         discard_draft_tool(fake_ctx),
         {"episode": 1, "doc_type": "reference_script_plan", "base_revision": opened["revision"]},
     )
 
     assert stale.get("is_error") is True
     assert "revision_conflict" in stale["content"][0]["text"]
-    assert _rv_quarantine_path(fake_ctx).exists()
+    assert rv_quarantine_path(fake_ctx).exists()
     discarded = _draft_result(
-        await _call(
+        await call(
             discard_draft_tool(fake_ctx),
             {"episode": 1, "doc_type": "reference_script_plan", "base_revision": patched["revision"]},
         )
@@ -706,23 +706,23 @@ async def test_discard_draft_rejects_stale_revision(fake_ctx: ToolContext) -> No
 
 
 async def test_discard_draft_keeps_formal_content_and_is_idempotent(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    formal_before = _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
-    opened = _draft_result(await _open_for_edit(fake_ctx))
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    formal_before = rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    opened = _draft_result(await open_for_edit(fake_ctx))
 
     args = {"episode": 1, "doc_type": "reference_script_plan", "base_revision": opened["revision"]}
-    first = _draft_result(await _call(discard_draft_tool(fake_ctx), args))
-    second = _draft_result(await _call(discard_draft_tool(fake_ctx), args))
+    first = _draft_result(await call(discard_draft_tool(fake_ctx), args))
+    second = _draft_result(await call(discard_draft_tool(fake_ctx), args))
 
     assert first["discarded"] is True
     assert second["discarded"] is False
-    assert not _rv_quarantine_path(fake_ctx).exists()
-    assert _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == formal_before
+    assert not rv_quarantine_path(fake_ctx).exists()
+    assert rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == formal_before
 
 
 async def test_open_reference_prompt_authoring_returns_flat_editable_content(fake_ctx: ToolContext) -> None:
-    _rv_project(fake_ctx)
+    rv_project(fake_ctx)
     _write_reference_prompt_authoring(
         fake_ctx,
         {
@@ -733,7 +733,7 @@ async def test_open_reference_prompt_authoring_returns_flat_editable_content(fak
         },
     )
 
-    out = await _call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "reference_prompt_authoring"})
+    out = await call(open_draft_tool(fake_ctx), {"episode": 1, "doc_type": "reference_prompt_authoring"})
 
     draft = _draft_result(out)
     assert draft["content"] == {"title": "第一集", "units": [{"text": "@[张三] 起身"}]}

--- a/tests/integration/server/agent_runtime/sdk_tools/test_entry.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_entry.py
@@ -56,7 +56,7 @@ async def test_upload_source_closes_temporary_file_before_loading(tmp_path: Path
         return handle
 
     def checked_load(*args, **kwargs):
-        assert tracked["handle"].closed  # type: ignore[union-attr]
+        assert tracked["handle"].closed
         return original_load(*args, **kwargs)
 
     monkeypatch.setattr(tool_runtime.tempfile, "NamedTemporaryFile", tracked_temp)
@@ -65,7 +65,7 @@ async def test_upload_source_closes_temporary_file_before_loading(tmp_path: Path
     uploaded = await upload_source_tool(ctx).handler({"filename": "novel.txt", "content": "hello"})
 
     assert json.loads(uploaded["content"][0]["text"])["source"]["path"] == "source/novel.txt"
-    assert not tracked["path"].exists()  # type: ignore[union-attr]
+    assert not tracked["path"].exists()
 
 
 async def test_upload_source_cleans_temporary_file_when_write_fails(tmp_path: Path, monkeypatch) -> None:

--- a/tests/integration/server/agent_runtime/sdk_tools/test_episode_planning.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_episode_planning.py
@@ -8,7 +8,7 @@ import pytest
 
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
+    call,
 )
 
 # ---------------------------------------------------------------------------
@@ -56,7 +56,7 @@ async def test_plan_episodes_happy(fake_ctx: ToolContext, monkeypatch) -> None:
         cursor={"source_file": "source/novel.txt", "offset": 1715},
     )
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result, captured))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
@@ -81,7 +81,7 @@ async def test_plan_episodes_forwards_instructions(fake_ctx: ToolContext, monkey
         cursor=None,
     )
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result, captured))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {"instructions": "  按章节对齐切分  "})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {"instructions": "  按章节对齐切分  "})
 
     assert out.get("is_error") is not True
     assert captured["plan_instructions"] == "按章节对齐切分"
@@ -96,7 +96,7 @@ async def test_plan_episodes_blank_instructions_treated_as_none(fake_ctx: ToolCo
     monkeypatch.setattr(
         mod, "EpisodePlanner", _fake_planner_cls(PlanResult(episodes=[], cursor=None, source_exhausted=True), captured)
     )
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {"instructions": "   \n "})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {"instructions": "   \n "})
 
     assert out.get("is_error") is not True
     assert captured["plan_instructions"] is None
@@ -108,7 +108,7 @@ async def test_plan_episodes_rejects_non_string_instructions(fake_ctx: ToolConte
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(PlanResult(episodes=[], cursor=None)))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {"instructions": ["按章切"]})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {"instructions": ["按章切"]})
 
     assert out.get("is_error") is True
     assert "instructions" in out["content"][0]["text"]
@@ -120,7 +120,7 @@ async def test_plan_episodes_rejects_overlong_instructions(fake_ctx: ToolContext
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(PlanResult(episodes=[], cursor=None)))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {"instructions": "章" * (mod.MAX_INSTRUCTIONS_LEN + 1)})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {"instructions": "章" * (mod.MAX_INSTRUCTIONS_LEN + 1)})
 
     assert out.get("is_error") is True
     assert "过长" in out["content"][0]["text"]
@@ -140,7 +140,7 @@ async def test_plan_episodes_accepts_boundary_length_instructions(fake_ctx: Tool
     )
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result, captured))
     text = "章" * mod.MAX_INSTRUCTIONS_LEN
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {"instructions": text})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {"instructions": text})
 
     assert out.get("is_error") is not True
     assert captured["plan_instructions"] == text
@@ -153,7 +153,7 @@ async def test_plan_episodes_planner_value_error_not_mislabeled_as_param_error(
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(ValueError("未找到可用的 text 供应商")))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
@@ -167,7 +167,7 @@ async def test_plan_episodes_source_exhausted(fake_ctx: ToolContext, monkeypatch
 
     result = PlanResult(episodes=[], cursor=None, source_exhausted=True)
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is not True
     assert "全部规划" in out["content"][0]["text"]
@@ -181,7 +181,7 @@ async def test_plan_episodes_source_exhausted_includes_ledger_stats(fake_ctx: To
     stats = LedgerStats(total_episodes=30, smallest=[(30, 57), (12, 640)], median_units=812, target_units=800)
     result = PlanResult(episodes=[], cursor=None, source_exhausted=True, ledger_stats=stats)
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
@@ -208,7 +208,7 @@ async def test_plan_episodes_normal_batch_reports_total_planned_line_only(fake_c
         ledger_stats=None,
     )
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(result))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
@@ -222,7 +222,7 @@ async def test_plan_episodes_error_envelope(fake_ctx: ToolContext, monkeypatch) 
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
     monkeypatch.setattr(mod, "EpisodePlanner", _fake_planner_cls(EpisodePlanningError("校验耗尽")))
-    out = await _call(mod.plan_episodes_tool(fake_ctx), {})
+    out = await call(mod.plan_episodes_tool(fake_ctx), {})
 
     assert out.get("is_error") is True
     assert "校验耗尽" in out["content"][0]["text"]
@@ -257,7 +257,7 @@ async def test_reset_episode_planning_happy(fake_ctx: ToolContext, monkeypatch) 
     )
     monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result, captured))
 
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
 
     assert out.get("is_error") is not True
     assert captured["args"][1:] == (1, False)
@@ -276,7 +276,7 @@ async def test_reset_episode_planning_confirmation_required(fake_ctx: ToolContex
         "reset_episode_planning",
         _fake_reset(ResetConfirmationRequired(consumed_episodes=[1, 3], archived_files=[])),
     )
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1})
 
     assert out.get("is_error") is not True  # 预期内的流程出口，不是错误
     text = out["content"][0]["text"]
@@ -292,7 +292,7 @@ async def test_reset_episode_planning_forwards_confirm(fake_ctx: ToolContext, mo
     result = EpisodeResetResult(removed_episodes=[1], deleted_files=[], archived_files=[], consumed_episodes=[1])
     monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result, captured))
 
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1, "confirm_consumed": True})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 1, "confirm_consumed": True})
 
     assert captured["args"][1:] == (1, True)
     assert "未删除" in out["content"][0]["text"]  # 产物保留须对主 Agent 说明
@@ -306,7 +306,7 @@ async def test_reset_episode_planning_partial_reset_error(fake_ctx: ToolContext,
     monkeypatch.setattr(
         mod, "reset_episode_planning", _fake_reset(EpisodeResetError("源文件已被修改或移除：source/novel.txt"))
     )
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 3})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 3})
 
     assert out.get("is_error") is True
     assert "源文件已被修改或移除" in out["content"][0]["text"]
@@ -322,7 +322,7 @@ async def test_reset_episode_planning_partial_reset_success_message(fake_ctx: To
     )
     monkeypatch.setattr(mod, "reset_episode_planning", _fake_reset(result))
 
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 2})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": 2})
 
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
@@ -337,7 +337,7 @@ async def test_reset_episode_planning_rejects_string_confirm_consumed(fake_ctx: 
     """confirm_consumed 是确认安全边界：非布尔值必须拒绝而非真值化。"""
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
-    out = await _call(
+    out = await call(
         mod.reset_episode_planning_tool(fake_ctx),
         {"from_episode": 1, "confirm_consumed": "true"},
     )
@@ -349,7 +349,7 @@ async def test_reset_episode_planning_rejects_string_confirm_consumed(fake_ctx: 
 async def test_reset_episode_planning_rejects_bad_from_episode(fake_ctx: ToolContext, bad: Any) -> None:
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": bad})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {"from_episode": bad})
     assert out.get("is_error") is True
     assert "from_episode" in out["content"][0]["text"]
 
@@ -357,5 +357,5 @@ async def test_reset_episode_planning_rejects_bad_from_episode(fake_ctx: ToolCon
 async def test_reset_episode_planning_requires_from_episode(fake_ctx: ToolContext) -> None:
     from server.agent_runtime.sdk_tools import episode_planning as mod
 
-    out = await _call(mod.reset_episode_planning_tool(fake_ctx), {})
+    out = await call(mod.reset_episode_planning_tool(fake_ctx), {})
     assert out.get("is_error") is True

--- a/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
@@ -36,37 +36,37 @@ from server.media_tools.context import ToolContext
 from server.text_generation import TextGenerationError, TextGenerationRequest, generate_reference_script_plan
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _RV_NOVEL,
-    _call,
-    _drama_project,
-    _drama_quarantine_path,
-    _drama_scene,
-    _drama_script_plan_path,
-    _nr_generator_returning,
-    _nr_quarantine_path,
-    _nr_script_plan_path,
-    _nr_segment,
-    _nr_source,
-    _open_drama_for_edit,
-    _open_for_edit,
-    _open_nr_for_edit,
-    _promote,
-    _promote_drama,
-    _promote_nr,
-    _read_drama_quarantine,
-    _read_nr_quarantine,
-    _read_rv_quarantine,
-    _run_rv_split,
-    _rv_generator_returning,
-    _rv_project,
-    _rv_quarantine_path,
-    _rv_saved_unit,
-    _rv_script_plan_path,
-    _rv_source,
-    _rv_unit,
-    _use_fake_caps,
-    _write_drama_script_plan,
-    _write_nr_script_plan,
-    _write_rv_script_plan,
+    call,
+    drama_project,
+    drama_quarantine_path,
+    drama_scene,
+    drama_script_plan_path,
+    nr_generator_returning,
+    nr_quarantine_path,
+    nr_script_plan_path,
+    nr_segment,
+    nr_source,
+    open_drama_for_edit,
+    open_for_edit,
+    open_nr_for_edit,
+    promote_drama,
+    promote_nr,
+    promote_reference_draft,
+    read_drama_quarantine,
+    read_nr_quarantine,
+    read_rv_quarantine,
+    run_rv_split,
+    rv_generator_returning,
+    rv_project,
+    rv_quarantine_path,
+    rv_saved_unit,
+    rv_script_plan_path,
+    rv_source,
+    rv_unit,
+    use_fake_caps,
+    write_drama_script_plan,
+    write_nr_script_plan,
+    write_rv_script_plan,
 )
 
 # ---------------------------------------------------------------------------
@@ -81,13 +81,13 @@ from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
 #: ``duration_off_tier``（时长不在该 unit 引用状态的生效档位内）需要另一套 caps 才触发，
 #: 单列在 ``test_split_reference_video_units_rejects_duration_off_reference_tier``。
 _RV_VIOLATION_CASES = [
-    ("unclosed_brace", _rv_unit("@[张三] 起身，喊了一句 {我来了")),
-    ("dialogue_line_syntax", _rv_unit("门开了\n@[张三]：我来了。")),
-    ("unregistered_asset", _rv_unit("@[不存在的人] 出场")),
-    ("unregistered_speaker", _rv_unit("门开了\n@[无名氏]：{我来了。}")),
-    ("braces_in_description", _rv_unit("@[张三] 推门，音量 {}，转身离开")),
-    ("source_text_not_verbatim", _rv_unit("@[张三] 起身", source_text="张三在城里等人")),
-    ("dialogue_overload", _rv_unit("@[张三] 起身\n@[张三]：{" + "这是一段非常长的台词" * 6 + "}", duration=4)),
+    ("unclosed_brace", rv_unit("@[张三] 起身，喊了一句 {我来了")),
+    ("dialogue_line_syntax", rv_unit("门开了\n@[张三]：我来了。")),
+    ("unregistered_asset", rv_unit("@[不存在的人] 出场")),
+    ("unregistered_speaker", rv_unit("门开了\n@[无名氏]：{我来了。}")),
+    ("braces_in_description", rv_unit("@[张三] 推门，音量 {}，转身离开")),
+    ("source_text_not_verbatim", rv_unit("@[张三] 起身", source_text="张三在城里等人")),
+    ("dialogue_overload", rv_unit("@[张三] 起身\n@[张三]：{" + "这是一段非常长的台词" * 6 + "}", duration=4)),
 ]
 
 
@@ -96,13 +96,13 @@ async def test_split_reference_video_units_quarantines_each_violation_class(
     fake_ctx: ToolContext, monkeypatch, code: str, unit: dict
 ) -> None:
     """六类阻断违约逐类：产物落草稿、正式文件不被写出、报告按违约类逐条定位。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [unit])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [unit])
 
     assert out.get("is_error") is True
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     assert envelope["kind"] == QUARANTINE_KIND_SCRIPT_PLAN
     assert [v["code"] for v in envelope["violations"]] == [code]
     assert envelope["violations"][0]["label"] == "unit E1U01"
@@ -113,7 +113,7 @@ async def test_split_reference_video_units_quarantines_each_violation_class(
     report = out["content"][0]["text"]
     assert f"[{code}]" in report
     assert "unit E1U01" in report
-    assert str(_rv_quarantine_path(fake_ctx)) in report
+    assert str(rv_quarantine_path(fake_ctx)) in report
     assert "promote_draft" in report
 
 
@@ -121,16 +121,16 @@ async def test_split_reference_video_units_reports_all_bad_units_in_one_round(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """报告逐条覆盖所有坏 unit，不停在第一个——否则 Agent 每修一处就要再跑一轮付费拆分。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     units = [
-        _rv_unit("@[张三] 起身"),
-        _rv_unit("@[不存在的人] 出场"),
-        _rv_unit("@[张三] 推门，音量 {}"),
+        rv_unit("@[张三] 起身"),
+        rv_unit("@[不存在的人] 出场"),
+        rv_unit("@[张三] 推门，音量 {}"),
     ]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
 
     assert out.get("is_error") is True
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     assert [v["label"] for v in envelope["violations"]] == ["unit E1U02", "unit E1U03"]
     assert [v["code"] for v in envelope["violations"]] == ["unregistered_asset", "braces_in_description"]
     # 合法的 unit 也原样留在草稿里：Agent 只需改坏的那些
@@ -140,11 +140,11 @@ async def test_split_reference_video_units_reports_all_bad_units_in_one_round(
 async def test_reference_script_plan_write_transaction_does_not_block_event_loop(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
-    _rv_source(fake_ctx)
-    resolver = _use_fake_caps(fake_ctx)
+    rv_source(fake_ctx)
+    resolver = use_fake_caps(fake_ctx)
     from server import text_generation as mod
 
-    monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning([_rv_unit("@[张三] 起身")]))
+    monkeypatch.setattr(mod.TextGenerator, "create", rv_generator_returning([rv_unit("@[张三] 起身")]))
     started = threading.Event()
     release = threading.Event()
     caller_thread = threading.get_ident()
@@ -182,16 +182,16 @@ async def test_reference_script_plan_write_transaction_does_not_block_event_loop
 async def test_cancelled_reference_script_plan_commit_restores_files_and_manifest(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
-    _rv_source(fake_ctx)
-    resolver = _use_fake_caps(fake_ctx)
+    rv_source(fake_ctx)
+    resolver = use_fake_caps(fake_ctx)
     from server import text_generation as mod
 
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 等待")])
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 等待")])
     write_quarantine(
         fake_ctx.project_path,
         1,
         QUARANTINE_KIND_SCRIPT_PLAN,
-        content={"units": [_rv_unit("@[张三] 等待")]},
+        content={"units": [rv_unit("@[张三] 等待")]},
         violations=[],
     )
     write_quarantine(
@@ -202,15 +202,15 @@ async def test_cancelled_reference_script_plan_commit_restores_files_and_manifes
         violations=[],
     )
     paths = (
-        _rv_script_plan_path(fake_ctx),
-        _rv_quarantine_path(fake_ctx),
+        rv_script_plan_path(fake_ctx),
+        rv_quarantine_path(fake_ctx),
         quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING),
     )
     before = {path: path.read_bytes() for path in paths}
     adapter = ProjectArtifactManifestAdapter(fake_ctx.project_path)
     key = ArtifactKey.episode_script_plan(1)
     manifest_before = adapter.get_entry(key)
-    monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning([_rv_unit("@[张三] 起身")]))
+    monkeypatch.setattr(mod.TextGenerator, "create", rv_generator_returning([rv_unit("@[张三] 起身")]))
     started = threading.Event()
     release = threading.Event()
 
@@ -243,61 +243,61 @@ async def test_cancelled_reference_script_plan_commit_restores_files_and_manifes
 
 async def test_promote_draft_promotes_after_repair(fake_ctx: ToolContext, monkeypatch) -> None:
     """Agent 修好草稿后晋升：正式 script_plan 落盘、草稿清除、结构由正文机械派生。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 在 @[村口] 出场"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert not rv_quarantine_path(fake_ctx).exists()
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["units"][0]["unit_id"] == "E1U01"
     assert saved["units"][0]["text"] == "@[张三] 在 @[村口] 出场"
 
 
 async def test_promote_draft_reports_again_without_round_limit(fake_ctx: ToolContext, monkeypatch) -> None:
     """再违约则再返回刷新后的报告、草稿留在原地，可反复晋升——无收敛轮次上限。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
     for _round in range(3):
-        out = await _promote(fake_ctx)
+        out = await promote_reference_draft(fake_ctx)
         assert out.get("is_error") is True
         assert "unregistered_asset" in out["content"][0]["text"]
-        assert _rv_quarantine_path(fake_ctx).exists()
-        assert not _rv_script_plan_path(fake_ctx).exists()
+        assert rv_quarantine_path(fake_ctx).exists()
+        assert not rv_script_plan_path(fake_ctx).exists()
 
     # 改成另一类违约后报告随之刷新，不是上一轮的陈旧快照
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 推门，音量 {}"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
-    await _promote(fake_ctx)
-    assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["braces_in_description"]
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    await promote_reference_draft(fake_ctx)
+    assert [v["code"] for v in read_rv_quarantine(fake_ctx)["violations"]] == ["braces_in_description"]
 
 
 async def test_promote_draft_rejects_stale_draft_revision(fake_ctx: ToolContext, monkeypatch) -> None:
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
     args = {"episode": 1, "doc_type": "reference_script_plan"}
-    opened = json.loads((await _call(open_draft_tool(fake_ctx), args))["content"][0]["text"])["draft"]
+    opened = json.loads((await call(open_draft_tool(fake_ctx), args))["content"][0]["text"])["draft"]
     updated = copy.deepcopy(opened["content"])
     updated["units"][0]["text"] = "@[张三] 在 @[村口] 出场"
-    patched = await _call(
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {**args, "content": updated, "base_revision": opened["revision"]},
     )
     assert patched.get("is_error") is not True, patched
 
-    out = await _call(promote_draft_tool(fake_ctx), {**args, "base_revision": opened["revision"]})
+    out = await call(promote_draft_tool(fake_ctx), {**args, "base_revision": opened["revision"]})
 
     assert out.get("is_error") is True
     assert "revision_conflict" in out["content"][0]["text"]
-    assert _rv_quarantine_path(fake_ctx).exists()
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert rv_quarantine_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -309,15 +309,15 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     """「用户在内容确认界面编辑 + Agent 改草稿并晋升」的双端并发：取回后正式文件被另一写入方
     改过时，晋升中止并返回冲突报告（含最新内容与合并指引），不静默覆盖对方的修改；草稿
     留在原地。按报告经 open_draft / patch_draft 显式接受 formal_revision 后方可重新晋升。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    await open_for_edit(fake_ctx, source="source/episode_1.txt")
 
     # 模拟取回之后 Web 端保存改写了正式文件
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 在 @[村口] 等候")])
-    web_version = _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 在 @[村口] 等候")])
+    web_version = rv_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     report = out["content"][0]["text"]
@@ -329,13 +329,13 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
     # 冲突报告附上盘上现值的扁平草稿单元，供 Agent 对照合并
     assert "在 @[村口] 等候" in report
     # 正式文件未被覆盖，草稿仍在场
-    assert _rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == web_version
-    assert _rv_quarantine_path(fake_ctx).exists()
+    assert rv_script_plan_path(fake_ctx).read_text(encoding="utf-8") == web_version
+    assert rv_quarantine_path(fake_ctx).exists()
 
     # 按报告指引通过工具合并并显式接受正式版本后，重新晋升即放行。
-    refreshed = json.loads((await _open_for_edit(fake_ctx))["content"][0]["text"])["draft"]
+    refreshed = json.loads((await open_for_edit(fake_ctx))["content"][0]["text"])["draft"]
     refreshed["content"]["units"][0]["text"] = "@[张三] 在 @[村口] 等候"
-    patched = await _call(
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -346,20 +346,20 @@ async def test_promote_conflicts_when_official_changed_after_open(fake_ctx: Tool
         },
     )
     assert patched.get("is_error") is not True, patched
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(fake_ctx: ToolContext) -> None:
     """取回后正式文件被删除：现值指纹是 null，报告须按 JSON 字面量给出而非字符串 "None"。
     照报告用 patch_draft 显式接受 null 后重晋升即放行——写成字符串则永远比对不上。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
-    _rv_script_plan_path(fake_ctx).unlink()
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    await open_for_edit(fake_ctx, source="source/episode_1.txt")
+    rv_script_plan_path(fake_ctx).unlink()
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     report = out["content"][0]["text"]
@@ -367,9 +367,9 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
     assert "None" not in report
     assert "accepts_formal_revision=true" in report
 
-    refreshed = json.loads((await _open_for_edit(fake_ctx))["content"][0]["text"])["draft"]
+    refreshed = json.loads((await open_for_edit(fake_ctx))["content"][0]["text"])["draft"]
     assert refreshed["formal_revision"] is None
-    patched = await _call(
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -380,59 +380,59 @@ async def test_promote_conflict_report_renders_missing_fingerprint_as_json_null(
         },
     )
     assert patched.get("is_error") is not True, patched
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_promote_without_base_fingerprint_meta_promotes_unchecked(fake_ctx: ToolContext) -> None:
     """基线机制引入前产出的存量草稿缺 meta.base_fingerprint 键：按无基线晋升，不被新校验卡死。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_rv_quarantine(fake_ctx)
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    await open_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_rv_quarantine(fake_ctx)
     del envelope["meta"]["base_fingerprint"]
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
     # 取回后正式文件又被改过——存量草稿无基线可比，照旧覆盖（维持引入前语义）
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 在 @[村口] 等候")])
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 在 @[村口] 等候")])
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_split_violation_quarantine_records_base_fingerprint(fake_ctx: ToolContext, monkeypatch) -> None:
     """拆分违约落草稿时同样记基线：修好晋升前正式文件被并发改写的话按基线中止。
     首拆时正式文件不存在，基线为 null——晋升时若正式文件已被另一次拆分写出，同样判冲突。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
-    meta = _read_rv_quarantine(fake_ctx)["meta"]
+    meta = read_rv_quarantine(fake_ctx)["meta"]
     assert "base_fingerprint" in meta
     assert meta["base_fingerprint"] is None
 
     # 草稿在场期间正式文件被写出（另一路径），修好草稿后晋升应报冲突而非覆盖
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    envelope = _read_rv_quarantine(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 出场"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
-    formal_fingerprint = script_review.content_fingerprint(_rv_script_plan_path(fake_ctx))
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    formal_fingerprint = script_review.content_fingerprint(rv_script_plan_path(fake_ctx))
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     assert "并发冲突" in out["content"][0]["text"]
     assert "base_revision" in out["content"][0]["text"]
-    assert script_review.content_fingerprint(_rv_script_plan_path(fake_ctx)) == formal_fingerprint
+    assert script_review.content_fingerprint(rv_script_plan_path(fake_ctx)) == formal_fingerprint
 
 
 async def test_split_violation_keeps_pre_generation_formal_baseline(fake_ctx: ToolContext, monkeypatch) -> None:
     from server import text_generation as mod
 
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
-    expected = script_review.content_fingerprint(_rv_script_plan_path(fake_ctx))
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    expected = script_review.content_fingerprint(rv_script_plan_path(fake_ctx))
     started = asyncio.Event()
     release = asyncio.Event()
 
@@ -442,14 +442,14 @@ async def test_split_violation_keeps_pre_generation_formal_baseline(fake_ctx: To
             await release.wait()
 
             class _Result:
-                text = json.dumps({"units": [_rv_unit("@[不存在的人] 出场")]}, ensure_ascii=False)
+                text = json.dumps({"units": [rv_unit("@[不存在的人] 出场")]}, ensure_ascii=False)
 
             return _Result()
 
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    resolver = _use_fake_caps(fake_ctx)
+    resolver = use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
     generation = asyncio.create_task(
         generate_reference_script_plan(
@@ -465,15 +465,15 @@ async def test_split_violation_keeps_pre_generation_formal_baseline(fake_ctx: To
         generation.cancel()
         await asyncio.gather(generation, return_exceptions=True)
         raise
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 在 @[村口] 等候")])
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 在 @[村口] 等候")])
     release.set()
 
     with pytest.raises(TextGenerationError):
         await asyncio.wait_for(generation, timeout=1)
 
-    current = script_review.content_fingerprint(_rv_script_plan_path(fake_ctx))
+    current = script_review.content_fingerprint(rv_script_plan_path(fake_ctx))
     assert current != expected
-    assert _read_rv_quarantine(fake_ctx)["meta"]["base_fingerprint"] == expected
+    assert read_rv_quarantine(fake_ctx)["meta"]["base_fingerprint"] == expected
 
 
 @pytest.mark.parametrize(
@@ -491,20 +491,20 @@ async def test_promote_draft_rejects_schema_breach(fake_ctx: ToolContext, monkey
     时长枚举在产出侧由 response_schema 卡死；晋升侧若只判内容约束，Agent 把 duration_seconds
     改成非档位值或整个删掉（收成 0 秒）就能一路进正式 script_plan。
     """
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     mutate(envelope["content"]["units"][0])
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     assert hint in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
-    assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["schema_invalid"]
+    assert not rv_script_plan_path(fake_ctx).exists()
+    assert [v["code"] for v in read_rv_quarantine(fake_ctx)["violations"]] == ["schema_invalid"]
 
 
 @pytest.mark.parametrize(
@@ -522,54 +522,54 @@ async def test_promote_draft_reports_broken_outer_shape(fake_ctx: ToolContext, m
     units 整个删掉 / 改成非数组 / 清空都是 Agent 编辑草稿时会犯的错。只有逐 unit 的字段违约
     刷新报告的话，这几种就被甩出了「按报告改完再晋升」的循环。
     """
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     mutate_content(envelope["content"])
     edited_content = copy.deepcopy(envelope["content"])
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     assert "content.units" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
-    refreshed = _read_rv_quarantine(fake_ctx)
+    assert not rv_script_plan_path(fake_ctx).exists()
+    refreshed = read_rv_quarantine(fake_ctx)
     assert [v["code"] for v in refreshed["violations"]] == ["schema_invalid"]
     # 草稿留在原地且原样保留 Agent 写的那份内容：做收编会把它的原稿改形，它照着报告回看时
     # 反而对不上自己写的东西，改完再晋升这条路就断了
-    assert _rv_quarantine_path(fake_ctx).exists()
+    assert rv_quarantine_path(fake_ctx).exists()
     assert refreshed["content"] == edited_content
 
 
 async def test_promote_draft_requires_source_provenance(fake_ctx: ToolContext, monkeypatch) -> None:
     """meta.source 被改掉后不晋升：按整个 source/ 重解析比产出时更松，别集的原文锚会恰好命中。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
 
-    envelope = _read_rv_quarantine(fake_ctx)
+    envelope = read_rv_quarantine(fake_ctx)
     assert "source" in envelope["meta"], "拆分侧须一律写出 source 键（未指定源文时为 null）"
     envelope["meta"] = {}
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is True
     assert json.loads(out["content"][0]["text"])["problem"]["code"] == "draft_invalid"
     assert "meta.source 缺失" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_promote_draft_reports_promotion_not_split(fake_ctx: ToolContext, monkeypatch) -> None:
     """晋升成功的摘要要说「晋升」：说成「拆分」会让 Agent 以为自己的修改被一次重抽覆盖了。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
-    envelope = _read_rv_quarantine(fake_ctx)
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert "晋升" in out["content"][0]["text"]
@@ -586,20 +586,20 @@ def _rv_scenes(fake_ctx: ToolContext, scenes: dict[str, Any]) -> None:
 
 async def _rv_draft_with(fake_ctx: ToolContext, monkeypatch, texts: list[str]) -> None:
     """铺一份待修复草稿，正文按 ``texts`` 覆盖（产出时用一条必违约的正文把草稿逼出来）。"""
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场") for _ in texts])
-    envelope = _read_rv_quarantine(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场") for _ in texts])
+    envelope = read_rv_quarantine(fake_ctx)
     for unit, text in zip(envelope["content"]["units"], texts, strict=True):
         unit["text"] = text
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
 
 async def test_promote_draft_report_names_units_without_scene_reference(fake_ctx: ToolContext, monkeypatch) -> None:
     """晋升被硬违约挡下时，报告也带软违约段：Agent 修草稿的每一轮都要看得见降级提示。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _rv_scenes(fake_ctx, {"村口": {"description": "黄昏的村口"}})
     await _rv_draft_with(fake_ctx, monkeypatch, ["@[张三] 起身", "@[不存在的人] 出场"])
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
@@ -607,18 +607,18 @@ async def test_promote_draft_report_names_units_without_scene_reference(fake_ctx
     assert "未引用场景" in text
     assert "unit E1U01：" in text
     # 软违约不进待修复草稿的违约条目：合流的话「非空即挡下」的判定会把降级提示变成硬违约。
-    assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["unregistered_asset"]
+    assert [v["code"] for v in read_rv_quarantine(fake_ctx)["violations"]] == ["unregistered_asset"]
 
 
 async def test_promote_draft_report_silent_when_every_unit_references_a_scene(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """每个 unit 都引用了场景时报告不带软违约段——没有降级可提示。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _rv_scenes(fake_ctx, {"村口": {"description": "黄昏的村口"}})
     await _rv_draft_with(fake_ctx, monkeypatch, ["@[村口] 黄昏，@[不存在的人] 出场"])
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is True
     assert "未引用场景" not in out["content"][0]["text"]
@@ -626,14 +626,14 @@ async def test_promote_draft_report_silent_when_every_unit_references_a_scene(
 
 async def test_promote_receipt_names_units_without_scene_reference(fake_ctx: ToolContext, monkeypatch) -> None:
     """晋升回执带软违约段，与拆分回执同口径——软违约不阻断晋升，正式文件照常落盘。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _rv_scenes(fake_ctx, {"村口": {"description": "黄昏的村口"}})
     await _rv_draft_with(fake_ctx, monkeypatch, ["@[村口] 黄昏，@[张三] 推门", "@[张三] 起身"])
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
     text = json.loads(out["content"][0]["text"])["draft"]["message"]
     assert "降级提示" in text
     assert "未引用场景" in text
@@ -643,11 +643,11 @@ async def test_promote_receipt_names_units_without_scene_reference(fake_ctx: Too
 
 async def test_promote_receipt_silent_when_every_unit_references_a_scene(fake_ctx: ToolContext, monkeypatch) -> None:
     """每个 unit 都引用了场景时回执不带软违约段。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _rv_scenes(fake_ctx, {"村口": {"description": "黄昏的村口"}})
     await _rv_draft_with(fake_ctx, monkeypatch, ["@[村口] 黄昏，@[张三] 推门"])
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert "未引用场景" not in json.loads(out["content"][0]["text"])["draft"]["message"]
@@ -656,11 +656,11 @@ async def test_promote_receipt_silent_when_every_unit_references_a_scene(fake_ct
 async def test_cancelled_reference_script_plan_promotion_finishes_commit_and_cleanup(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
-    envelope = _read_rv_quarantine(fake_ctx)
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
+    envelope = read_rv_quarantine(fake_ctx)
     envelope["content"]["units"][0]["text"] = "@[张三] 起身"
-    _rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    rv_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
     started = threading.Event()
     release = threading.Event()
 
@@ -670,7 +670,7 @@ async def test_cancelled_reference_script_plan_promotion_finishes_commit_and_cle
 
     draft = read_quarantine(fake_ctx.project_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
     assert draft is not None
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     workflow = DraftWorkflow(
         DraftContext(
             project_name=fake_ctx.project_name,
@@ -697,15 +697,15 @@ async def test_cancelled_reference_script_plan_promotion_finishes_commit_and_cle
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(promotion, timeout=1)
-    assert _rv_script_plan_path(fake_ctx).exists()
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert rv_script_plan_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 async def test_writing_reference_script_plan_clears_stale_prompt_authoring_quarantine(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """script_plan 一变即清掉在场的 prompt_authoring 草稿：它以旧 script_plan 为 diff 基底，留着就永远晋升不了。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     write_quarantine(
         fake_ctx.project_path,
         1,
@@ -716,7 +716,7 @@ async def test_writing_reference_script_plan_clears_stale_prompt_authoring_quara
     prompt_authoring_path = quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING)
     assert prompt_authoring_path.exists()
 
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身")])
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 起身")])
 
     assert out.get("is_error") is not True, out
     assert not prompt_authoring_path.exists()
@@ -728,8 +728,8 @@ async def test_promote_reference_script_plan_preserves_prompt_authoring_draft_wh
     """情况 B 中途放弃、原样晋升：取回草稿未改动即晋升，写回的 script_plan 与盘上原值逐字相同，
     此时不该清在场的 prompt_authoring 草稿——它的保结构 diff 仍然对得上这份没变的基底，Agent
     放弃 script_plan 修改不该连带销毁一份仍然有效的 prompt_authoring 修复草稿。"""
-    _rv_source(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
     write_quarantine(
         fake_ctx.project_path,
         1,
@@ -740,8 +740,8 @@ async def test_promote_reference_script_plan_preserves_prompt_authoring_draft_wh
     prompt_authoring_path = quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING)
     assert prompt_authoring_path.exists()
 
-    await _open_for_edit(fake_ctx, source="source/episode_1.txt")
-    out = await _promote(fake_ctx)
+    await open_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await promote_reference_draft(fake_ctx)
 
     assert out.get("is_error") is not True, out
     assert prompt_authoring_path.exists()
@@ -752,12 +752,12 @@ async def test_promote_draft_prompt_authoring_uses_async_factory(fake_ctx: ToolC
     metadata.generator 记成 "unknown"，与直接生成路径的同一份产物对不上。"""
     from lib.text_generator import TextGenerator
 
-    _rv_source(fake_ctx)
-    split = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 在 @[村口] 等候")])
+    rv_source(fake_ctx)
+    split = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 在 @[村口] 等候")])
     assert split.get("is_error") is not True, split
     project = fake_ctx.pm.project_payload
     project["episodes"][0]["script_plan_review"] = {
-        "fingerprint": script_review.content_fingerprint(_rv_script_plan_path(fake_ctx)),
+        "fingerprint": script_review.content_fingerprint(rv_script_plan_path(fake_ctx)),
         "confirmed_at": "2026-08-24T00:00:00Z",
     }
     (fake_ctx.project_path / "project.json").write_text(
@@ -783,7 +783,7 @@ async def test_promote_draft_prompt_authoring_uses_async_factory(fake_ctx: ToolC
         return _TextBoundary()
 
     monkeypatch.setattr(TextGenerator, "create", create_text_generator)
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is not True, out
     assert "episode_1.json" in out["content"][0]["text"]
     saved = json.loads((fake_ctx.project_path / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
@@ -796,12 +796,12 @@ async def test_promote_draft_waits_for_file_lock_without_blocking_event_loop(
 ) -> None:
     from lib.text_generator import TextGenerator
 
-    _rv_source(fake_ctx)
-    split = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身")])
+    rv_source(fake_ctx)
+    split = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 起身")])
     assert split.get("is_error") is not True, split
     project = fake_ctx.pm.project_payload
     project["episodes"][0]["script_plan_review"] = {
-        "fingerprint": script_review.content_fingerprint(_rv_script_plan_path(fake_ctx)),
+        "fingerprint": script_review.content_fingerprint(rv_script_plan_path(fake_ctx)),
         "confirmed_at": "2026-08-24T00:00:00Z",
     }
     (fake_ctx.project_path / "project.json").write_text(
@@ -819,7 +819,7 @@ async def test_promote_draft_waits_for_file_lock_without_blocking_event_loop(
     path = quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING)
     draft = read_quarantine(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING)
     assert draft is not None
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     workflow = DraftWorkflow(
         DraftContext(
             project_name=fake_ctx.project_name,
@@ -871,9 +871,9 @@ async def test_promote_draft_waits_for_file_lock_without_blocking_event_loop(
 
 
 async def test_open_script_plan_draft_waits_for_quarantine_lock(fake_ctx: ToolContext, monkeypatch) -> None:
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    target = _drama_quarantine_path(fake_ctx)
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    target = drama_quarantine_path(fake_ctx)
     pm = ProjectManager(str(fake_ctx.project_path.parent))
     attempted = asyncio.Event()
     original_async_lock = ProjectManager.async_file_lock
@@ -888,7 +888,7 @@ async def test_open_script_plan_draft_waits_for_quarantine_lock(fake_ctx: ToolCo
                 yield
 
         monkeypatch.setattr(ProjectManager, "async_file_lock", observed_async_lock)
-        opening = asyncio.create_task(_open_drama_for_edit(fake_ctx, source="source/episode_1.txt"))
+        opening = asyncio.create_task(open_drama_for_edit(fake_ctx, source="source/episode_1.txt"))
         await asyncio.wait_for(attempted.wait(), timeout=1)
         assert not opening.done()
 
@@ -899,7 +899,7 @@ async def test_open_script_plan_draft_waits_for_quarantine_lock(fake_ctx: ToolCo
 
 async def test_promote_draft_refuses_after_mode_switch(fake_ctx: ToolContext) -> None:
     """切走参考路径后不再晋升残留草稿：晋升会按参考路径的形状覆盖该集正式剧本。"""
-    _rv_project(fake_ctx, generation_mode="storyboard")
+    rv_project(fake_ctx, generation_mode="storyboard")
     write_quarantine(
         fake_ctx.project_path,
         1,
@@ -908,7 +908,7 @@ async def test_promote_draft_refuses_after_mode_switch(fake_ctx: ToolContext) ->
         violations=[],
     )
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is True
     assert "doc_type_not_applicable" in out["content"][0]["text"]
     assert quarantine_path(fake_ctx.project_path, 1, QUARANTINE_KIND_PROMPT_AUTHORING).exists(), (
@@ -922,8 +922,8 @@ async def test_promote_draft_prompt_authoring_blocked_by_review_gate(fake_ctx: T
     草稿在场期间用户在 Web 端改过 script_plan 会让确认指纹失效，该集回到 pending_review——此时晋升等于
     拿一份用户没确认过的 script_plan 合成正式剧本。
     """
-    _rv_project(fake_ctx)
-    script_plan = _rv_script_plan_path(fake_ctx)
+    rv_project(fake_ctx)
+    script_plan = rv_script_plan_path(fake_ctx)
     script_plan.parent.mkdir(parents=True, exist_ok=True)
     script_plan.write_text(json.dumps({"units": []}, ensure_ascii=False), encoding="utf-8")
     write_quarantine(
@@ -936,13 +936,13 @@ async def test_promote_draft_prompt_authoring_blocked_by_review_gate(fake_ctx: T
     project = json.loads((fake_ctx.project_path / "project.json").read_text(encoding="utf-8"))
     assert script_review.review_status(fake_ctx.project_path, project, 1) == "pending_review"
 
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is True
     assert "review_required" in out["content"][0]["text"]
 
 
 async def test_promote_draft_without_draft(fake_ctx: ToolContext) -> None:
-    out = await _promote(fake_ctx)
+    out = await promote_reference_draft(fake_ctx)
     assert out.get("is_error") is True
     assert "draft_not_found" in out["content"][0]["text"]
 
@@ -951,13 +951,13 @@ async def test_split_reference_video_units_clears_stale_quarantine_on_success(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """重拆分成功即清掉上一轮的草稿——留着会让内容确认与生成侧继续阻塞在已被取代的产物上。"""
-    _rv_source(fake_ctx)
-    await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
-    assert _rv_quarantine_path(fake_ctx).exists()
+    rv_source(fake_ctx)
+    await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
+    assert rv_quarantine_path(fake_ctx).exists()
 
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身")])
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 起身")])
     assert out.get("is_error") is not True, out
-    assert not _rv_quarantine_path(fake_ctx).exists()
+    assert not rv_quarantine_path(fake_ctx).exists()
 
 
 def _write_rv_quarantine(fake_ctx: ToolContext) -> None:
@@ -972,13 +972,13 @@ def _write_rv_quarantine(fake_ctx: ToolContext) -> None:
 
 async def test_generate_episode_script_blocked_by_quarantine(fake_ctx: ToolContext) -> None:
     """草稿在场时 prompt_authoring 入口阻塞，且给出「改草稿再晋升」而非「去 Web 端确认」的出路。"""
-    _rv_project(fake_ctx)
-    script_plan = _rv_script_plan_path(fake_ctx)
+    rv_project(fake_ctx)
+    script_plan = rv_script_plan_path(fake_ctx)
     script_plan.parent.mkdir(parents=True, exist_ok=True)
     script_plan.write_text(json.dumps({"units": []}, ensure_ascii=False), encoding="utf-8")
     _write_rv_quarantine(fake_ctx)
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
     assert out.get("is_error") is True
     assert "草稿待处置" in out["content"][0]["text"]
     assert "promote_draft" in out["content"][0]["text"]
@@ -986,11 +986,11 @@ async def test_generate_episode_script_blocked_by_quarantine(fake_ctx: ToolConte
 
 async def test_generate_episode_script_preserves_editable_draft_without_violations(fake_ctx: ToolContext) -> None:
     """可编辑草稿没有违约报告，prompt_authoring 入口应引导校验晋升而不是要求凭空修改。"""
-    _rv_project(fake_ctx)
-    _write_rv_script_plan(fake_ctx, [_rv_saved_unit("原始内容")])
-    await _open_for_edit(fake_ctx)
+    rv_project(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("原始内容")])
+    await open_for_edit(fake_ctx)
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "这是可编辑草稿" in text
@@ -1000,11 +1000,11 @@ async def test_generate_episode_script_preserves_editable_draft_without_violatio
 
 async def test_generate_episode_script_quarantine_precedes_missing_script_plan(fake_ctx: ToolContext) -> None:
     """首次拆分就违约时正式 script_plan 本就不存在——先报缺文件会把 Agent 引回重跑拆分（丢弃重抽）。"""
-    _rv_project(fake_ctx)
+    rv_project(fake_ctx)
     _write_rv_quarantine(fake_ctx)
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "草稿待处置" in text
@@ -1013,10 +1013,10 @@ async def test_generate_episode_script_quarantine_precedes_missing_script_plan(f
 
 async def test_generate_episode_script_ignores_quarantine_after_mode_switch(fake_ctx: ToolContext) -> None:
     """切走参考路径后残留的草稿与新路径无关：非参考路径不清它们，仍判会把该集永久卡死。"""
-    _rv_project(fake_ctx, generation_mode="storyboard")
+    rv_project(fake_ctx, generation_mode="storyboard")
     _write_rv_quarantine(fake_ctx)
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
     assert out.get("is_error") is True
     # 卡在「缺 narration script_plan」这道常规校验上，而不是参考路径的草稿
     assert "草稿待处置" not in out["content"][0]["text"]
@@ -1030,33 +1030,33 @@ async def test_generate_episode_script_ignores_quarantine_after_mode_switch(fake
 async def test_promote_drama_script_plan_rederives_needs_replan(fake_ctx: ToolContext) -> None:
     """needs_replan 由晋升侧按台词准入重新派生，不取草稿里的值——它是机器判据，
     手写值一旦被采信，后续重规划会漏掉真正需要重排的场景。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
 
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_drama_quarantine(fake_ctx)
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_drama_quarantine(fake_ctx)
     scene = envelope["content"]["scenes"][0]
     scene["utterances"] = [
         {"kind": "dialogue", "speaker": "阿离", "text": "我回来了。"},
         {"kind": "voiceover", "speaker": None, "text": "三年后。"},
     ]
     scene["needs_replan"] = False
-    _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx)
+    out = await promote_drama(fake_ctx)
 
     assert out.get("is_error") is not True, out
-    saved = json.loads(_drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    saved = json.loads(drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["scenes"][0]["needs_replan"] is True
 
 
 async def test_promote_drama_script_plan_returns_a_receipt_with_statistics(fake_ctx: ToolContext) -> None:
     """drama 晋升回执与产出回执同格式：Agent 两次都按同一份统计段读结果。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
 
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    out = await _promote_drama(fake_ctx)
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    out = await promote_drama(fake_ctx)
 
     assert out.get("is_error") is not True, out
     message = json.loads(out["content"][0]["text"])["draft"]["message"]
@@ -1066,47 +1066,47 @@ async def test_promote_drama_script_plan_returns_a_receipt_with_statistics(fake_
 
 async def test_promote_drama_script_plan_reports_schema_breach_without_writing(fake_ctx: ToolContext) -> None:
     """草稿被改坏时正式文件不写：草稿留在场、按 violations 继续改再晋升，不丢内容也不污染正式文件。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    before = _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    before = drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_drama_quarantine(fake_ctx)
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_drama_quarantine(fake_ctx)
     envelope["content"]["scenes"][0]["duration_seconds"] = 7  # 不在档位内
-    _drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    drama_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx)
+    out = await promote_drama(fake_ctx)
 
     assert out.get("is_error") is True
-    assert _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
-    assert _drama_quarantine_path(fake_ctx).exists()
+    assert drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert drama_quarantine_path(fake_ctx).exists()
     assert "content.scenes[i]" in out["content"][0]["text"]
 
 
 async def test_promote_drama_script_plan_aborts_on_concurrent_write(fake_ctx: ToolContext) -> None:
     """取回与晋升之间正式文件被别的写入方改过 → 中止并报冲突，不静默覆盖对方的保存。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
 
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    _write_drama_script_plan(fake_ctx, [_drama_scene(scene_description="别处改过的描述。")])
-    concurrent = _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    write_drama_script_plan(fake_ctx, [drama_scene(scene_description="别处改过的描述。")])
+    concurrent = drama_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    out = await _promote_drama(fake_ctx)
+    out = await promote_drama(fake_ctx)
 
     assert out.get("is_error") is True
-    assert _drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == concurrent
-    assert _drama_quarantine_path(fake_ctx).exists()
+    assert drama_script_plan_path(fake_ctx).read_text(encoding="utf-8") == concurrent
+    assert drama_quarantine_path(fake_ctx).exists()
 
 
 async def test_generate_episode_script_blocked_by_drama_quarantine(fake_ctx: ToolContext) -> None:
     """drama 的 prompt_authoring 与参考生视频同口径：草稿在场即拒绝生成，
     否则会拿正式文件那份上一版内容静默顶替待处置的正文。"""
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
 
     assert out.get("is_error") is True
     assert "草稿待处置" in out["content"][0]["text"]
@@ -1118,12 +1118,12 @@ async def test_normalize_drama_script_clears_quarantine_on_regeneration(fake_ctx
     指纹此刻也对不上，晋升只会反复报冲突——Agent 没有第二条出路。"""
     from server import text_generation as mod
 
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
-    assert _drama_quarantine_path(fake_ctx).exists()
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    assert drama_quarantine_path(fake_ctx).exists()
 
-    regenerated = {"title": "第一集", "scenes": [_drama_scene(scene_description="重新规范化后的描述。")]}
+    regenerated = {"title": "第一集", "scenes": [drama_scene(scene_description="重新规范化后的描述。")]}
 
     class _Generator:
         async def generate(self, _request, project_name=None):
@@ -1135,14 +1135,14 @@ async def test_normalize_drama_script_clears_quarantine_on_regeneration(fake_ctx
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
 
     assert out.get("is_error") is not True, out
-    assert not _drama_quarantine_path(fake_ctx).exists()
-    saved = json.loads(_drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert not drama_quarantine_path(fake_ctx).exists()
+    saved = json.loads(drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["scenes"][0]["scene_description"] == "重新规范化后的描述。"
 
 
@@ -1150,11 +1150,11 @@ async def test_normalize_drama_script_serializes_commit_with_draft_edits(fake_ct
     """重生成的正式文件提交与草稿 patch/promote 共用草稿锁，避免交叉覆盖。"""
     from server import text_generation as mod
 
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
 
-    regenerated = {"title": "第一集", "scenes": [_drama_scene(scene_description="重新规范化后的描述。")]}
+    regenerated = {"title": "第一集", "scenes": [drama_scene(scene_description="重新规范化后的描述。")]}
 
     class _Generator:
         async def generate(self, _request, project_name=None):
@@ -1166,10 +1166,10 @@ async def test_normalize_drama_script_serializes_commit_with_draft_edits(fake_ct
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
     pm = ProjectManager(str(fake_ctx.project_path.parent))
-    target = _drama_quarantine_path(fake_ctx)
+    target = drama_quarantine_path(fake_ctx)
     attempted = asyncio.Event()
     original_async_file_lock = ProjectManager.async_file_lock
     async with pm.async_file_lock(target):
@@ -1183,7 +1183,7 @@ async def test_normalize_drama_script_serializes_commit_with_draft_edits(fake_ct
 
         monkeypatch.setattr(ProjectManager, "async_file_lock", observed_async_file_lock)
         task = asyncio.create_task(
-            _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+            call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
         )
         await asyncio.wait_for(attempted.wait(), timeout=1)
         assert not task.done(), "generation commit must wait for the draft lock"
@@ -1197,13 +1197,13 @@ async def test_normalize_drama_script_preserves_draft_edited_during_model_call(
 ) -> None:
     from server import text_generation as mod
 
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene()])
-    opened_out = await _open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene()])
+    opened_out = await open_drama_for_edit(fake_ctx, source="source/episode_1.txt")
     opened = json.loads(opened_out["content"][0]["text"])["draft"]
     started = asyncio.Event()
     release = asyncio.Event()
-    regenerated = {"title": "第一集", "scenes": [_drama_scene(scene_description="重生成内容")]}
+    regenerated = {"title": "第一集", "scenes": [drama_scene(scene_description="重生成内容")]}
 
     class _Generator:
         async def generate(self, _request, project_name=None):
@@ -1218,15 +1218,15 @@ async def test_normalize_drama_script_preserves_draft_edited_during_model_call(
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
     generation = asyncio.create_task(
-        _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+        call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
     )
     await started.wait()
     edited = copy.deepcopy(opened["content"])
     edited["scenes"][0]["scene_description"] = "并发编辑内容"
-    patched = await _call(
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -1242,8 +1242,8 @@ async def test_normalize_drama_script_preserves_draft_edited_during_model_call(
 
     assert out.get("is_error") is True
     assert "draft_revision_conflict" in out["content"][0]["text"]
-    assert _read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "并发编辑内容"
-    formal = json.loads(_drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "并发编辑内容"
+    formal = json.loads(drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert formal["scenes"][0]["scene_description"] != "重生成内容"
 
 
@@ -1252,11 +1252,11 @@ async def test_normalize_drama_script_preserves_output_when_formal_changes_durin
 ) -> None:
     from server import text_generation as mod
 
-    _drama_project(fake_ctx)
-    _write_drama_script_plan(fake_ctx, [_drama_scene(scene_description="生成前内容")])
+    drama_project(fake_ctx)
+    write_drama_script_plan(fake_ctx, [drama_scene(scene_description="生成前内容")])
     started = asyncio.Event()
     release = asyncio.Event()
-    regenerated = {"title": "第一集", "scenes": [_drama_scene(scene_description="本次生成内容")]}
+    regenerated = {"title": "第一集", "scenes": [drama_scene(scene_description="本次生成内容")]}
 
     class _Generator:
         async def generate(self, _request, project_name=None):
@@ -1271,22 +1271,22 @@ async def test_normalize_drama_script_preserves_output_when_formal_changes_durin
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
     generation = asyncio.create_task(
-        _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+        call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
     )
     await started.wait()
-    _write_drama_script_plan(fake_ctx, [_drama_scene(scene_description="并发正式内容")])
+    write_drama_script_plan(fake_ctx, [drama_scene(scene_description="并发正式内容")])
     release.set()
 
     out = await generation
 
     assert out.get("is_error") is True
     assert "formal_revision_conflict" in out["content"][0]["text"]
-    formal = json.loads(_drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    formal = json.loads(drama_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert formal["scenes"][0]["scene_description"] == "并发正式内容"
-    assert _read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "本次生成内容"
+    assert read_drama_quarantine(fake_ctx)["content"]["scenes"][0]["scene_description"] == "本次生成内容"
 
 
 # ---------------------------------------------------------------------------
@@ -1304,21 +1304,21 @@ async def test_split_narration_segments_quarantines_violation_instead_of_discard
     """
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    segments = [_nr_segment("E1S01", 5, _RV_NOVEL, characters_in_segment=["王五"])]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    nr_source(fake_ctx)
+    segments = [nr_segment("E1S01", 5, _RV_NOVEL, characters_in_segment=["王五"])]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
 
     assert out.get("is_error") is True
     report = out["content"][0]["text"]
-    assert str(_nr_quarantine_path(fake_ctx)) in report
+    assert str(nr_quarantine_path(fake_ctx)) in report
     assert "[duration_off_tier]" in report
     assert "[unregistered_asset]" in report
     assert "segment E1S01" in report
-    assert not _nr_script_plan_path(fake_ctx).exists(), "正式文件一步不动"
-    envelope = _read_nr_quarantine(fake_ctx)
+    assert not nr_script_plan_path(fake_ctx).exists(), "正式文件一步不动"
+    envelope = read_nr_quarantine(fake_ctx)
     assert envelope["kind"] == QUARANTINE_KIND_NARRATION_SCRIPT_PLAN
     assert envelope["content"]["segments"][0]["segment_id"] == "E1S01"
     assert envelope["meta"]["source"] == "source/episode_1.txt"
@@ -1331,24 +1331,22 @@ async def test_split_narration_segments_clears_quarantine_on_regeneration(fake_c
     阻塞在一份已被取代的内容上。"""
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
+    nr_source(fake_ctx)
     write_quarantine(
         fake_ctx.project_path,
         1,
         QUARANTINE_KIND_NARRATION_SCRIPT_PLAN,
-        content={"segments": [_nr_segment("E1S01", 5)]},
+        content={"segments": [nr_segment("E1S01", 5)]},
         violations=[],
     )
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([_nr_segment("E1S01", 4, _RV_NOVEL)]))
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning([nr_segment("E1S01", 4, _RV_NOVEL)]))
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
 
     assert out.get("is_error") is not True, out
-    assert not _nr_quarantine_path(fake_ctx).exists()
-    assert (
-        json.loads(_nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 4
-    )
+    assert not nr_quarantine_path(fake_ctx).exists()
+    assert json.loads(nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 4
 
 
 @pytest.mark.parametrize("segment_id", [" ", "items[0]", "E1S1", "E2S01"])
@@ -1357,88 +1355,86 @@ async def test_split_narration_segments_rejects_malformed_segment_id(
 ) -> None:
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    nr_source(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(
         mod.TextGenerator,
         "create",
-        _nr_generator_returning([_nr_segment(segment_id, 4, _RV_NOVEL)]),
+        nr_generator_returning([nr_segment(segment_id, 4, _RV_NOVEL)]),
     )
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "source": "source/episode_1.txt"})
 
     assert out.get("is_error") is True
-    assert not _nr_script_plan_path(fake_ctx).exists()
+    assert not nr_script_plan_path(fake_ctx).exists()
 
 
 async def test_promote_narration_script_plan_rejects_segment_id_from_another_episode(fake_ctx: ToolContext) -> None:
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
-    envelope = _read_nr_quarantine(fake_ctx)
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    envelope = read_nr_quarantine(fake_ctx)
     envelope["content"]["segments"][0]["segment_id"] = "E2S01"
-    _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "[invalid_segment_id]" in out["content"][0]["text"]
-    assert _nr_quarantine_path(fake_ctx).exists()
+    assert nr_quarantine_path(fake_ctx).exists()
 
 
 async def test_promote_narration_script_plan_reports_schema_breach_without_writing(fake_ctx: ToolContext) -> None:
     """草稿被改到过不了产出时那份 schema：报告刷新、正式文件不写，草稿保留 Agent 手里那份原样内容。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
-    before = _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    before = nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    envelope = _read_nr_quarantine(fake_ctx)
+    envelope = read_nr_quarantine(fake_ctx)
     del envelope["content"]["segments"][0]["novel_text"]
-    _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "[schema_invalid]" in out["content"][0]["text"]
-    assert _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
-    assert "novel_text" not in _read_nr_quarantine(fake_ctx)["content"]["segments"][0]
+    assert nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert "novel_text" not in read_nr_quarantine(fake_ctx)["content"]["segments"][0]
 
 
 async def test_promote_narration_script_plan_aborts_on_concurrent_write(fake_ctx: ToolContext) -> None:
     """取回后正式文件被别的写入方改过：晋升中止、报冲突让 Agent 合并，不静默覆盖。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 6, _RV_NOVEL)])
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 6, _RV_NOVEL)])
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "并发冲突" in out["content"][0]["text"]
     assert "content.segments" in out["content"][0]["text"]
-    assert _nr_quarantine_path(fake_ctx).exists(), "冲突时草稿仍在场，合并后可重试"
-    assert (
-        json.loads(_nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 6
-    )
+    assert nr_quarantine_path(fake_ctx).exists(), "冲突时草稿仍在场，合并后可重试"
+    assert json.loads(nr_script_plan_path(fake_ctx).read_text(encoding="utf-8"))["segments"][0]["duration_seconds"] == 6
 
 
 async def test_promote_narration_script_plan_revalidates_against_current_source(fake_ctx: ToolContext) -> None:
     """晋升按现值重判原文覆盖：草稿里改写过的正文即便结构合法也拒，正式文件不被污染。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
-    before = _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    before = nr_script_plan_path(fake_ctx).read_text(encoding="utf-8")
 
-    envelope = _read_nr_quarantine(fake_ctx)
+    envelope = read_nr_quarantine(fake_ctx)
     envelope["content"]["segments"][0]["novel_text"] = "张三在村口等候"
-    _nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+    nr_quarantine_path(fake_ctx).write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is True
     assert "[novel_text_coverage]" in out["content"][0]["text"]
-    assert _nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
+    assert nr_script_plan_path(fake_ctx).read_text(encoding="utf-8") == before
 
 
 async def test_promote_narration_script_plan_names_source_scope_on_coverage_violation(fake_ctx: ToolContext) -> None:
@@ -1446,13 +1442,13 @@ async def test_promote_narration_script_plan_names_source_scope_on_coverage_viol
 
     草稿在场时不能重新取回，报告须指引 Agent 通过 patch_draft 更新源文范围。
     """
-    _nr_source(fake_ctx)
+    nr_source(fake_ctx)
     (fake_ctx.project_path / "source" / "episode_2.txt").write_text("李四走进院子", encoding="utf-8")
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx)
-    assert _read_nr_quarantine(fake_ctx)["meta"]["source"] is None
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx)
+    assert read_nr_quarantine(fake_ctx)["meta"]["source"] is None
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     text = out["content"][0]["text"]
     assert out.get("is_error") is True
@@ -1460,8 +1456,8 @@ async def test_promote_narration_script_plan_names_source_scope_on_coverage_viol
     assert "整个 source/ 目录" in text
     assert "patch_draft" in text
 
-    refreshed = json.loads((await _open_nr_for_edit(fake_ctx))["content"][0]["text"])["draft"]
-    patched = await _call(
+    refreshed = json.loads((await open_nr_for_edit(fake_ctx))["content"][0]["text"])["draft"]
+    patched = await call(
         patch_draft_tool(fake_ctx),
         {
             "episode": 1,
@@ -1472,17 +1468,17 @@ async def test_promote_narration_script_plan_names_source_scope_on_coverage_viol
         },
     )
     assert patched.get("is_error") is not True, patched
-    promoted = await _promote_nr(fake_ctx)
+    promoted = await promote_nr(fake_ctx)
     assert promoted.get("is_error") is not True, promoted
 
 
 async def test_promote_narration_script_plan_returns_a_receipt_with_statistics(fake_ctx: ToolContext) -> None:
     """narration 晋升回执与拆分回执同格式：Agent 两次都按同一份统计段读结果。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
-    await _open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
+    await open_nr_for_edit(fake_ctx, source="source/episode_1.txt")
 
-    out = await _promote_nr(fake_ctx)
+    out = await promote_nr(fake_ctx)
 
     assert out.get("is_error") is not True, out
     message = json.loads(out["content"][0]["text"])["draft"]["message"]
@@ -1493,17 +1489,17 @@ async def test_promote_narration_script_plan_returns_a_receipt_with_statistics(f
 
 async def test_generate_episode_script_blocked_by_narration_quarantine(fake_ctx: ToolContext) -> None:
     """narration 草稿在场时 prompt_authoring 生成被拦：正式文件此刻仍是上一版，拿它跑 prompt_authoring 等于静默换回旧内容。"""
-    _nr_source(fake_ctx)
-    _write_nr_script_plan(fake_ctx, [_nr_segment("E1S01", 4, _RV_NOVEL)])
+    nr_source(fake_ctx)
+    write_nr_script_plan(fake_ctx, [nr_segment("E1S01", 4, _RV_NOVEL)])
     write_quarantine(
         fake_ctx.project_path,
         1,
         QUARANTINE_KIND_NARRATION_SCRIPT_PLAN,
-        content={"segments": [_nr_segment("E1S01", 4, _RV_NOVEL)]},
+        content={"segments": [nr_segment("E1S01", 4, _RV_NOVEL)]},
         violations=[],
     )
 
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1})
 
     assert out.get("is_error") is True
     assert "草稿待处置" in out["content"][0]["text"]

--- a/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_promote_draft.py
@@ -577,9 +577,9 @@ async def test_promote_draft_reports_promotion_not_split(fake_ctx: ToolContext, 
 
 def _rv_scenes(fake_ctx: ToolContext, scenes: dict[str, Any]) -> None:
     """改写项目登记的场景资产（内存视图与盘上 project.json 同步）。"""
-    fake_ctx.pm.project_payload["scenes"] = scenes  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["scenes"] = scenes
     (fake_ctx.project_path / "project.json").write_text(
-        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),  # pyright: ignore[reportAttributeAccessIssue]
+        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),
         encoding="utf-8",
     )
 
@@ -755,7 +755,7 @@ async def test_promote_draft_prompt_authoring_uses_async_factory(fake_ctx: ToolC
     _rv_source(fake_ctx)
     split = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 在 @[村口] 等候")])
     assert split.get("is_error") is not True, split
-    project = fake_ctx.pm.project_payload  # pyright: ignore[reportAttributeAccessIssue]
+    project = fake_ctx.pm.project_payload
     project["episodes"][0]["script_plan_review"] = {
         "fingerprint": script_review.content_fingerprint(_rv_script_plan_path(fake_ctx)),
         "confirmed_at": "2026-08-24T00:00:00Z",
@@ -799,7 +799,7 @@ async def test_promote_draft_waits_for_file_lock_without_blocking_event_loop(
     _rv_source(fake_ctx)
     split = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身")])
     assert split.get("is_error") is not True, split
-    project = fake_ctx.pm.project_payload  # pyright: ignore[reportAttributeAccessIssue]
+    project = fake_ctx.pm.project_payload
     project["episodes"][0]["script_plan_review"] = {
         "fingerprint": script_review.content_fingerprint(_rv_script_plan_path(fake_ctx)),
         "confirmed_at": "2026-08-24T00:00:00Z",

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
@@ -115,14 +115,14 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
     from server import text_generation as mod
 
     project = {
-        **fake_ctx.pm.project_payload,  # type: ignore[attr-defined]
+        **fake_ctx.pm.project_payload,
         "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
         "content_mode": "narration",
         "generation_mode": "storyboard",
         "source_kind": "novel",
         "source_language": "中文",
     }
-    fake_ctx.pm.project_payload = project  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload = project
     project_file = fake_ctx.project_path / "project.json"
     project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
     source_dir = fake_ctx.project_path / "source"
@@ -138,7 +138,7 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
         async def generate(self, _request, project_name=None):
             second_source.write_text("等待供应商期间改过的第二段。", encoding="utf-8")
             latest = {**project, "source_language": "English"}
-            fake_ctx.pm.project_payload = latest  # type: ignore[attr-defined]
+            fake_ctx.pm.project_payload = latest
             project_file.write_text(json.dumps(latest, ensure_ascii=False), encoding="utf-8")
             return type(
                 "_Result",
@@ -272,7 +272,7 @@ async def test_split_narration_segments_accepts_asset_name_in_other_unicode_form
 
     _nr_source(fake_ctx)
     nfc_name = unicodedata.normalize("NFC", "Hiếu")
-    fake_ctx.pm.project_payload["characters"][nfc_name] = {"description": "配角"}  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"][nfc_name] = {"description": "配角"}
     segments = [
         _nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=[unicodedata.normalize("NFD", nfc_name)])
     ]

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_narration_segments.py
@@ -12,12 +12,12 @@ from server.agent_runtime.sdk_tools.text_generation import (
 )
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _nr_generator_returning,
-    _nr_project,
-    _nr_segment,
-    _nr_source,
-    _use_fake_caps,
+    call,
+    nr_generator_returning,
+    nr_project,
+    nr_segment,
+    nr_source,
+    use_fake_caps,
 )
 
 # ---------------------------------------------------------------------------
@@ -26,11 +26,11 @@ from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
 
 
 async def test_split_narration_segments_dry_run(fake_ctx: ToolContext) -> None:
-    _nr_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    nr_source(fake_ctx)
+    use_fake_caps(fake_ctx)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "DRY RUN" in prompt_text
@@ -45,11 +45,11 @@ async def test_split_narration_segments_dry_run(fake_ctx: ToolContext) -> None:
 async def test_split_narration_segments_injects_instructions(fake_ctx: ToolContext) -> None:
     """instructions 原样进 prompt 末尾的中性「用户意见」分节，不附加强度措辞。"""
 
-    _nr_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    nr_source(fake_ctx)
+    use_fake_caps(fake_ctx)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单个分镜出场人物尽量不超过两人"})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单个分镜出场人物尽量不超过两人"})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "# 用户意见" in prompt_text
@@ -60,18 +60,18 @@ async def test_split_narration_segments_injects_instructions(fake_ctx: ToolConte
 async def test_split_narration_segments_rejects_bad_instructions(fake_ctx: ToolContext) -> None:
     """instructions 超长 / 非字符串按参数错误拒绝；空白 strip 后视同未传（校验为四个生成工具共享）。"""
 
-    _nr_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    nr_source(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
 
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "长" * 4001})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "长" * 4001})
     assert out.get("is_error") is True
     assert "4000" in out["content"][0]["text"]
 
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": 42})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": 42})
     assert out.get("is_error") is True
 
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "   \n  "})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "   \n  "})
     assert out.get("is_error") is not True, out
     assert "# 用户意见" not in out["content"][0]["text"]
 
@@ -80,20 +80,20 @@ async def test_split_narration_segments_happy(fake_ctx: ToolContext, monkeypatch
     """happy path：结构化分镜 script_plan 落盘；模型经文本管道按 SCRIPT 任务解析并携带 project_name 入账。"""
     from server import text_generation as mod
 
-    _nr_project(fake_ctx)
+    nr_project(fake_ctx)
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
     (src / "episode_1.txt").write_text("张三走向村口。他停下脚步，久久凝望。", encoding="utf-8")
     captured: dict[str, Any] = {}
     segments = [
-        _nr_segment("E1S01", 4, "张三走向村口。", characters_in_segment=["张三"], scenes=["村口"]),
-        _nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
+        nr_segment("E1S01", 4, "张三走向村口。", characters_in_segment=["张三"], scenes=["村口"]),
+        nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
     ]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments, captured))
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments, captured))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is not True, out
 
     script_plan_path = fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json"
@@ -145,7 +145,7 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
                 (),
                 {
                     "text": json.dumps(
-                        {"episode": 1, "segments": [_nr_segment(novel_text=frozen_source)]}, ensure_ascii=False
+                        {"episode": 1, "segments": [nr_segment(novel_text=frozen_source)]}, ensure_ascii=False
                     )
                 },
             )()
@@ -153,10 +153,10 @@ async def test_split_narration_segments_registers_the_frozen_combined_source_bas
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
-    result = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1})
+    result = await call(generate_script_plan_tool(fake_ctx), {"episode": 1})
 
     assert result.get("is_error") is not True, result
     entry = ProjectArtifactManifestAdapter(fake_ctx.project_path).get_entry(ArtifactKey.episode_script_plan(1))
@@ -168,13 +168,13 @@ async def test_split_narration_segments_rejects_out_of_enum_duration(fake_ctx: T
     """静态分镜 schema 的 duration 是开区间，超出 supported_durations 的时长由工具后校验拦截，不落盘。"""
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    segments = [_nr_segment("E1S01", 5)]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    nr_source(fake_ctx)
+    segments = [nr_segment("E1S01", 5)]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert "不在模型档位" in out["content"][0]["text"]
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
@@ -183,13 +183,13 @@ async def test_split_narration_segments_rejects_out_of_enum_duration(fake_ctx: T
 async def test_split_narration_segments_rejects_duplicate_segment_ids(fake_ctx: ToolContext, monkeypatch) -> None:
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    segments = [_nr_segment("E1S01", 4), _nr_segment("E1S01", 6)]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    nr_source(fake_ctx)
+    segments = [nr_segment("E1S01", 4), nr_segment("E1S01", 6)]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert "segment_id 重复" in out["content"][0]["text"]
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
@@ -199,13 +199,13 @@ async def test_split_narration_segments_rejects_blank_novel_text(fake_ctx: ToolC
     """novel_text 为纯空白（如单个空格）满足 schema min_length=1 却无实际旁白内容，须被后校验拦截，不落盘。"""
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    segments = [_nr_segment("E1S01", 4, "张三在村口等人"), _nr_segment("E1S02", 4, novel_text=" ")]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    nr_source(fake_ctx)
+    segments = [nr_segment("E1S01", 4, "张三在村口等人"), nr_segment("E1S02", 4, novel_text=" ")]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert "novel_text 为空白" in out["content"][0]["text"]
     assert "E1S02" in out["content"][0]["text"]
@@ -215,12 +215,12 @@ async def test_split_narration_segments_rejects_blank_novel_text(fake_ctx: ToolC
 async def test_split_narration_segments_rejects_empty_segments(fake_ctx: ToolContext, monkeypatch) -> None:
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([]))
+    nr_source(fake_ctx)
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning([]))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
 
@@ -229,13 +229,13 @@ async def test_split_narration_segments_rejects_missing_field(fake_ctx: ToolCont
     """缺资产字段（characters_in_segment 等）由既有分镜 schema（NarrationScriptPlanSegment strict）拦截。"""
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
+    nr_source(fake_ctx)
     bad = {"segment_id": "E1S01", "novel_text": "缺字段", "duration_seconds": 4, "segment_break": False}
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning([bad]))
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning([bad]))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert "script_plan 拆分内容结构校验失败" in out["content"][0]["text"]
     assert not (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
@@ -247,13 +247,13 @@ async def test_split_narration_segments_rejects_unregistered_asset_reference(
     """characters_in_segment / scenes / props 引用了 project.json 未登记的名称须被拦截，不落盘。"""
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
-    segments = [_nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=["王五"])]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    nr_source(fake_ctx)
+    segments = [nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=["王五"])]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     assert "未登记的资产名" in out["content"][0]["text"]
     assert "王五" in out["content"][0]["text"]
@@ -270,16 +270,16 @@ async def test_split_narration_segments_accepts_asset_name_in_other_unicode_form
     """
     from server import text_generation as mod
 
-    _nr_source(fake_ctx)
+    nr_source(fake_ctx)
     nfc_name = unicodedata.normalize("NFC", "Hiếu")
     fake_ctx.pm.project_payload["characters"][nfc_name] = {"description": "配角"}
     segments = [
-        _nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=[unicodedata.normalize("NFD", nfc_name)])
+        nr_segment("E1S01", 4, "张三在村口等人", characters_in_segment=[unicodedata.normalize("NFD", nfc_name)])
     ]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1})
 
     assert out.get("is_error") is not True, out
     assert (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
@@ -288,15 +288,15 @@ async def test_split_narration_segments_accepts_asset_name_in_other_unicode_form
 async def _nr_source_and_call(fake_ctx: ToolContext, monkeypatch, source_text: str, segments: list[dict]):
     from server import text_generation as mod
 
-    _nr_project(fake_ctx)
+    nr_project(fake_ctx)
     src = fake_ctx.project_path / "source"
     src.mkdir(parents=True)
     (src / "episode_1.txt").write_text(source_text, encoding="utf-8")
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _nr_generator_returning(segments))
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", nr_generator_returning(segments))
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    return await _call(tool_obj, {"episode": 1})
+    return await call(tool_obj, {"episode": 1})
 
 
 async def test_split_narration_segments_rejects_truncated_novel_text(fake_ctx: ToolContext, monkeypatch) -> None:
@@ -305,7 +305,7 @@ async def test_split_narration_segments_rejects_truncated_novel_text(fake_ctx: T
         fake_ctx,
         monkeypatch,
         "张三走向村口。他停下脚步，久久凝望。",
-        [_nr_segment("E1S01", 4, "张三走向村口。")],
+        [nr_segment("E1S01", 4, "张三走向村口。")],
     )
     assert out.get("is_error") is True
     assert "未按序、逐字、完整覆盖小说原文" in out["content"][0]["text"]
@@ -319,8 +319,8 @@ async def test_split_narration_segments_rejects_rewritten_novel_text(fake_ctx: T
         monkeypatch,
         "张三走向村口。他停下脚步，久久凝望。",
         [
-            _nr_segment("E1S01", 4, "张三缓缓走向村口。"),
-            _nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
+            nr_segment("E1S01", 4, "张三缓缓走向村口。"),
+            nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
         ],
     )
     assert out.get("is_error") is True
@@ -335,8 +335,8 @@ async def test_split_narration_segments_rejects_reordered_novel_text(fake_ctx: T
         monkeypatch,
         "张三走向村口。他停下脚步，久久凝望。",
         [
-            _nr_segment("E1S01", 6, "他停下脚步，久久凝望。", segment_break=True),
-            _nr_segment("E1S02", 4, "张三走向村口。"),
+            nr_segment("E1S01", 6, "他停下脚步，久久凝望。", segment_break=True),
+            nr_segment("E1S02", 4, "张三走向村口。"),
         ],
     )
     assert out.get("is_error") is True
@@ -350,7 +350,7 @@ async def test_split_narration_segments_rejects_dropped_word_space(fake_ctx: Too
         fake_ctx,
         monkeypatch,
         "Hello world, this is fine.",
-        [_nr_segment("E1S01", 4, "Helloworld, this is fine.")],
+        [nr_segment("E1S01", 4, "Helloworld, this is fine.")],
     )
     assert out.get("is_error") is True
     assert "未按序、逐字、完整覆盖小说原文" in out["content"][0]["text"]
@@ -368,7 +368,7 @@ async def test_split_narration_segments_accepts_unicode_form_difference(fake_ctx
         fake_ctx,
         monkeypatch,
         unicodedata.normalize("NFD", text),
-        [_nr_segment("E1S01", 4, unicodedata.normalize("NFC", text))],
+        [nr_segment("E1S01", 4, unicodedata.normalize("NFC", text))],
     )
     assert out.get("is_error") is not True, out
     assert (fake_ctx.project_path / "drafts" / "episode_1" / "script_plan_segments.json").exists()
@@ -381,8 +381,8 @@ async def test_split_narration_segments_accepts_split_at_paragraph_break(fake_ct
         monkeypatch,
         "张三走向村口。\n他停下脚步，久久凝望。",
         [
-            _nr_segment("E1S01", 4, "张三走向村口。"),
-            _nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
+            nr_segment("E1S01", 4, "张三走向村口。"),
+            nr_segment("E1S02", 6, "他停下脚步，久久凝望。", segment_break=True),
         ],
     )
     assert out.get("is_error") is not True, out
@@ -399,8 +399,8 @@ async def test_split_narration_segments_accepts_split_at_halfwidth_punctuation(
         monkeypatch,
         "张三走向村口.他停下脚步.",
         [
-            _nr_segment("E1S01", 4, "张三走向村口."),
-            _nr_segment("E1S02", 6, "他停下脚步.", segment_break=True),
+            nr_segment("E1S01", 4, "张三走向村口."),
+            nr_segment("E1S02", 6, "他停下脚步.", segment_break=True),
         ],
     )
     assert out.get("is_error") is not True, out
@@ -416,7 +416,7 @@ async def test_split_narration_segments_rejects_dropped_space_after_punctuation(
         fake_ctx,
         monkeypatch,
         "Hello, world. This is fine.",
-        [_nr_segment("E1S01", 4, "Hello,world. This is fine.")],
+        [nr_segment("E1S01", 4, "Hello,world. This is fine.")],
     )
     assert out.get("is_error") is True
     assert "未按序、逐字、完整覆盖小说原文" in out["content"][0]["text"]
@@ -424,7 +424,7 @@ async def test_split_narration_segments_rejects_dropped_space_after_punctuation(
 
 
 async def test_split_narration_segments_no_source(fake_ctx: ToolContext) -> None:
-    _nr_project(fake_ctx)
+    nr_project(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -37,9 +37,7 @@ _VEO_CAPS = {
 
 def _veo_720p(fake_ctx: ToolContext) -> None:
     """把项目的生效分辨率钉在 720p——联动约束按已保存的档位求值。"""
-    fake_ctx.pm.project_payload["model_settings"] = {  # pyright: ignore[reportAttributeAccessIssue]
-        "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
-    }
+    fake_ctx.pm.project_payload["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}
 
 
 # ---------------------------------------------------------------------------
@@ -462,7 +460,7 @@ async def test_split_reference_video_units_names_units_without_scene_reference(
 ) -> None:
     """未引用场景的 unit 逐条指名：地点由模型自由决定，室内外交替的相邻 unit 会对不上。"""
     _rv_source(fake_ctx)
-    fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}
     out = await _run_rv_split(
         fake_ctx,
         monkeypatch,
@@ -481,7 +479,7 @@ async def test_split_reference_video_units_reports_soft_violations_alongside_the
 ) -> None:
     """产出即违约的报告同样带软违约段：Agent 修草稿这一轮就该看到降级提示，而非等到晋升。"""
     _rv_source(fake_ctx)
-    fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}
     out = await _run_rv_split(
         fake_ctx,
         monkeypatch,
@@ -506,7 +504,7 @@ async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_bac
     那条 warning 不在容忍列表内会被丢弃——超出段数上限这类提示反而不见了。
     """
     _rv_source(fake_ctx)
-    fake_ctx.pm.project_payload["characters"] = {  # pyright: ignore[reportAttributeAccessIssue]
+    fake_ctx.pm.project_payload["characters"] = {
         "张三": {"description": "主角", "reference_audio": "characters/refs_audio/张三.wav"},
         "李四": {"description": "", "reference_audio": "characters/refs_audio/李四.wav"},
     }

--- a/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_split_reference_video_units.py
@@ -11,16 +11,16 @@ from server.agent_runtime.sdk_tools.text_generation import (
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _RV_NOVEL,
-    _call,
-    _derived_reference_names,
-    _fake_caps_resolver,
-    _read_rv_quarantine,
-    _run_rv_split,
-    _rv_generator_returning,
-    _rv_script_plan_path,
-    _rv_source,
-    _rv_unit,
-    _use_fake_caps,
+    call,
+    derived_reference_names,
+    fake_caps_resolver,
+    read_rv_quarantine,
+    run_rv_split,
+    rv_generator_returning,
+    rv_script_plan_path,
+    rv_source,
+    rv_unit,
+    use_fake_caps,
 )
 
 # i2v 桶不可解析：不带图档位随之回退按 r2v 桶求值（``reference_unit_duration_tiers``）。
@@ -49,7 +49,7 @@ async def test_fetch_reference_caps_with_fallback_returns_declared_slots() -> No
     """unit 时长就是发给供应商的那个值，档位原样取自模型声明（不与任何静态区间求交）。"""
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         supported_durations=[1, 8, 16, 18],
         default_duration=16,
         max_reference_images=None,
@@ -73,7 +73,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_unit_duration_cap() ->
     """
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         provider_id="minimax",
         model="MiniMax-Hailuo-2.3",
         supported_durations=[6, 10],
@@ -91,7 +91,7 @@ async def test_fetch_reference_caps_with_fallback_narrows_slots_by_resolution() 
     """分辨率联动约束同样收窄 unit 档位：Veo 1080p 下只接受 8 秒。"""
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         provider_id="gemini-aistudio",
         model="veo-3.1-generate-preview",
         supported_durations=[4, 6, 8],
@@ -131,7 +131,7 @@ async def test_reference_unit_duration_tiers_does_not_assume_containment(monkeyp
         project,
         {"provider_id": "p", "model": "m"},
         [4, 6, 8],
-        config_resolver=_fake_caps_resolver(capability_errors=_NO_I2V),
+        config_resolver=fake_caps_resolver(capability_errors=_NO_I2V),
     )
 
     assert with_refs == [4, 6, 8]
@@ -144,7 +144,7 @@ async def test_reference_unit_duration_tiers_without_refs_follow_i2v_bucket() ->
     须与该桶模型的声明一致，否则会放行 r2v 独有档位、漏掉 i2v 独有档位。"""
     from server.media_tools import context as _context
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         by_capability={
             "i2v": {
                 "provider_id": "ark",
@@ -171,7 +171,7 @@ async def test_fetch_reference_caps_with_fallback_splits_tiers_by_reference_stat
     """
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         provider_id="gemini-aistudio",
         model="veo-3.1-generate-preview",
         supported_durations=[4, 6, 8],
@@ -194,7 +194,7 @@ async def test_fetch_reference_caps_with_fallback_uses_write_layer_default() -> 
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(error=ValueError("no provider configured"))
+    resolver = fake_caps_resolver(error=ValueError("no provider configured"))
     caps = await mod._fetch_reference_caps_with_fallback({}, 1, config_resolver=resolver)
     assert caps.default_duration is None
     assert caps.durations == DEFAULT_FALLBACK
@@ -210,7 +210,7 @@ async def test_fetch_reference_caps_with_fallback_preserves_silent_intent_on_fai
     """
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         error=ValueError("no provider configured"),
         requested_generate_audio=False,
     )
@@ -227,7 +227,7 @@ async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_fail
     """
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         error=ValueError("no provider configured"),
         generate_audio_error=RuntimeError("db unavailable"),
     )
@@ -237,11 +237,11 @@ async def test_fetch_reference_caps_with_fallback_degrades_silent_on_double_fail
 
 
 async def test_split_reference_video_units_dry_run(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    rv_source(fake_ctx)
+    use_fake_caps(fake_ctx)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "DRY RUN" in prompt_text
@@ -257,23 +257,23 @@ async def test_split_reference_video_units_happy_derives_structure(fake_ctx: Too
     """happy path：LLM 只写扁平正文，正文逐字落盘，只有 unit_id 由工具机械派生。"""
     from server import text_generation as mod
 
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     captured: dict[str, Any] = {}
     text = "@[张三] 走向 @[村口]\n@[张三] 停下脚步"
-    units = [_rv_unit(text)]
-    _use_fake_caps(fake_ctx)
-    monkeypatch.setattr(mod.TextGenerator, "create", _rv_generator_returning(units, captured))
+    units = [rv_unit(text)]
+    use_fake_caps(fake_ctx)
+    monkeypatch.setattr(mod.TextGenerator, "create", rv_generator_returning(units, captured))
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1})
     assert out.get("is_error") is not True, out
 
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     unit = saved["units"][0]
     assert unit["unit_id"] == "E1U01"
     assert unit["text"] == text
     # 参考图不落盘：读侧一律从正文的 @[名称] 派生
     assert "references" not in unit
-    assert _derived_reference_names(fake_ctx, unit["text"]) == ["张三", "村口"]
+    assert derived_reference_names(fake_ctx, unit["text"]) == ["张三", "村口"]
     assert unit["source_text"] == _RV_NOVEL
     assert captured["task_type"] is mod.TextTaskType.SCRIPT
     assert captured["create_project_name"] == "demo"
@@ -282,11 +282,11 @@ async def test_split_reference_video_units_happy_derives_structure(fake_ctx: Too
 
 async def test_split_reference_video_units_numbers_unit_ids_by_order(fake_ctx: ToolContext, monkeypatch) -> None:
     """unit_id 按数组序号机械编号：LLM 不写 id，也就不存在重复 / 错集号可写。"""
-    _rv_source(fake_ctx)
-    units = [_rv_unit("@[张三] 起身"), _rv_unit("@[张三] 出门")]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    rv_source(fake_ctx)
+    units = [rv_unit("@[张三] 起身"), rv_unit("@[张三] 出门")]
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
     assert out.get("is_error") is not True, out
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert [u["unit_id"] for u in saved["units"]] == ["E1U01", "E1U02"]
 
 
@@ -294,40 +294,38 @@ async def test_split_reference_video_units_derives_dialogue_without_reference_im
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """台词记号的说话人位不进参考图（画外说话的角色附参考图会诱导入画）。"""
-    _rv_source(fake_ctx)
-    units = [_rv_unit("门开了\n@[张三]：{我来了。}")]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    rv_source(fake_ctx)
+    units = [rv_unit("门开了\n@[张三]：{我来了。}")]
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
     assert out.get("is_error") is not True, out
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
-    assert _derived_reference_names(fake_ctx, saved["units"][0]["text"]) == []
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    assert derived_reference_names(fake_ctx, saved["units"][0]["text"]) == []
 
 
 async def test_split_reference_video_units_rejects_unregistered_asset(fake_ctx: ToolContext, monkeypatch) -> None:
     """正文引用未登记资产名 → fail-loud，不写盘（资产名引用完整性）。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[不存在的人] 出场")])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[不存在的人] 出场")])
     assert out.get("is_error") is True
     assert "未登记" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_unregistered_speaker(fake_ctx: ToolContext, monkeypatch) -> None:
     """说话人位未登记同样阻断：说话人决定该句台词绑哪段参考音频。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("门开了\n@[无名氏]：{我来了。}")])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("门开了\n@[无名氏]：{我来了。}")])
     assert out.get("is_error") is True
     assert "说话人未登记" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_over_max_refs(fake_ctx: ToolContext, monkeypatch) -> None:
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(
-        fake_ctx, monkeypatch, [_rv_unit("@[张三] 与 @[李四] 在 @[村口]")], max_reference_images=2
-    )
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 与 @[李四] 在 @[村口]")], max_reference_images=2)
     assert out.get("is_error") is True
     assert "参考图数" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_duration_off_reference_tier(
@@ -337,97 +335,97 @@ async def test_split_reference_video_units_rejects_duration_off_reference_tier(
 
     枚举卡的是两套档位的并集，这类越界过得了 schema；不在此拦，执行期才会申请不到。
     """
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _veo_720p(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身", duration=4)], **_VEO_CAPS)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 起身", duration=4)], **_VEO_CAPS)
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "生效档位" in text
     assert "[8]" in text
     # 与其余违约类同口径落草稿：档位越界同样是 Agent 改一改草稿就能修好的内容违约
-    assert not _rv_script_plan_path(fake_ctx).exists()
-    assert [v["code"] for v in _read_rv_quarantine(fake_ctx)["violations"]] == ["duration_off_tier"]
+    assert not rv_script_plan_path(fake_ctx).exists()
+    assert [v["code"] for v in read_rv_quarantine(fake_ctx)["violations"]] == ["duration_off_tier"]
 
 
 async def test_split_reference_video_units_accepts_wide_tier_without_references(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """无 `@` 引用的 unit 不受「参考图↔时长」约束，仍可取更短的档位。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     _veo_720p(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("门被风吹开", duration=4)], **_VEO_CAPS)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("门被风吹开", duration=4)], **_VEO_CAPS)
     assert out.get("is_error") is not True, out
-    saved = json.loads(_rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
+    saved = json.loads(rv_script_plan_path(fake_ctx).read_text(encoding="utf-8"))
     assert saved["units"][0]["duration_seconds"] == 4
-    assert _derived_reference_names(fake_ctx, saved["units"][0]["text"]) == []
+    assert derived_reference_names(fake_ctx, saved["units"][0]["text"]) == []
 
 
 async def test_split_reference_video_units_rejects_out_of_enum_duration(fake_ctx: ToolContext, monkeypatch) -> None:
     """本地校验复用动态 schema：超出 supported_durations 的 unit 时长被拦截，不落盘。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 起身", duration=5)])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 起身", duration=5)])
     assert out.get("is_error") is True
     assert "script_plan 拆分内容结构校验失败" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_empty_units(fake_ctx: ToolContext, monkeypatch) -> None:
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [])
     assert out.get("is_error") is True
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_non_verbatim_source_text(fake_ctx: ToolContext, monkeypatch) -> None:
     """source_text 非源文逐字子串 → 响亮失败（模型转述 / 杜撰原文）。"""
-    _rv_source(fake_ctx)
-    units = [_rv_unit("@[张三] 起身", source_text="张三在城里等人")]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    rv_source(fake_ctx)
+    units = [rv_unit("@[张三] 起身", source_text="张三在城里等人")]
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
     assert out.get("is_error") is True
     assert "不是小说原文的逐字片段" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_accepts_source_text_substring(fake_ctx: ToolContext, monkeypatch) -> None:
     """锚只需是源文子串：unit 是画面单元，不必覆盖整段原文。"""
-    _rv_source(fake_ctx)
-    units = [_rv_unit("@[张三] 起身", source_text="张三在村口")]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    rv_source(fake_ctx)
+    units = [rv_unit("@[张三] 起身", source_text="张三在村口")]
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
     assert out.get("is_error") is not True, out
 
 
 async def test_split_reference_video_units_rejects_dialogue_overload(fake_ctx: ToolContext, monkeypatch) -> None:
     """台词量按语速估算超过 unit 时长（宽容系数外）→ 阻断。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     long_line = "这是一段非常长的台词" * 6  # 60 字，zh 语速 5 字/秒 → 约 12 秒
-    units = [_rv_unit(f"@[张三] 起身\n@[张三]：{{{long_line}}}", duration=4)]
-    out = await _run_rv_split(fake_ctx, monkeypatch, units)
+    units = [rv_unit(f"@[张三] 起身\n@[张三]：{{{long_line}}}", duration=4)]
+    out = await run_rv_split(fake_ctx, monkeypatch, units)
     assert out.get("is_error") is True
     assert "超过该 unit" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_rejects_braces_in_description(fake_ctx: ToolContext, monkeypatch) -> None:
     """画面描述误用花括号保留语法 → 阻断（没被识别成发声记号的花括号须响亮失败）。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(fake_ctx, monkeypatch, [_rv_unit("@[张三] 推门，音量 {}，转身离开")])
+    rv_source(fake_ctx)
+    out = await run_rv_split(fake_ctx, monkeypatch, [rv_unit("@[张三] 推门，音量 {}，转身离开")])
     assert out.get("is_error") is True
     assert "花括号" in out["content"][0]["text"]
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
 
 
 async def test_split_reference_video_units_injects_instructions(fake_ctx: ToolContext) -> None:
-    _rv_source(fake_ctx)
-    _use_fake_caps(fake_ctx)
+    rv_source(fake_ctx)
+    use_fake_caps(fake_ctx)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单 unit 出场人物尽量不超过两人"})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "单 unit 出场人物尽量不超过两人"})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "# 用户意见" in prompt_text
@@ -438,18 +436,18 @@ async def test_split_reference_video_units_surfaces_tolerated_voice_warnings(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """三类声音降级 warning 不阻断落盘，但随产物呈现——否则直到生成后才听得出声音打了折。"""
-    _rv_source(fake_ctx)
-    out = await _run_rv_split(
+    rv_source(fake_ctx)
+    out = await run_rv_split(
         fake_ctx,
         monkeypatch,
-        [_rv_unit("@[张三] 起身\n@[张三]：{我来了。}")],
+        [rv_unit("@[张三] 起身\n@[张三]：{我来了。}")],
         voice_consistency="native",
         max_reference_audio_count=2,
         model="m",
     )
 
     assert out.get("is_error") is not True, out
-    assert _rv_script_plan_path(fake_ctx).exists()
+    assert rv_script_plan_path(fake_ctx).exists()
     text = out["content"][0]["text"]
     assert "降级提示" in text
     assert "未设置参考音频" in text
@@ -459,12 +457,12 @@ async def test_split_reference_video_units_names_units_without_scene_reference(
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """未引用场景的 unit 逐条指名：地点由模型自由决定，室内外交替的相邻 unit 会对不上。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}
-    out = await _run_rv_split(
+    out = await run_rv_split(
         fake_ctx,
         monkeypatch,
-        [_rv_unit("@[酒馆] 内景，@[张三] 推门。"), _rv_unit("@[张三] 起身。")],
+        [rv_unit("@[酒馆] 内景，@[张三] 推门。"), rv_unit("@[张三] 起身。")],
     )
 
     assert out.get("is_error") is not True, out
@@ -478,12 +476,12 @@ async def test_split_reference_video_units_reports_soft_violations_alongside_the
     fake_ctx: ToolContext, monkeypatch
 ) -> None:
     """产出即违约的报告同样带软违约段：Agent 修草稿这一轮就该看到降级提示，而非等到晋升。"""
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     fake_ctx.pm.project_payload["scenes"] = {"酒馆": {"description": "木质吧台"}}
-    out = await _run_rv_split(
+    out = await run_rv_split(
         fake_ctx,
         monkeypatch,
-        [_rv_unit("@[酒馆] 内景，@[张三] 推门。"), _rv_unit("@[不存在的人] 出场")],
+        [rv_unit("@[酒馆] 内景，@[张三] 推门。"), rv_unit("@[不存在的人] 出场")],
     )
 
     assert out.get("is_error") is True
@@ -492,7 +490,7 @@ async def test_split_reference_video_units_reports_soft_violations_alongside_the
     assert "降级提示" in text
     assert "未引用场景" in text
     assert "unit E1U02：" in text
-    assert not _rv_script_plan_path(fake_ctx).exists()
+    assert not rv_script_plan_path(fake_ctx).exists()
 
 
 async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_backend(
@@ -503,15 +501,15 @@ async def test_split_reference_video_units_keeps_voice_warnings_on_per_image_bac
     开着 ``reference_audio_per_image`` 而不给参考图集合，会把每个说话人都判成「无画面可挂」，
     那条 warning 不在容忍列表内会被丢弃——超出段数上限这类提示反而不见了。
     """
-    _rv_source(fake_ctx)
+    rv_source(fake_ctx)
     fake_ctx.pm.project_payload["characters"] = {
         "张三": {"description": "主角", "reference_audio": "characters/refs_audio/张三.wav"},
         "李四": {"description": "", "reference_audio": "characters/refs_audio/李四.wav"},
     }
-    out = await _run_rv_split(
+    out = await run_rv_split(
         fake_ctx,
         monkeypatch,
-        [_rv_unit("@[张三] 起身\n@[张三]：{我来了。}\n@[李四]：{你终于来了。}")],
+        [rv_unit("@[张三] 起身\n@[张三]：{我来了。}\n@[李四]：{你终于来了。}")],
         voice_consistency="native",
         max_reference_audio_count=1,
         model="m",

--- a/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
@@ -19,9 +19,9 @@ from server.agent_runtime.sdk_tools.text_generation import (
 from server.media_tools.context import ToolContext
 from server.text_generation import TextGenerationRequest, _parse_normalized_content
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _fake_caps_resolver,
-    _use_fake_caps,
+    call,
+    fake_caps_resolver,
+    use_fake_caps,
 )
 
 # i2v 桶不可解析：不带图档位随之回退按 r2v 桶求值（``reference_unit_duration_tiers``）。
@@ -33,29 +33,29 @@ _NO_I2V = {"i2v": ValueError("i2v bucket unresolvable in this test")}
 
 
 async def test_get_video_capabilities_happy(fake_ctx: ToolContext) -> None:
-    _use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
+    use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
     tool_obj = get_video_capabilities_tool(fake_ctx)
     assert tool_obj.name == "get_video_capabilities"
     assert isinstance(tool_obj.input_schema, dict)
     assert "project" not in tool_obj.input_schema["properties"]
-    out = await _call(tool_obj, {})
+    out = await call(tool_obj, {})
     assert out.get("is_error") is not True
     assert json.loads(out["content"][0]["text"])["video_capabilities"]["provider_id"] == "fake"
 
 
 async def test_get_video_capabilities_resolves_by_project(fake_ctx: ToolContext) -> None:
     """能力按项目生成模式解析：工具不收集号，多余的集号入参被忽略、不改变解析口径。"""
-    resolver = _use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
+    resolver = use_fake_caps(fake_ctx, provider_id="fake", supported_durations=[4, 6, 8])
     tool_obj = get_video_capabilities_tool(fake_ctx)
-    assert (await _call(tool_obj, {})).get("is_error") is not True
-    assert (await _call(tool_obj, {"episode": 3})).get("is_error") is not True
+    assert (await call(tool_obj, {})).get("is_error") is not True
+    assert (await call(tool_obj, {"episode": 3})).get("is_error") is not True
     assert resolver.capability_calls == [None, None]
 
 
 async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext) -> None:
     """参考路径项目另返回两套逐 unit 生效档位，供手工改 script_plan 时与生成侧对同一份数字。"""
     fake_ctx.pm.project_payload["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}
-    _use_fake_caps(
+    use_fake_caps(
         fake_ctx,
         provider_id="gemini-aistudio",
         model="veo-3.1-generate-preview",
@@ -63,7 +63,7 @@ async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: T
         generation_mode="reference_video",
         capability_errors=_NO_I2V,
     )
-    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    out = await call(get_video_capabilities_tool(fake_ctx), {})
     assert out.get("is_error") is not True, out
     payload = json.loads(out["content"][0]["text"])["video_capabilities"]
     assert payload["reference_unit_durations"] == {"with_references": [8], "without_references": [4, 6, 8]}
@@ -79,7 +79,7 @@ async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
     fake_ctx: ToolContext, generation_mode: str, content_mode: str
 ) -> None:
     """非剧集参考路径不补该字段：其它路径没有逐 unit 引用状态，ad 分镜时长也不受档位枚举管辖。"""
-    _use_fake_caps(
+    use_fake_caps(
         fake_ctx,
         provider_id="gemini-aistudio",
         model="veo-3.1-generate-preview",
@@ -87,7 +87,7 @@ async def test_get_video_capabilities_skips_tiers_off_episode_reference_path(
         generation_mode=generation_mode,
         content_mode=content_mode,
     )
-    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    out = await call(get_video_capabilities_tool(fake_ctx), {})
     payload = json.loads(out["content"][0]["text"])["video_capabilities"]
     assert "reference_unit_durations" not in payload
 
@@ -97,17 +97,17 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
 
     解析器不按项目名回到全局项目目录，非默认 projects_root 的会话也读取闭包里的项目。
     """
-    resolver = _use_fake_caps(fake_ctx, provider_id="kling", model="kling-v3-omni", supported_durations=[5])
-    out = await _call(get_video_capabilities_tool(fake_ctx), {})
+    resolver = use_fake_caps(fake_ctx, provider_id="kling", model="kling-v3-omni", supported_durations=[5])
+    out = await call(get_video_capabilities_tool(fake_ctx), {})
     assert out.get("is_error") is not True, out
     assert json.loads(out["content"][0]["text"])["video_capabilities"]["model"] == "kling-v3-omni"
     assert resolver.project_payloads == [fake_ctx.pm.project_payload]
 
 
 async def test_get_video_capabilities_error(fake_ctx: ToolContext) -> None:
-    _use_fake_caps(fake_ctx, error=FileNotFoundError("missing project.json"))
+    use_fake_caps(fake_ctx, error=FileNotFoundError("missing project.json"))
     tool_obj = get_video_capabilities_tool(fake_ctx)
-    out = await _call(tool_obj, {})
+    out = await call(tool_obj, {})
     assert out.get("is_error") is True
 
 
@@ -116,10 +116,10 @@ async def test_generate_script_plan_rejects_inapplicable_content_modes(
     fake_ctx: ToolContext, content_mode: str
 ) -> None:
     fake_ctx.pm.project_payload["content_mode"] = content_mode
-    resolver = _use_fake_caps(fake_ctx)
+    resolver = use_fake_caps(fake_ctx)
     caller_thread = threading.get_ident()
 
-    out = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "dry_run": True})
+    out = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "dry_run": True})
 
     assert out.get("is_error") is True
     assert json.loads(out["content"][0]["text"])["problem"]["code"] == "generation_refused"
@@ -157,14 +157,14 @@ async def test_generate_episode_script_dry_run(fake_ctx: ToolContext, monkeypatc
 
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
     tool_obj = generate_episode_script_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True
     assert "fake prompt" in out["content"][0]["text"]
 
 
 async def test_generate_episode_script_missing_script_plan(fake_ctx: ToolContext) -> None:
     tool_obj = generate_episode_script_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 99})
+    out = await call(tool_obj, {"episode": 99})
     assert out.get("is_error") is True
 
 
@@ -204,7 +204,7 @@ async def test_generate_episode_script_writes_to_default_project_scripts(fake_ct
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
     tool_obj = generate_episode_script_tool(fake_ctx)
 
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is not True
     # handler 不再传 output_path —— ScriptGenerator 自己决定写到哪里
     assert "output_path" not in captured["calls"]
@@ -229,7 +229,7 @@ async def test_generate_episode_script_ad_skips_script_plan(fake_ctx: ToolContex
 
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
     tool_obj = generate_episode_script_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is not True
 
 
@@ -256,12 +256,12 @@ async def test_generate_episode_script_scope_reaches_the_generator(fake_ctx: Too
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
     tool_obj = generate_episode_script_tool(fake_ctx)
 
-    out = await _call(tool_obj, {"episode": 1, "entry_ids": ["E1S02"]})
+    out = await call(tool_obj, {"episode": 1, "entry_ids": ["E1S02"]})
     assert out.get("is_error") is not True
     assert captured["scope"] == ("E1S02",)
     assert "E1S02" in out["content"][0]["text"]
 
-    await _call(tool_obj, {"episode": 1, "scope": "all"})
+    await call(tool_obj, {"episode": 1, "scope": "all"})
     assert captured["scope"] == "all"
 
 
@@ -286,7 +286,7 @@ async def test_generate_episode_script_unknown_entry_id_is_refused_not_internal(
             raise ScriptPlanEntryError("scope 指定的条目 id 不在当前脚本规划内: ['E9U99']")
 
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
-    out = await _call(generate_episode_script_tool(fake_ctx), {"episode": 1, "entry_ids": ["E9U99"]})
+    out = await call(generate_episode_script_tool(fake_ctx), {"episode": 1, "entry_ids": ["E9U99"]})
 
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
@@ -297,7 +297,7 @@ async def test_generate_episode_script_unknown_entry_id_is_refused_not_internal(
 async def test_generate_episode_script_rejects_entry_ids_with_scope_all(fake_ctx: ToolContext) -> None:
     """两种范围同时给出即请求自相矛盾，在入口拒绝而不是任选其一。"""
     tool_obj = generate_episode_script_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "scope": "all", "entry_ids": ["E1S01"]})
+    out = await call(tool_obj, {"episode": 1, "scope": "all", "entry_ids": ["E1S01"]})
     assert out.get("is_error") is True
 
 
@@ -311,7 +311,7 @@ async def test_generate_episode_script_scope_does_not_bypass_the_review_gate(fak
     tool_obj = generate_episode_script_tool(fake_ctx)
 
     for args in ({"episode": 1}, {"episode": 1, "scope": "all"}, {"episode": 1, "entry_ids": ["E1S01"]}):
-        out = await _call(tool_obj, args)
+        out = await call(tool_obj, args)
         assert out.get("is_error") is True, args
         assert "内容确认" in out["content"][0]["text"]
 
@@ -347,7 +347,7 @@ async def test_fetch_caps_with_fallback_uses_write_layer_default() -> None:
     from lib.custom_provider.duration_presets import DEFAULT_FALLBACK
     from server import text_generation as mod
 
-    resolver = _fake_caps_resolver(error=ValueError("no provider configured"))
+    resolver = fake_caps_resolver(error=ValueError("no provider configured"))
     default, durations = await mod._fetch_caps_with_fallback({}, 1, config_resolver=resolver)
     assert default is None
     assert durations == DEFAULT_FALLBACK
@@ -364,12 +364,12 @@ async def test_fetch_caps_with_fallback_drops_out_of_range_default() -> None:
     veo = {"provider_id": "gemini-aistudio", "model": "veo-3.1-generate-preview"}
     project_1080p = {"model_settings": {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "1080p"}}}
 
-    narrowed = _fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=4, **veo)
+    narrowed = fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=4, **veo)
     default, durations = await mod._fetch_caps_with_fallback(project_1080p, 1, config_resolver=narrowed)
     assert default is None
     assert durations == [8]
 
-    in_range = _fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=8, **veo)
+    in_range = fake_caps_resolver(supported_durations=[4, 6, 8], default_duration=8, **veo)
     default, durations = await mod._fetch_caps_with_fallback({}, 1, config_resolver=in_range)
     assert default == 8
     assert durations == [4, 6, 8]
@@ -383,7 +383,7 @@ async def test_fetch_video_caps_narrows_durations_by_constraints() -> None:
     """
     from server.media_tools import context as ctx_mod
 
-    resolver = _fake_caps_resolver(
+    resolver = fake_caps_resolver(
         provider_id="gemini-aistudio",
         model="veo-3.1-generate-preview",
         supported_durations=[4, 6, 8],
@@ -419,9 +419,9 @@ async def test_normalize_drama_script_dry_run(fake_ctx: ToolContext) -> None:
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True
     assert "DRY RUN" in out["content"][0]["text"]
 
@@ -441,9 +441,9 @@ async def test_normalize_drama_script_projects_durable_inputs_once(fake_ctx: Too
         return original(*args, **kwargs)
 
     monkeypatch.setattr(artifact_provenance, "project_script_plan_prompt_inputs", counted_projection)
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
 
-    result = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1, "dry_run": True})
+    result = await call(generate_script_plan_tool(fake_ctx), {"episode": 1, "dry_run": True})
 
     assert result.get("is_error") is not True, result
     assert calls == 1
@@ -460,9 +460,9 @@ async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContex
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("once upon a time", encoding="utf-8")
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True
     assert "English" in out["content"][0]["text"]
 
@@ -486,11 +486,11 @@ async def test_normalize_drama_script_rejects_empty_scenes(fake_ctx: ToolContext
     async def fake_create(task_type, project_name=None):
         return _EmptyGenerator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     # 空 scenes 不写盘，避免生成阶段才必然失败
     assert not (project_path / "drafts" / "episode_1" / "script_plan_normalized_script.json").exists()
@@ -504,9 +504,9 @@ async def test_normalize_drama_script_injects_episode_into_prompt(fake_ctx: Tool
     src.mkdir(parents=True)
     (src / "chapter2.txt").write_text("第二集开场", encoding="utf-8")
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 2, "dry_run": True, "source": "source/chapter2.txt"})
+    out = await call(tool_obj, {"episode": 2, "dry_run": True, "source": "source/chapter2.txt"})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "E2S01" in prompt_text
@@ -530,9 +530,9 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
         }
     ]
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "少年下山" in prompt_text
@@ -584,11 +584,11 @@ async def test_normalize_drama_script_passes_project_name_to_backend(fake_ctx: T
         captured["create_project_name"] = project_name
         return _FakeGenerator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
 
     assert out.get("is_error") is not True, out
     assert captured["task_type"] is mod.TextTaskType.SCRIPT
@@ -661,10 +661,10 @@ async def test_normalize_drama_script_registers_the_frozen_explicit_source_basis
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
-    result = await _call(
+    result = await call(
         generate_script_plan_tool(fake_ctx),
         {"episode": 1, "source": "source/selected.txt"},
     )
@@ -737,10 +737,10 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
     async def fake_create(_task_type, project_name=None):
         return _Generator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
-    result = await _call(
+    result = await call(
         generate_script_plan_tool(fake_ctx),
         {"episode": 1, "source": "source/selected.txt"},
     )
@@ -792,10 +792,10 @@ async def test_normalize_drama_script_marks_mixed_machine_candidate_before_revie
     async def fake_create(_task_type, project_name=None):
         return _FakeGenerator()
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod.TextGenerator, "create", fake_create)
 
-    result = await _call(generate_script_plan_tool(fake_ctx), {"episode": 1})
+    result = await call(generate_script_plan_tool(fake_ctx), {"episode": 1})
 
     assert result.get("is_error") is not True, result
     saved = json.loads(
@@ -807,7 +807,7 @@ async def test_normalize_drama_script_marks_mixed_machine_candidate_before_revie
 
 async def test_normalize_drama_script_no_source(fake_ctx: ToolContext) -> None:
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
 
 
@@ -817,9 +817,9 @@ async def test_normalize_drama_script_injects_instructions(fake_ctx: ToolContext
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = generate_script_plan_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "打斗场面多拆几个短镜头"})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "打斗场面多拆几个短镜头"})
     assert out.get("is_error") is not True, out
     prompt_text = out["content"][0]["text"]
     assert "# 用户意见" in prompt_text
@@ -867,11 +867,11 @@ async def test_generate_episode_script_forwards_instructions(fake_ctx: ToolConte
     monkeypatch.setattr(mod, "ScriptGenerator", _FakeGenerator)
     tool_obj = generate_episode_script_tool(fake_ctx)
 
-    out = await _call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "偏好特写镜头"})
+    out = await call(tool_obj, {"episode": 1, "dry_run": True, "instructions": "偏好特写镜头"})
     assert out.get("is_error") is not True, out
     assert captured["build_prompt"] == "偏好特写镜头"
 
-    out = await _call(tool_obj, {"episode": 1, "instructions": "偏好特写镜头"})
+    out = await call(tool_obj, {"episode": 1, "instructions": "偏好特写镜头"})
     assert out.get("is_error") is not True, out
     assert captured["generate"] == "偏好特写镜头"
 
@@ -895,7 +895,7 @@ async def test_generate_episode_script_reference_legacy_md_hints_resplit(fake_ct
     (drafts / "script_plan_reference_units.md").write_text("| E1U1 |", encoding="utf-8")
 
     tool_obj = generate_episode_script_tool(fake_ctx)
-    out = await _call(tool_obj, {"episode": 1})
+    out = await call(tool_obj, {"episode": 1})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "调用 generate_script_plan" in text

--- a/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_text_generation.py
@@ -54,9 +54,7 @@ async def test_get_video_capabilities_resolves_by_project(fake_ctx: ToolContext)
 
 async def test_get_video_capabilities_annotates_reference_unit_tiers(fake_ctx: ToolContext) -> None:
     """参考路径项目另返回两套逐 unit 生效档位，供手工改 script_plan 时与生成侧对同一份数字。"""
-    fake_ctx.pm.project_payload["model_settings"] = {  # type: ignore[attr-defined]
-        "gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}
-    }
+    fake_ctx.pm.project_payload["model_settings"] = {"gemini-aistudio/veo-3.1-generate-preview": {"resolution": "720p"}}
     _use_fake_caps(
         fake_ctx,
         provider_id="gemini-aistudio",
@@ -103,7 +101,7 @@ async def test_get_video_capabilities_shares_rest_resolution_entry(fake_ctx: Too
     out = await _call(get_video_capabilities_tool(fake_ctx), {})
     assert out.get("is_error") is not True, out
     assert json.loads(out["content"][0]["text"])["video_capabilities"]["model"] == "kling-v3-omni"
-    assert resolver.project_payloads == [fake_ctx.pm.project_payload]  # type: ignore[attr-defined]
+    assert resolver.project_payloads == [fake_ctx.pm.project_payload]
 
 
 async def test_get_video_capabilities_error(fake_ctx: ToolContext) -> None:
@@ -126,8 +124,8 @@ async def test_generate_script_plan_rejects_inapplicable_content_modes(
     assert out.get("is_error") is True
     assert json.loads(out["content"][0]["text"])["problem"]["code"] == "generation_refused"
     assert resolver.capability_calls == []
-    assert fake_ctx.pm.readonly_load_threads  # type: ignore[attr-defined]
-    assert all(thread != caller_thread for thread in fake_ctx.pm.readonly_load_threads)  # type: ignore[attr-defined]
+    assert fake_ctx.pm.readonly_load_threads
+    assert all(thread != caller_thread for thread in fake_ctx.pm.readonly_load_threads)
 
 
 @pytest.mark.parametrize("factory", [generate_episode_script_tool, generate_script_plan_tool])
@@ -456,7 +454,7 @@ async def test_normalize_drama_script_wires_target_language(fake_ctx: ToolContex
     非中文项目的 script_plan 输出语言据此切换，而非恒退默认中文。"""
 
     # 工具经 ctx.pm.load_project 取项目；source_language 是输出语言的唯一真相源
-    fake_ctx.pm.project_payload["source_language"] = "English"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["source_language"] = "English"
     project_path = fake_ctx.project_path
     src = project_path / "source"
     src.mkdir(parents=True)
@@ -523,7 +521,7 @@ async def test_normalize_drama_script_injects_episode_outline(fake_ctx: ToolCont
     src = project_path / "source"
     src.mkdir(parents=True)
     (src / "chapter1.txt").write_text("从前有座山", encoding="utf-8")
-    fake_ctx.pm.project_payload["episodes"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["episodes"] = [
         {
             "episode": 1,
             "title": "初入江湖",
@@ -612,14 +610,14 @@ async def test_normalize_drama_script_registers_the_frozen_explicit_source_basis
     from server import text_generation as mod
 
     project = {
-        **fake_ctx.pm.project_payload,  # type: ignore[attr-defined]
+        **fake_ctx.pm.project_payload,
         "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
         "content_mode": "drama",
         "generation_mode": "storyboard",
         "source_kind": "novel",
         "source_language": "中文",
     }
-    fake_ctx.pm.project_payload = project  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload = project
     project_file = fake_ctx.project_path / "project.json"
     project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
     source_path = fake_ctx.project_path / "source" / "selected.txt"
@@ -632,7 +630,7 @@ async def test_normalize_drama_script_registers_the_frozen_explicit_source_basis
         async def generate(self, _request, project_name=None):
             source_path.write_text("等待供应商期间改过的原文", encoding="utf-8")
             latest = {**project, "source_language": "English"}
-            fake_ctx.pm.project_payload = latest  # type: ignore[attr-defined]
+            fake_ctx.pm.project_payload = latest
             project_file.write_text(json.dumps(latest, ensure_ascii=False), encoding="utf-8")
             return type(
                 "_Result",
@@ -685,7 +683,7 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
     from server import text_generation as mod
 
     project = {
-        **fake_ctx.pm.project_payload,  # type: ignore[attr-defined]
+        **fake_ctx.pm.project_payload,
         "schema_version": 7,
         "title": "项目",
         "content_mode": "drama",
@@ -695,7 +693,7 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
         "overview": {},
         "episodes": [{"episode": 1, "title": "第一集", "script_file": "scripts/episode_1.json"}],
     }
-    fake_ctx.pm.project_payload = project  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload = project
     project_file = fake_ctx.project_path / "project.json"
     project_file.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
     source_dir = fake_ctx.project_path / "source"
@@ -708,7 +706,7 @@ async def test_normalize_drama_script_preserves_legacy_request_basis_when_manife
     class _Generator:
         async def generate(self, _request, project_name=None):
             activated = {**project, "schema_version": 8}
-            fake_ctx.pm.project_payload = activated  # type: ignore[attr-defined]
+            fake_ctx.pm.project_payload = activated
             project_file.write_text(json.dumps(activated, ensure_ascii=False), encoding="utf-8")
             return type(
                 "_Result",

--- a/tests/integration/server/agent_runtime/sdk_tools/test_validate_script_filename.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_validate_script_filename.py
@@ -28,6 +28,16 @@ def test_validate_script_filename_rejects_paths(bad: str) -> None:
         validate_script_filename(bad)
 
 
+@pytest.mark.parametrize("bad", [1, None, ["episode_1.json"], {"name": "episode_1.json"}])
+def test_validate_script_filename_rejects_non_string_agent_args(bad: object) -> None:
+    """Agent 传来的是原始 JSON 值，非字符串同样要落成 ValueError。"""
+
+    from server.media_tools.context import validate_script_filename
+
+    with pytest.raises(ValueError, match="script 文件名不能为空"):
+        validate_script_filename(bad)
+
+
 def test_validate_script_filename_accepts_basename() -> None:
     from server.media_tools.context import validate_script_filename
 

--- a/tests/integration/server/agent_runtime/test_assistant_rewrite.py
+++ b/tests/integration/server/agent_runtime/test_assistant_rewrite.py
@@ -136,7 +136,7 @@ async def rewriting(session_factory, tmp_path):
         resolve_project_cwd=service._resolve_project_cwd_safe,
     )
     runtime = FakeSessionManager(log_store)
-    service.session_manager = runtime  # type: ignore[assignment]
+    service.session_manager = runtime
 
     session_id = str(uuid4())
     await meta_store.create(PROJECT_NAME, session_id)

--- a/tests/integration/server/conftest.py
+++ b/tests/integration/server/conftest.py
@@ -12,7 +12,7 @@ from lib.generation_queue_client import wait_for_task
 from lib.generation_worker import CapacityTable, GenerationWorker
 from lib.project_change_hints import register_project_change_batch_listener
 from server.media_tools.context import ToolContext
-from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import FakePM, _fake_caps_resolver
+from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import FakePM, fake_caps_resolver
 
 
 def _build_fake_ctx(tmp_path: Path, session_factory, monkeypatch: pytest.MonkeyPatch) -> ToolContext:
@@ -33,7 +33,7 @@ def _build_fake_ctx(tmp_path: Path, session_factory, monkeypatch: pytest.MonkeyP
         projects_root=tmp_path,
         pm=FakePM("demo", project_dir),
         queue=queue,
-        config_resolver=_fake_caps_resolver(),
+        config_resolver=fake_caps_resolver(),
     )
 
 

--- a/tests/integration/server/conftest.py
+++ b/tests/integration/server/conftest.py
@@ -12,7 +12,7 @@ from lib.generation_queue_client import wait_for_task
 from lib.generation_worker import CapacityTable, GenerationWorker
 from lib.project_change_hints import register_project_change_batch_listener
 from server.media_tools.context import ToolContext
-from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import _fake_caps_resolver, _FakePM
+from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import FakePM, _fake_caps_resolver
 
 
 def _build_fake_ctx(tmp_path: Path, session_factory, monkeypatch: pytest.MonkeyPatch) -> ToolContext:
@@ -31,7 +31,7 @@ def _build_fake_ctx(tmp_path: Path, session_factory, monkeypatch: pytest.MonkeyP
     return ToolContext(
         project_name="demo",
         projects_root=tmp_path,
-        pm=_FakePM("demo", project_dir),  # type: ignore[arg-type]
+        pm=FakePM("demo", project_dir),
         queue=queue,
         config_resolver=_fake_caps_resolver(),
     )

--- a/tests/integration/server/media_tools/test_assets.py
+++ b/tests/integration/server/media_tools/test_assets.py
@@ -11,8 +11,8 @@ from server.media_tools.assets import (
 )
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _generation_result,
+    call,
+    read_generation_result,
 )
 
 # ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
 
 async def test_list_pending_assets_happy(fake_ctx: ToolContext) -> None:
     tool_obj = list_pending_assets_tool(fake_ctx)
-    out = await _call(tool_obj, {})
+    out = await call(tool_obj, {})
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
     assert "张三" in text
@@ -42,7 +42,7 @@ async def test_pending_asset_tools_include_an_unclaimed_schema8_sheet(tmp_path: 
     (project_dir / "scenes" / "客厅.png").write_bytes(b"png")
     ctx = ToolContext(project_name="demo", projects_root=projects_root, pm=pm)
 
-    listed = await _call(list_pending_assets_tool(ctx), {"type": "scene"})
+    listed = await call(list_pending_assets_tool(ctx), {"type": "scene"})
 
     assert "客厅" in listed["content"][0]["text"]
 
@@ -54,7 +54,7 @@ async def test_pending_asset_tools_include_an_unclaimed_schema8_sheet(tmp_path: 
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _capture_batch)
 
-    await _call(generate_assets_tool(ctx), {"type": "scene"})
+    await call(generate_assets_tool(ctx), {"type": "scene"})
 
     assert enqueued == ["客厅"]
 
@@ -65,7 +65,7 @@ async def test_list_pending_assets_error(fake_ctx: ToolContext, monkeypatch) -> 
 
     fake_ctx.pm.get_pending_characters = boom
     tool_obj = list_pending_assets_tool(fake_ctx)
-    out = await _call(tool_obj, {"type": "character"})
+    out = await call(tool_obj, {"type": "character"})
     assert out.get("is_error") is True
 
 
@@ -88,10 +88,10 @@ async def test_generate_assets_happy(fake_ctx: ToolContext, monkeypatch) -> None
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = generate_assets_tool(fake_ctx)
-    out = await _call(tool_obj, {"type": "character"})
+    out = await call(tool_obj, {"type": "character"})
     # 李四 没有 description，作为 blocked 逐 ID 报告；缺口存在时整体判为 error，
     # 调用方不需要读文本就知道哪几个 ID 还没做成。
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["character/张三"]
     assert result.blocked == ["character/李四"]
     assert sorted(result.requested) == sorted(result.succeeded + result.blocked)
@@ -130,9 +130,9 @@ async def test_generate_assets_legacy_project_reverifies_sheet_file_on_disk(fake
         return succ, []
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
-    out = await _call(generate_assets_tool(fake_ctx), {"type": "character"})
+    out = await call(generate_assets_tool(fake_ctx), {"type": "character"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     # 张三：文件真实存在，missing-only 复用旧图，不重新生成。
     assert "张三" not in enqueued
     assert [entry.unit_id for entry in result.skipped] == ["character/张三"]
@@ -150,7 +150,7 @@ async def test_generate_assets_rejects_an_explicitly_empty_name_list(fake_ctx: T
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fail_batch)
 
-    out = await _call(generate_assets_tool(fake_ctx), {"type": "character", "names": []})
+    out = await call(generate_assets_tool(fake_ctx), {"type": "character", "names": []})
 
     assert out.get("is_error") is True
     assert "不能为空数组" in out["content"][0]["text"]
@@ -158,5 +158,5 @@ async def test_generate_assets_rejects_an_explicitly_empty_name_list(fake_ctx: T
 
 async def test_generate_assets_names_without_type(fake_ctx: ToolContext) -> None:
     tool_obj = generate_assets_tool(fake_ctx)
-    out = await _call(tool_obj, {"names": ["张三"]})
+    out = await call(tool_obj, {"names": ["张三"]})
     assert out.get("is_error") is True

--- a/tests/integration/server/media_tools/test_assets.py
+++ b/tests/integration/server/media_tools/test_assets.py
@@ -63,7 +63,7 @@ async def test_list_pending_assets_error(fake_ctx: ToolContext, monkeypatch) -> 
     def boom(_name):
         raise RuntimeError("db down")
 
-    fake_ctx.pm.get_pending_characters = boom  # type: ignore[attr-defined]
+    fake_ctx.pm.get_pending_characters = boom
     tool_obj = list_pending_assets_tool(fake_ctx)
     out = await _call(tool_obj, {"type": "character"})
     assert out.get("is_error") is True
@@ -104,9 +104,9 @@ async def test_generate_assets_legacy_project_reverifies_sheet_file_on_disk(fake
     from server.media_tools import assets as mod
 
     # 未设置当前 schema：resolver 走 legacy 分支（没有 active Manifest）。
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["李四"]["character_sheet"] = "characters/lisi.png"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["李四"]["description"] = "配角"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
+    fake_ctx.pm.project_payload["characters"]["李四"]["character_sheet"] = "characters/lisi.png"
+    fake_ctx.pm.project_payload["characters"]["李四"]["description"] = "配角"
     # 只有张三的文件真的落盘；李四的 sheet 路径是失效元数据。
     sheet_path = fake_ctx.project_path / "characters" / "zhangsan.png"
     sheet_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/server/media_tools/test_grid.py
+++ b/tests/integration/server/media_tools/test_grid.py
@@ -65,10 +65,10 @@ def _fake_grid_waiter(enqueue, wait=None):
 
 
 async def test_generate_grid_list_only(fake_ctx: ToolContext) -> None:
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
     # Need enough segments to form a group with valid layout
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
     tool_obj = generate_grid_tool(fake_ctx)
@@ -89,9 +89,9 @@ async def test_generate_grid_list_only_respects_4k_gate(
     forbidden: str,
 ) -> None:
     # 非 4K 时 4×4 / 5×5 不出现在面向 Agent 的分组预览里
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S{i:02d}", "image_prompt": "p", "segment_break": False} for i in range(1, 13)
     ]
 
@@ -111,9 +111,9 @@ async def test_generate_grid_list_only_shows_split_for_oversized_group(
     fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # 超过单张格数上限的分组，预览按切块后的张数与档位展示，与实际入队同源
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S{i:02d}", "image_prompt": "p", "segment_break": False} for i in range(1, 13)
     ]
 
@@ -135,10 +135,10 @@ async def test_generate_grid_falls_back_on_null_aspect_ratio(
     # 否则 None 会写进宫格规划、任务 payload 与记录上冻结的比例
     from lib.grid_manager import GridManager
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["aspect_ratio"] = None  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.project_payload["aspect_ratio"] = None
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
 
@@ -177,9 +177,9 @@ async def test_generate_grid_split_failure_keeps_the_paid_image_and_fails_the_id
     fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """联合图已付费落盘、切分失败：该组每个分镜都记为 failed，不声称产物已就位。"""
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
 
@@ -230,9 +230,9 @@ async def test_generate_grid_explicit_failure_preserves_the_old_artifact_path(
 ) -> None:
     """点名强制重生成失败时，报告仍要带上剧本里登记的旧图路径——否则下游分不清
     「这次替换失败、旧图还在」和「原本就没有可复用产物」，给不出正确的下一步建议。"""
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {
             "segment_id": f"E1S0{i}",
             "image_prompt": "p",
@@ -271,9 +271,9 @@ async def test_generate_grid_wait_timeout_is_reported_as_interrupted_not_failed(
     打断（任务可能仍在跑）报成终态失败——那会诱导调用方重试、造成重复付费提交。"""
     from lib.generation_queue_client import TaskWaitTimeoutError
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
 
@@ -307,9 +307,9 @@ async def test_generate_grid_reports_each_scene_of_a_shared_grid(
     fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """同组分镜共享一张宫格，结果仍逐分镜 ID 报告：落格的成功、没落格的单独失败。"""
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
 
@@ -365,7 +365,7 @@ async def test_generate_grid_blocks_the_whole_group_when_one_scene_state_is_unre
     """
     from lib.artifact_manifest import ArtifactComparison, ArtifactStatus
 
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "generation_mode": "storyboard",
@@ -373,14 +373,12 @@ async def test_generate_grid_blocks_the_whole_group_when_one_scene_state_is_unre
             "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
         }
     )
-    fake_ctx.pm.script_payload["episode"] = 1  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["episode"] = 1
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
     # E1S02 已有一张旧联合图，但其 Manifest 状态读取会炸——组内其它三格都还没图。
-    fake_ctx.pm.script_payload["segments"][1]["generated_assets"] = {  # type: ignore[attr-defined]
-        "storyboard_image": "storyboards/scene_E1S02.png"
-    }
+    fake_ctx.pm.script_payload["segments"][1]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S02.png"}
 
     class _Resolver:
         def compare(self, key, *, artifact_path):
@@ -427,7 +425,7 @@ async def test_generate_grid_spares_an_already_reusable_sibling_when_one_scene_s
     "产物状态不可读、需要修复"是错误结论，仍应按正常复用记为 skipped。"""
     from lib.artifact_manifest import ArtifactComparison, ArtifactStatus
 
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "generation_mode": "storyboard",
@@ -435,17 +433,13 @@ async def test_generate_grid_spares_an_already_reusable_sibling_when_one_scene_s
             "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
         }
     )
-    fake_ctx.pm.script_payload["episode"] = 1  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["episode"] = 1
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
     # E1S02 状态读取会炸；E1S03 已有旧图且状态 CURRENT（可复用）；E1S01/E1S04 缺图。
-    fake_ctx.pm.script_payload["segments"][1]["generated_assets"] = {  # type: ignore[attr-defined]
-        "storyboard_image": "storyboards/scene_E1S02.png"
-    }
-    fake_ctx.pm.script_payload["segments"][2]["generated_assets"] = {  # type: ignore[attr-defined]
-        "storyboard_image": "storyboards/scene_E1S03.png"
-    }
+    fake_ctx.pm.script_payload["segments"][1]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S02.png"}
+    fake_ctx.pm.script_payload["segments"][2]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S03.png"}
 
     class _Resolver:
         def compare(self, key, *, artifact_path):
@@ -484,8 +478,8 @@ async def test_generate_grid_spares_an_already_reusable_sibling_when_one_scene_s
 
 async def test_generate_grid_rejects_an_explicitly_empty_scene_selection(fake_ctx: ToolContext) -> None:
     """显式空集合不是「全部」：拒绝请求，而不是静默扫全集。"""
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
 
     out = await _call(generate_grid_tool(fake_ctx), {"script": "episode_1.json", "scene_ids": []})
 
@@ -502,9 +496,9 @@ async def test_generate_grid_cleans_superseded_records(fake_ctx: ToolContext, mo
     from lib.grid.models import GridGeneration
     from lib.grid_manager import GridManager
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "video_prompt": "v", "segment_break": False}
         for i in range(1, 5)
     ]
@@ -579,13 +573,13 @@ async def test_generate_grid_cleanup_spares_a_fully_reusable_chunk_of_an_oversiz
     from lib.grid.models import GridGeneration
     from lib.grid_manager import GridManager
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
     # 前 9 个缺分镜图（要生成的一张 grid_9），后 4 个已有可复用旧图
     # （落在另一张 grid_4 里，整张都可复用、不产出替代品）。
     missing_ids = [f"E1S{i:02d}" for i in range(1, 10)]
     reusable_ids = [f"E1S{i:02d}" for i in range(10, 14)]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": sid, "image_prompt": "p", "video_prompt": "v", "segment_break": False} for sid in missing_ids
     ] + [
         {
@@ -647,10 +641,10 @@ async def test_generate_grid_list_only_falls_back_on_null_aspect_ratio(
     fake_ctx: ToolContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # 预览路径与入队路径同源，同样不能让 None 流进 plan_grid_chunks
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["aspect_ratio"] = None  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.project_payload["aspect_ratio"] = None
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
 
@@ -670,10 +664,10 @@ async def test_generate_grid_splits_oversized_group_into_multiple_grids(
     # 12 个分镜 + 非 4K（上限 9）：入队 2 张宫格，分镜不重不漏，每张 prompt 分镜数与格数一致
     from lib.grid_manager import GridManager
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
     all_ids = [f"E1S{i:02d}" for i in range(1, 13)]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": sid, "image_prompt": "p", "video_prompt": "v", "segment_break": False} for sid in all_ids
     ]
 
@@ -732,8 +726,8 @@ async def test_generate_grid_wrong_mode(fake_ctx: ToolContext) -> None:
 
 async def test_generate_grid_rejected_on_reference_video_route(fake_ctx: ToolContext) -> None:
     # reference_video 生成模式无分镜图步骤：即使残留 grid_storyboard=true 也不适用宫格工具
-    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
     tool_obj = generate_grid_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is True
@@ -745,10 +739,10 @@ async def test_generate_grid_legacy_unresolvable_episode_fails_before_enqueue(
 ) -> None:
     from server.media_tools import grid as mod
 
-    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["grid_storyboard"] = True  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload.pop("episode")  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
+    fake_ctx.pm.project_payload["grid_storyboard"] = True
+    fake_ctx.pm.script_payload.pop("episode")
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
     enqueue = AsyncMock(side_effect=AssertionError("must not enqueue"))

--- a/tests/integration/server/media_tools/test_grid.py
+++ b/tests/integration/server/media_tools/test_grid.py
@@ -13,8 +13,8 @@ from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.media_tools.context import ToolContext
 from server.media_tools.grid import generate_grid_tool
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _generation_result,
+    call,
+    read_generation_result,
 )
 
 
@@ -72,7 +72,7 @@ async def test_generate_grid_list_only(fake_ctx: ToolContext) -> None:
         {"segment_id": f"E1S0{i}", "image_prompt": "p", "segment_break": False} for i in range(1, 5)
     ]
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
+    out = await call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is not True
     assert "分组" in out["content"][0]["text"]
 
@@ -100,7 +100,7 @@ async def test_generate_grid_list_only_respects_4k_gate(
 
     monkeypatch.setattr("server.media_tools.grid.resolve_large_grid_allowed", _gate)
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
+    out = await call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
     assert expected in text
@@ -122,7 +122,7 @@ async def test_generate_grid_list_only_shows_split_for_oversized_group(
 
     monkeypatch.setattr("server.media_tools.grid.resolve_large_grid_allowed", _gate)
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
+    out = await call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
     assert "2 张宫格: grid_9 (3×3) + grid_4 (2×2)" in text
@@ -166,7 +166,7 @@ async def test_generate_grid_falls_back_on_null_aspect_ratio(
     monkeypatch.setattr("server.media_tools.grid.apply_grid_split", fake_split)
 
     tool_obj = generate_grid_tool(fake_ctx, batch_waiter=batch_waiter)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
 
     assert [p["video_aspect_ratio"] for p in payloads] == ["9:16"]
@@ -201,10 +201,10 @@ async def test_generate_grid_split_failure_keeps_the_paid_image_and_fails_the_id
     batch_waiter = _fake_grid_waiter(fake_enqueue, fake_wait)
     monkeypatch.setattr("server.media_tools.grid.apply_grid_split", failing_split)
 
-    out = await _call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
+    out = await call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == []
     # 逐分镜 ID 报告：一张宫格覆盖的四个分镜各自拿到自己的失败结论。
     assert result.failed == ["E1S01", "E1S02", "E1S03", "E1S04"]
@@ -253,12 +253,12 @@ async def test_generate_grid_explicit_failure_preserves_the_old_artifact_path(
     monkeypatch.setattr("server.media_tools.grid.resolve_large_grid_allowed", _gate)
     batch_waiter = _fake_grid_waiter(failing_enqueue)
 
-    out = await _call(
+    out = await call(
         generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json", "scene_ids": ["E1S01"]}
     )
 
     assert out.get("is_error") is True
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.failed == ["E1S01"]
     item = result.items[0]
     assert item.artifact_path == "storyboards/E1S01.png"
@@ -291,9 +291,9 @@ async def test_generate_grid_wait_timeout_is_reported_as_interrupted_not_failed(
     monkeypatch.setattr("server.media_tools.grid.resolve_large_grid_allowed", _gate)
     batch_waiter = _fake_grid_waiter(fake_enqueue, fake_wait)
 
-    out = await _call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
+    out = await call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == []
     assert result.failed == ["E1S01", "E1S02", "E1S03", "E1S04"]
     item = result.items[0]
@@ -338,9 +338,9 @@ async def test_generate_grid_reports_each_scene_of_a_shared_grid(
     batch_waiter = _fake_grid_waiter(fake_enqueue, fake_wait)
     monkeypatch.setattr("server.media_tools.grid.apply_grid_split", partial_split)
 
-    out = await _call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
+    out = await call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["E1S01", "E1S02", "E1S03"]
     assert result.failed == ["E1S04"]
     assert set(result.requested) == set(result.succeeded) | set(result.failed) | set(result.blocked)
@@ -404,9 +404,9 @@ async def test_generate_grid_blocks_the_whole_group_when_one_scene_state_is_unre
     )
     batch_waiter = _fake_grid_waiter(fake_enqueue)
 
-    out = await _call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
+    out = await call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert enqueued == []
     assert sorted(result.blocked) == ["E1S01", "E1S02", "E1S03", "E1S04"]
     assert result.succeeded == []
@@ -467,9 +467,9 @@ async def test_generate_grid_spares_an_already_reusable_sibling_when_one_scene_s
     )
     batch_waiter = _fake_grid_waiter(fake_enqueue)
 
-    out = await _call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
+    out = await call(generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert enqueued == []
     assert sorted(result.blocked) == ["E1S01", "E1S02", "E1S04"]
     assert "E1S03" not in result.requested
@@ -481,7 +481,7 @@ async def test_generate_grid_rejects_an_explicitly_empty_scene_selection(fake_ct
     fake_ctx.pm.project_payload["generation_mode"] = "storyboard"
     fake_ctx.pm.project_payload["grid_storyboard"] = True
 
-    out = await _call(generate_grid_tool(fake_ctx), {"script": "episode_1.json", "scene_ids": []})
+    out = await call(generate_grid_tool(fake_ctx), {"script": "episode_1.json", "scene_ids": []})
 
     assert out.get("is_error") is True
     assert "不能为空数组" in out["content"][0]["text"]
@@ -553,7 +553,7 @@ async def test_generate_grid_cleans_superseded_records(fake_ctx: ToolContext, mo
     gm.save(other_group)
 
     tool_obj = generate_grid_tool(fake_ctx, batch_waiter=batch_waiter)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
 
     remaining = gm.list_all()
@@ -630,7 +630,7 @@ async def test_generate_grid_cleanup_spares_a_fully_reusable_chunk_of_an_oversiz
     gm.save(fully_reusable_chunk)
 
     tool_obj = generate_grid_tool(fake_ctx, batch_waiter=batch_waiter)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
 
     remaining_ids = {g.id for g in gm.list_all()}
@@ -653,7 +653,7 @@ async def test_generate_grid_list_only_falls_back_on_null_aspect_ratio(
 
     monkeypatch.setattr("server.media_tools.grid.resolve_large_grid_allowed", _gate)
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
+    out = await call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is not True
     assert "grid_4 (2×2)" in out["content"][0]["text"]
 
@@ -699,7 +699,7 @@ async def test_generate_grid_splits_oversized_group_into_multiple_grids(
     monkeypatch.setattr("server.media_tools.grid.apply_grid_split", fake_split)
 
     tool_obj = generate_grid_tool(fake_ctx, batch_waiter=batch_waiter)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
     # 每张生成成功的宫格都被显式切分
     assert len(split_calls) == 2
@@ -720,7 +720,7 @@ async def test_generate_grid_splits_oversized_group_into_multiple_grids(
 async def test_generate_grid_wrong_mode(fake_ctx: ToolContext) -> None:
     # 项目未开启 grid_storyboard → error
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
 
 
@@ -729,7 +729,7 @@ async def test_generate_grid_rejected_on_reference_video_route(fake_ctx: ToolCon
     fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
     fake_ctx.pm.project_payload["grid_storyboard"] = True
     tool_obj = generate_grid_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "list_only": True})
+    out = await call(tool_obj, {"script": "episode_1.json", "list_only": True})
     assert out.get("is_error") is True
 
 
@@ -748,7 +748,7 @@ async def test_generate_grid_legacy_unresolvable_episode_fails_before_enqueue(
     enqueue = AsyncMock(side_effect=AssertionError("must not enqueue"))
     batch_waiter = enqueue
 
-    out = await _call(mod.generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "draft.json"})
+    out = await call(mod.generate_grid_tool(fake_ctx, batch_waiter=batch_waiter), {"script": "draft.json"})
 
     assert out.get("is_error") is True
     assert "无法确定集号" in out["content"][0]["text"]

--- a/tests/integration/server/media_tools/test_image_edits.py
+++ b/tests/integration/server/media_tools/test_image_edits.py
@@ -36,7 +36,7 @@ async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     project_path = fake_ctx.project_path
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
 
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
@@ -72,7 +72,7 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
     project_path = fake_ctx.project_path
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
 
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
@@ -127,8 +127,8 @@ async def test_edit_images_active_asset_without_a_manifest_claim_is_not_enqueued
     project_path = fake_ctx.project_path
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
     comparisons = []
 
     class _Currency:
@@ -173,10 +173,10 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
     (project_path / "characters" / "lisi.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["李四"]["character_sheet"] = "characters/lisi.png"  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["characters"]["李四"]["description"] = "配角"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
+    fake_ctx.pm.project_payload["characters"]["李四"]["character_sheet"] = "characters/lisi.png"
+    fake_ctx.pm.project_payload["characters"]["李四"]["description"] = "配角"
 
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
@@ -241,8 +241,8 @@ async def test_edit_images_storyboard_rejects_an_unbound_script_before_provider(
 ) -> None:
     from server.media_tools import image_edits as mod
 
-    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["episodes"] = []  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
+    fake_ctx.pm.project_payload["episodes"] = []
     resolver = _use_fake_caps(fake_ctx)
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
@@ -296,7 +296,7 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
     project_path = fake_ctx.project_path
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
 
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
@@ -385,7 +385,7 @@ async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) 
     project_path = fake_ctx.project_path
     (project_path / "characters").mkdir()
     (project_path / "characters" / "zhangsan.png").write_bytes(b"png")
-    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["characters"]["张三"]["character_sheet"] = "characters/zhangsan.png"
 
     async def fake_batch(*, project_name, specs, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult
@@ -412,7 +412,7 @@ async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
     def boom(_name: str) -> dict[str, Any]:
         raise RuntimeError("db down")
 
-    fake_ctx.pm.load_project = boom  # type: ignore[method-assign]
+    fake_ctx.pm.load_project = boom
     tool_obj = edit_images_tool(fake_ctx)
     out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "x"}]})
     assert out.get("is_error") is True

--- a/tests/integration/server/media_tools/test_image_edits.py
+++ b/tests/integration/server/media_tools/test_image_edits.py
@@ -12,10 +12,10 @@ from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.media_tools.context import ToolContext
 from server.media_tools.image_edits import edit_images_tool
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _fake_caps_resolver,
-    _generation_result,
-    _use_fake_caps,
+    call,
+    fake_caps_resolver,
+    read_generation_result,
+    use_fake_caps,
 )
 
 # ---------------------------------------------------------------------------
@@ -52,10 +52,10 @@ async def test_edit_images_happy(fake_ctx: ToolContext, monkeypatch) -> None:
         ]
         return succ, []
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {"resource_type": "character", "edits": [{"id": "张三", "instruction": "把头发改成红色"}]},
     )
@@ -83,15 +83,15 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
         ]
         return [], fail
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {"resource_type": "character", "edits": [{"id": "张三", "instruction": "把头发改成红色"}]},
     )
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.failed == ["张三"]
     item = result.items[0]
     assert item.artifact_path == "characters/zhangsan.png"
@@ -99,9 +99,9 @@ async def test_edit_images_failure_preserves_the_untouched_source_path(fake_ctx:
 
 async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext) -> None:
     """i2i 不可用时直接报错，不创建任何任务（复用服务端 fail-fast 判断点）。"""
-    _use_fake_caps(fake_ctx, image_backend_error=ValueError("未找到可用的 image 供应商"))
+    use_fake_caps(fake_ctx, image_backend_error=ValueError("未找到可用的 image 供应商"))
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {"resource_type": "character", "edits": [{"id": "张三", "instruction": "把头发改成红色"}]},
     )
@@ -109,7 +109,7 @@ async def test_edit_images_i2i_unavailable(fake_ctx: ToolContext) -> None:
 
     # i2i 不可用是入队前的共享前置条件，但调用方仍按逐 ID 契约读结果——每个
     # 请求到的 ID 各记一条 blocked，而不是只回一段无法编程消费的文本。
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.blocked == ["张三"]
     item = result.items[0]
     assert item.problem is not None
@@ -142,10 +142,10 @@ async def test_edit_images_active_asset_without_a_manifest_claim_is_not_enqueued
 
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _Currency())
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(
+    out = await call(
         edit_images_tool(fake_ctx),
         {"resource_type": "character", "edits": [{"id": "张三", "instruction": "换发色"}]},
     )
@@ -197,7 +197,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
             raise ArtifactManifestError("manifest sidecar unreadable")
         return _ImageEditSource(resource_id=resource_id, artifact_path="characters/lisi.png", formal_claims=())
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr("server.media_tools.image_edits.batch_enqueue_and_wait", fake_batch)
     monkeypatch.setattr(
         "server.media_tools.image_edits.active_artifact_currency_resolver",
@@ -208,7 +208,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
         fake_resolve_source,
     )
 
-    out = await _call(
+    out = await call(
         edit_images_tool(fake_ctx),
         {
             "resource_type": "character",
@@ -219,7 +219,7 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
         },
     )
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["李四"]
     assert result.blocked == ["张三"]
     blocked_item = next(entry for entry in result.items if entry.unit_id == "张三")
@@ -228,9 +228,9 @@ async def test_edit_images_one_manifest_fail_loud_error_does_not_abort_the_batch
 
 
 async def test_edit_images_storyboard_requires_script_file(fake_ctx: ToolContext) -> None:
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(tool_obj, {"resource_type": "storyboard", "edits": [{"id": "E1S01", "instruction": "去杂物"}]})
+    out = await call(tool_obj, {"resource_type": "storyboard", "edits": [{"id": "E1S01", "instruction": "去杂物"}]})
     assert out.get("is_error") is True
     assert "script_file" in out["content"][0]["text"]
 
@@ -243,11 +243,11 @@ async def test_edit_images_storyboard_rejects_an_unbound_script_before_provider(
 
     fake_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
     fake_ctx.pm.project_payload["episodes"] = []
-    resolver = _use_fake_caps(fake_ctx)
+    resolver = use_fake_caps(fake_ctx)
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(
+    out = await call(
         edit_images_tool(fake_ctx),
         {
             "resource_type": "storyboard",
@@ -265,17 +265,17 @@ async def test_edit_images_storyboard_rejects_an_unbound_script_before_provider(
 
 async def test_edit_images_rejects_unknown_resource_type(fake_ctx: ToolContext) -> None:
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(tool_obj, {"resource_type": "video", "edits": [{"id": "x", "instruction": "y"}]})
+    out = await call(tool_obj, {"resource_type": "video", "edits": [{"id": "x", "instruction": "y"}]})
     assert out.get("is_error") is True
 
 
 async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext) -> None:
     """资产没有可编辑的当前图（sheet 字段未设置）时跳过并告警，不入队。"""
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     tool_obj = edit_images_tool(fake_ctx)
     # 李四 没有 character_sheet
-    out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "李四", "instruction": "换发色"}]})
+    out = await call(tool_obj, {"resource_type": "character", "edits": [{"id": "李四", "instruction": "换发色"}]})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "李四" in text
@@ -284,7 +284,7 @@ async def test_edit_images_skips_missing_current_image(fake_ctx: ToolContext) ->
 
 async def test_edit_images_rejects_empty_edits(fake_ctx: ToolContext) -> None:
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(tool_obj, {"resource_type": "character", "edits": []})
+    out = await call(tool_obj, {"resource_type": "character", "edits": []})
     assert out.get("is_error") is True
     assert "edits 不能为空" in out["content"][0]["text"]
 
@@ -312,10 +312,10 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
         ]
         return succ, []
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {
             "resource_type": "character",
@@ -335,7 +335,7 @@ async def test_edit_images_build_specs_warnings(fake_ctx: ToolContext, monkeypat
     assert "缺少 id 的条目" in text
     assert "重复出现" in text
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["张三"]
     assert sorted(result.blocked) == ["李四", "王五"]
     problems = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
@@ -363,10 +363,10 @@ async def test_edit_images_storyboard_happy(fake_ctx: ToolContext, monkeypatch) 
         ]
         return succ, []
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {
             "resource_type": "storyboard",
@@ -396,10 +396,10 @@ async def test_edit_images_reports_failures(fake_ctx: ToolContext, monkeypatch) 
         ]
         return [], fail
 
-    _use_fake_caps(fake_ctx)
+    use_fake_caps(fake_ctx)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "改发型"}]})
+    out = await call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "改发型"}]})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "成功 0 件、失败 1 件" in text
@@ -414,7 +414,7 @@ async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
 
     fake_ctx.pm.load_project = boom
     tool_obj = edit_images_tool(fake_ctx)
-    out = await _call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "x"}]})
+    out = await call(tool_obj, {"resource_type": "character", "edits": [{"id": "张三", "instruction": "x"}]})
     assert out.get("is_error") is True
     assert "edit_images 失败" in out["content"][0]["text"]
 
@@ -422,7 +422,7 @@ async def test_edit_images_unexpected_exception(fake_ctx: ToolContext) -> None:
 async def test_i2i_provider_available_true() -> None:
     from server.media_tools import image_edits as mod
 
-    resolver = _fake_caps_resolver()
+    resolver = fake_caps_resolver()
     assert await mod._i2i_provider_available({}, config_resolver=resolver) is True
     # 判的是 i2i 槽位，不是项目默认图像槽
     assert resolver.image_capability_calls == ["i2i"]
@@ -431,5 +431,5 @@ async def test_i2i_provider_available_true() -> None:
 async def test_i2i_provider_available_false_on_value_error() -> None:
     from server.media_tools import image_edits as mod
 
-    resolver = _fake_caps_resolver(image_backend_error=ValueError("未找到可用的 image 供应商"))
+    resolver = fake_caps_resolver(image_backend_error=ValueError("未找到可用的 image 供应商"))
     assert await mod._i2i_provider_available({}, config_resolver=resolver) is False

--- a/tests/integration/server/media_tools/test_narration_audio.py
+++ b/tests/integration/server/media_tools/test_narration_audio.py
@@ -10,11 +10,11 @@ from lib.artifact_manifest import ArtifactKey, ArtifactStatus
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.media_tools.context import ToolContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _activate_unbound_project,
-    _call,
-    _generation_result,
-    _reference_video_script,
-    _use_reference_route,
+    activate_unbound_project,
+    call,
+    read_generation_result,
+    reference_video_script,
+    use_reference_route,
 )
 
 # ---------------------------------------------------------------------------
@@ -65,10 +65,10 @@ async def test_generate_narration_audio_missing_only_reuses_a_stale_recording(
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _AllStaleResolver())
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.requested == []
     assert {entry.unit_id: entry.artifact_status for entry in result.skipped} == {
         "E1S01": ArtifactStatus.STALE,
@@ -99,14 +99,14 @@ async def test_generate_narration_audio_explicit_ids_regenerate_a_stale_recordin
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _AllStaleResolver())
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(
+    out = await call(
         mod.generate_narration_audio_tool(fake_ctx),
         {"script": "episode_1.json", "segment_ids": ["E1S01"]},
     )
 
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1S01"]
-    assert _generation_result(out).succeeded == ["E1S01"]
+    assert read_generation_result(out).succeeded == ["E1S01"]
 
 
 async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: ToolContext, monkeypatch) -> None:
@@ -133,7 +133,7 @@ async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: Tool
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S01"]
@@ -151,8 +151,8 @@ async def test_generate_narration_audio_covers_reference_video_units(fake_ctx: T
     """参考生视频的 video_units 同样可点名配音——入口按当前骨架取单元，不限生成模式。"""
     from server.media_tools import narration_audio as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script(
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script(
         video_units=[{"unit_id": "E1U1", "duration_seconds": 5, "text": "{风吹过旷野。}"}]
     )
     captured: list[Any] = []
@@ -172,7 +172,7 @@ async def test_generate_narration_audio_covers_reference_video_units(fake_ctx: T
         ], []
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
-    out = await _call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1U1"]
@@ -186,7 +186,7 @@ async def test_generate_narration_audio_rejects_unbound_active_script_before_enq
 ) -> None:
     from server.media_tools import narration_audio as mod
 
-    _activate_unbound_project(fake_ctx)
+    activate_unbound_project(fake_ctx)
     fake_ctx.pm.script_payload = _narration_audio_script()
     enqueued = False
 
@@ -197,7 +197,7 @@ async def test_generate_narration_audio_rejects_unbound_active_script_before_enq
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
@@ -238,12 +238,12 @@ async def test_generate_narration_audio_uses_canonical_filename_when_episode_fie
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
 
-    out = await _call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_2.json"})
+    out = await call(mod.generate_narration_audio_tool(fake_ctx), {"script": "episode_2.json"})
 
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1S01"]
     # 集号取自项目绑定而非剧本自述：产物身份随之落在第 2 集
-    assert _generation_result(out).items[0].artifact_key == ArtifactKey.episode_audio(2, "E1S01").encode()
+    assert read_generation_result(out).items[0].artifact_key == ArtifactKey.episode_audio(2, "E1S01").encode()
 
 
 async def test_generate_narration_audio_selects_item_with_corrupt_generated_assets(
@@ -274,7 +274,7 @@ async def test_generate_narration_audio_selects_item_with_corrupt_generated_asse
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S01"]
@@ -297,7 +297,7 @@ async def test_generate_narration_audio_explicit_ids_regenerate(fake_ctx: ToolCo
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S02"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S02"]})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S02"]
@@ -324,18 +324,18 @@ async def test_generate_narration_audio_blank_text_reported(fake_ctx: ToolContex
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
 
     # 扫描模式：空白段根本不是缺口，不进 requested，也不阻塞其余段
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S01"]
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert "E1S03" not in result.requested
 
     # 显式点名空白段：该段按 blocked 上报，带稳定 code 与下一步动作
     captured.clear()
-    out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S03"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S03"]})
     assert out.get("is_error") is True
     assert captured == []
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.requested == ["E1S03"]
     assert result.blocked == ["E1S03"]
     problem = result.items[0].problem
@@ -362,11 +362,11 @@ async def test_generate_narration_audio_partial_unmatched_reported(fake_ctx: Too
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S01", "E1S99"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "segment_ids": ["E1S01", "E1S99"]})
 
     assert out.get("is_error") is True
     assert [s.resource_id for s in captured] == ["E1S01"]
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.requested) == ["E1S01", "E1S99"]
     assert result.succeeded == ["E1S01"]
     assert result.blocked == ["E1S99"]
@@ -402,7 +402,7 @@ async def test_generate_narration_audio_accepts_drama_narrator_scene(
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1S01"]
     assert captured[0].payload == {"prompt": None, "script_file": "episode_1.json"}
@@ -434,7 +434,7 @@ async def test_generate_narration_audio_uses_project_mode_for_drama_without_cont
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1S01"]
 
@@ -467,7 +467,7 @@ async def test_generate_narration_audio_accepts_reference_narrator_unit(
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in captured] == ["E1U1"]
 
@@ -482,7 +482,7 @@ async def test_generate_narration_audio_rejects_mismatched_script(fake_ctx: Tool
         "video_units": [{"unit_id": "E1U1"}],
     }
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "骨架" in text
@@ -495,7 +495,7 @@ async def test_generate_narration_audio_rejects_string_segment_ids(fake_ctx: Too
 
     fake_ctx.pm.script_payload = _narration_audio_script()
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": "E1S01"})
+    out = await call(tool_obj, {"script": "episode_1.json", "segment_ids": "E1S01"})
     assert out.get("is_error") is True
     assert "数组" in out["content"][0]["text"]
 
@@ -521,11 +521,11 @@ async def test_generate_narration_audio_skips_segment_without_id(fake_ctx: ToolC
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S01", "E1S02"]
-    assert _generation_result(out).requested == ["E1S01", "E1S02"]
+    assert read_generation_result(out).requested == ["E1S01", "E1S02"]
 
 
 async def test_generate_narration_audio_no_match_error(fake_ctx: ToolContext) -> None:
@@ -533,9 +533,9 @@ async def test_generate_narration_audio_no_match_error(fake_ctx: ToolContext) ->
 
     fake_ctx.pm.script_payload = _narration_audio_script()
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": ["NO_SUCH"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "segment_ids": ["NO_SUCH"]})
     assert out.get("is_error") is True
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.requested == ["NO_SUCH"]
     assert result.blocked == ["NO_SUCH"]
 
@@ -547,10 +547,10 @@ async def test_generate_narration_audio_all_done(fake_ctx: ToolContext) -> None:
     script["segments"][0]["generated_assets"] = {"narration_audio": "audio/segment_E1S01.wav"}
     fake_ctx.pm.script_payload = script
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
     # 已有配音的单元被复用而非重生：不进 requested，只作为 skipped 报告。
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.requested == []
     assert [entry.unit_id for entry in result.skipped] == ["E1S01", "E1S02"]
 
@@ -571,7 +571,7 @@ async def test_generate_narration_audio_task_failures_surface(fake_ctx: ToolCont
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
     assert "成功 0 件、失败 1 件" in text
@@ -582,6 +582,6 @@ async def test_generate_narration_audio_rejects_path_in_script_arg(fake_ctx: Too
     from server.media_tools import narration_audio as mod
 
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "../etc/passwd"})
+    out = await call(tool_obj, {"script": "../etc/passwd"})
     assert out.get("is_error") is True
     assert "路径分隔符" in out["content"][0]["text"]

--- a/tests/integration/server/media_tools/test_narration_audio.py
+++ b/tests/integration/server/media_tools/test_narration_audio.py
@@ -60,7 +60,7 @@ async def test_generate_narration_audio_missing_only_reuses_a_stale_recording(
 
     script = _narration_audio_script()
     script["segments"][0]["generated_assets"] = {"narration_audio": "audio/segment_E1S01.wav"}
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     enqueue = AsyncMock()
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _AllStaleResolver())
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
@@ -85,7 +85,7 @@ async def test_generate_narration_audio_explicit_ids_regenerate_a_stale_recordin
 
     script = _narration_audio_script()
     script["segments"][0]["generated_assets"] = {"narration_audio": "audio/segment_E1S01.wav"}
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -113,7 +113,7 @@ async def test_generate_narration_audio_enqueues_missing_segments(fake_ctx: Tool
     """不传 segment_ids → 只为缺 narration_audio 的段入队 tts 任务，prompt 为该段 novel_text。"""
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -152,7 +152,7 @@ async def test_generate_narration_audio_covers_reference_video_units(fake_ctx: T
     from server.media_tools import narration_audio as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script(
         video_units=[{"unit_id": "E1U1", "duration_seconds": 5, "text": "{风吹过旷野。}"}]
     )
     captured: list[Any] = []
@@ -187,7 +187,7 @@ async def test_generate_narration_audio_rejects_unbound_active_script_before_enq
     from server.media_tools import narration_audio as mod
 
     _activate_unbound_project(fake_ctx)
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     enqueued = False
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -213,8 +213,8 @@ async def test_generate_narration_audio_uses_canonical_filename_when_episode_fie
     script = _narration_audio_script()
     script.pop("episode")
     script["segments"] = script["segments"][:1]
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
+    fake_ctx.pm.project_payload.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "content_mode": "narration",
@@ -223,7 +223,7 @@ async def test_generate_narration_audio_uses_canonical_filename_when_episode_fie
         }
     )
     (fake_ctx.project_path / "project.json").write_text(
-        json.dumps(fake_ctx.pm.project_payload),  # type: ignore[attr-defined]
+        json.dumps(fake_ctx.pm.project_payload),
         encoding="utf-8",
     )
     captured: list[Any] = []
@@ -254,7 +254,7 @@ async def test_generate_narration_audio_selects_item_with_corrupt_generated_asse
 
     script = _narration_audio_script()
     script["segments"][0]["generated_assets"] = "corrupt"
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -284,7 +284,7 @@ async def test_generate_narration_audio_explicit_ids_regenerate(fake_ctx: ToolCo
     """传 segment_ids → 即使该段已有 narration_audio 也重新入队（批量范围/单段重生语义）。"""
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -309,7 +309,7 @@ async def test_generate_narration_audio_blank_text_reported(fake_ctx: ToolContex
 
     script = _narration_audio_script()
     script["segments"].append({"segment_id": "E1S03", "novel_text": "   ", "video_prompt": {}, "generated_assets": {}})
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -349,7 +349,7 @@ async def test_generate_narration_audio_partial_unmatched_reported(fake_ctx: Too
     """部分 id 不命中不能静默丢弃：命中的照常入队，未命中的按 blocked 逐 ID 上报。"""
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -381,8 +381,8 @@ async def test_generate_narration_audio_accepts_drama_narrator_scene(
 ) -> None:
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "drama"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = "drama"
+    fake_ctx.pm.script_payload = {
         "content_mode": "drama",
         "episode": 1,
         "scenes": [
@@ -414,8 +414,8 @@ async def test_generate_narration_audio_uses_project_mode_for_drama_without_cont
 ) -> None:
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "drama"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = "drama"
+    fake_ctx.pm.script_payload = {
         "episode": 1,
         "scenes": [
             {
@@ -445,8 +445,8 @@ async def test_generate_narration_audio_accepts_reference_narrator_unit(
 ) -> None:
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "video_units": [
@@ -476,7 +476,7 @@ async def test_generate_narration_audio_rejects_mismatched_script(fake_ctx: Tool
     """分镜图生视频项目下的 video_units 骨架剧本：结构报错 + 重拆指引，不静默换路径。"""
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "video_units": [{"unit_id": "E1U1"}],
@@ -493,7 +493,7 @@ async def test_generate_narration_audio_rejects_string_segment_ids(fake_ctx: Too
     """segment_ids 传裸字符串会被逐字符迭代成 {'E','1','S'...}，必须显式拒绝。"""
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": "E1S01"})
     assert out.get("is_error") is True
@@ -508,7 +508,7 @@ async def test_generate_narration_audio_skips_segment_without_id(fake_ctx: ToolC
     # 两个分镜都缺配音：本用例的主题是无 ID 分镜的可寻址性，不掺入已有配音的复用判定。
     script["segments"][1]["generated_assets"] = {}
     script["segments"].append({"novel_text": "有文本但缺 id 的片段。", "video_prompt": {}, "generated_assets": {}})
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     captured: list[Any] = []
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -531,7 +531,7 @@ async def test_generate_narration_audio_skips_segment_without_id(fake_ctx: ToolC
 async def test_generate_narration_audio_no_match_error(fake_ctx: ToolContext) -> None:
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "segment_ids": ["NO_SUCH"]})
     assert out.get("is_error") is True
@@ -545,7 +545,7 @@ async def test_generate_narration_audio_all_done(fake_ctx: ToolContext) -> None:
 
     script = _narration_audio_script()
     script["segments"][0]["generated_assets"] = {"narration_audio": "audio/segment_E1S01.wav"}
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     tool_obj = mod.generate_narration_audio_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
@@ -558,7 +558,7 @@ async def test_generate_narration_audio_all_done(fake_ctx: ToolContext) -> None:
 async def test_generate_narration_audio_task_failures_surface(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.media_tools import narration_audio as mod
 
-    fake_ctx.pm.script_payload = _narration_audio_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _narration_audio_script()
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
         from lib.generation_queue_client import BatchTaskResult

--- a/tests/integration/server/media_tools/test_storyboards.py
+++ b/tests/integration/server/media_tools/test_storyboards.py
@@ -70,12 +70,12 @@ async def test_generate_storyboards_happy(fake_ctx: ToolContext, monkeypatch) ->
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     # Strip storyboard_image to force selection
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {}  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {}
     semantic_prompt = {
         "scene": "村口黄昏",
         "composition": {"shot_type": "Medium Shot", "lighting": "暖光", "ambiance": "薄雾"},
     }
-    fake_ctx.pm.script_payload["segments"][0]["image_prompt"] = semantic_prompt  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["image_prompt"] = semantic_prompt
     tool_obj = generate_storyboards_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
@@ -90,7 +90,7 @@ async def test_generate_storyboards_legacy_project_reverifies_image_file_on_disk
     from server.media_tools import storyboards as mod
 
     # E1S01 的分镜图由 fixture 落在磁盘上；E1S02 只在剧本里登记路径，文件并不存在。
-    fake_ctx.pm.script_payload["segments"].append(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"].append(
         {
             "segment_id": "E1S02",
             "image_prompt": "村口清晨",
@@ -134,7 +134,7 @@ async def test_generate_storyboards_rejects_unbound_active_script_before_enqueue
     from server.media_tools import storyboards as mod
 
     _activate_unbound_project(fake_ctx)
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {}  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {}
     enqueued = False
 
     async def fake_batch(*, project_name, specs, on_success=None, on_failure=None, **_batch_kwargs):
@@ -175,7 +175,7 @@ async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
         return succ, []
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = "corrupt"  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = "corrupt"
     tool_obj = generate_storyboards_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
@@ -184,7 +184,7 @@ async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
 
 async def test_generate_storyboards_rejects_mismatched_unit_script(fake_ctx: ToolContext) -> None:
     """失配剧本不能落进"✨ 所有分镜的分镜图都已生成"的假成功——报结构错误并指引重拆。"""
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "video_units": [{"unit_id": "E1U1"}],
@@ -202,7 +202,7 @@ async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) ->
     def boom(*args, **kwargs):
         raise ValueError("bad script")
 
-    fake_ctx.pm.load_script = boom  # type: ignore[attr-defined]
+    fake_ctx.pm.load_script = boom
     tool_obj = generate_storyboards_tool(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
@@ -212,7 +212,7 @@ async def test_generate_storyboards_reports_a_partial_batch_per_id(fake_ctx: Too
     """一批里有成有败时逐 ID 分账，失败项带稳定 code，不需要读文本判断重试。"""
     from server.media_tools import storyboards as mod
 
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": "E1S01", "image_prompt": "村口黄昏", "generated_assets": {}},
         {"segment_id": "E1S02", "image_prompt": "山道清晨", "generated_assets": {}},
     ]

--- a/tests/integration/server/media_tools/test_storyboards.py
+++ b/tests/integration/server/media_tools/test_storyboards.py
@@ -7,9 +7,9 @@ from typing import Any
 from server.media_tools.context import ToolContext
 from server.media_tools.storyboards import generate_storyboards_tool
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _activate_unbound_project,
-    _call,
-    _generation_result,
+    activate_unbound_project,
+    call,
+    read_generation_result,
 )
 
 # ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ async def test_generate_storyboards_happy(fake_ctx: ToolContext, monkeypatch) ->
     }
     fake_ctx.pm.script_payload["segments"][0]["image_prompt"] = semantic_prompt
     tool_obj = generate_storyboards_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
     assert captured[0].payload["prompt"] == semantic_prompt
 
@@ -119,9 +119,9 @@ async def test_generate_storyboards_legacy_project_reverifies_image_file_on_disk
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert enqueued == ["E1S02"]
     assert result.succeeded == ["E1S02"]
     assert [entry.unit_id for entry in result.skipped] == ["E1S01"]
@@ -133,7 +133,7 @@ async def test_generate_storyboards_rejects_unbound_active_script_before_enqueue
 ) -> None:
     from server.media_tools import storyboards as mod
 
-    _activate_unbound_project(fake_ctx)
+    activate_unbound_project(fake_ctx)
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {}
     enqueued = False
 
@@ -144,7 +144,7 @@ async def test_generate_storyboards_rejects_unbound_active_script_before_enqueue
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(mod.generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(mod.generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
@@ -177,7 +177,7 @@ async def test_generate_storyboards_selects_item_with_corrupt_generated_assets(
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = "corrupt"
     tool_obj = generate_storyboards_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in captured] == ["E1S01"]
 
@@ -190,7 +190,7 @@ async def test_generate_storyboards_rejects_mismatched_unit_script(fake_ctx: Too
         "video_units": [{"unit_id": "E1U1"}],
     }
     tool_obj = generate_storyboards_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
@@ -204,7 +204,7 @@ async def test_generate_storyboards_error(fake_ctx: ToolContext, monkeypatch) ->
 
     fake_ctx.pm.load_script = boom
     tool_obj = generate_storyboards_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
 
 
@@ -243,10 +243,10 @@ async def test_generate_storyboards_reports_a_partial_batch_per_id(fake_ctx: Too
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
+    out = await call(generate_storyboards_tool(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["E1S01"]
     assert result.failed == ["E1S02"]
     assert set(result.requested) == {"E1S01", "E1S02"}
@@ -263,6 +263,6 @@ async def test_generate_storyboards_reports_a_partial_batch_per_id(fake_ctx: Too
 async def test_generate_storyboards_rejects_path_in_script_arg(fake_ctx: ToolContext) -> None:
     """Agent 传带路径分隔符的 script 名必须被 handler 拒绝（共享 validate_script_filename 防御）。"""
     tool_obj = generate_storyboards_tool(fake_ctx)
-    out = await _call(tool_obj, {"script": "../etc/passwd"})
+    out = await call(tool_obj, {"script": "../etc/passwd"})
     assert out.get("is_error") is True
     assert "路径分隔符" in out["content"][0]["text"]

--- a/tests/integration/server/media_tools/test_videos.py
+++ b/tests/integration/server/media_tools/test_videos.py
@@ -162,9 +162,7 @@ async def test_generate_videos_episode_scope_declares_the_missing_only_selection
     """整集生成从不强制重生：已有可用片段一律复用，所以选择模式如实报 missing-only。"""
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {  # type: ignore[attr-defined]
-        "storyboard_image": "storyboards/scene_E1S01.png"
-    }
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
 
     out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
@@ -180,7 +178,7 @@ async def test_generate_videos_episode_scope_skips_current_clip(fake_ctx: ToolCo
     from lib.artifact_manifest import ArtifactComparison
     from server.media_tools import videos as mod
 
-    project = fake_ctx.pm.project_payload  # type: ignore[attr-defined]
+    project = fake_ctx.pm.project_payload
     project.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
@@ -188,8 +186,8 @@ async def test_generate_videos_episode_scope_skips_current_clip(fake_ctx: ToolCo
             "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
         }
     )
-    fake_ctx.pm.script_payload["episode"] = 1  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["episode"] = 1
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {
         "storyboard_image": "storyboards/scene_E1S01.png",
         "video_clip": "videos/scene_E1S01.mp4",
     }
@@ -235,7 +233,7 @@ async def test_generate_videos_episode_scope_blocks_a_clip_whose_manifest_state_
     from lib.artifact_manifest import ArtifactComparison
     from server.media_tools import videos as mod
 
-    project = fake_ctx.pm.project_payload  # type: ignore[attr-defined]
+    project = fake_ctx.pm.project_payload
     project.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
@@ -243,8 +241,8 @@ async def test_generate_videos_episode_scope_blocks_a_clip_whose_manifest_state_
             "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
         }
     )
-    fake_ctx.pm.script_payload["episode"] = 1  # type: ignore[attr-defined]
-    segments = fake_ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["episode"] = 1
+    segments = fake_ctx.pm.script_payload["segments"]
     segments[0]["generated_assets"] = {
         "storyboard_image": "storyboards/scene_E1S01.png",
         "video_clip": "videos/scene_E1S01.mp4",
@@ -327,8 +325,8 @@ async def test_generate_videos_episode_scope_resolves_episode_from_canonical_fil
     from server.media_tools import videos as mod
     from server.services import video_batch_admission as admission_mod
 
-    fake_ctx.pm.script_payload.pop("episode")  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload.pop("episode")
+    fake_ctx.pm.project_payload.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "content_mode": "narration",
@@ -378,7 +376,7 @@ async def test_generate_videos_episode_scope_non_dict_generated_assets_does_not_
 
     project_dir = fake_ctx.pm.get_project_path("demo")
     (project_dir / "storyboards" / "scene_E1S02.png").write_bytes(b"png")
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {
             "segment_id": "E1S01",
             "novel_text": "第一段旁白。",
@@ -413,7 +411,7 @@ async def test_generate_videos_episode_scope_non_dict_generated_assets_does_not_
 
 
 async def test_generate_videos_episode_scope_error(fake_ctx: ToolContext) -> None:
-    fake_ctx.pm.script_payload = {"content_mode": "narration", "segments": [], "episode": 1}  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = {"content_mode": "narration", "segments": [], "episode": 1}
     tool_obj = _episode_scope(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
@@ -426,7 +424,7 @@ async def test_generate_reference_video_rejects_unbound_active_script_before_gen
     from server.media_tools import videos as mod
 
     _activate_unbound_project(fake_ctx, generation_mode="reference_video")
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
@@ -444,8 +442,8 @@ async def test_generate_reference_video_legacy_unresolvable_episode_fails_before
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload.pop("episode")  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
+    fake_ctx.pm.script_payload.pop("episode")
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
@@ -469,7 +467,7 @@ async def test_generate_videos_episode_scope_reference_rejects_malformed_unit_co
     ):
         # 键在场即按类型判定，不看真值：``{}`` / ``""`` / ``False`` 同样是类型错误，
         # 报成「为空」会把成因埋掉。
-        fake_ctx.pm.script_payload = _reference_video_script(video_units=malformed)  # type: ignore[attr-defined]
+        fake_ctx.pm.script_payload = _reference_video_script(video_units=malformed)
         tool_obj = _episode_scope(fake_ctx)
         out = await _call(tool_obj, {"script": "episode_1.json"})
         assert out.get("is_error") is True
@@ -485,7 +483,7 @@ async def test_generate_videos_episode_scope_reference_duration_needs_confirmati
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -576,7 +574,7 @@ async def test_generate_videos_episode_scope_reference_returns_structured_projec
     from lib.reference_video.request_projection import ProjectionProblem
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     class _BlockedProjection:
         unit_id = "E1U1"
@@ -669,7 +667,7 @@ async def test_generate_videos_episode_scope_reference_duration_confirm_enqueues
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -719,7 +717,7 @@ async def test_generate_videos_reference_force_false_reuses_existing_video(fake_
     )
     script = _reference_video_script()
     script["video_units"][0]["generated_assets"] = {"video_clip": video_path}
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     fake_ctx.queue = GenerationQueue(session_factory=db_factory)
 
     out = await _call(
@@ -743,7 +741,7 @@ async def test_generate_videos_scene_force_false_reuses_existing_video(fake_ctx:
         resource_id="E1S01",
         content=b"existing-video",
     )
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"]["video_clip"] = video_path  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"]["video_clip"] = video_path
 
     out = await _call(
         generate_videos_tool(fake_ctx),
@@ -845,7 +843,7 @@ async def test_generate_videos_resubmits_only_remaining_ids_from_a_durable_batch
     from lib.db.base import DEFAULT_USER_ID
     from server.tool_runtime import CallerContext
 
-    segments = fake_ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+    segments = fake_ctx.pm.script_payload["segments"]
     segments.append(
         {
             **segments[0],
@@ -907,7 +905,7 @@ async def test_generate_videos_episode_scope_confirms_two_tiers_in_one_batch(
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script(
         video_units=[
             {
                 "unit_id": "E1U1",
@@ -1080,7 +1078,7 @@ async def test_generate_videos_episode_scope_reference_honors_requested_narratio
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     enqueued: list[Any] = []
 
@@ -1156,7 +1154,7 @@ async def test_generate_videos_episode_scope_reference_duration_repeat_without_c
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -1192,7 +1190,7 @@ async def test_generate_videos_episode_scope_reference_duration_exact_enqueues_d
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
@@ -1247,7 +1245,7 @@ async def test_generate_videos_episode_scope_reference_duration_skips_unit_witho
     script = _reference_video_script()
     script["video_units"].append({"unit_id": "E1U2", "duration_seconds": 5})
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
 
     precheck_calls: list[str] = []
 
@@ -1319,7 +1317,7 @@ async def test_generate_videos_episode_scope_reference_duration_resolves_project
         }
     )
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
 
     context_calls: list[Any] = []
 
@@ -1358,7 +1356,7 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
     for unit in script["video_units"]:
         unit["text"] = ""
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
 
     projection_calls: list[str] = []
 
@@ -1388,7 +1386,7 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
     for unit in script["video_units"]:
         unit["text"] = "   "
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
 
     projection_calls: list[str] = []
 
@@ -1462,7 +1460,7 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
     from server.media_tools import videos as mod
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -1525,7 +1523,7 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
     from server.services.cost_estimation import VideoRequestQuote
 
     _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = _reference_video_script()
 
     def fake_precheck(_ctx, _unit):
         return DurationSlot(seconds=8, total_seconds=8, adjustment=EXACT)
@@ -1821,8 +1819,8 @@ async def test_generate_videos_scene_scope_use_tts_blocks_when_exact_cost_is_una
 async def test_generate_videos_scene_scope_accepts_legacy_drama_dialogue(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "drama"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = "drama"
+    fake_ctx.pm.script_payload = {
         "content_mode": "drama",
         "episode": 1,
         "scenes": [
@@ -1849,8 +1847,8 @@ async def test_generate_videos_scene_scope_accepts_legacy_drama_dialogue(fake_ct
 async def test_generate_videos_scene_scope_accepts_speech_free_legacy_drama(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "drama"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = "drama"
+    fake_ctx.pm.script_payload = {
         "content_mode": "drama",
         "episode": 1,
         "scenes": [
@@ -1877,8 +1875,8 @@ async def test_generate_videos_scene_scope_accepts_legacy_narration_string_promp
 ) -> None:
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "narration"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = "narration"
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "segments": [
@@ -1906,7 +1904,7 @@ async def test_generate_videos_episode_scope_storyboard_batch_blocks_on_mixed_sp
     project_dir = fake_ctx.pm.get_project_path("demo")
     for segment_id in ("E1S01", "E1S02"):
         (project_dir / "storyboards" / f"scene_{segment_id}.png").write_bytes(b"png")
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {
             "segment_id": "E1S01",
             "novel_text": "风吹过旷野。",
@@ -1951,10 +1949,8 @@ async def test_six_route_agent_single_video_generation_returns_structured_admiss
 ) -> None:
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
-        {"content_mode": case.content_mode, "generation_mode": case.generation_mode}
-    )
-    fake_ctx.pm.script_payload = case.script()  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload.update({"content_mode": case.content_mode, "generation_mode": case.generation_mode})
+    fake_ctx.pm.script_payload = case.script()
     batch_enqueue = AsyncMock()
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", batch_enqueue)
     # reference_video 生成模式在准入失败前先探测在途任务（真实 DB 查询）；三个 storyboard
@@ -1992,7 +1988,7 @@ async def test_generate_videos_scene_scope_missing(fake_ctx: ToolContext) -> Non
 async def test_generate_videos_scene_scope_rejects_invalid_storyboard_image(
     fake_ctx: ToolContext, storyboard_value: object
 ) -> None:
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}
     tool_obj = _scene_scope(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
@@ -2036,7 +2032,7 @@ async def test_generate_videos_all_scope_preserves_the_selected_manual_upload(
     fake_ctx.caller = CallerContext(user_id=DEFAULT_USER_ID, source=source)
 
     project_path = fake_ctx.project_path
-    fake_ctx.pm.project_payload.update(  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload.update(
         {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "episodes": [{"episode": 1, "script_file": "scripts/episode_1.json"}],
@@ -2048,7 +2044,7 @@ async def test_generate_videos_all_scope_preserves_the_selected_manual_upload(
         resource_id="E1S01",
         content=b"manual-video",
     )
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"]["video_clip"] = artifact_path  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"]["video_clip"] = artifact_path
     enqueue = AsyncMock(return_value=([], []))
     spec = TaskSpec.from_request(
         task_type="video",
@@ -2081,7 +2077,7 @@ async def test_generate_videos_all_scope_error(fake_ctx: ToolContext) -> None:
     def boom(*a, **kw):
         raise RuntimeError("broken")
 
-    fake_ctx.pm.load_script = boom  # type: ignore[attr-defined]
+    fake_ctx.pm.load_script = boom
     tool_obj = _all_scope(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
@@ -2282,7 +2278,7 @@ def test_build_video_specs_skips_non_dict_generated_assets_without_aborting_batc
 async def test_generate_videos_scene_scope_generated_assets_non_dict_readable_rejection(fake_ctx: ToolContext) -> None:
     """generated_assets 容器本身非 dict 时须走「没有分镜图」的可读拒绝分支，
     不应在单条路径上抛未处理 AttributeError。"""
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = ["bad"]  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = ["bad"]
     tool_obj = _scene_scope(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
@@ -2407,7 +2403,7 @@ async def test_resolve_voice_context_drama_reads_project_characters_and_gate(
 
     monkeypatch.setattr(admission_mod, "resolve_project_is_silent", fake_not_silent)
     characters = await admission_mod.resolve_voice_context(fake_ctx.pm.project_payload, "drama")
-    assert characters == fake_ctx.pm.project_payload["characters"]  # type: ignore[attr-defined]
+    assert characters == fake_ctx.pm.project_payload["characters"]
 
     async def fake_silent(_project, _episode=None):
         return True
@@ -2524,7 +2520,7 @@ def ad_reference_ctx(fake_ctx: ToolContext) -> ToolContext:
     fake_ctx.config_resolver = _fake_caps_resolver(supported_durations=(5,), default_duration=5)
 
     pm = fake_ctx.pm
-    pm.project_payload.update(  # type: ignore[attr-defined]
+    pm.project_payload.update(
         {
             "content_mode": "ad",
             "generation_mode": "reference_video",
@@ -2533,7 +2529,7 @@ def ad_reference_ctx(fake_ctx: ToolContext) -> ToolContext:
             "episodes": [{"episode": 1, "title": "短片", "script_file": "scripts/episode_1.json"}],
         }
     )
-    pm.script_payload = {  # type: ignore[attr-defined]
+    pm.script_payload = {
         "content_mode": "ad",
         "episode": 1,
         "title": "短片",
@@ -2575,8 +2571,8 @@ async def test_generate_videos_episode_scope_reference_skips_malformed_unit_entr
     """脏 unit 元素交给逐条校验拒绝，不在完成扫描、音频闸门或时长预检抛未处理异常。"""
     from server.media_tools import videos as mod
 
-    valid = ad_reference_ctx.pm.script_payload["video_units"][0]  # type: ignore[attr-defined]
-    ad_reference_ctx.pm.script_payload["video_units"] = ["bad", {}, valid]  # type: ignore[attr-defined]
+    valid = ad_reference_ctx.pm.script_payload["video_units"][0]
+    ad_reference_ctx.pm.script_payload["video_units"] = ["bad", {}, valid]
     enqueued: list[Any] = []
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _successful_reference_batch(ad_reference_ctx, enqueued))
 
@@ -2609,7 +2605,7 @@ async def test_generate_videos_episode_scope_ad_reference_enqueues_existing_vide
 
     assert out.get("is_error") is not True, out
     assert [spec.resource_id for spec in enqueued] == ["E1U1"]
-    script = ad_reference_ctx.pm.script_payload  # type: ignore[attr-defined]
+    script = ad_reference_ctx.pm.script_payload
     assert [unit["unit_id"] for unit in script["video_units"]] == ["E1U1"]
     assert "reference_units" not in script
 
@@ -2642,16 +2638,14 @@ async def test_generate_videos_episode_scope_ad_reference_preserves_the_selected
     from server.media_tools import videos as mod
 
     project_path = ad_reference_ctx.project_path
-    ad_reference_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
+    ad_reference_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
     artifact_path = _select_manual_video(
         project_path,
         resource_type="reference_videos",
         resource_id="E1U1",
         content=b"manual-reference-video",
     )
-    ad_reference_ctx.pm.script_payload["video_units"][0]["generated_assets"] = {  # type: ignore[attr-defined]
-        "video_clip": artifact_path
-    }
+    ad_reference_ctx.pm.script_payload["video_units"][0]["generated_assets"] = {"video_clip": artifact_path}
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "active_artifact_currency_resolver", lambda *_args: _MissingEverythingResolver())
     monkeypatch.setattr(mod, "artifact_is_usable", lambda *_args: False)
@@ -2678,14 +2672,12 @@ async def test_generate_videos_episode_scope_reference_blocks_a_clip_whose_manif
     from server.media_tools import videos as mod
 
     project_path = ad_reference_ctx.project_path
-    ad_reference_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION  # type: ignore[attr-defined]
+    ad_reference_ctx.pm.project_payload["schema_version"] = CURRENT_PROJECT_SCHEMA_VERSION
     artifact_path = "reference_videos/E1U1.mp4"
     output = project_path / artifact_path
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(b"\x00")
-    ad_reference_ctx.pm.script_payload["video_units"][0]["generated_assets"] = {  # type: ignore[attr-defined]
-        "video_clip": artifact_path
-    }
+    ad_reference_ctx.pm.script_payload["video_units"][0]["generated_assets"] = {"video_clip": artifact_path}
 
     class _BlockedResolver:
         def compare(self, key, *, artifact_path):
@@ -2729,7 +2721,7 @@ async def test_generate_videos_episode_scope_ad_reference_replan_shell_cannot_en
     """迁移保留的 needs_replan 空壳可被读取，但不能提交生成任务。"""
     from server.media_tools import videos as mod
 
-    ad_reference_ctx.pm.script_payload["video_units"] = [  # type: ignore[attr-defined]
+    ad_reference_ctx.pm.script_payload["video_units"] = [
         _ad_reference_unit(
             shots=[],
             references=[],
@@ -2767,7 +2759,7 @@ async def test_generate_videos_episode_scope_ad_reference_replan_unit_cannot_reu
     """迁移保留的已归属视频不能绕过 needs_replan 生成闸门。"""
     from server.media_tools import videos as mod
 
-    ad_reference_ctx.pm.script_payload["video_units"] = [  # type: ignore[attr-defined]
+    ad_reference_ctx.pm.script_payload["video_units"] = [
         _ad_reference_unit(
             needs_replan=True,
             migration_requires_content_replan=True,
@@ -2877,8 +2869,8 @@ def test_video_generation_dispatches_by_generation_mode_for_every_content_mode(
     generation_mode: str,
 ) -> None:
     """六个组合各自派给正确的生成模式，且骨架闸门放行本组合应有的骨架。"""
-    fake_ctx.pm.project_payload["content_mode"] = content_mode  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["generation_mode"] = generation_mode  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = content_mode
+    fake_ctx.pm.project_payload["generation_mode"] = generation_mode
     skeleton = _SKELETON_BY_MODE_PAIR[(content_mode, generation_mode)]
     script = {"content_mode": content_mode, "episode": 1, skeleton: []}
 
@@ -2895,8 +2887,8 @@ def test_video_generation_refuses_a_script_from_the_other_generation_mode(
 ) -> None:
     """骨架来自另一种生成模式时六个组合一律拒绝入队，不静默按剧本形态改派。"""
     other_mode = "storyboard" if generation_mode == "reference_video" else "reference_video"
-    fake_ctx.pm.project_payload["content_mode"] = content_mode  # type: ignore[attr-defined]
-    fake_ctx.pm.project_payload["generation_mode"] = generation_mode  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["content_mode"] = content_mode
+    fake_ctx.pm.project_payload["generation_mode"] = generation_mode
     mismatched = _SKELETON_BY_MODE_PAIR[(content_mode, other_mode)]
     script = {"content_mode": content_mode, "episode": 1, mismatched: []}
 
@@ -2908,10 +2900,8 @@ async def test_post_production_video_never_asks_for_the_missing_tts(fake_ctx: To
     """后期配音的视频请求既不自动补 TTS，也不把缺 TTS 报成一条待办。"""
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.project_payload["content_mode"] = "narration"  # type: ignore[attr-defined]
-    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {  # type: ignore[attr-defined]
-        "storyboard_image": "storyboards/scene_E1S01.png"
-    }
+    fake_ctx.pm.project_payload["content_mode"] = "narration"
+    fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
 
     out = await _call(
@@ -2941,7 +2931,7 @@ async def test_generate_videos_rejects_mismatched_unit_script_on_storyboard_rout
 
     静默降档与悄悄换路径都不可构造——存量混排集的唯一出路是重拆重生成。
     """
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "video_units": [{"unit_id": "E1U1", "text": "x", "duration_seconds": 5}],
@@ -2960,7 +2950,7 @@ async def test_generate_videos_episode_scope_rejects_mismatched_storyboard_scrip
 ) -> None:
     """反向：参考生视频项目下的分镜骨架剧本同样被拒，指引重跑 unit 拆分。"""
 
-    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"  # type: ignore[attr-defined]
+    fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
     tool_obj = _episode_scope(fake_ctx)
     out = await _call(tool_obj, {"script": "episode_1.json"})
 

--- a/tests/integration/server/media_tools/test_videos.py
+++ b/tests/integration/server/media_tools/test_videos.py
@@ -23,33 +23,33 @@ from server.media_tools.context import ToolContext
 from server.media_tools.videos import generate_videos_tool
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
     _CLAIMED_BASIS_DIGEST,
-    _activate_unbound_project,
-    _call,
-    _fake_caps_resolver,
-    _fake_reference_projection,
-    _fake_scene_batch,
-    _generation_result,
-    _reference_video_script,
-    _use_reference_route,
-    _videos_tool_for_scope,
+    activate_unbound_project,
+    call,
+    fake_caps_resolver,
+    fake_reference_projection,
+    fake_scene_batch,
+    read_generation_result,
+    reference_video_script,
+    use_reference_route,
+    videos_tool_for_scope,
 )
 from tests.speech_contract_cases import SPEECH_CONTRACT_CASES, SpeechContractCase
 
 
 def _episode_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "episode")
+    return videos_tool_for_scope(ctx, "episode")
 
 
 def _scene_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "scene")
+    return videos_tool_for_scope(ctx, "scene")
 
 
 def _all_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "all")
+    return videos_tool_for_scope(ctx, "all")
 
 
 def _selected_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "selected")
+    return videos_tool_for_scope(ctx, "selected")
 
 
 def _select_manual_video(
@@ -152,7 +152,7 @@ async def test_generate_videos_episode_scope_happy(fake_ctx: ToolContext, monkey
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
 
 
@@ -163,12 +163,12 @@ async def test_generate_videos_episode_scope_declares_the_missing_only_selection
     from server.media_tools import videos as mod
 
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.selection.value == "missing_only"
     assert result.succeeded == ["E1S01"]
 
@@ -216,10 +216,10 @@ async def test_generate_videos_episode_scope_skips_current_clip(fake_ctx: ToolCo
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert enqueued == []
     assert result.succeeded == []
     assert [entry.unit_id for entry in result.skipped] == ["E1S01"]
@@ -272,9 +272,9 @@ async def test_generate_videos_episode_scope_blocks_a_clip_whose_manifest_state_
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert enqueued == []
     assert result.succeeded == []
     assert result.blocked == ["E1S01"]
@@ -290,7 +290,7 @@ async def test_generate_videos_episode_scope_rejects_unbound_active_script_befor
     from lib.generation_queue_client import TaskSpec
     from server.media_tools import videos as mod
 
-    _activate_unbound_project(fake_ctx)
+    activate_unbound_project(fake_ctx)
     spec = TaskSpec.from_request(
         task_type="video",
         media_type="video",
@@ -306,7 +306,7 @@ async def test_generate_videos_episode_scope_rejects_unbound_active_script_befor
     monkeypatch.setattr(mod, "build_storyboard_video_specs", fake_build_specs)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
@@ -358,10 +358,10 @@ async def test_generate_videos_episode_scope_resolves_episode_from_canonical_fil
 
     monkeypatch.setattr(mod, "build_storyboard_video_specs", _capture_episode)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _batch)
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_2.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_2.json"})
 
     assert captured == {"episode": 2}
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.blocked == ["E1S01"]
     assert _blocked_problems_of(result) == {"E1S01": ("generation_unit_input_unusable", "generate_dependency")}
 
@@ -398,11 +398,11 @@ async def test_generate_videos_episode_scope_non_dict_generated_assets_does_not_
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     # E1S01 的分镜图绑定不可用：整批准入不成立，零任务入队，合法条目也如实报告被搁置的原因。
     assert enqueued == []
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.blocked) == ["E1S01", "E1S02"]
     codes = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
     assert codes["E1S01"] == "generation_unit_input_unusable"
@@ -413,7 +413,7 @@ async def test_generate_videos_episode_scope_non_dict_generated_assets_does_not_
 async def test_generate_videos_episode_scope_error(fake_ctx: ToolContext) -> None:
     fake_ctx.pm.script_payload = {"content_mode": "narration", "segments": [], "episode": 1}
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
 
 
@@ -423,12 +423,12 @@ async def test_generate_reference_video_rejects_unbound_active_script_before_gen
 ) -> None:
     from server.media_tools import videos as mod
 
-    _activate_unbound_project(fake_ctx, generation_mode="reference_video")
-    fake_ctx.pm.script_payload = _reference_video_script()
+    activate_unbound_project(fake_ctx, generation_mode="reference_video")
+    fake_ctx.pm.script_payload = reference_video_script()
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "not bound" in out["content"][0]["text"]
@@ -441,13 +441,13 @@ async def test_generate_reference_video_legacy_unresolvable_episode_fails_before
 ) -> None:
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
     fake_ctx.pm.script_payload.pop("episode")
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "draft.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "draft.json"})
 
     assert out.get("is_error") is True
     assert "无法确定集号" in out["content"][0]["text"]
@@ -457,7 +457,7 @@ async def test_generate_reference_video_legacy_unresolvable_episode_fails_before
 async def test_generate_videos_episode_scope_reference_rejects_malformed_unit_container(fake_ctx: ToolContext) -> None:
     """``video_units`` 非数组：生成模式闸门只问键在不在，容器校验落在入队侧，
     须报出可定位的结构错误而不是下传到 unit 迭代抛 TypeError。"""
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     for malformed in (
         {"E1U1": {}},
         {},
@@ -467,9 +467,9 @@ async def test_generate_videos_episode_scope_reference_rejects_malformed_unit_co
     ):
         # 键在场即按类型判定，不看真值：``{}`` / ``""`` / ``False`` 同样是类型错误，
         # 报成「为空」会把成因埋掉。
-        fake_ctx.pm.script_payload = _reference_video_script(video_units=malformed)
+        fake_ctx.pm.script_payload = reference_video_script(video_units=malformed)
         tool_obj = _episode_scope(fake_ctx)
-        out = await _call(tool_obj, {"script": "episode_1.json"})
+        out = await call(tool_obj, {"script": "episode_1.json"})
         assert out.get("is_error") is True
         text = out["content"][0]["text"]
         assert "video_units 必须是数组" in text
@@ -482,8 +482,8 @@ async def test_generate_videos_episode_scope_reference_duration_needs_confirmati
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -494,21 +494,18 @@ async def test_generate_videos_episode_scope_reference_duration_needs_confirmati
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     async def fake_active_tasks(**_kwargs):
         return []
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     monkeypatch.setattr("server.services.video_batch_admission.get_active_tasks_for_resources", fake_active_tasks)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True
     text = out["content"][0]["text"]
@@ -558,7 +555,7 @@ async def test_generate_videos_episode_scope_reference_duration_needs_confirmati
     }
     assert enqueued == []
     # 待确认不是 prose-only 的死角：调用方能拿到机器可读结论，不必解析文本猜测。
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.blocked == ["E1U1"]
     item = result.items[0]
     assert item.problem is not None
@@ -573,8 +570,8 @@ async def test_generate_videos_episode_scope_reference_returns_structured_projec
     """Agent 失败信封保留公共投影的稳定 problem 字段，不只返回人读文本。"""
     from lib.reference_video.request_projection import ProjectionProblem
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     class _BlockedProjection:
         unit_id = "E1U1"
@@ -611,7 +608,7 @@ async def test_generate_videos_episode_scope_reference_returns_structured_projec
 
     monkeypatch.setattr("server.services.video_batch_admission.project_reference_unit_request", _blocked)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert out["request_projections"][0] == {
@@ -666,8 +663,8 @@ async def test_generate_videos_episode_scope_reference_duration_confirm_enqueues
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -688,17 +685,14 @@ async def test_generate_videos_episode_scope_reference_duration_confirm_enqueues
                 )
         return [], []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(
+    out = await call(
         tool_obj,
         {"script": "episode_1.json", "confirmed_request_duration_seconds": 8},
     )
@@ -708,19 +702,19 @@ async def test_generate_videos_episode_scope_reference_duration_confirm_enqueues
 
 
 async def test_generate_videos_reference_force_false_reuses_existing_video(fake_ctx: ToolContext, db_factory) -> None:
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     video_path = _select_manual_video(
         fake_ctx.project_path,
         resource_type="reference_videos",
         resource_id="E1U1",
         content=b"existing-video",
     )
-    script = _reference_video_script()
+    script = reference_video_script()
     script["video_units"][0]["generated_assets"] = {"video_clip": video_path}
     fake_ctx.pm.script_payload = script
     fake_ctx.queue = GenerationQueue(session_factory=db_factory)
 
-    out = await _call(
+    out = await call(
         generate_videos_tool(fake_ctx),
         {
             "script": "episode_1.json",
@@ -743,7 +737,7 @@ async def test_generate_videos_scene_force_false_reuses_existing_video(fake_ctx:
     )
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"]["video_clip"] = video_path
 
-    out = await _call(
+    out = await call(
         generate_videos_tool(fake_ctx),
         {"script": "episode_1.json", "target": {"scope": "scene", "ids": ["E1S01"]}},
     )
@@ -776,7 +770,7 @@ async def test_generate_videos_rejects_invalid_target_or_non_explicit_force(
     target: dict[str, Any],
     force: bool,
 ) -> None:
-    out = await _call(
+    out = await call(
         generate_videos_tool(fake_ctx),
         {"script": "episode_1.json", "target": target, "force": force},
     )
@@ -790,9 +784,9 @@ async def test_generate_videos_ignores_legacy_batch_checkpoint_files(fake_ctx: T
     checkpoint = fake_ctx.project_path / "videos" / ".checkpoint_ep1.json"
     checkpoint.parent.mkdir(parents=True, exist_ok=True)
     checkpoint.write_text("not-json", encoding="utf-8")
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True
     assert checkpoint.read_text(encoding="utf-8") == "not-json"
@@ -824,7 +818,7 @@ def test_generate_videos_definition_has_only_the_unified_name_and_no_resume(fake
 
 
 async def test_generate_videos_rejects_retired_resume_parameter(fake_ctx: ToolContext) -> None:
-    out = await _call(
+    out = await call(
         generate_videos_tool(fake_ctx),
         {
             "script": "episode_1.json",
@@ -855,7 +849,7 @@ async def test_generate_videos_resubmits_only_remaining_ids_from_a_durable_batch
     queue = fake_ctx.queue
     fake_ctx.caller = CallerContext(user_id=DEFAULT_USER_ID, source="mcp")
 
-    first = await _call(
+    first = await call(
         generate_videos_tool(fake_ctx),
         {"script": "episode_1.json", "target": {"scope": "episode", "episode": 1}},
     )
@@ -880,7 +874,7 @@ async def test_generate_videos_resubmits_only_remaining_ids_from_a_durable_batch
     assert terminal.generation_result.succeeded == ["E1S01"]
     assert terminal.generation_result.failed == ["E1S02"]
 
-    retried = await _call(
+    retried = await call(
         generate_videos_tool(fake_ctx),
         {
             "script": "episode_1.json",
@@ -904,8 +898,8 @@ async def test_generate_videos_episode_scope_confirms_two_tiers_in_one_batch(
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script(
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script(
         video_units=[
             {
                 "unit_id": "E1U1",
@@ -943,13 +937,13 @@ async def test_generate_videos_episode_scope_confirms_two_tiers_in_one_batch(
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _episode_scope(fake_ctx)
 
     # 未确认：两个档位都在结论里，零任务入队。
-    unconfirmed = await _call(tool_obj, {"script": "episode_1.json"})
+    unconfirmed = await call(tool_obj, {"script": "episode_1.json"})
     assert enqueued == []
     listed = {
         tier["request_duration_seconds"]: tier["unit_ids"]
@@ -957,7 +951,7 @@ async def test_generate_videos_episode_scope_confirms_two_tiers_in_one_batch(
     }
     assert listed == {8: ["E1U1"], 12: ["E1U2"]}
 
-    out = await _call(
+    out = await call(
         tool_obj,
         {"script": "episode_1.json", "confirmed_request_durations": {"E1U1": 8, "E1U2": 12}},
     )
@@ -1077,8 +1071,8 @@ async def test_generate_videos_episode_scope_reference_honors_requested_narratio
     from lib.generation_queue_client import BatchTaskResult
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     enqueued: list[Any] = []
 
@@ -1098,7 +1092,7 @@ async def test_generate_videos_episode_scope_reference_honors_requested_narratio
         return [], []
 
     projected_deliveries: list[str] = []
-    base_projection = _fake_reference_projection()
+    base_projection = fake_reference_projection()
 
     async def _capture_delivery(**kwargs):
         projected_deliveries.append(kwargs["options"].narration_delivery)
@@ -1110,7 +1104,7 @@ async def test_generate_videos_episode_scope_reference_honors_requested_narratio
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _episode_scope(fake_ctx)
 
-    completed = await _call(
+    completed = await call(
         tool_obj,
         {"script": "episode_1.json", "narration_delivery": "post_production"},
     )
@@ -1124,7 +1118,7 @@ async def test_generate_videos_episode_scope_reference_honors_requested_narratio
     }
 
     projected_deliveries.clear()
-    await _call(tool_obj, {"script": "episode_1.json", "narration_delivery": "use_tts"})
+    await call(tool_obj, {"script": "episode_1.json", "narration_delivery": "use_tts"})
     assert projected_deliveries == ["use_tts"]
     active_tts.assert_awaited()
 
@@ -1153,8 +1147,8 @@ async def test_generate_videos_episode_scope_reference_duration_repeat_without_c
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -1165,18 +1159,15 @@ async def test_generate_videos_episode_scope_reference_duration_repeat_without_c
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    await _call(tool_obj, {"script": "episode_1.json"})
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    await call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True
     assert enqueued == []
@@ -1189,8 +1180,8 @@ async def test_generate_videos_episode_scope_reference_duration_exact_enqueues_d
     from lib.reference_video.duration_slots import EXACT, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=5, total_seconds=5, adjustment=EXACT)
@@ -1214,17 +1205,14 @@ async def test_generate_videos_episode_scope_reference_duration_exact_enqueues_d
                 on_success(done)
         return successes, []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert [s.resource_id for s in enqueued] == ["E1U1"]
@@ -1242,9 +1230,9 @@ async def test_generate_videos_episode_scope_reference_duration_skips_unit_witho
     from lib.reference_video.duration_slots import EXACT, DurationSlot
     from server.media_tools import videos as mod
 
-    script = _reference_video_script()
+    script = reference_video_script()
     script["video_units"].append({"unit_id": "E1U2", "duration_seconds": 5})
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     fake_ctx.pm.script_payload = script
 
     precheck_calls: list[str] = []
@@ -1272,22 +1260,19 @@ async def test_generate_videos_episode_scope_reference_duration_skips_unit_witho
                 on_success(done)
         return successes, []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert precheck_calls == ["E1U1"]
     # 整批准入不成立，本次零任务入队。
     assert enqueued == []
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.blocked) == ["E1U1", "E1U2"]
     codes = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
     assert codes["E1U2"] == "generation_unit_request_invalid"
@@ -1301,7 +1286,7 @@ async def test_generate_videos_episode_scope_reference_duration_resolves_project
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    script = _reference_video_script()
+    script = reference_video_script()
     script["video_units"].append(
         {
             "unit_id": "E1U2",
@@ -1316,7 +1301,7 @@ async def test_generate_videos_episode_scope_reference_duration_resolves_project
             "duration_seconds": 5,
         }
     )
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     fake_ctx.pm.script_payload = script
 
     context_calls: list[Any] = []
@@ -1332,12 +1317,12 @@ async def test_generate_videos_episode_scope_reference_duration_resolves_project
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck, calls=context_calls),
+        fake_reference_projection(fake_precheck, calls=context_calls),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     # 三个 unit 均 5 秒、申请 8 秒 → 都需确认，本批不入队；实际水合桶随每个结果可观察。
     assert out.get("is_error") is not True, out
@@ -1352,10 +1337,10 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
     重构不能让「全部已完成/全部被跳过」的批次凭空多付一轮 DB 往返。"""
     from server.media_tools import videos as mod
 
-    script = _reference_video_script()
+    script = reference_video_script()
     for unit in script["video_units"]:
         unit["text"] = ""
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     fake_ctx.pm.script_payload = script
 
     projection_calls: list[str] = []
@@ -1365,12 +1350,12 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(calls=projection_calls),
+        fake_reference_projection(calls=projection_calls),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    await _call(tool_obj, {"script": "episode_1.json"})
+    await call(tool_obj, {"script": "episode_1.json"})
 
     assert projection_calls == []
 
@@ -1382,10 +1367,10 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
     不能先触发项目能力解析再让 build_specs 事后跳过。"""
     from server.media_tools import videos as mod
 
-    script = _reference_video_script()
+    script = reference_video_script()
     for unit in script["video_units"]:
         unit["text"] = "   "
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     fake_ctx.pm.script_payload = script
 
     projection_calls: list[str] = []
@@ -1395,12 +1380,12 @@ async def test_generate_videos_episode_scope_reference_skips_duration_context_wh
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(calls=projection_calls),
+        fake_reference_projection(calls=projection_calls),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert projection_calls == []
     assert "E1U1" in out["content"][0]["text"]
@@ -1425,17 +1410,14 @@ async def test_generate_videos_episode_scope_ad_reference_duration_needs_confirm
         enqueued.extend(specs)
         return [], []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
     tool_obj = _episode_scope(ad_reference_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     assert enqueued == []
@@ -1459,8 +1441,8 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
     from lib.reference_video.duration_slots import UP, DurationSlot
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(ctx, unit):
         return DurationSlot(seconds=8, total_seconds=5, adjustment=UP)
@@ -1481,21 +1463,18 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
                 )
         return [], []
 
-    async def fake_duration_context(_project, _episode=None, *, capability=None):
-        return None
-
     async def fake_active_tasks(**_kwargs):
         return []
 
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     monkeypatch.setattr("server.services.video_batch_admission.get_active_tasks_for_resources", fake_active_tasks)
 
     tool_obj = make_tool(fake_ctx)
-    pending = await _call(tool_obj, {"script": "episode_1.json", **extra_args})
+    pending = await call(tool_obj, {"script": "episode_1.json", **extra_args})
 
     assert pending.get("is_error") is not True, pending
     assert enqueued == []
@@ -1504,7 +1483,7 @@ async def test_generate_video_reference_duration_confirmation_across_entries(
     assert "本次请求" in text
     assert "confirmed_request_duration_seconds" in text
 
-    confirmed = await _call(
+    confirmed = await call(
         tool_obj,
         {"script": "episode_1.json", **extra_args, "confirmed_request_duration_seconds": 8},
     )
@@ -1522,8 +1501,8 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
     from server.media_tools import videos as mod
     from server.services.cost_estimation import VideoRequestQuote
 
-    _use_reference_route(fake_ctx)
-    fake_ctx.pm.script_payload = _reference_video_script()
+    use_reference_route(fake_ctx)
+    fake_ctx.pm.script_payload = reference_video_script()
 
     def fake_precheck(_ctx, _unit):
         return DurationSlot(seconds=8, total_seconds=8, adjustment=EXACT)
@@ -1557,7 +1536,7 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
     )
     monkeypatch.setattr(
         "server.services.video_batch_admission.project_reference_unit_request",
-        _fake_reference_projection(fake_precheck),
+        fake_reference_projection(fake_precheck),
     )
     monkeypatch.setattr(
         "server.services.video_batch_admission.active_tts_resource_ids", AsyncMock(return_value=frozenset())
@@ -1572,7 +1551,7 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
     )
     tool_obj = _scene_scope(fake_ctx)
 
-    pending = await _call(
+    pending = await call(
         tool_obj,
         {"script": "episode_1.json", "scene_id": "E1U1", "narration_delivery": "use_tts"},
     )
@@ -1589,7 +1568,7 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
     assert "现有视觉档位 4s，将申请 8s（成片更长 4s）" in pending["content"][0]["text"]
     assert enqueued == []
 
-    accepted = await _call(
+    accepted = await call(
         tool_obj,
         {
             "script": "episode_1.json",
@@ -1608,9 +1587,9 @@ async def test_generate_videos_scene_scope_reference_use_tts_exposes_the_shared_
 async def test_generate_videos_scene_scope_happy(fake_ctx: ToolContext, monkeypatch) -> None:
     from server.media_tools import videos as mod
 
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
     tool_obj = _scene_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is not True
 
 
@@ -1661,7 +1640,7 @@ async def test_generate_videos_scene_scope_use_tts_returns_structured_blocker_wi
     )
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(
+    out = await call(
         _scene_scope(fake_ctx),
         {"script": "episode_1.json", "scene_id": "E1S01", "narration_delivery": "use_tts"},
     )
@@ -1705,7 +1684,7 @@ async def test_generate_videos_scene_scope_use_tts_requires_exact_tier_and_queue
             cost=VideoRequestCostFacts("openai", "sora-2", "720p", 12, True),
         )
 
-    enqueue = AsyncMock(side_effect=_fake_scene_batch)
+    enqueue = AsyncMock(side_effect=fake_scene_batch)
     monkeypatch.setattr(
         "server.services.video_batch_admission.active_tts_resource_ids", AsyncMock(return_value=frozenset())
     )
@@ -1720,7 +1699,7 @@ async def test_generate_videos_scene_scope_use_tts_requires_exact_tier_and_queue
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
     tool_obj = _scene_scope(fake_ctx)
 
-    pending = await _call(
+    pending = await call(
         tool_obj,
         {"script": "episode_1.json", "scene_id": "E1S01", "narration_delivery": "use_tts"},
     )
@@ -1736,7 +1715,7 @@ async def test_generate_videos_scene_scope_use_tts_requires_exact_tier_and_queue
     assert "1.2 USD" in pending["content"][0]["text"]
     enqueue.assert_not_awaited()
 
-    completed = await _call(
+    completed = await call(
         tool_obj,
         {
             "script": "episode_1.json",
@@ -1802,7 +1781,7 @@ async def test_generate_videos_scene_scope_use_tts_blocks_when_exact_cost_is_una
     monkeypatch.setattr("server.services.video_batch_admission.quote_video_request", AsyncMock(return_value=None))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    result = await _call(
+    result = await call(
         _scene_scope(fake_ctx),
         {"script": "episode_1.json", "scene_id": "E1S01", "narration_delivery": "use_tts"},
     )
@@ -1838,8 +1817,8 @@ async def test_generate_videos_scene_scope_accepts_legacy_drama_dialogue(fake_ct
         ],
     }
 
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
-    out = await _call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
+    out = await call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
 
     assert out.get("is_error") is not True, out
 
@@ -1864,8 +1843,8 @@ async def test_generate_videos_scene_scope_accepts_speech_free_legacy_drama(fake
         ],
     }
 
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
-    out = await _call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
+    out = await call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
 
     assert out.get("is_error") is not True, out
 
@@ -1889,8 +1868,8 @@ async def test_generate_videos_scene_scope_accepts_legacy_narration_string_promp
         ],
     }
 
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
-    out = await _call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
+    out = await call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": "E1S01"})
 
     assert out.get("is_error") is not True, out
 
@@ -1931,11 +1910,11 @@ async def test_generate_videos_episode_scope_storyboard_batch_blocks_on_mixed_sp
         "server.services.video_batch_admission.get_active_tasks_for_resources", AsyncMock(return_value=[])
     )
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert enqueued == []
     assert out["is_error"] is True
-    result = _generation_result(out)
+    result = read_generation_result(out)
     codes = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
     assert codes["E1S01"] == "mixed_speech"
     assert codes["E1S02"] == "generation_batch_admission_withheld"
@@ -1959,7 +1938,7 @@ async def test_six_route_agent_single_video_generation_returns_structured_admiss
         "server.services.video_batch_admission.get_active_tasks_for_resources", AsyncMock(return_value=[])
     )
 
-    out = await _call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": case.unit_id})
+    out = await call(_scene_scope(fake_ctx), {"script": "episode_1.json", "scene_id": case.unit_id})
 
     assert out.get("is_error") is True
     problem = out["speech_admission"]["problems"][0]
@@ -1973,7 +1952,7 @@ async def test_six_route_agent_single_video_generation_returns_structured_admiss
 
 async def test_generate_videos_scene_scope_missing(fake_ctx: ToolContext) -> None:
     tool_obj = _scene_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "NO_SUCH"})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_id": "NO_SUCH"})
     assert out.get("is_error") is True
 
 
@@ -1990,7 +1969,7 @@ async def test_generate_videos_scene_scope_rejects_invalid_storyboard_image(
 ) -> None:
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}
     tool_obj = _scene_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
     # 锁定 resolve_storyboard_image_ref 抛出的 canonical 消息，而不是模糊子串或通用失败文本
     assert f"invalid storyboard image path: {storyboard_value!r}" in out["content"][0]["text"]
@@ -2012,7 +1991,7 @@ async def test_generate_videos_all_scope_happy(fake_ctx: ToolContext, monkeypatc
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _all_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is not True
 
 
@@ -2058,7 +2037,7 @@ async def test_generate_videos_all_scope_preserves_the_selected_manual_upload(
     monkeypatch.setattr(mod, "build_storyboard_video_specs", lambda **_kwargs: ([spec], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_all_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_all_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
     # 选中的手动上传照旧可用：既不进 requested 也不重生，只作为 skipped 报告。
@@ -2066,7 +2045,7 @@ async def test_generate_videos_all_scope_preserves_the_selected_manual_upload(
         assert out["generation_batch"]["members"] == []
         assert [entry["unit_id"] for entry in out["generation_batch"]["skipped"]] == ["E1S01"]
     else:
-        result = _generation_result(out)
+        result = read_generation_result(out)
         assert result.requested == []
         assert [entry.unit_id for entry in result.skipped] == ["E1S01"]
         assert out["batch_id"]
@@ -2079,7 +2058,7 @@ async def test_generate_videos_all_scope_error(fake_ctx: ToolContext) -> None:
 
     fake_ctx.pm.load_script = boom
     tool_obj = _all_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
     assert out.get("is_error") is True
 
 
@@ -2103,13 +2082,13 @@ async def test_generate_videos_selected_scope_happy(fake_ctx: ToolContext, monke
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
     tool_obj = _selected_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1S01"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_ids": ["E1S01"]})
     assert out.get("is_error") is not True
 
 
 async def test_generate_videos_selected_scope_no_match(fake_ctx: ToolContext) -> None:
     tool_obj = _selected_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_ids": ["NO_SUCH"]})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_ids": ["NO_SUCH"]})
     assert out.get("is_error") is True
 
 
@@ -2280,7 +2259,7 @@ async def test_generate_videos_scene_scope_generated_assets_non_dict_readable_re
     不应在单条路径上抛未处理 AttributeError。"""
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = ["bad"]
     tool_obj = _scene_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
+    out = await call(tool_obj, {"script": "episode_1.json", "scene_id": "E1S01"})
     assert out.get("is_error") is True
     assert "请先运行 generate_storyboards" in out["content"][0]["text"]
 
@@ -2517,7 +2496,7 @@ def _ad_reference_unit(**overrides: Any) -> dict[str, Any]:
 
 @pytest.fixture
 def ad_reference_ctx(fake_ctx: ToolContext) -> ToolContext:
-    fake_ctx.config_resolver = _fake_caps_resolver(supported_durations=(5,), default_duration=5)
+    fake_ctx.config_resolver = fake_caps_resolver(supported_durations=(5,), default_duration=5)
 
     pm = fake_ctx.pm
     pm.project_payload.update(
@@ -2576,14 +2555,14 @@ async def test_generate_videos_episode_scope_reference_skips_malformed_unit_entr
     enqueued: list[Any] = []
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _successful_reference_batch(ad_reference_ctx, enqueued))
 
-    out = await _call(
+    out = await call(
         _episode_scope(ad_reference_ctx),
         {"script": "episode_1.json"},
     )
 
     # 脏 unit 逐条记为 blocked（没有 unit_id 可寻址时按位置编号），并拦住整批。
     assert enqueued == []
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.blocked) == ["E1U1", "video_units[0]", "video_units[1]"]
     codes = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
     assert codes["E1U1"] == "generation_batch_admission_withheld"
@@ -2598,7 +2577,7 @@ async def test_generate_videos_episode_scope_ad_reference_enqueues_existing_vide
     enqueued: list[Any] = []
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _successful_reference_batch(ad_reference_ctx, enqueued))
 
-    out = await _call(
+    out = await call(
         _episode_scope(ad_reference_ctx),
         {"script": "episode_1.json"},
     )
@@ -2622,7 +2601,7 @@ async def test_generate_videos_episode_scope_ad_reference_does_not_claim_orphan_
     enqueued: list[Any] = []
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _successful_reference_batch(ad_reference_ctx, enqueued))
 
-    out = await _call(
+    out = await call(
         _episode_scope(ad_reference_ctx),
         {"script": "episode_1.json"},
     )
@@ -2651,10 +2630,10 @@ async def test_generate_videos_episode_scope_ad_reference_preserves_the_selected
     monkeypatch.setattr(mod, "artifact_is_usable", lambda *_args: False)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_all_scope(ad_reference_ctx), {"script": "episode_1.json"})
+    out = await call(_all_scope(ad_reference_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.requested == []
     assert [entry.unit_id for entry in result.skipped] == ["E1U1"]
     enqueue.assert_not_awaited()
@@ -2704,9 +2683,9 @@ async def test_generate_videos_episode_scope_reference_blocks_a_clip_whose_manif
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_episode_scope(ad_reference_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(ad_reference_ctx), {"script": "episode_1.json"})
 
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == []
     assert result.blocked == ["E1U1"]
     blocked_item = next(item for item in result.items if item.unit_id == "E1U1")
@@ -2739,7 +2718,7 @@ async def test_generate_videos_episode_scope_ad_reference_replan_shell_cannot_en
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fail_if_enqueued)
 
-    out = await _call(
+    out = await call(
         _episode_scope(ad_reference_ctx),
         {"script": "episode_1.json"},
     )
@@ -2778,7 +2757,7 @@ async def test_generate_videos_episode_scope_ad_reference_replan_unit_cannot_reu
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fail_if_enqueued)
 
-    out = await _call(
+    out = await call(
         _episode_scope(ad_reference_ctx),
         {"script": "episode_1.json"},
     )
@@ -2797,7 +2776,7 @@ async def test_generate_videos_selected_scope_ad_reference_regenerates_named_uni
     enqueued: list[Any] = []
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _successful_reference_batch(ad_reference_ctx, enqueued))
 
-    out = await _call(
+    out = await call(
         _selected_scope(ad_reference_ctx),
         {"script": "episode_1.json", "scene_ids": ["E1U1"]},
     )
@@ -2902,15 +2881,15 @@ async def test_post_production_video_never_asks_for_the_missing_tts(fake_ctx: To
 
     fake_ctx.pm.project_payload["content_mode"] = "narration"
     fake_ctx.pm.script_payload["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-    monkeypatch.setattr(mod, "batch_enqueue_and_wait", _fake_scene_batch)
+    monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_scene_batch)
 
-    out = await _call(
+    out = await call(
         _scene_scope(fake_ctx),
         {"script": "episode_1.json", "scene_id": "E1S01", "narration_delivery": "post_production"},
     )
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert result.succeeded == ["E1S01"]
     assert all(item.problem is None for item in result.items)
 
@@ -2936,8 +2915,8 @@ async def test_generate_videos_rejects_mismatched_unit_script_on_storyboard_rout
         "episode": 1,
         "video_units": [{"unit_id": "E1U1", "text": "x", "duration_seconds": 5}],
     }
-    tool_obj = _videos_tool_for_scope(fake_ctx, scope)
-    out = await _call(tool_obj, args)
+    tool_obj = videos_tool_for_scope(fake_ctx, scope)
+    out = await call(tool_obj, args)
 
     assert out.get("is_error") is True
     text = out["content"][0]["text"]
@@ -2952,7 +2931,7 @@ async def test_generate_videos_episode_scope_rejects_mismatched_storyboard_scrip
 
     fake_ctx.pm.project_payload["generation_mode"] = "reference_video"
     tool_obj = _episode_scope(fake_ctx)
-    out = await _call(tool_obj, {"script": "episode_1.json"})
+    out = await call(tool_obj, {"script": "episode_1.json"})
 
     assert out.get("is_error") is True
     assert "generate_script_plan" in out["content"][0]["text"]

--- a/tests/integration/server/media_tools/test_videos_admission.py
+++ b/tests/integration/server/media_tools/test_videos_admission.py
@@ -42,7 +42,7 @@ async def test_generate_videos_episode_scope_reports_an_interrupted_batch_enqueu
     from lib.generation_queue_client import BatchTaskResult
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": "E1S01", "novel_text": "第一段旁白。", "video_prompt": "第一镜"},
         {"segment_id": "E1S02", "novel_text": "第二段旁白。", "video_prompt": "第二镜"},
     ]
@@ -50,7 +50,7 @@ async def test_generate_videos_episode_scope_reports_an_interrupted_batch_enqueu
     for segment_id in ("E1S01", "E1S02"):
         image = project_dir / "storyboards" / f"scene_{segment_id}.png"
         image.write_bytes(b"png")
-        for item in fake_ctx.pm.script_payload["segments"]:  # type: ignore[attr-defined]
+        for item in fake_ctx.pm.script_payload["segments"]:
             if item["segment_id"] == segment_id:
                 item["generated_assets"] = {"storyboard_image": f"storyboards/scene_{segment_id}.png"}
 
@@ -94,7 +94,7 @@ async def test_generate_videos_episode_scope_batch_is_all_or_nothing_when_a_unit
 ) -> None:
     """在途任务冲突拦下整批：一个都不入队，其余 unit 报告自己是被谁扣下的。"""
     fake_ctx = idle_fake_ctx
-    fake_ctx.pm.script_payload["segments"] = [  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"] = [
         {"segment_id": "E1S01", "novel_text": "第一段旁白。", "video_prompt": "第一镜"},
         {"segment_id": "E1S02", "novel_text": "第二段旁白。", "video_prompt": "第二镜"},
     ]
@@ -102,7 +102,7 @@ async def test_generate_videos_episode_scope_batch_is_all_or_nothing_when_a_unit
     for segment_id in ("E1S01", "E1S02"):
         image = project_dir / "storyboards" / f"scene_{segment_id}.png"
         image.write_bytes(b"png")
-        for item in fake_ctx.pm.script_payload["segments"]:  # type: ignore[attr-defined]
+        for item in fake_ctx.pm.script_payload["segments"]:
             if item["segment_id"] == segment_id:
                 item["generated_assets"] = {"storyboard_image": f"storyboards/scene_{segment_id}.png"}
 
@@ -161,7 +161,7 @@ async def test_generate_reference_videos_reads_active_tts_from_the_callers_queue
     )
     _use_reference_route(fake_ctx)
     (fake_ctx.project_path / "project.json").write_text(
-        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),  # type: ignore[attr-defined]
+        json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),
         encoding="utf-8",
     )
     script = _reference_video_script()
@@ -173,7 +173,7 @@ async def test_generate_reference_videos_reads_active_tts_from_the_callers_queue
             "duration_seconds": 5,
         }
     )
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     async with concurrent_session_factory() as session:
         session.add(User(id="tenant-user", username="tenant-user"))
         await session.commit()
@@ -245,7 +245,7 @@ async def test_generate_videos_all_scope_creates_zero_tasks_when_one_artifact_st
     from lib.generation_result import GenerationCandidate, GenerationTargetState
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.script_payload["segments"].append(  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload["segments"].append(
         {
             "segment_id": "E1S02",
             "image_prompt": "山道清晨",
@@ -295,7 +295,7 @@ async def test_generate_videos_all_scope_admits_legacy_narration_stored_under_sc
     """narration 数据落在 scenes 键的历史剧本按实际骨架做发声准入，不被整批判成解析失败。"""
     from server.media_tools import videos as mod
 
-    fake_ctx.pm.script_payload = {  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = {
         "content_mode": "narration",
         "episode": 1,
         "scenes": [
@@ -383,7 +383,7 @@ async def test_generate_reference_episode_refuses_a_non_scalar_unit_id(
     script = _reference_video_script()
     healthy = script["video_units"][0]
     script["video_units"] = [{**healthy, "unit_id": ["U9"]}, healthy]
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
@@ -406,7 +406,7 @@ async def test_generate_reference_units_refuses_a_duplicated_named_unit(
     _use_reference_route(fake_ctx)
     script = _reference_video_script()
     script["video_units"] = [*script["video_units"], {**script["video_units"][0]}]
-    fake_ctx.pm.script_payload = script  # type: ignore[attr-defined]
+    fake_ctx.pm.script_payload = script
     duplicated_id = script["video_units"][0]["unit_id"]
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)

--- a/tests/integration/server/media_tools/test_videos_admission.py
+++ b/tests/integration/server/media_tools/test_videos_admission.py
@@ -15,24 +15,24 @@ from server.media_tools.context import ToolContext
 from server.services.narration_delivery_tasks import ResolvedTtsSettingsResolver, active_tts_resource_ids
 from server.tool_runtime import CallerContext
 from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import (
-    _call,
-    _generation_result,
-    _reference_video_script,
-    _use_reference_route,
-    _videos_tool_for_scope,
+    call,
+    read_generation_result,
+    reference_video_script,
+    use_reference_route,
+    videos_tool_for_scope,
 )
 
 
 def _episode_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "episode")
+    return videos_tool_for_scope(ctx, "episode")
 
 
 def _all_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "all")
+    return videos_tool_for_scope(ctx, "all")
 
 
 def _selected_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "selected")
+    return videos_tool_for_scope(ctx, "selected")
 
 
 async def test_generate_videos_episode_scope_reports_an_interrupted_batch_enqueue_per_id(
@@ -78,7 +78,7 @@ async def test_generate_videos_episode_scope_reports_an_interrupted_batch_enqueu
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", _interrupted)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     payload = out["generation_result"]
     assert payload["succeeded"] == ["E1S01"]
@@ -135,7 +135,7 @@ async def test_generate_videos_episode_scope_batch_is_all_or_nothing_when_a_unit
     assert (await fake_ctx.queue.get_task(other_user["task_id"])) is not None
     assert [task["task_id"] for task in caller_active] == [occupied["task_id"]]
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out["is_error"] is True
     other_task = await fake_ctx.queue.get_task(other_user["task_id"])
@@ -144,7 +144,7 @@ async def test_generate_videos_episode_scope_batch_is_all_or_nothing_when_a_unit
     assert other_task["user_id"] == "default"
     assert occupied_task is not None
     assert occupied_task["user_id"] == "tenant-user"
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.blocked) == ["E1S01", "E1S02"]
     codes = {item.unit_id: item.problem.code for item in result.items if item.problem is not None}
     assert codes["E1S02"] == "generation_active_task_conflict"
@@ -159,12 +159,12 @@ async def test_generate_reference_videos_reads_active_tts_from_the_callers_queue
     fake_ctx.tts_settings_resolver = ResolvedTtsSettingsResolver(
         TtsSynthesisSettings(provider_id="dashscope", model_id="qwen3-tts-flash", voice="Cherry", speed=None)
     )
-    _use_reference_route(fake_ctx)
+    use_reference_route(fake_ctx)
     (fake_ctx.project_path / "project.json").write_text(
         json.dumps(fake_ctx.pm.project_payload, ensure_ascii=False),
         encoding="utf-8",
     )
-    script = _reference_video_script()
+    script = reference_video_script()
     script["video_units"][0]["text"] = "海面。\n{风从远方吹来。}"
     script["video_units"].append(
         {
@@ -209,7 +209,7 @@ async def test_generate_reference_videos_reads_active_tts_from_the_callers_queue
         queue=fake_ctx.queue,
     ) == frozenset({"E1U1"})
 
-    out = await _call(
+    out = await call(
         _episode_scope(fake_ctx),
         {"script": "episode_1.json", "narration_delivery": "use_tts"},
     )
@@ -221,7 +221,7 @@ async def test_generate_reference_videos_reads_active_tts_from_the_callers_queue
     assert other_task["user_id"] == "default"
     assert caller_task is not None
     assert caller_task["user_id"] == "tenant-user"
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert sorted(result.blocked) == ["E1U1", "E1U2"]
     problems = {item.unit_id: item.problem for item in result.items if item.problem is not None}
     assert problems["E1U1"].code == "tts_missing"
@@ -277,7 +277,7 @@ async def test_generate_videos_all_scope_creates_zero_tasks_when_one_artifact_st
     monkeypatch.setattr(mod, "select_generation_targets", _one_unavailable)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_all_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_all_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("batch_admission") is not None, out
     assert out["batch_admission"]["decision"] == "blocked"
@@ -330,10 +330,10 @@ async def test_generate_videos_all_scope_admits_legacy_narration_stored_under_sc
 
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", fake_batch)
 
-    out = await _call(_all_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_all_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("is_error") is not True, out
-    result = _generation_result(out)
+    result = read_generation_result(out)
     assert list(result.succeeded) == ["E1S01"]
 
 
@@ -362,7 +362,7 @@ async def test_generate_videos_all_scope_reports_an_all_unreadable_selection_as_
     monkeypatch.setattr(mod, "select_generation_targets", _all_unavailable)
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_all_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_all_scope(fake_ctx), {"script": "episode_1.json"})
 
     assert out.get("batch_admission") is not None, out
     assert out["batch_admission"]["decision"] == "blocked"
@@ -379,15 +379,15 @@ async def test_generate_reference_episode_refuses_a_non_scalar_unit_id(
     """整集参考生成遇到非标量 unit_id：它按位置记名拒收，健康的兄弟条目不会独自入队计费。"""
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    script = _reference_video_script()
+    use_reference_route(fake_ctx)
+    script = reference_video_script()
     healthy = script["video_units"][0]
     script["video_units"] = [{**healthy, "unit_id": ["U9"]}, healthy]
     fake_ctx.pm.script_payload = script
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
+    out = await call(_episode_scope(fake_ctx), {"script": "episode_1.json"})
 
     enqueue.assert_not_awaited()
     codes = {
@@ -403,15 +403,15 @@ async def test_generate_reference_units_refuses_a_duplicated_named_unit(
     """点名的 unit 在剧本里有两份：无从判定要做哪一条，整批停在建任务之前。"""
     from server.media_tools import videos as mod
 
-    _use_reference_route(fake_ctx)
-    script = _reference_video_script()
+    use_reference_route(fake_ctx)
+    script = reference_video_script()
     script["video_units"] = [*script["video_units"], {**script["video_units"][0]}]
     fake_ctx.pm.script_payload = script
     duplicated_id = script["video_units"][0]["unit_id"]
     enqueue = AsyncMock(return_value=([], []))
     monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
 
-    out = await _call(
+    out = await call(
         _selected_scope(fake_ctx),
         {"script": "episode_1.json", "scene_ids": [duplicated_id]},
     )

--- a/tests/integration/server/media_tools/test_videos_audio_switch.py
+++ b/tests/integration/server/media_tools/test_videos_audio_switch.py
@@ -66,7 +66,7 @@ def _ctx(tmp_path: Path, project: dict[str, Any]) -> ToolContext:
     return ToolContext(
         project_name="demo",
         projects_root=tmp_path,
-        pm=_FakePM(project),  # type: ignore[arg-type]
+        pm=_FakePM(project),
     )
 
 
@@ -300,7 +300,7 @@ class TestStoryboardGateSkipsEmptyBatches:
         ctx = ToolContext(
             project_name="demo",
             projects_root=tmp_path,
-            pm=_EpisodePM(project_dir, with_storyboard=with_storyboard, with_video=with_video),  # type: ignore[arg-type]
+            pm=_EpisodePM(project_dir, with_storyboard=with_storyboard, with_video=with_video),
         )
         if with_video:
             _claim_existing_video(project_dir, "E1S01")
@@ -350,7 +350,7 @@ class TestStoryboardGateEntersAdmission:
         return ToolContext(
             project_name="demo",
             projects_root=tmp_path,
-            pm=_EpisodePM(project_dir, with_storyboard=True),  # type: ignore[arg-type]
+            pm=_EpisodePM(project_dir, with_storyboard=True),
         )
 
     async def test_audio_switch_conflict_is_reported_as_a_blocked_admission(self, tmp_path, monkeypatch):
@@ -382,7 +382,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        ctx.pm.script_payload["segments"][0]["video_prompt"] = "   "  # type: ignore[attr-defined]
+        ctx.pm.script_payload["segments"][0]["video_prompt"] = "   "
 
         tool_obj = _episode_scope(ctx)
         out = await tool_obj.handler({"script": "episode_1.json", "narration_delivery": "post_production"})
@@ -405,7 +405,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments.append({**segments[0]})
 
         tool_obj = _episode_scope(ctx)
@@ -467,7 +467,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        ctx.pm.script_payload["segments"][0]["segment_id"] = ["E1S01"]  # type: ignore[attr-defined]
+        ctx.pm.script_payload["segments"][0]["segment_id"] = ["E1S01"]
 
         tool_obj = _episode_scope(ctx)
         out = await tool_obj.handler({"script": "episode_1.json", "narration_delivery": "post_production"})
@@ -490,7 +490,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        ctx.pm.script_payload["segments"].insert(0, 42)  # type: ignore[attr-defined]
+        ctx.pm.script_payload["segments"].insert(0, 42)
 
         tool_obj = _episode_scope(ctx)
         out = await tool_obj.handler({"script": "episode_1.json", "narration_delivery": "post_production"})
@@ -513,7 +513,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments.insert(0, 42)
         segments[1]["segment_id"] = "items[0]"
 
@@ -535,7 +535,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         first = segments[0]
         first["scene_id"] = "SC1"
         segments.append({**first, "segment_id": "E1S02"})
@@ -562,7 +562,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments[0]["scene_id"] = ["E1S01"]
 
         tool_obj = _selected_scope(ctx)
@@ -584,7 +584,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments[0]["scene_id"] = "A"
         segments.append({**segments[0], "scene_id": "B"})
 
@@ -614,7 +614,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments[0]["segment_id"] = 0
         segments[0]["scene_id"] = "E1S01"
 
@@ -640,7 +640,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments.append({**segments[0], "segment_id": ""})
 
         tool_obj = _all_scope(ctx)
@@ -665,7 +665,7 @@ class TestStoryboardGateEntersAdmission:
         monkeypatch.setattr(admission_mod, "assert_audio_switch_supported", _allow)
         monkeypatch.setattr(mod, "batch_enqueue_and_wait", enqueue)
         ctx = self._ctx(tmp_path)
-        segments = ctx.pm.script_payload["segments"]  # type: ignore[attr-defined]
+        segments = ctx.pm.script_payload["segments"]
         segments.append({**segments[0]})
 
         tool_obj = _selected_scope(ctx)

--- a/tests/integration/server/media_tools/test_videos_audio_switch.py
+++ b/tests/integration/server/media_tools/test_videos_audio_switch.py
@@ -27,22 +27,22 @@ from server.media_tools.context import ToolContext
 from server.services import video_batch_admission as admission_mod
 from server.services.video_batch_admission import admit_reference_video_batch
 from server.services.video_caps import assert_audio_switch_supported
-from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import _videos_tool_for_scope
+from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import videos_tool_for_scope
 
 _ALWAYS_AUDIBLE = "dashscope/wan2.7-i2v"
 _CONTROLLABLE = "ark/doubao-seedance-2-0-260128"
 
 
 def _episode_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "episode")
+    return videos_tool_for_scope(ctx, "episode")
 
 
 def _selected_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "selected")
+    return videos_tool_for_scope(ctx, "selected")
 
 
 def _all_scope(ctx: ToolContext):
-    return _videos_tool_for_scope(ctx, "all")
+    return videos_tool_for_scope(ctx, "all")
 
 
 async def _seed_settings(factory: async_sessionmaker[AsyncSession], **settings: str) -> None:
@@ -52,22 +52,6 @@ async def _seed_settings(factory: async_sessionmaker[AsyncSession], **settings: 
         for key, value in settings.items():
             await svc.set_setting(key, value)
         await session.commit()
-
-
-class _FakePM:
-    def __init__(self, project: dict[str, Any]) -> None:
-        self.project = project
-
-    def load_project(self, _name: str) -> dict[str, Any]:
-        return self.project
-
-
-def _ctx(tmp_path: Path, project: dict[str, Any]) -> ToolContext:
-    return ToolContext(
-        project_name="demo",
-        projects_root=tmp_path,
-        pm=_FakePM(project),
-    )
 
 
 def _unit_spec(unit: dict[str, Any]) -> TaskSpec:

--- a/tests/integration/server/routers/projects_router_support.py
+++ b/tests/integration/server/routers/projects_router_support.py
@@ -433,7 +433,7 @@ class _FakeSummaries:
         )
 
 
-def _client(monkeypatch, fake_pm, fake_summaries=None):
+def build_projects_client(monkeypatch, fake_pm, fake_summaries=None):
     monkeypatch.setattr(projects, "get_project_manager", lambda: fake_pm)
 
     app = FastAPI()
@@ -448,6 +448,6 @@ def _client(monkeypatch, fake_pm, fake_summaries=None):
     return TestClient(app)
 
 
-def _override(client: TestClient, dependency: Callable[..., Any], provider: Callable[..., Any]) -> None:
-    """给 ``_client`` 建好的 app 补挂依赖覆盖（``TestClient.app`` 的静态类型只是裸 ASGI 可调用）。"""
+def override(client: TestClient, dependency: Callable[..., Any], provider: Callable[..., Any]) -> None:
+    """给 ``build_projects_client`` 建好的 app 补挂依赖覆盖（``TestClient.app`` 的静态类型只是裸 ASGI 可调用）。"""
     cast(FastAPI, client.app).dependency_overrides[dependency] = provider

--- a/tests/integration/server/routers/test_generate_router.py
+++ b/tests/integration/server/routers/test_generate_router.py
@@ -1008,7 +1008,7 @@ class TestGenerateRouter:
         def _raise_dirty(*args, **kwargs):
             raise ScriptEditError("segments 必须是列表，当前为 NoneType")
 
-        fake_pm.load_script = _raise_dirty  # type: ignore[method-assign]
+        fake_pm.load_script = _raise_dirty
         fake_queue = _FakeQueue()
         client = _client(monkeypatch, fake_pm, fake_queue)
 
@@ -1047,7 +1047,7 @@ class TestGenerateRouter:
         def _raise_missing(*args, **kwargs):
             raise FileNotFoundError(f"剧本文件不存在: {missing_script_path}")
 
-        fake_pm.load_script = _raise_missing  # type: ignore[method-assign]
+        fake_pm.load_script = _raise_missing
         fake_queue = _FakeQueue()
         client = _client(monkeypatch, fake_pm, fake_queue)
 
@@ -1547,7 +1547,7 @@ class TestNoServerPathLeak:
         def _raise(*args, **kwargs):
             raise FileNotFoundError(f"项目元数据文件不存在: {tmp_path / 'projects' / 'demo' / 'project.json'}")
 
-        fake_pm.load_project = _raise  # type: ignore[method-assign]
+        fake_pm.load_project = _raise
         return _client(monkeypatch, fake_pm, _FakeQueue())
 
     def test_file_not_found_404_hides_path_for_all_endpoints(self, tmp_path, monkeypatch):
@@ -1577,7 +1577,7 @@ class TestNoServerPathLeak:
         def _raise(*args, **kwargs):
             raise FileNotFoundError(f"剧本文件不存在: {project_path / 'scripts' / 'episode_1.json'}")
 
-        fake_pm.load_script = _raise  # type: ignore[method-assign]
+        fake_pm.load_script = _raise
         client = _client(monkeypatch, fake_pm, _FakeQueue())
 
         with client:
@@ -1608,7 +1608,7 @@ class TestNoServerPathLeak:
         def _raise(*args, **kwargs):
             raise RuntimeError(f"boom at {tmp_path / 'projects' / 'demo' / 'project.json'}")
 
-        fake_pm.load_project = _raise  # type: ignore[method-assign]
+        fake_pm.load_project = _raise
         client = _client(monkeypatch, fake_pm, _FakeQueue())
 
         with client:

--- a/tests/integration/server/routers/test_projects_ad_creation.py
+++ b/tests/integration/server/routers/test_projects_ad_creation.py
@@ -1,14 +1,14 @@
 """Tests for projects_ad_creation."""
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
 class TestProjectsRouter:
     def test_create_ad_project(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             # 默认档位：不传 target_duration → 60；brief 可空；episodes 恒单条；无 default_duration
             created = client.post(
@@ -45,7 +45,7 @@ class TestProjectsRouter:
             assert custom.json()["project"]["brief"] == "卖点"
 
     def test_create_ad_project_rejects_incompatible_fields(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             # ad 不暴露 default_duration
             with_default = client.post(
@@ -99,7 +99,7 @@ class TestProjectsRouter:
 
     def test_patch_ad_project_fields(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             ignored_mode = client.patch(
                 "/api/v1/projects/ready",

--- a/tests/integration/server/routers/test_projects_agent_profile.py
+++ b/tests/integration/server/routers/test_projects_agent_profile.py
@@ -2,15 +2,15 @@
 
 from lib.i18n.zh import errors as zh_errors
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
 class TestProjectsRouter:
     def test_agent_profile_status_and_explicit_reset(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             status = client.get("/api/v1/projects/ready/agent-profile")
             assert status.status_code == 200
@@ -25,7 +25,7 @@ class TestProjectsRouter:
             assert fake_pm.profile_reset_calls == ["ready"]
 
     def test_agent_profile_endpoints_reject_invalid_project_name(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             status = client.get("/api/v1/projects/illegal-name/agent-profile")
             reset = client.post("/api/v1/projects/illegal-name/agent-profile/reset")

--- a/tests/integration/server/routers/test_projects_creation_fields.py
+++ b/tests/integration/server/routers/test_projects_creation_fields.py
@@ -3,15 +3,15 @@
 import pytest
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
 class TestProjectsRouter:
     def test_create_project_with_style_template_id_expands_prompt(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -32,7 +32,7 @@ class TestProjectsRouter:
 
     def test_create_project_with_unknown_template_id_returns_400(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -48,7 +48,7 @@ class TestProjectsRouter:
 
     def test_create_project_with_model_fields_persists(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -77,7 +77,7 @@ class TestProjectsRouter:
     def test_create_project_persists_episode_target_duration(self, tmp_path, monkeypatch):
         """单集目标时长在创建向导写入；越界值 422 且不留下半成品项目。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -107,7 +107,7 @@ class TestProjectsRouter:
     def test_create_project_with_image_default_layer(self, tmp_path, monkeypatch):
         """项目默认图片模型（default_image_backend）可在创建时写入，不必配桶。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -128,7 +128,7 @@ class TestProjectsRouter:
     def test_video_bucket_fields_create_patch_and_clear(self, tmp_path, monkeypatch):
         """项目级视频桶键（video_provider_i2v/r2v）可创建时写入、PATCH 设置；空值 = 清除、回退默认层。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             created = client.post(
@@ -163,7 +163,7 @@ class TestProjectsRouter:
     def test_create_project_ignores_legacy_image_backend(self, tmp_path, monkeypatch):
         """退役的 image_backend 字段已从写模型移除，传入时被静默忽略。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -181,7 +181,7 @@ class TestProjectsRouter:
 
     def test_create_project_empty_model_fields_not_written(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -202,7 +202,7 @@ class TestProjectsRouter:
     def test_create_project_persists_speech_rate(self, tmp_path, monkeypatch):
         """创建时可选填口播语速估算：区间内落盘，未填不落盘（回退语言默认）。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -227,7 +227,7 @@ class TestProjectsRouter:
     @pytest.mark.parametrize("bad", [0, -1, 20.5])
     def test_create_project_rejects_out_of_range_speech_rate(self, tmp_path, monkeypatch, bad):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -245,7 +245,7 @@ class TestProjectsRouter:
     def test_create_project_rejects_boolean_speech_rate(self, tmp_path, monkeypatch, value):
         """JSON 布尔不得被 Pydantic 折成 1.0 / 0.0 混进语速覆盖，两个取值都应 422 且不建目录。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -263,7 +263,7 @@ class TestProjectsRouter:
     def test_create_project_with_invalid_backend_returns_400(self, tmp_path, monkeypatch):
         """非法 backend 字符串应被校验器拒绝。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.post(
@@ -278,7 +278,7 @@ class TestProjectsRouter:
             assert resp.status_code == 400
 
     def test_create_requires_binary_generation_mode(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             # 缺失 generation_mode：必填无默认值，不被悄悄锁进某种生成模式
             missing = client.post(
@@ -304,7 +304,7 @@ class TestProjectsRouter:
                 assert created.json()["project"]["generation_mode"] == mode
 
     def test_create_persists_grid_storyboard(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             # 缺省 false 也落盘为显式值
             default_off = client.post(

--- a/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
+++ b/tests/integration/server/routers/test_projects_crud_and_batch_edit.py
@@ -14,15 +14,15 @@ from server.error_handlers import register_error_handlers
 from server.routers import projects
 from tests.auth_deps import AUTH_DEPENDENCIES
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
-    _override,
+    build_projects_client,
+    override,
 )
 
 
 class TestProjectsRouter:
     def test_list_and_create_and_delete(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             listed = client.get("/api/v1/projects")
             assert listed.status_code == 200
@@ -87,7 +87,7 @@ class TestProjectsRouter:
             assert delete_ok.status_code == 200
 
     def test_create_persists_source_kind_and_defaults_novel(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             # 显式 screenplay 持久化于 project.json 顶层
             screenplay = client.post(
@@ -126,7 +126,7 @@ class TestProjectsRouter:
 
     def test_source_kind_silently_ignored_on_patch(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"source_kind": "screenplay"})
             assert resp.status_code == 200
@@ -135,7 +135,7 @@ class TestProjectsRouter:
 
     def test_project_details_and_updates(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             detail = client.get("/api/v1/projects/ready")
@@ -278,8 +278,8 @@ class TestProjectsRouter:
                     revision=revision,
                 )
 
-        client = _client(monkeypatch, fake_pm)
-        _override(client, projects.get_script_batch_editor_factory, lambda: lambda _manager=None: CapturingEditor())
+        client = build_projects_client(monkeypatch, fake_pm)
+        override(client, projects.get_script_batch_editor_factory, lambda: lambda _manager=None: CapturingEditor())
 
         with client:
             response = client.post(
@@ -295,7 +295,7 @@ class TestProjectsRouter:
         assert observed_sources == ["webui"]
 
     def test_revisioned_batch_endpoint_rejects_invalid_project_name(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
 
         with client:
             response = client.post(

--- a/tests/integration/server/routers/test_projects_episodes_patch.py
+++ b/tests/integration/server/routers/test_projects_episodes_patch.py
@@ -6,8 +6,8 @@ from lib.artifact_manifest import ArtifactKey, ArtifactManifestEntry, ProjectArt
 from lib.i18n.zh import errors as zh_errors
 from lib.project_manager import ProjectManager
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
@@ -75,7 +75,7 @@ class TestProjectsRouter:
         )
         adapter.put_entry(unrelated, unrelated_entry)
 
-        with _client(monkeypatch, pm) as client:
+        with build_projects_client(monkeypatch, pm) as client:
             response = client.patch(
                 "/api/v1/projects/demo",
                 json={"episodes": [{"episode": 1, "script_file": "scripts/new.json"}]},
@@ -94,7 +94,7 @@ class TestProjectsRouter:
             {"episode": 2, "title": "第二集", "script_file": "scripts/ep2.json"},
         ]
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -115,7 +115,7 @@ class TestProjectsRouter:
             {"episode": 1, "title": "第一集", "script_file": "scripts/ep1.json"},
         ]
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -132,7 +132,7 @@ class TestProjectsRouter:
             {"episode": 1, "title": "原标题", "script_file": "scripts/ep1.json"},
         ]
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -177,7 +177,7 @@ class TestProjectsRouter:
             {"episode": 2, "title": "第二集", "script_file": "scripts/ep2.json"},
         ]
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -197,7 +197,7 @@ class TestProjectsRouter:
         # 剧本带 episode 字段，触发 _apply_episode_sync 镜像（与真实生成剧本一致）
         fake_pm.scripts[("ready", "episode_1.json")]["episode"] = 1
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": "  新集名  "})
             assert resp.status_code == 200
@@ -210,7 +210,7 @@ class TestProjectsRouter:
 
     def test_update_episode_title_empty_rejected(self, tmp_path, monkeypatch):
         """空/纯空白标题被拒（422），不进锁。"""
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             for blank in ("", "   "):
                 resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": blank})
@@ -218,7 +218,7 @@ class TestProjectsRouter:
 
     def test_update_episode_missing_episode_404(self, tmp_path, monkeypatch):
         """不存在的 episode → 404。"""
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.patch("/api/v1/projects/ready/episodes/99", json={"title": "x"})
             assert resp.status_code == 404
@@ -229,7 +229,7 @@ class TestProjectsRouter:
         锁内抛出的 NotFoundError 不是 HTTPException 子类，外层 except 阶梯必须
         同时放行 ApiError，否则被兜底分支吞成 internal_server_error。
         """
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.patch("/api/v1/projects/nope/episodes/1", json={"title": "x"})
             assert resp.status_code == 404
@@ -240,7 +240,7 @@ class TestProjectsRouter:
         fake_pm = _FakePM(tmp_path)
         fake_pm.project_data["ready"]["episodes"][0]["script_file"] = "scripts/gone.json"
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready/episodes/1", json={"title": "x"})
             assert resp.status_code == 404

--- a/tests/integration/server/routers/test_projects_error_leakage.py
+++ b/tests/integration/server/routers/test_projects_error_leakage.py
@@ -3,9 +3,9 @@
 from lib.i18n.zh import errors as zh_errors
 from server.routers import projects
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
-    _override,
+    build_projects_client,
+    override,
 )
 
 
@@ -52,7 +52,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_create_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_create_project"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         # _sync 里最早命中 get_project_manager()，RuntimeError 绕过 ValueError/HTTPException 分支
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
@@ -65,7 +65,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_get_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_get_project"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.get("/api/v1/projects/ready")
@@ -74,7 +74,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_project"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"title": "X"})
@@ -83,7 +83,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_delete_project_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_delete_project"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.delete("/api/v1/projects/remove-me")
@@ -92,7 +92,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_get_script_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_get_script"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.get("/api/v1/projects/ready/scripts/episode_1.json")
@@ -101,7 +101,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_scene_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_scene"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.patch(
@@ -113,7 +113,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_shot_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_shot"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.patch(
@@ -125,7 +125,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_reorder_shots_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_reorder_shots"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.post(
@@ -137,7 +137,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_segment_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_segment"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.patch(
@@ -149,7 +149,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_episode_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_episode"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         # title 非空校验在 try 前；_sync 里最早命中 get_project_manager()
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
@@ -159,7 +159,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_set_project_source_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_set_source"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             # content 走 multipart form；get_project_manager() 在 try 内最早被调用
@@ -173,7 +173,7 @@ class TestUnexpectedErrorsDoNotLeak:
     def test_set_project_source_overview_error_does_not_leak_path(self, tmp_path, monkeypatch):
         # 概览生成是上传的可选后续：失败时上传仍成功（200），错误只降级回传 overview_error。
         # 底层异常文本可能携带服务器绝对路径，该分支不得把裸 str(e) 透传给客户端。
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.post(
                 "/api/v1/projects/leaky/source",
@@ -193,7 +193,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_generate_overview_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_generate_overview"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.post("/api/v1/projects/ready/generate-overview")
@@ -203,7 +203,7 @@ class TestUnexpectedErrorsDoNotLeak:
     def test_generate_overview_corrupted_project_maps_to_500_not_provider_error(self, tmp_path, monkeypatch):
         # JSONDecodeError 是 ValueError 子类：损坏的 project.json 不能被 except ValueError
         # 误判为「未配置文本供应商」，须先于其拦截并映射为通用 500
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.post("/api/v1/projects/corrupted/generate-overview")
             assert resp.status_code == 500
@@ -212,7 +212,7 @@ class TestUnexpectedErrorsDoNotLeak:
     def test_generate_overview_schema_failure_maps_to_ai_response_invalid(self, tmp_path, monkeypatch):
         # pydantic ValidationError 也是 ValueError 子类：模型输出不合 schema 时须命中
         # 「AI 响应无效」专属分支，不能被通用 ValueError 处理误判为「未配置文本供应商」
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.post("/api/v1/projects/bad-schema/generate-overview")
             assert resp.status_code == 400
@@ -221,7 +221,7 @@ class TestUnexpectedErrorsDoNotLeak:
     def test_generate_overview_invalid_project_name_maps_to_400_not_provider_error(self, tmp_path, monkeypatch):
         # get_project_path 抛出的非法项目名 ValueError（路径穿越等）不能被 generate_overview()
         # 内部供应商解析链路的 except ValueError 误判为「未配置文本供应商」
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.post("/api/v1/projects/illegal-name/generate-overview")
             assert resp.status_code == 400
@@ -230,7 +230,7 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_update_overview_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_update_overview"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.patch("/api/v1/projects/ready/overview", json={"synopsis": "新简介"})
@@ -239,10 +239,10 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_create_export_token_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_export_token"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         # scope 合法（默认 full）；_sync 里最早命中 get_project_manager()。
         # 归档服务改由依赖覆盖给出，免得同一个哨兵在依赖解析期就抛、绕过处理器兜底。
-        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
+        override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         monkeypatch.setattr(projects, "get_project_manager", _raise(sentinel))
         with client:
             resp = client.post("/api/v1/projects/ready/export/token")
@@ -251,10 +251,10 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_export_project_archive_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_export_archive"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         # download_token 校验先放行，再让归档服务抛 RuntimeError 落到兜底
         monkeypatch.setattr(projects, "verify_download_token", lambda token, name: {"sub": "u"})
-        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
+        override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         with client:
             resp = client.get("/api/v1/projects/ready/export?download_token=tok&scope=full")
             assert resp.status_code == 500
@@ -262,9 +262,9 @@ class TestUnexpectedErrorsDoNotLeak:
 
     def test_import_project_archive_unexpected_error_maps_to_500(self, tmp_path, monkeypatch):
         sentinel = "LEAKED_SECRET_import_archive"
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         # 上传副本写盘成功后，_sync 调归档服务抛 RuntimeError，落到 JSONResponse(500) 兜底
-        _override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
+        override(client, projects.get_archive_service, lambda: _raising_service(sentinel))
         with client:
             resp = client.post(
                 "/api/v1/projects/import",

--- a/tests/integration/server/routers/test_projects_list_and_status.py
+++ b/tests/integration/server/routers/test_projects_list_and_status.py
@@ -1,9 +1,9 @@
 """Tests for projects_list_and_status."""
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
     _FakeSummaries,
+    build_projects_client,
 )
 
 
@@ -22,7 +22,7 @@ class TestProjectsRouter:
         fake_pm.load_script = _counting_load
 
         fake_summaries = _FakeSummaries()
-        client = _client(monkeypatch, fake_pm, fake_summaries)
+        client = build_projects_client(monkeypatch, fake_pm, fake_summaries)
         with client:
             resp = client.get("/api/v1/projects")
             assert resp.status_code == 200
@@ -38,7 +38,7 @@ class TestProjectsRouter:
 
     def test_list_projects_status_comes_from_the_project_summary(self, tmp_path, monkeypatch):
         """列表页的阶段与计数一律来自项目摘要：四值阶段在，五值 current_phase 不在。"""
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects")
 
@@ -52,7 +52,7 @@ class TestProjectsRouter:
 
     def test_get_project_status_comes_from_the_project_summary(self, tmp_path, monkeypatch):
         """全局头读的项目级状态与列表同源。"""
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready")
 
@@ -68,7 +68,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["episodes"] = [
             {"episode": 1, "title": "第一集", "script_file": "scripts/ep1.json"},
         ]
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.get("/api/v1/projects/ready")
 
@@ -90,7 +90,7 @@ class TestProjectsRouter:
 
     def test_get_project_scripts_carry_no_derived_totals(self, tmp_path, monkeypatch):
         """剧本响应不再注入条目数 / 总时长 / 出场名单：这些派生值只有项目摘要一个来源。"""
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready")
 
@@ -109,7 +109,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"].pop("style_template_id", None)
         fake_pm.project_data["ready"]["style"] = ""
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.get("/api/v1/projects")
             assert resp.status_code == 200
@@ -120,7 +120,7 @@ class TestProjectsRouter:
     def test_get_project_includes_asset_fingerprints(self, tmp_path, monkeypatch):
         """项目 API 应返回 asset_fingerprints 字段"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.get("/api/v1/projects/ready")

--- a/tests/integration/server/routers/test_projects_list_and_status.py
+++ b/tests/integration/server/routers/test_projects_list_and_status.py
@@ -19,7 +19,7 @@ class TestProjectsRouter:
             calls.append((name, script_file))
             return orig_load_script(name, script_file)
 
-        fake_pm.load_script = _counting_load  # type: ignore[method-assign]
+        fake_pm.load_script = _counting_load
 
         fake_summaries = _FakeSummaries()
         client = _client(monkeypatch, fake_pm, fake_summaries)

--- a/tests/integration/server/routers/test_projects_model_settings.py
+++ b/tests/integration/server/routers/test_projects_model_settings.py
@@ -1,15 +1,15 @@
 """projects 路由的 model_settings 读写。"""
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
 class TestModelSettingsApi:
     def test_create_project_with_model_settings(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.post(
                 "/api/v1/projects",
@@ -32,7 +32,7 @@ class TestModelSettingsApi:
 
     def test_patch_project_model_settings(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             # 先创建（利用现有 ready 项目）
             resp = client.patch(

--- a/tests/integration/server/routers/test_projects_prompt_preview.py
+++ b/tests/integration/server/routers/test_projects_prompt_preview.py
@@ -7,7 +7,7 @@ from server.services.prompt_preview import (
     RenderedPrompt,
     ScriptItemNotFound,
 )
-from tests.integration.server.routers.projects_router_support import _client, _FakePM
+from tests.integration.server.routers.projects_router_support import _FakePM, build_projects_client
 
 
 class TestPromptPreviewEndpoint:
@@ -32,7 +32,7 @@ class TestPromptPreviewEndpoint:
             )
 
         monkeypatch.setattr(projects, "preview_item_prompts", _preview)
-        client = _client(monkeypatch, self._pm(tmp_path))
+        client = build_projects_client(monkeypatch, self._pm(tmp_path))
 
         with client:
             response = client.get(
@@ -58,7 +58,7 @@ class TestPromptPreviewEndpoint:
             raise ScriptItemNotFound(item_id)
 
         monkeypatch.setattr(projects, "preview_item_prompts", _preview)
-        client = _client(monkeypatch, self._pm(tmp_path))
+        client = build_projects_client(monkeypatch, self._pm(tmp_path))
 
         with client:
             response = client.get(
@@ -69,7 +69,7 @@ class TestPromptPreviewEndpoint:
         assert response.status_code == 404
 
     def test_script_file_is_required(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, self._pm(tmp_path))
+        client = build_projects_client(monkeypatch, self._pm(tmp_path))
 
         with client:
             response = client.get("/api/v1/projects/ready/script-items/E1S01/prompt-preview")

--- a/tests/integration/server/routers/test_projects_script_edit_endpoints.py
+++ b/tests/integration/server/routers/test_projects_script_edit_endpoints.py
@@ -7,8 +7,8 @@ from copy import deepcopy
 import pytest
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
@@ -24,7 +24,7 @@ class TestProjectsRouter:
             "segments": [{"segment_id": "E1S01", "duration_seconds": 4}],
         }
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             patch_scene = client.patch(
@@ -76,7 +76,7 @@ class TestProjectsRouter:
             ],
         }
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         nfd_cafe = unicodedata.normalize("NFD", "Café")
 
         with client:
@@ -123,7 +123,7 @@ class TestProjectsRouter:
                 }
             ],
         }
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -149,7 +149,7 @@ class TestProjectsRouter:
                 }
             ],
         }
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -173,7 +173,7 @@ class TestProjectsRouter:
             "scenes": [{"scene_id": "E1S01"}],
         }
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.patch(
@@ -198,7 +198,7 @@ class TestProjectsRouter:
             raise ValueError("脚本内 episode=1 与文件名 episode_10 不一致")
 
         monkeypatch.setattr(fake_pm, "locked_script", _raising_locked_script)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             resp = client.patch(
@@ -226,7 +226,7 @@ class TestProjectsRouter:
             ],
         }
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         nfd_cafe = unicodedata.normalize("NFD", "Café")
 
         with client:
@@ -280,7 +280,7 @@ class TestProjectsRouter:
             ],
         }
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         utterances = [
             {"kind": "dialogue", "speaker": "Alice", "text": "你来了。"},
             {"kind": "voiceover", "speaker": None, "text": "命运就此转向。"},
@@ -308,7 +308,7 @@ class TestProjectsRouter:
             "content_mode": "drama",
             "scenes": [{"scene_id": "001", "duration_seconds": 8, "utterances": utterances}],
         }
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -336,7 +336,7 @@ class TestProjectsRouter:
                 }
             ],
         }
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -382,7 +382,7 @@ class TestProjectsRouter:
     def test_update_shot_edits_voiceover_section_duration(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02"])
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             patched = client.patch(
@@ -412,7 +412,7 @@ class TestProjectsRouter:
         script = self._ad_script(["E1S01"])
         script["shots"][0]["video_prompt"] = {"dialogue": [{"speaker": "Alice", "line": "快走。"}]}
         fake_pm.scripts[("ad-ready", "episode_1.json")] = script
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -435,7 +435,7 @@ class TestProjectsRouter:
         }
         script["shots"][0]["needs_replan"] = True
         fake_pm.scripts[("ad-ready", "episode_1.json")] = script
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             response = client.patch(
@@ -458,7 +458,7 @@ class TestProjectsRouter:
     def test_update_shot_ignores_non_whitelisted_fields(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01"])
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             patched = client.patch(
@@ -476,7 +476,7 @@ class TestProjectsRouter:
 
     def test_update_shot_rejects_non_ad_script(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             rejected = client.patch(
@@ -488,7 +488,7 @@ class TestProjectsRouter:
     def test_update_shot_unknown_id_404(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01"])
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             missing = client.patch(
@@ -500,7 +500,7 @@ class TestProjectsRouter:
     def test_reorder_shots_full_permutation(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02", "E1S03"])
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             reordered = client.post(
@@ -515,7 +515,7 @@ class TestProjectsRouter:
     def test_reorder_shots_rejects_mismatched_ids(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = self._ad_script(["E1S01", "E1S02"])
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             # 数量不一致
@@ -542,7 +542,7 @@ class TestProjectsRouter:
 
     def test_reorder_shots_rejects_non_ad_script(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             rejected = client.post(
@@ -555,7 +555,7 @@ class TestProjectsRouter:
         """shots 非列表 / 含非对象元素时返回 422，且不被 reorder 空排列覆盖成 []。"""
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[("ad-ready", "episode_1.json")] = {"content_mode": "ad", "shots": "oops"}
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             # 非列表 shots：reorder 传空排列也必须 422，不得把损坏数据覆盖成空列表
@@ -665,7 +665,7 @@ class TestProjectsRouter:
         fake_pm = _FakePM(tmp_path)
         record_migration_failure(fake_pm.base / project_name, ValueError("坏数据"), schema_version=7)
         monkeypatch.setattr(guard, "get_project_manager", lambda: fake_pm)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         before_project_data = deepcopy(fake_pm.project_data)
         before_scripts = deepcopy(fake_pm.scripts)
 
@@ -753,7 +753,7 @@ class TestProjectsRouter:
         fake_pm = _FakePM(tmp_path)
         fake_pm.scripts[(project_name, script_file)] = script
         before = deepcopy(script)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         body = {"script_file": script_file, **request_body}
 
         with client:

--- a/tests/integration/server/routers/test_projects_update_fields.py
+++ b/tests/integration/server/routers/test_projects_update_fields.py
@@ -3,8 +3,8 @@
 import pytest
 
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
@@ -16,7 +16,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["style_image"] = "style_reference.png"
         fake_pm.project_data["ready"]["style_description"] = "old desc"
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -30,7 +30,7 @@ class TestProjectsRouter:
             assert "style_description" not in data
 
     def test_update_project_with_unknown_template_id_returns_400(self, tmp_path, monkeypatch):
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -44,7 +44,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["style_template_id"] = "live_premium_drama"
         fake_pm.project_data["ready"]["style"] = "画风：真人电视剧风格，精品短剧画风，大师级构图"
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -61,7 +61,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["style_image"] = "style_reference.png"
         fake_pm.project_data["ready"]["style_description"] = "some desc"
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -75,7 +75,7 @@ class TestProjectsRouter:
     def test_update_project_persists_narration_overrides(self, tmp_path, monkeypatch):
         """PATCH 旁白配音项目级覆盖：audio_backend / narration_voice / narration_speed 写入 project.json。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -98,7 +98,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["narration_voice"] = "Cherry"
         fake_pm.project_data["ready"]["narration_speed"] = 1.2
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -122,7 +122,7 @@ class TestProjectsRouter:
     def test_update_project_persists_character_voice_binding(self, tmp_path, monkeypatch):
         """PATCH 角色声音绑定方式：合法枚举写入，空值回落默认（从 project.json 移除）。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"character_voice_binding": "reference_audio"})
             assert resp.status_code == 200
@@ -135,7 +135,7 @@ class TestProjectsRouter:
     def test_update_project_rejects_unknown_character_voice_binding(self, tmp_path, monkeypatch):
         """非法枚举 422，且不写回 project.json。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"character_voice_binding": "native"})
             assert resp.status_code == 422
@@ -144,7 +144,7 @@ class TestProjectsRouter:
     def test_update_project_rejects_non_positive_narration_speed(self, tmp_path, monkeypatch):
         """语速 0/负数应 422，且不写回 project.json。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"narration_speed": 0})
             assert resp.status_code == 422
@@ -153,7 +153,7 @@ class TestProjectsRouter:
     def test_update_project_persists_and_clears_speech_rate(self, tmp_path, monkeypatch):
         """PATCH 口播语速估算：区间内写入 project.json，null 清除回落语言默认。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"speech_rate_units_per_second": 6.5})
             assert resp.status_code == 200
@@ -167,7 +167,7 @@ class TestProjectsRouter:
     def test_update_project_rejects_out_of_range_speech_rate(self, tmp_path, monkeypatch, bad):
         """口播语速估算越界（≤0 或 >20）应 422，且不写回 project.json。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"speech_rate_units_per_second": bad})
             assert resp.status_code == 422
@@ -177,7 +177,7 @@ class TestProjectsRouter:
     def test_update_project_rejects_boolean_speech_rate(self, tmp_path, monkeypatch, value):
         """PATCH 同样拒布尔：否则 true 会作为 1.0 落盘、false 被当成未填静默跳过。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"speech_rate_units_per_second": value})
             assert resp.status_code == 422
@@ -186,7 +186,7 @@ class TestProjectsRouter:
     def test_update_project_persists_and_clears_episode_target_duration(self, tmp_path, monkeypatch):
         """PATCH 单集目标时长：区间内写入 project.json，null 清除回落「未设目标」。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"episode_target_duration": 120})
             assert resp.status_code == 200
@@ -199,7 +199,7 @@ class TestProjectsRouter:
     @pytest.mark.parametrize("bad", [5, 900, 0, -30])
     def test_update_project_rejects_out_of_range_episode_target_duration(self, tmp_path, monkeypatch, bad):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"episode_target_duration": bad})
             assert resp.status_code == 422
@@ -208,7 +208,7 @@ class TestProjectsRouter:
     def test_update_project_rejects_invalid_audio_backend(self, tmp_path, monkeypatch):
         """audio_backend 非法 provider 应 400（复用 backend 格式校验）。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch("/api/v1/projects/ready", json={"audio_backend": "garbage"})
             assert resp.status_code == 400
@@ -221,7 +221,7 @@ class TestProjectsRouter:
         fake_pm.project_data["ready"]["style_image"] = "style_reference.png"
         fake_pm.project_data["ready"]["style_description"] = "some desc"
 
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             resp = client.patch(
                 "/api/v1/projects/ready",
@@ -237,7 +237,7 @@ class TestProjectsRouter:
     def test_patch_image_default_layer_set_and_clear(self, tmp_path, monkeypatch):
         """项目默认图片模型可设置 / 清除；格式非法与非图片模型均 400。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             updated = client.patch(
                 "/api/v1/projects/ready",
@@ -264,7 +264,7 @@ class TestProjectsRouter:
     def test_patch_text_tier_fields_set_and_clear(self, tmp_path, monkeypatch):
         """项目级档位 / 默认模型三字段可设置；空值 = 清除、继承全局。"""
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             updated = client.patch(
                 "/api/v1/projects/ready",
@@ -299,7 +299,7 @@ class TestProjectsRouter:
 
     def test_video_bucket_field_rejects_non_video_model(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
 
         with client:
             rejected = client.patch(
@@ -311,7 +311,7 @@ class TestProjectsRouter:
     def test_patch_toggles_grid_storyboard_but_not_route(self, tmp_path, monkeypatch):
         fake_pm = _FakePM(tmp_path)
         fake_pm.project_data["ready"]["generation_mode"] = "storyboard"
-        client = _client(monkeypatch, fake_pm)
+        client = build_projects_client(monkeypatch, fake_pm)
         with client:
             # 宫格开关创建后可随时切换
             on = client.patch("/api/v1/projects/ready", json={"grid_storyboard": True})

--- a/tests/integration/server/routers/test_projects_video_capabilities.py
+++ b/tests/integration/server/routers/test_projects_video_capabilities.py
@@ -3,8 +3,8 @@
 from lib.i18n.zh import errors as zh_errors
 from server.routers import projects
 from tests.integration.server.routers.projects_router_support import (
-    _client,
     _FakePM,
+    build_projects_client,
 )
 
 
@@ -36,7 +36,7 @@ class TestGetVideoCapabilities:
             "generation_mode": "reference_video",
         }
         self._patch_resolver(monkeypatch, return_value=fake_caps)
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready/video-capabilities")
             assert resp.status_code == 200
@@ -55,7 +55,7 @@ class TestGetVideoCapabilities:
         resolver_instance.video_capabilities_for_model = AsyncMock(return_value={"model": "candidate"})
         monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
 
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get(
                 "/api/v1/projects/ready/video-capabilities",
@@ -75,7 +75,7 @@ class TestGetVideoCapabilities:
         resolver_instance.video_capabilities_for_model = AsyncMock(return_value={"model": "candidate"})
         monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
 
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             assert client.get("/api/v1/projects/ready/video-capabilities").status_code == 200
             resp = client.get(
@@ -98,7 +98,7 @@ class TestGetVideoCapabilities:
         resolver_instance.video_capabilities = AsyncMock(return_value={"model": "saved-model"})
         monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
 
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready/video-capabilities", params={"episode": 3})
         assert resp.status_code == 200
@@ -106,7 +106,7 @@ class TestGetVideoCapabilities:
 
     def test_malformed_video_backend_returns_400(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, return_value={})
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get(
                 "/api/v1/projects/ready/video-capabilities",
@@ -126,7 +126,7 @@ class TestGetVideoCapabilities:
         resolver_instance.video_capabilities_for_model = AsyncMock(return_value={"model": "candidate"})
         monkeypatch.setattr(projects, "ConfigResolver", lambda _factory: resolver_instance)
 
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get(
                 "/api/v1/projects/ready/video-capabilities",
@@ -140,14 +140,14 @@ class TestGetVideoCapabilities:
 
     def test_unknown_project_returns_404(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, side_effect=FileNotFoundError("项目 'nonexistent' 不存在"))
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/nonexistent/video-capabilities")
             assert resp.status_code == 404
 
     def test_resolver_value_error_returns_422(self, tmp_path, monkeypatch):
         self._patch_resolver(monkeypatch, side_effect=ValueError("model not found: grok/unknown"))
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready/video-capabilities")
             assert resp.status_code == 422
@@ -170,7 +170,7 @@ class TestGetVideoCapabilities:
                 message="video model kling/kling-v3 lacks the capability required by the r2v bucket",
             ),
         )
-        client = _client(monkeypatch, _FakePM(tmp_path))
+        client = build_projects_client(monkeypatch, _FakePM(tmp_path))
         with client:
             resp = client.get("/api/v1/projects/ready/video-capabilities")
             assert resp.status_code == 400

--- a/tests/integration/server/routers/test_reference_videos_router_ad.py
+++ b/tests/integration/server/routers/test_reference_videos_router_ad.py
@@ -85,13 +85,13 @@ def ad_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app.include_router(router_mod.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
     app.dependency_overrides[get_current_user] = lambda: CurrentUserInfo(id="u1", sub="test", role="admin")
     client = TestClient(app)
-    client.fake_queue = fake_queue  # type: ignore[attr-defined]
-    client.project_dir = project_dir  # type: ignore[attr-defined]
+    client.fake_queue = fake_queue
+    client.project_dir = project_dir
     return client
 
 
 def _script(client: TestClient) -> dict:
-    path: Path = client.project_dir / "scripts/episode_1.json"  # type: ignore[attr-defined]
+    path: Path = client.project_dir / "scripts/episode_1.json"
     return json.loads(path.read_text(encoding="utf-8"))
 
 
@@ -118,7 +118,7 @@ def test_ad_units_support_crud_and_product_mentions(ad_client: TestClient) -> No
         json={"prompt": "@[按摩仪] 正面朝向镜头"},
     )
     assert patched.status_code == 200, patched.text
-    project = ProjectManager(ad_client.project_dir.parent).load_project("ad-demo")  # type: ignore[attr-defined]
+    project = ProjectManager(ad_client.project_dir.parent).load_project("ad-demo")
     assert [(ref.type, ref.name) for ref in unit_reference_declarations(project, patched.json()["unit"])] == [
         ("product", "按摩仪")
     ]
@@ -140,7 +140,7 @@ def test_generate_enqueues_self_contained_unit(ad_client: TestClient) -> None:
         json={"confirmed_request_duration_seconds": 8},
     )
     assert response.status_code == 202, response.text
-    kwargs = ad_client.fake_queue.enqueue_task.call_args.kwargs  # type: ignore[attr-defined]
+    kwargs = ad_client.fake_queue.enqueue_task.call_args.kwargs
     assert kwargs["resource_id"] == "E1U1"
     assert kwargs["script_file"] == "scripts/episode_1.json"
     assert "prompt" not in kwargs["payload"]
@@ -153,7 +153,7 @@ def test_generate_enqueues_self_contained_unit(ad_client: TestClient) -> None:
 def test_replan_shell_and_mixed_speech_are_blocked_before_enqueue(ad_client: TestClient) -> None:
     script = _script(ad_client)
     script["video_units"][0].update({"text": "", "duration_seconds": 0, "needs_replan": True})
-    path: Path = ad_client.project_dir / "scripts/episode_1.json"  # type: ignore[attr-defined]
+    path: Path = ad_client.project_dir / "scripts/episode_1.json"
     path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
     response = ad_client.post("/api/v1/projects/ad-demo/reference-videos/episodes/1/units/E1U1/generate")
@@ -163,13 +163,13 @@ def test_replan_shell_and_mixed_speech_are_blocked_before_enqueue(ad_client: Tes
     assert detail["unit_id"] == "E1U1"
     assert detail["problems"][0]["code"] == "needs_replan"
     assert detail["problems"][0]["locations"] == [{"path": ["needs_replan"], "line": None}]
-    ad_client.fake_queue.enqueue_task.assert_not_awaited()  # type: ignore[attr-defined]
+    ad_client.fake_queue.enqueue_task.assert_not_awaited()
 
 
 def test_non_planning_patch_keeps_replan_marker_until_content_is_repaired(ad_client: TestClient) -> None:
     script = _script(ad_client)
     script["video_units"][0]["needs_replan"] = True
-    path: Path = ad_client.project_dir / "scripts/episode_1.json"  # type: ignore[attr-defined]
+    path: Path = ad_client.project_dir / "scripts/episode_1.json"
     path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
     noted = ad_client.patch(
@@ -191,7 +191,7 @@ def test_duration_repair_clears_an_independent_migration_marker(ad_client: TestC
     script = _script(ad_client)
     # 旧聚合时长非法时迁移会夹到结构下限并标 replan，但不会留下内容归属 provenance。
     script["video_units"][0].update({"duration_seconds": 1, "needs_replan": True})
-    path: Path = ad_client.project_dir / "scripts/episode_1.json"  # type: ignore[attr-defined]
+    path: Path = ad_client.project_dir / "scripts/episode_1.json"
     path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
     repaired = ad_client.patch(
@@ -206,7 +206,7 @@ def test_duration_repair_clears_an_independent_migration_marker(ad_client: TestC
 def test_empty_migration_shell_can_repair_body_and_duration_atomically(ad_client: TestClient) -> None:
     script = _script(ad_client)
     script["video_units"][0].update({"text": "", "duration_seconds": 0, "needs_replan": True})
-    path: Path = ad_client.project_dir / "scripts/episode_1.json"  # type: ignore[attr-defined]
+    path: Path = ad_client.project_dir / "scripts/episode_1.json"
     path.write_text(json.dumps(script, ensure_ascii=False), encoding="utf-8")
 
     repaired = ad_client.patch(

--- a/tests/integration/server/services/generation_tasks_support.py
+++ b/tests/integration/server/services/generation_tasks_support.py
@@ -232,7 +232,7 @@ class _FakePM:
         return self.project
 
 
-class _FakeGenerator:
+class FakeGenerator:
     def __init__(self, project_path: Path | None = None):
         # 传入项目目录时把产出落到产物的规范路径，让任务按生产口径登记清单
         self.project_path = project_path

--- a/tests/integration/server/services/generation_tasks_support.py
+++ b/tests/integration/server/services/generation_tasks_support.py
@@ -17,7 +17,7 @@ from server.services.generation_context import AudioLaneResult, GenerationContex
 from tests.fakes import persist_fake_script
 
 
-def _async_return(value):
+def async_return(value):
     """Create an async function that always returns the given value (ignoring args)."""
 
     async def _inner(*args, **kwargs):
@@ -26,7 +26,7 @@ def _async_return(value):
     return _inner
 
 
-def _fake_resolve_ctx(
+def fake_resolve_ctx(
     generator,
     *,
     image_provider=("openai", "gpt-image-2"),
@@ -291,7 +291,7 @@ class FakeGenerator:
         return True
 
 
-def _prepare_files(tmp_path: Path):
+def prepare_files(tmp_path: Path):
     project_path = tmp_path / "projects" / "demo"
     (project_path / "storyboards").mkdir(parents=True, exist_ok=True)
     (project_path / "characters").mkdir(parents=True, exist_ok=True)
@@ -318,7 +318,7 @@ def _register_episode_script_artifact(project_path: Path) -> None:
     )
 
 
-def _persist_active_fake_project(fake_pm: _FakePM, *, register_script: bool = True) -> None:
+def persist_active_fake_project(fake_pm: _FakePM, *, register_script: bool = True) -> None:
     """Persist the fake manager's mutated state back onto its schema-8 project on disk."""
 
     fake_pm.project.update(
@@ -344,7 +344,7 @@ def _persist_active_fake_project(fake_pm: _FakePM, *, register_script: bool = Tr
         _register_episode_script_artifact(fake_pm.project_path)
 
 
-def _seed_current_storyboard(fake_pm: _FakePM, resource_id: str = "E1S01") -> None:
+def seed_current_storyboard(fake_pm: _FakePM, resource_id: str = "E1S01") -> None:
     """Record one already-generated storyboard the way production does.
 
     A video task consumes the storyboard through the script pointer plus the Manifest
@@ -355,14 +355,14 @@ def _seed_current_storyboard(fake_pm: _FakePM, resource_id: str = "E1S01") -> No
     items, id_field, _kind = generation_tasks.resolve_items(fake_pm.script)
     item = next(candidate for candidate in items if str(candidate.get(id_field)) == resource_id)
     item.setdefault("generated_assets", {})["storyboard_image"] = artifact_path
-    _register_stale_visual_claim(
+    register_stale_visual_claim(
         fake_pm.project_path,
         ArtifactKey.episode_storyboard(1, resource_id),
         artifact_path,
     )
 
 
-def _register_asset_sheet_claims(fake_pm: _FakePM) -> None:
+def register_asset_sheet_claims(fake_pm: _FakePM) -> None:
     """Register every asset sheet the fake project already has on disk.
 
     A sheet is only injectable once the Manifest claims it, so a fixture that wants
@@ -376,14 +376,14 @@ def _register_asset_sheet_claims(fake_pm: _FakePM) -> None:
         for name, entry in bucket.items():
             sheet = (entry or {}).get(spec.sheet_field)
             if isinstance(sheet, str) and sheet and (fake_pm.project_path / sheet).is_file():
-                _register_stale_visual_claim(
+                register_stale_visual_claim(
                     fake_pm.project_path,
                     ArtifactKey.asset_sheet(asset_type, name),
                     sheet,
                 )
 
 
-def _currency_resolver(project_path: Path, project: dict):
+def build_currency_resolver(project_path: Path, project: dict):
     """Persist the project and build the resolver production hands the reference collectors."""
 
     from lib.artifact_activation import active_artifact_currency_resolver
@@ -392,7 +392,7 @@ def _currency_resolver(project_path: Path, project: dict):
     return active_artifact_currency_resolver(project_path, project)
 
 
-def _register_stale_visual_claim(project_path: Path, key: ArtifactKey, artifact_path: str) -> None:
+def register_stale_visual_claim(project_path: Path, key: ArtifactKey, artifact_path: str) -> None:
     ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register(
         key,
         artifact_path=artifact_path,
@@ -400,7 +400,7 @@ def _register_stale_visual_claim(project_path: Path, key: ArtifactKey, artifact_
     )
 
 
-def _ad_pm(project_path: Path, *, with_sheet: bool) -> _FakePM:
+def ad_pm(project_path: Path, *, with_sheet: bool) -> _FakePM:
     """ad 项目 fixture：商品分镜 E1S02（引用保温杯）+ 氛围分镜 E1S01/E1S03。"""
     pm = _FakePM(project_path)
     pm.project["content_mode"] = "ad"
@@ -434,5 +434,5 @@ def _ad_pm(project_path: Path, *, with_sheet: bool) -> _FakePM:
             },
         ],
     }
-    _register_asset_sheet_claims(pm)
+    register_asset_sheet_claims(pm)
     return pm

--- a/tests/integration/server/services/reference_video_tasks_support.py
+++ b/tests/integration/server/services/reference_video_tasks_support.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from lib.project_migrations.runner import migrate_project_dir
 
 
-def _load_project_and_unit(proj_dir: Path, unit_id: str) -> tuple[dict, dict]:
+def load_project_and_unit(proj_dir: Path, unit_id: str) -> tuple[dict, dict]:
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     script = json.loads((proj_dir / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
     unit = next(u for u in script["video_units"] if u["unit_id"] == unit_id)
@@ -22,7 +22,7 @@ _TINY_PNG = (
 )
 
 
-def _write_project(tmp_path: Path, *, register_script: bool = True) -> Path:
+def write_project(tmp_path: Path, *, register_script: bool = True) -> Path:
     project = {
         "title": "T",
         "content_mode": "narration",
@@ -73,7 +73,7 @@ def _write_project(tmp_path: Path, *, register_script: bool = True) -> Path:
     return proj_dir
 
 
-def _register_asset_sheet(proj_dir: Path, asset_type: str, name: str, relative_path: str) -> None:
+def register_asset_sheet(proj_dir: Path, asset_type: str, name: str, relative_path: str) -> None:
     """把新增资产补成生产形态：sheet 文件在盘上，且在产物清单里登记。
 
     调用前 project.json 必须已经写盘并带上该资产的 sheet 指针——清单登记的依据来自

--- a/tests/integration/server/services/test_ad_product_fidelity.py
+++ b/tests/integration/server/services/test_ad_product_fidelity.py
@@ -4,12 +4,12 @@ from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _ad_pm,
-    _async_return,
-    _currency_resolver,
-    _fake_resolve_ctx,
-    _prepare_files,
-    _seed_current_storyboard,
+    ad_pm,
+    async_return,
+    build_currency_resolver,
+    fake_resolve_ctx,
+    prepare_files,
+    seed_current_storyboard,
 )
 
 
@@ -22,14 +22,14 @@ class TestAdProductFidelityStoryboard:
 
     def _patch(self, monkeypatch, pm, generator):
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(generator))
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_a, **_kw: True)
 
     async def test_product_shot_injects_sheet_then_originals_before_other_sheets(self, tmp_path, monkeypatch):
         """有确认 sheet 的商品分镜：注入集为「sheet 多角度 + 原图压阵」，排序绝对优先于角色/场景 sheet。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
-        pm = _ad_pm(project_path, with_sheet=True)
+        pm = ad_pm(project_path, with_sheet=True)
         generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
@@ -55,8 +55,8 @@ class TestAdProductFidelityStoryboard:
 
     async def test_product_shot_without_sheet_injects_originals_directly(self, tmp_path, monkeypatch):
         """无 sheet 的商品分镜：原图直注、仍排首位；声明但缺失的原图跳过。"""
-        project_path = _prepare_files(tmp_path)
-        pm = _ad_pm(project_path, with_sheet=False)
+        project_path = prepare_files(tmp_path)
+        pm = ad_pm(project_path, with_sheet=False)
         generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
@@ -75,8 +75,8 @@ class TestAdProductFidelityStoryboard:
 
     async def test_fidelity_instruction_only_names_products_with_injected_references(self, tmp_path, monkeypatch):
         """指令点名的商品与实际注入参考的商品一致：图全缺的商品不被指令点名（避免指向不存在的参考）。"""
-        project_path = _prepare_files(tmp_path)
-        pm = _ad_pm(project_path, with_sheet=False)
+        project_path = prepare_files(tmp_path)
+        pm = ad_pm(project_path, with_sheet=False)
         pm.project["products"]["杯刷"] = {
             "description": "配套杯刷",
             "product_sheet": "",
@@ -98,9 +98,9 @@ class TestAdProductFidelityStoryboard:
 
     async def test_atmosphere_shot_zero_product_images(self, tmp_path, monkeypatch):
         """氛围分镜（products_in_shot 为空）：零商品图，场景/角色 sheet 照常注入，prompt 无保真指令。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
-        pm = _ad_pm(project_path, with_sheet=True)
+        pm = ad_pm(project_path, with_sheet=True)
         generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
@@ -118,12 +118,12 @@ class TestAdProductFidelityStoryboard:
 
     def test_collect_shot_product_references_skips_non_list_products_in_shot(self, tmp_path):
         """products_in_shot 为 str/dict 等非列表脏数据：跳过不抛，零商品参考（str 不得被逐字符迭代）。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         project = {
             "schema_version": CURRENT_PROJECT_SCHEMA_VERSION,
             "products": {"保温杯": {"reference_images": ["products/refs/保温杯_1.jpg"]}},
         }
-        resolver = _currency_resolver(project_path, project)
+        resolver = build_currency_resolver(project_path, project)
 
         for dirty in ("保温杯", {"保温杯": True}, 7):
             item = {"shot_id": "E1S02", "products_in_shot": dirty}
@@ -156,7 +156,7 @@ class TestAdProductFidelityStoryboard:
         形式不同静默跳过。"""
         import unicodedata
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         name_nfc = unicodedata.normalize("NFC", "Hiếu")
         name_nfd = unicodedata.normalize("NFD", "Hiếu")
         assert name_nfc != name_nfd
@@ -169,7 +169,7 @@ class TestAdProductFidelityStoryboard:
             project,
             project_path,
             [name_nfc],
-            currency_resolver=_currency_resolver(project_path, project),
+            currency_resolver=build_currency_resolver(project_path, project),
         )
         assert [r["image"] for r in refs] == [project_path / "products" / "refs" / "保温杯_1.jpg"]
 
@@ -179,7 +179,7 @@ class TestAdProductFidelityStoryboard:
         挤掉真正的角色/场景参考。"""
         import unicodedata
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         name_nfc = unicodedata.normalize("NFC", "Hiếu")
         name_nfd = unicodedata.normalize("NFD", "Hiếu")
         assert name_nfc != name_nfd
@@ -192,16 +192,16 @@ class TestAdProductFidelityStoryboard:
             project,
             project_path,
             [name_nfc, name_nfd],
-            currency_resolver=_currency_resolver(project_path, project),
+            currency_resolver=build_currency_resolver(project_path, project),
         )
         assert [r["image"] for r in refs] == [project_path / "products" / "refs" / "保温杯_1.jpg"]
 
 
 def _patch_video_path(monkeypatch, pm, generator):
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-    monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
+    monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(generator))
     monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_a, **_kw: True)
-    monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+    monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
     monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
 
@@ -209,11 +209,11 @@ class TestAdProductVideoRequest:
     """商品分镜的视频请求走纯图生视频：分镜图作首帧，不带参考图。"""
 
     async def test_product_shot_video_request_carries_no_reference_images(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
         (project_path / "storyboards" / "scene_E1S02.png").write_bytes(b"png")
-        pm = _ad_pm(project_path, with_sheet=True)
-        _seed_current_storyboard(pm, "E1S02")
+        pm = ad_pm(project_path, with_sheet=True)
+        seed_current_storyboard(pm, "E1S02")
         generator = FakeGenerator()
         _patch_video_path(monkeypatch, pm, generator)
 

--- a/tests/integration/server/services/test_ad_product_fidelity.py
+++ b/tests/integration/server/services/test_ad_product_fidelity.py
@@ -3,11 +3,11 @@
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _ad_pm,
     _async_return,
     _currency_resolver,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _prepare_files,
     _seed_current_storyboard,
 )
@@ -30,7 +30,7 @@ class TestAdProductFidelityStoryboard:
         project_path = _prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
         pm = _ad_pm(project_path, with_sheet=True)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
         await generation_tasks.execute_storyboard_task(
@@ -57,7 +57,7 @@ class TestAdProductFidelityStoryboard:
         """无 sheet 的商品分镜：原图直注、仍排首位；声明但缺失的原图跳过。"""
         project_path = _prepare_files(tmp_path)
         pm = _ad_pm(project_path, with_sheet=False)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
         await generation_tasks.execute_storyboard_task(
@@ -85,7 +85,7 @@ class TestAdProductFidelityStoryboard:
             "selling_points": [],
         }
         pm.script["shots"][1]["products_in_shot"] = ["保温杯", "杯刷"]
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
         await generation_tasks.execute_storyboard_task(
@@ -101,7 +101,7 @@ class TestAdProductFidelityStoryboard:
         project_path = _prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
         pm = _ad_pm(project_path, with_sheet=True)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         self._patch(monkeypatch, pm, generator)
 
         await generation_tasks.execute_storyboard_task(
@@ -214,7 +214,7 @@ class TestAdProductVideoRequest:
         (project_path / "storyboards" / "scene_E1S02.png").write_bytes(b"png")
         pm = _ad_pm(project_path, with_sheet=True)
         _seed_current_storyboard(pm, "E1S02")
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_video_path(monkeypatch, pm, generator)
 
         result = await generation_tasks.execute_video_task(

--- a/tests/integration/server/services/test_collect_sheet_references.py
+++ b/tests/integration/server/services/test_collect_sheet_references.py
@@ -5,8 +5,8 @@ from lib.artifact_manifest import (
 )
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from tests.integration.server.services.generation_tasks_support import (
-    _currency_resolver,
-    _register_stale_visual_claim,
+    build_currency_resolver,
+    register_stale_visual_claim,
 )
 
 
@@ -31,7 +31,7 @@ class TestCollectSheetReferences:
         }
         items = [{"characters_in_segment": char_names}]
         for name in char_names:
-            _register_stale_visual_claim(
+            register_stale_visual_claim(
                 tmp_path,
                 ArtifactKey.asset_sheet("character", name),
                 f"{name}.png",
@@ -45,7 +45,7 @@ class TestCollectSheetReferences:
             scene_field="scenes",
             prop_field="props",
             max_count=6,
-            currency_resolver=_currency_resolver(tmp_path, project),
+            currency_resolver=build_currency_resolver(tmp_path, project),
         )
 
         assert len(refs) == 6

--- a/tests/integration/server/services/test_compute_affected_fingerprints.py
+++ b/tests/integration/server/services/test_compute_affected_fingerprints.py
@@ -3,7 +3,7 @@
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     _FakePM,
-    _prepare_files,
+    prepare_files,
 )
 
 
@@ -72,7 +72,7 @@ class TestGenerationTasks:
         assert all(not key.startswith("/") for key in fps)
 
     def test_product_fingerprints(self, monkeypatch, tmp_path):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)

--- a/tests/integration/server/services/test_cost_estimation_service.py
+++ b/tests/integration/server/services/test_cost_estimation_service.py
@@ -1653,7 +1653,7 @@ class TestCostEstimationService:
     async def test_narration_reference_video_estimate_handles_token_priced_video_model(self, db_factory):
         """按 token 计费的视频模型（Ark/Seedance）也要能算出非零视频预估。
 
-        ``_estimate_unit_video_cost`` 只传 ``duration_seconds``，若不换算 usage_tokens，
+        参考生视频的视频估值只传 ``duration_seconds``，若不换算 usage_tokens，
         ``PerTokenVideo`` 定价形状会因 ``usage_tokens`` 缺失恒算出 0。
         """
         resolver = ConfigResolver(db_factory)

--- a/tests/integration/server/services/test_execute_generation_task.py
+++ b/tests/integration/server/services/test_execute_generation_task.py
@@ -14,26 +14,26 @@ from lib.storyboard_sequence import (
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _async_return,
-    _fake_resolve_ctx,
     _FakePM,
-    _prepare_files,
-    _register_asset_sheet_claims,
-    _seed_current_storyboard,
+    async_return,
+    fake_resolve_ctx,
+    prepare_files,
+    register_asset_sheet_claims,
+    seed_current_storyboard,
 )
 
 
 class TestGenerationTasks:
     async def test_execute_task_dispatch(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _register_asset_sheet_claims(fake_pm)
-        _seed_current_storyboard(fake_pm)
+        register_asset_sheet_claims(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator(project_path)
         emitted_batches = []
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(
             generation_tasks,
             "emit_project_change_batch",
@@ -147,7 +147,7 @@ class TestGenerationTasks:
             return reused
 
         emitted: list[dict] = []
-        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(prepare_files(tmp_path)))
         monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "video", _executor)
         monkeypatch.setattr(
             generation_tasks,
@@ -188,7 +188,7 @@ class TestGenerationTasks:
         def _fail_emit(_project_name, _changes):
             raise RuntimeError("event emission failed")
 
-        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(prepare_files(tmp_path)))
         monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "storyboard", _executor)
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", _fail_emit)
 
@@ -218,7 +218,7 @@ class TestGenerationTasks:
         def _cancel_emit(_project_name, _changes):
             raise asyncio.CancelledError
 
-        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(_prepare_files(tmp_path)))
+        monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: _FakePM(prepare_files(tmp_path)))
         monkeypatch.setitem(generation_tasks._TASK_EXECUTORS, "storyboard", _executor)
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", _cancel_emit)
 
@@ -236,10 +236,10 @@ class TestGenerationTasks:
         assert compensation_threads[0] != event_loop_thread
 
     async def test_execute_task_validation_errors(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(FakeGenerator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(FakeGenerator()))
 
         with pytest.raises(ValueError, match=r"script_file is required for storyboard task"):
             await generation_tasks.execute_storyboard_task("demo", "E1S01", {"prompt": "x"})
@@ -264,10 +264,10 @@ class TestGenerationTasks:
         """任务只声明自己用到的 lane：图片类任务不声明 video/audio（只配置图片供应商的项目
         不因视频供应商缺配置失败，未声明 lane 不解析见 tests/server/test_generation_context.py），
         视频任务只声明 video；带参考图时 image lane 请求 i2i 能力。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _register_asset_sheet_claims(fake_pm)
-        _seed_current_storyboard(fake_pm)
+        register_asset_sheet_claims(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator(project_path)
         seen: list[dict] = []
 
@@ -275,9 +275,9 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, seen_lane_requests=seen),
+            fake_resolve_ctx(fake_generator, seen_lane_requests=seen),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         # E1S02 引用角色/场景/道具 sheet → 带参考图 → i2i；character 带 reference_image → i2i

--- a/tests/integration/server/services/test_execute_generation_task.py
+++ b/tests/integration/server/services/test_execute_generation_task.py
@@ -13,9 +13,9 @@ from lib.storyboard_sequence import (
 )
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _async_return,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _FakePM,
     _prepare_files,
     _register_asset_sheet_claims,
@@ -29,7 +29,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         _register_asset_sheet_claims(fake_pm)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator(project_path)
+        fake_generator = FakeGenerator(project_path)
         emitted_batches = []
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -239,7 +239,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(_FakeGenerator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(FakeGenerator()))
 
         with pytest.raises(ValueError, match=r"script_file is required for storyboard task"):
             await generation_tasks.execute_storyboard_task("demo", "E1S01", {"prompt": "x"})
@@ -268,7 +268,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         _register_asset_sheet_claims(fake_pm)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator(project_path)
+        fake_generator = FakeGenerator(project_path)
         seen: list[dict] = []
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)

--- a/tests/integration/server/services/test_execute_product_task.py
+++ b/tests/integration/server/services/test_execute_product_task.py
@@ -3,9 +3,9 @@
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _fake_resolve_ctx,
     _FakePM,
-    _prepare_files,
+    fake_resolve_ctx,
+    prepare_files,
 )
 
 
@@ -13,12 +13,12 @@ class TestGenerationTasks:
     async def test_execute_product_task_injects_reference_images(self, tmp_path, monkeypatch):
         """product sheet 生成把用户上传原图作为参考注入（标准化整理的输入），缺失文件跳过；
         完成后回写 product_sheet。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator(project_path)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         result = await generation_tasks.execute_product_task(
             "demo",
@@ -38,20 +38,20 @@ class TestGenerationTasks:
         assert "保温杯" in call["prompt"]
 
     async def test_execute_product_task_without_refs_is_t2i(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["products"]["保温杯"]["reference_images"] = []
         fake_generator = FakeGenerator(project_path)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         await generation_tasks.execute_product_task("demo", "保温杯", {"prompt": "保温杯"})
         assert fake_generator.image_calls[0]["reference_images"] is None
 
     def test_collect_product_reference_images_rejects_path_escape(self, tmp_path):
         """reference_images 中的绝对路径与 `..` 穿越值不得越出项目目录读取宿主机文件；目录路径同样跳过。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         outside = tmp_path / "outside.jpg"
         outside.write_bytes(b"jpg")
         project = {

--- a/tests/integration/server/services/test_execute_product_task.py
+++ b/tests/integration/server/services/test_execute_product_task.py
@@ -2,8 +2,8 @@
 
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _FakePM,
     _prepare_files,
 )
@@ -15,7 +15,7 @@ class TestGenerationTasks:
         完成后回写 product_sheet。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator(project_path)
+        fake_generator = FakeGenerator(project_path)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -41,7 +41,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["products"]["保温杯"]["reference_images"] = []
-        fake_generator = _FakeGenerator(project_path)
+        fake_generator = FakeGenerator(project_path)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))

--- a/tests/integration/server/services/test_execute_reference_video_task.py
+++ b/tests/integration/server/services/test_execute_reference_video_task.py
@@ -17,8 +17,8 @@ from lib.reference_video.request_projection import resolve_reference_assets
 from tests.fakes import FakeConfigResolver
 from tests.integration.server.services.reference_video_tasks_support import (
     _TINY_PNG,
-    _register_asset_sheet,
-    _write_project,
+    register_asset_sheet,
+    write_project,
 )
 
 
@@ -133,7 +133,7 @@ def _wire_context(
 
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     # Patch project_manager helpers
     from server.services import reference_video_tasks as rvt
@@ -188,7 +188,7 @@ async def test_execute_reference_video_task_rejects_changed_claim_provider_befor
     from lib.generation_queue import DispatchProviderChanged
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     fake_pm = MagicMock()
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     fake_pm.get_project_path.return_value = proj_dir
@@ -227,7 +227,7 @@ async def test_execute_reference_video_task_blocks_a_dirty_text_before_submissio
 ):
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     script["video_units"][0]["text"] = 42
@@ -272,7 +272,7 @@ async def test_execute_reference_video_task_bucket_follows_resolved_references(
     降级让 r2v 桶配置为拒空参考模型（DashScope R2V / MiniMax S2V）的项目也能生成
     无参考图的视频单元——若恒声明 r2v，这类视频单元执行期必以 video_reference_images_required 失败。
     """
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     if strip_mentions:
         script_path = proj_dir / "scripts" / "episode_1.json"
         script = json.loads(script_path.read_text(encoding="utf-8"))
@@ -338,7 +338,7 @@ async def test_execute_reference_video_task_bucket_follows_resolved_references(
 async def test_execute_reference_video_task_rechecks_text_to_video_capability(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     script["video_units"][0]["text"] = "空镜头，推门而入"
@@ -384,7 +384,7 @@ async def test_execute_reference_video_task_sends_reference_audio_in_prompt_orde
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """A 类 tracer bullet：请求 reference_audio_files 的顺序与第一段 @音频N 指认严格一致。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     project["characters"]["张三"]["voice_style"] = "低沉沙哑的男声"
@@ -396,7 +396,7 @@ async def test_execute_reference_video_task_sends_reference_audio_in_prompt_orde
         "reference_audio": "characters/refs_audio/李四.mp3",
     }
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
+    register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
     refs_audio = proj_dir / "characters" / "refs_audio"
     refs_audio.mkdir(parents=True)
     (refs_audio / "张三.wav").write_bytes(b"RIFF")
@@ -489,7 +489,7 @@ async def test_execute_reference_video_task_omits_reference_audio_when_episode_i
 ):
     """无声视频：即便角色配好了音色档案、模型也是 A 类，请求里也不带任何参考音频负载；
     台词文本照常下发（供应商可用作口型参考），并随结果回一条无声知会。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     project["characters"]["张三"]["voice_style"] = "低沉沙哑的男声"
@@ -561,7 +561,7 @@ async def test_execute_reference_video_task_rechecks_audio_switch_for_latest_mod
 ):
     """任务等待期间切到恒有声音轨模型后，worker 按当前模型阻止无声请求。"""
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     from server.services import reference_video_tasks as rvt
 
     fake_pm = MagicMock()
@@ -607,7 +607,7 @@ async def test_execute_reference_video_task_aligns_reference_audio_targets_for_p
 ):
     """backend 要求音频逐段挂参考图（如 wan2.7-r2v）时，reference_audio_targets 须按名字
     对齐到正确的参考图下标，纯画外角色（李四）降级不绑定——不能假设两个列表天然同序。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     project["characters"]["张三"]["voice_style"] = "低沉沙哑的男声"
@@ -619,7 +619,7 @@ async def test_execute_reference_video_task_aligns_reference_audio_targets_for_p
         "reference_audio": "characters/refs_audio/李四.mp3",
     }
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
+    register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
     refs_audio = proj_dir / "characters" / "refs_audio"
     refs_audio.mkdir(parents=True)
     (refs_audio / "张三.wav").write_bytes(b"RIFF")
@@ -684,7 +684,7 @@ async def test_execute_reference_video_task_omits_audio_field_for_soft_tier(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """B 类：无音频字段，但第一段仍带 voice_style 声音特征声明。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     project["characters"]["张三"]["voice_style"] = "低沉沙哑的男声"
     project["characters"]["张三"]["reference_audio"] = "characters/refs_audio/张三.wav"
@@ -743,7 +743,7 @@ async def test_execute_reference_video_task_omits_audio_field_for_soft_tier(
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_surfaces_render_warnings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """渲染期降级 warning 与既有 result.warnings 通道贯通（超上限截断降级）。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
     project["characters"]["张三"]["reference_audio"] = "characters/refs_audio/张三.wav"
     project["characters"]["李四"] = {
@@ -752,7 +752,7 @@ async def test_execute_reference_video_task_surfaces_render_warnings(tmp_path: P
         "reference_audio": "characters/refs_audio/李四.mp3",
     }
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
+    register_asset_sheet(proj_dir, "character", "李四", "characters/李四.png")
     refs_audio = proj_dir / "characters" / "refs_audio"
     refs_audio.mkdir(parents=True)
     (refs_audio / "张三.wav").write_bytes(b"RIFF")
@@ -803,13 +803,69 @@ async def test_execute_reference_video_task_surfaces_render_warnings(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_execute_reference_video_task_reports_reference_image_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """参考图超出型号上限：截断到上限张，并按 count / model / max_count 报出一条超限 warning。"""
+    proj_dir = write_project(tmp_path)
+    project = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
+
+    from server.services import reference_video_tasks as rvt
+
+    script_path = proj_dir / "scripts" / "episode_1.json"
+    fake_pm = MagicMock()
+    fake_pm.load_project.return_value = project
+    fake_pm.get_project_path.return_value = proj_dir
+    fake_pm.load_script.side_effect = lambda _n, _f: json.loads(script_path.read_text(encoding="utf-8"))
+    _wire_locked_script(fake_pm)
+    monkeypatch.setattr(rvt, "get_project_manager", lambda: fake_pm)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_generate_video_async(**kwargs):
+        captured["reference_images"] = kwargs.get("reference_images")
+        out = proj_dir / "reference_videos" / "E1U1.mp4"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x00\x00\x00 ftypmp42")
+        return out, 1, None, None
+
+    fake_generator = MagicMock()
+    fake_generator.generate_video_async = AsyncMock(side_effect=_fake_generate_video_async)
+    fake_generator.versions.get_versions.return_value = {"versions": [{"created_at": "2026-04-17T10:00:00"}]}
+    _wire_context(
+        monkeypatch,
+        rvt,
+        fake_generator,
+        backend_name="ark",
+        backend_model="doubao-seedance-2-0-260128",
+        max_refs=1,
+    )
+
+    async def _fake_extract(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(rvt, "extract_video_thumbnail", _fake_extract)
+
+    result = await rvt.execute_reference_video_task(
+        "demo", "E1U1", {"script_file": "scripts/episode_1.json"}, user_id="u1"
+    )
+
+    assert len(captured["reference_images"]) == 1
+    assert {
+        "key": "ref_too_many_images",
+        "params": {"count": 2, "model": "doubao-seedance-2-0-260128", "max_count": 1},
+    } in result["warnings"]
+
+
+@pytest.mark.asyncio
 async def test_execute_reference_video_task_clears_stale_video_uri_and_thumbnail(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
     """重跑时新结果不含 video_uri 且缩略图提取失败 → 旧 video_uri / video_thumbnail 必须被清空，
     不能保留指向过期 URI / 已删除文件的旧值。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     # 预置上一次成功生成留下的旧产物
     script_path = proj_dir / "scripts" / "episode_1.json"
@@ -879,7 +935,7 @@ async def test_execute_reference_video_task_grok_uses_provider_default_resolutio
     档位的解析/兜底逻辑（provider fallback、model_settings 优先级）在
     tests/server/test_generation_context.py 覆盖。
     """
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     from server.services import reference_video_tasks as rvt
 
@@ -941,7 +997,7 @@ async def test_execute_reference_video_task_narrows_durations_by_registry_provid
     拿它查 ModelInfo 会静默落空，收窄整个失效——3 秒剧本会取到 4 秒，而 Veo 3.1 带参考图
     只接受 8 秒，执行期必然被 backend 拒绝。
     """
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     from server.services import reference_video_tasks as rvt
 
@@ -995,7 +1051,7 @@ async def test_execute_reference_video_task_narrows_durations_by_registry_provid
 
 @pytest.mark.asyncio
 async def test_execute_reference_video_task_missing_reference_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     (proj_dir / "characters" / "张三.png").unlink()
 
     from server.services import reference_video_tasks as rvt
@@ -1042,7 +1098,7 @@ async def test_execute_reference_video_task_rejects_unclaimed_formal_sheet_befor
     from lib.reference_video.request_projection import ReferenceProjectionBlockedError
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     ProjectArtifactManifestAdapter(proj_dir).delete_entry(ArtifactKey.asset_sheet("character", "张三"))
 
     fake_pm = MagicMock()
@@ -1085,7 +1141,7 @@ async def test_execute_reference_video_task_rejects_unclaimed_bound_script_befor
 ):
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path, register_script=False)
+    proj_dir = write_project(tmp_path, register_script=False)
 
     fake_pm = MagicMock()
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
@@ -1128,7 +1184,7 @@ async def test_execute_reference_video_task_rechecks_formal_sheet_claim_before_p
     from lib.artifact_manifest import ArtifactKey, ProjectArtifactManifestAdapter
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     fake_pm = MagicMock()
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
@@ -1185,7 +1241,7 @@ async def test_execute_reference_video_task_blocks_an_unmigrated_project_before_
     from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     project_path = proj_dir / "project.json"
     project = json.loads(project_path.read_text(encoding="utf-8"))
     project["schema_version"] = 7
@@ -1240,7 +1296,7 @@ async def test_execute_reference_video_task_rejects_a_replaced_sheet_before_prov
 ):
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     project_path = proj_dir / "project.json"
     project = json.loads(project_path.read_text(encoding="utf-8"))
 
@@ -1297,7 +1353,7 @@ async def test_execute_reference_video_task_refuses_a_script_outside_the_episode
 
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     canonical_script = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(canonical_script.read_text(encoding="utf-8"))
     unbound_script = proj_dir / "scripts" / "unbound.json"
@@ -1353,7 +1409,7 @@ async def test_execute_reference_video_task_uses_real_media_generator(tmp_path: 
     from lib.video_backends.base import VideoCapabilities, VideoGenerationResult
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     fake_pm = MagicMock()
     fake_pm.load_project.return_value = json.loads((proj_dir / "project.json").read_text(encoding="utf-8"))
@@ -1451,7 +1507,7 @@ async def test_execute_reference_video_task_passes_source_refs(tmp_path: Path, m
     """执行器把**源 sheet 路径**直接交给 generate_video_async（单次调用），压缩下沉
     咽喉层——不预压缩到临时文件，不在 R2V 层做二次压缩重试。
     """
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     from server.services import reference_video_tasks as rvt
 
@@ -1509,7 +1565,7 @@ async def test_execute_reference_video_task_rejects_duration_above_lane_maximum(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Executor never truncates a unit whose duration exceeds the current model tier."""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     # 改造 unit 让它有 2 张 refs + 15s duration，便于验证 clamp
     script_path = proj_dir / "scripts" / "episode_1.json"
@@ -1579,7 +1635,7 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     须按 `constrained_refs` 长度重新 slice，用整条 `unit.references` 渲染会让 `@图片N` 越界
     （例如 5 张裁到 1 张，prompt 里仍出现 `@图片5`）。
     """
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     # 新增一个道具 sheet，让 unit 拥有 3 张 refs（1 character + 1 scene + 1 prop）。
     (proj_dir / "props").mkdir()
@@ -1588,7 +1644,7 @@ async def test_execute_reference_video_task_prompt_matches_clipped_refs(
     project = json.loads(project_path.read_text(encoding="utf-8"))
     project["props"] = {"瓶子": {"description": "x", "prop_sheet": "props/瓶子.png"}}
     project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "prop", "瓶子", "props/瓶子.png")
+    register_asset_sheet(proj_dir, "prop", "瓶子", "props/瓶子.png")
 
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
@@ -1694,7 +1750,7 @@ async def test_execute_reference_video_task_prompt_matches_deduped_refs(
     会错误绑到与 `@图片1` 相同的资产、后面一条真正不同的参考丢失编号。"""
     import unicodedata
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     name_nfc = unicodedata.normalize("NFC", "Hiếu")
     name_nfd = unicodedata.normalize("NFD", "Hiếu")
     assert name_nfc != name_nfd
@@ -1703,7 +1759,7 @@ async def test_execute_reference_video_task_prompt_matches_deduped_refs(
     project = json.loads(project_path.read_text(encoding="utf-8"))
     project["characters"][name_nfc] = {"description": "x", "character_sheet": "characters/hieu.png"}
     project_path.write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", name_nfc, "characters/hieu.png")
+    register_asset_sheet(proj_dir, "character", name_nfc, "characters/hieu.png")
 
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
@@ -1770,7 +1826,7 @@ async def test_execute_reference_video_task_reprojects_fresh_tts_duration_and_co
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Worker only trusts current TTS media and rejects an accepted tier after it changes."""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     # 5 不是 [4,8,12] 成员 → 按 8 秒申请
@@ -1934,7 +1990,7 @@ async def test_execute_reference_video_task_reuses_same_tier_visual_without_prov
     from server.services import reference_video_tasks as rvt
     from server.services.narration_delivery_tasks import reference_video_visual_basis_digest
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     unit = script["video_units"][0]
@@ -2106,7 +2162,7 @@ async def test_execute_reference_video_task_persists_effective_duration_when_rou
     monkeypatch: pytest.MonkeyPatch,
 ):
     """取档偏移时 checkpoint 冻结实际申请秒数，enqueue payload 保持无内容快照。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     script_path = proj_dir / "scripts" / "episode_1.json"
     script = json.loads(script_path.read_text(encoding="utf-8"))
     script["video_units"][0]["text"] = "@张三 推门"
@@ -2167,7 +2223,7 @@ async def test_execute_reference_video_task_persists_duration_when_unchanged(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """未偏移时 checkpoint 也冻结 unit 实际时长，resume 不读当前 project 默认值。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     from lib.reference_video.execution_checkpoint import ReferenceSubmissionCheckpoint
     from server.services import reference_video_tasks as rvt
@@ -2222,7 +2278,7 @@ async def test_execute_reference_video_task_persists_execution_identity(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """当前投影解析出的 registry/provider/backend 身份在 provider submit 前原子冻结。"""
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
 
     from lib.reference_video.execution_checkpoint import ReferenceSubmissionCheckpoint
     from server.services import reference_video_tasks as rvt
@@ -2297,7 +2353,7 @@ async def test_execute_reference_video_task_stages_actual_request_and_checkpoint
     from lib.reference_video.execution_checkpoint import ReferenceSubmissionCheckpoint
     from server.services import reference_video_tasks as rvt
 
-    proj_dir = _write_project(tmp_path)
+    proj_dir = write_project(tmp_path)
     tts_audio = proj_dir / "audio" / "segment_E1U1.wav"
     tts_audio.parent.mkdir()
     tts_audio.write_bytes(b"narration-is-not-a-provider-input")

--- a/tests/integration/server/services/test_execute_reference_video_task.py
+++ b/tests/integration/server/services/test_execute_reference_video_task.py
@@ -99,7 +99,7 @@ def _wire_context(
         supported_durations=supported_durations,
         max_duration=max_duration,
         max_reference_images=max_refs,
-        voice_consistency=voice_consistency,  # type: ignore[arg-type]
+        voice_consistency=voice_consistency,
         max_reference_audio_count=max_reference_audio_count,
         reference_audio_per_image=reference_audio_per_image,
         requested_generate_audio=requested_generate_audio,

--- a/tests/integration/server/services/test_execute_video_task.py
+++ b/tests/integration/server/services/test_execute_video_task.py
@@ -28,23 +28,23 @@ from lib.video_visual_provenance import build_storyboard_video_visual_basis
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _ad_pm,
-    _async_return,
-    _fake_resolve_ctx,
     _FakePM,
-    _persist_active_fake_project,
-    _prepare_files,
-    _register_stale_visual_claim,
-    _seed_current_storyboard,
+    ad_pm,
+    async_return,
+    fake_resolve_ctx,
+    persist_active_fake_project,
+    prepare_files,
+    register_stale_visual_claim,
+    seed_current_storyboard,
 )
 
 
 class TestGenerationTasks:
     async def test_execute_video_task_generates_thumbnail(self, monkeypatch, tmp_path):
         """视频生成后应自动提取首帧缩略图"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         thumbnail_path = project_path / "thumbnails" / "scene_E1S01.jpg"
@@ -55,7 +55,7 @@ class TestGenerationTasks:
             return out_path
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", fake_extract)
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
@@ -78,9 +78,9 @@ class TestGenerationTasks:
     ):
         from lib.reference_video.execution_checkpoint import StoryboardSubmissionCheckpoint
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         item = fake_pm.script["segments"][0]
         item["novel_text"] = "旁白正文"
         current_prompt = {"action": "current action", "camera_motion": "Static", "dialogue": []}
@@ -113,9 +113,9 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, supported_durations=(4, 8, 12)),
+            fake_resolve_ctx(fake_generator, supported_durations=(4, 8, 12)),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
 
         await generation_tasks.execute_video_task(
             "demo",
@@ -151,9 +151,9 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_lane_bucket_follows_project_route(self, monkeypatch, tmp_path):
         """lane 归桶按项目生成模式求值，与提交入口使用同一口径。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         seen_lanes: list[dict] = []
 
@@ -161,7 +161,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, seen_lane_requests=seen_lanes),
+            fake_resolve_ctx(fake_generator, seen_lane_requests=seen_lanes),
         )
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
@@ -179,13 +179,13 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_rejects_unsupported_duration(self, monkeypatch, tmp_path):
         """执行层在解析出 ProviderModel 后，对越界 duration 以明确错误拒绝。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(VideoCapabilityError) as exc:
             await generation_tasks.execute_video_task(
@@ -203,14 +203,14 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_supported_duration_passes(self, monkeypatch, tmp_path):
         """合法 duration 通过守卫，正常进入后端生成。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         result = await generation_tasks.execute_video_task(
@@ -227,9 +227,9 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_refuses_a_script_outside_the_episode_ledger(self, monkeypatch, tmp_path):
         """剧本身份只认 project.json 的 episodes 账本：未绑定的剧本文件一律拒绝，不猜集号。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         (project_path / "scripts" / "unbound_script.json").write_text(
             json.dumps(fake_pm.script, ensure_ascii=False),
             encoding="utf-8",
@@ -237,8 +237,8 @@ class TestGenerationTasks:
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         with pytest.raises(ValueError, match="is not bound to episode"):
@@ -255,9 +255,9 @@ class TestGenerationTasks:
         assert fake_generator.video_calls == []
 
     async def test_execute_video_task_reprojects_current_tts_and_rejects_changed_tier(self, monkeypatch, tmp_path):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         current_tts_duration = 6.2
         seen_lane_requests: list[dict] = []
@@ -286,7 +286,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(
+            fake_resolve_ctx(
                 fake_generator,
                 supported_durations=(4, 8, 12),
                 seen_lane_requests=seen_lane_requests,
@@ -298,7 +298,7 @@ class TestGenerationTasks:
             fake_prepare_current_narrated_video_duration,
         )
         monkeypatch.setattr(generation_tasks, "tts_task_in_progress", AsyncMock(return_value=False))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
         payload = {
             "script_file": "episode_1.json",
@@ -342,9 +342,9 @@ class TestGenerationTasks:
         from lib.video_artifact_facts import VideoArtifactCurrencyFacts
         from lib.visual_artifact_provenance import build_storyboard_video_artifact_visual_basis
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_generator.versions = VersionManager(project_path)
         item = fake_pm.script["segments"][0]
@@ -444,7 +444,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(
+            fake_resolve_ctx(
                 fake_generator,
                 video_provider=("ark", "configured-seedance"),
                 video_backend_model="seedance",
@@ -489,20 +489,20 @@ class TestGenerationTasks:
         """宫格项目 storyboard_image 指向 scene_{id}_first.png（非 canonical 文件名），只要登记在
         产物清单里且落在 storyboards/ 目录内就正常解析——与 end_frame_image 不同，这里不要求
         文件名与 canonical 路径逐一比对。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01_first.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01_first.png"}
-        _register_stale_visual_claim(
+        register_stale_visual_claim(
             project_path,
             ArtifactKey.episode_storyboard(1, "E1S01"),
             "storyboards/scene_E1S01_first.png",
         )
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -515,13 +515,13 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_missing_storyboard_image_fails_hard(self, monkeypatch, tmp_path):
         """storyboard_image 字段指向的文件缺失时硬失败，不调用后端生成。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_missing.png"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="storyboard not found"):
             await generation_tasks.execute_video_task(
@@ -536,14 +536,14 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_schema8_requires_registered_storyboard(self, monkeypatch, tmp_path):
         """Schema 8 workers reject an existing storyboard whose Manifest claim is absent."""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="storyboard is not registered"):
             await generation_tasks.execute_video_task(
@@ -563,15 +563,15 @@ class TestGenerationTasks:
     ):
         """A restore that drops the selected claim cannot race a paid video submission."""
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         item = fake_pm.script["segments"][0]
         item["novel_text"] = "旁白正文"
         item["video_prompt"] = {"action": "跑", "camera_motion": "Static", "dialogue": []}
         item["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
         key = ArtifactKey.episode_storyboard(1, "E1S01")
-        _register_stale_visual_claim(project_path, key, "storyboards/scene_E1S01.png")
+        register_stale_visual_claim(project_path, key, "storyboards/scene_E1S01.png")
 
         provider_submissions: list[str] = []
 
@@ -583,7 +583,7 @@ class TestGenerationTasks:
 
         fake_generator = _SubmittingGenerator()
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         original_stage = generation_tasks.stage_provider_media_for_task
 
@@ -616,8 +616,8 @@ class TestGenerationTasks:
     ):
         from lib.artifact_activation import activate_artifact_target_state
 
-        project_path = _prepare_files(tmp_path)
-        fake_pm = _ad_pm(project_path, with_sheet=False)
+        project_path = prepare_files(tmp_path)
+        fake_pm = ad_pm(project_path, with_sheet=False)
         item = fake_pm.script["shots"][0]
         item["video_prompt"] = {"action": "跑", "camera_motion": "Static", "dialogue": []}
         item["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
@@ -646,13 +646,13 @@ class TestGenerationTasks:
 
         fake_generator = _SubmittingGenerator()
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         original_stage = generation_tasks.stage_provider_media_for_task
 
         async def _stage_then_replace_and_reactivate(project_dir, task_id, inputs):
             staged = await original_stage(project_dir, task_id, inputs)
             (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"replacement")
-            _register_stale_visual_claim(
+            register_stale_visual_claim(
                 project_path,
                 ArtifactKey.episode_storyboard(1, "E1S01"),
                 "storyboards/scene_E1S01.png",
@@ -686,14 +686,14 @@ class TestGenerationTasks:
         按「无登记指针」拒绝——不猜同名文件，也不抛未捕获 AttributeError。"""
         from lib.storyboard_sequence import StoryboardImageBindingRequired
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = ["bad"]
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         with pytest.raises(StoryboardImageBindingRequired, match="storyboard binding missing"):
@@ -729,7 +729,7 @@ class TestGenerationTasks:
     ):
         """剧本是磁盘 JSON，storyboard_image 字段不可信：越界 / 绕开 storyboards 目录 / 脏数据
         一律硬失败，不把任意服务器文件送进视频请求上传给供应商。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (tmp_path / "outside.png").write_bytes(b"png")
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
@@ -739,7 +739,7 @@ class TestGenerationTasks:
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match=re.escape(expected_message)):
             await generation_tasks.execute_video_task(
@@ -758,7 +758,7 @@ class TestGenerationTasks:
         """storyboard_image 是项目 storyboards/ 内的绝对路径时同样硬失败：`os.path.join` 遇绝对
         路径会丢弃项目根，越界校验只看结果是否落在项目内，光靠目录归属挡不住这类值，须显式拒绝
         绝对路径本身。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
@@ -766,7 +766,7 @@ class TestGenerationTasks:
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": absolute_value}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="invalid storyboard image path"):
             await generation_tasks.execute_video_task(
@@ -783,14 +783,14 @@ class TestGenerationTasks:
         """storyboard_image 是无盘符的根路径（如 `\\Users\\...`）时同样硬失败：`Path.is_absolute()`
         在 Windows 原生运行时对这类值返回 False，但 `os.path.join` 遇到根路径仍会丢弃项目根（仅
         保留 base 的盘符），须按正斜杠归一化后单独判断根分隔符开头。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "\\Users\\Alice\\scene.png"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="invalid storyboard image path"):
             await generation_tasks.execute_video_task(
@@ -807,14 +807,14 @@ class TestGenerationTasks:
         """storyboard_image 指向 storyboards/ 内一个存在的目录（而非文件）时硬失败：目录同样
         通过 `exists()`，若不显式要求是文件，目录会被当作 start_image 传给视频后端，在编码阶段
         才失败且原因不可读。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (project_path / "storyboards" / "subdir").mkdir(parents=True)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/subdir"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="storyboard not found"):
             await generation_tasks.execute_video_task(
@@ -830,9 +830,9 @@ class TestGenerationTasks:
     async def test_execute_video_task_end_frame_image_passed_to_generator(self, monkeypatch, tmp_path):
         """镜头设置了 end_frame_image 时，生成视频请求携带 end_image；快照路径取自
         镜头持久字段拼接的项目内固定相对路径。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
@@ -841,8 +841,8 @@ class TestGenerationTasks:
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -859,9 +859,9 @@ class TestGenerationTasks:
         """尾帧字段是裸文件名（无 `end_frames/` 前缀）时按校验侧
         data_validator._resolve_existing_path 的 default_dir 回退口径解析——否则通过导入校验
         （校验器对裸文件名会补目录重试）的值会在生成期无理由硬失败。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
@@ -870,8 +870,8 @@ class TestGenerationTasks:
         fake_pm.script["segments"][0]["end_frame_image"] = "scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -885,16 +885,16 @@ class TestGenerationTasks:
     @pytest.mark.parametrize("missing", [True, False], ids=["field-absent", "empty-string"])
     async def test_execute_video_task_without_end_frame_image_passes_none(self, monkeypatch, tmp_path, missing):
         """未设置尾帧的镜头行为不变：字段缺失或显式空字符串，end_image 均为 None。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         if not missing:
             fake_pm.script["segments"][0]["end_frame_image"] = ""
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -907,14 +907,14 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_missing_end_frame_snapshot_fails_hard(self, monkeypatch, tmp_path):
         """尾帧字段指向的快照文件缺失时硬失败，不调用后端生成。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="end frame snapshot not found"):
             await generation_tasks.execute_video_task(
@@ -947,18 +947,18 @@ class TestGenerationTasks:
     ):
         """剧本是磁盘 JSON，尾帧字段不可信：越界 / 绕开 end_frames 快照目录 / 脏数据一律硬失败，
         不把任意服务器文件送进视频请求。约束与写侧 end_frame.py、校验侧 data_validator 同口径。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         (tmp_path / "outside.png").write_bytes(b"png")
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
         (end_frame_dir / "scene_E1S02.png").write_bytes(b"png")  # 别的镜头的快照，供跨镜头误引用例检查
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = end_frame_value
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="invalid end frame snapshot path"):
             await generation_tasks.execute_video_task(
@@ -975,18 +975,18 @@ class TestGenerationTasks:
         """尾帧字段值恰是当前镜头的 canonical 相对路径，但磁盘上那个位置被替换成指向别处
         （另一镜头快照）的符号链接：try_safe_join / safe_join 都会展开符号链接把两侧解析到
         同一真实目标，仅凭路径相等挡不住「路径字符串对、磁盘对象被调包」，须显式拒绝。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
         (end_frame_dir / "scene_E1S02.png").write_bytes(b"png")
         (end_frame_dir / "scene_E1S01.png").symlink_to(end_frame_dir / "scene_E1S02.png")
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="invalid end frame snapshot path"):
             await generation_tasks.execute_video_task(
@@ -1003,18 +1003,18 @@ class TestGenerationTasks:
         """符号链接调包不止发生在文件名这一级：`end_frames/` 目录本身被替换成指向项目内
         别的目录的符号链接时，最终文件名一致、realpath 展开后两侧路径也相等，仅检查文件名
         这一段挡不住——须逐段检查 canonical 路径的每个组件（含父目录）。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         real_dir = project_path / "storyboards_end_frames_swap"
         real_dir.mkdir(parents=True, exist_ok=True)
         (real_dir / "scene_E1S01.png").write_bytes(b"png")
         (project_path / "end_frames").symlink_to(real_dir)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="invalid end frame snapshot path"):
             await generation_tasks.execute_video_task(
@@ -1032,7 +1032,7 @@ class TestGenerationTasks:
         `Path.is_symlink()` 识别不到；`end_frames/` 被联接到项目内别的目录时须靠 `is_junction()`
         单独挡住。非 Windows 平台无法真实创建 junction，这里 monkeypatch `Path.is_junction()`
         模拟该状态，验证逐段检查确实调用了它而非只查符号链接。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         real_dir = project_path / "storyboards_end_frames_swap"
         real_dir.mkdir(parents=True, exist_ok=True)
         (real_dir / "scene_E1S01.png").write_bytes(b"png")
@@ -1040,12 +1040,12 @@ class TestGenerationTasks:
         end_frames_dir.mkdir(parents=True, exist_ok=True)
         (end_frames_dir / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(Path, "is_junction", lambda self: self == end_frames_dir)
 
         with pytest.raises(ValueError, match="invalid end frame snapshot path"):
@@ -1065,9 +1065,9 @@ class TestGenerationTasks:
         替身只替换 provider 调用，能力判定交给生产代码 gate_video_request 跑真值（caps
         last_frame=False）——否则替身按自己的条件抛异常，验的是替身而非接线是否真能触达
         gating。能力组合的各分支另见 tests/test_video_frame_slots.py。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
@@ -1088,7 +1088,7 @@ class TestGenerationTasks:
         fake_generator.generate_video_async = _plan_with_real_gating
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(VideoCapabilityError) as exc:
             await generation_tasks.execute_video_task(
@@ -1103,9 +1103,9 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_reuses_end_frame_on_regeneration(self, monkeypatch, tmp_path):
         """视频重生成无需额外操作即自动沿用尾帧：字段是镜头持久属性，每次执行都从剧本重新加载。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
@@ -1114,8 +1114,8 @@ class TestGenerationTasks:
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         for _ in range(2):
@@ -1135,7 +1135,7 @@ class TestGenerationTasks:
     async def test_execute_video_task_drama_dialogue_from_utterances(self, monkeypatch, tmp_path):
         """drama 口型台词从分镜级 dialogue-kind utterances 取（覆盖 payload 已不带的
         video_prompt.dialogue）；voiceover-kind 不进视频 YAML。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
 
@@ -1160,11 +1160,11 @@ class TestGenerationTasks:
                 }
             ],
         }
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         # payload 的 video_prompt 不带 dialogue（drama 新结构）
@@ -1214,18 +1214,18 @@ class TestGenerationTasks:
     async def test_execute_video_task_injects_voice_profiles_for_audible_model(self, monkeypatch, tmp_path):
         """有音轨模型（voice_consistency != none）：dialogue speaker 命中的角色资产
         非空 voice_style 机械派生进 Voice_Profiles 顶部声明段。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
-            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+            generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator, voice_consistency="soft")
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1246,18 +1246,18 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_skips_voice_profiles_for_silent_model(self, monkeypatch, tmp_path):
         """C 类（真无声，voice_consistency == none）模型不注入 Voice_Profiles。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
-            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="none")
+            generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator, voice_consistency="none")
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1279,20 +1279,20 @@ class TestGenerationTasks:
     async def test_execute_video_task_skips_voice_profiles_when_episode_audio_disabled(self, monkeypatch, tmp_path):
         """本集关闭音频（requested_generate_audio=False）：即便模型有音轨也不注入 Voice_Profiles，
         与 C 类真无声模型同口径。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
+            fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1315,14 +1315,14 @@ class TestGenerationTasks:
         """narration/ad（item 无 utterances 字段）请求体自带 voice_profiles 时一律剥离：
         该声明段唯一来源是 build_drama_video_prompt 的机械派生，调用方不得越权注入、绕过
         C 类（真无声）门控。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1347,18 +1347,18 @@ class TestGenerationTasks:
         """utterances 迁移前的存量 drama 剧本（scene 无 utterances 字段，台词仍在
         video_prompt.dialogue）：load_script 按原始 JSON 读盘不过 pydantic 迁移，改走 legacy
         出口派生 Voice_Profiles，不因缺 utterances 静默丢失。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = FakeGenerator()
         fake_pm.script = self._legacy_drama_script()
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
-            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+            generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator, voice_consistency="soft")
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1385,20 +1385,20 @@ class TestGenerationTasks:
         self, monkeypatch, tmp_path
     ):
         """legacy dialogue 出口同过无声门控：本集关闭音频时不注入 Voice_Profiles，台词照常下发。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
         fake_generator = FakeGenerator()
         fake_pm.script = self._legacy_drama_script()
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
+            fake_resolve_ctx(fake_generator, voice_consistency="soft", requested_generate_audio=False),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1427,7 +1427,7 @@ class TestGenerationTasks:
         """存量 episode 剧本省略顶层 content_mode 时回退到 project.json 的 content_mode
         （与 lib.data_validator 已校验通过的既定口径一致），不因回退缺失而被误判为
         narration、静默跳过 dialogue 重建与 Voice_Profiles 注入。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["content_mode"] = "drama"
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
@@ -1451,13 +1451,13 @@ class TestGenerationTasks:
                 }
             ],
         }
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
-            generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator, voice_consistency="soft")
+            generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator, voice_consistency="soft")
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         await generation_tasks.execute_video_task(
@@ -1477,18 +1477,18 @@ class TestGenerationTasks:
 
     async def test_execute_video_task_default_duration_from_caps(self, monkeypatch, tmp_path):
         """无显式 duration 时，默认值由 caps 收口（取 supported_durations[0]），且必然合法。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, supported_durations=(6, 10)),
+            fake_resolve_ctx(fake_generator, supported_durations=(6, 10)),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
         # 项目默认 duration 也置空，强制走 caps 默认。
         fake_pm.project.pop("default_duration", None)
@@ -1506,23 +1506,23 @@ class TestGenerationTasks:
 
         Veo + 4k 只接受 8 秒；取首项 4 秒会让默认设置必然撞上 backend 的执行期拒绝。
         """
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(
+            fake_resolve_ctx(
                 fake_generator,
                 video_provider=("gemini-aistudio", "veo-3.1-generate-preview"),
                 video_resolution="4k",
                 supported_durations=(4, 6, 8),
             ),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
         fake_pm.project.pop("default_duration", None)
 
@@ -1536,18 +1536,18 @@ class TestGenerationTasks:
     async def test_empty_supported_durations_guard_permissive(self, monkeypatch, tmp_path):
         """能力不可解析时 lane 交付空 supported_durations：守卫放行（不更坏），
         resolution 仍取自 lane 已解析出的值，不因能力缺失被改写。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _seed_current_storyboard(fake_pm)
+        seed_current_storyboard(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(fake_generator, supported_durations=()),
+            fake_resolve_ctx(fake_generator, supported_durations=()),
         )
-        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+        monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
         monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
 
         result = await generation_tasks.execute_video_task(
@@ -1565,7 +1565,7 @@ class TestGenerationTasks:
 
     async def test_video_resolve_failure_fails_task_without_fallback(self, monkeypatch, tmp_path):
         """视频解析失败即任务失败：异常原样上抛留痕，无硬编码 provider/model 兜底，后端不被调用。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
 

--- a/tests/integration/server/services/test_execute_video_task.py
+++ b/tests/integration/server/services/test_execute_video_task.py
@@ -27,10 +27,10 @@ from lib.video_frame_slots import gate_video_request
 from lib.video_visual_provenance import build_storyboard_video_visual_basis
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _ad_pm,
     _async_return,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _FakePM,
     _persist_active_fake_project,
     _prepare_files,
@@ -45,7 +45,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         thumbnail_path = project_path / "thumbnails" / "scene_E1S01.jpg"
 
@@ -90,7 +90,7 @@ class TestGenerationTasks:
         manifest_before = manifest.read_bytes()
         submitted: dict[str, Mapping[str, object]] = {}
 
-        class _CheckpointingGenerator(_FakeGenerator):
+        class _CheckpointingGenerator(FakeGenerator):
             async def generate_video_async(self, **kwargs):
                 self.video_calls.append(kwargs)
                 start_image = kwargs["start_image"]
@@ -154,7 +154,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         seen_lanes: list[dict] = []
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -182,7 +182,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -206,7 +206,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -234,7 +234,7 @@ class TestGenerationTasks:
             json.dumps(fake_pm.script, ensure_ascii=False),
             encoding="utf-8",
         )
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -258,7 +258,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         current_tts_duration = 6.2
         seen_lane_requests: list[dict] = []
 
@@ -345,7 +345,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_generator.versions = VersionManager(project_path)
         item = fake_pm.script["segments"][0]
         item["novel_text"] = "current narration"
@@ -492,7 +492,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01_first.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01_first.png"}
         _register_stale_visual_claim(
             project_path,
@@ -517,7 +517,7 @@ class TestGenerationTasks:
         """storyboard_image 字段指向的文件缺失时硬失败，不调用后端生成。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_missing.png"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -538,7 +538,7 @@ class TestGenerationTasks:
         """Schema 8 workers reject an existing storyboard whose Manifest claim is absent."""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
         _persist_active_fake_project(fake_pm)
 
@@ -575,7 +575,7 @@ class TestGenerationTasks:
 
         provider_submissions: list[str] = []
 
-        class _SubmittingGenerator(_FakeGenerator):
+        class _SubmittingGenerator(FakeGenerator):
             async def generate_video_async(self, **kwargs):
                 await kwargs["before_submit"](72)
                 provider_submissions.append("submitted")
@@ -638,7 +638,7 @@ class TestGenerationTasks:
         assert activate_artifact_target_state(project_path, bump_schema=False) is True
         provider_submissions: list[str] = []
 
-        class _SubmittingGenerator(_FakeGenerator):
+        class _SubmittingGenerator(FakeGenerator):
             async def generate_video_async(self, **kwargs):
                 await kwargs["before_submit"](73)
                 provider_submissions.append("submitted")
@@ -688,7 +688,7 @@ class TestGenerationTasks:
 
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = ["bad"]
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -735,7 +735,7 @@ class TestGenerationTasks:
         end_frame_dir.mkdir(parents=True, exist_ok=True)
         (end_frame_dir / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": storyboard_value}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -761,7 +761,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         absolute_value = str(project_path / "storyboards" / "scene_E1S01.png")
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": absolute_value}
 
@@ -786,7 +786,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         (project_path / "storyboards" / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "\\Users\\Alice\\scene.png"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -810,7 +810,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         (project_path / "storyboards" / "subdir").mkdir(parents=True)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/subdir"}
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -833,7 +833,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
@@ -862,7 +862,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
@@ -888,7 +888,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         if not missing:
             fake_pm.script["segments"][0]["end_frame_image"] = ""
 
@@ -910,7 +910,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -954,7 +954,7 @@ class TestGenerationTasks:
         (end_frame_dir / "scene_E1S02.png").write_bytes(b"png")  # 别的镜头的快照，供跨镜头误引用例检查
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = end_frame_value
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -982,7 +982,7 @@ class TestGenerationTasks:
         (end_frame_dir / "scene_E1S01.png").symlink_to(end_frame_dir / "scene_E1S02.png")
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -1010,7 +1010,7 @@ class TestGenerationTasks:
         (project_path / "end_frames").symlink_to(real_dir)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -1041,7 +1041,7 @@ class TestGenerationTasks:
         (end_frames_dir / "scene_E1S01.png").write_bytes(b"png")
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script["segments"][0]["end_frame_image"] = "end_frames/scene_E1S01.png"
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
@@ -1068,7 +1068,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
@@ -1106,7 +1106,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         end_frame_dir = project_path / "end_frames"
         end_frame_dir.mkdir(parents=True, exist_ok=True)
@@ -1137,7 +1137,7 @@ class TestGenerationTasks:
         video_prompt.dialogue）；voiceover-kind 不进视频 YAML。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         # 改用 drama 剧本：E1S01 携带有序 utterances（voiceover 在前、dialogue 在后）
         fake_pm.script = {
@@ -1217,7 +1217,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
         _seed_current_storyboard(fake_pm)
 
@@ -1249,7 +1249,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
         _seed_current_storyboard(fake_pm)
 
@@ -1282,7 +1282,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = self._drama_script()
         _seed_current_storyboard(fake_pm)
 
@@ -1318,7 +1318,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -1350,7 +1350,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = self._legacy_drama_script()
         _seed_current_storyboard(fake_pm)
 
@@ -1388,7 +1388,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = self._legacy_drama_script()
         _seed_current_storyboard(fake_pm)
 
@@ -1431,7 +1431,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_pm.project["content_mode"] = "drama"
         fake_pm.project["characters"]["王"] = {"voice_style": "低沉沙哑"}
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         fake_pm.script = {
             "episode": 1,
             # 顶层无 content_mode：存量 episode 省略该字段，真相源退到 project.json。
@@ -1480,7 +1480,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
@@ -1509,7 +1509,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
@@ -1539,7 +1539,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         _seed_current_storyboard(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(
@@ -1567,7 +1567,7 @@ class TestGenerationTasks:
         """视频解析失败即任务失败：异常原样上抛留痕，无硬编码 provider/model 兜底，后端不被调用。"""
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         async def _boom(*args, **kwargs):
             raise RuntimeError("video provider unconfigured")

--- a/tests/integration/server/services/test_formal_image_finalization.py
+++ b/tests/integration/server/services/test_formal_image_finalization.py
@@ -17,18 +17,18 @@ from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _fake_resolve_ctx,
     _FakePM,
-    _persist_active_fake_project,
-    _prepare_files,
-    _register_asset_sheet_claims,
-    _register_stale_visual_claim,
+    fake_resolve_ctx,
+    persist_active_fake_project,
+    prepare_files,
+    register_asset_sheet_claims,
+    register_stale_visual_claim,
 )
 
 
 class TestGenerationTasks:
     async def test_storyboard_registers_manifest_only_after_finalization_succeeds(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         registered: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
@@ -38,7 +38,7 @@ class TestGenerationTasks:
 
         fake_generator = _BrokenVersionLookup()
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(
             generation_tasks,
             "register_current_resource_artifact",
@@ -55,12 +55,12 @@ class TestGenerationTasks:
         assert registered == []
 
     async def test_storyboard_registers_manifest_after_successful_formal_commit(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         registered: list[tuple[tuple[object, ...], dict[str, object]]] = []
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(
             generation_tasks,
             "register_current_resource_artifact",
@@ -83,14 +83,14 @@ class TestGenerationTasks:
         assert isinstance(kwargs["basis"], ArtifactBasis)
 
     async def test_schema8_storyboard_excludes_unclaimed_formal_references(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_args, **_kwargs: True)
 
         await generation_tasks.execute_storyboard_task(
@@ -102,13 +102,13 @@ class TestGenerationTasks:
         assert fake_generator.image_calls[0]["reference_images"] is None
 
     async def test_schema8_storyboard_rejects_an_unclaimed_bound_script_before_provider(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path, register_script=False)
-        _persist_active_fake_project(fake_pm, register_script=False)
+        persist_active_fake_project(fake_pm, register_script=False)
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="episode script is not registered"):
             await generation_tasks.execute_storyboard_task(
@@ -120,11 +120,11 @@ class TestGenerationTasks:
         assert fake_generator.image_calls == []
 
     async def test_schema8_video_rejects_an_unclaimed_bound_script_before_provider(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path, register_script=False)
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
-        _persist_active_fake_project(fake_pm, register_script=False)
-        _register_stale_visual_claim(
+        persist_active_fake_project(fake_pm, register_script=False)
+        register_stale_visual_claim(
             project_path,
             ArtifactKey.episode_storyboard(1, "E1S01"),
             "storyboards/scene_E1S01.png",
@@ -132,7 +132,7 @@ class TestGenerationTasks:
         fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         with pytest.raises(ValueError, match="episode script is not registered"):
             await generation_tasks.execute_video_task(
@@ -154,7 +154,7 @@ class TestGenerationTasks:
         from lib.project_migrations.runner import migrate_project_dir
         from lib.version_manager import VersionManager
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.project.update(
             {
@@ -262,15 +262,15 @@ class TestGenerationTasks:
         assert entry.basis_digest == basis.digest
 
     async def test_storyboard_rechecks_selected_manifest_claims_before_provider(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.script["segments"][2]["scenes"] = []
         fake_pm.script["segments"][2]["props"] = []
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
         key = ArtifactKey.asset_sheet("character", "Alice")
-        _register_stale_visual_claim(project_path, key, "characters/Alice.png")
+        register_stale_visual_claim(project_path, key, "characters/Alice.png")
         fake_generator = FakeGenerator()
-        resolve_context = _fake_resolve_ctx(fake_generator)
+        resolve_context = fake_resolve_ctx(fake_generator)
 
         async def _delete_claim_then_resolve(*args, **kwargs):
             ProjectArtifactManifestAdapter(project_path).delete_entry(key)
@@ -289,16 +289,16 @@ class TestGenerationTasks:
         assert fake_generator.image_calls == []
 
     async def test_storyboard_rejects_same_basis_bytes_replaced_before_provider(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.script["segments"][2]["scenes"] = []
         fake_pm.script["segments"][2]["props"] = []
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
         key = ArtifactKey.asset_sheet("character", "Alice")
         artifact_path = "characters/Alice.png"
-        _register_stale_visual_claim(project_path, key, artifact_path)
+        register_stale_visual_claim(project_path, key, artifact_path)
         fake_generator = FakeGenerator()
-        resolve_context = _fake_resolve_ctx(fake_generator)
+        resolve_context = fake_resolve_ctx(fake_generator)
 
         async def _replace_bytes_then_resolve(*args, **kwargs):
             (project_path / artifact_path).write_bytes(b"replacement")
@@ -317,9 +317,9 @@ class TestGenerationTasks:
         assert fake_generator.image_calls == []
 
     async def test_legacy_storyboard_rejects_sheet_replaced_after_reference_freeze(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        _register_asset_sheet_claims(fake_pm)
+        register_asset_sheet_claims(fake_pm)
         provider_submissions: list[str] = []
 
         class _SubmittingGenerator(FakeGenerator):
@@ -329,7 +329,7 @@ class TestGenerationTasks:
                 return await super().generate_image_async(**kwargs)
 
         fake_generator = _SubmittingGenerator(project_path)
-        resolve_context = _fake_resolve_ctx(fake_generator)
+        resolve_context = fake_resolve_ctx(fake_generator)
         character_path = project_path / "characters" / "Alice.png"
 
         async def _replace_sheet_then_resolve(*args, **kwargs):
@@ -356,22 +356,22 @@ class TestGenerationTasks:
     ):
         from lib.visual_artifact_provenance import VisualReference, build_storyboard_image_visual_basis
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
         fake_pm.script["segments"][1]["scenes"] = []
         fake_pm.script["segments"][1]["props"] = []
-        _persist_active_fake_project(fake_pm)
+        persist_active_fake_project(fake_pm)
         character_path = project_path / "characters" / "Alice.png"
         previous_path = project_path / "storyboards" / "scene_E1S01.png"
         character_path.write_bytes(b"selected-character")
         previous_path.write_bytes(b"selected-previous")
-        _register_stale_visual_claim(
+        register_stale_visual_claim(
             project_path,
             ArtifactKey.asset_sheet("character", "Alice"),
             "characters/Alice.png",
         )
-        _register_stale_visual_claim(
+        register_stale_visual_claim(
             project_path,
             ArtifactKey.episode_storyboard(1, "E1S01"),
             "storyboards/scene_E1S01.png",
@@ -414,7 +414,7 @@ class TestGenerationTasks:
 
         fake_generator = _RacingGenerator()
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         def _register(*_args, **kwargs):
             captured_basis.append(kwargs["basis"])
@@ -432,7 +432,7 @@ class TestGenerationTasks:
         assert captured_basis == [expected_basis]
 
     async def test_formal_image_commit_requires_the_exact_selected_version_record(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         current = project_path / "characters" / "Alice.png"
         staged = project_path / "characters" / ".Alice.stage.png"
@@ -461,7 +461,7 @@ class TestGenerationTasks:
         monkeypatch.setattr(
             generation_tasks,
             "resolve_generation_context",
-            _fake_resolve_ctx(_IncompleteVersions()),
+            fake_resolve_ctx(_IncompleteVersions()),
         )
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_args, **_kwargs: True)
 
@@ -479,7 +479,7 @@ class TestGenerationTasks:
     ):
         from lib.visual_artifact_provenance import build_storyboard_image_visual_basis
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         captured: list[ArtifactBasis] = []
@@ -492,7 +492,7 @@ class TestGenerationTasks:
 
         fake_generator.generate_image_async = _generate
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         class _Receipt:
             def compensate_cancelled(self) -> None:
@@ -543,7 +543,7 @@ class TestGenerationTasks:
     ):
         from lib.visual_artifact_provenance import VisualReference, build_asset_sheet_visual_basis
 
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         captured: list[ArtifactBasis] = []
@@ -556,7 +556,7 @@ class TestGenerationTasks:
 
         fake_generator.generate_image_async = _generate
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
 
         class _Receipt:
             def compensate_cancelled(self) -> None:
@@ -634,7 +634,7 @@ class TestGenerationTasks:
                 return current, version
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(_Generator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(_Generator()))
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_args, **_kwargs: True)
 
         result = await generation_tasks.execute_character_task(
@@ -660,7 +660,7 @@ class TestGenerationTasks:
         assert ArtifactBasis.from_evidence_dict(record["artifact_image_basis"]) == expected
 
     async def test_storyboard_cancellation_waits_for_registration_and_returns_compensation(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
         fake_generator = FakeGenerator()
         registration_started = threading.Event()
@@ -677,7 +677,7 @@ class TestGenerationTasks:
             return _Receipt()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(fake_generator))
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", _register)
         monkeypatch.setattr(generation_tasks, "register_task_current_resource_artifact", _register, raising=False)
 
@@ -747,7 +747,7 @@ class TestGenerationTasks:
                 compensated.append("manifest")
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(_Generator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(_Generator()))
         monkeypatch.setattr(generation_tasks, "register_task_current_resource_artifact", lambda *_a, **_kw: _Receipt())
         ArtifactManifest(ProjectArtifactManifestAdapter(project_path)).register(
             ArtifactKey.episode_script(1),
@@ -852,7 +852,7 @@ class TestGenerationTasks:
                 return current, version
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-        monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(_Generator()))
+        monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(_Generator()))
         monkeypatch.setattr(
             generation_tasks,
             "register_task_current_resource_artifact",

--- a/tests/integration/server/services/test_formal_image_finalization.py
+++ b/tests/integration/server/services/test_formal_image_finalization.py
@@ -16,8 +16,8 @@ from lib.generation_queue import CompensableGenerationResult
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION
 from server.services import generation_tasks
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _FakePM,
     _persist_active_fake_project,
     _prepare_files,
@@ -32,7 +32,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         registered: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-        class _BrokenVersionLookup(_FakeGenerator):
+        class _BrokenVersionLookup(FakeGenerator):
             def get_versions(self, resource_type, resource_id):
                 raise RuntimeError("injected finalization failure")
 
@@ -57,7 +57,7 @@ class TestGenerationTasks:
     async def test_storyboard_registers_manifest_after_successful_formal_commit(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         registered: list[tuple[tuple[object, ...], dict[str, object]]] = []
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -87,7 +87,7 @@ class TestGenerationTasks:
         fake_pm = _FakePM(project_path)
         fake_pm.script["segments"][0]["generated_assets"] = {"storyboard_image": "storyboards/scene_E1S01.png"}
         _persist_active_fake_project(fake_pm)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -105,7 +105,7 @@ class TestGenerationTasks:
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path, register_script=False)
         _persist_active_fake_project(fake_pm, register_script=False)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -129,7 +129,7 @@ class TestGenerationTasks:
             ArtifactKey.episode_storyboard(1, "E1S01"),
             "storyboards/scene_E1S01.png",
         )
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
 
         monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: fake_pm)
         monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(fake_generator))
@@ -269,7 +269,7 @@ class TestGenerationTasks:
         _persist_active_fake_project(fake_pm)
         key = ArtifactKey.asset_sheet("character", "Alice")
         _register_stale_visual_claim(project_path, key, "characters/Alice.png")
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         resolve_context = _fake_resolve_ctx(fake_generator)
 
         async def _delete_claim_then_resolve(*args, **kwargs):
@@ -297,7 +297,7 @@ class TestGenerationTasks:
         key = ArtifactKey.asset_sheet("character", "Alice")
         artifact_path = "characters/Alice.png"
         _register_stale_visual_claim(project_path, key, artifact_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         resolve_context = _fake_resolve_ctx(fake_generator)
 
         async def _replace_bytes_then_resolve(*args, **kwargs):
@@ -322,7 +322,7 @@ class TestGenerationTasks:
         _register_asset_sheet_claims(fake_pm)
         provider_submissions: list[str] = []
 
-        class _SubmittingGenerator(_FakeGenerator):
+        class _SubmittingGenerator(FakeGenerator):
             async def generate_image_async(self, **kwargs):
                 await kwargs["before_submit"]()
                 provider_submissions.append("submitted")
@@ -400,7 +400,7 @@ class TestGenerationTasks:
         )
         captured_basis: list[ArtifactBasis] = []
 
-        class _RacingGenerator(_FakeGenerator):
+        class _RacingGenerator(FakeGenerator):
             def __init__(self):
                 super().__init__()
                 self.reference_bytes: list[bytes] = []
@@ -481,7 +481,7 @@ class TestGenerationTasks:
 
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         captured: list[ArtifactBasis] = []
         original_generate = fake_generator.generate_image_async
 
@@ -545,7 +545,7 @@ class TestGenerationTasks:
 
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         captured: list[ArtifactBasis] = []
         original_generate = fake_generator.generate_image_async
 
@@ -662,7 +662,7 @@ class TestGenerationTasks:
     async def test_storyboard_cancellation_waits_for_registration_and_returns_compensation(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         fake_pm = _FakePM(project_path)
-        fake_generator = _FakeGenerator()
+        fake_generator = FakeGenerator()
         registration_started = threading.Event()
         finish_registration = threading.Event()
         compensated: list[str] = []

--- a/tests/integration/server/services/test_generation_context.py
+++ b/tests/integration/server/services/test_generation_context.py
@@ -538,7 +538,7 @@ class TestValueObjectAssembly:
             resolution=None,
         )
         with pytest.raises(AttributeError):
-            lane.resolution = "720p"  # type: ignore[misc]
+            lane.resolution = "720p"
 
     @pytest.mark.parametrize(
         ("voice_consistency", "requested_generate_audio", "expected"),

--- a/tests/integration/server/services/test_generation_context.py
+++ b/tests/integration/server/services/test_generation_context.py
@@ -76,7 +76,7 @@ def project_env(monkeypatch, tmp_path: Path):
 
 
 @pytest.fixture(autouse=True)
-def _clean_backend_cache():
+def clean_backend_cache():
     """除清空缓存条目外，同时清空 per-key 锁。
 
     ``invalidate_backend_cache()`` 按设计只清条目、不清 ``_locks``（生产环境同一事件循环

--- a/tests/integration/server/services/test_jianying_draft_service.py
+++ b/tests/integration/server/services/test_jianying_draft_service.py
@@ -100,7 +100,7 @@ def _result(
         audio = _media(audio_path, project_path, kind="audio", duration=audio_duration)
     presentation = materialize_speech_presentation(
         _speech(unit_id, mode, "甲", "乙乙"),
-        variant=variant,  # type: ignore[arg-type]
+        variant=variant,
         video=_media(video_path, project_path, kind="video", duration=duration),
         narration_audio=audio,
         provider_audio_enabled=provider_audio_enabled,

--- a/tests/integration/server/services/test_prompt_preview.py
+++ b/tests/integration/server/services/test_prompt_preview.py
@@ -6,10 +6,10 @@ import pytest
 
 from server.services import generation_tasks, prompt_preview
 from tests.integration.server.services.generation_tasks_support import (
+    FakeGenerator,
     _ad_pm,
     _async_return,
     _fake_resolve_ctx,
-    _FakeGenerator,
     _FakePM,
     _prepare_files,
     _register_asset_sheet_claims,
@@ -82,7 +82,7 @@ def _item_of(pm: _FakePM) -> dict:
     return next(item for item in items if str(item.get(id_field)) == ITEM_ID)
 
 
-def _patch_execution(monkeypatch, pm: _FakePM, generator: _FakeGenerator, *, register_artifacts: bool = False) -> None:
+def _patch_execution(monkeypatch, pm: _FakePM, generator: FakeGenerator, *, register_artifacts: bool = False) -> None:
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
     monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
     monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
@@ -102,7 +102,7 @@ class TestPreviewMatchesExecution:
     async def test_storyboard_image_prompt_is_verbatim(self, tmp_path, monkeypatch, content_mode):
         project_path = _prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -118,7 +118,7 @@ class TestPreviewMatchesExecution:
         pm = _pm_for(content_mode, project_path)
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
         _seed_current_storyboard(pm, ITEM_ID)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -133,7 +133,7 @@ class TestPreviewMatchesExecution:
         _item_of(pm)["video_prompt"] = "镜头缓缓推近，雨水顺着伞沿滑落"
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
         _seed_current_storyboard(pm, ITEM_ID)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -155,7 +155,7 @@ class TestPreviewMatchesExecution:
         project_path = _prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         _item_of(pm)["image_prompt"] = body
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -178,7 +178,7 @@ class TestPreviewMatchesExecution:
         _item_of(pm)["video_prompt"] = body
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
         _seed_current_storyboard(pm, ITEM_ID)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -194,7 +194,7 @@ class TestPreviewMatchesExecution:
         """结构化 → 文本以当前渲染结果为初值：再渲染一次不叠出第二份风格与反向约束。"""
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
         structured = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
@@ -212,7 +212,7 @@ class TestPreviewMatchesExecution:
         """视频侧同理：drama 的 Voice_Profiles / Dialogue 声明段已在正文里时不再追加第二份。"""
         project_path = _prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         structured = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
         seed = structured.video.text
@@ -229,7 +229,7 @@ class TestPreviewIsReadOnly:
         pm = _pm_for("ad", project_path)
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
         _seed_current_storyboard(pm, ITEM_ID)
-        generator = _FakeGenerator()
+        generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
         manifest = project_path / ".arcreel_artifacts.json"
         manifest_before = manifest.read_bytes()
@@ -248,7 +248,7 @@ class TestPreviewUnavailableSides:
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _item_of(pm).pop("video_prompt")
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
 
@@ -260,7 +260,7 @@ class TestPreviewUnavailableSides:
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _item_of(pm)["image_prompt"] = {"composition": {}}
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         preview = await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
 
@@ -270,7 +270,7 @@ class TestPreviewUnavailableSides:
     async def test_unknown_item_id_is_reported(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         with pytest.raises(prompt_preview.ScriptItemNotFound):
             await prompt_preview.preview_item_prompts("demo", "episode_1.json", "E9S99")
@@ -305,7 +305,7 @@ class TestPromptPreviewTool:
     async def test_returns_the_same_preview_as_the_service(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("drama", project_path)
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         outcome = await self._call(pm, project_path)
 
@@ -315,7 +315,7 @@ class TestPromptPreviewTool:
     async def test_unknown_item_is_a_typed_problem(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         outcome = await self._call(pm, project_path, item_id="E9S99")
 
@@ -326,7 +326,7 @@ class TestPromptPreviewTool:
     async def test_script_must_be_a_bare_filename(self, tmp_path, monkeypatch):
         project_path = _prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
-        _patch_execution(monkeypatch, pm, _FakeGenerator())
+        _patch_execution(monkeypatch, pm, FakeGenerator())
 
         outcome = await self._call(pm, project_path, script="../other/episode_1.json")
 

--- a/tests/integration/server/services/test_prompt_preview.py
+++ b/tests/integration/server/services/test_prompt_preview.py
@@ -7,13 +7,13 @@ import pytest
 from server.services import generation_tasks, prompt_preview
 from tests.integration.server.services.generation_tasks_support import (
     FakeGenerator,
-    _ad_pm,
-    _async_return,
-    _fake_resolve_ctx,
     _FakePM,
-    _prepare_files,
-    _register_asset_sheet_claims,
-    _seed_current_storyboard,
+    ad_pm,
+    async_return,
+    fake_resolve_ctx,
+    prepare_files,
+    register_asset_sheet_claims,
+    seed_current_storyboard,
 )
 
 ITEM_ID = "E1S02"
@@ -54,7 +54,7 @@ def _drama_pm(project_path: Path) -> _FakePM:
             }
         ],
     }
-    _register_asset_sheet_claims(pm)
+    register_asset_sheet_claims(pm)
     return pm
 
 
@@ -63,13 +63,13 @@ def _pm_for(content_mode: str, project_path: Path) -> _FakePM:
         return _drama_pm(project_path)
     if content_mode == "ad":
         (project_path / "products" / "保温杯.png").write_bytes(b"png")
-        pm = _ad_pm(project_path, with_sheet=True)
+        pm = ad_pm(project_path, with_sheet=True)
         shot = pm.script["shots"][1]
         shot["image_prompt"] = STRUCTURED_IMAGE_PROMPT
         shot["video_prompt"] = STRUCTURED_VIDEO_PROMPT
         return pm
     pm = _FakePM(project_path)
-    _register_asset_sheet_claims(pm)
+    register_asset_sheet_claims(pm)
     segment = pm.script["segments"][1]
     segment["image_prompt"] = STRUCTURED_IMAGE_PROMPT
     segment["video_prompt"] = {**STRUCTURED_VIDEO_PROMPT, "dialogue": [{"speaker": "Alice", "line": "hello"}]}
@@ -84,8 +84,8 @@ def _item_of(pm: _FakePM) -> dict:
 
 def _patch_execution(monkeypatch, pm: _FakePM, generator: FakeGenerator, *, register_artifacts: bool = False) -> None:
     monkeypatch.setattr(generation_tasks, "get_project_manager", lambda: pm)
-    monkeypatch.setattr(generation_tasks, "resolve_generation_context", _fake_resolve_ctx(generator))
-    monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", _async_return(None))
+    monkeypatch.setattr(generation_tasks, "resolve_generation_context", fake_resolve_ctx(generator))
+    monkeypatch.setattr(generation_tasks, "extract_video_thumbnail", async_return(None))
     monkeypatch.setattr(generation_tasks, "emit_project_change_batch", lambda *a, **kw: None)
     if not register_artifacts:
         monkeypatch.setattr(generation_tasks, "register_current_resource_artifact", lambda *_a, **_kw: True)
@@ -100,7 +100,7 @@ class TestPreviewMatchesExecution:
 
     @pytest.mark.parametrize("content_mode", CONTENT_MODES)
     async def test_storyboard_image_prompt_is_verbatim(self, tmp_path, monkeypatch, content_mode):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
@@ -114,10 +114,10 @@ class TestPreviewMatchesExecution:
 
     @pytest.mark.parametrize("content_mode", CONTENT_MODES)
     async def test_video_prompt_is_verbatim(self, tmp_path, monkeypatch, content_mode):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
-        _seed_current_storyboard(pm, ITEM_ID)
+        seed_current_storyboard(pm, ITEM_ID)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
@@ -128,11 +128,11 @@ class TestPreviewMatchesExecution:
 
     async def test_drama_text_form_video_prompt_keeps_utterance_speech(self, tmp_path, monkeypatch):
         """文本形态不承载台词：发声序列仍由 utterances 决定，渲染层照常注入。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _drama_pm(project_path)
         _item_of(pm)["video_prompt"] = "镜头缓缓推近，雨水顺着伞沿滑落"
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
-        _seed_current_storyboard(pm, ITEM_ID)
+        seed_current_storyboard(pm, ITEM_ID)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
@@ -152,7 +152,7 @@ class TestPreviewMatchesExecution:
     async def test_text_form_image_prompt_is_the_prompt_body(self, tmp_path, monkeypatch, content_mode):
         """文本形态的分镜图提示词就是提示词主体，渲染层只注入项目风格与反向约束。"""
         body = "一条被雨水打湿的老街，霓虹反射在积水上"
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         _item_of(pm)["image_prompt"] = body
         generator = FakeGenerator()
@@ -173,11 +173,11 @@ class TestPreviewMatchesExecution:
     async def test_text_form_video_prompt_is_the_prompt_body(self, tmp_path, monkeypatch, content_mode):
         """视频侧同理：文本形态正文领先，逐字等于执行期实发文本。"""
         body = "镜头缓缓推近，雨水顺着伞沿滑落"
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         _item_of(pm)["video_prompt"] = body
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
-        _seed_current_storyboard(pm, ITEM_ID)
+        seed_current_storyboard(pm, ITEM_ID)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
 
@@ -192,7 +192,7 @@ class TestPreviewMatchesExecution:
 
     async def test_rendering_a_preview_text_again_does_not_duplicate_injections(self, tmp_path, monkeypatch):
         """结构化 → 文本以当前渲染结果为初值：再渲染一次不叠出第二份风格与反向约束。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
@@ -210,7 +210,7 @@ class TestPreviewMatchesExecution:
         self, tmp_path, monkeypatch, content_mode
     ):
         """视频侧同理：drama 的 Voice_Profiles / Dialogue 声明段已在正文里时不再追加第二份。"""
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for(content_mode, project_path)
         _patch_execution(monkeypatch, pm, FakeGenerator())
 
@@ -225,10 +225,10 @@ class TestPreviewMatchesExecution:
 
 class TestPreviewIsReadOnly:
     async def test_preview_calls_no_provider_and_writes_no_manifest(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("ad", project_path)
         (project_path / "storyboards" / f"scene_{ITEM_ID}.png").write_bytes(b"png")
-        _seed_current_storyboard(pm, ITEM_ID)
+        seed_current_storyboard(pm, ITEM_ID)
         generator = FakeGenerator()
         _patch_execution(monkeypatch, pm, generator)
         manifest = project_path / ".arcreel_artifacts.json"
@@ -245,7 +245,7 @@ class TestPreviewIsReadOnly:
 
 class TestPreviewUnavailableSides:
     async def test_missing_prompt_reports_that_side_only(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _item_of(pm).pop("video_prompt")
         _patch_execution(monkeypatch, pm, FakeGenerator())
@@ -257,7 +257,7 @@ class TestPreviewUnavailableSides:
         assert preview.storyboard_image.text
 
     async def test_malformed_prompt_reports_invalid(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _item_of(pm)["image_prompt"] = {"composition": {}}
         _patch_execution(monkeypatch, pm, FakeGenerator())
@@ -268,7 +268,7 @@ class TestPreviewUnavailableSides:
         assert preview.storyboard_image.unavailable == prompt_preview.UNAVAILABLE_INVALID
 
     async def test_unknown_item_id_is_reported(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _patch_execution(monkeypatch, pm, FakeGenerator())
 
@@ -303,7 +303,7 @@ class TestPromptPreviewTool:
         )
 
     async def test_returns_the_same_preview_as_the_service(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("drama", project_path)
         _patch_execution(monkeypatch, pm, FakeGenerator())
 
@@ -313,7 +313,7 @@ class TestPromptPreviewTool:
         assert outcome.value == await prompt_preview.preview_item_prompts("demo", "episode_1.json", ITEM_ID)
 
     async def test_unknown_item_is_a_typed_problem(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _patch_execution(monkeypatch, pm, FakeGenerator())
 
@@ -324,7 +324,7 @@ class TestPromptPreviewTool:
         assert outcome.problem.code == "item_not_found"
 
     async def test_script_must_be_a_bare_filename(self, tmp_path, monkeypatch):
-        project_path = _prepare_files(tmp_path)
+        project_path = prepare_files(tmp_path)
         pm = _pm_for("narration", project_path)
         _patch_execution(monkeypatch, pm, FakeGenerator())
 

--- a/tests/integration/server/services/test_reference_visual_basis.py
+++ b/tests/integration/server/services/test_reference_visual_basis.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 from lib.reference_video.request_projection import resolve_reference_assets
 from tests.integration.server.services.reference_video_tasks_support import (
-    _load_project_and_unit,
-    _write_project,
+    load_project_and_unit,
+    write_project,
 )
 
 
@@ -15,8 +15,8 @@ def test_reference_visual_basis_hashes_only_audio_sent_for_the_unit(tmp_path: Pa
     from lib.reference_video.request_projection import ProviderProjectionCandidate
     from server.services.narration_delivery_tasks import reference_video_visual_basis_digest
 
-    proj_dir = _write_project(tmp_path)
-    project, unit = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, unit = load_project_and_unit(proj_dir, "E1U1")
     project["characters"]["张三"].update(
         {
             "voice_style": "低沉男声",

--- a/tests/integration/server/services/test_resolve_reference_assets.py
+++ b/tests/integration/server/services/test_resolve_reference_assets.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from lib.reference_video.request_projection import resolve_reference_assets
-from server.services.reference_video_tasks import (
-    _clamp_resolved_reference_images,
-)
+from lib.reference_video.request_projection import clamp_reference_assets, resolve_reference_assets
 from tests.integration.server.services.reference_video_tasks_support import (
-    _load_project_and_unit,
-    _register_asset_sheet,
-    _write_project,
+    load_project_and_unit,
+    register_asset_sheet,
+    write_project,
 )
 
 
@@ -21,15 +18,15 @@ def _resolved_names(project: dict, proj_dir: Path, text: str) -> list[str]:
 
 
 def test_resolve_reference_assets_maps_sheets(tmp_path: Path):
-    proj_dir = _write_project(tmp_path)
-    project, unit = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, unit = load_project_and_unit(proj_dir, "E1U1")
     assert _resolved_names(project, proj_dir, unit["text"]) == ["张三.png", "酒馆.png"]
 
 
 def test_product_reference_uses_its_sheet_without_type_priority(tmp_path: Path):
     """商品与其它资产同一条规则：有资产图就只用资产图，且不排到提及顺序之前。"""
-    proj_dir = _write_project(tmp_path)
-    project, _unit = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, _unit = load_project_and_unit(proj_dir, "E1U1")
     products_dir = proj_dir / "products"
     refs_dir = products_dir / "refs"
     refs_dir.mkdir(parents=True)
@@ -45,44 +42,33 @@ def test_product_reference_uses_its_sheet_without_type_priority(tmp_path: Path):
         },
     }
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "product", "商品甲", "products/甲-sheet.png")
+    register_asset_sheet(proj_dir, "product", "商品甲", "products/甲-sheet.png")
 
     assert _resolved_names(project, proj_dir, "@[张三] 拿起 @[商品甲]") == ["张三.png", "甲-sheet.png"]
 
 
 def test_clamp_keeps_the_first_mentions_without_type_priority(tmp_path: Path):
-    """超上限时按正文提及顺序截断，并附一条超限 warning。"""
-    proj_dir = _write_project(tmp_path)
-    project, _unit = _load_project_and_unit(proj_dir, "E1U1")
+    """超上限时按正文提及顺序截断：商品资产图不因类型排到先被提及的资产之前。"""
+    proj_dir = write_project(tmp_path)
+    project, _unit = load_project_and_unit(proj_dir, "E1U1")
     products_dir = proj_dir / "products"
     products_dir.mkdir(exist_ok=True)
     image = (proj_dir / "characters" / "张三.png").read_bytes()
     (products_dir / "甲-sheet.png").write_bytes(image)
     project["products"] = {"商品甲": {"description": "x", "product_sheet": "products/甲-sheet.png"}}
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "product", "商品甲", "products/甲-sheet.png")
+    register_asset_sheet(proj_dir, "product", "商品甲", "products/甲-sheet.png")
 
     entries = list(resolve_reference_assets(project, proj_dir, {"text": "@[张三] 在 @[酒馆] 拿起 @[商品甲]"}))
-    clamped, warnings = _clamp_resolved_reference_images(
-        entries,
-        2,
-        provider="custom-openai",
-        model="video-model",
-    )
+    clamped = clamp_reference_assets(entries, 2)
 
     assert [entry.path.name for entry in clamped] == ["张三.png", "酒馆.png"]
-    assert warnings == [
-        {
-            "key": "ref_too_many_images",
-            "params": {"count": 3, "model": "video-model", "max_count": 2},
-        }
-    ]
 
 
 def test_product_reference_with_original_only_is_executable(tmp_path: Path):
     """尚无标准 sheet 的商品仍以实拍原图作为保真锚点，不被误判为缺图。"""
-    proj_dir = _write_project(tmp_path)
-    project, _unit = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, _unit = load_project_and_unit(proj_dir, "E1U1")
     refs_dir = proj_dir / "products" / "refs"
     refs_dir.mkdir(parents=True)
     (refs_dir / "original.png").write_bytes((proj_dir / "characters" / "张三.png").read_bytes())
@@ -100,8 +86,8 @@ def test_product_reference_with_original_only_is_executable(tmp_path: Path):
 
 
 def test_resolve_reference_assets_ignores_an_unregistered_mention(tmp_path: Path):
-    proj_dir = _write_project(tmp_path)
-    project, _ = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, _ = load_project_and_unit(proj_dir, "E1U1")
 
     assert _resolved_names(project, proj_dir, "@[不存在的道具] 掉在地上") == []
 
@@ -114,11 +100,11 @@ def test_resolve_reference_assets_resolves_nfd_registered_name_by_nfc_mention(tm
     name_nfd = unicodedata.normalize("NFD", "Hiếu")
     assert name_nfc != name_nfd
 
-    proj_dir = _write_project(tmp_path)
-    project, _ = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, _ = load_project_and_unit(proj_dir, "E1U1")
     project["characters"][name_nfd] = {"description": "x", "character_sheet": "characters/hieu.png"}
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", name_nfd, "characters/hieu.png")
+    register_asset_sheet(proj_dir, "character", name_nfd, "characters/hieu.png")
 
     assert _resolved_names(project, proj_dir, f"@[{name_nfc}] 推门") == ["hieu.png"]
 
@@ -131,10 +117,10 @@ def test_resolve_reference_assets_dedupes_a_repeated_mention(tmp_path: Path):
     name_nfd = unicodedata.normalize("NFD", "Hiếu")
     assert name_nfc != name_nfd
 
-    proj_dir = _write_project(tmp_path)
-    project, _ = _load_project_and_unit(proj_dir, "E1U1")
+    proj_dir = write_project(tmp_path)
+    project, _ = load_project_and_unit(proj_dir, "E1U1")
     project["characters"][name_nfc] = {"description": "x", "character_sheet": "characters/hieu.png"}
     (proj_dir / "project.json").write_text(json.dumps(project, ensure_ascii=False), encoding="utf-8")
-    _register_asset_sheet(proj_dir, "character", name_nfc, "characters/hieu.png")
+    register_asset_sheet(proj_dir, "character", name_nfc, "characters/hieu.png")
 
     assert _resolved_names(project, proj_dir, f"@[{name_nfc}] 推门，@[{name_nfd}] 回头") == ["hieu.png"]

--- a/tests/integration/server/services/test_resume_custom_endpoint_chain.py
+++ b/tests/integration/server/services/test_resume_custom_endpoint_chain.py
@@ -38,7 +38,7 @@ from tests.http_capture import capture_http
 
 
 @pytest.fixture(autouse=True)
-def _clean_backend_cache():
+def clean_backend_cache():
     """除清空缓存条目外，同时清空 per-key 锁。
 
     pytest-asyncio 按测试函数切换独立事件循环，跨测试复用同一缓存 key 时，

--- a/tests/integration/server/services/test_script_review.py
+++ b/tests/integration/server/services/test_script_review.py
@@ -110,7 +110,7 @@ def _stub_video_caps(
 
 
 @pytest.fixture(autouse=True)
-def _unresolvable_video_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+def unresolvable_video_caps(monkeypatch: pytest.MonkeyPatch) -> None:
     """本模块默认让能力查询解析不到型号：不碰 DB，也不让系统级默认模型的档位漂进断言。
 
     需要具体档位表的用例用 ``_stub_video_caps`` 就地覆盖。

--- a/tests/integration/server/services/test_video_artifact_currency.py
+++ b/tests/integration/server/services/test_video_artifact_currency.py
@@ -378,7 +378,7 @@ async def test_formal_selection_reloads_current_tts_settings_for_currency_check(
 
     monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", _current_basis)
     committer = VideoArtifactCommitter(
-        project_manager=_PM(),  # type: ignore[arg-type]
+        project_manager=_PM(),
         project_name="demo",
         project_path=project_path,
         versions=versions,
@@ -442,7 +442,7 @@ async def test_failed_formal_selection_validation_archives_paid_video_without_cu
         AsyncMock(return_value=TtsSynthesisSettings("p", "m", "v", None)),
     )
     committer = VideoArtifactCommitter(
-        project_manager=_PM(),  # type: ignore[arg-type]
+        project_manager=_PM(),
         project_name="demo",
         project_path=project_path,
         versions=versions,
@@ -569,7 +569,7 @@ def test_selected_video_cancellation_compensation_restores_media_manifest_and_on
 
     monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", lambda **_kwargs: new_basis)
     committer = VideoArtifactCommitter(
-        project_manager=_PM(),  # type: ignore[arg-type]
+        project_manager=_PM(),
         project_name="demo",
         project_path=project_path,
         versions=versions,
@@ -681,7 +681,7 @@ def test_selected_video_compensation_preserves_the_original_and_rollback_failure
 
     monkeypatch.setattr(video_artifact_currency, "build_current_video_artifact_basis", lambda **_kwargs: new_basis)
     committer = VideoArtifactCommitter(
-        project_manager=_PM(),  # type: ignore[arg-type]
+        project_manager=_PM(),
         project_name="demo",
         project_path=project_path,
         versions=versions,

--- a/tests/integration/server/services/test_workflow_planner.py
+++ b/tests/integration/server/services/test_workflow_planner.py
@@ -259,8 +259,8 @@ async def test_planner_uses_shared_admission_and_never_reads_the_real_task_singl
     monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
     request = WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
-    first = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)  # type: ignore[arg-type]
-    second = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)  # type: ignore[arg-type]
+    first = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)
+    second = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", request)
 
     assert first == second
     assert len(admission_calls) == 2
@@ -301,7 +301,7 @@ async def test_active_task_and_provider_checkpoint_are_reported_as_separate_axes
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
     monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
     )
 
@@ -361,7 +361,7 @@ async def test_grid_storyboard_plan_waits_for_active_grid_task(tmp_path: Path, m
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())
 
     assert next(step for step in plan.steps if step.id == "storyboard").state is WorkflowStepState.ACTIVE
     assert plan.next_action.type == "wait_for_task"
@@ -402,7 +402,7 @@ async def test_asset_sheet_plan_waits_for_active_asset_task(tmp_path: Path, monk
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())
 
     step = next(item for item in plan.steps if item.id == "asset_sheets")
     assert step.state is WorkflowStepState.ACTIVE
@@ -473,7 +473,7 @@ async def test_product_task_replanning_returns_its_durable_handle_without_crossi
         provider_id="test-provider",
     )
 
-    planner = workflow_planner.WorkflowPlanner(planner_pm)  # type: ignore[arg-type]
+    planner = workflow_planner.WorkflowPlanner(planner_pm)
     plan = await planner.get_plan("demo", WorkflowPlanRequest(), user_id=caller, queue=queue)
     other_plan = await planner.get_plan("demo", WorkflowPlanRequest(), user_id="caller-b", queue=queue)
 
@@ -523,7 +523,7 @@ async def test_recovery_checkpoint_without_provider_job_remains_visible(
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
     monkeypatch.setattr(workflow_planner, "admit_storyboard_video_request", _admit)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
     )
 
@@ -549,7 +549,7 @@ async def test_mixed_speech_blocks_before_storyboard_and_uses_atomic_script_edit
 
     monkeypatch.setattr(workflow_planner, "get_active_tasks_for_resources", _active_tasks)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan("demo", WorkflowPlanRequest())
 
     structure = next(step for step in plan.steps if step.id == "script_structure")
     storyboard = next(step for step in plan.steps if step.id == "storyboard")
@@ -608,7 +608,7 @@ async def test_planner_refuses_a_unit_whose_video_input_is_unusable(
     monkeypatch.setattr(video_batch_admission, "get_active_tasks_for_resources", _no_active_tasks)
 
     before = sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*"))  # noqa: ASYNC240 -- 测试内本地小文件读写/断言，不在生产事件循环上
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
     )
 
@@ -652,7 +652,7 @@ async def test_planner_reports_the_audio_switch_conflict_before_any_task_exists(
     monkeypatch.setattr(video_batch_admission, "get_active_tasks_for_resources", _no_active_tasks)
     monkeypatch.setattr(video_batch_admission, "assert_audio_switch_supported", _reject)
 
-    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(  # type: ignore[arg-type]
+    plan = await workflow_planner.WorkflowPlanner(pm).get_plan(
         "demo", WorkflowPlanRequest(narration_delivery=POST_PRODUCTION)
     )
 

--- a/tests/integration/server/test_auth_enforcement.py
+++ b/tests/integration/server/test_auth_enforcement.py
@@ -56,7 +56,7 @@ _PARAM_PLACEHOLDERS = {"path": "x/y.png"}
 
 # module 级：整个文件共用一套认证环境；私有缓存在进出时清空，不污染其它测试模块。
 @pytest.fixture(scope="module", autouse=True)
-def _auth_env():
+def auth_env():
     auth_module._cached_token_secret = None
     auth_module._cached_password_hash = None
     with patch.dict(

--- a/tests/integration/server/test_error_handlers.py
+++ b/tests/integration/server/test_error_handlers.py
@@ -20,36 +20,38 @@ def _make_client() -> TestClient:
     app = FastAPI()
     register_error_handlers(app)
 
+    # 以下路由桩由 @app.get 就地注册，函数体内无其它引用；basedpyright 把函数作用域内的符号
+    # 一律判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @app.get("/api-error-404")
-    async def _api_error_404():
+    async def _api_error_404():  # pyright: ignore[reportUnusedFunction]
         raise NotFoundError("segment_not_found", id="E1S01")
 
     @app.get("/api-error-400")
-    async def _api_error_400():
+    async def _api_error_400():  # pyright: ignore[reportUnusedFunction]
         raise BadRequestError("audio_provider_not_configured")
 
     @app.get("/api-error-422-with-diagnostic")
-    async def _api_error_422_with_diagnostic():
+    async def _api_error_422_with_diagnostic():  # pyright: ignore[reportUnusedFunction]
         raise UnprocessableError("script_validation_failed").with_diagnostic("scenes[0].shots must be a list")
 
     @app.get("/api-error-custom-status")
-    async def _api_error_custom():
+    async def _api_error_custom():  # pyright: ignore[reportUnusedFunction]
         raise ApiError("internal_server_error", status_code=503)
 
     @app.get("/task-spec-error")
-    async def _task_spec_error():
+    async def _task_spec_error():  # pyright: ignore[reportUnusedFunction]
         raise TaskSpecValidationError("prompt_text_empty")
 
     @app.get("/active-video-request-conflict")
-    async def _active_video_request_conflict():
+    async def _active_video_request_conflict():  # pyright: ignore[reportUnusedFunction]
         raise ActiveTaskRequestConflict(resource_id="E1S01", existing_task_id="task-existing")
 
     @app.get("/script-edit-error")
-    async def _script_edit_error():
+    async def _script_edit_error():  # pyright: ignore[reportUnusedFunction]
         raise ScriptEditError("segments 必须是列表，当前为 NoneType")
 
     @app.get("/script-edit-error-keyed")
-    async def _script_edit_error_keyed():
+    async def _script_edit_error_keyed():  # pyright: ignore[reportUnusedFunction]
         raise ScriptEditError(
             "segments 必须是列表，当前为 NoneType",
             key="script_edit_items_not_list",
@@ -58,11 +60,11 @@ def _make_client() -> TestClient:
         )
 
     @app.get("/file-not-found")
-    async def _file_not_found():
+    async def _file_not_found():  # pyright: ignore[reportUnusedFunction]
         raise FileNotFoundError(f"剧本文件不存在: {_SERVER_PATH}")
 
     @app.get("/unexpected")
-    async def _unexpected():
+    async def _unexpected():  # pyright: ignore[reportUnusedFunction]
         raise RuntimeError(f"boom at {_SERVER_PATH}")
 
     return TestClient(app, raise_server_exceptions=False)
@@ -184,7 +186,7 @@ def _make_cors_client(allow_origins, allow_credentials) -> TestClient:
     register_error_handlers(app, cors_allow_origins=allow_origins, cors_allow_credentials=allow_credentials)
 
     @app.get("/unexpected")
-    async def _unexpected():
+    async def _unexpected():  # pyright: ignore[reportUnusedFunction]
         raise RuntimeError("boom")
 
     return TestClient(app, raise_server_exceptions=False)
@@ -227,7 +229,7 @@ class TestUnexpectedErrorCorsHeaders:
         register_error_handlers(app)
 
         @app.get("/unexpected")
-        async def _unexpected():
+        async def _unexpected():  # pyright: ignore[reportUnusedFunction]
             raise RuntimeError("boom")
 
         client = TestClient(app, raise_server_exceptions=False)

--- a/tests/integration/server/test_remote_mcp.py
+++ b/tests/integration/server/test_remote_mcp.py
@@ -37,7 +37,7 @@ from server.media_tools.storyboards import generate_storyboards_tool
 from server.media_tools.videos import generate_videos_tool
 from server.remote_mcp import ArcApiKeyVerifier, RemoteMCPHost, build_remote_mcp_server
 from server.tool_runtime import Services
-from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import _call
+from tests.integration.server.agent_runtime.sdk_tools.sdk_tools_support import call
 
 
 class _Planner:
@@ -1013,7 +1013,7 @@ async def test_text_task_is_shared_by_remote_and_embedded_hosts_and_cancelled_be
                 pm=projects,
                 queue=queue,
             )
-            embedded = asyncio.create_task(_call(generate_episode_script_tool(embedded_ctx), {"episode": 1}))
+            embedded = asyncio.create_task(call(generate_episode_script_tool(embedded_ctx), {"episode": 1}))
             await queue.deduped.wait()
 
             assert not embedded.done()

--- a/tests/integration/server/test_text_task_queue.py
+++ b/tests/integration/server/test_text_task_queue.py
@@ -126,7 +126,7 @@ async def test_all_text_long_calls_submit_single_member_batches(
     assert await queue.acquire_or_renew_worker_lease(name="default", owner_id="test-worker", ttl_seconds=60)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -160,7 +160,7 @@ async def test_text_mcp_rejects_lost_worker_lease_without_persisting_queue_state
     await queue.release_worker_lease(name="default", owner_id="lost-worker")
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -191,7 +191,7 @@ async def test_text_mcp_migration_rejection_cleans_only_the_fresh_batch(
     assert await queue.acquire_or_renew_worker_lease(name="default", owner_id="test-worker", ttl_seconds=60)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -270,7 +270,7 @@ async def test_text_submission_cancellation_only_cleans_a_fresh_batch(
     )
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -342,7 +342,7 @@ async def test_queued_plan_ignores_internal_payload_and_preserves_typed_failure(
                 cursor=None,
             )
 
-    result = await execute_queued_text_task(task, planner_cls=Planner)  # type: ignore[arg-type]
+    result = await execute_queued_text_task(task, planner_cls=Planner)
     assert result["episodes"][0]["title"] == "第一集"
 
     class FailingPlanner(Planner):
@@ -350,7 +350,7 @@ async def test_queued_plan_ignores_internal_payload_and_preserves_typed_failure(
             raise EpisodePlanningError("invalid source window")
 
     with pytest.raises(RuntimeError) as raised:
-        await execute_queued_text_task(task, planner_cls=FailingPlanner)  # type: ignore[arg-type]
+        await execute_queued_text_task(task, planner_cls=FailingPlanner)
     problem = problem_from_task_failure(str(raised.value))
     assert problem.code == "episode_planning_failed"
     assert problem.action is GenerationAction.RETRY
@@ -438,7 +438,7 @@ async def test_episode_script_terminal_update_race_cancels_batch_and_compensates
     worker = await _start_text_worker(queue, execute)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -523,7 +523,7 @@ async def test_cancel_during_started_episode_script_commit_restores_formal_state
     worker = await _start_text_worker(queue, execute, dispatch_cancellation=True)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -597,7 +597,7 @@ async def test_episode_plan_terminal_update_race_cancels_batch_and_compensates_l
             )
 
     async def create_planner(_cls, path):
-        return EpisodePlanner(path, generator=Generator())  # type: ignore[arg-type]
+        return EpisodePlanner(path, generator=Generator())
 
     monkeypatch.setattr(EpisodePlanner, "create", classmethod(create_planner))
     queue = GenerationQueue(session_factory=file_db_factory, project_manager=projects)
@@ -609,7 +609,7 @@ async def test_episode_plan_terminal_update_race_cancels_batch_and_compensates_l
     )
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -675,7 +675,7 @@ async def test_cancel_during_started_episode_plan_commit_restores_batch_and_ledg
             return result
 
     async def create_planner(_cls, path):
-        planner = EpisodePlanner(path, generator=Generator())  # type: ignore[arg-type]
+        planner = EpisodePlanner(path, generator=Generator())
         planner.pm = BlockingProjectManager(projects.projects_root)
         return planner
 
@@ -689,7 +689,7 @@ async def test_cancel_during_started_episode_plan_commit_restores_batch_and_ledg
     worker = await _start_text_worker(queue, execute, dispatch_cancellation=True)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )
@@ -786,7 +786,7 @@ async def test_cancel_during_invalid_script_plan_quarantine_leaves_no_workflow_b
     worker = await _start_text_worker(queue, execute, dispatch_cancellation=True)
     services = Services(
         projects=projects,
-        workflow_planner=object(),  # type: ignore[arg-type]
+        workflow_planner=object(),
         capabilities=ConfigResolver(async_session_factory),
         queue=queue,
     )

--- a/tests/integration/server/test_tool_runtime_entry.py
+++ b/tests/integration/server/test_tool_runtime_entry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -42,8 +42,8 @@ class _Unused:
 def _services(tmp_path: Path) -> Services:
     return Services(
         projects=ProjectManager(tmp_path / "projects"),
-        workflow_planner=_Unused(),  # type: ignore[arg-type]
-        capabilities=_Unused(),  # type: ignore[arg-type]
+        workflow_planner=_Unused(),
+        capabilities=_Unused(),
     )
 
 
@@ -108,8 +108,8 @@ async def test_create_project_rolls_back_when_metadata_initialization_fails(tmp_
     projects_root = tmp_path / "projects"
     services = Services(
         projects=FailingMetadataProjectManager(projects_root),
-        workflow_planner=_Unused(),  # type: ignore[arg-type]
-        capabilities=_Unused(),  # type: ignore[arg-type]
+        workflow_planner=_Unused(),
+        capabilities=_Unused(),
     )
     request = ToolRequest(
         CreateProjectToolRequest(
@@ -141,8 +141,8 @@ async def test_create_project_settles_publication_before_propagating_cancellatio
     projects = BlockingMetadataProjectManager(tmp_path / "projects")
     services = Services(
         projects=projects,
-        workflow_planner=_Unused(),  # type: ignore[arg-type]
-        capabilities=_Unused(),  # type: ignore[arg-type]
+        workflow_planner=_Unused(),
+        capabilities=_Unused(),
     )
     caller = CallerContext(user_id="test", source="mcp")
     creation = asyncio.create_task(
@@ -279,7 +279,7 @@ async def test_upload_source_settles_write_before_propagating_cancellation(tmp_p
 
     class BlockingSourceProjectManager(ProjectManager):
         @contextmanager
-        def locked_source_mutation(self, project_name: str) -> Iterator[Path]:
+        def locked_source_mutation(self, project_name: str) -> Generator[Path]:
             with super().locked_source_mutation(project_name) as source_dir:
                 started.set()
                 release.wait()
@@ -293,8 +293,8 @@ async def test_upload_source_settles_write_before_propagating_cancellation(tmp_p
     projects.create_project_metadata("demo", "Demo")
     services = Services(
         projects=projects,
-        workflow_planner=_Unused(),  # type: ignore[arg-type]
-        capabilities=_Unused(),  # type: ignore[arg-type]
+        workflow_planner=_Unused(),
+        capabilities=_Unused(),
     )
     task = asyncio.create_task(
         upload_source(

--- a/tests/unit/lib/agent_session_store/test_conformance.py
+++ b/tests/unit/lib/agent_session_store/test_conformance.py
@@ -50,9 +50,11 @@ async def test_db_session_store_passes_sdk_conformance():
             engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         engines.append(engine)
         async with engine.begin() as conn:
-            # Import model modules to register tables on Base.metadata.
-            import lib.agent_session_store.models
-            import lib.db.models  # noqa: F401  (users / agent_sessions / config etc.)
+            from lib.agent_session_store.models import register_models as register_agent_session_models
+            from lib.db.models import register_models as register_db_models
+
+            register_agent_session_models()
+            register_db_models()
 
             await conn.run_sync(Base.metadata.create_all)
         # PG enforces FK constraints; seed the conformance user.

--- a/tests/unit/lib/audio_backends/test_audio_backends.py
+++ b/tests/unit/lib/audio_backends/test_audio_backends.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import re
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -86,7 +86,7 @@ def _dashscope_audio_routes(
     download: httpx.Response | list[httpx.Response | Exception] | None = None,
     audio_url: str = _AUDIO_URL,
     synth_url: str = _SYNTH_URL,
-) -> Iterator[_DashScopeRoutes]:
+) -> Generator[_DashScopeRoutes]:
     """DashScope TTS 的两条出站流：合成 POST 与音频 GET。
 
     走 respx 在 transport 层拦截，断言对象是真实序列化后的请求（URL 拼接、鉴权头、body 编码

--- a/tests/unit/lib/config/test_config_service.py
+++ b/tests/unit/lib/config/test_config_service.py
@@ -73,7 +73,7 @@ async def test_video_poll_timeout_defaults_and_round_trips(config_service: Confi
 @pytest.mark.parametrize("value", [True, 0, 59, 60.5])
 async def test_video_poll_timeout_rejects_values_below_minimum(config_service: ConfigService, value: object):
     with pytest.raises(ValueError, match="at least 60"):
-        await config_service.set_video_poll_timeout_seconds(value)  # pyright: ignore[reportArgumentType]
+        await config_service.set_video_poll_timeout_seconds(value)
 
 
 async def test_get_default_video_backend(config_service: ConfigService):

--- a/tests/unit/lib/custom_provider/test_custom_provider_factory.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_factory.py
@@ -6,7 +6,7 @@ endpoints 模块内的真实后端类换成记录型工厂：工厂的产出就�
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -41,7 +41,7 @@ _ENDPOINT_BACKEND_CLASSES = (
 
 
 @contextmanager
-def _endpoint_backends() -> Iterator[list[dict[str, Any]]]:
+def _endpoint_backends() -> Generator[list[dict[str, Any]]]:
     """endpoints 模块各后端类的构造记录器：记类名与构造参数，不建 SDK 客户端。"""
     records: list[dict[str, Any]] = []
 

--- a/tests/unit/lib/custom_provider/test_model_discovery.py
+++ b/tests/unit/lib/custom_provider/test_model_discovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
@@ -13,7 +13,7 @@ import pytest
 
 
 @contextmanager
-def _recorded_genai_clients(models: list[Any] | None = None) -> Iterator[list[dict[str, Any]]]:
+def _recorded_genai_clients(models: list[Any] | None = None) -> Generator[list[dict[str, Any]]]:
     """genai 客户端构造的记录器：收下建客户端的参数，回一个列出给定模型的替身。
 
     鉴权与 base_url 透传的契约就是构造参数本身，断言落在记录的参数上，而不是替身的调用对象。

--- a/tests/unit/lib/db/models/test_asset_model.py
+++ b/tests/unit/lib/db/models/test_asset_model.py
@@ -5,8 +5,10 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-import lib.db.models  # noqa: F401 — ensure all models registered for Base.metadata
+from lib.db.models import register_models
 from lib.db.models.asset import Asset
+
+register_models()
 
 
 async def test_asset_create_and_fetch(db_session):

--- a/tests/unit/lib/db/models/test_custom_provider_models.py
+++ b/tests/unit/lib/db/models/test_custom_provider_models.py
@@ -6,8 +6,9 @@ import pytest
 from sqlalchemy import inspect, select
 from sqlalchemy.exc import IntegrityError
 
-import lib.db.models  # noqa: F401 — ensure all models registered
-from lib.db.models import CustomProvider, CustomProviderModel
+from lib.db.models import CustomProvider, CustomProviderModel, register_models
+
+register_models()
 
 
 class TestCustomProviderTable:

--- a/tests/unit/lib/db/models/test_db_models.py
+++ b/tests/unit/lib/db/models/test_db_models.py
@@ -4,9 +4,10 @@ from datetime import UTC, datetime
 
 from sqlalchemy import inspect, select
 
-import lib.db.models  # noqa: F401 — ensure all models registered for Base.metadata
 from lib.db.base import TimestampMixin, UserOwnedMixin
-from lib.db.models import AgentSession, Task, User
+from lib.db.models import AgentSession, Task, User, register_models
+
+register_models()
 
 
 class TestModelsCreateTables:

--- a/tests/unit/lib/image_backends/test_agnes_image_backend.py
+++ b/tests/unit/lib/image_backends/test_agnes_image_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -40,7 +40,7 @@ def _make_ref(tmp_path: Path, name: str) -> ReferenceImage:
 
 
 @contextmanager
-def _generate_route(response: httpx.Response, download: AsyncMock | None = None) -> Iterator[respx.Route]:
+def _generate_route(response: httpx.Response, download: AsyncMock | None = None) -> Generator[respx.Route]:
     """拦截建图 POST 并（可选）挡住产物下载，产出该路由供断言真实请求。"""
     with capture_http() as router:
         route = router.post(_ENDPOINT).mock(return_value=response)

--- a/tests/unit/lib/image_backends/test_ark.py
+++ b/tests/unit/lib/image_backends/test_ark.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,7 +68,7 @@ class _RecordingArkClient:
 @contextmanager
 def _recorded_ark_client(
     response: _FakeImagesResponse | None = None,
-) -> Iterator[tuple[list[dict[str, Any]], _RecordingArkClient]]:
+) -> Generator[tuple[list[dict[str, Any]], _RecordingArkClient]]:
     """create_ark_client 的记录器：收下建客户端的参数，回一个记录型客户端。"""
     created: list[dict[str, Any]] = []
     client = _RecordingArkClient(response)

--- a/tests/unit/lib/image_backends/test_dashscope_image_backend.py
+++ b/tests/unit/lib/image_backends/test_dashscope_image_backend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -35,7 +35,7 @@ def _generate_route(
     download: AsyncMock,
     *,
     host: str = _DEFAULT_HOST,
-) -> Iterator[respx.Route]:
+) -> Generator[respx.Route]:
     """拦截建图 POST 并挡住产物下载，产出该路由供断言真实请求。"""
     with (
         capture_http() as router,

--- a/tests/unit/lib/image_backends/test_gemini.py
+++ b/tests/unit/lib/image_backends/test_gemini.py
@@ -23,7 +23,7 @@ def fake_rate_limiter():
 
 
 @pytest.fixture
-def _patch_genai():
+def patch_genai():
     """Patch google.genai so GeminiImageBackend can be imported without real SDK."""
     mock_genai = MagicMock()
     mock_types = MagicMock()
@@ -40,7 +40,7 @@ def _patch_genai():
 
 
 @pytest.fixture
-def backend_aistudio(fake_rate_limiter, _patch_genai):
+def backend_aistudio(fake_rate_limiter, patch_genai):
     from lib.image_backends.gemini import GeminiImageBackend
 
     return GeminiImageBackend(
@@ -51,7 +51,7 @@ def backend_aistudio(fake_rate_limiter, _patch_genai):
 
 
 @pytest.fixture
-def backend_vertex(fake_rate_limiter, _patch_genai):
+def backend_vertex(fake_rate_limiter, patch_genai):
     """Create a Vertex backend, patching credential loading."""
     mock_sa = MagicMock()
     mock_sa.Credentials.from_service_account_file.return_value = MagicMock()

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Generator
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,7 @@ import pytest
 import respx
 
 from lib.image_backends.base import ImageCapability, ImageGenerationRequest, ReferenceImage
+from tests.fakes import blocking_file_read_gate
 from tests.http_capture import capture_http
 
 # ---------------------------------------------------------------------------
@@ -192,6 +194,33 @@ class TestGenerateI2I:
 
         call_kwargs = grok_backend._client.image.sample.call_args.kwargs
         assert len(call_kwargs["image_urls"]) == 2
+
+    async def test_i2i_reference_encoding_keeps_event_loop_running(self, grok_backend, tmp_path, monkeypatch):
+        """参考图 base64 编码要读整张图，必须卸载到线程，否则事件循环被读堵住。"""
+        ref_image = tmp_path / "ref.png"
+        ref_image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        output = tmp_path / "output.png"
+        mock_response = MagicMock()
+        mock_response.respect_moderation = True
+        mock_response.url = "https://example.com/edited.png"
+        grok_backend._client.image.sample = AsyncMock(return_value=mock_response)
+
+        with _image_download(mock_response.url, b"\x89PNG\r\n\x1a\n" + b"\x00" * 50):
+            request = ImageGenerationRequest(
+                prompt="Make it darker",
+                output_path=output,
+                reference_images=[ReferenceImage(path=str(ref_image), label="base")],
+            )
+            with blocking_file_read_gate(monkeypatch, ref_image) as gate:
+                task = asyncio.create_task(grok_backend.generate(request))
+                await gate.wait_until_read_started()
+                gate.release()
+                await task
+                gate.assert_read_was_offloaded()
+
+        call_kwargs = grok_backend._client.image.sample.call_args.kwargs
+        assert call_kwargs["image_urls"][0].startswith("data:image/png;base64,")
 
     async def test_i2i_skips_missing_ref(self, grok_backend, tmp_path):
         """参考图不存在时退化为 T2I。"""

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,7 +19,7 @@ from tests.http_capture import capture_http
 
 
 @contextmanager
-def _image_download(url: str, content: bytes) -> Iterator[respx.Route]:
+def _image_download(url: str, content: bytes) -> Generator[respx.Route]:
     """成图下载的出站流：base 层用真实 httpx 取字节，走 respx 在 transport 层拦截。"""
     with capture_http() as router:
         yield router.get(url).mock(return_value=httpx.Response(200, content=content))

--- a/tests/unit/lib/image_backends/test_grok.py
+++ b/tests/unit/lib/image_backends/test_grok.py
@@ -26,7 +26,7 @@ def _image_download(url: str, content: bytes) -> Generator[respx.Route]:
 
 
 @pytest.fixture
-def _patch_xai_sdk():
+def patch_xai_sdk():
     """Patch create_grok_client 以免依赖真实 SDK。"""
     mock_client_instance = MagicMock()
     with patch("lib.image_backends.grok.create_grok_client", return_value=mock_client_instance):
@@ -34,14 +34,14 @@ def _patch_xai_sdk():
 
 
 @pytest.fixture
-def grok_backend(_patch_xai_sdk):
+def grok_backend(patch_xai_sdk):
     from lib.image_backends.grok import GrokImageBackend
 
     return GrokImageBackend(api_key="fake-xai-key")
 
 
 @pytest.fixture
-def backend_pro(_patch_xai_sdk):
+def backend_pro(patch_xai_sdk):
     from lib.image_backends.grok import GrokImageBackend
 
     return GrokImageBackend(api_key="fake-xai-key", model="grok-imagine-image-pro")

--- a/tests/unit/lib/image_backends/test_kling_image_backend.py
+++ b/tests/unit/lib/image_backends/test_kling_image_backend.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import NamedTuple
@@ -41,7 +41,7 @@ class _KlingImageRoutes(NamedTuple):
 
 
 @contextmanager
-def _kling_image_api() -> Iterator[_KlingImageRoutes]:
+def _kling_image_api() -> Generator[_KlingImageRoutes]:
     with capture_http() as router:
         yield _KlingImageRoutes(
             submit=router.post(_GENERATIONS_URL),

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -59,7 +59,7 @@ def _error_response(status_code: int) -> httpx.Response:
 
 
 @contextmanager
-def _generation_route(resp: httpx.Response, download: AsyncMock | None = None) -> Iterator[respx.Route]:
+def _generation_route(resp: httpx.Response, download: AsyncMock | None = None) -> Generator[respx.Route]:
     """成图端点的出站流：走 respx 在 transport 层拦截。
 
     端点派生、请求体字段、鉴权头都是「发出去的请求长什么样」的契约，断言落在路由捕获的

--- a/tests/unit/lib/image_backends/test_registry.py
+++ b/tests/unit/lib/image_backends/test_registry.py
@@ -16,7 +16,7 @@ class _DummyBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_image_registry():
+def clean_image_registry():
     """注册表是模块级全局：清空后跑，跑完还原，避免测试用后端泄漏给其他用例。"""
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()

--- a/tests/unit/lib/reference_video/test_reference_video_draft_validation.py
+++ b/tests/unit/lib/reference_video/test_reference_video_draft_validation.py
@@ -237,7 +237,7 @@ class TestDialogueLoad:
 
     def test_non_string_language_falls_back_to_default_rate(self):
         """project.json 的 source_language 可能是脏数据：估算按默认语速走，不抛 AttributeError。"""
-        assert validate_dialogue_load("unit E1U01", "@[李明]：{我来了。}", 4, 123) is None  # pyright: ignore[reportArgumentType]
+        assert validate_dialogue_load("unit E1U01", "@[李明]：{我来了。}", 4, 123) is None
 
     def test_normalizes_unicode_before_estimating(self):
         """NFD 台词先归一再估：组合附加符会被词计数拆成多个单位，不归一会把念得完的 unit 判超载。"""

--- a/tests/unit/lib/source_loader/test_base.py
+++ b/tests/unit/lib/source_loader/test_base.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from lib.source_loader.base import ExtractedText, FormatExtractor, NormalizeResult  # noqa: F401
+from lib.source_loader.base import ExtractedText, FormatExtractor, NormalizeResult
 
 
 def test_extracted_text_defaults():
@@ -30,7 +30,7 @@ def test_format_extractor_protocol_runtime_check():
         def extract(self, path: Path) -> ExtractedText:
             return ExtractedText(text="x")
 
-    stub = _Stub()
+    stub: FormatExtractor = _Stub()
     # Protocol 仅做静态检查；运行期通过 hasattr 验证 duck-typing
     assert hasattr(stub, "extract")
     assert isinstance(stub.extract(Path(".")), ExtractedText)

--- a/tests/unit/lib/test_agent_provider_catalog.py
+++ b/tests/unit/lib/test_agent_provider_catalog.py
@@ -105,4 +105,4 @@ def test_preset_dataclass_is_frozen() -> None:
     assert p is not None
     assert dataclasses.is_dataclass(p)
     with pytest.raises(dataclasses.FrozenInstanceError):
-        p.display_name = "x"  # type: ignore[misc]
+        p.display_name = "x"

--- a/tests/unit/lib/test_app_data_dir.py
+++ b/tests/unit/lib/test_app_data_dir.py
@@ -9,9 +9,9 @@ import pytest
 
 def _import_fresh():
     """Re-import the module fresh — `@functools.cache` traps env values."""
-    from lib.app_data_dir import _reset_for_tests, app_data_dir
+    from lib.app_data_dir import app_data_dir, reset_for_tests
 
-    _reset_for_tests()
+    reset_for_tests()
     return app_data_dir
 
 

--- a/tests/unit/lib/test_ark_shared.py
+++ b/tests/unit/lib/test_ark_shared.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -54,7 +54,7 @@ class TestApiKeyResolution:
 
 
 @contextmanager
-def _recorded_ark_sdk() -> Iterator[list[dict[str, Any]]]:
+def _recorded_ark_sdk() -> Generator[list[dict[str, Any]]]:
     """Ark SDK 类构造的记录器：收下建客户端的参数，回一个空替身。"""
     created: list[dict[str, Any]] = []
 

--- a/tests/unit/lib/test_artifact_manifest.py
+++ b/tests/unit/lib/test_artifact_manifest.py
@@ -47,7 +47,7 @@ def test_formal_input_selection_retains_identity_for_the_provider_recheck() -> N
             return ArtifactComparison(status=ArtifactStatus.CURRENT, artifact_path=entry.artifact_path)
 
     assert artifact_input_is_usable(
-        resolver=_Resolver(),  # type: ignore[arg-type]
+        resolver=_Resolver(),
         key=key,
         artifact_path="scripts/episode_1.json",
         claims=claims,
@@ -83,7 +83,7 @@ def test_artifact_key_round_trips_without_display_string_parsing(key: ArtifactKe
 @pytest.mark.parametrize("variant", ["", "automatic", "USE_TTS", 1])
 def test_rendition_artifact_keys_reject_unknown_variants(variant: object) -> None:
     with pytest.raises(ValueError, match="variant"):
-        ArtifactKey.episode_presentation(1, "E1U01", variant)  # type: ignore[arg-type]
+        ArtifactKey.episode_presentation(1, "E1U01", variant)
 
 
 def test_artifact_key_rejects_direct_construction_that_cannot_round_trip() -> None:
@@ -451,3 +451,19 @@ def test_manifest_blocks_windows_aliases_of_runtime_paths(artifact_path: str) ->
     assert comparison.status is ArtifactStatus.BLOCKED
     assert comparison.blocker is not None
     assert comparison.blocker.code == "artifact_path_invalid"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"kind": 5, "kind_version": 1, "digest": "sha256-v1:" + "0" * 64},
+        {"kind": ["artifact/x"], "kind_version": 1, "digest": "sha256-v1:" + "0" * 64},
+        {"kind": "artifact/x", "kind_version": 1, "digest": 123},
+        {"kind": "artifact/x", "kind_version": 1, "digest": None},
+    ],
+)
+def test_basis_descriptor_from_dict_rejects_non_string_fields_as_value_error(payload: dict[str, object]) -> None:
+    """磁盘 JSON 的 kind/digest 可为任意类型，调用方只接 ValueError。"""
+
+    with pytest.raises(ValueError, match="artifact basis descriptor"):
+        ArtifactBasisDescriptor.from_dict(payload)

--- a/tests/unit/lib/test_generation_queue.py
+++ b/tests/unit/lib/test_generation_queue.py
@@ -22,10 +22,10 @@ class TestGenerationQueue:
         tmp_path,
         monkeypatch,
     ):
-        from lib.app_data_dir import _reset_for_tests
+        from lib.app_data_dir import reset_for_tests
 
         monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path / "app-data"))
-        _reset_for_tests()
+        reset_for_tests()
         async with generation_admission_lock(
             project_name="admission-demo",
             script_file="scripts/episode_01.json",

--- a/tests/unit/lib/test_generation_queue_client.py
+++ b/tests/unit/lib/test_generation_queue_client.py
@@ -715,7 +715,7 @@ class TestBatchEnqueueOnly:
                 blocked=[],
                 specs=[],
                 source="mcp",
-                queue=_Queue(),  # type: ignore[arg-type]
+                queue=_Queue(),
             )
 
         assert calls == ["migration"]

--- a/tests/unit/lib/test_generation_result.py
+++ b/tests/unit/lib/test_generation_result.py
@@ -83,7 +83,7 @@ def test_missing_only_selects_missing_and_reuses_stale(tmp_path: Path) -> None:
     selection = select_generation_targets(
         candidates=[_candidate("A"), _candidate("B"), _candidate("C")],
         requested_ids=None,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     assert selection.mode is GenerationSelectionMode.MISSING_ONLY
@@ -100,7 +100,7 @@ def test_missing_only_never_regenerates_a_blocked_artifact(tmp_path: Path) -> No
     selection = select_generation_targets(
         candidates=[_candidate("A"), _candidate("B")],
         requested_ids=None,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     assert selection.target_ids == ("A",)
@@ -122,7 +122,7 @@ def test_explicit_selection_takes_named_ids_regardless_of_state(tmp_path: Path) 
     selection = select_generation_targets(
         candidates=[_candidate("A"), _candidate("B")],
         requested_ids=["A", "ZZ"],
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     assert selection.mode is GenerationSelectionMode.EXPLICIT
@@ -138,7 +138,7 @@ def test_explicit_empty_collection_is_invalid_not_everything(tmp_path: Path) -> 
         select_generation_targets(
             candidates=[_candidate("A")],
             requested_ids=[],
-            resolver=_Resolver({}),  # type: ignore[arg-type]
+            resolver=_Resolver({}),
         )
 
 
@@ -162,7 +162,7 @@ def test_missing_only_reselects_a_recorded_path_the_manifest_no_longer_claims() 
             _candidate("KEPT", path="videos/kept.mp4"),
         ],
         requested_ids=None,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     assert selection.target_ids == ("GONE",)
@@ -177,7 +177,7 @@ def test_missing_only_admits_an_override_leg_without_rechecking_the_filesystem(t
     selection = select_generation_targets(
         candidates=[_candidate("A", path="videos/gone.mp4")],
         requested_ids=None,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
         reusable_override=lambda _candidate: True,
     )
 
@@ -193,7 +193,7 @@ def test_missing_only_does_not_recheck_the_filesystem(tmp_path: Path) -> None:
     selection = select_generation_targets(
         candidates=[_candidate("A"), _candidate("B")],
         requested_ids=None,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     assert selection.target_ids == ("B",)
@@ -206,13 +206,13 @@ def test_observe_artifact_status_separates_unobservable_from_missing() -> None:
 
     # 没有 key 可比对的单元：该轴不可观测，与「缺失」不是一回事。
     assert observe_artifact_status(
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
         key=None,
         artifact_path="videos/a.mp4",
     ) == (None, None)
     assert (
         observe_artifact_status(
-            resolver=resolver,  # type: ignore[arg-type]
+            resolver=resolver,
             key=key,
             artifact_path=None,
         )[0]
@@ -220,7 +220,7 @@ def test_observe_artifact_status_separates_unobservable_from_missing() -> None:
     )
 
     status, blocker = observe_artifact_status(
-        resolver=_Resolver({}, raises={"A"}),  # type: ignore[arg-type]
+        resolver=_Resolver({}, raises={"A"}),
         key=key,
         artifact_path="videos/a.mp4",
     )
@@ -424,7 +424,7 @@ def test_every_registered_failure_code_resolves_to_a_declared_action() -> None:
 
 
 def _batch(resource_id: str, *, status: str = "succeeded", **kwargs: object) -> BatchTaskResult:
-    return BatchTaskResult(resource_id=resource_id, task_id=f"task-{resource_id}", status=status, **kwargs)  # type: ignore[arg-type]
+    return BatchTaskResult(resource_id=resource_id, task_id=f"task-{resource_id}", status=status, **kwargs)
 
 
 def test_recording_a_batch_reports_task_provider_and_artifact_axes_separately() -> None:
@@ -441,7 +441,7 @@ def test_recording_a_batch_reports_task_provider_and_artifact_axes_separately() 
         successes=[_batch("A", result={"file_path": "videos/a.mp4"}, task={"provider_job_id": "job-1"})],
         failures=[],
         states=states,
-        resolver=resolver,  # type: ignore[arg-type]
+        resolver=resolver,
     )
 
     item = builder.build().items[0]
@@ -548,7 +548,7 @@ def test_recording_a_success_with_no_known_state_does_not_crash_under_an_active_
         successes=[_batch("张三", result={"file_path": "characters/张三.png"})],
         failures=[],
         states={},  # unit 不在映射里 -> _state() 退回无 artifact_key 的默认 state
-        resolver=_Resolver({}),  # type: ignore[arg-type]
+        resolver=_Resolver({}),
     )
 
     item = builder.build().items[0]

--- a/tests/unit/lib/test_generation_worker_wake.py
+++ b/tests/unit/lib/test_generation_worker_wake.py
@@ -45,7 +45,7 @@ async def test_wake_claims_task_without_waiting_for_poll_interval() -> None:
         return {"ok": True}
 
     worker = GenerationWorker(
-        queue=queue,  # type: ignore[arg-type]
+        queue=queue,
         capacity=CapacityTable(_limits={}, _defaults={"text": 1}),
         provider_projection=text_provider,
         executor=execute,

--- a/tests/unit/lib/test_grid_executor.py
+++ b/tests/unit/lib/test_grid_executor.py
@@ -114,35 +114,35 @@ def _register_sheet(project_path, resource_type, resource_id):
 
 class TestGroupBySegmentBreak:
     def test_groups(self, project_with_script):
-        from server.services.generation_tasks import _group_scenes_by_segment_break
+        from lib.storyboard_sequence import group_scenes_by_segment_break
 
         script = json.loads((project_with_script / "scripts" / "episode_1.json").read_text(encoding="utf-8"))
         items = script["segments"]
-        groups = _group_scenes_by_segment_break(items, "segment_id")
+        groups = group_scenes_by_segment_break(items, "segment_id")
         # E1S03 has segment_break=True, so groups: [E1S01,E1S02] and [E1S03,E1S04,E1S05,E1S06]
         assert len(groups) == 2
         assert len(groups[0]) == 2
         assert len(groups[1]) == 4
 
     def test_no_breaks(self):
-        from server.services.generation_tasks import _group_scenes_by_segment_break
+        from lib.storyboard_sequence import group_scenes_by_segment_break
 
         items = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
-        groups = _group_scenes_by_segment_break(items, "id")
+        groups = group_scenes_by_segment_break(items, "id")
         assert len(groups) == 1
         assert len(groups[0]) == 3
 
     def test_empty_list(self):
-        from server.services.generation_tasks import _group_scenes_by_segment_break
+        from lib.storyboard_sequence import group_scenes_by_segment_break
 
-        groups = _group_scenes_by_segment_break([], "id")
+        groups = group_scenes_by_segment_break([], "id")
         assert groups == []
 
     def test_break_at_first_item(self):
-        from server.services.generation_tasks import _group_scenes_by_segment_break
+        from lib.storyboard_sequence import group_scenes_by_segment_break
 
         items = [{"id": "a", "segment_break": True}, {"id": "b"}, {"id": "c"}]
-        groups = _group_scenes_by_segment_break(items, "id")
+        groups = group_scenes_by_segment_break(items, "id")
         # segment_break on first item: current is empty so no split, all in one group
         assert len(groups) == 1
         assert len(groups[0]) == 3

--- a/tests/unit/lib/test_ledger.py
+++ b/tests/unit/lib/test_ledger.py
@@ -88,7 +88,7 @@ class TestSettlementDispatch:
         assert s.output_tokens == 50
 
     def test_unknown_channel_raises(self) -> None:
-        with pytest.raises(ValueError, match="unknown ledger channel"):
+        with pytest.raises(AssertionError, match="Expected code to be unreachable"):
             _settlement_from_result("bogus", object())
 
 

--- a/tests/unit/lib/test_ledger.py
+++ b/tests/unit/lib/test_ledger.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -89,7 +89,7 @@ class TestSettlementDispatch:
 
     def test_unknown_channel_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown ledger channel"):
-            _settlement_from_result("bogus", object())  # type: ignore[arg-type]
+            _settlement_from_result("bogus", object())
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +167,7 @@ class TestRecordBracket:
         monkeypatch.setattr("lib.ledger.UsageRepository", _BoomOnFailRepo)
 
         @asynccontextmanager
-        async def _dummy_session() -> AsyncIterator[None]:
+        async def _dummy_session() -> AsyncGenerator[None]:
             yield None
 
         ledger = Ledger(session_factory=lambda: _dummy_session())
@@ -197,7 +197,7 @@ class TestRecordBracket:
         monkeypatch.setattr("lib.ledger.UsageRepository", _BoomOnSuccessRepo)
 
         @asynccontextmanager
-        async def _dummy_session() -> AsyncIterator[None]:
+        async def _dummy_session() -> AsyncGenerator[None]:
             yield None
 
         ledger = Ledger(session_factory=lambda: _dummy_session())

--- a/tests/unit/lib/test_logging_persistence.py
+++ b/tests/unit/lib/test_logging_persistence.py
@@ -14,7 +14,7 @@ from lib import logging_config
 
 
 @pytest.fixture(autouse=True)
-def _reset_root_logger():
+def reset_root_logger():
     """每个用例前后清空 root logger handlers，避免污染。
 
     setup_logging() / attach_file_handler() 不止改 root.handlers——还动
@@ -134,9 +134,9 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterat
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(data_root))
     monkeypatch.delenv("ARCREEL_LOG_DIR", raising=False)
     monkeypatch.setattr(logging_config, "PROJECT_ROOT", project_root)
-    app_data_dir_mod._reset_for_tests()
+    app_data_dir_mod.reset_for_tests()
     yield tmp_path
-    app_data_dir_mod._reset_for_tests()
+    app_data_dir_mod.reset_for_tests()
 
 
 def test_resolve_log_dir_default_is_project_root(isolated_data_dir: Path) -> None:
@@ -276,7 +276,7 @@ def test_migrate_noop_when_paths_equal(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("ARCREEL_LOG_DIR", raising=False)
     monkeypatch.setattr(logging_config, "PROJECT_ROOT", tmp_path)
-    app_data_dir_mod._reset_for_tests()
+    app_data_dir_mod.reset_for_tests()
     try:
         logs = tmp_path / "logs"
         logs.mkdir()
@@ -286,7 +286,7 @@ def test_migrate_noop_when_paths_equal(tmp_path: Path, monkeypatch: pytest.Monke
 
         assert (logs / "arcreel.log").read_text(encoding="utf-8") == "hi\n"
     finally:
-        app_data_dir_mod._reset_for_tests()
+        app_data_dir_mod.reset_for_tests()
 
 
 def test_migrate_falls_back_to_copy_on_exdev(isolated_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/lib/test_narration_delivery.py
+++ b/tests/unit/lib/test_narration_delivery.py
@@ -66,7 +66,7 @@ def _settings(**overrides: object) -> TtsSynthesisSettings:
         "speed": None,
     }
     values.update(overrides)
-    return TtsSynthesisSettings(**values)  # type: ignore[arg-type]
+    return TtsSynthesisSettings(**values)
 
 
 def _comparison(status: ArtifactStatus, path: str = "audio/segment_E1U1.wav") -> ArtifactComparison:
@@ -76,7 +76,7 @@ def _comparison(status: ArtifactStatus, path: str = "audio/segment_E1U1.wav") ->
 @pytest.mark.parametrize("invalid", [True, 0, -1, 8.5, "8"])
 def test_request_confirmation_is_an_exact_positive_integer(invalid: object) -> None:
     with pytest.raises(ValueError, match="positive integer"):
-        NarrationDeliveryRequestOptions(confirmed_request_duration_seconds=invalid)  # type: ignore[arg-type]
+        NarrationDeliveryRequestOptions(confirmed_request_duration_seconds=invalid)
 
 
 def test_canonical_text_is_nfc_line_normalized_and_ordered() -> None:
@@ -365,7 +365,7 @@ async def test_tts_settings_resolution_rejects_a_configured_identity_only_resolv
     resolver = _ConfiguredIdentityOnlyResolver()
 
     with pytest.raises(AttributeError):
-        await resolve_tts_synthesis_settings({}, resolver)  # type: ignore[arg-type]
+        await resolve_tts_synthesis_settings({}, resolver)
 
     assert resolver.calls == []
 
@@ -452,7 +452,7 @@ async def test_current_state_adapter_post_production_does_not_touch_tts_config(t
         preparation=_narrator_preparation(),
         project_path=tmp_path,
         delivery=POST_PRODUCTION,
-        resolver=_ExplodingResolver(),  # type: ignore[arg-type]
+        resolver=_ExplodingResolver(),
     )
 
     assert prepared.allowed is True

--- a/tests/unit/lib/test_profile_manifest.py
+++ b/tests/unit/lib/test_profile_manifest.py
@@ -459,7 +459,7 @@ def test_repo_profile_resolves_for_every_content_mode() -> None:
 
     repo_profile = Path(__file__).resolve().parents[3] / "agent_runtime_profile"
     for mode in sorted(VALID_CONTENT_MODES):
-        mapping = resolve_profile_files_for_mode(repo_profile, mode)  # type: ignore[arg-type]
+        mapping = resolve_profile_files_for_mode(repo_profile, mode)
         assert mapping["CLAUDE.md"] == f"CLAUDE.{mode}.md"
         assert mapping[".claude/skills/video-workflow/SKILL.md"] == f".claude/skills/video-workflow/SKILL.{mode}.md"
 
@@ -509,7 +509,7 @@ def test_resolve_invalid_mode_raises(tmp_path: Path) -> None:
 
     profile = _make_profile(tmp_path)
     with pytest.raises(ValueError, match="content_mode"):
-        resolve_profile_files_for_mode(profile, "reference_video")  # type: ignore[arg-type]
+        resolve_profile_files_for_mode(profile, "reference_video")
 
 
 def test_resolve_double_dot_filename_not_treated_as_variant(tmp_path: Path) -> None:
@@ -675,7 +675,7 @@ def test_sync_invalid_mode_raises(tmp_path: Path) -> None:
     profile = _make_profile(tmp_path)
     project = _fresh_project(tmp_path / "proj_root")
     with pytest.raises(ValueError, match="content_mode"):
-        sync_profile_to_project(profile, project, content_mode="reference_video")  # type: ignore[arg-type]
+        sync_profile_to_project(profile, project, content_mode="reference_video")
 
 
 # ---------- force_resync_profile ----------
@@ -713,7 +713,7 @@ def test_variants_to_common_upgrade_preserves_modified_legacy_files_and_reports_
 
     profile = _make_profile(tmp_path)
     project = _fresh_project(tmp_path / "proj_root")
-    sync_profile_to_project(profile, project, content_mode=mode)  # type: ignore[arg-type]
+    sync_profile_to_project(profile, project, content_mode=mode)
     old_agent = project / ".claude" / "agents" / "generate-assets.md"
     old_agent.write_text("user customized legacy agent", encoding="utf-8")
 
@@ -730,7 +730,7 @@ def test_variants_to_common_upgrade_preserves_modified_legacy_files_and_reports_
     for variant in ("narration", "drama", "ad"):
         (references / f"workflow-mode.{variant}.md").write_text(variant, encoding="utf-8")
 
-    sync_profile_to_project(profile, project, content_mode=mode)  # type: ignore[arg-type]
+    sync_profile_to_project(profile, project, content_mode=mode)
 
     assert (project / "CLAUDE.md").read_text(encoding="utf-8") == "common top"
     assert (project / ".claude" / "skills" / "video-workflow" / "SKILL.md").read_text(
@@ -738,7 +738,7 @@ def test_variants_to_common_upgrade_preserves_modified_legacy_files_and_reports_
     ) == "common skill"
     assert (project / ".claude" / "references" / "workflow-mode.md").read_text(encoding="utf-8") == mode
     assert old_agent.read_text(encoding="utf-8") == "user customized legacy agent"
-    assert get_profile_status(profile, project, content_mode=mode) == {  # type: ignore[arg-type]
+    assert get_profile_status(profile, project, content_mode=mode) == {
         "customized": True,
         "customized_files": [".claude/agents/generate-assets.md"],
     }
@@ -855,7 +855,7 @@ def test_force_resync_invalid_mode_raises(tmp_path: Path) -> None:
     profile = _make_profile(tmp_path)
     project = _fresh_project(tmp_path / "proj_root")
     with pytest.raises(ValueError, match="content_mode"):
-        force_resync_profile(profile, project, content_mode="bad")  # type: ignore[arg-type]
+        force_resync_profile(profile, project, content_mode="bad")
 
 
 # ---------- ProjectManager 集成 ----------

--- a/tests/unit/lib/test_project_manager_ad_mode.py
+++ b/tests/unit/lib/test_project_manager_ad_mode.py
@@ -65,7 +65,7 @@ class TestCreateAdProjectMetadata:
         pm = _pm(tmp_path)
         pm.create_project("demo-ad", content_mode="ad")
         with pytest.raises(ValueError, match="brief"):
-            pm.create_project_metadata("demo-ad", "短片", "Realistic", "ad", brief=123)  # type: ignore[arg-type]
+            pm.create_project_metadata("demo-ad", "短片", "Realistic", "ad", brief=123)
 
     def test_extras_cannot_override_core_fields(self, tmp_path):
         pm = _pm(tmp_path)

--- a/tests/unit/lib/test_prompt_builders_script_duration.py
+++ b/tests/unit/lib/test_prompt_builders_script_duration.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import pytest
 
 from lib.prompt_builders_script import (
-    _format_duration_constraint,
     build_narration_split_prompt,
     build_normalize_prompt,
+    format_duration_constraint,
 )
 from lib.prompt_rules.episode_target_duration import (
     EPISODE_TARGET_DURATION_RULE_TEMPLATE,
@@ -20,30 +20,30 @@ _RULE_HEAD = EPISODE_TARGET_DURATION_RULE_TEMPLATE.split("{seconds}")[0]
 
 class TestFormatDurationConstraint:
     def test_discrete_set(self):
-        text = _format_duration_constraint([4, 6, 8], default_duration=None)
+        text = format_duration_constraint([4, 6, 8], default_duration=None)
         for duration in (4, 6, 8):
             assert str(duration) in text
 
     def test_discrete_set_with_default(self):
-        text = _format_duration_constraint([4, 6, 8], default_duration=6)
+        text = format_duration_constraint([4, 6, 8], default_duration=6)
         assert "6" in text
-        assert text != _format_duration_constraint([4, 6, 8], default_duration=None)
+        assert text != format_duration_constraint([4, 6, 8], default_duration=None)
 
     def test_default_duration_must_be_in_supported(self):
         """default_duration 不在 supported 集合时应抛错，避免 prompt 自相矛盾。"""
         with pytest.raises(ValueError, match="default_duration=6 不在"):
-            _format_duration_constraint([4, 8], default_duration=6)
+            format_duration_constraint([4, 8], default_duration=6)
 
     def test_continuous_range_uses_min_max_phrasing(self):
         """长度 ≥5 且连续整数时压缩为只包含边界的区间。"""
-        text = _format_duration_constraint([3, 4, 5, 6, 7, 8, 9, 10], default_duration=None)
+        text = format_duration_constraint([3, 4, 5, 6, 7, 8, 9, 10], default_duration=None)
         assert "3" in text
         assert "10" in text
         assert "[3, 4, 5, 6, 7, 8, 9, 10]" not in text
 
     def test_short_continuous_still_uses_list(self):
         """长度 <5 即使连续，仍保留中间值。"""
-        text = _format_duration_constraint([4, 5, 6], default_duration=None)
+        text = format_duration_constraint([4, 5, 6], default_duration=None)
         assert "5" in text
 
 
@@ -52,7 +52,7 @@ class TestBuildersRequireDurations:
 
     def test_format_constraint_rejects_empty(self):
         with pytest.raises(ValueError, match="supported_durations 不能为空"):
-            _format_duration_constraint([], default_duration=None)
+            format_duration_constraint([], default_duration=None)
 
 
 def _drama_prompt(**overrides) -> str:

--- a/tests/unit/lib/test_prompt_utils.py
+++ b/tests/unit/lib/test_prompt_utils.py
@@ -172,7 +172,7 @@ class TestBuildDramaVideoPrompt:
             ([_utterance("王", "x")], {"王": "not-a-dict"}),
             ([_utterance("王", "x")], "not-a-dict"),
         ):
-            prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters=characters)  # type: ignore[arg-type]
+            prompt = build_drama_video_prompt(_BASE_PROMPT, utterances, characters=characters)
             assert "voice_profiles" not in prompt
 
     def test_does_not_mutate_caller_prompt(self):

--- a/tests/unit/lib/test_script_models.py
+++ b/tests/unit/lib/test_script_models.py
@@ -511,9 +511,9 @@ class TestEnumDriftNormalization:
 
     def test_non_string_enum_still_rejected(self):
         with pytest.raises(ValidationError):
-            Composition.model_validate(self._composition(123))  # type: ignore[arg-type]
+            Composition.model_validate(self._composition(123))
         with pytest.raises(ValidationError):
-            VideoPrompt.model_validate(self._video_prompt(None))  # type: ignore[arg-type]
+            VideoPrompt.model_validate(self._video_prompt(None))
 
     def test_dialogue_null_coerces_to_empty_list(self):
         vp = VideoPrompt.model_validate(self._video_prompt("Static", dialogue=None))

--- a/tests/unit/lib/test_speech_artifact_provenance.py
+++ b/tests/unit/lib/test_speech_artifact_provenance.py
@@ -327,7 +327,7 @@ def test_tts_change_stales_tts_subtitle_and_tts_presentation_but_not_video_or_po
 @pytest.mark.parametrize("invalid", [0, -1, True, 8.5, "8"])
 def test_video_duration_basis_requires_a_request_tier(invalid: object) -> None:
     with pytest.raises(ValueError, match="positive integer"):
-        build_video_duration_basis(invalid)  # type: ignore[arg-type]
+        build_video_duration_basis(invalid)
 
 
 def test_use_tts_subtitle_and_presentation_require_narration_audio() -> None:
@@ -341,4 +341,26 @@ def test_use_tts_subtitle_and_presentation_require_narration_audio() -> None:
             variant=USE_TTS,
             video=video,
             subtitle=_basis("test/subtitle", "v1"),
+        )
+
+
+@pytest.mark.parametrize("invalid", [True, False, "8", None])
+def test_selected_media_evidence_rejects_non_number_duration(invalid: object) -> None:
+    """时长从磁盘 JSON 重建，bool 与字符串都不是可接受的秒数。"""
+
+    with pytest.raises(ValueError, match="positive and finite"):
+        SelectedMediaEvidence(
+            basis=ArtifactBasisDescriptor.from_basis(_basis("test/video", "v1")),
+            content_digest="sha256-v1:" + "0" * 64,
+            actual_duration_seconds=invalid,
+        )
+
+
+@pytest.mark.parametrize("invalid", [123, None, "bad"])
+def test_selected_media_evidence_rejects_non_digest_content_digest(invalid: object) -> None:
+    with pytest.raises(ValueError, match="canonical sha256-v1 digest"):
+        SelectedMediaEvidence(
+            basis=ArtifactBasisDescriptor.from_basis(_basis("test/video", "v1")),
+            content_digest=invalid,
+            actual_duration_seconds=8.0,
         )

--- a/tests/unit/lib/test_storyboard_sequence.py
+++ b/tests/unit/lib/test_storyboard_sequence.py
@@ -180,3 +180,23 @@ class TestMismatchedScriptStaysEditable:
         assert kind == "video_units"
         assert id_field == "unit_id"
         assert [item["unit_id"] for item in items] == ["E1U01"]
+
+
+class TestCorruptScriptEntries:
+    """磁盘剧本 JSON 的条目数组只保证外层是 list，元素形状由访问处判定。"""
+
+    def test_find_storyboard_item_skips_non_mapping_entries(self):
+        from lib.storyboard_sequence import find_storyboard_item
+
+        items = ["E1S01", None, {"segment_id": "E1S02"}]
+
+        assert find_storyboard_item(items, "segment_id", "E1S02") == ({"segment_id": "E1S02"}, 2)
+        assert find_storyboard_item(items, "segment_id", "E1S01") is None
+
+    def test_resolve_previous_storyboard_path_skips_non_mapping_predecessor(self, tmp_path: Path):
+        project_path = tmp_path / "demo"
+        (project_path / "storyboards").mkdir(parents=True)
+
+        items = ["broken", {"segment_id": "E1S02", "segment_break": False}]
+
+        assert resolve_previous_storyboard_path(project_path, items, "segment_id", "E1S02") is None

--- a/tests/unit/lib/test_thumbnail_fallback.py
+++ b/tests/unit/lib/test_thumbnail_fallback.py
@@ -11,10 +11,10 @@ import lib.thumbnail as thumbnail_module
 
 
 @pytest.fixture(autouse=True)
-def _reset_ffmpeg_cache():
-    thumbnail_module._reset_for_tests()
+def reset_ffmpeg_cache():
+    thumbnail_module.reset_for_tests()
     yield
-    thumbnail_module._reset_for_tests()
+    thumbnail_module.reset_for_tests()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/lib/test_tts_skeleton.py
+++ b/tests/unit/lib/test_tts_skeleton.py
@@ -406,7 +406,7 @@ class TestWorkerAudioLane:
                 return None
 
         w = GenerationWorker(
-            queue=_Q(),  # type: ignore[arg-type]
+            queue=_Q(),
             capacity=CapacityTable(
                 _limits={"dashscope": {"image": 0, "video": 0, "audio": 1}},
                 _defaults={"image": 5, "video": 3, "audio": 10},
@@ -438,7 +438,7 @@ class TestWorkerAudioLane:
             return "dashscope"
 
         w = GenerationWorker(
-            queue=_Q(),  # type: ignore[arg-type]
+            queue=_Q(),
             capacity=CapacityTable(
                 _limits={"dashscope": {"image": 0, "video": 0, "audio": 2}},
                 _defaults={"image": 5, "video": 3, "audio": 10},
@@ -449,7 +449,7 @@ class TestWorkerAudioLane:
         async def _fake_process(task):
             await asyncio.sleep(0)
 
-        w._process_task = _fake_process  # type: ignore[method-assign]
+        w._process_task = _fake_process
 
         claimed = await w._claim_tasks()
         assert claimed is True
@@ -498,7 +498,7 @@ class TestOrphanAudioRestartLost:
 
         q = _Q()
         w = GenerationWorker(
-            queue=q,  # type: ignore[arg-type]
+            queue=q,
             capacity=CapacityTable(_limits={}, _defaults={"image": 5, "video": 3, "audio": 10}),
         )
         await w._handle_orphan_tasks_on_start()

--- a/tests/unit/lib/test_video_artifact_facts.py
+++ b/tests/unit/lib/test_video_artifact_facts.py
@@ -142,3 +142,14 @@ def test_video_artifact_currency_accepts_unlimited_reference_projection_but_reje
             reference_image_limit=-1,
             parent_version=0,
         )
+
+
+@pytest.mark.parametrize("speakers", [[123], [["阿离"]], [{"name": "阿离"}]])
+def test_video_artifact_currency_rejects_non_string_speakers_as_value_error(speakers: list[object]) -> None:
+    """checkpoint JSON 损坏时调用方只接 ValueError，形状错误不得漏成其他异常。"""
+
+    raw = _facts().to_dict()
+    raw["voice_style_speakers"] = speakers
+
+    with pytest.raises(ValueError, match="not self-verifying"):
+        VideoArtifactCurrencyFacts.from_dict(raw)

--- a/tests/unit/lib/test_vidu_shared.py
+++ b/tests/unit/lib/test_vidu_shared.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 
 import httpx
@@ -46,7 +46,7 @@ class TestViduConnectionTestKeyResolution:
 
 
 @contextmanager
-def _probe_route(*, status_code: int, body: str = "") -> Iterator[respx.Route]:
+def _probe_route(*, status_code: int, body: str = "") -> Generator[respx.Route]:
     """连接测试探针的出站流：走 respx 在 transport 层拦截。
 
     白名单判定的输入是真实响应的状态码，URL 拼接与 Authorization 头都在断言范围内。

--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -1,6 +1,6 @@
 """ArkTextBackend tests."""
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +14,7 @@ from tests.fakes import bounded_poll_clock, captured_ark_clients
 
 
 @contextmanager
-def _recorded_openai_clients() -> Iterator[list[dict[str, Any]]]:
+def _recorded_openai_clients() -> Generator[list[dict[str, Any]]]:
     """OpenAI 兼容客户端构造的记录器：收下建客户端的参数，回一个空替身。"""
     created: list[dict[str, Any]] = []
 
@@ -27,7 +27,7 @@ def _recorded_openai_clients() -> Iterator[list[dict[str, Any]]]:
 
 
 @contextmanager
-def _recorded_instructor_fallback(result: tuple[str, int, int]) -> Iterator[list[dict[str, Any]]]:
+def _recorded_instructor_fallback(result: tuple[str, int, int]) -> Generator[list[dict[str, Any]]]:
     """instructor 降级入口的记录器：收下降级调用参数，回固定结果。"""
     calls: list[dict[str, Any]] = []
 
@@ -40,7 +40,7 @@ def _recorded_instructor_fallback(result: tuple[str, int, int]) -> Iterator[list
 
 
 @contextmanager
-def _recorded_instructor_wire(result: tuple[Any, Any]) -> Iterator[list[dict[str, Any]]]:
+def _recorded_instructor_wire(result: tuple[Any, Any]) -> Generator[list[dict[str, Any]]]:
     """instructor patched client 的记录器：收下最终发往端点的参数。"""
     calls: list[dict[str, Any]] = []
 

--- a/tests/unit/lib/text_backends/test_instructor_support.py
+++ b/tests/unit/lib/text_backends/test_instructor_support.py
@@ -1,6 +1,6 @@
 """instructor_support 模块测试。"""
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
@@ -58,7 +58,7 @@ def _retry_exhausted(
         "retries exhausted",
         last_completion=_completion(content),
         n_attempts=3,
-        total_usage=SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),  # type: ignore[arg-type]
+        total_usage=SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),
         failed_attempts=[
             FailedAttempt(attempt_number=i, exception=e)
             for i, e in enumerate(recorded, 1)
@@ -112,7 +112,7 @@ def _tools_rejected_error() -> InstructorRetryException:
 @contextmanager
 def _recorded_instructor(
     result: tuple[Any, Any], *, is_async: bool = False
-) -> Iterator[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
+) -> Generator[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
     """instructor 入口的记录器：记下 from_openai 与 create_with_completion 的参数。
 
     mode 选择、导线参数名这些契约都是「最终发往端点的调用长什么样」，断言落在记录的参数上，
@@ -491,7 +491,7 @@ class TestInstructorExceptionShape:
 
         client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
         rejection = _bad_request("tools is not supported by this endpoint")
-        client.chat.completions.create = MagicMock(side_effect=rejection)  # type: ignore[method-assign]
+        client.chat.completions.create = MagicMock(side_effect=rejection)
         patched = instructor.from_openai(client, mode=Mode.TOOLS)
 
         with pytest.raises(InstructorRetryException) as exc_info:
@@ -531,7 +531,7 @@ class TestInstructorExceptionShape:
         )
         outage = ConnectionError("connection reset by peer")
         client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
-        client.chat.completions.create = MagicMock(side_effect=[completion, outage])  # type: ignore[method-assign]
+        client.chat.completions.create = MagicMock(side_effect=[completion, outage])
         patched = instructor.from_openai(client, mode=Mode.MD_JSON)
 
         with pytest.raises(InstructorRetryException) as exc_info:
@@ -555,7 +555,7 @@ class TestInstructorExceptionShape:
             usage=None,
         )
         client = OpenAI(api_key="sk-test", base_url="https://proxy.invalid/v1")
-        client.chat.completions.create = MagicMock(return_value=completion)  # type: ignore[method-assign]
+        client.chat.completions.create = MagicMock(return_value=completion)
         patched = instructor.from_openai(client, mode=Mode.TOOLS)
 
         with pytest.raises(InstructorRetryException) as exc_info:

--- a/tests/unit/lib/text_backends/test_registry.py
+++ b/tests/unit/lib/text_backends/test_registry.py
@@ -32,7 +32,7 @@ class FakeTextBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_text_registry():
+def clean_text_registry():
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()
     yield

--- a/tests/unit/lib/video_backends/test_agnes_video_backend.py
+++ b/tests/unit/lib/video_backends/test_agnes_video_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import re
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import NamedTuple
@@ -42,7 +42,7 @@ class _AgnesRoutes(NamedTuple):
 
 
 @contextmanager
-def _agnes_api(*, base_url: str = _BASE_URL) -> Iterator[_AgnesRoutes]:
+def _agnes_api(*, base_url: str = _BASE_URL) -> Generator[_AgnesRoutes]:
     host = base_url.removesuffix("/v1")
     with capture_http() as router:
         yield _AgnesRoutes(

--- a/tests/unit/lib/video_backends/test_grok_video_backend.py
+++ b/tests/unit/lib/video_backends/test_grok_video_backend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,7 +18,7 @@ from tests.http_capture import capture_http
 
 
 @contextmanager
-def _video_download(url: str, content: bytes) -> Iterator[respx.Route]:
+def _video_download(url: str, content: bytes) -> Generator[respx.Route]:
     """成片下载的出站流：base 层用真实 httpx 流式取字节，走 respx 在 transport 层拦截。"""
     with capture_http() as router:
         yield router.get(url).mock(return_value=httpx.Response(200, content=content))

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -12,7 +13,7 @@ from openai.types.video_create_error import VideoCreateError
 
 from lib.providers import PROVIDER_OPENAI
 from lib.video_backends.base import VideoGenerationRequest
-from tests.fakes import bounded_poll_clock, captured_openai_clients
+from tests.fakes import blocking_file_read_gate, bounded_poll_clock, captured_openai_clients
 
 
 def _make_mock_video(status="completed", seconds="8", video_id="vid_123"):
@@ -129,6 +130,38 @@ class TestOpenAIVideoBackend:
         assert isinstance(ref, tuple)
         assert ref[0] == "start.png"
         assert isinstance(ref[1], bytes)
+        assert ref[2] == "image/png"
+
+    async def test_start_image_encoding_keeps_event_loop_running(self, tmp_path: Path, monkeypatch):
+        """首帧读字节做 multipart 上传体，必须卸载到线程，否则事件循环被读堵住。"""
+        start_image = tmp_path / "start.png"
+        start_image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        mock_client = AsyncMock()
+        _stub_client_completed(mock_client, seconds="4")
+
+        with (
+            captured_openai_clients(mock_client),
+            bounded_poll_clock(),
+        ):
+            from lib.video_backends.openai import OpenAIVideoBackend
+
+            backend = OpenAIVideoBackend(api_key="test-key")
+            request = VideoGenerationRequest(
+                prompt="Animate this",
+                output_path=tmp_path / "output.mp4",
+                start_image=start_image,
+                duration_seconds=4,
+            )
+            with blocking_file_read_gate(monkeypatch, start_image) as gate:
+                task = asyncio.create_task(backend.generate(request))
+                await gate.wait_until_read_started()
+                gate.release()
+                await task
+                gate.assert_read_was_offloaded()
+
+        ref = mock_client.videos.create.call_args[1]["input_reference"]
+        assert ref[0] == "start.png"
         assert ref[2] == "image/png"
 
     async def test_failed_video_raises(self, tmp_path: Path):

--- a/tests/unit/lib/video_backends/test_openai_video_backend.py
+++ b/tests/unit/lib/video_backends/test_openai_video_backend.py
@@ -532,7 +532,7 @@ class TestOpenAIVideoBackend:
         assert _is_openai_not_found(RuntimeError("session expired but task is fine")) is False
         # 仍能识别 status_code=404
         exc = RuntimeError("any")
-        exc.status_code = 404  # type: ignore[attr-defined]
+        exc.status_code = 404
         assert _is_openai_not_found(exc) is True
 
     async def test_resume_video_not_found_raises_resume_expired(self, tmp_path: Path):

--- a/tests/unit/lib/video_backends/test_provider_registry.py
+++ b/tests/unit/lib/video_backends/test_provider_registry.py
@@ -131,7 +131,6 @@ def test_kling_image_models() -> None:
 
 def test_kling_video_backend_registered() -> None:
     """可灵视频后端在 video registry 自注册（JWT 直连）。"""
-    import lib.video_backends  # noqa: F401  触发自注册
     from lib.video_backends.kling import KlingVideoBackend
     from lib.video_backends.registry import _BACKEND_FACTORIES as video_reg
 
@@ -140,9 +139,6 @@ def test_kling_video_backend_registered() -> None:
 
 def test_ark_agent_plan_backend_registered() -> None:
     """复用现有 ark backend 类支持 ark-agent-plan provider。"""
-    import lib.image_backends  # 副作用导入：触发供应商自注册
-    import lib.text_backends
-    import lib.video_backends  # noqa: F401
     from lib.image_backends.ark import ArkImageBackend
     from lib.image_backends.registry import _BACKEND_FACTORIES as image_reg
     from lib.text_backends.ark import ArkTextBackend

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -647,7 +647,7 @@ class TestIsArkNotFound:
         from lib.video_backends.ark import _is_ark_not_found
 
         exc = RuntimeError("any")
-        exc.status_code = 404  # type: ignore[attr-defined]
+        exc.status_code = 404
         assert _is_ark_not_found(exc) is True
 
 

--- a/tests/unit/lib/video_backends/test_video_backend_ark.py
+++ b/tests/unit/lib/video_backends/test_video_backend_ark.py
@@ -1,5 +1,6 @@
 """ArkVideoBackend 单元测试 — mock Ark SDK。"""
 
+import asyncio
 import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,7 +17,7 @@ from lib.video_backends.base import (
     VideoGenerationResult,
 )
 from lib.video_frame_slots import FIRST_FRAME_ADAPTIVE_RATIO, resolve_first_frame_aspect_ratio
-from tests.fakes import bounded_poll_clock, captured_ark_clients
+from tests.fakes import blocking_file_read_gate, bounded_poll_clock, captured_ark_clients
 
 
 @pytest.fixture
@@ -129,6 +130,44 @@ class TestArkGenerate:
         assert content_arg[1]["type"] == "image_url"
         assert content_arg[1]["image_url"]["url"].startswith("data:image/")
         assert content_arg[1]["role"] == "first_frame"
+
+    async def test_start_image_encoding_keeps_event_loop_running(self, ark_backend, tmp_path, monkeypatch):
+        """首帧 base64 编码要读整张图，必须卸载到线程，否则事件循环被读堵住。"""
+        output = tmp_path / "out.mp4"
+        frame = tmp_path / "scene_E1S01.png"
+        frame.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        create_result = MagicMock()
+        create_result.id = "cgt-i2v-gate"
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+
+        get_result = MagicMock()
+        get_result.status = "succeeded"
+        get_result.content = MagicMock()
+        get_result.content.video_url = "https://cdn.example.com/video-gate.mp4"
+        get_result.usage = MagicMock()
+        get_result.usage.completion_tokens = 1
+        ark_backend._client.content_generation.tasks.get = MagicMock(return_value=get_result)
+
+        patcher = _mock_httpx_stream()
+        try:
+            request = VideoGenerationRequest(
+                prompt="girl opens eyes",
+                output_path=output,
+                start_image=frame,
+            )
+            with blocking_file_read_gate(monkeypatch, frame) as gate:
+                task = asyncio.create_task(ark_backend.generate(request))
+                await gate.wait_until_read_started()
+                gate.release()
+                result = await task
+                gate.assert_read_was_offloaded()
+        finally:
+            patcher.stop()
+
+        assert result.provider == "ark"
+        content_arg = ark_backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        assert content_arg[1]["image_url"]["url"].startswith("data:image/png;base64,")
 
     async def test_first_last_frame_role_fields(self, ark_backend, tmp_path):
         """首尾帧：start_image/end_image 必须分别带 role=first_frame / role=last_frame，
@@ -730,6 +769,33 @@ class TestArkReferenceAudio:
         # 顺序即 prompt 中「音频N」的编号：第一段必须是请求里的第一段
         assert audio_items[0]["audio_url"]["url"].startswith("data:audio/mp3;base64,")
         assert audio_items[1]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+
+    async def test_reference_audio_encoding_keeps_event_loop_running(self, tmp_path, monkeypatch):
+        """参考音频 base64 编码要读整段音频，必须卸载到线程，否则事件循环被读堵住。"""
+        ark_backend = self._seedance_2_backend()
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"ID3" + b"\x00" * 100)
+
+        create_result = MagicMock()
+        create_result.id = "cgt-audio-gate"
+        ark_backend._client.content_generation.tasks.create = MagicMock(return_value=create_result)
+
+        request = VideoGenerationRequest(
+            prompt="两人对话",
+            output_path=tmp_path / "out.mp4",
+            reference_audio_files=[audio],
+        )
+        with blocking_file_read_gate(monkeypatch, audio) as gate:
+            task = asyncio.create_task(ark_backend._create_task(request))
+            await gate.wait_until_read_started()
+            gate.release()
+            task_id = await task
+            gate.assert_read_was_offloaded()
+
+        assert task_id == "cgt-audio-gate"
+        content = ark_backend._client.content_generation.tasks.create.call_args.kwargs["content"]
+        audio_items = [c for c in content if c["type"] == "audio_url"]
+        assert audio_items[0]["audio_url"]["url"].startswith("data:audio/mp3;base64,")
 
     async def test_no_audio_entries_when_request_has_none(self, tmp_path):
         ark_backend = self._seedance_2_backend()

--- a/tests/unit/lib/video_backends/test_video_backend_registry.py
+++ b/tests/unit/lib/video_backends/test_video_backend_registry.py
@@ -19,7 +19,7 @@ class _FakeBackend:
 
 
 @pytest.fixture(autouse=True)
-def _clean_video_registry():
+def clean_video_registry():
     saved = dict(_BACKEND_FACTORIES)
     _BACKEND_FACTORIES.clear()
     yield

--- a/tests/unit/server/agent_runtime/test_agent_access_policy.py
+++ b/tests/unit/server/agent_runtime/test_agent_access_policy.py
@@ -23,7 +23,7 @@ def _make_policy(tmp_path: Path, **overrides: object) -> AgentAccessPolicy:
         "log_dir": project_root / "logs",
     }
     kwargs.update(overrides)
-    return AgentAccessPolicy(**kwargs)  # type: ignore[arg-type]
+    return AgentAccessPolicy(**kwargs)
 
 
 @pytest.fixture
@@ -164,8 +164,8 @@ def test_protected_script_plan_filenames_match_shared_constant() -> None:
     from lib.episode_paths import AGENT_PROTECTED_SCRIPT_PLAN_FILENAMES
 
     assert (
-        frozenset(  # pyright: ignore[reportPrivateUsage]
-            AgentAccessPolicy._normalize_path_for_protected_compare(Path(name))  # pyright: ignore[reportPrivateUsage]
+        frozenset(
+            AgentAccessPolicy._normalize_path_for_protected_compare(Path(name))
             for name in AGENT_PROTECTED_SCRIPT_PLAN_FILENAMES
         )
         == AgentAccessPolicy._PROTECTED_SCRIPT_PLAN_FILENAMES_NORM

--- a/tests/unit/server/agent_runtime/test_assistant_service.py
+++ b/tests/unit/server/agent_runtime/test_assistant_service.py
@@ -588,7 +588,7 @@ class TestAssistantService:
         )
         service._new_session_client_keys["ck-a"] = "sdk-deleted"
 
-        result = await service._find_accepted_new_session("ck-a", "demo")  # pyright: ignore[reportPrivateUsage]
+        result = await service._find_accepted_new_session("ck-a", "demo")
 
         assert result is None  # 本测试的兜底查询返回 None，不影响本次断言重点
         assert service._new_session_client_keys["ck-a"] == "sdk-fresh"  # 未被误删
@@ -617,7 +617,7 @@ class TestAssistantService:
             find_new_session_by_client_key=find_new_session_by_client_key,
         )
 
-        result = await service._find_accepted_new_session("ck-b", "demo")  # pyright: ignore[reportPrivateUsage]
+        result = await service._find_accepted_new_session("ck-b", "demo")
 
         assert result is not None
         assert result["session_id"] == "sdk-old"  # 本次调用仍返回自己查到的权威条目

--- a/tests/unit/server/agent_runtime/test_entry_pipeline.py
+++ b/tests/unit/server/agent_runtime/test_entry_pipeline.py
@@ -33,7 +33,7 @@ def _make_pipeline(session_id: str | None = "s1"):
     store = _RecordingStore()
     broadcasts: list[dict] = []
     pipeline = SessionEntryPipeline(
-        store,  # type: ignore[arg-type]
+        store,
         session_id_provider=lambda: session_id,
         broadcast=broadcasts.append,
     )
@@ -271,7 +271,7 @@ class TestSessionEntryPipeline:
 
         broadcasts: list[dict] = []
         pipeline = SessionEntryPipeline(
-            _BrokenStore(),  # type: ignore[arg-type]
+            _BrokenStore(),
             session_id_provider=lambda: "s1",
             broadcast=broadcasts.append,
         )
@@ -388,7 +388,7 @@ class TestSessionEntryPipeline:
         store = _FlakyStore()
         broadcasts: list[dict] = []
         pipeline = SessionEntryPipeline(
-            store,  # type: ignore[arg-type]
+            store,
             session_id_provider=lambda: "s1",
             broadcast=broadcasts.append,
         )
@@ -452,7 +452,7 @@ class TestReplayedUserEchoLink:
         store = _FailingStore()
         broadcasts: list[dict] = []
         pipeline = SessionEntryPipeline(
-            store,  # type: ignore[arg-type]
+            store,
             session_id_provider=lambda: "s1",
             broadcast=broadcasts.append,
         )

--- a/tests/unit/server/agent_runtime/test_event_log.py
+++ b/tests/unit/server/agent_runtime/test_event_log.py
@@ -663,7 +663,7 @@ class TestEventLogStore:
         from sqlalchemy.exc import IntegrityError
 
         calls = {"n": 0}
-        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+        original_append_once = log_store._append_once
 
         async def _flaky_append_once(session_id, entries, client_key):
             calls["n"] += 1
@@ -695,7 +695,7 @@ class TestEventLogStore:
             sqlstate="23505",
         )
         calls = {"n": 0}
-        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+        original_append_once = log_store._append_once
 
         async def _flaky_append_once(session_id, entries, client_key):
             calls["n"] += 1
@@ -768,7 +768,7 @@ class TestEventLogStore:
         但不排除病态构造）时按 id() 去重仍能终止,不陷入死循环。"""
         from sqlalchemy.exc import IntegrityError
 
-        from server.agent_runtime.event_log import _first_driver_attr  # pyright: ignore[reportPrivateUsage]
+        from server.agent_runtime.event_log import _first_driver_attr
 
         err_a = _FakeDriverError("a")
         err_b = _FakeDriverError("b")
@@ -788,7 +788,7 @@ class TestEventLogStore:
         冲突；需先剥离 ``[SQL: ...]`` 之后的部分再匹配。"""
         from sqlalchemy.exc import IntegrityError
 
-        from server.agent_runtime.event_log import _is_client_key_violation  # pyright: ignore[reportPrivateUsage]
+        from server.agent_runtime.event_log import _is_client_key_violation
 
         exc = IntegrityError(
             "INSERT INTO agent_session_event_log (session_id, seq, client_key, payload) VALUES (?, ?, ?, ?)",
@@ -807,7 +807,7 @@ class TestEventLogStore:
         from sqlalchemy.exc import IntegrityError
 
         calls = {"n": 0}
-        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+        original_append_once = log_store._append_once
         # 驱动只给出含 client_key 字样的文案：真实分类器据此判为 True，正是要被
         # 结构性排除的那种误判。
         misleading = _FakeDriverError(
@@ -856,7 +856,7 @@ class TestEventLogStore:
 
         driver_error = _FakeDriverError("constraint failed", sqlite_errorname="SQLITE_CONSTRAINT_PRIMARYKEY")
         calls = {"n": 0}
-        original_append_once = log_store._append_once  # pyright: ignore[reportPrivateUsage]
+        original_append_once = log_store._append_once
 
         async def _flaky_append_once(session_id, entries, client_key):
             calls["n"] += 1
@@ -1069,14 +1069,14 @@ class TestLazyBackfill:
 
         for i in range(50):
             await service.ensure_backfilled(f"empty-{i}", None)
-        assert len(service._backfill_locks) == 0  # pyright: ignore[reportPrivateUsage]
+        assert len(service._backfill_locks) == 0
 
         # transcript 补齐内容后，并发访问只灌入一次
-        adapter._messages = [{"type": "user", "content": "hi", "uuid": "u1"}]  # pyright: ignore[reportPrivateUsage]
+        adapter._messages = [{"type": "user", "content": "hi", "uuid": "u1"}]
         await asyncio.gather(*[service.ensure_backfilled("old", None) for _ in range(5)])
         assert len(await log_store.list_after("old")) == 1
         # 写入成功后锁引用被清理
-        assert "old" not in service._backfill_locks  # pyright: ignore[reportPrivateUsage]
+        assert "old" not in service._backfill_locks
 
     async def test_backfill_skips_message_that_fails_normalization(self, log_store: EventLogStore, monkeypatch):
         """历史消息规范化单条抛异常时容错跳过，不让整个懒生成因一条脏数据失败。"""

--- a/tests/unit/server/agent_runtime/test_event_log_session_flow.py
+++ b/tests/unit/server/agent_runtime/test_event_log_session_flow.py
@@ -11,7 +11,7 @@ import pytest
 from server.agent_runtime.event_log import EventLogStore, build_user_entry
 from server.agent_runtime.session_manager import AgentStartupError, SessionManager
 from server.agent_runtime.session_store import SessionMetaStore
-from tests.fakes import FakeSDKClient
+from tests.fakes import FakeSDKClient, empty_sdk_response_stream
 
 SDK_ID = "sdk-e2e-1"
 
@@ -127,8 +127,8 @@ class _CrashBeforeInitClient(FakeSDKClient):
         self._record("receive_response")
         if self._stderr_callback is not None:
             self._stderr_callback("OPENAI_API_KEY=pre-init-secret\nprovider stderr detail")
-        if False:
-            yield {}
+        async for message in empty_sdk_response_stream():
+            yield message
         raise RuntimeError("receive_response crashed before init")
 
 

--- a/tests/unit/server/agent_runtime/test_failure_observation.py
+++ b/tests/unit/server/agent_runtime/test_failure_observation.py
@@ -11,7 +11,7 @@ def test_startup_observation_uses_standard_exception_chain_without_serializing_a
     try:
         raise RuntimeError("provider failed") from root
     except RuntimeError as exc:
-        exc.response = {"future_payload": object()}  # type: ignore[attr-defined]
+        exc.response = {"future_payload": object()}
         observation = build_startup_failure_observation(exc, project_name="demo", session_id=None, sdk_stderr="")
 
     raw_exception = observation["raw"]["exception"]

--- a/tests/unit/server/agent_runtime/test_options_assembler.py
+++ b/tests/unit/server/agent_runtime/test_options_assembler.py
@@ -7,6 +7,7 @@ project_cwd 解析器 / 凭证 loader 直接构造装配器，断言凭证注入
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -18,6 +19,7 @@ from server.agent_runtime.options_assembler import (
     load_provider_env_overrides,
 )
 from server.auth import verify_token
+from tests.fakes import blocking_file_read_gate
 
 _ALLOWED_TOOLS = ["Skill", "Task", "Bash", "BashOutput", "KillBash", "Read", "Write", "Edit"]
 _SETTING_SOURCES = ["project"]
@@ -182,3 +184,53 @@ async def test_build_sandbox_disabled_strips_bash(tmp_path: Path) -> None:
         assert tool not in options.allowed_tools
     assert "Read" in options.allowed_tools
     assert options.sandbox == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_json_pre_validation_hook_keeps_event_loop_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PreToolUse JSON 校验读整份剧本 JSON，必须卸载到线程，否则事件循环被读堵住。"""
+    project_cwd = tmp_path / "projects" / "demo"
+    project_cwd.mkdir(parents=True, exist_ok=True)
+    script = project_cwd / "script.json"
+    script.write_text('{"a": 1}', encoding="utf-8")
+
+    hook = _make_assembler(tmp_path)._build_json_validation_hook(project_cwd)
+    input_data = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(script), "old_string": '"a": 1', "new_string": '"a": 2'},
+    }
+
+    with blocking_file_read_gate(monkeypatch, script, method="read_text") as gate:
+        task = asyncio.create_task(hook(input_data, "tu-1", None))
+        await gate.wait_until_read_started()
+        gate.release()
+        result = await task
+        gate.assert_read_was_offloaded()
+
+    # 替换后仍是合法 JSON → 放行
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_json_post_validation_hook_keeps_event_loop_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PostToolUse JSON 校验回读落盘结果，必须卸载到线程，否则事件循环被读堵住。"""
+    project_cwd = tmp_path / "projects" / "demo"
+    project_cwd.mkdir(parents=True, exist_ok=True)
+    script = project_cwd / "script.json"
+    script.write_text('{"a": 2}', encoding="utf-8")
+
+    hook = _make_assembler(tmp_path)._build_json_post_validation_hook(project_cwd, {})
+    input_data = {"tool_name": "Edit", "tool_input": {"file_path": str(script)}}
+
+    with blocking_file_read_gate(monkeypatch, script, method="read_text") as gate:
+        task = asyncio.create_task(hook(input_data, "tu-1", None))
+        await gate.wait_until_read_started()
+        gate.release()
+        result = await task
+        gate.assert_read_was_offloaded()
+
+    assert result == {}

--- a/tests/unit/server/agent_runtime/test_session_manager.py
+++ b/tests/unit/server/agent_runtime/test_session_manager.py
@@ -90,7 +90,6 @@ async def _cold_revival_clients(session_manager, monkeypatch):
         m.setattr("server.agent_runtime.options_assembler.SDK_AVAILABLE", True)
         m.setattr("server.agent_runtime.options_assembler.ClaudeAgentOptions", _FakeOptions)
         m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
-        m.setattr("server.agent_runtime.options_assembler.HookMatcher", None)
         yield created_clients
 
 
@@ -162,7 +161,6 @@ class TestSessionManager:
             m.setattr("server.agent_runtime.options_assembler.SDK_AVAILABLE", True)
             m.setattr("server.agent_runtime.options_assembler.ClaudeAgentOptions", _FakeOptions)
             m.setattr(sm_mod, "ClaudeSDKClient", _track_client)
-            m.setattr("server.agent_runtime.options_assembler.HookMatcher", None)
             managed = await session_manager.get_or_connect(meta.id)
             # Let the actor enter the async-context (connect).
             await asyncio.sleep(0)
@@ -245,7 +243,7 @@ class TestSessionManager:
         async def _boom(prompt, session_id: str = "default"):
             raise RuntimeError("query failed")
 
-        client.query = _boom  # type: ignore[method-assign]
+        client.query = _boom
 
         @asynccontextmanager
         async def _boom_factory():

--- a/tests/unit/server/agent_runtime/test_session_manager.py
+++ b/tests/unit/server/agent_runtime/test_session_manager.py
@@ -12,7 +12,7 @@ from server.agent_runtime.models import Heartbeat, LiveMessage, SubscriptionRead
 from server.agent_runtime.session_actor import SessionActor
 from server.agent_runtime.session_manager import ManagedSession, SessionBusyError
 from server.agent_runtime.session_store import SessionMetaStore
-from tests.fakes import FakeSDKClient
+from tests.fakes import FakeSDKClient, empty_sdk_response_stream
 
 
 class _FakeOptions:
@@ -48,9 +48,8 @@ class _FakeClaudeClient:
     async def interrupt(self):
         pass
 
-    async def receive_response(self):
-        if False:
-            yield None
+    def receive_response(self):
+        return empty_sdk_response_stream()
 
 
 def _dummy_actor() -> SessionActor:
@@ -1222,9 +1221,8 @@ async def test_send_query_raises_on_cmd_error():
         async def interrupt(self):
             pass
 
-        async def receive_response(self):
-            if False:
-                yield {}
+        def receive_response(self):
+            return empty_sdk_response_stream()
 
     actor = SessionActor(client_factory=lambda: _Explode(), on_message=lambda m: None)
     managed = ManagedSession(session_id="t", actor=actor, status="idle", project_name="p")

--- a/tests/unit/server/agent_runtime/test_session_manager_sdk_session_id.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_sdk_session_id.py
@@ -77,7 +77,7 @@ class TestSessionManagerSdkSessionId:
         meta = await meta_store.create("demo", "sdk-usage-789")
         managed = _make_managed(session_id=meta.id, project_name="demo", assistant_model="claude-sonnet-4")
         managed.last_user_prompt = "hello assistant"
-        session_manager._user_id = "assistant-user"  # type: ignore[attr-defined]
+        session_manager._user_id = "assistant-user"
 
         await session_manager._finalize_turn(
             managed,

--- a/tests/unit/server/agent_runtime/test_session_manager_store_injection.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_store_injection.py
@@ -62,8 +62,8 @@ def test_store_uses_session_factory_seam(monkeypatch, tmp_path):
     sm = _build_sm(tmp_path)
 
     sentinel = object()
-    sm._session_factory = sentinel  # type: ignore[attr-defined]
-    sm._user_id = "test-user"  # type: ignore[attr-defined]
+    sm._session_factory = sentinel
+    sm._user_id = "test-user"
 
     store = sm._build_session_store()
     assert isinstance(store, DbSessionStore)

--- a/tests/unit/server/agent_runtime/test_session_manager_user_input.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_user_input.py
@@ -55,8 +55,6 @@ async def _seed(session_manager, meta_store, *, messages=None, status="idle", bl
 def _on_actor_message_full(session_manager, managed, raw_msg):
     """Replicate SessionManager's production on_message behavior for tests."""
     msg_dict = message_to_dict(raw_msg)
-    if not isinstance(msg_dict, dict):
-        return
     echo = match_user_echo(managed.pending_user_echoes, msg_dict)
     if echo is not None:
         msg_dict[REPLAYED_USER_ECHO_KEY] = True

--- a/tests/unit/server/routers/test_providers_api.py
+++ b/tests/unit/server/routers/test_providers_api.py
@@ -545,7 +545,7 @@ def _make_mock_svc() -> ConfigService:
     svc = MagicMock(spec=ConfigService)
     svc.set_provider_config = AsyncMock()
     svc.delete_provider_config = AsyncMock()
-    return svc  # type: ignore[return-value]
+    return svc
 
 
 class TestPatchProviderConfig:

--- a/tests/unit/server/routers/test_providers_api.py
+++ b/tests/unit/server/routers/test_providers_api.py
@@ -523,24 +523,6 @@ class TestGetProviderConfig:
 # ---------------------------------------------------------------------------
 
 
-def _make_patch_app(mock_svc_instance: ConfigService) -> FastAPI:
-    """创建用于 PATCH 端点测试的应用，通过 patch ConfigService 构造函数注入 mock。"""
-    app = FastAPI()
-    mock_session = AsyncMock()
-    mock_session.commit = AsyncMock()
-
-    async def _override_session():
-        yield mock_session
-
-    app.dependency_overrides[get_async_session] = _override_session
-
-    with patch("server.routers.providers.ConfigService", return_value=mock_svc_instance):
-        override_auth(app)
-        app.include_router(providers.router, prefix="/api/v1", dependencies=AUTH_DEPENDENCIES)
-
-    return app
-
-
 def _make_mock_svc() -> ConfigService:
     svc = MagicMock(spec=ConfigService)
     svc.set_provider_config = AsyncMock()

--- a/tests/unit/server/routers/test_system_logs_router.py
+++ b/tests/unit/server/routers/test_system_logs_router.py
@@ -25,9 +25,9 @@ async def logs_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, auth_disa
     log_dir.mkdir()
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(log_dir))
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path / "data"))
-    from lib.app_data_dir import _reset_for_tests
+    from lib.app_data_dir import reset_for_tests
 
-    _reset_for_tests()
+    reset_for_tests()
 
     import importlib
 
@@ -98,9 +98,9 @@ async def test_missing_logs_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     assert not log_dir.exists()
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(log_dir))
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path / "data"))
-    from lib.app_data_dir import _reset_for_tests
+    from lib.app_data_dir import reset_for_tests
 
-    _reset_for_tests()
+    reset_for_tests()
 
     import importlib
 
@@ -123,9 +123,9 @@ async def test_download_requires_auth(monkeypatch: pytest.MonkeyPatch, tmp_path:
     monkeypatch.setenv("AUTH_TOKEN_SECRET", "test-secret-32-chars-long-xxxxx")
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(tmp_path / "logs"))
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path / "data"))
-    from lib.app_data_dir import _reset_for_tests
+    from lib.app_data_dir import reset_for_tests
 
-    _reset_for_tests()
+    reset_for_tests()
 
     import importlib
 

--- a/tests/unit/server/routers/test_system_version_api.py
+++ b/tests/unit/server/routers/test_system_version_api.py
@@ -45,7 +45,7 @@ def _release_body(version: str) -> dict[str, str]:
 
 
 @pytest.fixture(autouse=True)
-def _shared_http_client():
+def shared_http_client():
     """生产由 app lifespan 建共享客户端；这里自己建一个，respx 在 transport 层拦它。"""
     asyncio.run(startup_http_client())
     yield
@@ -53,7 +53,7 @@ def _shared_http_client():
 
 
 @pytest.fixture(autouse=True)
-def _clear_release_cache():
+def clear_release_cache():
     """`_latest_release_cache` 与 `_read_app_version` 的 lru_cache 都是模块级进程内状态。"""
     system_config._latest_release_cache.update({"expires_at": None, "payload": None, "fetched_at": None})
     system_config._read_app_version.cache_clear()

--- a/tests/unit/server/services/test_diagnostics_service.py
+++ b/tests/unit/server/services/test_diagnostics_service.py
@@ -7,12 +7,12 @@ from pathlib import Path
 import pytest
 
 import server.services.diagnostics as diag_mod
-from lib.app_data_dir import _reset_for_tests
+from lib.app_data_dir import reset_for_tests
 
 
 def test_collect_returns_text(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path))
-    _reset_for_tests()
+    reset_for_tests()
 
     text = diag_mod.collect_diagnostics()
     assert isinstance(text, str)
@@ -30,7 +30,7 @@ def test_collect_masks_db_password(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         "DATABASE_URL",
         "postgresql+asyncpg://arcuser:supersecretpassword@db.example.com:5432/arcreel",
     )
-    _reset_for_tests()
+    reset_for_tests()
 
     text = diag_mod.collect_diagnostics()
     db_line = next(line for line in text.splitlines() if line.startswith("Database URL:"))
@@ -45,7 +45,7 @@ def test_collect_masks_db_query_secrets(monkeypatch: pytest.MonkeyPatch, tmp_pat
         "DATABASE_URL",
         "postgresql://host.example.com/arcreel?sslmode=require&password=topsecret&token=abc123",
     )
-    _reset_for_tests()
+    reset_for_tests()
 
     text = diag_mod.collect_diagnostics()
     db_line = next(line for line in text.splitlines() if line.startswith("Database URL:"))
@@ -60,7 +60,7 @@ def test_collect_masks_db_query_secrets(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
 def test_collect_swallows_field_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("ARCREEL_DATA_DIR", str(tmp_path))
-    _reset_for_tests()
+    reset_for_tests()
 
     def boom() -> str:
         raise RuntimeError("simulated failure")
@@ -73,7 +73,7 @@ def test_collect_swallows_field_errors(monkeypatch: pytest.MonkeyPatch, tmp_path
 def test_collect_returns_log_dir_matching_logging_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     log_dir = tmp_path / "custom-logs"
     monkeypatch.setenv("ARCREEL_LOG_DIR", str(log_dir))
-    _reset_for_tests()
+    reset_for_tests()
 
     text = diag_mod.collect_diagnostics()
     assert str(log_dir) in text

--- a/tests/unit/server/services/test_execute_tts_task.py
+++ b/tests/unit/server/services/test_execute_tts_task.py
@@ -9,7 +9,7 @@ import copy
 import json
 import math
 import re
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -512,10 +512,8 @@ class TestExecuteTtsTask:
         formal.write_bytes(b"paid-old-audio")
         pm.project["episodes"] = [{"episode": 1, "script_file": "scripts/episode_1.json"}]
 
-        @contextmanager
-        def _failed_transaction(*_args, **_kwargs):
+        def _failed_transaction(*_args, **_kwargs) -> AbstractContextManager[object]:
             raise OSError("project snapshot unavailable")
-            yield
 
         monkeypatch.setattr(pm, "locked_episode_script", _failed_transaction)
 

--- a/tests/unit/server/services/test_image_edit_executor.py
+++ b/tests/unit/server/services/test_image_edit_executor.py
@@ -486,17 +486,17 @@ class TestExecuteImageEditTask:
             )
         )
         manager = VersionManager(project_path)
-        provider_reference: Path | None = None
+        provider_references: list[Path] = []
 
         class _Generator:
             def __init__(self) -> None:
                 self.versions = manager
 
             async def generate_image_async(self, **kwargs):
-                nonlocal provider_reference
                 current.write_bytes(b"source-changed-during-await")
                 provider_reference = Path(kwargs["reference_images"][0])
-                assert provider_reference.read_bytes() == b"source-before-await"
+                provider_references.append(provider_reference)
+                assert provider_reference.read_bytes() == b"source-before-await"  # noqa: ASYNC240 -- 测试内本地小文件读写/断言，不在生产事件循环上
 
                 def _mutate(project):
                     project["style"] = "style-changed-during-await"
@@ -539,8 +539,8 @@ class TestExecuteImageEditTask:
             is ArtifactStatus.STALE
         )
         assert current.read_bytes() == b"edited-image"
-        assert provider_reference is not None
-        assert not provider_reference.exists()  # noqa: ASYNC240 -- 测试内本地小文件读写/断言，不在生产事件循环上
+        assert len(provider_references) == 1
+        assert not provider_references[0].exists()
 
         adapter.delete_entry(source_key)
         monkeypatch.setattr(versions_router, "get_project_manager", lambda: pm)

--- a/tests/unit/server/services/test_resume_executor.py
+++ b/tests/unit/server/services/test_resume_executor.py
@@ -195,7 +195,7 @@ def _fake_video_context(
     from server.services.generation_context import AudioLaneResult, GenerationContext, VideoLaneResult
 
     return GenerationContext(
-        generator=fake_generator,  # type: ignore[arg-type]
+        generator=fake_generator,
         video_lane=VideoLaneResult(
             provider_model=ProviderModel(provider_id, provider_model_id),
             backend_name="openai",

--- a/tests/unit/server/test_auth_kill_switch.py
+++ b/tests/unit/server/test_auth_kill_switch.py
@@ -12,7 +12,7 @@ import server.auth as auth_module
 
 
 @pytest.fixture(autouse=True)
-def _isolated_auth_env():
+def isolated_auth_env():
     """Clear cached secret/password hash per-test so env tweaks take effect."""
     auth_module._cached_token_secret = None
     auth_module._cached_password_hash = None

--- a/tests/unit/server/test_auth_middleware.py
+++ b/tests/unit/server/test_auth_middleware.py
@@ -14,7 +14,7 @@ import server.auth as auth_module
 
 
 @pytest.fixture(autouse=True)
-def _auth_env():
+def auth_env():
     """为所有测试设置固定的认证环境变量，测试结束后清理缓存。"""
     auth_module._cached_token_secret = None
     auth_module._cached_password_hash = None

--- a/tests/unit/server/test_request_logging_middleware.py
+++ b/tests/unit/server/test_request_logging_middleware.py
@@ -21,16 +21,18 @@ def _build_app_with_ok_routes() -> FastAPI:
     app = FastAPI()
     app.middleware("http")(request_logging_middleware)
 
+    # 以下路由桩由装饰器就地注册，函数体内无其它引用；basedpyright 把函数作用域内的符号一律
+    # 判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @app.get("/api/v1/tasks")
-    async def _tasks() -> dict:
+    async def _tasks() -> dict:  # pyright: ignore[reportUnusedFunction]
         return {"tasks": []}
 
     @app.get("/api/v1/tasks/stats")
-    async def _tasks_stats() -> dict:
+    async def _tasks_stats() -> dict:  # pyright: ignore[reportUnusedFunction]
         return {"stats": {}}
 
     @app.get("/api/v1/projects")
-    async def _projects() -> dict:
+    async def _projects() -> dict:  # pyright: ignore[reportUnusedFunction]
         return {"projects": []}
 
     return app
@@ -59,8 +61,10 @@ async def test_quiet_endpoint_5xx_still_info(caplog: pytest.LogCaptureFixture) -
     app = FastAPI()
     app.middleware("http")(request_logging_middleware)
 
+    # 以下路由桩由装饰器就地注册，函数体内无其它引用；basedpyright 把函数作用域内的符号一律
+    # 判为私有，逐个标注的 reportUnusedFunction 均为工具误报。
     @app.get("/api/v1/tasks")
-    async def _tasks_error() -> dict:
+    async def _tasks_error() -> dict:  # pyright: ignore[reportUnusedFunction]
         raise HTTPException(status_code=500, detail="boom")
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/tests/unit/server/test_tool_runtime.py
+++ b/tests/unit/server/test_tool_runtime.py
@@ -194,7 +194,7 @@ async def test_generation_batch_remains_readable_when_project_migration_is_block
             projects=_MigrationBlockedProjects({}),
             workflow_planner=_Planner(_status()),
             capabilities=_Capabilities(),
-            queue=queue,  # type: ignore[arg-type]
+            queue=queue,
         ),
     )
 
@@ -233,7 +233,7 @@ async def test_text_task_service_registration_is_cleaned_when_batch_read_fails()
         projects=_Projects({}),
         workflow_planner=_Planner(_status()),
         capabilities=_Capabilities(),
-        queue=_Queue(),  # type: ignore[arg-type]
+        queue=_Queue(),
     )
 
     with pytest.raises(RuntimeError, match="database unavailable") as exc_info:
@@ -273,7 +273,7 @@ async def test_mcp_dedupe_does_not_remove_embedded_text_task_registration() -> N
         projects=_Projects({}),
         workflow_planner=_Planner(_status()),
         capabilities=_Capabilities(),
-        queue=_Queue(),  # type: ignore[arg-type]
+        queue=_Queue(),
     )
     tool_runtime._TEXT_TASK_SERVICES["task-shared"] = owner
     try:
@@ -325,7 +325,7 @@ async def test_text_task_conflict_deletes_the_unassociated_batch() -> None:
             projects=_Projects({}),
             workflow_planner=_Planner(_status()),
             capabilities=_Capabilities(),
-            queue=queue,  # type: ignore[arg-type]
+            queue=queue,
         ),
     )
 
@@ -610,12 +610,12 @@ async def test_project_file_read_rejects_oversized_regular_file(tmp_path: Path) 
 @pytest.mark.parametrize("episode", [0, -1, True, 1.5, "1"])
 def test_draft_locator_requires_a_strict_positive_episode(episode: object) -> None:
     with pytest.raises(ValidationError, match=r"DraftLocator\nepisode"):
-        DraftLocator(episode=episode, doc_type="reference_script_plan")  # type: ignore[arg-type]
+        DraftLocator(episode=episode, doc_type="reference_script_plan")
 
 
 def test_draft_locator_rejects_unknown_document_types() -> None:
     with pytest.raises(ValidationError, match=r"DraftLocator\ndoc_type"):
-        DraftLocator(episode=1, doc_type="unsupported")  # type: ignore[arg-type]
+        DraftLocator(episode=1, doc_type="unsupported")
 
 
 def test_draft_dependency_points_from_sdk_adapter_to_shared_workflow() -> None:
@@ -641,3 +641,57 @@ def test_draft_dependency_points_from_sdk_adapter_to_shared_workflow() -> None:
     assert not any(name.startswith("server.agent_runtime.sdk_tools") for name in shared_imports)
     assert "server.draft_workflow" in sdk_imports
     assert '"is_error"' not in shared_source
+
+
+@pytest.mark.parametrize("script", [1, ["episode_1.json"], {"name": "episode_1.json"}, None])
+async def test_episode_script_reader_reports_invalid_request_for_non_string_names(
+    tmp_path: Path, script: object
+) -> None:
+    """工具入参是模型给的原始 JSON，形状不合规须落成 invalid_request 而非异常。"""
+
+    project_dir = tmp_path / "demo"
+    project_dir.mkdir(parents=True)
+    (project_dir / "project.json").write_text(
+        f'{{"content_mode":"drama","schema_version":{CURRENT_PROJECT_SCHEMA_VERSION}}}', encoding="utf-8"
+    )
+    services = Services(
+        projects=ProjectManager(tmp_path), workflow_planner=_Planner(_status()), capabilities=_Capabilities()
+    )
+
+    outcome = await get_episode_script(
+        ToolRequest(script),
+        ProjectScope("demo", tmp_path),
+        CallerContext(user_id="u1", source="mcp"),
+        services,
+    )
+
+    assert outcome.problem is not None
+    assert outcome.problem.code == "invalid_request"
+
+
+@pytest.mark.parametrize("path", [1, ["source/novel.txt"], {"path": "source/novel.txt"}])
+async def test_business_file_readers_reject_non_string_paths(tmp_path: Path, path: object) -> None:
+    project_dir = tmp_path / "demo"
+    (project_dir / "source").mkdir(parents=True)
+    (project_dir / "project.json").write_text(
+        f'{{"content_mode":"drama","schema_version":{CURRENT_PROJECT_SCHEMA_VERSION}}}', encoding="utf-8"
+    )
+    services = Services(
+        projects=ProjectManager(tmp_path), workflow_planner=_Planner(_status()), capabilities=_Capabilities()
+    )
+    scope = ProjectScope("demo", tmp_path)
+    caller = CallerContext(user_id="u1", source="mcp")
+
+    source_text = await get_source_text(ToolRequest(path), scope, caller, services)
+    project_file = await read_project_file(ToolRequest(path), scope, caller, services)
+
+    assert source_text.problem is not None
+    assert project_file.problem is not None
+
+
+@pytest.mark.parametrize("entry_ids", [(1,), (["E1U01"],), ({"id": "E1U01"},)])
+def test_text_generation_request_rejects_non_string_entry_ids(entry_ids: tuple[object, ...]) -> None:
+    """entry_ids 经队列 payload JSON 往返回来，元素类型必须真的校验。"""
+
+    with pytest.raises(ValueError, match="entry_ids must be non-empty strings"):
+        shared_text_generation.TextGenerationRequest(episode=1, scope="stale", entry_ids=entry_ids)

--- a/tests/unit/server/test_tool_runtime.py
+++ b/tests/unit/server/test_tool_runtime.py
@@ -686,7 +686,9 @@ async def test_business_file_readers_reject_non_string_paths(tmp_path: Path, pat
     project_file = await read_project_file(ToolRequest(path), scope, caller, services)
 
     assert source_text.problem is not None
+    assert source_text.problem.code == "unsafe_path"
     assert project_file.problem is not None
+    assert project_file.problem.code == "unsafe_path"
 
 
 @pytest.mark.parametrize("entry_ids", [(1,), (["E1U01"],), ({"id": "E1U01"},)])


### PR DESCRIPTION
## Summary

Spec #2229 Stage 3 / 3：basedpyright warning 全面阻断，unused / unreachable / deprecated 规则进闸门，存量清零。

- CI、pre-push hook、`CLAUDE.md` 闸门三处改为 `basedpyright --warnings`，已配置规则不再「写了但不生效」；tests/scripts/alembic 域此前显式降级的规则改为 `none` 并注明「该域不做闸门」（诚实表达既有决策，非豁免扩张）
- 既有 warning 清零：`reportUnnecessaryIsInstance` 147、`reportUnnecessaryTypeIgnoreComment` 385（含 tests 域显形部分）、`reportUnnecessaryComparison` 21；新开 `reportUnusedImport` / `reportUnusedVariable` / `reportUnusedClass` / `reportDeprecated`（`@contextmanager` 标注改 `Generator`/`AsyncGenerator`）
- 新开 `reportUnusedFunction`（146 处：真死代码删除 / 模块级 `_` 名与重置钩子改公开名 / 装饰器注册的嵌套函数以行内带理由 ignore 标注）与 `reportUnreachable`（27 处：`match` 穷尽兜底改 `assert_never`，真死分支删除）
- 重置钩子公开化为 `reset_*_for_tests`，`CONTRIBUTING.md` seam 一节写明；其 fixture 注入 seam 改造另见 #2246
- 批次清尾（#2247）：async 生产路径上 ruff `ASYNC240` 跨函数漏报的同步阻塞 I/O 收口（`ark` 的 base64 读图与参考音频、`grok-image`、`openai-video`、`options_assembler` 的 `read_text`）

## 审查期修复

- 静态「永真」的 isinstance 在 JSON/Agent 入参重建入口仍是活判定：新增 `lib/schema_guards.py` 收口，修复 7 处降级路径回归并补 28 个回归用例

## 需要点名的行为语义变化

- `_reset_project_manager_for_tests` 按零引用删除后，`get_project_manager()` 单例不再有重置 seam（现有测试改 patch 公开的 `get_project_manager`）
- `lib/gemini_shared.py` 删除双检锁的无锁快路径，属并发/性能语义改动（锁语义核实无变化：`_shared_rate_limiter` 仅在锁内赋值，删快路径只损未争用锁的开销，不引竞态）
- `lib/ledger.py` 通道兜底由 `ValueError` 改为 `assert_never` 的 `AssertionError`（Spec 处方；该函数无外部调用方，ledger 内只有 `except Exception`，降级路径不变）
- `ark` 参考音频改 `gather` 并发编码后，**多段同时非法**时报错里指名的文件由「必然第一段」变为「最先失败的那段」。错误码（`video_reference_audio_format_unsupported` / `video_reference_audio_unreadable`）、「必抛不跳过」的契约与成功条目的顺序均不变；同性质已存在于既有的 `grok` 参考图范式

## 审查循环期修复

- `server/tool_runtime.py::get_source_text`：模型给的非 str `path` 在 `startswith` 上抛 AttributeError，越过本族 reader 的降级口径落成 `internal_error`（同族 `read_project_file` 得到 `unsafe_path`）。补形状判定使两者同码；原用例只断言 `problem is not None`，未咬住该缺陷，改为断言具体错误码
- `lib/storyboard_sequence.py`：`find_storyboard_item` 与 `resolve_previous_storyboard_path` 对磁盘剧本 JSON 条目无条件 `.get`，按本 PR「容器访问器只校验外层 list、元素处判定必要」的口径补守卫，配两条回归用例
- `lib/reference_video/draft_validation.py::validate_dialogue_load` 的 `language` 改 `object` 收参：取自 `project.json` 的脏数据，函数内已收窄，签名的 `str | None` 是不实的一侧

## Validation

- `basedpyright --warnings` 全仓 0 errors / 0 warnings / 0 notes；负向验证（注入 warning → CI 等价命令与 pre-push hook 均打红）
- backend full gate（stage HEAD `d17e9a3ba`）：`ruff check` / `ruff format --check`（1484 files formatted）、`lint-imports`（2 kept, 0 broken）、`deptry`（no issues）、`pytest -n 4 --dist loadfile` **11232 passed, 3 skipped**、`audit_tests.py --check` 0 违规、`pre-commit actionlint` / `zizmor` Passed
- `--collect-only` 用例 ID 集合与基线逐条一致（净增本批新写的回归用例，零删除）
- 本 stage diff 不含 `frontend/` 与 `website/`；两处 `pnpm check` 各跑一次确认无涉及（frontend 170 files / 2017 tests passed）

Refs #2229
Refs #2246

Closes #2236
Closes #2237
Closes #2247
