### PR TITLE
chore(mutmut): 固化可复跑的 [tool.mutmut] 配置与 mutants/ 忽略规则

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ tests/
 htmlcov
 *.egg-info
 .claude/worktrees
+mutants/

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ docs/verification-reports/
 .impeccable/live/deferred-svelte-component-accepts.json
 .impeccable/live/*.png
 # impeccable-ignore-end
+
+# mutmut 变异测试的工作副本（`mutmut run` 生成的整仓复制品）
+mutants/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,8 +320,10 @@ source_paths = ["lib", "server"]
 # only_mutate = ["lib/speech_rate.py"]
 # 变异后的模块 import mutmut.__main__，而该 import 在模块级就按 CWD 解析 [tool.mutmut]；
 # tests/unit/test_skill_script_path_guards.py 的用例一律在项目外的 tmp 目录启子进程跑 skill 脚本，
-# 子进程 CWD 无 pyproject.toml 即崩在 _guess_source_paths()。它们守的是 skill 脚本自己的 CWD 护栏，
-# 与被变异代码无关，故整体排除。
+# 子进程 CWD 无 pyproject.toml 即崩在 _guess_source_paths()，故整体排除。
+# 这些子进程确实会 import lib.project_manager / lib.script_models，排除后由它们独家覆盖的
+# mutant 会掉进存活集合；但保留同样杀不死——子进程在断言前就崩在上面那个 import。
+# 排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死（把无效测试藏起来）。
 pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
 # 但候选集约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
@@ -333,11 +335,16 @@ pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
 #        uv pip install --python .venv mutmut==3.7.0   # 不写进 pyproject，uv sync 会清掉
 #   2. tests-for-mutant 只在项目根可用，在 mutants/ 里跑报 Failed to load stats：
 #        .venv/bin/mutmut tests-for-mutant <名> > /tmp/nodeids.txt
-#   3. nodeid 列表用 xargs 传，不要用 $(...)：zsh 不对未加引号的命令替换做词分割，整串会被
-#      当成单个参数，pytest 报 no tests ran；bash 下能跑，因此这条只在 zsh 里暴露：
-#        cd mutants && xargs env MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q < /tmp/nodeids.txt
-# 复核用 .venv 的解释器而非 uv run：mutants/ 里那份 pyproject.toml 副本缺 README.md，
-# 在其中跑 uv run 会栽在 hatchling 构建。
+#   3. nodeid 列表按 NUL 分隔传，既不能用 $(...) 也不能用裸 xargs：
+#      $(...) 在 zsh 下不做词分割（bash 下做），整串成一个参数，pytest 静默报 no tests ran；
+#      裸 xargs 按空白切分并吞掉引号，而本套件有 180+ 个含空格或引号的参数化 nodeid，
+#      例如 test_static_code_enumeration_rejects_partially_dynamic_expressions["a" if cond else "b"-expected1]
+#      会被拆成 5 个参数且丢掉双引号。-0 两者都免疫：
+#        cd mutants && tr '\n' '\0' < /tmp/nodeids.txt \
+#          | xargs -0 env MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q
+# 复核用 .venv 的解释器而非 uv run。往 also_copy 补 README.md 只能修掉 mutants/ 里
+# uv run 栽在 hatchling 构建这一层：uv 会按那份 pyproject.toml 副本另建一个环境，而 mutmut
+# 按验收标准不在依赖里，变异模块顶部的 trampoline import 照样 ModuleNotFoundError。
 also_copy = [
     "agent_runtime_profile",
     "alembic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,3 +310,34 @@ reportCallIssue = "none"
 reportIndexIssue = "none"
 # 脚本用 sys.path 注入后再 import，静态不可解析，此域不做闸门
 reportMissingImports = "none"
+
+# 变异测试（mutmut 3.7.0）。不进 dev 依赖，按需 `uv run --with mutmut==3.7.0 mutmut run`。
+# 变异得分是信号不是闸门：不为杀死变异体补写测试，只用存活 mutant 筛选待审查的测试。
+[tool.mutmut]
+# 必须显式写：不写时 mutmut 只推断出 lib/，漏掉 server/
+source_paths = ["lib", "server"]
+# 按批次填写待变异模块；留空则变异 source_paths 全域（一轮数小时，不实用）
+# only_mutate = ["lib/speech_rate.py"]
+# 变异后的模块 import mutmut.__main__，而该 import 在模块级就按 CWD 解析 [tool.mutmut]；
+# 本文件的用例一律在项目外的 tmp 目录启子进程跑 skill 脚本，子进程 CWD 无 pyproject.toml 即崩在
+# _guess_source_paths()。它们守的是 skill 脚本的 CWD 护栏，与被变异代码无关，故整体排除。
+pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
+# pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
+# 但候选集约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
+# timeout_multiplier / timeout_constant 保持默认（15 / 1.0），不要调小。
+# mutmut 的 fork 模型与本仓库的多线程测试套件不相容，存活 mutant 必然耗满墙钟预算被记成 ⏰；
+# 调小预算并不能省时间，只会让已证实的真存活被记成 killed（假杀死），把无效测试藏起来。
+# ⏰ 一律不算 killed，须在新进程里复核：
+#   cd mutants && MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q $(mutmut tests-for-mutant <名>)
+# 注意不要在 mutants/ 里跑 uv run：那份 pyproject.toml 的复制品缺 README.md，hatchling 构建失败。
+also_copy = [
+    "agent_runtime_profile",
+    "alembic",
+    "alembic.ini",
+    "scripts",
+    "skills",
+    "skills-lock.json",
+    "public",
+    ".github",
+    "frontend/src",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,17 +319,25 @@ source_paths = ["lib", "server"]
 # 按批次填写待变异模块；留空则变异 source_paths 全域（一轮数小时，不实用）
 # only_mutate = ["lib/speech_rate.py"]
 # 变异后的模块 import mutmut.__main__，而该 import 在模块级就按 CWD 解析 [tool.mutmut]；
-# 本文件的用例一律在项目外的 tmp 目录启子进程跑 skill 脚本，子进程 CWD 无 pyproject.toml 即崩在
-# _guess_source_paths()。它们守的是 skill 脚本的 CWD 护栏，与被变异代码无关，故整体排除。
+# tests/unit/test_skill_script_path_guards.py 的用例一律在项目外的 tmp 目录启子进程跑 skill 脚本，
+# 子进程 CWD 无 pyproject.toml 即崩在 _guess_source_paths()。它们守的是 skill 脚本自己的 CWD 护栏，
+# 与被变异代码无关，故整体排除。
 pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
 # 但候选集约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
 # timeout_multiplier / timeout_constant 保持默认（15 / 1.0），不要调小。
 # mutmut 的 fork 模型与本仓库的多线程测试套件不相容，存活 mutant 必然耗满墙钟预算被记成 ⏰；
 # 调小预算并不能省时间，只会让已证实的真存活被记成 killed（假杀死），把无效测试藏起来。
-# ⏰ 一律不算 killed，须在新进程里复核：
-#   cd mutants && MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q $(mutmut tests-for-mutant <名>)
-# 注意不要在 mutants/ 里跑 uv run：那份 pyproject.toml 的复制品缺 README.md，hatchling 构建失败。
+# ⏰ 一律不算 killed，须在新进程里复核（每个 3-11s）。三个前提缺一不可：
+#   1. mutmut 要能被 .venv 的解释器 import——变异后的模块顶部就 import 它的 trampoline：
+#        uv pip install --python .venv mutmut==3.7.0   # 不写进 pyproject，uv sync 会清掉
+#   2. tests-for-mutant 只在项目根可用，在 mutants/ 里跑报 Failed to load stats：
+#        .venv/bin/mutmut tests-for-mutant <名> > /tmp/nodeids.txt
+#   3. nodeid 列表用 xargs 传，不要用 $(...)：zsh 不对未加引号的命令替换做词分割，整串会被
+#      当成单个参数，pytest 报 no tests ran；bash 下能跑，因此这条只在 zsh 里暴露：
+#        cd mutants && xargs env MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q < /tmp/nodeids.txt
+# 复核用 .venv 的解释器而非 uv run：mutants/ 里那份 pyproject.toml 副本缺 README.md，
+# 在其中跑 uv run 会栽在 hatchling 构建。
 also_copy = [
     "agent_runtime_profile",
     "alembic",


### PR DESCRIPTION
## 背景

Closes #2256（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)「先合一个只加 mutmut 配置的 PR」这条决策的落地）。

纯配置改动，不动任何生产代码或测试。内容取自 #2253 实跑验证过的配置草案。

## 改了什么

`pyproject.toml` 新增 `[tool.mutmut]`：

- `source_paths` 显式写 `["lib", "server"]` —— 不写时 mutmut 只推断出 `lib/`，会漏掉 `server/`。
- `only_mutate` 注释掉，按批次填写；留空会变异 `source_paths` 全域（一轮数小时，不实用）。
- `pytest_add_cli_args` 排除 `tests/unit/test_skill_script_path_guards.py`：这些用例在项目外的 tmp 目录启子进程，而变异后的模块 import `mutmut.__main__` 时会在模块级按 CWD 解析 `[tool.mutmut]`，子进程 CWD 无 `pyproject.toml` 即崩在 `_guess_source_paths()`。这些子进程确实会 import `lib.project_manager` / `lib.script_models`，但保留它们也杀不死对应 mutant —— 崩溃发生在任何断言之前。排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死。
- `also_copy` 九项：补齐 `mutants/` 副本里测试运行所需的仓库外围文件。不含 `README.md`：补上它只能修掉 `mutants/` 里 `uv run` 栽在 hatchling 构建这一层，uv 仍会按副本 pyproject 另建一个不含 mutmut 的环境，trampoline import 照样失败。
- 不设 `pytest_add_cli_args_test_selection`，走全量 `testpaths`。仅 `tests/unit` 快 5.5 倍，但候选集约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
- `timeout_multiplier` / `timeout_constant` 保持默认，并在配置里写明**不要调小**的理由：mutmut 的 fork 模型与本仓库多线程测试套件不相容，存活 mutant 必然耗满墙钟预算被记成 ⏰；调小预算不省时间，只会把已证实的真存活记成 killed（假杀死），反而把无效测试藏起来。
- ⏰ 复核 runbook 写进注释，三个前提缺一不可：① mutmut 要装进 `.venv`（`uv run --with` 的 overlay 环境在命令退出时就拆了）；② `tests-for-mutant` 只在项目根可用；③ nodeid 列表按 NUL 分隔传（`$(...)` 在 zsh 下不分词；裸 `xargs` 按空白切分并吞掉引号，而本套件有 184 个含空格或引号的参数化 nodeid）。

`.gitignore` / `.dockerignore` 新增 `mutants/`：它是 47 MB 的整仓复制品，且测试会在里面写运行时目录。

## 不做什么

- mutmut **不进** `[dependency-groups]`，按需 `uv run --with mutmut==3.7.0 mutmut run`。
- 不接 CI，变异得分是信号不是闸门（与仓库既有「覆盖率是信号不是闸门」同构）。

## 验收

在本分支上把 `only_mutate` 临时填 `lib/speech_rate.py` 实跑：**exit 0**，38 个 mutant / 35 killed / 3 ⏰，与 #2253 的记录一致，两次独立复跑存活集合完全相同。那 3 个 ⏰ 经新进程复核为真存活（35 passed）。跑完已把 `only_mutate` 还原为注释。

闸门：`ruff check` / `ruff format` / `basedpyright --warnings`（0 errors, 0 warnings）/ `lint-imports`（2 contracts kept）/ `deptry` 全部通过。上面那轮 mutmut 的 clean-tests 阶段已完整跑过全量测试套件。

https://claude.ai/code/session_01DTa399BCR6Qa21vcFQSaim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试**
  - 新增变异测试配置，覆盖核心代码路径。
  - 优化测试参数，减少无关检查干扰。
  - 完善测试所需文件准备规则，提升测试执行的稳定性与一致性。

- **维护**
  - 忽略变异测试生成的临时工作副本，避免其进入版本控制。
  - 同步排除相关临时内容，保持项目文件与构建产物整洁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
