### PR TITLE
fix(ci): release PR 无变化时 release-please 不再红

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,7 +54,9 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           PUSH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_BRANCH: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          # release PR 无变化时 action 不输出 pr，取值为空串。step 级 env 先于 if 求值，
+          # 直接 fromJson 会解析空串失败并让整个 job 红；短路后 fromJson 只在有值时调用
+          PR_BRANCH: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).headBranchName }}
         run: |
           uv lock
           if ! git diff --quiet uv.lock; then


### PR DESCRIPTION
## 现象

main 上 `ee52466` 的 release-please job 失败（[run 33493713591](https://github.com/ArcReel/ArcReel/actions/runs/33493713591)）：

```
##[error]The template is not valid. .github/workflows/release-please.yml (Line: 57, Col: 22):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

## 根因

同一次运行里 release step 打印 `✔ PR #2238 remained the same` —— release PR 的内容与上一版一致，`release-please-action` 此时**不输出** `pr`，`steps.release.outputs.pr` 是空串。

`Sync uv.lock` 的 step 级 `env` 里直接写了 `fromJson(steps.release.outputs.pr).headBranchName`。step 级 `env` 在 `if:` 判定**之前**求值，于是 `fromJson('')` 抛模板错误，整个 job 红。三个 step 的 `if: ${{ steps.release.outputs.pr }}` 守卫都拦不住它。

与 CI 内容无关，任何一次「release PR 保持不变」的 main push 都会命中；上一次成功（`aacf2c6`）是因为那次 release PR 确实被更新、`pr` 有值。

## 改动

`PR_BRANCH` 改用短路表达式，`fromJson` 只在 `pr` 有值时求值：

```yaml
PR_BRANCH: ${{ steps.release.outputs.pr && fromJson(steps.release.outputs.pr).headBranchName }}
```

`pr` 为空时 `PR_BRANCH` 为空串，step 仍由既有的 `if` 跳过，行为不变。

第 39 行 checkout 的 `ref:` 用同一个表达式但不受影响：`with:` 的输入在 `if` 为 false 时不求值，本次运行也印证了这点（只有 `env` 那处报错），故不动。

## 验证

- `uv run pre-commit run --all-files actionlint` → Passed
- `uv run pre-commit run --all-files zizmor` → Passed

https://claude.ai/code/session_01DTa399BCR6Qa21vcFQSaim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复发布流程在没有检测到变更时可能失败的问题。
  * 提升自动发布任务的稳定性，避免因空结果导致流程中断。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->