### PR TITLE
test(digest): 文件摘要拒绝非常规路径时断言错误携带该路径

### DIFF
--- a/tests/unit/lib/test_content_digest.py
+++ b/tests/unit/lib/test_content_digest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import re
 from pathlib import Path
 
 import pytest
@@ -47,7 +48,7 @@ def test_sha256_file_with_size_reports_byte_count(tmp_path: Path) -> None:
 
 
 def test_sha256_file_rejects_non_file(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match=re.escape(str(tmp_path))):
         sha256_file(tmp_path)
 
 


### PR DESCRIPTION
## 背景

#2263 的曳光弹（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)）：把 #2258 判为类 3 的 48 条里改动面最小的一条（C023）单独走完「补断言 → 全套闸门 → 8 模块全量复跑 → 三层验收 → PR」流程，目的是探路，不是为了这一条断言。本 PR 不关闭 #2263，后续还有 47 条批量 PR。

## 改了什么

`tests/unit/lib/test_content_digest.py::test_sha256_file_rejects_non_file`：`pytest.raises(FileNotFoundError)` 补 `match=re.escape(str(tmp_path))`。原用例只查异常类型，`FileNotFoundError(path)` 的 payload 被改成 `None` 也照样通过；现在断言异常消息携带被拒绝的路径。只加强断言，输入不变，不新增用例。

**硬门**：`git diff --name-only origin/main` 只有这一个测试文件，未触及 `lib/` 与 `server/`。

## 三层验收（8 模块全量复跑，616 个 mutant）

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 目标 `lib.content_digest.x_sha256_file_with_size__mutmut_2` | 1 | ⏰ → killed，新进程复核 1684 个关联用例 **恰 1 failed**（就是本用例），59 s |
| 原 killed 护栏 | 486 | **0 回退** |
| 其余候选 | 129 | 0 顺手杀死；11 个 ⏰ 与基线逐个一致 |

基线取 `research/mutmut-batch-1/baseline/`（#2257），8 个模块源码自基线提交以来零变动，mutant 编号可比对。

## 计划外发现：mutmut 并行子进程的假杀死链

第一轮复跑（无 debug）跑出 **44 条假杀死**（含目标本身）：运行序第 303 位之后零存活、302 个 mutant 全部记 killed。调用链从日志里抓到了：

1. 第 305 个子进程的 pytest 在 `pytest_sessionfinish` 清理 `pytest-of-<user>/pytest-current` 软链时撞 `FileNotFoundError`——mutmut 默认按 CPU 数并行 fork 子进程，多个 pytest 会话同时创建/清理同一条软链是竞争；
2. 该异常沿 mutmut CLI 栈冒到顶层，子进程走**异常退出**而非 `os._exit`，退出码 1 被记成 killed，且 **atexit 会跑**；
3. `tests/conftest.py` 在 atexit 上注册了 `shutil.rmtree(_OWNED_TEST_DB_DIR)`，共享的临时 sqlite 库目录被删；
4. 之后每个子进程的 `shared_db_schema` 会话 fixture 都报错，任何用例集都 0.1–1.8 s 内退出码 1，整批假杀死。

第二轮以 `debug = true` 干净复跑（无并发命令）未复现，结果即上表。**判据上的结论**：「顺手杀死」名单里出现类 5（等价变异体）即整轮作废——等价变异体不可能被杀，它是最灵敏的假杀死探针。

## 曳光弹成本

| 步骤 | 墙钟 |
| --- | ---: |
| 改断言 + 单文件用例 | < 1 min |
| 8 模块全量复跑（第一轮，作废） | 6:43 |
| 8 模块全量复跑（第二轮，debug） | 17:47 |
| 目标 mutant 新进程复核 | 59 s |
| 全量本地闸门（`pytest -n 4` 4:33） | ≈ 6 min |
| 假杀死链的识别与定位 | ≈ 25 min |

票面估的 33 min 是 A、B 两组分开跑的加总，合成一轮 8 模块只要 ~18 min（含 11 个 ⏰ 各耗满预算）。

## 闸门

`ruff check` / `ruff format` / `basedpyright --warnings`（0 errors, 0 warnings）/ `lint-imports`（2 contracts kept）/ `deptry` / `audit_tests.py --check`（0 违规）全部通过。`pytest -n 4 --dist loadfile` 11271 passed，另 `test_project_events_service.py::TestProjectEventService::test_subscribe_cancellation_cleans_up_subscriber` 在全量负载下失败一次，单独与 `-n 4` 各复跑 4 次全过，不在本 PR diff 内。

https://claude.ai/code/session_01P3Uw2pumTBTZXJ9dvHLZLr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 增强了无效文件输入场景的验证。
  - 测试现在会同时确认操作失败，并检查错误信息是否包含对应路径，从而提升错误提示校验的准确性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->