### PR TITLE
test(discovery): 模型发现断言 SDK 构造参数与完整返回项，配图裁剪与语速用例断言具体值

### DIFF
--- a/tests/unit/lib/custom_provider/test_model_discovery.py
+++ b/tests/unit/lib/custom_provider/test_model_discovery.py
@@ -89,11 +89,11 @@ class TestDiscoverModelsOpenAI:
             api_key="sk-test",
         )
 
-        # 鉴权与 base_url 透传到 SDK 客户端构造参数，base_url 已补全 /v1
-        assert mock_openai_cls.call_args.kwargs == {
-            "api_key": "sk-test",
-            "base_url": "https://api.example.com/v1",
-        }
+        # 鉴权与 base_url 原样透传到 SDK 客户端构造参数
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-test",
+            base_url="https://api.example.com/v1",
+        )
         assert len(result) == 3
         # 按 id 排序
         ids = [m["model_id"] for m in result]

--- a/tests/unit/lib/custom_provider/test_model_discovery.py
+++ b/tests/unit/lib/custom_provider/test_model_discovery.py
@@ -89,6 +89,11 @@ class TestDiscoverModelsOpenAI:
             api_key="sk-test",
         )
 
+        # 鉴权与 base_url 透传到 SDK 客户端构造参数，base_url 已补全 /v1
+        assert mock_openai_cls.call_args.kwargs == {
+            "api_key": "sk-test",
+            "base_url": "https://api.example.com/v1",
+        }
         assert len(result) == 3
         # 按 id 排序
         ids = [m["model_id"] for m in result]
@@ -393,7 +398,7 @@ class TestUnknownFormat:
 class TestDiscoverModelsAnthropic:
     @patch("lib.custom_provider.discovery.get_http_client")
     async def test_basic_discovery(self, mock_get_client):
-        """Anthropic 协议返回的模型按 id 排序，仅保留 model_id。"""
+        """Anthropic 协议返回的模型按 id 排序，返回项与 OpenAI/Google 路径同形态且 endpoint 为空。"""
         from unittest.mock import AsyncMock
 
         mock_response = MagicMock()
@@ -416,8 +421,22 @@ class TestDiscoverModelsAnthropic:
             api_key="sk-ant-test",
         )
 
-        ids = [m["model_id"] for m in result]
-        assert ids == ["claude-haiku-4-5", "claude-opus-4-7"]
+        assert result == [
+            {
+                "model_id": "claude-haiku-4-5",
+                "display_name": "Haiku 4.5",
+                "endpoint": "",
+                "is_default": False,
+                "is_enabled": True,
+            },
+            {
+                "model_id": "claude-opus-4-7",
+                "display_name": "Opus 4.7",
+                "endpoint": "",
+                "is_default": False,
+                "is_enabled": True,
+            },
+        ]
         # URL 规范化：/v1 应被剥掉，请求 path 为 /v1/models
         called_url = mock_client.get.call_args.args[0]
         assert called_url == "https://example.com/v1/models"
@@ -425,6 +444,8 @@ class TestDiscoverModelsAnthropic:
         headers = mock_client.get.call_args.kwargs["headers"]
         assert headers["x-api-key"] == "sk-ant-test"
         assert headers["anthropic-version"] == "2023-06-01"
+        # 发现请求带 15 秒超时，不沿用共享客户端的默认超时
+        assert mock_client.get.call_args.kwargs["timeout"] == 15.0
 
     @patch("lib.custom_provider.discovery.get_http_client")
     async def test_default_base_url_when_none(self, mock_get_client):
@@ -447,7 +468,7 @@ class TestDiscoverModelsAnthropic:
 
     @patch("lib.custom_provider.discovery.get_http_client")
     async def test_skips_entries_without_id(self, mock_get_client):
-        """data 中 id 缺失的条目被跳过。"""
+        """data 中 id 缺失的条目被跳过；缺 display_name 的条目以 id 作显示名。"""
         from unittest.mock import AsyncMock
 
         mock_response = MagicMock()
@@ -463,6 +484,7 @@ class TestDiscoverModelsAnthropic:
 
         result = await discover_models(discovery_format="anthropic", base_url=None, api_key="k")
         assert [m["model_id"] for m in result] == ["claude-x"]
+        assert result[0]["display_name"] == "claude-x"
 
     async def test_unknown_format_raises(self):
         """anthropic 仍是已知 format；未知 format 抛 ValueError 含 anthropic。"""

--- a/tests/unit/lib/grid/test_grid_splitter.py
+++ b/tests/unit/lib/grid/test_grid_splitter.py
@@ -9,7 +9,8 @@ class TestCenterCropToRatio:
     def test_no_crop_needed(self):
         img = Image.new("RGB", (160, 90))
         result = center_crop_to_ratio(img, "16:9")
-        assert result.size == (160, 90)
+        # 比例已匹配时原图直接返回，不重新裁出一张同尺寸副本
+        assert result is img
 
     def test_crop_2_1_to_16_9(self):
         img = Image.new("RGB", (200, 100))  # 2:1 → 16:9

--- a/tests/unit/lib/test_speech_rate.py
+++ b/tests/unit/lib/test_speech_rate.py
@@ -54,10 +54,12 @@ class TestEstimateSpokenSeconds:
         assert longer > short
 
     def test_language_changes_timing(self):
-        # 同为 5 个阅读单位，zh（计字）与 en（计词）语速不同 → 时长不同，
-        # 证明语速随语言变化、非全局写死单值。
+        # 同为 5 个阅读单位，zh（计字）与 en（计词）各按本语言的语速换算：
+        # language 既决定阅读单位计法，也决定语速，两处都不能退回默认。
         zh = estimate_spoken_seconds("一二三四五", "zh")
         en = estimate_spoken_seconds("one two three four five", "en")
+        assert zh == pytest.approx(5 / speech_rate_units_per_second("zh"))
+        assert en == pytest.approx(5 / speech_rate_units_per_second("en"))
         assert zh != en
 
     def test_unknown_language_uses_default_rate(self):


### PR DESCRIPTION
## 摘要

Map #2250 / 票 #2263 第二步（批量 47 条）的第一个 PR：把 #2258 判为「值得保护、断言太弱」的 27 条候选改造到位，只加强断言，不新增用例、不改输入、不动生产代码。

- `tests/unit/lib/custom_provider/test_model_discovery.py`（25 条）
  - OpenAI 路径断言 SDK 客户端的构造参数（api_key 与补全 `/v1` 的 base_url）——覆盖 `discover_models` 分派透传与 `OpenAI(...)` 构造实参共 7 个 mutant
  - Anthropic 路径断言完整返回项（display_name / endpoint / is_default / is_enabled）与请求 `timeout=15.0`——覆盖返回 dict 形态 15 个 + timeout 3 个 mutant；缺 display_name 时以 id 作显示名一并断言
- `tests/unit/lib/grid/test_grid_splitter.py`（1 条）：比例已匹配时断言 `result is img`，而非仅比尺寸
- `tests/unit/lib/test_speech_rate.py`（1 条）：zh / en 时长各按本语言语速换算成具体秒数，而非只断 `zh != en`

## 验收

与 #2263 的第二个 PR 共用同一轮 8 模块全量 mutmut 复跑（三层判据），记录见 #2263 的结算评论。

硬门：`git diff --name-only` 只含测试文件。

Part of #2263


https://claude.ai/code/session_018ehN37nRfeqKUHP8P9aCQR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 增强自定义模型发现的验证，涵盖默认状态、启用状态、端点信息、请求超时及客户端配置传递。
  * 补充缺少显示名称时使用模型标识作为名称的场景验证。
  * 完善图像裁剪逻辑测试，确认无需裁剪时保留原始图像对象。
  * 细化不同语言语速下的语音时长估算验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->