### PR TITLE
test(text): OpenAI 文本后端断言客户端构造参数、视觉 messages 结构与 Instructor 降级实参

### DIFF
--- a/tests/unit/lib/text_backends/test_openai_text_backend.py
+++ b/tests/unit/lib/text_backends/test_openai_text_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -40,12 +41,15 @@ def _make_mock_response(content="Hello", input_tokens=10, output_tokens=5):
 
 class TestOpenAITextBackend:
     def test_name_and_model(self):
-        with captured_openai_clients():
+        with captured_openai_clients() as created:
             from lib.text_backends.openai import OpenAITextBackend
 
             backend = OpenAITextBackend(api_key="test-key")
             assert backend.name == PROVIDER_OPENAI
             assert backend.model == "gpt-5.4-mini"
+
+        # 未给 base_url 时回填官方端点；SDK 内置重试关闭，由 generate() 统一管理重试
+        assert created == [{"api_key": "test-key", "base_url": "https://api.openai.com/v1", "max_retries": 0}]
 
     def test_custom_model(self):
         with captured_openai_clients():
@@ -110,7 +114,8 @@ class TestOpenAITextBackend:
         mock_client.chat.completions.create = AsyncMock(return_value=_make_mock_response("I see a cat"))
 
         img_path = tmp_path / "test.png"
-        img_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 10
+        img_path.write_bytes(png_bytes)
 
         with captured_openai_clients(mock_client):
             from lib.text_backends.openai import OpenAITextBackend
@@ -124,11 +129,17 @@ class TestOpenAITextBackend:
 
         assert result.text == "I see a cat"
         call_kwargs = mock_client.chat.completions.create.call_args[1]
-        user_msg = call_kwargs["messages"][-1]
-        assert isinstance(user_msg["content"], list)
-        types = [part["type"] for part in user_msg["content"]]
-        assert "image_url" in types
-        assert "text" in types
+        # 本地图片内联为 data URI 的 image_url part，文本 part 排在图片之后
+        data_uri = "data:image/png;base64," + base64.b64encode(png_bytes).decode()
+        assert call_kwargs["messages"] == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                    {"type": "text", "text": "What is this?"},
+                ],
+            }
+        ]
 
     async def test_generate_structured_output(self):
         schema_response = json.dumps({"name": "Alice", "age": 30})
@@ -232,7 +243,7 @@ class TestInstructorFallback:
 
         with (
             captured_openai_clients(mock_client),
-            patch("instructor.from_openai", return_value=mock_patched),
+            patch("instructor.from_openai", return_value=mock_patched) as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
 
@@ -249,6 +260,12 @@ class TestInstructorFallback:
         assert result.input_tokens == 150
         assert result.output_tokens == 80
         mock_client.chat.completions.create.assert_awaited_once()
+        # 降级复用同一个客户端，并把原生调用的 model / messages 原样交给 Instructor
+        assert from_openai.call_args.args == (mock_client,)
+        fallback_kwargs = mock_patched.chat.completions.create_with_completion.call_args.kwargs
+        assert fallback_kwargs["model"] == "gpt-5.4-mini"
+        assert fallback_kwargs["messages"] == [{"role": "user", "content": "Extract info"}]
+        assert fallback_kwargs["response_model"] is _PersonSchema
 
     async def test_schema_violating_json_triggers_instructor_fallback_pydantic(self):
         """原生返回 200 + 合法 JSON 但违反 response_schema（代理接受却不强制 schema），应降级到 Instructor。"""
@@ -407,7 +424,7 @@ class TestInstructorFallback:
 
         with (
             captured_openai_clients(mock_client),
-            patch("instructor.from_openai", return_value=mock_patched),
+            patch("instructor.from_openai", return_value=mock_patched) as from_openai,
         ):
             from lib.text_backends.openai import OpenAITextBackend
 
@@ -422,6 +439,12 @@ class TestInstructorFallback:
         assert result.provider == PROVIDER_OPENAI
         assert result.input_tokens == 20
         assert result.output_tokens == 10
+        # 降级复用同一个客户端，并把原生调用的 model / messages 原样交给 Instructor
+        assert from_openai.call_args.args == (mock_client,)
+        fallback_kwargs = mock_patched.chat.completions.create_with_completion.call_args.kwargs
+        assert fallback_kwargs["model"] == "gpt-5.4-mini"
+        assert fallback_kwargs["messages"] == [{"role": "user", "content": "Extract info"}]
+        assert fallback_kwargs["response_model"] is _PersonSchema
 
     async def test_response_format_rejected_succeeds_via_tools_mode(self):
         """上游拒收 response_format 但支持 tools：降级链首档 TOOLS 即产出合规结构化结果。"""

--- a/tests/unit/lib/text_backends/test_openai_text_backend.py
+++ b/tests/unit/lib/text_backends/test_openai_text_backend.py
@@ -260,8 +260,8 @@ class TestInstructorFallback:
         assert result.input_tokens == 150
         assert result.output_tokens == 80
         mock_client.chat.completions.create.assert_awaited_once()
-        # 降级复用同一个客户端，并把原生调用的 model / messages 原样交给 Instructor
-        assert from_openai.call_args.args == (mock_client,)
+        # 降级复用同一个客户端、从 TOOLS 档起步，并把原生调用的 model / messages 原样交给 Instructor
+        from_openai.assert_called_once_with(mock_client, mode=Mode.TOOLS)
         fallback_kwargs = mock_patched.chat.completions.create_with_completion.call_args.kwargs
         assert fallback_kwargs["model"] == "gpt-5.4-mini"
         assert fallback_kwargs["messages"] == [{"role": "user", "content": "Extract info"}]
@@ -439,8 +439,8 @@ class TestInstructorFallback:
         assert result.provider == PROVIDER_OPENAI
         assert result.input_tokens == 20
         assert result.output_tokens == 10
-        # 降级复用同一个客户端，并把原生调用的 model / messages 原样交给 Instructor
-        assert from_openai.call_args.args == (mock_client,)
+        # 降级复用同一个客户端、从 TOOLS 档起步，并把原生调用的 model / messages 原样交给 Instructor
+        from_openai.assert_called_once_with(mock_client, mode=Mode.TOOLS)
         fallback_kwargs = mock_patched.chat.completions.create_with_completion.call_args.kwargs
         assert fallback_kwargs["model"] == "gpt-5.4-mini"
         assert fallback_kwargs["messages"] == [{"role": "user", "content": "Extract info"}]


### PR DESCRIPTION
## 摘要

Map #2250 / 票 #2263 第二步（批量 47 条）的第二个 PR：把 #2258 判为「值得保护、断言太弱」的 20 条 `lib/text_backends/openai.py` 候选改造到位，只加强断言，不新增用例、不改输入、不动生产代码。

`tests/unit/lib/text_backends/test_openai_text_backend.py`：

- 构造：断言 `captured_openai_clients` 记录的 AsyncOpenAI 构造参数（api_key、官方 base_url 回填、`max_retries=0`）——5 个 mutant
- 视觉输入：断言完整 messages 结构（image_url part 的 data URI 载荷与 text part 的键值），而非只看各 part 的 `type`——11 个 mutant
- Instructor 降级（非 JSON 响应 / BadRequestError 两条路径）：断言降级复用同一客户端，且 model / messages / response_model 原样交给 `create_with_completion`——4 个 mutant

## 验收

与 #2263 的第一个 PR 共用同一轮 8 模块全量 mutmut 复跑（三层判据），记录见 #2263 的结算评论。

硬门：`git diff --name-only` 只含测试文件。

Part of #2263


https://claude.ai/code/session_018ehN37nRfeqKUHP8P9aCQR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 增强 OpenAI 文本后端测试，覆盖未提供服务端点时的默认配置及 SDK 重试设置。
  * 补充视觉消息格式校验，确保本地图片以 Base64 数据 URI 传递，且文本与图片顺序正确。
  * 完善结构化响应降级测试，验证客户端复用、工具模式启动，以及模型、消息和响应类型的正确传递。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->