### PR TITLE
docs(testing): 固化 mutmut 变异测试 runbook、三层验收比对脚本与独立依赖组

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,14 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 覆盖率是信号，不是闸门：CI 不因覆盖率数字失败，Codecov 为唯一信号载体（PR 覆盖评论与趋势图，status 一律 informational）。不为覆盖率数字写测试；删除无意义测试允许覆盖率下降。
 
+### 变异测试
+
+变异得分是信号，不是闸门，与覆盖率同构：不为杀死 mutant 写测试，不做覆盖补偿，不进 CI。按批次手动跑，把本批模块填进 `pyproject.toml` 的 `[tool.mutmut] only_mutate`；操作步骤与已知陷阱见 [`docs/testing/mutmut-runbook.md`](docs/testing/mutmut-runbook.md)。
+
+- **存活只是把测试送上审查台，不是删除依据**。存活 mutant 落在已有测试覆盖的代码上时，按无意义测试判据的三步处置逐条判定；两种情形不处置：保持既有用例输入不变只加强断言杀不死、须换输入才能杀死的（属覆盖补偿，不做），以及等价变异体（改了源码但行为不变）。无覆盖代码上的存活一律不管。
+- **超时不算 killed**。mutmut 的 fork 模型与本仓库的多线程测试套件不相容，真正存活的 mutant 会被记成超时；`.meta` 里 exit code 不等于 1 的一律在新进程里只跑关联用例复核，复核确认存活的才进入判定。
+- **改造后的三层验收**（`scripts/mutmut_compare.py`）：本次改造针对的 mutant 全部 killed；基线里 killed 的 mutant 没有一个变成存活，变成超时的须新进程复核；基线里存活且本次未改造的 mutant 被杀死只登记不报警，其中判为等价变异体的被杀死即整轮作废。改造 PR 的 diff 不得触及 `lib/` 与 `server/`。
+
 ### 闸门
 
 - 入口唯一：本地 `uv run python scripts/audit_tests.py --check`，CI 的独立 `test-lint` 作业跑同一脚本、同一 `--check`（脚本零第三方依赖，该作业只装 Python 不装项目依赖）；输出 `规则号 file:line 修复指引`。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 ### 变异测试
 
-变异得分是信号，不是闸门，与覆盖率同构：不为杀死 mutant 写测试，不做覆盖补偿，不进 CI。按批次手动跑，把本批模块填进 `pyproject.toml` 的 `[tool.mutmut] only_mutate`；操作步骤与已知陷阱见 [`docs/testing/mutmut-runbook.md`](docs/testing/mutmut-runbook.md)。
+变异得分是信号，不是闸门，与覆盖率同构：不为杀死 mutant 写测试，不做覆盖补偿，不进 CI。按批次手动跑，把本批模块填进 `pyproject.toml` 的 `[tool.mutmut] only_mutate`；操作步骤与已知陷阱见 [`docs/testing/mutmut-runbook.md`](https://github.com/ArcReel/ArcReel/blob/main/docs/testing/mutmut-runbook.md)。
 
 - **存活只是把测试送上审查台，不是删除依据**。存活 mutant 落在已有测试覆盖的代码上时，按无意义测试判据的三步处置逐条判定；两种情形不处置：保持既有用例输入不变只加强断言杀不死、须换输入才能杀死的（属覆盖补偿，不做），以及等价变异体（改了源码但行为不变）。无覆盖代码上的存活一律不管。
 - **超时不算 killed**。mutmut 的 fork 模型与本仓库的多线程测试套件不相容，真正存活的 mutant 会被记成超时；`.meta` 里 exit code 不等于 1 的一律在新进程里只跑关联用例复核，复核确认存活的才进入判定。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 变异得分是信号，不是闸门，与覆盖率同构：不为杀死 mutant 写测试，不做覆盖补偿，不进 CI。按批次手动跑，把本批模块填进 `pyproject.toml` 的 `[tool.mutmut] only_mutate`；操作步骤与已知陷阱见 [`docs/testing/mutmut-runbook.md`](https://github.com/ArcReel/ArcReel/blob/main/docs/testing/mutmut-runbook.md)。
 
 - **存活只是把测试送上审查台，不是删除依据**。存活 mutant 落在已有测试覆盖的代码上时，按无意义测试判据的三步处置逐条判定；两种情形不处置：保持既有用例输入不变只加强断言杀不死、须换输入才能杀死的（属覆盖补偿，不做），以及等价变异体（改了源码但行为不变）。无覆盖代码上的存活一律不管。
-- **超时不算 killed**。mutmut 的 fork 模型与本仓库的多线程测试套件不相容，真正存活的 mutant 会被记成超时；`.meta` 里 exit code 不等于 1 的一律在新进程里只跑关联用例复核，复核确认存活的才进入判定。
+- **超时不算 killed**。mutmut 的 fork 模型与本仓库的多线程测试套件不相容，真正存活的 mutant 会被记成超时；`.meta` 里 exit code 既不是 1 也不是 0 的一律在新进程里只跑关联用例复核，复核确认存活的才进入判定（0 是 pytest 全部通过，本身就是确认存活）。
 - **改造后的三层验收**（`scripts/mutmut_compare.py`）：本次改造针对的 mutant 全部 killed；基线里 killed 的 mutant 没有一个变成存活，变成超时的须新进程复核；基线里存活且本次未改造的 mutant 被杀死只登记不报警，其中判为等价变异体的被杀死即整轮作废。改造 PR 的 diff 不得触及 `lib/` 与 `server/`。
 
 ### 闸门

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -70,7 +70,7 @@ uv run python scripts/mutmut_compare.py \
   --equivalent equivalent.txt
 ```
 
-`reworked.txt` 一行一个本次改造针对的 mutant 名；`equivalent.txt` 可选，一行一个判定为等价变异体的 mutant 名。脚本输出三层表与待复核清单，exit code 0 通过、1 未通过、2 输入不一致（基线与本轮 mutant 名集合不同、名单里的 mutant 不在基线等）。
+`reworked.txt` 一行一个本次改造针对的 mutant 名；`equivalent.txt` 可选，一行一个判定为等价变异体的 mutant 名。脚本输出三层表与待复核清单，exit code 0 通过、1 未通过或有待复核项、2 输入不一致（基线与本轮 mutant 名集合不同、名单里的 mutant 不在基线等）。有待复核项时不判通过：按第 4 节复核后，确认 killed 的把本轮 `.meta` 里该 mutant 的 exit code 改成 1，确认存活的改成 0，再比对一次拿最终结论。
 
 | 层 | 通过条件 | 未通过怎么办 |
 | --- | --- | --- |

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -39,7 +39,7 @@ uv sync --group mutation
 | 3 | mutmut 把 pytest 内部错误当 killed | 复核 |
 | 其他（含 −11 段错误、None 未检查） | 可疑或未记 | 复核 |
 
-判据只有一条：**exit code 不等于 1 的一律复核**，复核确认存活的才进入判定。
+判据只有一条：**exit code 既不是 1 也不是 0 的一律复核**，复核确认存活的才进入判定。0 是 pytest 全部通过，本身就是确认存活，不用复核。
 
 ## 4. 超时的新进程复核
 
@@ -56,7 +56,7 @@ cd mutants && MUTANT_UNDER_TEST=lib.speech_rate.x_estimate_spoken_seconds__mutmu
 
 pytest 原生支持 `@文件` 读参数，一行一个、原样保留空格和引号，本套件 180 多个含空格或引号的参数化 nodeid 都能过。不要用 `$(cat …)` 或裸 `xargs`：前者在 zsh 下整串成一个参数、pytest 静默跑 0 个用例，后者会把带空格的 nodeid 拆开。
 
-判读：**1 failed 即 killed；全部通过即存活。** 复核确认 killed 的（含段错误之类两头不落的），在第 2 节保存的基线副本里把该 mutant 的 exit code 改成 1，这样第 5 节会把它们归入「基线 killed」那层护栏；确认存活的保持原样。首批 616 个 mutant 里 exit code 不等于 1 的 130 个，复核后 2 个段错误确认 killed、12 个超时全部确认存活。
+判读：**1 failed 即 killed；全部通过即存活。** 复核确认 killed 的（含段错误之类两头不落的），在第 2 节保存的基线副本里把该 mutant 的 exit code 改成 1，这样第 5 节会把它们归入「基线 killed」那层护栏；确认存活的保持原样。首批 616 个 mutant 里 exit code 不等于 1 的 130 个，其中要复核的只有 12 个超时和 2 个段错误：复核后 2 个段错误确认 killed、12 个超时全部确认存活。
 
 ## 5. 改造后的三层验收
 

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -1,0 +1,107 @@
+# mutmut 变异测试 runbook
+
+跑一批变异测试、复核结果、改造测试后验收的操作步骤。规范（信号不闸门、存活 mutant 如何接入三步处置、三层验收判据）在 [CONTRIBUTING「变异测试」](../../CONTRIBUTING.md#变异测试)，本文只讲怎么跑。配置在 `pyproject.toml` 的 `[tool.mutmut]`，配置项的取舍理由写在那里的注释里。
+
+## 1. 环境
+
+mutmut 在独立依赖组 `mutation` 里，不随默认 `uv sync` 安装：
+
+```bash
+uv sync --group mutation
+```
+
+变异后的模块顶部会 import mutmut 的 trampoline，所以它必须装在 `.venv` 里，`uv run --with mutmut` 覆盖不了后面的复核步骤。跑完一批想清掉时再 `uv sync`。
+
+## 2. 跑一批
+
+1. `git fetch` 后从 `origin/main` 切分支，并核对树里已含上一批合入的 PR。基线若从过期的本地 `main` 切出，上一批改造针对的 mutant 会在本批「复活」，白花一轮复核。
+2. 在 `[tool.mutmut]` 的 `only_mutate` 填本批模块。留空会变异 `source_paths` 全域，一轮数小时。
+3. 跑：
+
+   ```bash
+   uv run mutmut run
+   ```
+
+   `--max-children N` 可降并行，代价与理由见第 6 节的假杀死链。
+4. 跑完把 `mutants/**/*.meta` 复制到一个不会被下一次 `mutmut run` 覆盖的地方，这是第 5 节验收要用的基线。首批放在 `research/mutmut-batch-1` 分支的 `baseline/` 下。
+
+`only_mutate` 跑完记得还原成注释，`mutants/` 已在 `.gitignore`。
+
+## 3. 读结果
+
+**从 `.meta` 文件算，不读终端汇总。** 每个源模块在 `mutants/` 里有一份 `<模块>.py.meta`，其中 `exit_code_by_key` 是「mutant 名 → pytest exit code」。mutmut 的终端汇总只枚举它认识的几个 exit code，段错误（−11）之类一个计数器都不落，#2257 就漏过两个。
+
+| exit code | mutmut 的解释 | 本仓库的处理 |
+| --- | --- | --- |
+| 1 | killed | killed |
+| 0 | 存活（🙁） | 存活，进入判定 |
+| 36 / −24 / 24 / 152 / 255 | 超时（⏰） | 按第 4 节新进程复核 |
+| 3 | mutmut 把 pytest 内部错误当 killed | 复核 |
+| 其他（含 −11 段错误、None 未检查） | 可疑或未记 | 复核 |
+
+判据只有一条：**exit code 不等于 1 的一律复核**，复核确认存活的才进入判定。
+
+## 4. 超时的新进程复核
+
+mutmut 用 fork 起子进程，本仓库测试套件里有 fixture 起线程，两者不相容：真正存活的 mutant 会耗满超时预算被记成超时，而不是存活。所以超时不算 killed，要在新进程里只跑关联用例再确认一次，每个 3 到 11 秒。首批的超时与「关联用例集含 `tests/integration/lib/test_script_generator_reference_branch.py`」完全重合（12 对 12，其余 120 个候选零超时），根治见 #2283。
+
+```bash
+# 在项目根跑：tests-for-mutant 读 mutants/mutmut-stats.json，在 mutants/ 里跑会报 Failed to load stats
+uv run mutmut tests-for-mutant lib.speech_rate.x_estimate_spoken_seconds__mutmut_8 > nodeids.txt
+
+# 在 mutants/ 里跑，用 .venv 的解释器，不要用 uv run（见第 6 节）
+cd mutants && MUTANT_UNDER_TEST=lib.speech_rate.x_estimate_spoken_seconds__mutmut_8 \
+  ../.venv/bin/python -m pytest -x -q @../nodeids.txt
+```
+
+pytest 原生支持 `@文件` 读参数，一行一个、原样保留空格和引号，本套件 180 多个含空格或引号的参数化 nodeid 都能过。不要用 `$(cat …)` 或裸 `xargs`：前者在 zsh 下整串成一个参数、pytest 静默跑 0 个用例，后者会把带空格的 nodeid 拆开。
+
+判读：**1 failed 即 killed；全部通过即存活。** 复核确认 killed 的（含段错误之类两头不落的），在第 2 节保存的基线副本里把该 mutant 的 exit code 改成 1，这样第 5 节会把它们归入「基线 killed」那层护栏；确认存活的保持原样。首批 616 个 mutant 里 exit code 不等于 1 的 130 个，复核后 2 个段错误确认 killed、12 个超时全部确认存活。
+
+## 5. 改造后的三层验收
+
+改完断言后，对同一批模块**全量复跑**一次 `mutmut run`，然后比对：
+
+```bash
+uv run python scripts/mutmut_compare.py \
+  --baseline research/mutmut-batch-1/baseline \
+  --current mutants \
+  --reworked reworked.txt \
+  --equivalent equivalent.txt
+```
+
+`reworked.txt` 一行一个本次改造针对的 mutant 名；`equivalent.txt` 可选，一行一个判定为等价变异体的 mutant 名。脚本输出三层表与待复核清单，exit code 0 通过、1 未通过、2 输入不一致（基线与本轮 mutant 名集合不同、名单里的 mutant 不在基线等）。
+
+| 层 | 通过条件 | 未通过怎么办 |
+| --- | --- | --- |
+| 本次改造针对的 mutant | 全部 exit code 1 | 变超时 → 按第 4 节复核，1 failed 即 killed；仍存活 → 四路分诊（见下） |
+| 基线 killed 的 mutant | 没有一个变成 exit code 0 | 变超时 → 新进程复核，1 failed 即护栏成立，只有全部通过才是回退；回退 = 改坏了别的用例 |
+| 基线存活且本次未改造的 mutant | 被杀死只登记 | 判为等价变异体的被杀死 → 整轮作废，先查第 6 节的假杀死链 |
+
+同时有一道独立硬门：`git diff --name-only origin/main` 不得含 `lib/` 与 `server/`。生产代码一变，`mutants/` 重生成、mutant 名错位，比对本身不成立。
+
+**四路分诊**（改造后目标 mutant 仍存活时，一次性判定，补的断言不撤）：断言没写到位、断言没被执行 → 继续修；实际要换输入才能杀死 → 停手，依据是「不做覆盖补偿」；实际是等价变异体 → 停手。
+
+只跑部分模块查不到第二层，复跑取整批模块。
+
+## 6. 已知陷阱
+
+- **假杀死链**（根治见 #2284）。mutmut 默认按 CPU 数 fork 子进程，多个 pytest 会话同时建/清 `pytest-of-<user>/pytest-current` 软链会竞争抛 `FileNotFoundError`；该异常让子进程走异常退出而非 `os._exit`，退出码 1 记成 killed 且 atexit 会跑，`tests/conftest.py` 注册的清理把共享临时库删了，之后所有子进程的会话级 DB fixture 全部报错、整批记 killed。探针是第 5 节第三层：等价变异体不可能被杀，出现即整轮作废。规避是 `mutmut run --max-children 4`，代价是 8 模块复跑从 17:47 变 1:22:36（4.6 倍），因为每个超时都耗满预算，并行度减半后串行叠加。
+- **基线 killed 的 mutant 在并行下也会被记超时。** 关联用例只有几个的 mutant 超时预算极小，pytest 启动开销就能撞线。所以第 5 节第二层把「变超时」列为待复核而不是回退。
+- **不要在 `mutants/` 里跑 `uv run`。** uv 会按那份 `pyproject.toml` 副本另建一个环境，mutmut 不在里面，变异模块顶部的 trampoline import 直接 `ModuleNotFoundError`。用 `../.venv/bin/python`。
+- **`tests-for-mutant` 只在项目根可用。** 它读 `mutants/mutmut-stats.json`，在 `mutants/` 里跑找不到。
+- **`tests/unit/test_skill_script_path_guards.py` 被整体排除**，理由在 `[tool.mutmut]` 注释。排除只会多出假存活（多复核一个），不会造成假杀死。
+- **`timeout_multiplier` 不要调小。** 调小不省时间，只会让已证实的真存活被记成 killed，把无效测试藏起来。
+- **测试选集走全量。** 只跑 `tests/unit` 快 5.5 倍，但约 45% 的存活是假的，每个都要复核一次全量套件，总账更贵。
+
+## 7. 成本参考
+
+首批 8 模块、共 616 个 mutant 的实测：
+
+| 项 | 数值 |
+| --- | ---: |
+| mutant 密度 | 约 1100 个 / 千行源码 |
+| 一轮墙钟（8 路并行） | 65 到 75 分钟 / 千行；墙钟随超时数走，不随 mutant 总数走 |
+| 一轮墙钟（`--max-children 4`） | 上项的 4.6 倍 |
+| 超时新进程复核 | 3 到 11 秒 / 个 |
+| 逐条判定 | 约 3 秒 / 个 |

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -76,7 +76,7 @@ uv run python scripts/mutmut_compare.py \
 | --- | --- | --- |
 | 本次改造针对的 mutant | 全部 exit code 1 | 变超时 → 按第 4 节复核，1 failed 即 killed；仍存活 → 四路分诊（见下） |
 | 基线 killed 的 mutant | 没有一个变成 exit code 0 | 变超时 → 新进程复核，1 failed 即护栏成立，只有全部通过才是回退；回退 = 改坏了别的用例 |
-| 基线存活且本次未改造的 mutant | 被杀死只登记 | 判为等价变异体的被杀死 → 整轮作废，先查第 6 节的假杀死链 |
+| 基线存活且本次未改造的 mutant | 被杀死只登记；等价变异体的 exit code 仍是 0 | 判为等价变异体的被杀死 → 整轮作废，先查第 6 节的假杀死链；等价变异体变超时或段错误 → 按第 4 节复核，1 failed 即被杀死。其余未改造 mutant 的异常 exit code 不影响结论 |
 
 同时有一道独立硬门：`git diff --name-only origin/main` 不得含 `lib/` 与 `server/`。生产代码一变，`mutants/` 重生成、mutant 名错位，比对本身不成立。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ dev = [
     "respx>=0.22.0",
     "deptry>=0.24.0",
 ]
+# 变异测试工具，不进 dev：只在按批次跑 mutmut 时 `uv sync --group mutation` 装入。
+# 独立成组是为了让版本 pin 进 uv.lock、被 dependabot 看到；流程见 docs/testing/mutmut-runbook.md。
+mutation = [
+    "mutmut==3.7.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -183,6 +188,7 @@ DEP002 = [
     "python-multipart", # Starlette 解析 multipart/form-data 的后端
     "socksio",          # httpx 的 SOCKS 代理传输后端
     "lxml",             # BeautifulSoup 的 lxml / lxml-xml 解析器后端
+    "mutmut",           # 变异测试 CLI，源码不 import 它；变异后的模块只在 mutants/ 副本里 import
 ]
 # DEP004（import 了 dev 依赖）——tests/ 与 scripts/ 在扫描范围内，deptry 无法按目录区分
 # dev 与生产文件，故逐项列出它们正当 import 的测试框架包；其余 dev 依赖仍受本规则守护。
@@ -314,6 +320,7 @@ reportMissingImports = "none"
 # 变异测试（mutmut 3.7.0）。不进 dev 依赖，按需 `uv run --with mutmut==3.7.0 mutmut run`。
 # 变异得分是信号不是闸门：不为杀死变异体补写测试，只用存活 mutant 筛选待审查的测试。
 [tool.mutmut]
+# 操作流程（跑一批、超时复核、三层验收、已知陷阱）见 docs/testing/mutmut-runbook.md；这里只写配置项的取舍。
 # 必须显式写：不写时 mutmut 只推断出 lib/，漏掉 server/
 source_paths = ["lib", "server"]
 # 按批次填写待变异模块；留空则变异 source_paths 全域（一轮数小时，不实用）
@@ -326,25 +333,10 @@ source_paths = ["lib", "server"]
 # 排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死（把无效测试藏起来）。
 pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
-# 但候选集约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
+# 但存活集合约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
 # timeout_multiplier / timeout_constant 保持默认（15 / 1.0），不要调小。
-# mutmut 的 fork 模型与本仓库的多线程测试套件不相容，存活 mutant 必然耗满墙钟预算被记成 ⏰；
+# mutmut 的 fork 模型与本仓库的多线程测试套件不相容，存活 mutant 必然耗满墙钟预算被记成超时；
 # 调小预算并不能省时间，只会让已证实的真存活被记成 killed（假杀死），把无效测试藏起来。
-# ⏰ 一律不算 killed，须在新进程里复核（每个 3-11s）。三个前提缺一不可：
-#   1. mutmut 要能被 .venv 的解释器 import——变异后的模块顶部就 import 它的 trampoline：
-#        uv pip install --python .venv mutmut==3.7.0   # 不写进 pyproject，uv sync 会清掉
-#   2. tests-for-mutant 只在项目根可用，在 mutants/ 里跑报 Failed to load stats：
-#        .venv/bin/mutmut tests-for-mutant <名> > /tmp/nodeids.txt
-#   3. nodeid 列表按 NUL 分隔传，既不能用 $(...) 也不能用裸 xargs：
-#      $(...) 在 zsh 下不做词分割（bash 下做），整串成一个参数，pytest 静默报 no tests ran；
-#      裸 xargs 按空白切分并吞掉引号，而本套件有 180+ 个含空格或引号的参数化 nodeid，
-#      例如 test_static_code_enumeration_rejects_partially_dynamic_expressions["a" if cond else "b"-expected1]
-#      会被拆成 5 个参数且丢掉双引号。-0 两者都免疫：
-#        cd mutants && tr '\n' '\0' < /tmp/nodeids.txt \
-#          | xargs -0 env MUTANT_UNDER_TEST=<名> ../.venv/bin/python -m pytest -x -q
-# 复核用 .venv 的解释器而非 uv run。往 also_copy 补 README.md 只能修掉 mutants/ 里
-# uv run 栽在 hatchling 构建这一层：uv 会按那份 pyproject.toml 副本另建一个环境，而 mutmut
-# 按验收标准不在依赖里，变异模块顶部的 trampoline import 照样 ModuleNotFoundError。
 also_copy = [
     "agent_runtime_profile",
     "alembic",

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -49,11 +49,15 @@ class ComparisonReport:
     untouched_total: int = 0
     untouched_killed: list[str] = field(default_factory=list)
     equivalent_killed: list[str] = field(default_factory=list)
+    equivalent_recheck: list[tuple[str, int]] = field(default_factory=list)
 
     @property
     def pending_recheck(self) -> bool:
-        """有 mutant 变成超时之类的非 0/1 exit code，结论要等新进程复核。"""
-        return bool(self.reworked_recheck or self.baseline_killed_recheck)
+        """有 mutant 变成超时之类的非 0/1 exit code，结论要等新进程复核。
+
+        第三层只对等价变异体复核：其余未改造 mutant 被杀只登记，异常 exit code 不影响结论。
+        """
+        return bool(self.reworked_recheck or self.baseline_killed_recheck or self.equivalent_recheck)
 
     @property
     def passed(self) -> bool:
@@ -198,6 +202,8 @@ def compare(
                 report.untouched_killed.append(name)
                 if name in equivalent_set:
                     report.equivalent_killed.append(name)
+            elif after != SURVIVED and name in equivalent_set:
+                report.equivalent_recheck.append((name, _code(after)))
     return report
 
 
@@ -226,7 +232,7 @@ def render(report: ComparisonReport) -> str:
     )
     lines.append(
         f"| 基线存活且未改造的 mutant | {report.untouched_total} | 顺手杀死 {len(report.untouched_killed)}，"
-        f"其中等价变异体 {len(report.equivalent_killed)} |"
+        f"其中等价变异体 {len(report.equivalent_killed)}，等价变异体待复核 {len(report.equivalent_recheck)} |"
     )
 
     _section(lines, "改造后仍存活（改造未生效）", report.reworked_survived)
@@ -239,6 +245,11 @@ def render(report: ComparisonReport) -> str:
     )
     _section(lines, "顺手杀死（只登记）", report.untouched_killed)
     _section(lines, "等价变异体被杀死——整轮作废，先查假杀死链", report.equivalent_killed)
+    _section(
+        lines,
+        "等价变异体待复核（新进程复核，1 failed 即被杀死、整轮作废）",
+        _with_codes(report.equivalent_recheck),
+    )
     lines.append("")
     if report.passed:
         lines.append("验收通过")

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""比对两轮 mutmut 结果，按 CONTRIBUTING「变异测试」的三层验收判据出报告。
+
+输入是两个目录下的 `*.meta` 文件（mutmut 写在 `mutants/` 里，每个源模块一份），
+只读其中的 `exit_code_by_key`（mutant 名 → exit code），不读 mutmut 的终端汇总——
+汇总只枚举它认识的几个 exit code，段错误之类两头不落。
+
+三层：
+1. 本次改造针对的 mutant（`--reworked` 名单）：须全部 killed；
+2. 基线里 killed 的 mutant：不得变成存活；变成超时须新进程复核；
+3. 基线里存活且本次未改造的 mutant：被杀死只登记不报警；
+   其中判为等价变异体的（`--equivalent` 名单）被杀死即整轮作废。
+
+`exit code == 1` 视为 killed，其余一律列为待复核，与 runbook 的判据一致。
+基线与本轮的 mutant 名集合不一致时直接失败：源码一变 `mutants/` 重生成，比对本身不成立。
+
+零第三方依赖。用法见 `--help`，流程见 `docs/testing/mutmut-runbook.md`。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+KILLED = 1
+SURVIVED = 0
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_INVALID = 2
+
+
+@dataclass
+class ComparisonReport:
+    """三层验收的结果。`invalid` 非空时其余字段不可信。"""
+
+    invalid: list[str] = field(default_factory=list)
+    reworked_killed: list[str] = field(default_factory=list)
+    reworked_survived: list[str] = field(default_factory=list)
+    reworked_recheck: list[tuple[str, int]] = field(default_factory=list)
+    baseline_killed_total: int = 0
+    regressed: list[str] = field(default_factory=list)
+    baseline_killed_recheck: list[tuple[str, int]] = field(default_factory=list)
+    untouched_total: int = 0
+    untouched_killed: list[str] = field(default_factory=list)
+    equivalent_killed: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return not (
+            self.invalid or self.reworked_survived or self.reworked_recheck or self.regressed or self.equivalent_killed
+        )
+
+
+def load_exit_codes(root: Path) -> dict[str, int | None]:
+    """合并目录下全部 `*.meta` 的 `exit_code_by_key`。"""
+    merged: dict[str, int | None] = {}
+    for meta in sorted(root.rglob("*.meta")):
+        with meta.open(encoding="utf-8") as f:
+            data = json.load(f)
+        codes = data.get("exit_code_by_key")
+        if not isinstance(codes, dict):
+            raise ValueError(f"{meta} 缺少 exit_code_by_key")
+        for key, code in codes.items():
+            if not isinstance(key, str) or not (code is None or isinstance(code, int)):
+                raise ValueError(f"{meta} 的 exit_code_by_key 含非法项：{key!r}: {code!r}")
+            if key in merged:
+                raise ValueError(f"mutant {key} 在 {root} 下出现多次")
+            merged[key] = code
+    if not merged:
+        raise ValueError(f"{root} 下没有任何 *.meta 或其 exit_code_by_key 为空")
+    return merged
+
+
+def read_names(path: Path) -> list[str]:
+    """一行一个 mutant 名，忽略空行与 `#` 开头的行。"""
+    names: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            names.append(stripped)
+    return names
+
+
+def compare(
+    baseline: Mapping[str, int | None],
+    current: Mapping[str, int | None],
+    reworked: Iterable[str],
+    equivalent: Iterable[str] = (),
+) -> ComparisonReport:
+    reworked_set = set(reworked)
+    equivalent_set = set(equivalent)
+    invalid: list[str] = []
+
+    missing = sorted(set(baseline) - set(current))
+    extra = sorted(set(current) - set(baseline))
+    if missing or extra:
+        invalid.append(
+            f"基线与本轮的 mutant 名集合不一致（基线独有 {len(missing)}，本轮独有 {len(extra)}）：源码变了，先重建基线"
+        )
+        invalid.extend(f"  基线独有 {name}" for name in missing[:10])
+        invalid.extend(f"  本轮独有 {name}" for name in extra[:10])
+    invalid.extend(f"改造名单里的 mutant 不在基线中：{name}" for name in sorted(reworked_set - set(baseline)))
+    invalid.extend(
+        f"改造名单里的 mutant 在基线已是 killed，无从证明改造有效：{name}"
+        for name in sorted(reworked_set & set(baseline))
+        if baseline[name] == KILLED
+    )
+    invalid.extend(
+        f"同一 mutant 既在改造名单又在等价变异体名单：{name}" for name in sorted(equivalent_set & reworked_set)
+    )
+    invalid.extend(f"等价变异体名单里的 mutant 不在基线中：{name}" for name in sorted(equivalent_set - set(baseline)))
+    if invalid:
+        return ComparisonReport(invalid=invalid)
+
+    report = ComparisonReport()
+    for name in sorted(baseline):
+        before = baseline[name]
+        after = current[name]
+        if name in reworked_set:
+            if after == KILLED:
+                report.reworked_killed.append(name)
+            elif after == SURVIVED:
+                report.reworked_survived.append(name)
+            else:
+                report.reworked_recheck.append((name, _code(after)))
+        elif before == KILLED:
+            report.baseline_killed_total += 1
+            if after == SURVIVED:
+                report.regressed.append(name)
+            elif after != KILLED:
+                report.baseline_killed_recheck.append((name, _code(after)))
+        else:
+            report.untouched_total += 1
+            if after == KILLED:
+                report.untouched_killed.append(name)
+                if name in equivalent_set:
+                    report.equivalent_killed.append(name)
+    return report
+
+
+def _code(value: int | None) -> int:
+    # None 是 mutmut 的「未检查」；用一个不与任何真实 exit code 冲突的值占位，让报告可排序可打印。
+    return -1 if value is None else value
+
+
+def render(report: ComparisonReport) -> str:
+    lines: list[str] = []
+    if report.invalid:
+        lines.append("比对无效：")
+        lines.extend(report.invalid)
+        return "\n".join(lines)
+
+    lines.append("| 层 | 数量 | 结果 |")
+    lines.append("| --- | ---: | --- |")
+    reworked_total = len(report.reworked_killed) + len(report.reworked_survived) + len(report.reworked_recheck)
+    lines.append(
+        f"| 本次改造针对的 mutant | {reworked_total} | killed {len(report.reworked_killed)}，"
+        f"存活 {len(report.reworked_survived)}，待复核 {len(report.reworked_recheck)} |"
+    )
+    lines.append(
+        f"| 基线 killed 的 mutant | {report.baseline_killed_total} | 回退 {len(report.regressed)}，"
+        f"待复核 {len(report.baseline_killed_recheck)} |"
+    )
+    lines.append(
+        f"| 基线存活且未改造的 mutant | {report.untouched_total} | 顺手杀死 {len(report.untouched_killed)}，"
+        f"其中等价变异体 {len(report.equivalent_killed)} |"
+    )
+
+    _section(lines, "改造后仍存活（改造未生效）", report.reworked_survived)
+    _section(lines, "改造后待复核（新进程只跑关联用例，1 failed 即 killed）", _with_codes(report.reworked_recheck))
+    _section(lines, "回退（基线 killed、本轮存活）", report.regressed)
+    _section(
+        lines,
+        "基线 killed 变待复核（新进程复核，1 failed 即护栏成立；只有全部通过才是回退）",
+        _with_codes(report.baseline_killed_recheck),
+    )
+    _section(lines, "顺手杀死（只登记）", report.untouched_killed)
+    _section(lines, "等价变异体被杀死——整轮作废，先查假杀死链", report.equivalent_killed)
+    lines.append("")
+    lines.append("验收通过" if report.passed else "验收未通过")
+    return "\n".join(lines)
+
+
+def _with_codes(items: list[tuple[str, int]]) -> list[str]:
+    return [f"{name}  exit code {code}" for name, code in items]
+
+
+def _section(lines: list[str], title: str, items: list[str]) -> None:
+    if not items:
+        return
+    lines.append("")
+    lines.append(f"## {title}（{len(items)}）")
+    lines.extend(f"- {item}" for item in items)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--baseline", type=Path, required=True, help="改造前那轮的 *.meta 所在目录")
+    parser.add_argument("--current", type=Path, required=True, help="改造后复跑的 *.meta 所在目录，通常是 mutants/")
+    parser.add_argument("--reworked", type=Path, required=True, help="本次改造针对的 mutant 名单，一行一个")
+    parser.add_argument("--equivalent", type=Path, help="判为等价变异体的 mutant 名单，一行一个；被杀死即整轮作废")
+    args = parser.parse_args(argv)
+
+    try:
+        baseline = load_exit_codes(args.baseline)
+        current = load_exit_codes(args.current)
+        reworked = read_names(args.reworked)
+        equivalent = read_names(args.equivalent) if args.equivalent else []
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"读取输入失败：{exc}", file=sys.stderr)
+        return EXIT_INVALID
+
+    report = compare(baseline, current, reworked, equivalent)
+    print(render(report))
+    if report.invalid:
+        return EXIT_INVALID
+    return EXIT_OK if report.passed else EXIT_FAILED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -11,7 +11,7 @@
 3. 基线里存活且本次未改造的 mutant：被杀死只登记不报警；
    其中判为等价变异体的（`--equivalent` 名单）被杀死即整轮作废。
 
-`exit code == 1` 视为 killed，其余一律列为待复核，与 runbook 的判据一致。
+`exit code == 1` 视为 killed，其余一律列为待复核，与 runbook 的判据一致；有待复核项时不判通过。
 基线与本轮的 mutant 名集合不一致时直接失败：源码一变 `mutants/` 重生成，比对本身不成立。
 
 零第三方依赖。用法见 `--help`，流程见 `docs/testing/mutmut-runbook.md`。
@@ -50,9 +50,14 @@ class ComparisonReport:
     equivalent_killed: list[str] = field(default_factory=list)
 
     @property
+    def pending_recheck(self) -> bool:
+        """有 mutant 变成超时之类的非 0/1 exit code，结论要等新进程复核。"""
+        return bool(self.reworked_recheck or self.baseline_killed_recheck)
+
+    @property
     def passed(self) -> bool:
         return not (
-            self.invalid or self.reworked_survived or self.reworked_recheck or self.regressed or self.equivalent_killed
+            self.invalid or self.reworked_survived or self.regressed or self.equivalent_killed or self.pending_recheck
         )
 
 
@@ -182,7 +187,12 @@ def render(report: ComparisonReport) -> str:
     _section(lines, "顺手杀死（只登记）", report.untouched_killed)
     _section(lines, "等价变异体被杀死——整轮作废，先查假杀死链", report.equivalent_killed)
     lines.append("")
-    lines.append("验收通过" if report.passed else "验收未通过")
+    if report.passed:
+        lines.append("验收通过")
+    elif report.reworked_survived or report.regressed or report.equivalent_killed:
+        lines.append("验收未通过")
+    else:
+        lines.append("验收未完成：有待复核项，新进程复核后按结果改基线或改本轮 .meta 再比对")
     return "\n".join(lines)
 
 

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -12,7 +12,8 @@
    其中判为等价变异体的（`--equivalent` 名单）被杀死即整轮作废。
 
 `exit code == 1` 视为 killed，其余一律列为待复核，与 runbook 的判据一致；有待复核项时不判通过。
-基线与本轮的 mutant 名集合不一致时直接失败：源码一变 `mutants/` 重生成，比对本身不成立。
+基线与本轮的 mutant 名集合不一致、或同名函数的源码哈希不同时直接失败：源码一变 `mutants/` 重生成，比对本身不成立；
+改造名单为空同样视为无效输入。
 
 零第三方依赖。用法见 `--help`，流程见 `docs/testing/mutmut-runbook.md`。
 """
@@ -61,24 +62,47 @@ class ComparisonReport:
         )
 
 
-def load_exit_codes(root: Path) -> dict[str, int | None]:
-    """合并目录下全部 `*.meta` 的 `exit_code_by_key`。"""
-    merged: dict[str, int | None] = {}
+@dataclass(frozen=True)
+class MetaSnapshot:
+    """一轮 mutmut 的结果：mutant 名 → exit code，以及被变异函数的源码哈希。"""
+
+    exit_codes: Mapping[str, int | None]
+    function_hashes: Mapping[str, str]
+
+
+def load_meta(root: Path) -> MetaSnapshot:
+    """合并目录下全部 `*.meta` 的 `exit_code_by_key` 与 `hash_by_function_name`。
+
+    哈希以「模块.函数」为键：mutant 名是 `lib.a.x_f__mutmut_3`，同一 .meta 里的 `hash_by_function_name`
+    键是 `x_f`，模块前缀取自该文件的 mutant 名。
+    """
+    exit_codes: dict[str, int | None] = {}
+    function_hashes: dict[str, str] = {}
     for meta in sorted(root.rglob("*.meta")):
         with meta.open(encoding="utf-8") as f:
             data = json.load(f)
         codes = data.get("exit_code_by_key")
-        if not isinstance(codes, dict):
-            raise ValueError(f"{meta} 缺少 exit_code_by_key")
+        hashes = data.get("hash_by_function_name", {})
+        if not isinstance(codes, dict) or not isinstance(hashes, dict):
+            raise ValueError(f"{meta} 缺少 exit_code_by_key 或 hash_by_function_name 不是对象")
+        modules: set[str] = set()
         for key, code in codes.items():
             if not isinstance(key, str) or not (code is None or isinstance(code, int)):
                 raise ValueError(f"{meta} 的 exit_code_by_key 含非法项：{key!r}: {code!r}")
-            if key in merged:
+            if key in exit_codes:
                 raise ValueError(f"mutant {key} 在 {root} 下出现多次")
-            merged[key] = code
-    if not merged:
+            exit_codes[key] = code
+            modules.add(key.partition("__mutmut_")[0].rpartition(".")[0])
+        if len(modules) > 1:
+            raise ValueError(f"{meta} 混有多个模块的 mutant：{sorted(modules)}")
+        module = modules.pop() if modules else ""
+        for func, digest in hashes.items():
+            if not isinstance(func, str) or not isinstance(digest, str):
+                raise ValueError(f"{meta} 的 hash_by_function_name 含非法项：{func!r}: {digest!r}")
+            function_hashes[f"{module}.{func}" if module else func] = digest
+    if not exit_codes:
         raise ValueError(f"{root} 下没有任何 *.meta 或其 exit_code_by_key 为空")
-    return merged
+    return MetaSnapshot(exit_codes=exit_codes, function_hashes=function_hashes)
 
 
 def read_names(path: Path) -> list[str]:
@@ -96,11 +120,26 @@ def compare(
     current: Mapping[str, int | None],
     reworked: Iterable[str],
     equivalent: Iterable[str] = (),
+    *,
+    baseline_hashes: Mapping[str, str] | None = None,
+    current_hashes: Mapping[str, str] | None = None,
 ) -> ComparisonReport:
     reworked_set = set(reworked)
     equivalent_set = set(equivalent)
     invalid: list[str] = []
 
+    if not reworked_set:
+        invalid.append("改造名单为空：没有任何 mutant 可验收，检查名单文件是否生成正确")
+    changed_functions = sorted(
+        func
+        for func, digest in (baseline_hashes or {}).items()
+        if func in (current_hashes or {}) and (current_hashes or {})[func] != digest
+    )
+    if changed_functions:
+        invalid.append(
+            f"基线与本轮有 {len(changed_functions)} 个函数源码哈希不同：mutant 名可能没变但语义已变，先重建基线"
+        )
+        invalid.extend(f"  源码已变 {func}" for func in changed_functions[:10])
     missing = sorted(set(baseline) - set(current))
     extra = sorted(set(current) - set(baseline))
     if missing or extra:
@@ -217,15 +256,22 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        baseline = load_exit_codes(args.baseline)
-        current = load_exit_codes(args.current)
+        baseline = load_meta(args.baseline)
+        current = load_meta(args.current)
         reworked = read_names(args.reworked)
         equivalent = read_names(args.equivalent) if args.equivalent else []
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"读取输入失败：{exc}", file=sys.stderr)
         return EXIT_INVALID
 
-    report = compare(baseline, current, reworked, equivalent)
+    report = compare(
+        baseline.exit_codes,
+        current.exit_codes,
+        reworked,
+        equivalent,
+        baseline_hashes=baseline.function_hashes,
+        current_hashes=current.function_hashes,
+    )
     print(render(report))
     if report.invalid:
         return EXIT_INVALID

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -11,7 +11,7 @@
 3. 基线里存活且本次未改造的 mutant：被杀死只登记不报警；
    其中判为等价变异体的（`--equivalent` 名单）被杀死即整轮作废。
 
-`exit code == 1` 视为 killed，其余一律列为待复核，与 runbook 的判据一致；有待复核项时不判通过。
+`exit code == 1` 视为 killed，`0` 视为存活，其余列为待复核，与 runbook 的判据一致；有待复核项时不判通过。
 基线与本轮的 mutant 名集合不一致、或同名函数的源码哈希不同时直接失败：源码一变 `mutants/` 重生成，比对本身不成立；
 改造名单为空同样视为无效输入。
 
@@ -176,6 +176,11 @@ def compare(
         f"同一 mutant 既在改造名单又在等价变异体名单：{name}" for name in sorted(equivalent_set & reworked_set)
     )
     invalid.extend(f"等价变异体名单里的 mutant 不在基线中：{name}" for name in sorted(equivalent_set - set(baseline)))
+    invalid.extend(
+        f"等价变异体名单里的 mutant 在基线已是 killed：等价变异体不可能被杀，基线本身可疑，先查假杀死链：{name}"
+        for name in sorted(equivalent_set & set(baseline))
+        if baseline[name] == KILLED
+    )
     if invalid:
         return ComparisonReport(invalid=invalid)
 

--- a/scripts/mutmut_compare.py
+++ b/scripts/mutmut_compare.py
@@ -74,7 +74,8 @@ def load_meta(root: Path) -> MetaSnapshot:
     """合并目录下全部 `*.meta` 的 `exit_code_by_key` 与 `hash_by_function_name`。
 
     哈希以「模块.函数」为键：mutant 名是 `lib.a.x_f__mutmut_3`，同一 .meta 里的 `hash_by_function_name`
-    键是 `x_f`，模块前缀取自该文件的 mutant 名。
+    键是 `x_f`，模块前缀取自该文件的 mutant 名。缺少 `hash_by_function_name`、或有 mutant 对应的函数
+    没有哈希，一律拒绝：源码哈希核对是比对有效性的前提，缺项会让它静默失效。
     """
     exit_codes: dict[str, int | None] = {}
     function_hashes: dict[str, str] = {}
@@ -82,9 +83,9 @@ def load_meta(root: Path) -> MetaSnapshot:
         with meta.open(encoding="utf-8") as f:
             data = json.load(f)
         codes = data.get("exit_code_by_key")
-        hashes = data.get("hash_by_function_name", {})
+        hashes = data.get("hash_by_function_name")
         if not isinstance(codes, dict) or not isinstance(hashes, dict):
-            raise ValueError(f"{meta} 缺少 exit_code_by_key 或 hash_by_function_name 不是对象")
+            raise ValueError(f"{meta} 缺少 exit_code_by_key 或 hash_by_function_name")
         modules: set[str] = set()
         for key, code in codes.items():
             if not isinstance(key, str) or not (code is None or isinstance(code, int)):
@@ -96,6 +97,9 @@ def load_meta(root: Path) -> MetaSnapshot:
         if len(modules) > 1:
             raise ValueError(f"{meta} 混有多个模块的 mutant：{sorted(modules)}")
         module = modules.pop() if modules else ""
+        unhashed = sorted({key.partition("__mutmut_")[0].rpartition(".")[2] for key in codes} - set(hashes))
+        if unhashed:
+            raise ValueError(f"{meta} 的 hash_by_function_name 缺少 mutant 对应的函数：{unhashed}")
         for func, digest in hashes.items():
             if not isinstance(func, str) or not isinstance(digest, str):
                 raise ValueError(f"{meta} 的 hash_by_function_name 含非法项：{func!r}: {digest!r}")
@@ -140,6 +144,16 @@ def compare(
             f"基线与本轮有 {len(changed_functions)} 个函数源码哈希不同：mutant 名可能没变但语义已变，先重建基线"
         )
         invalid.extend(f"  源码已变 {func}" for func in changed_functions[:10])
+    if baseline_hashes is not None or current_hashes is not None:
+        hash_only_baseline = sorted(set(baseline_hashes or {}) - set(current_hashes or {}))
+        hash_only_current = sorted(set(current_hashes or {}) - set(baseline_hashes or {}))
+        if hash_only_baseline or hash_only_current:
+            invalid.append(
+                f"基线与本轮的函数哈希集合不一致（基线独有 {len(hash_only_baseline)}，"
+                f"本轮独有 {len(hash_only_current)}）：源码变了或 .meta 不完整，先重建基线"
+            )
+            invalid.extend(f"  基线独有哈希 {func}" for func in hash_only_baseline[:10])
+            invalid.extend(f"  本轮独有哈希 {func}" for func in hash_only_current[:10])
     missing = sorted(set(baseline) - set(current))
     extra = sorted(set(current) - set(baseline))
     if missing or extra:

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -57,6 +57,18 @@ def test_baseline_killed_turning_survived_is_regression_but_timeout_is_recheck()
     assert report.baseline_killed_recheck == [("lib.b.x_g__mutmut_1", 36)]
 
 
+def test_baseline_killed_timeout_alone_blocks_the_verdict_until_rechecked() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_2": 1, "lib.b.x_g__mutmut_1": -24}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2"])
+
+    assert not report.passed
+    assert report.pending_recheck
+    assert report.regressed == []
+    assert report.baseline_killed_recheck == [("lib.b.x_g__mutmut_1", -24)]
+    assert render(report).splitlines()[-1].startswith("验收未完成")
+
+
 def test_killed_equivalent_mutant_invalidates_the_round() -> None:
     current = {**_BASELINE, "lib.a.x_f__mutmut_2": 1, "lib.a.x_f__mutmut_5": 1}
 

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -82,6 +82,19 @@ def test_killed_equivalent_mutant_invalidates_the_round() -> None:
     assert "整轮作废" in render(report)
 
 
+def test_equivalent_mutant_with_abnormal_exit_code_blocks_the_verdict_until_rechecked() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_2": 1, "lib.a.x_f__mutmut_5": -11, "lib.a.x_f__mutmut_4": 36}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2"], equivalent=["lib.a.x_f__mutmut_5"])
+
+    assert not report.passed
+    assert report.pending_recheck
+    assert report.equivalent_recheck == [("lib.a.x_f__mutmut_5", -11)]
+    assert report.untouched_killed == []
+    assert "等价变异体待复核 1" in render(report)
+    assert "验收未完成" in render(report)
+
+
 @pytest.mark.parametrize(
     ("current", "reworked", "equivalent", "expected_fragment"),
     [

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -103,6 +103,12 @@ def test_equivalent_mutant_with_abnormal_exit_code_blocks_the_verdict_until_rech
         (dict(_BASELINE), ["lib.a.x_f__mutmut_1"], [], "在基线已是 killed"),
         (dict(_BASELINE), ["lib.a.x_f__mutmut_2"], ["lib.a.x_f__mutmut_2"], "既在改造名单又在等价变异体名单"),
         (dict(_BASELINE), [], [], "改造名单为空"),
+        (
+            dict(_BASELINE),
+            ["lib.a.x_f__mutmut_2"],
+            ["lib.b.x_g__mutmut_1"],
+            "等价变异体名单里的 mutant 在基线已是 killed",
+        ),
     ],
 )
 def test_inconsistent_inputs_make_the_comparison_invalid(

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.mutmut_compare import EXIT_FAILED, EXIT_INVALID, EXIT_OK, compare, load_exit_codes, main, render
+from scripts.mutmut_compare import EXIT_FAILED, EXIT_INVALID, EXIT_OK, compare, load_meta, main, render
 
 _BASELINE = {
     "lib.a.x_f__mutmut_1": 1,
@@ -17,9 +17,9 @@ _BASELINE = {
 }
 
 
-def _write_meta(root: Path, name: str, codes: dict[str, int | None]) -> None:
+def _write_meta(root: Path, name: str, codes: dict[str, int | None], hashes: dict[str, str] | None = None) -> None:
     root.mkdir(parents=True, exist_ok=True)
-    payload = {"exit_code_by_key": codes, "hash_by_function_name": {}}
+    payload = {"exit_code_by_key": codes, "hash_by_function_name": hashes or {}}
     (root / name).write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -87,6 +87,7 @@ def test_killed_equivalent_mutant_invalidates_the_round() -> None:
         (dict(_BASELINE), ["lib.zzz__mutmut_9"], [], "不在基线中：lib.zzz__mutmut_9"),
         (dict(_BASELINE), ["lib.a.x_f__mutmut_1"], [], "在基线已是 killed"),
         (dict(_BASELINE), ["lib.a.x_f__mutmut_2"], ["lib.a.x_f__mutmut_2"], "既在改造名单又在等价变异体名单"),
+        (dict(_BASELINE), [], [], "改造名单为空"),
     ],
 )
 def test_inconsistent_inputs_make_the_comparison_invalid(
@@ -99,24 +100,63 @@ def test_inconsistent_inputs_make_the_comparison_invalid(
     assert report.reworked_killed == []
 
 
-def test_load_exit_codes_merges_meta_files_recursively_and_rejects_duplicates(tmp_path: Path) -> None:
-    _write_meta(tmp_path / "lib", "a.py.meta", {"lib.a.x_f__mutmut_1": 1, "lib.a.x_f__mutmut_2": None})
-    _write_meta(tmp_path / "server", "b.py.meta", {"server.b.x_g__mutmut_1": 0})
+def test_changed_function_hash_invalidates_even_when_mutant_names_match() -> None:
+    hashes_before = {"lib.a.x_f": "h1", "lib.b.x_g": "h2"}
+    hashes_after = {"lib.a.x_f": "h1-changed", "lib.b.x_g": "h2"}
 
-    assert load_exit_codes(tmp_path) == {
+    report = compare(
+        _BASELINE,
+        {**_BASELINE, "lib.a.x_f__mutmut_2": 1},
+        reworked=["lib.a.x_f__mutmut_2"],
+        baseline_hashes=hashes_before,
+        current_hashes=hashes_after,
+    )
+
+    assert not report.passed
+    assert report.invalid == [
+        "基线与本轮有 1 个函数源码哈希不同：mutant 名可能没变但语义已变，先重建基线",
+        "  源码已变 lib.a.x_f",
+    ]
+
+
+def test_load_meta_merges_meta_files_recursively_and_rejects_duplicates(tmp_path: Path) -> None:
+    _write_meta(tmp_path / "lib", "a.py.meta", {"lib.a.x_f__mutmut_1": 1, "lib.a.x_f__mutmut_2": None}, {"x_f": "h1"})
+    _write_meta(tmp_path / "server", "b.py.meta", {"server.b.x_g__mutmut_1": 0}, {"x_g": "h2"})
+
+    snapshot = load_meta(tmp_path)
+
+    assert snapshot.exit_codes == {
         "lib.a.x_f__mutmut_1": 1,
         "lib.a.x_f__mutmut_2": None,
         "server.b.x_g__mutmut_1": 0,
     }
+    assert snapshot.function_hashes == {"lib.a.x_f": "h1", "server.b.x_g": "h2"}
 
     _write_meta(tmp_path / "dup", "a.py.meta", {"lib.a.x_f__mutmut_1": 1})
     with pytest.raises(ValueError, match=r"lib\.a\.x_f__mutmut_1 在 .* 下出现多次"):
-        load_exit_codes(tmp_path)
+        load_meta(tmp_path)
+
+
+def test_load_meta_rejects_meta_file_mixing_modules(tmp_path: Path) -> None:
+    _write_meta(tmp_path, "mixed.py.meta", {"lib.a.x_f__mutmut_1": 1, "lib.b.x_g__mutmut_1": 0}, {"x_f": "h1"})
+
+    with pytest.raises(ValueError, match=r"混有多个模块的 mutant：\['lib\.a', 'lib\.b'\]"):
+        load_meta(tmp_path)
+
+
+def _write_round(root: Path, codes: dict[str, int | None], hashes: dict[str, str] | None = None) -> None:
+    """按真实 mutmut 的布局落盘：一个源模块一份 .meta。"""
+    for module in {key.partition("__mutmut_")[0].rpartition(".")[0] for key in codes}:
+        module_codes = {key: code for key, code in codes.items() if key.startswith(f"{module}.")}
+        module_hashes = {
+            func.rpartition(".")[2]: digest for func, digest in (hashes or {}).items() if func.startswith(f"{module}.")
+        }
+        _write_meta(root, f"{module}.py.meta", module_codes, module_hashes)
 
 
 def test_main_exit_codes_follow_verdict(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    _write_meta(tmp_path / "baseline", "a.py.meta", _BASELINE)
-    _write_meta(tmp_path / "current", "a.py.meta", {**_BASELINE, "lib.a.x_f__mutmut_2": 1})
+    _write_round(tmp_path / "baseline", _BASELINE)
+    _write_round(tmp_path / "current", {**_BASELINE, "lib.a.x_f__mutmut_2": 1})
     reworked = tmp_path / "reworked.txt"
     reworked.write_text("# 本次改造\nlib.a.x_f__mutmut_2\n\n", encoding="utf-8")
     args = ["--baseline", str(tmp_path / "baseline"), "--current", str(tmp_path / "current"), "--reworked"]
@@ -130,6 +170,12 @@ def test_main_exit_codes_follow_verdict(tmp_path: Path, capsys: pytest.CaptureFi
 
     reworked.write_text("lib.a.x_f__mutmut_1\n", encoding="utf-8")
     assert main([*args, str(reworked)]) == EXIT_INVALID
+
+    reworked.write_text("lib.a.x_f__mutmut_2\n", encoding="utf-8")
+    _write_round(tmp_path / "baseline", _BASELINE, {"lib.a.x_f": "h1"})
+    _write_round(tmp_path / "current", {**_BASELINE, "lib.a.x_f__mutmut_2": 1}, {"lib.a.x_f": "h1-changed"})
+    assert main([*args, str(reworked)]) == EXIT_INVALID
+    assert "源码已变 lib.a.x_f" in capsys.readouterr().out
 
     assert main([*args, str(tmp_path / "missing.txt")]) == EXIT_INVALID
     assert "读取输入失败" in capsys.readouterr().err

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -18,8 +18,10 @@ _BASELINE = {
 
 
 def _write_meta(root: Path, name: str, codes: dict[str, int | None], hashes: dict[str, str] | None = None) -> None:
+    """按真实 .meta 的形状落盘：每个 mutant 对应的函数都有哈希，未指定的用占位值。"""
     root.mkdir(parents=True, exist_ok=True)
-    payload = {"exit_code_by_key": codes, "hash_by_function_name": hashes or {}}
+    derived = {key.partition("__mutmut_")[0].rpartition(".")[2]: "h" for key in codes}
+    payload = {"exit_code_by_key": codes, "hash_by_function_name": {**derived, **(hashes or {})}}
     (root / name).write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -117,6 +119,34 @@ def test_changed_function_hash_invalidates_even_when_mutant_names_match() -> Non
         "基线与本轮有 1 个函数源码哈希不同：mutant 名可能没变但语义已变，先重建基线",
         "  源码已变 lib.a.x_f",
     ]
+
+
+def test_mismatched_function_hash_sets_invalidate_the_comparison() -> None:
+    report = compare(
+        _BASELINE,
+        {**_BASELINE, "lib.a.x_f__mutmut_2": 1},
+        reworked=["lib.a.x_f__mutmut_2"],
+        baseline_hashes={"lib.a.x_f": "h1", "lib.b.x_g": "h2"},
+        current_hashes={"lib.a.x_f": "h1"},
+    )
+
+    assert not report.passed
+    assert report.invalid == [
+        "基线与本轮的函数哈希集合不一致（基线独有 1，本轮独有 0）：源码变了或 .meta 不完整，先重建基线",
+        "  基线独有哈希 lib.b.x_g",
+    ]
+
+
+def test_load_meta_rejects_meta_without_hash_for_every_mutant(tmp_path: Path) -> None:
+    payload = {"exit_code_by_key": {"lib.a.x_f__mutmut_1": 1}}
+    (tmp_path / "a.py.meta").write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match=r"缺少 exit_code_by_key 或 hash_by_function_name"):
+        load_meta(tmp_path)
+
+    payload["hash_by_function_name"] = {"x_other": "h1"}
+    (tmp_path / "a.py.meta").write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match=r"hash_by_function_name 缺少 mutant 对应的函数：\['x_f'\]"):
+        load_meta(tmp_path)
 
 
 def test_load_meta_merges_meta_files_recursively_and_rejects_duplicates(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_mutmut_compare.py
+++ b/tests/unit/scripts/test_mutmut_compare.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.mutmut_compare import EXIT_FAILED, EXIT_INVALID, EXIT_OK, compare, load_exit_codes, main, render
+
+_BASELINE = {
+    "lib.a.x_f__mutmut_1": 1,
+    "lib.a.x_f__mutmut_2": 0,
+    "lib.a.x_f__mutmut_3": 36,
+    "lib.a.x_f__mutmut_4": 0,
+    "lib.a.x_f__mutmut_5": 0,
+    "lib.b.x_g__mutmut_1": 1,
+}
+
+
+def _write_meta(root: Path, name: str, codes: dict[str, int | None]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    payload = {"exit_code_by_key": codes, "hash_by_function_name": {}}
+    (root / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_all_three_layers_pass_and_incidental_kills_are_only_recorded() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_2": 1, "lib.a.x_f__mutmut_4": 1}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2"])
+
+    assert report.passed
+    assert report.reworked_killed == ["lib.a.x_f__mutmut_2"]
+    assert report.baseline_killed_total == 2
+    assert report.regressed == []
+    assert report.untouched_total == 3
+    assert report.untouched_killed == ["lib.a.x_f__mutmut_4"]
+    assert report.equivalent_killed == []
+
+
+def test_reworked_mutant_still_surviving_fails_and_timeouts_go_to_recheck() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_2": 0, "lib.a.x_f__mutmut_4": -24}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2", "lib.a.x_f__mutmut_4"])
+
+    assert not report.passed
+    assert report.reworked_survived == ["lib.a.x_f__mutmut_2"]
+    assert report.reworked_recheck == [("lib.a.x_f__mutmut_4", -24)]
+
+
+def test_baseline_killed_turning_survived_is_regression_but_timeout_is_recheck() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_1": 0, "lib.b.x_g__mutmut_1": 36, "lib.a.x_f__mutmut_2": 1}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2"])
+
+    assert not report.passed
+    assert report.regressed == ["lib.a.x_f__mutmut_1"]
+    assert report.baseline_killed_recheck == [("lib.b.x_g__mutmut_1", 36)]
+
+
+def test_killed_equivalent_mutant_invalidates_the_round() -> None:
+    current = {**_BASELINE, "lib.a.x_f__mutmut_2": 1, "lib.a.x_f__mutmut_5": 1}
+
+    report = compare(_BASELINE, current, reworked=["lib.a.x_f__mutmut_2"], equivalent=["lib.a.x_f__mutmut_5"])
+
+    assert not report.passed
+    assert report.untouched_killed == ["lib.a.x_f__mutmut_5"]
+    assert report.equivalent_killed == ["lib.a.x_f__mutmut_5"]
+    assert "整轮作废" in render(report)
+
+
+@pytest.mark.parametrize(
+    ("current", "reworked", "equivalent", "expected_fragment"),
+    [
+        ({**_BASELINE, "lib.c.x_h__mutmut_1": 1}, ["lib.a.x_f__mutmut_2"], [], "本轮独有 lib.c.x_h__mutmut_1"),
+        (dict(_BASELINE), ["lib.zzz__mutmut_9"], [], "不在基线中：lib.zzz__mutmut_9"),
+        (dict(_BASELINE), ["lib.a.x_f__mutmut_1"], [], "在基线已是 killed"),
+        (dict(_BASELINE), ["lib.a.x_f__mutmut_2"], ["lib.a.x_f__mutmut_2"], "既在改造名单又在等价变异体名单"),
+    ],
+)
+def test_inconsistent_inputs_make_the_comparison_invalid(
+    current: dict[str, int | None], reworked: list[str], equivalent: list[str], expected_fragment: str
+) -> None:
+    report = compare(_BASELINE, current, reworked=reworked, equivalent=equivalent)
+
+    assert not report.passed
+    assert any(expected_fragment in line for line in report.invalid)
+    assert report.reworked_killed == []
+
+
+def test_load_exit_codes_merges_meta_files_recursively_and_rejects_duplicates(tmp_path: Path) -> None:
+    _write_meta(tmp_path / "lib", "a.py.meta", {"lib.a.x_f__mutmut_1": 1, "lib.a.x_f__mutmut_2": None})
+    _write_meta(tmp_path / "server", "b.py.meta", {"server.b.x_g__mutmut_1": 0})
+
+    assert load_exit_codes(tmp_path) == {
+        "lib.a.x_f__mutmut_1": 1,
+        "lib.a.x_f__mutmut_2": None,
+        "server.b.x_g__mutmut_1": 0,
+    }
+
+    _write_meta(tmp_path / "dup", "a.py.meta", {"lib.a.x_f__mutmut_1": 1})
+    with pytest.raises(ValueError, match=r"lib\.a\.x_f__mutmut_1 在 .* 下出现多次"):
+        load_exit_codes(tmp_path)
+
+
+def test_main_exit_codes_follow_verdict(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_meta(tmp_path / "baseline", "a.py.meta", _BASELINE)
+    _write_meta(tmp_path / "current", "a.py.meta", {**_BASELINE, "lib.a.x_f__mutmut_2": 1})
+    reworked = tmp_path / "reworked.txt"
+    reworked.write_text("# 本次改造\nlib.a.x_f__mutmut_2\n\n", encoding="utf-8")
+    args = ["--baseline", str(tmp_path / "baseline"), "--current", str(tmp_path / "current"), "--reworked"]
+
+    assert main([*args, str(reworked)]) == EXIT_OK
+    assert "验收通过" in capsys.readouterr().out
+
+    reworked.write_text("lib.a.x_f__mutmut_2\nlib.a.x_f__mutmut_4\n", encoding="utf-8")
+    assert main([*args, str(reworked)]) == EXIT_FAILED
+    assert "改造后仍存活" in capsys.readouterr().out
+
+    reworked.write_text("lib.a.x_f__mutmut_1\n", encoding="utf-8")
+    assert main([*args, str(reworked)]) == EXIT_INVALID
+
+    assert main([*args, str(tmp_path / "missing.txt")]) == EXIT_INVALID
+    assert "读取输入失败" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,10 @@ requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -244,6 +246,9 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
+mutation = [
+    { name = "mutmut" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -302,6 +307,7 @@ dev = [
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.16.0" },
 ]
+mutation = [{ name = "mutmut", specifier = "==3.7.0" }]
 
 [[package]]
 name = "argon2-cffi"
@@ -1548,6 +1554,69 @@ wheels = [
 ]
 
 [[package]]
+name = "libcst"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/098e5c91ff1537f00c85a6438b6cb1863d17144680cc91f47c87f104a200/libcst-1.9.0.tar.gz", hash = "sha256:087b58a9afe076bb08e2d726478e1f16cb928d67ffa9092817e033c335de522a", size = 914739, upload-time = "2026-07-29T21:28:43.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/bb/d22c37c33dfe18084634f5ef89f8f0749ffe7b6e0ad312722aafd86bbbdb/libcst-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd1a3500c41784075c4946a995d5ad89f68fa0d226b63ff3c4d78f6ea6dd23e5", size = 2043159, upload-time = "2026-07-29T19:24:49.013Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b8/2dedef84d72e7271119217503b69ed6dc5d0b2077685e163caae669d9c70/libcst-1.9.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:611cebd3bbc2014576f4dcc7b845b3c594c96ddc287a3db9b78f22eff156a7d3", size = 2203245, upload-time = "2026-07-29T19:24:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/90/e02ac2dad647423f947bb11f8322bfdba8ccfdd380e6c7b695add2d1acd4/libcst-1.9.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8d731abe1307720ea1a52d447555e8443a6d130e0e520243c0634a58f6edbc9d", size = 2255388, upload-time = "2026-07-29T19:24:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5f/6089a51518cfd2ff40950eb26bcc36951d7b6d4f4213568aa0290265aff7/libcst-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5351d92ca6ac1cc32e097700e1161ad1ceaa4d9b2cca5abadb1e94576b325", size = 2268982, upload-time = "2026-07-29T19:24:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/78/26881ec466fb70cbc129dca26ccb5a52a0061face2c5822e4b61f00f9699/libcst-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03165a264653bb77f6a11b412ae09c08bdb0c25864f3b8d42b816ac64b9d4b9e", size = 2378174, upload-time = "2026-07-29T19:24:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/7a/a4dba5f11faf12a12ffba06d18019987851aab33b590242a602ffd4fb1bd/libcst-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:b755ed4a4bc2faee849b54820023137d60d4c199e0a0822f0ff0c1bc49e49b48", size = 2103462, upload-time = "2026-07-29T19:24:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/13/57cb129093e0d6744b3c914ba6cbbdf51ed1b2c823882936c553a3a0cf1b/libcst-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e50576bad7d56459d9792cd0b0dfe5469dad13646e9a9c0a8b1ba20b269f332", size = 1979825, upload-time = "2026-07-29T19:24:58.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b1/befc0544283bb3923a928accf79ed685e5a725524bdb3491826670affc07/libcst-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8b9df30f524317b097dc53065b25dda33d6a4cc3c7c8bf4fc83ca7559c58cc0", size = 2043754, upload-time = "2026-07-29T19:24:59.885Z" },
+    { url = "https://files.pythonhosted.org/packages/45/50/fef7c172a8457c95894edf5fb04805024899cdfea41fa01b0636587b79e1/libcst-1.9.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e465a7bc9c2b9533eb9e06d2391f8819f811b5112919d4064c9fb8565aaafa08", size = 2203548, upload-time = "2026-07-29T19:25:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/764cd2be1fd99d774fc44039c319dc0ed1d9d9afeaa02759a05121cccd4b/libcst-1.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8504b422c95676a8c27b517e1ac01413ece91bf356865c587ca9bdcd5708a2f7", size = 2255274, upload-time = "2026-07-29T19:25:02.764Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a7/474748a27a02fa83e3556b260d5f5236ca48164fa7beffecf3b2cad24dca/libcst-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bcb9f9d4fcfe2ec7a40d2c26e03a538d5d9dc189c38551eb3f94ab661afee7c0", size = 2269126, upload-time = "2026-07-29T19:25:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b7/655e45363b8cf87b91e41e060b21c89e5316c7ef36eb14a1a498b27bb71e/libcst-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8d671c39a431c309476099b8ec811e412503ec0f4465f6fc907cb51c70e8e6b", size = 2378602, upload-time = "2026-07-29T19:25:06.424Z" },
+    { url = "https://files.pythonhosted.org/packages/db/13/6da63f0902ece43bf9d737017251ad7ad06edd9d3c4e1856450403cb4473/libcst-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:4d382fba04077eb556a1ea4295a4482e192aa93639c5a07ba0885841965ea0c0", size = 2103486, upload-time = "2026-07-29T19:25:07.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/dccb1a55e38b4e47256a97242d61d2bef5366c744faf88fb087d4fa0f995/libcst-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:a621e261990148c1cfbe26c1798bd2375c131cf358a44a7a4659fc41c1a336e1", size = 1979907, upload-time = "2026-07-29T19:25:09.532Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2a/4943c71d90975bc59034a057dea346b365c276f308c1d31f5cf2bd85492d/libcst-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eccf4c57d273cdd3fe1c67b72cf9bb1bbd4547aa011824e96ccf5b7136057aa4", size = 2044529, upload-time = "2026-07-29T19:25:11.04Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1168b98c2a0f338be3a44753647baab051feaf6167cc887bf4447f8fd920/libcst-1.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32395244edfe6538e0ea2bf82051d60103d3f54861274805c4fb3745efb70a85", size = 2203519, upload-time = "2026-07-29T19:25:12.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7d/2eaa697a80f899bcf2245680bbfcc1e478eb3b3328c21d4b2880bdf00dac/libcst-1.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:444e84c76cd035cd2fe136838c1a524d34b08216521f6f5093df8a6f6cfa5799", size = 2255879, upload-time = "2026-07-29T19:25:14.137Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/793b9fd96dd52d202f5f2b88d7e54f05ebed767d1bb3b32395a1817bf6ab/libcst-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb5d0946f2b4c6711b5d69fe4f833b364f9e7a1a2b08f88b98619dc18975099a", size = 2269807, upload-time = "2026-07-29T19:25:15.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/1bc7aaea03971c45e8a885fed9fc1c73176dbbd00b0296a3cde9529bafd6/libcst-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45808c03528b3ad40b14095348a918e08d98c47b4a125d631cb78e817c0a5b16", size = 2378171, upload-time = "2026-07-29T19:25:17.289Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f7/bc49e367d2bc8817213594dd52cf6b2da2dbbda90b5382d60653999274ac/libcst-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:568288cdbfe3b4ca3ae4852cb0a439ff053dd54c841bc4995bf2b71238b5de40", size = 2177847, upload-time = "2026-07-29T19:25:19.35Z" },
+    { url = "https://files.pythonhosted.org/packages/87/80/4d81577a22e6d535d1a3409f3a1c6903e09036f0e17fc47f92169dbc3501/libcst-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:107593af46945593e7825821793393262bc4fa1d3ea24c3ed487b61269bbbdf8", size = 2058134, upload-time = "2026-07-29T19:25:20.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7f/c3f3a0e7a1a2adaa76e815e82a7814d6bfe7d49432276bba652248c68d0b/libcst-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f6248cb07444ab9a6733a855737a9febed8b9adca51347019348b09a3ac7dfe9", size = 2036102, upload-time = "2026-07-29T19:25:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/af/2f5543255b2c7d749b966adeccc6bfb1652cf8b425afb913d0f3f025a865/libcst-1.9.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:496c24e0d3240bc7da45dae543aff3f5b6509978c39262d6b84ed2fb999dded2", size = 2194806, upload-time = "2026-07-29T19:25:24.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/03f4cddce426d005e208b39ea7b2d456e667cdee0f1891360f0fc8430f20/libcst-1.9.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ea490fa8540503db5f321f0268becab46eb50f710e8cec8041e241fd66f6874f", size = 2246762, upload-time = "2026-07-29T19:25:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/31/9d5fe1e43dc3dbcc74f70f3e0e73fcdd8d84effc1059d8b45974f0d0d2eb/libcst-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50ab94bb2524b419056d4003032b8c67102ac800f8d85b3c4260a01746d94dbb", size = 2259633, upload-time = "2026-07-29T19:25:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/6752b28d88c3a19b3bc0b9e1838443b6760d5c862b4f4b37955402659e24/libcst-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a2faaf92500d0226358125630f5aab4758e8aad3f2d70a10892ec3c700781a54", size = 2368043, upload-time = "2026-07-29T19:25:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/94/775825b2637f8ab05694b6a4b3802ae6783b4e799f9b58d2400c7e2d4369/libcst-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c7b548512db25af9c2997a95fa731bd6b6928ecbad6c0915d7482d8bb42d34f", size = 2176432, upload-time = "2026-07-29T19:25:29.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/88ad67427c6fd9db929e087912b0a540e5140e5cb77e7ca4170edaac8531/libcst-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:497d5329345f1f5df84e41b0bbd00204b64a2fd30dfe3cfaeaebca633a31e877", size = 2052931, upload-time = "2026-07-29T19:25:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/ad790b043a38b10cea13166c8dd716654ad8b227c20f12eebf6326191cd9/libcst-1.9.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:a5068bf6114f6f4d79af7a6c80a28d1deb50441150ea1db13b5458ab34bec159", size = 2043987, upload-time = "2026-08-11T05:54:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/d3cd8275cc54ffc9817ade91442b3e6e9edd1a4518bd4e6dda13e3152dbe/libcst-1.9.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:7acfd18adcdd32dcf41ce676cf121002afcbe9ad2c72dc0c18d78465beedc228", size = 2204003, upload-time = "2026-08-11T05:54:04.031Z" },
+    { url = "https://files.pythonhosted.org/packages/da/62/87eddccb11d5d221d50ac4fff4b6e9b8d48c547028d01f7d0fbc5c8a1d75/libcst-1.9.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:86361e2b426bd1b403e52375703c8b764e226e571adcb30442510710681edbf0", size = 2256053, upload-time = "2026-08-11T05:54:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/a44126aeb9fca8b4e342e0cc803ea00ca8f6cd5712619a7897b3eba13797/libcst-1.9.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8c14abe844bec8b021111b3985474e49f5af799c020e8e40dedcac87c97a40c5", size = 2270576, upload-time = "2026-08-11T05:54:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/51/3af3dd44b117d66486e0ed61e43a16b7fc8cc5c372e1dd4ca0e70b888d46/libcst-1.9.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:8930971d2299b7006bb5d10c10038f44efb6da89d5bca2823595e31a9cdb96af", size = 2378573, upload-time = "2026-08-11T05:54:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e8/e545087d298dbf6494e84a8092f0f5dbd62eedacabd4ecd6b364367b4804/libcst-1.9.0-cp315-cp315-win_amd64.whl", hash = "sha256:5891ce9cff815077614f509e3a23888c5ddb8081d6188e8ba1172c0ccc369022", size = 2177937, upload-time = "2026-08-11T05:54:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/84/17/93a00a8e03494a84db102dd0e3d35b8876b1084ca2c194b331a168d86eb1/libcst-1.9.0-cp315-cp315-win_arm64.whl", hash = "sha256:1260b5d070a3324447a53a00387225a55472a62077ce01922d30a2a78cc4b138", size = 2058633, upload-time = "2026-08-11T05:54:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/c3751b12eb81822ea0b6131d374a98bc6c024c4b9ec5f6ea8f53dc23e967/libcst-1.9.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:02ee2dbdb5c218116f16a021350fc267a14be205b50d81c33f5d73857ab6fbf7", size = 2036178, upload-time = "2026-08-11T05:54:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/48ff486eb5adc593f4818569e8896b74b672414ab4722a74b17e4c4cf31e/libcst-1.9.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:3e5b684191a0462b2d40a73261ea7f4da6a49e7a030b7e0fceca46bebb51dfe5", size = 2195496, upload-time = "2026-08-11T05:54:17.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/18/b13a4669864d41a4801fed7b86ede1049dc9a1e1dde250a7ee1f9c3b1285/libcst-1.9.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:2b150c4f298fe54eb0fe73abf71f57db74d070796140a8c206c9615b6861f01e", size = 2245769, upload-time = "2026-08-11T05:54:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c7/cf2d46744825e84afbd7228fdeeea8d23cf6c4b2074253c27efb7705c653/libcst-1.9.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:50b913e37187f00a6fb88962009364e1cf1b1284aa1762304f34b52b972f2218", size = 2260576, upload-time = "2026-08-11T05:54:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/5433d3d62250b2e4325938db101766bcab2a006819684713bcccb6259a88/libcst-1.9.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9f92c75283030fd58fb7d6e560168a00381e0e3368ec8a026a3ec8a828a05f93", size = 2368709, upload-time = "2026-08-11T05:54:23.276Z" },
+    { url = "https://files.pythonhosted.org/packages/87/39/9f0e1690727623f99489895db0e42048a3e1e8cea0627517c593e437fd83/libcst-1.9.0-cp315-cp315t-win_amd64.whl", hash = "sha256:4adf97bb1aff8039b0bd4991e2f838be6e4fad552821b26b71a5d1a653c2582f", size = 2177866, upload-time = "2026-08-11T05:54:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/79/9dc7811883e67ea771057e8937bc536eb3e77f3635fc5a93cd85b6fe1ea8/libcst-1.9.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8f0dd08a5773d7051e105250b2a2c73d8065ea9b2d68e7e1bdc5244660e75f93", size = 2052908, upload-time = "2026-08-11T05:54:26.835Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1693,6 +1762,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -1779,6 +1853,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -1887,6 +1973,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f9/a63500696f3f35c443ef566528e55630bf7e064436416278927f7bc9c408/mutmut-3.7.0.tar.gz", hash = "sha256:dc93260fabb3a6fd3693aa8d1746825885cb6f9e66c7f9cc1a0f34fc6388e14a", size = 63735, upload-time = "2026-07-31T10:52:58.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/16/93e3e6aa30e5bc4141724463ae9d9bcc283d08b02aa85dbf5a2b665f3108/mutmut-3.7.0-py3-none-any.whl", hash = "sha256:1d2f9a1bfa4a474b2213df6b17223150b492bf4a85af0eda4fb322297337fb32", size = 59070, upload-time = "2026-07-31T10:53:00.005Z" },
 ]
 
 [[package]]
@@ -2680,6 +2783,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2955,6 +3082,64 @@ wheels = [
 ]
 
 [[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3075,6 +3260,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3172,7 +3374,7 @@ name = "uiautomation"
 version = "2.0.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comtypes" },
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/23/8238b5cb73e54c3618ce4d443c1830a2749264a0d61a9b61637096b8dc7a/uiautomation-2.0.29.tar.gz", hash = "sha256:3c169112043ce21065aead1d79c3baebdafc9cf03bd24ded02b2db11d423d88d", size = 203970, upload-time = "2025-08-05T05:14:41.194Z" }
 wheels = [

--- a/website/scripts/sync-contributing.mjs
+++ b/website/scripts/sync-contributing.mjs
@@ -28,6 +28,7 @@ const ANCHORS = new Map([
   ["### 共享设施", "shared-test-fixtures"],
   ["### 时序与偶发失败", "timing-and-flakiness"],
   ["### 覆盖率", "coverage"],
+  ["### 变异测试", "mutation-testing"],
   ["### 闸门", "test-gates"],
   ["### 前端测试（vitest）", "frontend-vitest"],
   ["## 代码质量", "code-quality"],


### PR DESCRIPTION
## 背景

mutmut 首批治理（#2257 / #2263）沉淀出的操作配方与验收判据此前只活在 `pyproject.toml` 的 `[tool.mutmut]` 注释里（30 行，只有打开 pyproject 的人看得到）。本 PR 按 #2281 的决议把它们落到该在的位置。

## 改动

- **CONTRIBUTING「测试」章新增「变异测试」小节**：只写规范——变异得分是信号不是闸门；存活 mutant 只是送上审查台，处置走既有三步处置，覆盖补偿与等价变异体不处置；超时不算 killed；三层验收判据。文档站 `sync-contributing.mjs` 锚点表同步登记 `mutation-testing`。
- **新增 `docs/testing/mutmut-runbook.md`**（内部文档，不上站）：跑一批、从 `.meta` 的 `exit_code_by_key` 读结果（exit code ≠ 1 一律复核）、超时的新进程复核、三层验收、已知陷阱、成本参考。超时复核改用 pytest 原生 `@文件` 传 nodeid（已实测含三个空格的参数化 id 原样收集），去掉原来 `tr '\n' '\0' | xargs -0` 那套。
- **新增 `scripts/mutmut_compare.py` + 测试**：读两轮 `.meta`，按「本次改造针对的 / 基线 killed 的 / 基线存活且未改造的」三层出报告；基线 killed 变超时列为待复核而非回退；等价变异体被杀即整轮作废；基线与本轮 mutant 名集合不一致直接拒绝。已用首批真实基线（616 个 mutant）冒烟。
- **mutmut 进独立依赖组 `mutation`**（`uv sync --group mutation`），不进 dev；pin 进 `uv.lock`，dependabot 可见；deptry DEP002 豁免。实测普通 `uv run` 不会清掉它。`[tool.mutmut]` 注释缩成配置取舍并指向 runbook。

不新增术语：runbook 只用 mutmut 原生词（killed / 存活 / 超时）与 CONTRIBUTING 既有的三步处置编号。

## 验证

- `ruff check` / `ruff format` / `basedpyright --warnings`（0/0/0）/ `lint-imports` / `deptry` 通过
- `uv run python -m pytest -n 4 --dist loadfile`：11290 passed, 3 skipped（改了 pyproject，跑全量）
- `scripts/audit_tests.py --check`：0 违规
- `(cd website && pnpm check)` 通过，`sync-contributing` 产出含 `### 变异测试 {#mutation-testing}`

Refs #2281

https://claude.ai/code/session_018ehN37nRfeqKUHP8P9aCQR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增变异测试结果比较工具，可生成 Markdown 报告并识别已杀死、存活及待复核的变异体。
  * 比较结果会校验测试快照与源码一致性，发现异常时阻止验收通过。
  * 增加变异测试依赖配置，便于执行相关检查。

* **文档**
  * 新增中文变异测试操作手册，涵盖环境准备、执行流程、结果判读、超时复核及验收步骤。
  * 明确退出码为 0 表示测试全部通过，无需额外复核。
  * 为贡献指南中的变异测试章节增加可引用锚点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->