### PR TITLE
test(mutmut): 会话按进程隔离临时目录与临时库回收，不再需要 --max-children

### DIFF
--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -22,7 +22,7 @@ uv sync --group mutation
    uv run mutmut run
    ```
 
-   `--max-children N` 可降并行，代价与理由见第 6 节的假杀死链。
+   并行度默认取 CPU 数，不用降。各 pytest 会话的临时目录与临时库回收由 `tests/conftest.py` 按进程隔离，并行子进程之间不共享清理动作。
 4. 跑完把 `mutants/**/*.meta` 复制到一个不会被下一次 `mutmut run` 覆盖的地方，这是第 5 节验收要用的基线。首批放在 `research/mutmut-batch-1` 分支的 `baseline/` 下。
 
 `only_mutate` 跑完记得还原成注释，`mutants/` 已在 `.gitignore`。
@@ -76,7 +76,7 @@ uv run python scripts/mutmut_compare.py \
 | --- | --- | --- |
 | 本次改造针对的 mutant | 全部 exit code 1 | 变超时 → 按第 4 节复核，1 failed 即 killed；仍存活 → 四路分诊（见下） |
 | 基线 killed 的 mutant | 没有一个变成 exit code 0 | 变超时 → 新进程复核，1 failed 即护栏成立，只有全部通过才是回退；回退 = 改坏了别的用例 |
-| 基线存活且本次未改造的 mutant | 被杀死只登记；等价变异体的 exit code 仍是 0 | 判为等价变异体的被杀死 → 整轮作废，先查第 6 节的假杀死链；等价变异体变超时或段错误 → 按第 4 节复核，1 failed 即被杀死。其余未改造 mutant 的异常 exit code 不影响结论 |
+| 基线存活且本次未改造的 mutant | 被杀死只登记；等价变异体的 exit code 仍是 0 | 判为等价变异体的被杀死 → 整轮作废：等价变异体不可能被杀，说明这轮子进程的结果不可信（如异常退出被记成 killed）；等价变异体变超时或段错误 → 按第 4 节复核，1 failed 即被杀死。其余未改造 mutant 的异常 exit code 不影响结论 |
 
 同时有一道独立硬门：`git diff --name-only origin/main` 不得含 `lib/` 与 `server/`。生产代码一变，`mutants/` 重生成、mutant 名错位，比对本身不成立。
 
@@ -86,7 +86,6 @@ uv run python scripts/mutmut_compare.py \
 
 ## 6. 已知陷阱
 
-- **假杀死链**（根治见 #2284）。mutmut 默认按 CPU 数 fork 子进程，多个 pytest 会话同时建/清 `pytest-of-<user>/pytest-current` 软链会竞争抛 `FileNotFoundError`；该异常让子进程走异常退出而非 `os._exit`，退出码 1 记成 killed 且 atexit 会跑，`tests/conftest.py` 注册的清理把共享临时库删了，之后所有子进程的会话级 DB fixture 全部报错、整批记 killed。探针是第 5 节第三层：等价变异体不可能被杀，出现即整轮作废。规避是 `mutmut run --max-children 4`，代价是并行度减半；超时归零前曾量到 4.6 倍（每个超时耗满预算、串行叠加），归零后按并行度反比估。
 - **新增的测试文件不触及任何被变异函数时，增量 stats 会中止。** mutmut 检测到新用例只对它们跑一次 stats，若这批用例没碰到任何 mutant，报 `Stopping early, because we could not find any test case for any mutant` 退出。删 `mutants/mutmut-stats.json` 走全量 stats。
 - **不要在 `mutants/` 里跑 `uv run`。** uv 会按那份 `pyproject.toml` 副本另建一个环境，mutmut 不在里面，变异模块顶部的 trampoline import 直接 `ModuleNotFoundError`。用 `../.venv/bin/python`。
 - **`tests-for-mutant` 只在项目根可用。** 它读 `mutants/mutmut-stats.json`，在 `mutants/` 里跑找不到。
@@ -102,6 +101,5 @@ uv run python scripts/mutmut_compare.py \
 | --- | ---: |
 | mutant 密度 | 约 1100 个 / 千行源码 |
 | 一轮墙钟（8 路并行） | 8 模块 616 个 mutant 约 10 分钟（不含全量 stats 约 5 分钟）；超时归零前是 17:47，墙钟随超时数走 |
-| 一轮墙钟（`--max-children 4`） | 按并行度反比估；超时归零前量到 8 路的 4.6 倍 |
 | 超时新进程复核 | 3 到 11 秒 / 个 |
 | 逐条判定 | 约 3 秒 / 个 |

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -22,7 +22,7 @@ uv sync --group mutation
    uv run mutmut run
    ```
 
-   并行度默认取 CPU 数，不用降。各 pytest 会话的临时目录与临时库回收由 `tests/conftest.py` 按进程隔离，并行子进程之间不共享清理动作。
+   并行度默认取 CPU 数，不用降。各会话的临时目录由 `tests/mutmut_plugin.py`（经 `[tool.mutmut] pytest_add_cli_args` 加载）设为私有，临时库回收由 `tests/conftest.py` 按创建者进程守卫，并行子进程之间不共享清理动作。
 4. 跑完把 `mutants/**/*.meta` 复制到一个不会被下一次 `mutmut run` 覆盖的地方，这是第 5 节验收要用的基线。首批放在 `research/mutmut-batch-1` 分支的 `baseline/` 下。
 
 `only_mutate` 跑完记得还原成注释，`mutants/` 已在 `.gitignore`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,9 @@ source_paths = ["lib", "server"]
 # 这些子进程确实会 import lib.project_manager / lib.script_models，排除后由它们独家覆盖的
 # mutant 会掉进存活集合；但保留同样杀不死——子进程在断言前就崩在上面那个 import。
 # 排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死（把无效测试藏起来）。
-pytest_add_cli_args = ["--ignore=tests/unit/test_skill_script_path_guards.py"]
+# tests.mutmut_plugin 给每个 mutmut 会话一个私有 basetemp，让并行子进程收尾时不再竞争共享根下的软链；
+# 它只在这里加载，本地与 CI 的 pytest 不带它。
+pytest_add_cli_args = ["-p", "tests.mutmut_plugin", "--ignore=tests/unit/test_skill_script_path_guards.py"]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
 # 但存活集合约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
 # timeout_multiplier / timeout_constant 保持默认（15 / 1.0），不要调小。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,24 +77,6 @@ def _discard_pooled_connections_in_forked_child() -> None:
 _fork_hook_registered = False
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_configure(config: pytest.Config) -> None:
-    """mutmut 会话各用一个私有 basetemp，不进共享的 ``pytest-of-<user>`` 根。
-
-    mutmut 按 mutant fork 出多个 pytest 会话并行跑，它们在会话收尾时同时清理共享根下的
-    ``pytest-current`` 软链，竞争抛出的 ``FileNotFoundError`` 从 ``pytest.main`` 冒出，
-    让子进程走正常退出路径、退出码 1 记成 killed。显式给定的 basetemp 不登记任何清理，
-    收尾时无事可做；目录由本会话在 unconfigure 时自己回收。``MUTANT_UNDER_TEST`` 由
-    mutmut 在其进程内设置（stats、forced-fail 与各 mutant 子进程），本地 pytest 不受影响。
-    ``tryfirst`` 使赋值先于 pytest 自带 tmpdir 插件读取 ``config.option.basetemp``。
-    """
-    if not os.environ.get("MUTANT_UNDER_TEST") or config.option.basetemp is not None:
-        return
-    private_basetemp = Path(tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-"))
-    config.option.basetemp = private_basetemp
-    config.add_cleanup(lambda: shutil.rmtree(private_basetemp, ignore_errors=True))
-
-
 @pytest.fixture(scope="session", autouse=True)
 def discard_pooled_connections_after_fork() -> None:
     """把 ``_discard_pooled_connections_in_forked_child`` 挂到本进程的 fork 钩子上。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,28 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 # 从而每个进程都独占一个库。
 _OWNED_DB_MARKER = "ARCREEL_TEST_OWNED_DB"
 _OWNED_TEST_DB_DIR: str | None = None
+_OWNED_TEST_DB_OWNER_PID = os.getpid()
+
+
+def _remove_owned_test_db_dir() -> None:
+    """只在铸造临时库的进程里回收它。
+
+    atexit 登记表随 fork 复制到子进程。mutmut 按 mutant fork 出的 pytest 会话若走了
+    正常退出路径而非 ``os._exit``，会带着父进程的登记表跑一遍；不设 pid 守卫时它会
+    删掉所有并行子进程共用的库，之后每个子进程的会话级 DB fixture 都报错。
+    """
+    if _OWNED_TEST_DB_DIR is None or os.getpid() != _OWNED_TEST_DB_OWNER_PID:
+        return
+    shutil.rmtree(_OWNED_TEST_DB_DIR, ignore_errors=True)
+
+
 if not os.environ.get("DATABASE_URL", "").strip() or os.environ.get(_OWNED_DB_MARKER) == "1":
     _OWNED_TEST_DB_DIR = tempfile.mkdtemp(prefix="arcreel-test-db-")
     os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{_OWNED_TEST_DB_DIR}/.arcreel.db"
     os.environ[_OWNED_DB_MARKER] = "1"
     # 回收挂在 atexit 而非 fixture teardown 上：`--collect-only`（CI 的分类 marker 闸门）
     # 与收集期中断都只 import conftest、不跑 fixture。
-    atexit.register(shutil.rmtree, _OWNED_TEST_DB_DIR, ignore_errors=True)
+    atexit.register(_remove_owned_test_db_dir)
 
 import lib.generation_queue as generation_queue_module
 from lib.db.base import Base
@@ -60,6 +75,24 @@ def _discard_pooled_connections_in_forked_child() -> None:
 
 
 _fork_hook_registered = False
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """mutmut 会话各用一个私有 basetemp，不进共享的 ``pytest-of-<user>`` 根。
+
+    mutmut 按 mutant fork 出多个 pytest 会话并行跑，它们在会话收尾时同时清理共享根下的
+    ``pytest-current`` 软链，竞争抛出的 ``FileNotFoundError`` 从 ``pytest.main`` 冒出，
+    让子进程走正常退出路径、退出码 1 记成 killed。显式给定的 basetemp 不登记任何清理，
+    收尾时无事可做；目录由本会话在 unconfigure 时自己回收。``MUTANT_UNDER_TEST`` 由
+    mutmut 在其进程内设置（stats、forced-fail 与各 mutant 子进程），本地 pytest 不受影响。
+    ``tryfirst`` 使赋值先于 pytest 自带 tmpdir 插件读取 ``config.option.basetemp``。
+    """
+    if not os.environ.get("MUTANT_UNDER_TEST") or config.option.basetemp is not None:
+        return
+    private_basetemp = tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-")
+    config.option.basetemp = private_basetemp
+    config.add_cleanup(lambda: shutil.rmtree(private_basetemp, ignore_errors=True))
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     if not os.environ.get("MUTANT_UNDER_TEST") or config.option.basetemp is not None:
         return
-    private_basetemp = tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-")
+    private_basetemp = Path(tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-"))
     config.option.basetemp = private_basetemp
     config.add_cleanup(lambda: shutil.rmtree(private_basetemp, ignore_errors=True))
 

--- a/tests/integration/test_conftest_fork_isolation.py
+++ b/tests/integration/test_conftest_fork_isolation.py
@@ -1,0 +1,84 @@
+"""根 conftest 在 mutmut 的 fork 模型下保持进程隔离。
+
+mutmut 在一个父进程里跑过 stats 之后，按 mutant fork 出多个 pytest 会话并行跑，子进程
+继承父进程的 atexit 登记表与 conftest 模块状态。两条契约：走正常退出路径的子进程不得
+删掉各子进程共用的临时库；带 ``MUTANT_UNDER_TEST`` 的会话各用私有 basetemp，不进共享
+的 ``pytest-of-<user>`` 根，多个会话收尾时不再竞争同一条软链。
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SQLITE_URL_PREFIX = "sqlite+aiosqlite:///"
+_PROBE_ENV = "ARCREEL_BASETEMP_PROBE"
+
+
+def _owned_test_db_dir() -> Path:
+    url = os.environ.get("DATABASE_URL", "")
+    if not url.startswith(_SQLITE_URL_PREFIX):
+        pytest.skip("DATABASE_URL 由外部给定，conftest 不持有临时库")
+    return Path(url.removeprefix(_SQLITE_URL_PREFIX)).parent
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="平台无 fork")
+def test_forked_child_running_atexit_handlers_keeps_shared_test_db_dir():
+    db_dir = _owned_test_db_dir()
+    assert db_dir.is_dir()
+
+    pid = os.fork()
+    if pid == 0:  # pragma: no cover - 子进程
+        # 正常退出路径会跑 atexit 登记表；这里显式跑一遍再 ``os._exit``，
+        # 免得子进程沿 pytest 的调用栈把整个会话再跑一遍。
+        try:
+            atexit._run_exitfuncs()
+        except BaseException:
+            os._exit(3)
+        os._exit(0)
+
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert db_dir.is_dir()
+
+
+def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path):
+    if os.environ.get(_PROBE_ENV):
+        # 子进程里的探针：本会话的 tmp_path 不在 pytest 会建共享根的 temproot 之下。
+        assert not tmp_path.is_relative_to(os.environ["PYTEST_DEBUG_TEMPROOT"])
+        return
+
+    temproot = tmp_path / "temproot"
+    temproot.mkdir()
+    tmpdir = tmp_path / "tmpdir"
+    tmpdir.mkdir()
+    env = {
+        **os.environ,
+        _PROBE_ENV: "1",
+        "MUTANT_UNDER_TEST": "probe",
+        "PYTEST_DEBUG_TEMPROOT": str(temproot),
+        "TMPDIR": str(tmpdir),
+    }
+    nodeid = (
+        f"{Path(__file__).relative_to(_REPO_ROOT)}"
+        f"::{test_mutmut_session_uses_private_basetemp_outside_shared_root.__name__}"
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", nodeid],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=90,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    # 共享根从未被建立；私有 basetemp 与临时库都已由该会话自己回收。
+    assert list(temproot.iterdir()) == []
+    assert list(tmpdir.iterdir()) == []

--- a/tests/integration/test_conftest_fork_isolation.py
+++ b/tests/integration/test_conftest_fork_isolation.py
@@ -66,7 +66,7 @@ def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path
         "TMPDIR": str(tmpdir),
     }
     nodeid = (
-        f"{Path(__file__).relative_to(_REPO_ROOT)}"
+        f"{Path(__file__).relative_to(_REPO_ROOT).as_posix()}"
         f"::{test_mutmut_session_uses_private_basetemp_outside_shared_root.__name__}"
     )
     result = subprocess.run(

--- a/tests/integration/test_mutmut_fork_isolation.py
+++ b/tests/integration/test_mutmut_fork_isolation.py
@@ -1,9 +1,10 @@
-"""根 conftest 在 mutmut 的 fork 模型下保持进程隔离。
+"""测试设施在 mutmut 的 fork 模型下保持进程隔离。
 
 mutmut 在一个父进程里跑过 stats 之后，按 mutant fork 出多个 pytest 会话并行跑，子进程
 继承父进程的 atexit 登记表与 conftest 模块状态。两条契约：走正常退出路径的子进程不得
-删掉各子进程共用的临时库；带 ``MUTANT_UNDER_TEST`` 的会话各用私有 basetemp，不进共享
-的 ``pytest-of-<user>`` 根，多个会话收尾时不再竞争同一条软链。
+删掉各子进程共用的临时库（根 conftest）；mutmut 会话各用私有 basetemp，不进共享的
+``pytest-of-<user>`` 根，多个会话收尾时不再竞争同一条软链（`tests/mutmut_plugin.py`，
+经 ``[tool.mutmut] pytest_add_cli_args`` 加载）。
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import atexit
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -19,6 +21,7 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SQLITE_URL_PREFIX = "sqlite+aiosqlite:///"
 _PROBE_ENV = "ARCREEL_BASETEMP_PROBE"
+_MUTMUT_PLUGIN = "tests.mutmut_plugin"
 
 
 def _owned_test_db_dir() -> Path:
@@ -26,6 +29,14 @@ def _owned_test_db_dir() -> Path:
     if not url.startswith(_SQLITE_URL_PREFIX):
         pytest.skip("DATABASE_URL 由外部给定，conftest 不持有临时库")
     return Path(url.removeprefix(_SQLITE_URL_PREFIX)).parent
+
+
+def _mutmut_pytest_args() -> list[str]:
+    """mutmut 实际附加给每个 pytest 会话的参数，插件由此接入而非由测试自行加载。"""
+    with (_REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        args: list[str] = tomllib.load(fh)["tool"]["mutmut"]["pytest_add_cli_args"]
+    assert args[args.index("-p") + 1] == _MUTMUT_PLUGIN
+    return args
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="平台无 fork")
@@ -51,7 +62,7 @@ def test_forked_child_running_atexit_handlers_keeps_shared_test_db_dir():
 def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path):
     if os.environ.get(_PROBE_ENV):
         # 子进程里的探针：本会话的 tmp_path 不在 pytest 会建共享根的 temproot 之下。
-        assert not tmp_path.is_relative_to(os.environ["PYTEST_DEBUG_TEMPROOT"])
+        assert not tmp_path.is_relative_to(Path(os.environ["PYTEST_DEBUG_TEMPROOT"]).resolve())
         return
 
     temproot = tmp_path / "temproot"
@@ -61,7 +72,6 @@ def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path
     env = {
         **os.environ,
         _PROBE_ENV: "1",
-        "MUTANT_UNDER_TEST": "probe",
         "PYTEST_DEBUG_TEMPROOT": str(temproot),
         "TMPDIR": str(tmpdir),
     }
@@ -70,7 +80,7 @@ def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path
         f"::{test_mutmut_session_uses_private_basetemp_outside_shared_root.__name__}"
     )
     result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", nodeid],
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *_mutmut_pytest_args(), nodeid],
         cwd=str(_REPO_ROOT),
         env=env,
         capture_output=True,

--- a/tests/mutmut_plugin.py
+++ b/tests/mutmut_plugin.py
@@ -1,0 +1,30 @@
+"""mutmut 拉起的 pytest 会话各用一个私有 basetemp，不进共享的 ``pytest-of-<user>`` 根。
+
+只由 ``pyproject.toml`` 的 ``[tool.mutmut] pytest_add_cli_args`` 以 ``-p tests.mutmut_plugin``
+加载，本地与 CI 的 pytest 不加载它。
+
+mutmut 按 mutant fork 出多个 pytest 会话并行跑，它们在会话收尾时同时清理共享根下的
+``pytest-current`` 软链，竞争抛出的 ``FileNotFoundError`` 从 ``pytest.main`` 冒出，让子进程
+走正常退出路径、退出码 1 记成 killed。显式给定的 basetemp 不登记任何清理，收尾时无事可做；
+目录由本会话在 unconfigure 时自己回收。
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """``tryfirst`` 使赋值先于 pytest 自带 tmpdir 插件读取 ``config.option.basetemp``。
+
+    该选项经命令行解析后是 str，xdist 派给 worker 的也是 str，这里保持同一类型。
+    """
+    if config.option.basetemp is not None:
+        return
+    private_basetemp = tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-")
+    config.option.basetemp = private_basetemp
+    config.add_cleanup(lambda: shutil.rmtree(private_basetemp, ignore_errors=True))


### PR DESCRIPTION
## 背景

mutmut 按 mutant fork 出多个 pytest 会话并行跑，它们在 `pytest_sessionfinish` 里同时清理共享根 `pytest-of-<user>` 下的 `pytest-current` 软链。pytest 9.1.1 的 `cleanup_dead_symlinks` 对 `unlink()` 无保护，竞争抛出的 `FileNotFoundError` 从 `pytest.main` 冒出，子进程走正常退出路径而非 `os._exit`：退出码 1 记成 killed，且 atexit 跑掉 conftest 登记的 `rmtree`，删掉所有并行子进程共用的临时库，此后整批记 killed（#2263 曳光弹第一轮 302 个）。当前规避是 `--max-children 4`。

## 改动

不改生产代码，本地 pytest 与 xdist 行为不变：

- **临时库回收加创建者 pid 守卫**（`tests/conftest.py`）：atexit 登记表随 fork 复制到子进程，守卫后子进程不再有权删共享库（断链）。
- **mutmut 会话各用私有 basetemp**（`tests/mutmut_plugin.py`）：`pytest_configure(tryfirst)` 给 `config.option.basetemp` 指一个 `mkdtemp` 目录，`config.add_cleanup` 回收。显式 basetemp 下 pytest 不登记任何软链清理，竞争本身消失。插件只由 `[tool.mutmut] pytest_add_cli_args` 以 `-p tests.mutmut_plugin` 加载，本地与 CI 的 pytest 不带它；外部已给 basetemp 时不介入。

回归用例 `tests/integration/test_mutmut_fork_isolation.py`：fork 子进程跑 atexit 登记表后共享库仍在；按 pyproject 里 mutmut 实际附加的参数起的子进程会话不在 `PYTEST_DEBUG_TEMPROOT` 下建目录、退出后私有目录与临时库零残留。去掉任一修复即失败。

runbook 删掉「假杀死链」段落与 `--max-children` 引用。

## 验收（#2284 票面判据）

首批 8 模块 616 个 mutant **不带 `--max-children`**（8 路）全量复跑，与 #2283 收尾的基线逐条比对：

| 项 | 结果 |
| --- | --- |
| exit code 逐条相同 | 616 / 616（534 killed / 82 存活 / 0 超时） |
| 源码哈希与 mutant 名集合 | 相同 |
| 基线存活被「顺手杀死」 | 0 / 82 |
| 临时目录残留（basetemp / 临时库） | 0 |
| 墙钟 | 8:36（含增量 stats） |

插件化后（453ab85ce）以 `lib/speech_rate.py` 38 个 mutant 实跑复核：exit code 与基线逐条相同，temproot 未被建立，basetemp 零残留。

## 闸门

ruff / basedpyright / lint-imports / deptry / `audit_tests.py --check` 通过；`pytest -n 4 --dist loadfile` 11301 passed。

Closes #2284

https://claude.ai/code/session_01JH2pznYnVBuhw7nALjbGVE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 提升并行变异测试的进程隔离性，避免临时目录竞争导致测试进程被误判为失败。
  - 改进测试临时数据库的清理机制，防止子进程退出时误删共享资源。

- **文档**
  - 更新变异测试运行指南，补充当前并行度、临时目录隔离与资源回收规则。
  - 移除已不适用的并行参数说明及相关故障排查指引。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
