### PR TITLE
test(custom-provider): 视频包装层链式构造后断言保留供应商名，并修复 mutmut 子进程在 macOS 的段错误

### DIFF
--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -27,6 +27,8 @@ uv sync --group mutation
 
 `only_mutate` 跑完记得还原成注释，`mutants/` 已在 `.gitignore`。
 
+**凡读源码文本而不是 import 模块的测试，都要在 `pytest_add_cli_args` 里 `--ignore`。** `mutants/` 里的源文件同时含所有 mutant 变体（每个字符串字面量都多出 `XXfooXX` / `FOO` 两份），任何用正则扫 `lib/` `server/` 源码字面量再比对登记表的用例都会在 stats 阶段报「未登记」，整轮起不来。已排除的是 `tests/integration/lib/test_task_failure_capability.py`；新加排除时在 `[tool.mutmut]` 注释里写明它独家能杀什么、为何排除不漏杀（判据同 `test_skill_script_path_guards.py`：排除只多出假存活，不藏假杀死）。
+
 ## 3. 读结果
 
 **从 `.meta` 文件算，不读终端汇总。** 每个源模块在 `mutants/` 里有一份 `<模块>.py.meta`，其中 `exit_code_by_key` 是「mutant 名 → pytest exit code」。mutmut 的终端汇总只枚举它认识的几个 exit code，段错误（−11）之类一个计数器都不落，#2257 就漏过两个。
@@ -83,6 +85,15 @@ uv run python scripts/mutmut_compare.py \
 **四路分诊**（改造后目标 mutant 仍存活时，一次性判定，补的断言不撤）：断言没写到位、断言没被执行 → 继续修；实际要换输入才能杀死 → 停手，依据是「不做覆盖补偿」；实际是等价变异体 → 停手。
 
 只跑部分模块查不到第二层，复跑取整批模块。
+
+### 5.1 一批模块拆成多张改造票
+
+一批模块的存活 mutant 常拆成几张改造票跨会话合入，它们共用第 2 节保存的同一份基线，各票分别验收：
+
+- `--reworked` 只填本票的清单；`--equivalent` 填整批的等价变异体清单（每票都要查它零被杀）。
+- 先合入的票已杀死的目标，在后面的票里落在第三层「基线存活且本次未改造」，被杀只登记，不算异常。
+- 每票切分支前 `git fetch` 并核对基线的模块在 `origin/main` 上自基线提交以来零变动：`git diff --stat <基线提交> origin/main -- <模块列表>` 为空。改造 PR 自身不会动这些模块（硬门），但 `main` 上别的提交会。
+- 模块被别的提交改了时，脚本会以「同名函数源码哈希不同」拒绝比对，此时旧基线与判定表对该模块都作废：mutant 名按函数内的序号编号，源码一变序号整体错位，判定行对不上任何 mutant。处置是**对该模块重跑一轮基线并重新判定它的存活 mutant**（其余未变动的模块继续用旧基线；`only_mutate` 换了模块集要连 stats 一起删），不要 rebase 研究分支——研究分支存的是结果快照，rebase 改不了快照里的 mutant 名。改动只落在个别函数时也一样：mutmut 不保证其他函数的编号不变，不做局部续用。
 
 ## 6. 已知陷阱
 

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -27,7 +27,7 @@ uv sync --group mutation
 
 `only_mutate` 跑完记得还原成注释，`mutants/` 已在 `.gitignore`。
 
-**凡读源码文本而不是 import 模块的测试，都要在 `pytest_add_cli_args` 里 `--ignore`。** `mutants/` 里的源文件同时含所有 mutant 变体（每个字符串字面量都多出 `XXfooXX` / `FOO` 两份），任何用正则扫 `lib/` `server/` 源码字面量再比对登记表的用例都会在 stats 阶段报「未登记」，整轮起不来。已排除的是 `tests/integration/lib/test_task_failure_capability.py`；新加排除时在 `[tool.mutmut]` 注释里写明它独家能杀什么、为何排除不漏杀（判据同 `test_skill_script_path_guards.py`：排除只多出假存活，不藏假杀死）。
+**凡读源码文本而不是 import 模块的用例，都要在 `pytest_add_cli_args` 里按 nodeid `--deselect`，不要整文件 `--ignore`。** `mutants/` 里的源文件同时含所有 mutant 变体（每个字符串字面量都多出 `XXfooXX` / `FOO` 两份），任何扫 `lib/` `server/` 源码字面量再比对登记表的用例都会在 stats 阶段报「未登记」，整轮起不来。`--ignore` 的粒度是文件：同文件里的行为测试会一并消失，它们独家覆盖的 mutant 就记成存活（`test_task_failure_capability.py` 三个扫描用例之外的 100 余个用例就是这种情况）。已排除的是该文件的 `test_capability_codes_registered_no_drift` / `test_no_unscannable_capability_construction_sites` / `test_capability_construction_sites_supply_every_template_param`；新加排除时在 `[tool.mutmut]` 注释里写明它独家能杀什么、为何排除不漏杀（判据同 `test_skill_script_path_guards.py`：排除只多出假存活，不藏假杀死）。
 
 ## 3. 读结果
 

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -102,6 +102,7 @@ uv run python scripts/mutmut_compare.py \
 - **`tests-for-mutant` 只在项目根可用。** 它读 `mutants/mutmut-stats.json`，在 `mutants/` 里跑找不到。
 - **`tests/unit/test_skill_script_path_guards.py` 被整体排除**，理由在 `[tool.mutmut]` 注释。排除只会多出假存活（多复核一个），不会造成假杀死。
 - **`timeout_multiplier` 不要调小。** 调小不省时间，只会让已证实的真存活被记成 killed，把无效测试藏起来。
+- **−11（段错误）成批出现即整轮作废，不要逐个复核。** 已知的一种成因在 macOS：环境里没有 `*_proxy` 变量时，`urllib.request.getproxies()` 经 `_scproxy` 调 SystemConfiguration 读系统代理，该框架在 fork 出的多线程子进程里直接段错误，凡构造 `openai.OpenAI` / `httpx.Client` 的用例都中招（第二批 2186 个里 577 个），而同一个 mutant 在新进程里复核却正常。`tests/mutmut_plugin.py` 已把这两个入口换成常量实现；再成批出现就用 `PYTHONFAULTHANDLER=1 uv run mutmut run <mutant>` 单跑一个看崩溃栈，别当成负载或偶发。判据：−11 只该零星出现（首批 616 个里 2 个）。
 - **测试选集走全量。** 只跑 `tests/unit` 快 5.5 倍，但约 45% 的存活是假的，每个都要复核一次全量套件，总账更贵。
 
 ## 7. 成本参考

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,15 +333,19 @@ source_paths = ["lib", "server"]
 # 排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死（把无效测试藏起来）。
 # tests.mutmut_plugin 给每个 mutmut 会话一个私有 basetemp，让并行子进程收尾时不再竞争共享根下的软链；
 # 它只在这里加载，本地与 CI 的 pytest 不带它。
-# tests/integration/lib/test_task_failure_capability.py 用正则扫 lib/ 源码里的 capability code 字面量并与登记表比对；
-# mutants/ 里的源文件同时含全部字符串 mutant 变体（XXcodeXX / CODE），扫描必报「未登记」，stats 阶段直接失败。
-# 凡读源码文本而非 import 模块的测试都要这样排除。排除同样只会多出假存活：该文件独家能杀的只有 code 字面量的变体，
-# 而各 backend 用例都断言 exc.code。
+# tests/integration/lib/test_task_failure_capability.py 里三个用例用 ast 扫 lib/ server/ 源码里的 capability code
+# 字面量并与登记表比对；mutants/ 里的源文件同时含全部字符串 mutant 变体（XXcodeXX / CODE），扫描必报「未登记」，
+# stats 阶段直接失败。凡读源码文本而非 import 模块的用例都要这样按 nodeid --deselect，不整文件 --ignore：
+# 同文件其余用例是 bound_reason / collapse_cascade_reason / 级联渲染的行为测试，其中部分路径由它们独家覆盖，
+# 整文件排除会让 lib/task_failure.py 的真变异体记成存活。
+# 只排除扫描用例同样只会多出假存活：它们独家能杀的只有 code 字面量的变体，而各 backend 用例都断言 exc.code。
 pytest_add_cli_args = [
     "-p",
     "tests.mutmut_plugin",
     "--ignore=tests/unit/test_skill_script_path_guards.py",
-    "--ignore=tests/integration/lib/test_task_failure_capability.py",
+    "--deselect=tests/integration/lib/test_task_failure_capability.py::test_capability_codes_registered_no_drift",
+    "--deselect=tests/integration/lib/test_task_failure_capability.py::test_no_unscannable_capability_construction_sites",
+    "--deselect=tests/integration/lib/test_task_failure_capability.py::test_capability_construction_sites_supply_every_template_param",
 ]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
 # 但存活集合约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,7 +333,16 @@ source_paths = ["lib", "server"]
 # 排除只把这类 mutant 推向假存活（多复核一个），不会造成假杀死（把无效测试藏起来）。
 # tests.mutmut_plugin 给每个 mutmut 会话一个私有 basetemp，让并行子进程收尾时不再竞争共享根下的软链；
 # 它只在这里加载，本地与 CI 的 pytest 不带它。
-pytest_add_cli_args = ["-p", "tests.mutmut_plugin", "--ignore=tests/unit/test_skill_script_path_guards.py"]
+# tests/integration/lib/test_task_failure_capability.py 用正则扫 lib/ 源码里的 capability code 字面量并与登记表比对；
+# mutants/ 里的源文件同时含全部字符串 mutant 变体（XXcodeXX / CODE），扫描必报「未登记」，stats 阶段直接失败。
+# 凡读源码文本而非 import 模块的测试都要这样排除。排除同样只会多出假存活：该文件独家能杀的只有 code 字面量的变体，
+# 而各 backend 用例都断言 exc.code。
+pytest_add_cli_args = [
+    "-p",
+    "tests.mutmut_plugin",
+    "--ignore=tests/unit/test_skill_script_path_guards.py",
+    "--ignore=tests/integration/lib/test_task_failure_capability.py",
+]
 # pytest_add_cli_args_test_selection 不设：走全量 testpaths。仅 tests/unit 快 5.5 倍，
 # 但存活集合约 45% 是假存活，复核每个都要跑一次全量套件，总账反而更贵。
 # timeout_multiplier / timeout_constant 保持默认（15 / 1.0），不要调小。

--- a/tests/integration/test_mutmut_fork_isolation.py
+++ b/tests/integration/test_mutmut_fork_isolation.py
@@ -1,10 +1,11 @@
 """测试设施在 mutmut 的 fork 模型下保持进程隔离。
 
 mutmut 在一个父进程里跑过 stats 之后，按 mutant fork 出多个 pytest 会话并行跑，子进程
-继承父进程的 atexit 登记表与 conftest 模块状态。两条契约：走正常退出路径的子进程不得
+继承父进程的 atexit 登记表与 conftest 模块状态。三条契约：走正常退出路径的子进程不得
 删掉各子进程共用的临时库（根 conftest）；mutmut 会话各用私有 basetemp，不进共享的
-``pytest-of-<user>`` 根，多个会话收尾时不再竞争同一条软链（`tests/mutmut_plugin.py`，
-经 ``[tool.mutmut] pytest_add_cli_args`` 加载）。
+``pytest-of-<user>`` 根，多个会话收尾时不再竞争同一条软链；mutmut 会话在 macOS 上不经
+``_scproxy`` 读系统代理，构造 httpx / openai 客户端不会在 fork 出的子进程里段错误
+（后两条在 `tests/mutmut_plugin.py`，经 ``[tool.mutmut] pytest_add_cli_args`` 加载）。
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SQLITE_URL_PREFIX = "sqlite+aiosqlite:///"
 _PROBE_ENV = "ARCREEL_BASETEMP_PROBE"
+_SCPROXY_PROBE_ENV = "ARCREEL_SCPROXY_PROBE"
 _MUTMUT_PLUGIN = "tests.mutmut_plugin"
 
 
@@ -92,3 +94,37 @@ def test_mutmut_session_uses_private_basetemp_outside_shared_root(tmp_path: Path
     # 共享根从未被建立；私有 basetemp 与临时库都已由该会话自己回收。
     assert list(temproot.iterdir()) == []
     assert list(tmpdir.iterdir()) == []
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="_scproxy 只在 macOS 存在")
+def test_mutmut_session_resolves_proxies_without_touching_macos_sysconf():
+    if os.environ.get(_SCPROXY_PROBE_ENV):
+        # 子进程里的探针：urllib 在模块顶层就绑定了 _scproxy 的两个入口，把它们换成会抛错的桩，
+        # 凡走到系统代理发现的路径都会失败。环境里没有 *_proxy 变量，urllib 只剩系统代理这条路。
+        import urllib.request
+
+        def _boom(*_args: object) -> object:
+            raise AssertionError("mutmut 会话不得调用 SystemConfiguration 读系统代理")
+
+        urllib.request._get_proxies = _boom
+        urllib.request._get_proxy_settings = _boom
+        assert urllib.request.getproxies() == {}
+        assert urllib.request.proxy_bypass("example.com") is False
+        return
+
+    env = {k: v for k, v in os.environ.items() if not k.lower().endswith("_proxy")}
+    env[_SCPROXY_PROBE_ENV] = "1"
+    nodeid = (
+        f"{Path(__file__).relative_to(_REPO_ROOT).as_posix()}"
+        f"::{test_mutmut_session_resolves_proxies_without_touching_macos_sysconf.__name__}"
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *_mutmut_pytest_args(), nodeid],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=90,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/mutmut_plugin.py
+++ b/tests/mutmut_plugin.py
@@ -1,20 +1,35 @@
-"""mutmut 拉起的 pytest 会话各用一个私有 basetemp，不进共享的 ``pytest-of-<user>`` 根。
+"""mutmut 拉起的 pytest 会话的进程隔离：私有 basetemp，且不触碰 macOS 的系统代理发现。
 
 只由 ``pyproject.toml`` 的 ``[tool.mutmut] pytest_add_cli_args`` 以 ``-p tests.mutmut_plugin``
 加载，本地与 CI 的 pytest 不加载它。
 
-mutmut 按 mutant fork 出多个 pytest 会话并行跑，它们在会话收尾时同时清理共享根下的
-``pytest-current`` 软链，竞争抛出的 ``FileNotFoundError`` 从 ``pytest.main`` 冒出，让子进程
-走正常退出路径、退出码 1 记成 killed。显式给定的 basetemp 不登记任何清理，收尾时无事可做；
-目录由本会话在 unconfigure 时自己回收。
+mutmut 按 mutant fork 出多个 pytest 会话并行跑。两处 fork 相关的处理：
+
+- 会话收尾时它们会同时清理共享根下的 ``pytest-current`` 软链，竞争抛出的 ``FileNotFoundError``
+  从 ``pytest.main`` 冒出，让子进程走正常退出路径、退出码 1 记成 killed。显式给定的 basetemp
+  不登记任何清理，收尾时无事可做；目录由本会话在 unconfigure 时自己回收。
+- macOS 上 ``urllib.request.getproxies()`` 在环境里没有 ``*_proxy`` 变量时会经 ``_scproxy``
+  调 SystemConfiguration 读系统代理，而该框架在 fork 出的多线程子进程里直接段错误。任何构造
+  ``openai.OpenAI`` / ``httpx.Client`` 的用例都会走到这里，整批 mutant 记成 −11。这里把两个
+  macOS 专属入口换成「无系统代理」的常量实现：测试从不依赖真实系统代理，环境变量给的代理
+  仍按原路生效。
 """
 
 from __future__ import annotations
 
 import shutil
 import tempfile
+import urllib.request
 
 import pytest
+
+
+def _no_system_proxies() -> dict[str, str]:
+    return {}
+
+
+def _never_bypass_by_system_settings(host: str) -> bool:
+    return False
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -23,6 +38,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
     该选项经命令行解析后是 str，xdist 派给 worker 的也是 str，这里保持同一类型。
     """
+    if hasattr(urllib.request, "getproxies_macosx_sysconf"):
+        urllib.request.getproxies_macosx_sysconf = _no_system_proxies
+        urllib.request.proxy_bypass_macosx_sysconf = _never_bypass_by_system_settings
     if config.option.basetemp is not None:
         return
     private_basetemp = tempfile.mkdtemp(prefix="arcreel-mutmut-basetemp-")

--- a/tests/unit/lib/custom_provider/test_custom_backends.py
+++ b/tests/unit/lib/custom_provider/test_custom_backends.py
@@ -240,6 +240,7 @@ class TestCustomVideoBackend:
         result = backend.video_capabilities_for_tier("pro", resolution="1080p")
 
         assert result is pro_caps
+        assert backend.name == "vid-provider"
         delegate.video_capabilities_for_tier.assert_called_once_with("pro", resolution="1080p")
 
     def test_video_capabilities_for_tier_merges_sparse_override_onto_delegate_base(self):

--- a/tests/unit/lib/custom_provider/test_custom_provider_factory.py
+++ b/tests/unit/lib/custom_provider/test_custom_provider_factory.py
@@ -333,6 +333,7 @@ class TestVideoEndpointRecorded:
         result, _built_record = _built(_make_provider(), "sora-2", "openai-video")
         assert isinstance(result, CustomVideoBackend)
         assert result.endpoint == "openai-video"
+        assert result.name == "custom-42"
 
     def test_endpoint_survives_capability_injection(self):
         """能力注入返回新实例，endpoint 不能在链式构造中丢失。"""


### PR DESCRIPTION
## 变更

[#2299](https://github.com/ArcReel/ArcReel/issues/2299) 的曳光弹（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)）：把 #2297 判为 ③ 的 92 条里 `lib/custom_provider/backends.py` 的 2 条单独走完「补断言 → 全套闸门 → 8 模块全量复跑 → 三层验收 → PR」，目的是验证第二批的验收配方与两处回填通不通，不是为这两条断言。本 PR 不关闭 #2299，其余 90 条（instructor_support 46 / ark 32 / grok 12）另按模块切 3 个 PR。

- `test_custom_provider_factory.py::TestVideoEndpointRecorded::test_video_backend_records_endpoint`：补 `result.name == "custom-42"`。检查的是 `with_endpoint` 返回的新实例保留 provider_id（name）。
- `test_custom_backends.py::TestCustomVideoBackend::test_video_capabilities_for_tier_ignores_full_injected_capabilities`：补 `backend.name == "vid-provider"`。检查的是 `with_video_capabilities` 返回的新实例保留 provider_id（name）。
- **回填 `pyproject.toml` `[tool.mutmut]`**：`pytest_add_cli_args` 按 nodeid `--deselect` `tests/integration/lib/test_task_failure_capability.py` 里三个 ast 扫源码的用例（`test_capability_codes_registered_no_drift` / `test_no_unscannable_capability_construction_sites` / `test_capability_construction_sites_supply_every_template_param`）。它们扫 `lib/` `server/` 源码里的 capability code 字面量比对登记表，`mutants/` 里同时含全部字符串变体，stats 阶段必失败（#2297）。不整文件 `--ignore`：同文件其余 104 个是 `bound_reason` / `collapse_cascade_reason` / 级联渲染的行为用例，整文件排除会让 `lib/task_failure.py` 的真变异体记成存活。只排除扫描用例仍只多出假存活：它们独家能杀的只有 code 字面量变体，各 backend 用例都断言 `exc.code`。`mutants/` 布局下 `--collect-only` 核对 107 → 104。
- **回填 runbook**：§2 加「凡读源码文本而非 import 模块的测试都要这样排除」；新增 §5.1「一批模块拆成多张改造票」（同一基线多票复用、`--reworked` 只填本票、他票已合入的目标落第三层只登记、切分支前核对基线模块在 `origin/main` 零变动、模块被别的提交改动时对该模块重跑基线并重判，不 rebase 研究分支）；§6 新增「−11 成批即整轮作废」的判据与定位方法。
- **计划外修复 `tests/mutmut_plugin.py`**（见下「计划外发现」）：mutmut 会话在 macOS 上不再经 `_scproxy` 读系统代理，附探针用例 `test_mutmut_session_resolves_proxies_without_touching_macos_sysconf`（去掉修复即失败）。

只加强断言，输入不变，不新增用例。**硬门**：`git diff --name-only <merge-base> HEAD` 只有 6 个文件（docs / pyproject / tests），不含 `lib/` 与 `server/`；8 个基线模块在当前 `origin/main`（比分支基点前进 9 个提交）上自基线以来仍零变动。

## 验证

三层验收：基线取 `research/mutmut-batch-2/baseline/`（#2297，基线 `cd6451797`），8 个模块自基线以来在 `origin/main` 上零变动。8 模块 2186 个 mutant 全量复跑后 `scripts/mutmut_compare.py`：

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 目标（`with_endpoint__mutmut_1` / `with_video_capabilities__mutmut_1`） | 2 | **2 killed** |
| 基线 killed 护栏 | 1414 | **0 回退**；1 个 ⏰（`GeminiVideoBackend.__init__` 的 mutant，关联 21 个用例）新进程复核 1 failed，护栏成立 |
| 其余基线存活（含本票另 90 条与票 2 的 106 条） | 770 | 0 顺手杀死 |
| 等价变异体清单 | 173 | 0 被杀 |

除两个目标外，2184 个 mutant 的 exit code 与基线逐条相同。

闸门：`ruff check` / `ruff format --check` / `basedpyright --warnings`（0 errors, 0 warnings）/ `lint-imports`（2 kept）/ `deptry` / `audit_tests.py --check`（0 违规）通过；`pytest -n 4 --dist loadfile`：11396 passed, 3 skipped（3:27）。

## 计划外发现：macOS 上 mutmut 子进程成批段错误

第一轮全量复跑 2186 个 mutant 里 **577 个记 −11（SIGSEGV）**，集中在 ark（233/247）、minimax（150）、dashscope（119）、instructor_support（70）；第二轮补跑同一批 577 个原样复现，抽样在新进程里复核却都是正常的 killed / 存活。`PYTHONFAULTHANDLER=1 uv run mutmut run <mutant>` 单跑拿到崩溃栈：

```
urllib/request.py getproxies_macosx_sysconf
  ← urllib.request.getproxies ← httpx._utils.get_environment_proxies
  ← httpx.Client.__init__ ← openai.OpenAI.__init__
  ← mutants/lib/text_backends/ark.py ArkTextBackend.__init__（fixture backend_with_structured）
```

环境里没有 `*_proxy` 变量时，`urllib.request.getproxies()` 走 `_scproxy` 调 macOS SystemConfiguration，该框架在 fork 出的多线程子进程里段错误；凡构造 `openai.OpenAI` / `httpx.Client` 的用例都中招。#2297 的基线一轮 0 个 −11，推断那个会话的环境里有代理变量、从未走到这条路——runbook 之前把 −11 归为负载产物是错的，本 PR 一并改正。修复放在 `tests/mutmut_plugin.py`（只由 mutmut 会话加载）：把 `getproxies_macosx_sysconf` / `proxy_bypass_macosx_sysconf` 换成「无系统代理」的常量实现，环境变量给的代理仍按原路生效。修复后补跑 577 个：−11 归零。

## 曳光弹成本

| 步骤 | 墙钟 |
| --- | ---: |
| 改 2 条断言 + pyproject / runbook 回填 | ≈ 15 min |
| 第一轮全量复跑（机器 load 230+，运行 34 min 后中断，作废） | 34 min |
| 第二轮全量复跑（577 个 −11） | 9:18 |
| 补跑 577 个（未修复，原样复现） | 8:11 |
| 定位根因 + 插件修复 + 探针用例 | ≈ 35 min |
| 补跑 577 个（带修复，−11 归零） | 10:25 |
| ⏰ 新进程复核（21 个用例） | 70 s |
| 全量本地闸门 | ≈ 6 min（pytest -n 4 3:27 + 静态闸门） |

多票分批验收的「基线模块被 `main` 改动」处置本轮未触发（8 模块零变动），runbook §5.1 写的是推演出的处置，票 2 若触发再核。

## 风险与遗留

- `tests/mutmut_plugin.py` 的代理短路只在 mutmut 会话生效，本地与 CI 的 pytest 不加载该插件，行为不变。
- 机器同时跑多个全量套件时（load average 100–400），mutmut 一轮墙钟与 ⏰ 数都会抬高；本轮 1 个 ⏰ 即出在此情形下。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试改进**
  - 增强视频自定义后端测试，确保能力注入后仍正确保留后端名称及提供方标识。
  - 增加 macOS 下代理解析隔离测试，提升变异测试运行的稳定性，并避免系统代理设置导致异常崩溃。

- **工具与配置**
  - 优化源码扫描相关的变异测试排除规则，减少不适用测试造成的误报和失败。

- **文档**
  - 更新变异测试运行手册，补充基线复用、验收流程、等价变异体判断及崩溃处理说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
