### PR TITLE
test(text-backends): Instructor 降级链用例断言发往端点的 model / messages / provider 与终局异常字段

### DIFF
--- a/tests/unit/lib/text_backends/test_instructor_support.py
+++ b/tests/unit/lib/text_backends/test_instructor_support.py
@@ -952,9 +952,10 @@ class TestInstructorFallbackAsync:
         sample = SampleModel(name="Bob", age=25)
         completion = SimpleNamespace(usage=None)
 
-        with _recorded_instructor((sample, completion), is_async=True) as (_patched_with, calls):
+        client = AsyncMock()
+        with _recorded_instructor((sample, completion), is_async=True) as (patched_with, calls):
             result = await instructor_fallback_async(
-                client=AsyncMock(),
+                client=client,
                 model="async-model",
                 messages=[{"role": "user", "content": "test"}],
                 response_schema=SampleModel,
@@ -972,6 +973,7 @@ class TestInstructorFallbackAsync:
                 "max_completion_tokens": 600,
             }
         ]
+        assert patched_with == [{"client": client, "mode": Mode.TOOLS}]
         assert result.input_tokens is None
         assert result.output_tokens is None
 

--- a/tests/unit/lib/text_backends/test_instructor_support.py
+++ b/tests/unit/lib/text_backends/test_instructor_support.py
@@ -300,7 +300,7 @@ class TestGenerateStructuredViaInstructorAsync:
             mock_instructor.from_openai.return_value = mock_patched
             mock_patched.chat.completions.create_with_completion = AsyncMock(return_value=(sample, mock_completion))
 
-            await generate_structured_via_instructor_async(
+            _json_text, input_tokens, output_tokens = await generate_structured_via_instructor_async(
                 client=AsyncMock(),
                 model="test-model",
                 messages=[{"role": "user", "content": "test"}],
@@ -312,6 +312,8 @@ class TestGenerateStructuredViaInstructorAsync:
             call_kwargs = mock_patched.chat.completions.create_with_completion.call_args[1]
             assert call_kwargs["max_completion_tokens"] == 2345
             assert "max_tokens" not in call_kwargs
+        assert input_tokens is None
+        assert output_tokens is None
 
     async def test_incomplete_output_maps_to_truncated_error(self):
         """异步版 IncompleteOutputException 同样归一为 TextOutputTruncatedError。"""
@@ -379,17 +381,24 @@ class TestInstructorFallbackSync:
         assert result.provider == "test-provider"
         assert result.input_tokens == 30
         assert result.output_tokens == 15
+        assert result.model == "test-model"
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["response_format"] == {"type": "json_object"}
+        assert call_kwargs["model"] == "test-model"
+        assert call_kwargs["messages"] == [
+            {"role": "system", "content": "Respond in JSON format."},
+            {"role": "user", "content": "test"},
+        ]
 
     def test_pydantic_branch_forwards_token_param(self):
         """Pydantic 分支的 token_param 一路传到导线：值以 max_completion_tokens 为参数名上线。"""
         sample = SampleModel(name="Alice", age=30)
         completion = SimpleNamespace(usage=None)
 
-        with _recorded_instructor((sample, completion)) as (_patched_with, calls):
+        client = MagicMock()
+        with _recorded_instructor((sample, completion)) as (patched_with, calls):
             instructor_fallback_sync(
-                client=MagicMock(),
+                client=client,
                 model="test-model",
                 messages=[{"role": "user", "content": "test"}],
                 response_schema=SampleModel,
@@ -407,6 +416,7 @@ class TestInstructorFallbackSync:
                 "max_completion_tokens": 500,
             }
         ]
+        assert patched_with == [{"client": client, "mode": Mode.TOOLS}]
 
     def test_dict_branch_default_token_param(self):
         """dict 分支默认以 max_tokens 为参数名上线。"""
@@ -475,6 +485,7 @@ class TestInstructorFallbackSync:
 
         assert exc_info.value.provider == "test-provider"
         assert exc_info.value.model == "test-model"
+        assert exc_info.value.output_tokens == 999
 
 
 class TestInstructorExceptionShape:
@@ -596,6 +607,7 @@ class TestStructuredModeChainSync:
             result = self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
+        assert [call.kwargs["provider"] for call in mock_gen.call_args_list] == ["test-provider"]
         assert result.text == sample.model_dump_json()
 
     def test_tools_param_rejected_falls_back_to_md_json(self):
@@ -637,6 +649,7 @@ class TestStructuredModeChainSync:
         assert self._modes(mock_gen) == [Mode.TOOLS]
         assert exc_info.value.__cause__ is exhausted
         assert exc_info.value.provider == "test-provider"
+        assert exc_info.value.model == "test-model"
 
     def test_md_json_exhaustion_raises_structured_output_exhausted(self):
         """末档耗尽同样收敛为终局异常，不把 InstructorRetryException 原文透出去。"""
@@ -645,11 +658,12 @@ class TestStructuredModeChainSync:
                 "lib.text_backends.instructor_support.generate_structured_via_instructor",
                 side_effect=[_tools_rejected_error(), _retry_exhausted(_validation_error())],
             ) as mock_gen,
-            pytest.raises(StructuredOutputExhaustedError, match="结构化输出能力不足"),
+            pytest.raises(StructuredOutputExhaustedError, match="结构化输出能力不足") as exc_info,
         ):
             self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert "最后一次 ValidationError" in exc_info.value.reason
 
     def test_transient_error_propagates_unchanged(self):
         """瞬态错误既不降档也不收敛为终局异常，原样冒泡交调用方的重试装饰器判定。"""
@@ -837,6 +851,7 @@ class TestStructuredModeChainAsync:
             result = await self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS, Mode.MD_JSON]
+        assert [call.kwargs["provider"] for call in mock_gen.call_args_list] == ["async-provider", "async-provider"]
         assert result.text == sample.model_dump_json()
 
     async def test_validation_exhaustion_is_terminal(self):
@@ -845,11 +860,13 @@ class TestStructuredModeChainAsync:
                 "lib.text_backends.instructor_support.generate_structured_via_instructor_async",
                 side_effect=[_retry_exhausted(_validation_error())],
             ) as mock_gen,
-            pytest.raises(StructuredOutputExhaustedError),
+            pytest.raises(StructuredOutputExhaustedError) as exc_info,
         ):
             await self._call()
 
         assert self._modes(mock_gen) == [Mode.TOOLS]
+        assert exc_info.value.provider == "async-provider"
+        assert exc_info.value.model == "async-model"
 
     async def test_transient_error_propagates_unchanged(self):
         with (
@@ -922,6 +939,13 @@ class TestInstructorFallbackAsync:
         assert result.provider == "async-provider"
         assert result.input_tokens == 25
         assert result.output_tokens == 12
+        assert result.model == "async-model"
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "async-model"
+        assert call_kwargs["messages"] == [
+            {"role": "system", "content": "Respond in JSON format."},
+            {"role": "user", "content": "test"},
+        ]
 
     async def test_pydantic_branch_forwards_token_param_async(self):
         """异步 Pydantic 分支的 token_param 一路传到导线：值以 max_completion_tokens 为参数名上线。"""
@@ -929,7 +953,7 @@ class TestInstructorFallbackAsync:
         completion = SimpleNamespace(usage=None)
 
         with _recorded_instructor((sample, completion), is_async=True) as (_patched_with, calls):
-            await instructor_fallback_async(
+            result = await instructor_fallback_async(
                 client=AsyncMock(),
                 model="async-model",
                 messages=[{"role": "user", "content": "test"}],
@@ -948,6 +972,8 @@ class TestInstructorFallbackAsync:
                 "max_completion_tokens": 600,
             }
         ]
+        assert result.input_tokens is None
+        assert result.output_tokens is None
 
     async def test_dict_branch_default_token_param_async(self):
         """异步 dict 分支默认以 max_tokens 为参数名上线。"""
@@ -1016,3 +1042,4 @@ class TestInstructorFallbackAsync:
 
         assert exc_info.value.provider == "async-provider"
         assert exc_info.value.model == "async-model"
+        assert exc_info.value.output_tokens == 999


### PR DESCRIPTION
## 变更

[#2299](https://github.com/ArcReel/ArcReel/issues/2299) 批量改造三张 PR 之一（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)）：`lib/text_backends/instructor_support.py` 在 #2297 判为 ③「断言不够严」的 46 个存活 mutant，对应 `tests/unit/lib/text_backends/test_instructor_support.py` 里 12 个用例，只加强断言。只改这一个测试文件；曳光弹 [#2323](https://github.com/ArcReel/ArcReel/pull/2323) 已单独走完 2 条，ark / grok 另两张 PR。

- `test_explicit_token_param_max_completion_tokens`（async）：接住返回的 token 计数，断言两者为 `None`。检查的是 instructor 路径不产生 usage 时计数保持 `None` 而不是被改成别的哑值。
- `test_dict_schema_uses_json_object` / async 同名：断言 `result.model`、发往端点的 `model`，以及 `messages` 恰为「系统提示 `Respond in JSON format.` 插在 0 位 + 原 user 消息」。检查的是 `_inject_json_instruction` 插入位置、role / content 字面量与 model 透传。
- `test_pydantic_branch_forwards_token_param`：用具名 `client`，断言 `instructor.from_openai` 恰收到 `{"client": client, "mode": Mode.TOOLS}`。检查的是同步 Pydantic 分支把调用方 client 与 mode=TOOLS 交给 instructor。
- 两处截断用例：断言 `exc_info.value.output_tokens == 999`。检查的是截断异常携带的输出 token 数来自 usage 而非常量。
- 降级链用例（sync / async）：断言每次调用发往 provider 的值、终局 `StructuredOutputExhaustedError` 的 `model` / `provider`、`reason` 含「最后一次 ValidationError」。检查的是 `_handle_mode_failure` / `_failure_reason` 组装终局异常时的字段来源。
- `test_pydantic_branch_forwards_token_param`（async）：断言结果 token 计数为 `None`；另按 review 与同步版对齐，具名 client 传入并断言 `instructor.from_openai` 恰收到 `{"client": client, "mode": Mode.TOOLS}`（这一条不在 ③ 清单内，是对称性补齐）。

## 验证

三层验收对 [#2299](https://github.com/ArcReel/ArcReel/issues/2299) 的 90 条批量改造**一次做完**（instructor_support 46 + ark 32 + grok 12 同一分支上 8 模块 2186 个 mutant 全量复跑，`scripts/mutmut_compare.py --reworked` 填 90 条），再按模块切成 3 个 PR；本 PR 是其中一个，验收数字是整批的：

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 目标（90 条 ③） | 90 | **90 killed**，存活 0 |
| 基线 killed 护栏 | 1414 | **0 回退**；1 个 ⏰（`GeminiVideoBackend.__init__` 的 mutant，关联 21 个用例）新进程复核 1 failed，护栏成立 |
| 其余基线存活（曳光弹 2 条 + 票 2 的 106 条 + 无覆盖 / 等价） | 682 | 顺手杀死 2，均为曳光弹 #2323 的两个目标（该 PR 与本批共用同一基线，按 runbook §5.1 只登记） |
| 等价变异体清单 | 173 | 0 被杀 |

基线取 `research/mutmut-batch-2/baseline/`（#2297，`cd6451797`），8 个模块在 `origin/main` 上自基线以来零变动。**硬门**：本 PR diff 只有 1 个测试文件，不含 `lib/` 与 `server/`。

闸门：`ruff check` / `ruff format --check` / `basedpyright --warnings` / `lint-imports` / `deptry` / `audit_tests.py --check` 通过；`pytest -n 4 --dist loadfile`：11396 passed, 3 skipped（3:14）。

## 风险与遗留

- 只加强断言、不改输入、不新增用例；每条断言检查的内容不超出 `research/mutmut-batch-2/verdicts.md` 里对应条目的「加强后的断言检查的是什么」。
- 三张批量 PR 各自独立基于 `main`，合入顺序无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试**
  - 扩充同步与异步结构化输出流程的测试覆盖范围。
  - 增加对模型请求参数、响应格式、提供方信息及工具模式的校验。
  - 完善无令牌用量、输出截断和最终异常场景的断言，提升相关行为验证的准确性与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
