### PR TITLE
test(text-backends): Ark 用例断言 plain 与原生结构化调用的 model / messages / response_format 形态与截断异常的 output_tokens

### DIFF
--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -104,6 +104,10 @@ class TestGenerate:
         assert result.provider == "ark"
         assert result.input_tokens == 15
         assert result.output_tokens == 8
+        assert result.model == backend.model
+        call_kwargs = backend._test_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == backend.model
+        assert call_kwargs["messages"] == [{"role": "user", "content": "hello"}]
 
 
 class TestVision:
@@ -154,6 +158,7 @@ class TestVision:
         call_args = mock_client.chat.completions.create.call_args
         messages = call_args.kwargs["messages"]
         assert messages[0] == {"role": "system", "content": "you are helpful"}
+        assert messages[1]["role"] == "user"
         user_content = messages[1]["content"]
         assert user_content[0] == {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
         assert user_content[1] == {"type": "text", "text": "describe"}
@@ -220,7 +225,12 @@ class TestCapabilityAwareStructured:
 
         assert result.text == '{"key": "value"}'
         call_args = backend_with_structured._test_client.chat.completions.create.call_args
-        assert "response_format" in call_args.kwargs
+        assert call_args.kwargs["model"] == "mock-model-with-structured"
+        assert call_args.kwargs["messages"] == [{"role": "user", "content": "gen"}]
+        assert call_args.kwargs["response_format"] == {
+            "type": "json_schema",
+            "json_schema": {"name": "response", "schema": schema},
+        }
 
     async def test_unknown_model_falls_back_to_instructor(self, mock_ark):
         """未注册模型保守降级为 Instructor。"""
@@ -291,6 +301,7 @@ class TestCapabilityAwareStructured:
 
         assert exc_info.value.provider == "ark"
         assert exc_info.value.model == "mock-model-with-structured"
+        assert exc_info.value.output_tokens == 8192
 
     async def test_max_output_tokens_plain(self, backend_no_structured, sync_to_thread):
         """plain 路径透传 max_tokens。"""

--- a/tests/unit/lib/text_backends/test_ark.py
+++ b/tests/unit/lib/text_backends/test_ark.py
@@ -105,9 +105,10 @@ class TestGenerate:
         assert result.input_tokens == 15
         assert result.output_tokens == 8
         assert result.model == backend.model
-        call_kwargs = backend._test_client.chat.completions.create.call_args.kwargs
-        assert call_kwargs["model"] == backend.model
-        assert call_kwargs["messages"] == [{"role": "user", "content": "hello"}]
+        backend._test_client.chat.completions.create.assert_called_once_with(
+            model=backend.model,
+            messages=[{"role": "user", "content": "hello"}],
+        )
 
 
 class TestVision:
@@ -224,13 +225,14 @@ class TestCapabilityAwareStructured:
         result = await backend_with_structured.generate(TextGenerationRequest(prompt="gen", response_schema=schema))
 
         assert result.text == '{"key": "value"}'
-        call_args = backend_with_structured._test_client.chat.completions.create.call_args
-        assert call_args.kwargs["model"] == "mock-model-with-structured"
-        assert call_args.kwargs["messages"] == [{"role": "user", "content": "gen"}]
-        assert call_args.kwargs["response_format"] == {
-            "type": "json_schema",
-            "json_schema": {"name": "response", "schema": schema},
-        }
+        backend_with_structured._test_client.chat.completions.create.assert_called_once_with(
+            model="mock-model-with-structured",
+            messages=[{"role": "user", "content": "gen"}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "response", "schema": schema},
+            },
+        )
 
     async def test_unknown_model_falls_back_to_instructor(self, mock_ark):
         """未注册模型保守降级为 Instructor。"""


### PR DESCRIPTION
## 变更

[#2299](https://github.com/ArcReel/ArcReel/issues/2299) 批量改造三张 PR 之一（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)）：`lib/text_backends/ark.py` 在 #2297 判为 ③「断言不够严」的 32 个存活 mutant，对应 `tests/unit/lib/text_backends/test_ark.py` 里 4 个用例，只加强断言。只改这一个测试文件；曳光弹 [#2323](https://github.com/ArcReel/ArcReel/pull/2323) 已单独走完 2 条，instructor_support / grok 另两张 PR。

- `test_plain_text`：断言 `result.model == backend.model`、发往端点的 `model` 与 `messages == [{"role": "user", "content": "hello"}]`。检查的是 plain 调用的 model 透传与 user 消息的 role / content 字面量。
- `test_vision_message_format`：断言第二条消息 `role == "user"`。检查的是 vision 消息的 role 字面量。
- `test_native_path_when_supported`：把「有 `response_format`」收紧为 `model` / `messages` / `response_format == {"type": "json_schema", "json_schema": {"name": "response", "schema": schema}}`。检查的是原生结构化路径发出的 response_format 形态与 schema 透传。
- 截断用例：断言 `exc_info.value.output_tokens == 8192`。检查的是截断异常携带的输出 token 数来自 usage。
- 按 review，`test_plain_text` 与 `test_native_path_when_supported` 对 `create` 的断言改写为 `assert_called_once_with(...)`：值不变，额外约束恰好一次调用、无位置参数、无多余关键字。

## 验证

三层验收对 [#2299](https://github.com/ArcReel/ArcReel/issues/2299) 的 90 条批量改造**一次做完**（instructor_support 46 + ark 32 + grok 12 同一分支上 8 模块 2186 个 mutant 全量复跑，`scripts/mutmut_compare.py --reworked` 填 90 条），再按模块切成 3 个 PR；本 PR 是其中一个，验收数字是整批的：

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 目标（90 条 ③） | 90 | **90 killed**，存活 0 |
| 基线 killed 护栏 | 1414 | **0 回退**；1 个 ⏰（`GeminiVideoBackend.__init__` 的 mutant，关联 21 个用例）新进程复核 1 failed，护栏成立 |
| 其余基线存活（曳光弹 2 条 + 票 2 的 106 条 + 无覆盖 / 等价） | 682 | 顺手杀死 2，均为曳光弹 #2323 的两个目标（该 PR 与本批共用同一基线，按 runbook §5.1 只登记） |
| 等价变异体清单 | 173 | 0 被杀 |

基线取 `research/mutmut-batch-2/baseline/`（#2297，`cd6451797`），8 个模块在 `origin/main` 上自基线以来零变动。**硬门**：本 PR diff 只有 1 个测试文件，不含 `lib/` 与 `server/`。

闸门：`ruff check` / `ruff format --check` / `basedpyright --warnings` / `lint-imports` / `deptry` / `audit_tests.py --check` 通过；`pytest -n 4 --dist loadfile`：11396 passed, 3 skipped（3:14）。

## 风险与遗留

- 只加强断言、不改输入、不新增用例；每条断言检查的内容不超出 `research/mutmut-batch-2/verdicts.md` 里对应条目的「加强后的断言检查的是什么」。
- 三张批量 PR 各自独立基于 `main`，合入顺序无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **测试**
  - 增强了 AI 文本请求和原生路径场景的自动化验证。
  - 现已完整校验请求调用参数，包括模型、消息内容及相关配置。
  - 扩展了视觉消息角色、消息结构以及结构化输出截断令牌限制的断言。
  - 提升了不同请求路径下参数验证的一致性与覆盖范围。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
