### PR TITLE
test(text-backends): Grok 用例断言 chat.parse 收到的动态模型字段与构造时传入的 api_key

### DIFF
--- a/tests/unit/lib/text_backends/test_grok.py
+++ b/tests/unit/lib/text_backends/test_grok.py
@@ -25,7 +25,7 @@ class TestProperties:
 
             b = GrokTextBackend(api_key="k")
         assert b.name == "grok"
-        assert create_client.call_args.kwargs == {"api_key": "k"}
+        create_client.assert_called_once_with(api_key="k")
 
     def test_default_model(self, mock_xai):
         with patch("lib.text_backends.grok.create_grok_client"):

--- a/tests/unit/lib/text_backends/test_grok.py
+++ b/tests/unit/lib/text_backends/test_grok.py
@@ -20,11 +20,12 @@ def mock_xai():
 
 class TestProperties:
     def test_name(self, mock_xai):
-        with patch("lib.text_backends.grok.create_grok_client"):
+        with patch("lib.text_backends.grok.create_grok_client") as create_client:
             from lib.text_backends.grok import GrokTextBackend
 
             b = GrokTextBackend(api_key="k")
         assert b.name == "grok"
+        assert create_client.call_args.kwargs == {"api_key": "k"}
 
     def test_default_model(self, mock_xai):
         with patch("lib.text_backends.grok.create_grok_client"):
@@ -87,6 +88,11 @@ class TestGenerate:
         result = await backend.generate(TextGenerationRequest(prompt="gen", response_schema=schema))
 
         assert result.text == '{"name": "test"}'
+        dynamic_model = mock_chat.parse.call_args.args[0]
+        assert set(dynamic_model.model_fields) == {"name"}
+        name_field = dynamic_model.model_fields["name"]
+        assert name_field.annotation == (str | None)
+        assert name_field.is_required() is False
 
     async def test_max_output_tokens_passed_to_chat_create(self, backend):
         """max_output_tokens 透传为 xai_sdk chat.create(max_tokens=)。"""


### PR DESCRIPTION
## 变更

[#2299](https://github.com/ArcReel/ArcReel/issues/2299) 批量改造三张 PR 之一（[地图 #2250](https://github.com/ArcReel/ArcReel/issues/2250)）：`lib/text_backends/grok.py` 在 #2297 判为 ③「断言不够严」的 12 个存活 mutant，对应 `tests/unit/lib/text_backends/test_grok.py` 里 2 个用例，只加强断言。只改这一个测试文件；曳光弹 [#2323](https://github.com/ArcReel/ArcReel/pull/2323) 已单独走完 2 条，instructor_support / ark 另两张 PR。

- `test_name`：`create_grok_client.assert_called_once_with(api_key="k")`。检查的是构造时 api_key 关键字透传，且恰好一次、无位置参数（按 review 从 `call_args.kwargs == {...}` 改写）。
- `test_structured_output`：取 `chat.parse` 收到的动态模型，断言字段集合恰为 `{"name"}`、注解为 `str | None`、非必填。检查的是 `_build_dynamic_model` 由 schema 生成的字段名、可选类型与默认值。

## 验证

三层验收对 [#2299](https://github.com/ArcReel/ArcReel/issues/2299) 的 90 条批量改造**一次做完**（instructor_support 46 + ark 32 + grok 12 同一分支上 8 模块 2186 个 mutant 全量复跑，`scripts/mutmut_compare.py --reworked` 填 90 条），再按模块切成 3 个 PR；本 PR 是其中一个，验收数字是整批的：

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 目标（90 条 ③） | 90 | **90 killed**，存活 0 |
| 基线 killed 护栏 | 1414 | **0 回退**；1 个 ⏰（`GeminiVideoBackend.__init__` 的 mutant，关联 21 个用例）新进程复核 1 failed，护栏成立 |
| 其余基线存活（曳光弹 2 条 + 票 2 的 106 条 + 无覆盖 / 等价） | 682 | 顺手杀死 2，均为曳光弹 #2323 的两个目标（该 PR 与本批共用同一基线，按 runbook §5.1 只登记） |
| 等价变异体清单 | 173 | 0 被杀 |

基线取 `research/mutmut-batch-2/baseline/`（#2297，`cd6451797`），8 个模块在 `origin/main` 上自基线以来零变动。**硬门**：本 PR diff 只有 1 个测试文件，不含 `lib/` 与 `server/`。

闸门：`ruff check` / `ruff format --check` / `basedpyright --warnings` / `lint-imports` / `deptry` / `audit_tests.py --check` 通过；`pytest -n 4 --dist loadfile`：11396 passed, 3 skipped（3:14）。

## 风险与遗留

- 只加强断言、不改输入、不新增用例；每条断言检查的内容不超出 `research/mutmut-batch-2/verdicts.md` 里对应条目的「加强后的断言检查的是什么」。
- 三张批量 PR 各自独立基于 `main`，合入顺序无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 增强 Grok 后端测试，验证客户端仅使用指定 API 密钥创建一次。
  * 完善结构化输出测试，确认生成的模型仅包含预期字段，并正确处理字符串类型及可选状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
