### PR TITLE
fix(artifact-manifest): Windows 下按二进制描述符算内容摘要并统一源文换行口径

### DIFF
--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -188,10 +188,10 @@ def ensure_imported_artifact_target_state(
             replaced: list[str] = []
             for key, entry in preserved_entries.items():
                 evidence = _archived_content_evidence(adapter, entry.artifact_path, preserved_content_digests[key])
-                if evidence == "complete":
+                if evidence == "exact":
                     restored[key] = entry
-                elif evidence == "prefix_only":
-                    # 只证明到首个 0x1A 之前的字节，绑不住整份产物：这条 claim 按无信封归档的口径，
+                elif evidence == "text_mode":
+                    # 文本模式摘要丢了字节，绑不住整份产物：这条 claim 按无信封归档的口径，
                     # 用当前投影自证补录；投影不出条目的目标不登记。
                     projected = plan.entries.get(key)
                     if projected is not None:
@@ -229,22 +229,19 @@ def _archived_content_evidence(
     adapter: ProjectArtifactManifestAdapter,
     artifact_path: str,
     archived_digest: str,
-) -> Literal["complete", "prefix_only", "mismatch"]:
-    """Classify how far the archived content digest binds a claim to the imported bytes.
+) -> Literal["exact", "text_mode", "mismatch"]:
+    """Classify whether the archived content digest binds a claim to the imported bytes.
 
-    Archives exported through a text-mode descriptor hashed CRLF folded to LF and stopped at the
-    first ``0x1A``.  The fold alone still covers every byte, so the claim stays bound; a read cut
-    short at ``0x1A`` proves only the prefix (every PNG signature carries that byte) and cannot
-    bind the frozen basis to the whole artifact.
+    Archives exported through a text-mode descriptor hashed CRLF folded to LF and stopped at
+    the first ``0x1A``.  Both translations drop bytes, so such a digest cannot prove the whole
+    artifact; it only shows the bytes came through that export path.
     """
 
     if read_artifact_content_digest(adapter, artifact_path) == archived_digest:
-        return "complete"
+        return "exact"
     content, _digest = read_artifact_content_snapshot(adapter, artifact_path)
-    prefix, delimiter, _rest = content.partition(b"\x1a")
-    if hashlib.sha256(prefix.replace(b"\r\n", b"\n")).hexdigest() != archived_digest:
-        return "mismatch"
-    return "prefix_only" if delimiter else "complete"
+    text_mode_view = content.split(b"\x1a", 1)[0].replace(b"\r\n", b"\n")
+    return "text_mode" if hashlib.sha256(text_mode_view).hexdigest() == archived_digest else "mismatch"
 
 
 def _plan_preserved_artifact_target_state(project_dir: Path) -> ArtifactTargetStatePlan:

--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -158,9 +158,13 @@ def ensure_imported_artifact_target_state(
 
     Official exports carry the complete source Manifest in their visible archive
     envelope.  Its basis digests are immutable generation evidence and its content
-    digests bind those claims to the exported formal bytes.  Validate both against
-    the imported canonical target plan, then restore that whole snapshot in one
-    commit.  Legacy archives without the envelope retain the self-proving path.
+    digests bind those claims to the exported formal bytes.  Validate the claims
+    against the imported canonical target plan, then commit one snapshot in which
+    each claim is settled by its content evidence: an exact digest match restores
+    the frozen claim; a digest that only matches the text-mode view (CRLF folded,
+    cut at ``0x1A``) cannot prove the whole artifact, so that key is re-registered
+    from the current self-proving projection instead; any other digest rejects the
+    import.  Legacy archives without the envelope retain the self-proving path.
     """
 
     raw = (project_dir / "project.json").read_bytes()

--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -11,6 +11,7 @@ state; ordinary readers never repair or infer entries on first access.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import time
@@ -25,6 +26,7 @@ from lib.artifact_currency import (
     active_artifact_currency_resolver,
     artifact_is_usable,
     read_artifact_content_digest,
+    read_artifact_content_snapshot,
     resolve_artifact_episode,
     resolve_current_artifact_basis,
     resolve_current_artifact_target,
@@ -185,7 +187,7 @@ def ensure_imported_artifact_target_state(
             replaced = [
                 key.encode()
                 for key, entry in preserved_entries.items()
-                if read_artifact_content_digest(adapter, entry.artifact_path) != preserved_content_digests[key]
+                if not _archived_content_digest_matches(adapter, entry.artifact_path, preserved_content_digests[key])
             ]
             if replaced:
                 raise ValueError(
@@ -212,6 +214,29 @@ def snapshot_preserved_artifact_manifest(
         }
         _assert_preflight_unchanged(project_dir, plan)
     return ArtifactManifestArchiveSnapshot(entries=rebased, content_digests=content_digests)
+
+
+def _archived_content_digest_matches(
+    adapter: ProjectArtifactManifestAdapter,
+    artifact_path: str,
+    archived_digest: str,
+) -> bool:
+    """Accept archived formal-byte evidence hashed from the raw bytes or from a text-mode descriptor view.
+
+    Windows archives can carry digests taken through a text-mode descriptor: CRLF folded to LF
+    and the read stopped at the first ``0x1A`` byte.  Such evidence still proves the same formal bytes.
+    """
+
+    if read_artifact_content_digest(adapter, artifact_path) == archived_digest:
+        return True
+    content, _digest = read_artifact_content_snapshot(adapter, artifact_path)
+    return hashlib.sha256(_text_mode_descriptor_view(content)).hexdigest() == archived_digest
+
+
+def _text_mode_descriptor_view(content: bytes) -> bytes:
+    """Bytes a Windows C-runtime text-mode read yields for ``content``."""
+
+    return content.split(b"\x1a", 1)[0].replace(b"\r\n", b"\n")
 
 
 def _plan_preserved_artifact_target_state(project_dir: Path) -> ArtifactTargetStatePlan:

--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -17,7 +17,7 @@ import os
 import time
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from lib.artifact_currency import (
     ArtifactComparer,
@@ -184,17 +184,26 @@ def ensure_imported_artifact_target_state(
                 raise ValueError(f"archive Artifact Manifest contains unprovable formal claims: {sorted(invalid)}")
             _assert_preflight_unchanged(project_dir, plan)
             adapter = ProjectArtifactManifestAdapter(project_dir)
-            replaced = [
-                key.encode()
-                for key, entry in preserved_entries.items()
-                if not _archived_content_digest_matches(adapter, entry.artifact_path, preserved_content_digests[key])
-            ]
+            restored: dict[ArtifactKey, ArtifactManifestEntry] = {}
+            replaced: list[str] = []
+            for key, entry in preserved_entries.items():
+                evidence = _archived_content_evidence(adapter, entry.artifact_path, preserved_content_digests[key])
+                if evidence == "complete":
+                    restored[key] = entry
+                elif evidence == "prefix_only":
+                    # 只证明到首个 0x1A 之前的字节，绑不住整份产物：这条 claim 按无信封归档的口径，
+                    # 用当前投影自证补录；投影不出条目的目标不登记。
+                    projected = plan.entries.get(key)
+                    if projected is not None:
+                        restored[key] = projected
+                else:
+                    replaced.append(key.encode())
             if replaced:
                 raise ValueError(
                     f"archive Artifact Manifest formal artifact content does not match its claims: {sorted(replaced)}"
                 )
             _assert_preflight_unchanged(project_dir, plan)
-            return adapter.replace_entries_atomically(preserved_entries)
+            return adapter.replace_entries_atomically(restored)
     return activate_artifact_target_state(project_dir, bump_schema=False)
 
 
@@ -216,27 +225,26 @@ def snapshot_preserved_artifact_manifest(
     return ArtifactManifestArchiveSnapshot(entries=rebased, content_digests=content_digests)
 
 
-def _archived_content_digest_matches(
+def _archived_content_evidence(
     adapter: ProjectArtifactManifestAdapter,
     artifact_path: str,
     archived_digest: str,
-) -> bool:
-    """Accept archived formal-byte evidence hashed from the raw bytes or from a text-mode descriptor view.
+) -> Literal["complete", "prefix_only", "mismatch"]:
+    """Classify how far the archived content digest binds a claim to the imported bytes.
 
-    Windows archives can carry digests taken through a text-mode descriptor: CRLF folded to LF
-    and the read stopped at the first ``0x1A`` byte.  Such evidence still proves the same formal bytes.
+    Archives exported through a text-mode descriptor hashed CRLF folded to LF and stopped at the
+    first ``0x1A``.  The fold alone still covers every byte, so the claim stays bound; a read cut
+    short at ``0x1A`` proves only the prefix (every PNG signature carries that byte) and cannot
+    bind the frozen basis to the whole artifact.
     """
 
     if read_artifact_content_digest(adapter, artifact_path) == archived_digest:
-        return True
+        return "complete"
     content, _digest = read_artifact_content_snapshot(adapter, artifact_path)
-    return hashlib.sha256(_text_mode_descriptor_view(content)).hexdigest() == archived_digest
-
-
-def _text_mode_descriptor_view(content: bytes) -> bytes:
-    """Bytes a Windows C-runtime text-mode read yields for ``content``."""
-
-    return content.split(b"\x1a", 1)[0].replace(b"\r\n", b"\n")
+    prefix, delimiter, _rest = content.partition(b"\x1a")
+    if hashlib.sha256(prefix.replace(b"\r\n", b"\n")).hexdigest() != archived_digest:
+        return "mismatch"
+    return "prefix_only" if delimiter else "complete"
 
 
 def _plan_preserved_artifact_target_state(project_dir: Path) -> ArtifactTargetStatePlan:

--- a/lib/artifact_activation.py
+++ b/lib/artifact_activation.py
@@ -11,7 +11,6 @@ state; ordinary readers never repair or infer entries on first access.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import time
@@ -26,7 +25,6 @@ from lib.artifact_currency import (
     active_artifact_currency_resolver,
     artifact_is_usable,
     read_artifact_content_digest,
-    read_artifact_content_snapshot,
     resolve_artifact_episode,
     resolve_current_artifact_basis,
     resolve_current_artifact_target,
@@ -77,6 +75,7 @@ from lib.artifact_registration import (
     register_task_current_resource_artifact,
     resolve_current_resource_artifact_basis,
 )
+from lib.content_digest import TextModeDigest
 from lib.formal_write import project_metadata_lock
 from lib.json_io import atomic_write_bytes, atomic_write_json
 from lib.project_schema import project_schema_is_current
@@ -234,14 +233,14 @@ def _archived_content_evidence(
 
     Archives exported through a text-mode descriptor hashed CRLF folded to LF and stopped at
     the first ``0x1A``.  Both translations drop bytes, so such a digest cannot prove the whole
-    artifact; it only shows the bytes came through that export path.
+    artifact; it only shows the bytes came through that export path.  Both digests come from
+    one streamed read so large formal media is never buffered.
     """
 
-    if read_artifact_content_digest(adapter, artifact_path) == archived_digest:
+    text_mode = TextModeDigest()
+    if read_artifact_content_digest(adapter, artifact_path, chunk_observer=text_mode.update) == archived_digest:
         return "exact"
-    content, _digest = read_artifact_content_snapshot(adapter, artifact_path)
-    text_mode_view = content.split(b"\x1a", 1)[0].replace(b"\r\n", b"\n")
-    return "text_mode" if hashlib.sha256(text_mode_view).hexdigest() == archived_digest else "mismatch"
+    return "text_mode" if text_mode.hexdigest() == archived_digest else "mismatch"
 
 
 def _plan_preserved_artifact_target_state(project_dir: Path) -> ArtifactTargetStatePlan:

--- a/lib/artifact_currency.py
+++ b/lib/artifact_currency.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -26,10 +26,15 @@ from lib.project_migration_failure import ProjectMigrationError
 from lib.project_schema import CURRENT_PROJECT_SCHEMA_VERSION, parse_project_schema_version, project_schema_is_current
 
 
-def read_artifact_content_digest(adapter: ProjectArtifactManifestAdapter, artifact_path: str) -> str:
+def read_artifact_content_digest(
+    adapter: ProjectArtifactManifestAdapter,
+    artifact_path: str,
+    *,
+    chunk_observer: Callable[[bytes], None] | None = None,
+) -> str:
     """Hash one safely admitted formal path without requiring an active Manifest."""
 
-    observation = adapter.inspect_artifact_content(artifact_path)
+    observation = adapter.inspect_artifact_content(artifact_path, chunk_observer=chunk_observer)
     if observation.blocker is not None:
         raise ArtifactManifestError(observation.blocker.detail)
     if not observation.present:

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -642,10 +642,19 @@ class ProjectArtifactManifestAdapter:
     def inspect_artifact(self, artifact_path: str) -> ArtifactObservation:
         return self._inspect_artifact(artifact_path, include_content_digest=False)
 
-    def inspect_artifact_content(self, artifact_path: str) -> ArtifactObservation:
-        """Inspect and hash one artifact through the same confined file handle."""
+    def inspect_artifact_content(
+        self,
+        artifact_path: str,
+        *,
+        chunk_observer: Callable[[bytes], None] | None = None,
+    ) -> ArtifactObservation:
+        """Inspect and hash one artifact through the same confined file handle.
 
-        return self._inspect_artifact(artifact_path, include_content_digest=True)
+        ``chunk_observer`` sees every chunk as it is hashed, so callers can derive
+        a second digest from the same read without buffering the artifact.
+        """
+
+        return self._inspect_artifact(artifact_path, include_content_digest=True, chunk_observer=chunk_observer)
 
     def inspect_artifact_snapshot(self, artifact_path: str) -> ArtifactObservation:
         """Read and hash one artifact from the same confined file descriptor."""
@@ -662,6 +671,7 @@ class ProjectArtifactManifestAdapter:
         *,
         include_content_digest: bool,
         include_content_bytes: bool = False,
+        chunk_observer: Callable[[bytes], None] | None = None,
     ) -> ArtifactObservation:
         try:
             normalized = normalize_artifact_path(artifact_path)
@@ -673,11 +683,13 @@ class ProjectArtifactManifestAdapter:
                 normalized,
                 include_content_digest=include_content_digest,
                 include_content_bytes=include_content_bytes,
+                chunk_observer=chunk_observer,
             )
         return self._inspect_artifact_portable(
             normalized,
             include_content_digest=include_content_digest,
             include_content_bytes=include_content_bytes,
+            chunk_observer=chunk_observer,
         )
 
     def _read_open_artifact(
@@ -688,15 +700,19 @@ class ProjectArtifactManifestAdapter:
         *,
         include_content_digest: bool,
         include_content_bytes: bool,
+        chunk_observer: Callable[[bytes], None] | None = None,
     ) -> tuple[str | None, bytes | None, ArtifactObservation | None]:
         if not include_content_digest:
             os.read(fd, 1)
             return None, None, None
 
-        hexdigest, _size, content = digest_stream(
-            lambda size: os.read(fd, size),
-            collect_content=include_content_bytes,
-        )
+        def _read(size: int) -> bytes:
+            chunk = os.read(fd, size)
+            if chunk_observer is not None and chunk:
+                chunk_observer(chunk)
+            return chunk
+
+        hexdigest, _size, content = digest_stream(_read, collect_content=include_content_bytes)
         completed_stat = os.fstat(fd)
         opened_version = (opened_stat.st_size, opened_stat.st_mtime_ns, opened_stat.st_ctime_ns)
         completed_version = (completed_stat.st_size, completed_stat.st_mtime_ns, completed_stat.st_ctime_ns)
@@ -718,6 +734,7 @@ class ProjectArtifactManifestAdapter:
         *,
         include_content_digest: bool = False,
         include_content_bytes: bool = False,
+        chunk_observer: Callable[[bytes], None] | None = None,
     ) -> ArtifactObservation:
         parts = PurePosixPath(normalized).parts
         directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | self._nofollow_flag
@@ -843,6 +860,7 @@ class ProjectArtifactManifestAdapter:
                     opened_file_stat,
                     include_content_digest=include_content_digest,
                     include_content_bytes=include_content_bytes,
+                    chunk_observer=chunk_observer,
                 )
                 if content_blocker is not None:
                     return content_blocker
@@ -877,6 +895,7 @@ class ProjectArtifactManifestAdapter:
         *,
         include_content_digest: bool = False,
         include_content_bytes: bool = False,
+        chunk_observer: Callable[[bytes], None] | None = None,
     ) -> ArtifactObservation:
         if _is_linkish(self._project_dir):
             return self._artifact_blocked(
@@ -890,6 +909,7 @@ class ProjectArtifactManifestAdapter:
                     normalized,
                     include_content_digest=include_content_digest,
                     include_content_bytes=include_content_bytes,
+                    chunk_observer=chunk_observer,
                 )
         except ArtifactManifestError as exc:
             return self._artifact_blocked(normalized, "artifact_unreadable", str(exc))
@@ -900,6 +920,7 @@ class ProjectArtifactManifestAdapter:
         *,
         include_content_digest: bool = False,
         include_content_bytes: bool = False,
+        chunk_observer: Callable[[bytes], None] | None = None,
     ) -> ArtifactObservation:
         path = self._project_dir.joinpath(*PurePosixPath(normalized).parts)
         cursor = self._project_dir
@@ -948,6 +969,7 @@ class ProjectArtifactManifestAdapter:
                     opened_stat,
                     include_content_digest=include_content_digest,
                     include_content_bytes=include_content_bytes,
+                    chunk_observer=chunk_observer,
                 )
                 if content_blocker is not None:
                     return content_blocker

--- a/lib/artifact_manifest.py
+++ b/lib/artifact_manifest.py
@@ -38,6 +38,17 @@ from lib.content_digest import (
 )
 from lib.schema_guards import is_str
 
+
+def _binary_open_flag() -> int:
+    """文件 fd 一律按二进制打开的标志位；POSIX 无此标志，取 0。
+
+    Windows 的 C 运行时缺省文本模式会折叠 CRLF、遇 0x1A 停读，经 fd 算出的内容摘要会与
+    按字节读同一文件的摘要不一致。
+    """
+
+    return getattr(os, "O_BINARY", 0)
+
+
 _KEY_PREFIX = "artifact-key-v1:"
 MANIFEST_FILENAME = ".arcreel_artifacts.json"
 LOCK_FILENAME = ".artifact_manifest.lock"
@@ -710,7 +721,7 @@ class ProjectArtifactManifestAdapter:
     ) -> ArtifactObservation:
         parts = PurePosixPath(normalized).parts
         directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | self._nofollow_flag
-        file_flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0)
+        file_flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0) | _binary_open_flag()
         with contextlib.ExitStack() as stack:
             if not self._nofollow_flag and _is_linkish(self._project_dir):
                 return self._artifact_blocked(
@@ -920,7 +931,7 @@ class ProjectArtifactManifestAdapter:
                 detail=f"artifact path is not a regular file: {normalized}",
             )
             return ArtifactObservation(artifact_path=normalized, present=False, blocker=blocker)
-        flags = os.O_RDONLY | self._nofollow_flag
+        flags = os.O_RDONLY | self._nofollow_flag | _binary_open_flag()
         try:
             fd = os.open(path, flags)
             try:
@@ -1375,7 +1386,7 @@ class ProjectArtifactManifestAdapter:
             checked_manifest_identity = self._runtime_file_identity(path, "artifact manifest")
             if checked_manifest_identity is None:
                 return {}, None
-        flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0)
+        flags = os.O_RDONLY | self._nofollow_flag | getattr(os, "O_NONBLOCK", 0) | _binary_open_flag()
         try:
             fd = os.open(MANIFEST_FILENAME, flags, dir_fd=root_fd) if root_fd is not None else os.open(path, flags)
         except FileNotFoundError:

--- a/lib/artifact_planner.py
+++ b/lib/artifact_planner.py
@@ -24,7 +24,12 @@ from lib.artifact_manifest import (
     ArtifactManifestError,
     ProjectArtifactManifestAdapter,
 )
-from lib.artifact_provenance import build_ad_episode_script_basis, build_episode_script_basis, build_script_plan_basis
+from lib.artifact_provenance import (
+    build_ad_episode_script_basis,
+    build_episode_script_basis,
+    build_script_plan_basis,
+    decode_script_plan_source,
+)
 from lib.artifact_version_provenance import parse_typed_audio_settings, parse_typed_media_version_target
 from lib.asset_types import ASSET_SPECS, asset_name_comparison_key
 from lib.episode_paths import episode_source_relpath
@@ -488,7 +493,7 @@ class TargetStatePlanner:
         if source_observation.blocker is None and source_observation.present:
             source_raw = self._read_dependency(source_rel, "episode source")
             try:
-                source_content = source_raw.decode("utf-8")
+                source_content = decode_script_plan_source(source_raw)
             except UnicodeDecodeError as exc:
                 raise ValueError(f"episode source {source_rel} is not UTF-8") from exc
             try:

--- a/lib/artifact_provenance.py
+++ b/lib/artifact_provenance.py
@@ -15,6 +15,7 @@ from lib.episode_ledger import episode_outline_context
 from lib.episode_target_duration import project_episode_target_duration
 from lib.speech_rate import project_speech_rate_override, speech_rate_units_per_second
 from lib.text_metrics import reading_unit_noun
+from lib.text_utils import normalize_newlines
 
 _STRUCTURED_CONTENT_MODES = frozenset({"narration", "drama"})
 _GENERATION_MODES = frozenset({"storyboard", "reference_video"})
@@ -23,6 +24,19 @@ _DEFAULT_SOURCE_LANGUAGE = "中文"
 _AD_OVERVIEW_FIELDS = ("synopsis", "genre", "theme")
 
 ScriptPlanPromptVariant = Literal["drama", "narration", "reference_video"]
+
+
+def decode_script_plan_source(raw: bytes) -> str:
+    """Decode episode source bytes into the text the script_plan tools consume.
+
+    Script_plan generation reads the source through ``Path.read_text`` and the
+    basis freezes that text, so canonical basis reconstruction must apply the
+    same universal-newline translation: ``\\r\\n`` and lone ``\\r`` both become
+    ``\\n``.  Otherwise a source written with platform line endings never
+    matches its registered basis and the script_plan reads stale forever.
+    """
+
+    return normalize_newlines(raw.decode("utf-8"))
 
 
 def build_script_plan_basis(

--- a/lib/content_digest.py
+++ b/lib/content_digest.py
@@ -51,6 +51,38 @@ def digest_stream(
     return digest.hexdigest(), size, b"".join(chunks) if chunks is not None else None
 
 
+class TextModeDigest:
+    """流式复现 Windows C 运行时文本模式读同一份字节得到的 sha256：CRLF 折叠为 LF，读到首个 0x1A 为止。
+
+    按块喂入 ``update``，块边界上的 ``\\r`` 会留到下一块再决定是否折叠，结果与整体读取一致。
+    """
+
+    def __init__(self) -> None:
+        self._digest = hashlib.sha256()
+        self._pending_cr = False
+        self._truncated = False
+
+    def update(self, chunk: bytes) -> None:
+        if self._truncated or not chunk:
+            return
+        if self._pending_cr:
+            chunk = b"\r" + chunk
+            self._pending_cr = False
+        head, delimiter, _rest = chunk.partition(b"\x1a")
+        if delimiter:
+            self._truncated = True
+        elif head.endswith(b"\r"):
+            head = head[:-1]
+            self._pending_cr = True
+        self._digest.update(head.replace(b"\r\n", b"\n"))
+
+    def hexdigest(self) -> str:
+        digest = self._digest.copy()
+        if self._pending_cr:
+            digest.update(b"\r")
+        return digest.hexdigest()
+
+
 def sha256_file_with_size(path: Path) -> tuple[str, int]:
     """流式取文件摘要与字节数；路径不是常规文件时抛 ``FileNotFoundError``。"""
 

--- a/lib/episode_ledger.py
+++ b/lib/episode_ledger.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from lib.episode_paths import episode_drafts_dir, episode_script_relpath
 from lib.path_safety import safe_exists
+from lib.text_utils import normalize_newlines
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +161,7 @@ def normalize_source_text(text: str) -> str:
     source_range / planning_cursor 的偏移量全部落在本函数输出的坐标系内，
     任何按偏移切片源文的消费方必须先对源文执行本函数。
     """
-    return unicodedata.normalize("NFC", text).replace("\r\n", "\n").replace("\r", "\n")
+    return unicodedata.normalize("NFC", normalize_newlines(text))
 
 
 @dataclass

--- a/lib/episode_planner.py
+++ b/lib/episode_planner.py
@@ -952,7 +952,8 @@ class EpisodePlanner:
         # 校验全部通过后统一落盘：校验类失败不会留下按新布局部分重写的派生文件
         source_dir.mkdir(exist_ok=True)
         for episode_path, content in writes:
-            episode_path.write_text(content, encoding="utf-8")
+            # 派生文件的字节与账本切片文本一致：不做平台换行翻译，Manifest 依据按字节重算才稳定。
+            episode_path.write_text(content, encoding="utf-8", newline="\n")
         for num, path in discover_episode_files(self.project_path).items():
             if num not in keep:
                 try:

--- a/lib/text_utils.py
+++ b/lib/text_utils.py
@@ -11,6 +11,11 @@ _OPENING_FENCE = re.compile(r"^```[ \t]*(?:json)?[ \t]*\n?", re.IGNORECASE)
 _CLOSING_FENCE = re.compile(r"\n?```$")
 
 
+def normalize_newlines(text: str) -> str:
+    """把 ``\\r\\n`` 与孤立的 ``\\r`` 统一为 ``\\n``，与 ``Path.read_text`` 的通用换行翻译同口径。"""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def strip_json_code_fences(text: str) -> str:
     """剥离 LLM 输出最外层的 markdown 代码栅栏，返回可交给 json.loads 的纯文本。
 

--- a/tests/integration/lib/test_artifact_manifest_storage.py
+++ b/tests/integration/lib/test_artifact_manifest_storage.py
@@ -24,6 +24,7 @@ from lib.artifact_manifest import (
     ArtifactStatus,
     ProjectArtifactManifestAdapter,
 )
+from lib.visual_artifact_provenance import visual_file_digest
 
 _RUNTIME_FIFO_COMPARISON = """
 import json
@@ -1162,3 +1163,66 @@ def test_project_adapter_reports_excessive_manifest_nesting_as_blocked_without_r
     with pytest.raises(ArtifactManifestError):
         manifest.register(key, artifact_path="episode.json", basis=basis)
     assert manifest_path.read_bytes() == malformed
+
+
+def test_project_adapter_hashes_content_through_a_binary_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Content digests must come from the raw bytes: a CRLF / 0x1A payload hashes like ``sha256`` of the file.
+
+    Platforms whose C runtime defaults descriptors to text mode translate line endings and stop at
+    ``0x1A`` unless the open request carries ``O_BINARY``; the portable content path and the manifest
+    read path must both request it whenever the platform defines the flag, and the digest must equal
+    the byte-for-byte hash either way.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    payload = b'{"a":1}\r\n\x1a{"trailing":2}\r\n'
+    (project / "episode.json").write_bytes(payload)
+    fake_binary_flag = 0x8000
+    monkeypatch.setattr(os, "O_BINARY", fake_binary_flag, raising=False)
+    original_open = os.open
+    open_flags: dict[str, list[int]] = {"episode.json": [], MANIFEST_FILENAME: []}
+
+    def record_open(path: str | bytes | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        name = os.path.basename(os.fsdecode(path))
+        if name in open_flags:
+            open_flags[name].append(flags)
+        # 假标志位只用于观察请求，真实 POSIX open 不认识它。
+        return original_open(path, flags & ~fake_binary_flag, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr("lib.artifact_manifest.os.open", record_open)
+    adapter = ProjectArtifactManifestAdapter(project, nofollow_supported=False)
+
+    snapshot = adapter.inspect_artifact_content("episode.json")
+
+    assert snapshot.present
+    assert snapshot.content_digest == hashlib.sha256(payload).hexdigest()
+
+    manifest = ArtifactManifest(adapter)
+    key = ArtifactKey.episode_script(1)
+    basis = ArtifactBasis.build("test/script", kind_version=1, inputs={"script_plan": "source"})
+    manifest.register(key, artifact_path="episode.json", basis=basis)
+    assert manifest.compare(key, artifact_path="episode.json", basis=basis).status is ArtifactStatus.CURRENT
+
+    for name, recorded in open_flags.items():
+        assert recorded, name
+        assert all(flags & fake_binary_flag for flags in recorded), (name, recorded)
+
+
+def test_project_adapter_content_digest_matches_visual_file_digest(tmp_path: Path) -> None:
+    """Asset bytes hash identically through the adapter and through ``visual_file_digest``.
+
+    The PNG signature already contains CRLF and ``0x1A``, so the two digests agree only when both
+    sides read the file byte for byte.
+    """
+    project = tmp_path / "project"
+    (project / "characters").mkdir(parents=True)
+    image = project / "characters" / "江照.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"IHDR\r\n" * 3)
+
+    snapshot = ProjectArtifactManifestAdapter(project).inspect_artifact_content("characters/江照.png")
+
+    assert snapshot.present
+    assert snapshot.content_digest == visual_file_digest(image) == hashlib.sha256(image.read_bytes()).hexdigest()

--- a/tests/integration/lib/test_artifact_manifest_storage.py
+++ b/tests/integration/lib/test_artifact_manifest_storage.py
@@ -1226,3 +1226,31 @@ def test_project_adapter_content_digest_matches_visual_file_digest(tmp_path: Pat
 
     assert snapshot.present
     assert snapshot.content_digest == visual_file_digest(image) == hashlib.sha256(image.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize("inspection_path", ["posix", "portable"])
+def test_project_adapter_streams_hashed_chunks_to_the_observer(tmp_path: Path, inspection_path: str) -> None:
+    """``chunk_observer`` sees exactly the bytes hashed, chunk by chunk, so callers derive a second digest without buffering."""
+    if inspection_path == "posix" and os.name != "posix":
+        pytest.skip("descriptor traversal is the POSIX artifact inspection path")
+    project = tmp_path / "project"
+    project.mkdir()
+    payload = b"\x89PNG\r\n\x1a\n" + bytes(range(256)) * 8 * 1024
+    (project / "sheet.png").write_bytes(payload)
+    adapter = ProjectArtifactManifestAdapter(project)
+    seen: list[bytes] = []
+
+    if inspection_path == "posix":
+        observation = adapter._inspect_artifact_posix(
+            "sheet.png", include_content_digest=True, chunk_observer=seen.append
+        )
+    else:
+        observation = adapter._inspect_artifact_portable(
+            "sheet.png", include_content_digest=True, chunk_observer=seen.append
+        )
+
+    assert observation.present
+    assert observation.content_bytes is None
+    assert len(seen) > 1
+    assert b"".join(seen) == payload
+    assert observation.content_digest == hashlib.sha256(payload).hexdigest()

--- a/tests/integration/lib/test_workflow_state.py
+++ b/tests/integration/lib/test_workflow_state.py
@@ -2254,3 +2254,44 @@ def test_nested_ledger_script_path_is_blocked_before_dispatch(tmp_path: Path) ->
     assert status.target.script_filename == "archive/custom.json"
     assert status.blockers[0].code == "invalid_script_path"
     assert status.next_action.type == "none"
+
+
+def test_script_plan_registered_from_read_text_source_stays_current_with_crlf_bytes(tmp_path: Path) -> None:
+    """A derived source persisted with CRLF must not leave the registered script_plan stale.
+
+    The split tool freezes the basis over ``Path.read_text`` output; canonical reconstruction reads
+    the same file as bytes and must reach the identical digest, otherwise the workflow reports a
+    permanently stale script_plan that no rebuild can clear.
+    """
+    from lib.artifact_currency import ArtifactCurrencyResolver
+    from lib.artifact_manifest import ArtifactStatus
+    from lib.artifact_provenance import build_script_plan_request
+
+    pm, project_path = _make_project(tmp_path, "narration")
+    source_text = "第一行\n第二行\n"
+    _write_source_and_complete(pm, project_path, source_text)
+
+    def _plan(project: dict) -> None:
+        project["episodes"] = [{"episode": 1, "script_file": "scripts/episode_1.json", "ledger_status": "planned"}]
+
+    pm.update_project("demo", _plan)
+    source_path = project_path / "source" / "episode_1.txt"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(source_text.replace("\n", "\r\n").encode("utf-8"))
+    draft_dir = project_path / "drafts" / "episode_1"
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(draft_dir / "script_plan_segments.json", {"episode": 1, "segments": []})
+    project = pm.load_project("demo")
+    _prompt_inputs, basis = build_script_plan_request(
+        source_path.read_text(encoding="utf-8"),
+        episode=1,
+        project=project,
+        expected_variant="narration",
+    )
+    key = ArtifactKey.episode_script_plan(1)
+    artifact_path = "drafts/episode_1/script_plan_segments.json"
+    register_current_artifact(project_path, key, artifact_path=artifact_path, basis=basis)
+
+    comparison = ArtifactCurrencyResolver(project_path).compare(key, artifact_path=artifact_path)
+
+    assert comparison.status is ArtifactStatus.CURRENT

--- a/tests/integration/server/services/test_project_archive_service.py
+++ b/tests/integration/server/services/test_project_archive_service.py
@@ -420,6 +420,42 @@ class TestProjectArchiveService:
         assert any(item.code == "artifact_activation_failed" for item in exc_info.value.diagnostics.blocking)
         assert not (pm.projects_root / "demo").exists()
 
+    def test_import_accepts_official_manifest_claim_hashed_through_a_text_mode_descriptor(self, tmp_path):
+        """归档信封里的 content_digest 若是文本模式读取视角（CRLF 折叠、读到 0x1A 为止）的摘要，仍能证明同一份字节。"""
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        formal_bytes = b"\x89PNG\r\n\x1a\nIHDR\r\n"
+        _write_bytes(project_dir / "characters" / "Hero.png", formal_bytes)
+        project = pm.load_project("demo")
+        project["schema_version"] = 7
+        _write_json(project_dir / "project.json", project)
+        _activate_artifact_manifest(project_dir)
+        key = ArtifactKey.asset_sheet("character", "Hero")
+
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+        legacy_path = tmp_path / "legacy.zip"
+        with (
+            zipfile.ZipFile(archive_path) as source,
+            zipfile.ZipFile(legacy_path, "w", compression=zipfile.ZIP_DEFLATED) as target,
+        ):
+            for member in source.infolist():
+                content = source.read(member)
+                if member.filename == f"demo/{ARCHIVE_MANIFEST_NAME}":
+                    envelope = json.loads(content)
+                    entry = envelope["artifact_manifest"]["entries"][key.encode()]
+                    assert entry["content_digest"] == hashlib.sha256(formal_bytes).hexdigest()
+                    entry["content_digest"] = hashlib.sha256(b"\x89PNG\n").hexdigest()
+                    content = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+                target.writestr(member, content)
+        shutil.rmtree(project_dir)
+
+        service.import_project_archive(legacy_path, uploaded_filename="legacy.zip")
+
+        imported_dir = pm.get_project_path("demo")
+        assert (imported_dir / "characters" / "Hero.png").read_bytes() == formal_bytes
+        assert ProjectArtifactManifestAdapter(imported_dir).get_entry(key) is not None
+
     def test_official_round_trip_preserves_a_stale_asset_claim(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)

--- a/tests/integration/server/services/test_project_archive_service.py
+++ b/tests/integration/server/services/test_project_archive_service.py
@@ -420,41 +420,116 @@ class TestProjectArchiveService:
         assert any(item.code == "artifact_activation_failed" for item in exc_info.value.diagnostics.blocking)
         assert not (pm.projects_root / "demo").exists()
 
-    def test_import_accepts_official_manifest_claim_hashed_through_a_text_mode_descriptor(self, tmp_path):
-        """归档信封里的 content_digest 若是文本模式读取视角（CRLF 折叠、读到 0x1A 为止）的摘要，仍能证明同一份字节。"""
+    @staticmethod
+    def _rewrite_archive(source_path: Path, target_path: Path, *, rewrite) -> None:
+        """按成员名逐个改写归档内容，其余成员原样复制。"""
+        with (
+            zipfile.ZipFile(source_path) as source,
+            zipfile.ZipFile(target_path, "w", compression=zipfile.ZIP_DEFLATED) as target,
+        ):
+            for member in source.infolist():
+                target.writestr(member, rewrite(member.filename, source.read(member)))
+
+    def test_import_restores_a_claim_whose_archived_digest_folded_line_endings(self, tmp_path):
+        """信封 content_digest 若来自文本模式读取（CRLF 折叠为 LF），且产物不含 0x1A，证据覆盖全部字节，冻结的 claim 原样恢复。"""
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
-        formal_bytes = b"\x89PNG\r\n\x1a\nIHDR\r\n"
-        _write_bytes(project_dir / "characters" / "Hero.png", formal_bytes)
         project = pm.load_project("demo")
         project["schema_version"] = 7
         _write_json(project_dir / "project.json", project)
+        _write_text(project_dir / "source" / "episode_1.txt", "原文")
+        script_plan_path = project_dir / "drafts" / "episode_1" / "script_plan_segments.json"
+        _write_json(script_plan_path, {"segments": [{"segment_id": "E1S01", "text": "原文"}]})
         _activate_artifact_manifest(project_dir)
-        key = ArtifactKey.asset_sheet("character", "Hero")
+        key = ArtifactKey.episode_script(1)
+        before = ProjectArtifactManifestAdapter(project_dir).get_entry(key)
+        assert before is not None
+        assert script_review.delete_script_plan_file(project_dir, 1, script_plan_path)
+        assert (
+            ArtifactCurrencyResolver(project_dir).compare(key, artifact_path="scripts/episode_1.json").status
+            is ArtifactStatus.STALE
+        )
 
         service = ProjectArchiveService(pm)
         archive_path, _ = service.export_project("demo")
         legacy_path = tmp_path / "legacy.zip"
-        with (
-            zipfile.ZipFile(archive_path) as source,
-            zipfile.ZipFile(legacy_path, "w", compression=zipfile.ZIP_DEFLATED) as target,
-        ):
-            for member in source.infolist():
-                content = source.read(member)
-                if member.filename == f"demo/{ARCHIVE_MANIFEST_NAME}":
-                    envelope = json.loads(content)
-                    entry = envelope["artifact_manifest"]["entries"][key.encode()]
-                    assert entry["content_digest"] == hashlib.sha256(formal_bytes).hexdigest()
-                    entry["content_digest"] = hashlib.sha256(b"\x89PNG\n").hexdigest()
-                    content = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
-                target.writestr(member, content)
+        crlf_bytes: dict[str, bytes] = {}
+
+        def _write_script_with_crlf(name: str, content: bytes) -> bytes:
+            # 文本模式导出的形状：成员按平台换行落盘，信封摘要却按折叠后的 LF 字节计算。
+            if name != "demo/scripts/episode_1.json":
+                return content
+            crlf_bytes[name] = content.replace(b"\n", b"\r\n")
+            return crlf_bytes[name]
+
+        self._rewrite_archive(archive_path, legacy_path, rewrite=_write_script_with_crlf)
+        with zipfile.ZipFile(legacy_path) as archive:
+            envelope = json.loads(archive.read(f"demo/{ARCHIVE_MANIFEST_NAME}"))
+            archived_digest = envelope["artifact_manifest"]["entries"][key.encode()]["content_digest"]
+        member = crlf_bytes["demo/scripts/episode_1.json"]
+        assert archived_digest == hashlib.sha256(member.replace(b"\r\n", b"\n")).hexdigest()
+        assert archived_digest != hashlib.sha256(member).hexdigest()
         shutil.rmtree(project_dir)
 
         service.import_project_archive(legacy_path, uploaded_filename="legacy.zip")
 
         imported_dir = pm.get_project_path("demo")
-        assert (imported_dir / "characters" / "Hero.png").read_bytes() == formal_bytes
-        assert ProjectArtifactManifestAdapter(imported_dir).get_entry(key) is not None
+        assert (imported_dir / "scripts" / "episode_1.json").read_bytes() == member
+        assert ProjectArtifactManifestAdapter(imported_dir).get_entry(key) == before
+        assert (
+            ArtifactCurrencyResolver(imported_dir).compare(key, artifact_path="scripts/episode_1.json").status
+            is ArtifactStatus.STALE
+        )
+
+    def test_import_reprojects_a_claim_whose_archived_digest_covers_only_the_bytes_before_0x1a(self, tmp_path):
+        """信封 content_digest 若止于首个 0x1A，只证明前缀：其后字节被换掉的 PNG 不得沿用冻结 claim，改按当前投影补录。"""
+        pm = ProjectManager(tmp_path / "projects")
+        project_dir = _create_project(pm)
+        _write_bytes(project_dir / "characters" / "Hero.png", b"\x89PNG\r\n\x1a\nIHDR\r\n")
+        project = pm.load_project("demo")
+        project["schema_version"] = 7
+        _write_json(project_dir / "project.json", project)
+        _activate_artifact_manifest(project_dir)
+        key = ArtifactKey.asset_sheet("character", "Hero")
+        before = ProjectArtifactManifestAdapter(project_dir).get_entry(key)
+        assert before is not None
+        project = pm.load_project("demo")
+        project["characters"]["Hero"]["description"] = "Changed after generation"
+        _write_json(project_dir / "project.json", project)
+        assert (
+            ArtifactCurrencyResolver(project_dir).compare(key, artifact_path="characters/Hero.png").status
+            is ArtifactStatus.STALE
+        )
+        swapped_bytes = b"\x89PNG\r\n\x1a\nIDAT-other-image\r\n"
+
+        service = ProjectArchiveService(pm)
+        archive_path, _ = service.export_project("demo")
+        legacy_path = tmp_path / "legacy.zip"
+
+        def _truncate_digest_and_swap_image(name: str, content: bytes) -> bytes:
+            if name == "demo/characters/Hero.png":
+                return swapped_bytes
+            if name != f"demo/{ARCHIVE_MANIFEST_NAME}":
+                return content
+            envelope = json.loads(content)
+            entry = envelope["artifact_manifest"]["entries"][key.encode()]
+            entry["content_digest"] = hashlib.sha256(b"\x89PNG\n").hexdigest()
+            return json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+
+        self._rewrite_archive(archive_path, legacy_path, rewrite=_truncate_digest_and_swap_image)
+        shutil.rmtree(project_dir)
+
+        service.import_project_archive(legacy_path, uploaded_filename="legacy.zip")
+
+        imported_dir = pm.get_project_path("demo")
+        assert (imported_dir / "characters" / "Hero.png").read_bytes() == swapped_bytes
+        imported = ProjectArtifactManifestAdapter(imported_dir).get_entry(key)
+        assert imported is not None
+        assert imported != before
+        assert (
+            ArtifactCurrencyResolver(imported_dir).compare(key, artifact_path="characters/Hero.png").status
+            is ArtifactStatus.CURRENT
+        )
 
     def test_official_round_trip_preserves_a_stale_asset_claim(self, tmp_path):
         pm = ProjectManager(tmp_path / "projects")

--- a/tests/integration/server/services/test_project_archive_service.py
+++ b/tests/integration/server/services/test_project_archive_service.py
@@ -430,8 +430,8 @@ class TestProjectArchiveService:
             for member in source.infolist():
                 target.writestr(member, rewrite(member.filename, source.read(member)))
 
-    def test_import_restores_a_claim_whose_archived_digest_folded_line_endings(self, tmp_path):
-        """信封 content_digest 若来自文本模式读取（CRLF 折叠为 LF），且产物不含 0x1A，证据覆盖全部字节，冻结的 claim 原样恢复。"""
+    def test_import_reprojects_a_claim_whose_archived_digest_folded_line_endings(self, tmp_path):
+        """信封 content_digest 若来自文本模式读取（CRLF 折叠为 LF），折叠不可逆，绑不住冻结 claim，改按当前投影补录。"""
         pm = ProjectManager(tmp_path / "projects")
         project_dir = _create_project(pm)
         project = pm.load_project("demo")
@@ -444,7 +444,7 @@ class TestProjectArchiveService:
         key = ArtifactKey.episode_script(1)
         before = ProjectArtifactManifestAdapter(project_dir).get_entry(key)
         assert before is not None
-        assert script_review.delete_script_plan_file(project_dir, 1, script_plan_path)
+        _write_json(script_plan_path, {"segments": [{"segment_id": "E1S01", "text": "改写后的原文"}]})
         assert (
             ArtifactCurrencyResolver(project_dir).compare(key, artifact_path="scripts/episode_1.json").status
             is ArtifactStatus.STALE
@@ -475,10 +475,12 @@ class TestProjectArchiveService:
 
         imported_dir = pm.get_project_path("demo")
         assert (imported_dir / "scripts" / "episode_1.json").read_bytes() == member
-        assert ProjectArtifactManifestAdapter(imported_dir).get_entry(key) == before
+        imported = ProjectArtifactManifestAdapter(imported_dir).get_entry(key)
+        assert imported is not None
+        assert imported != before
         assert (
             ArtifactCurrencyResolver(imported_dir).compare(key, artifact_path="scripts/episode_1.json").status
-            is ArtifactStatus.STALE
+            is ArtifactStatus.CURRENT
         )
 
     def test_import_reprojects_a_claim_whose_archived_digest_covers_only_the_bytes_before_0x1a(self, tmp_path):

--- a/tests/unit/lib/test_artifact_provenance.py
+++ b/tests/unit/lib/test_artifact_provenance.py
@@ -7,6 +7,7 @@ from lib.artifact_provenance import (
     build_ad_episode_script_basis,
     build_episode_script_basis,
     build_script_plan_basis,
+    decode_script_plan_source,
 )
 
 
@@ -569,3 +570,28 @@ def test_script_plan_basis_tracks_a_set_episode_target_duration() -> None:
 
     assert targeted.digest != unset.digest
     assert retargeted.digest != targeted.digest
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (b"line one\r\nline two\r\n", "line one\nline two\n"),
+        (b"line one\rline two", "line one\nline two"),
+        (b"line one\nline two\n", "line one\nline two\n"),
+    ],
+)
+def test_decode_script_plan_source_matches_universal_newline_reads(raw: bytes, expected: str) -> None:
+    """Basis reconstruction decodes the source exactly as ``Path.read_text`` hands it to the tools."""
+    assert decode_script_plan_source(raw) == expected
+
+
+def test_script_plan_basis_is_stable_across_source_line_endings() -> None:
+    """A source persisted with CRLF yields the same basis as the LF text the split tool froze."""
+    project = {"content_mode": "narration", "generation_mode": "storyboard", "episodes": [{"episode": 1}]}
+    frozen = build_script_plan_basis("第一行\n第二行\n", episode=1, project=project)
+    reconstructed = build_script_plan_basis(
+        decode_script_plan_source("第一行\r\n第二行\r\n".encode()),
+        episode=1,
+        project=project,
+    )
+    assert reconstructed.digest == frozen.digest

--- a/tests/unit/lib/test_content_digest.py
+++ b/tests/unit/lib/test_content_digest.py
@@ -13,6 +13,7 @@ import pytest
 from lib.content_digest import (
     CHUNK_BYTES,
     HASH_ALGORITHM,
+    TextModeDigest,
     canonical_json,
     canonical_json_bytes,
     canonical_json_digest,
@@ -95,3 +96,46 @@ def test_canonical_json_rejects_non_finite_floats_when_strict() -> None:
 def test_prefixed_canonical_json_digest_matches_bare_digest() -> None:
     payload = {"kind": "demo", "version": 1}
     assert prefixed_canonical_json_digest(payload) == prefixed(canonical_json_digest(payload))
+
+
+def _text_mode_view(content: bytes) -> bytes:
+    return content.split(b"\x1a", 1)[0].replace(b"\r\n", b"\n")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"",
+        b"plain\n",
+        b"a\r\nb\r\n",
+        b"lone\rcr\r",
+        b"\x89PNG\r\n\x1a\nIHDR\r\n",
+        b"\x1a",
+        b"tail-cr\r",
+    ],
+)
+def test_text_mode_digest_matches_whole_read_view(content: bytes) -> None:
+    digest = TextModeDigest()
+    digest.update(content)
+
+    assert digest.hexdigest() == hashlib.sha256(_text_mode_view(content)).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("chunks", "content"),
+    [
+        ((b"a\r", b"\nb"), b"a\r\nb"),
+        ((b"a\r", b"\r\nb"), b"a\r\r\nb"),
+        ((b"a\r", b"x"), b"a\rx"),
+        ((b"a\r", b""), b"a\r"),
+        ((b"a\r", b"\x1a\r\n"), b"a\r\x1a\r\n"),
+        ((b"head\x1a", b"\r\ntail\r"), b"head\x1a\r\ntail\r"),
+    ],
+)
+def test_text_mode_digest_folds_across_chunk_boundaries(chunks: tuple[bytes, ...], content: bytes) -> None:
+    """块边界上的 ``\\r`` 要等到下一块才能决定是否折叠，结果须与一次性读取一致。"""
+    digest = TextModeDigest()
+    for chunk in chunks:
+        digest.update(chunk)
+
+    assert digest.hexdigest() == hashlib.sha256(_text_mode_view(content)).hexdigest()

--- a/tests/unit/lib/test_text_utils.py
+++ b/tests/unit/lib/test_text_utils.py
@@ -1,10 +1,10 @@
-"""strip_json_code_fences 单元测试：覆盖大小写变体、裸 JSON、仅开/闭栏、空白等输入。"""
+"""text_utils 单元测试：strip_json_code_fences 覆盖大小写变体、裸 JSON、仅开/闭栏、空白等输入；normalize_newlines 覆盖三种换行。"""
 
 import json
 
 import pytest
 
-from lib.text_utils import strip_json_code_fences
+from lib.text_utils import normalize_newlines, strip_json_code_fences
 
 
 @pytest.mark.parametrize(
@@ -50,3 +50,16 @@ def test_bare_json_untouched() -> None:
 def test_case_insensitive_opening_marker() -> None:
     """大小写变体开栏标记均剥离 7 字前缀，不把语言标注残留进正文。"""
     assert strip_json_code_fences('```JSON\n{"a": 1}\n```').startswith("{")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("a\r\nb\r\n", "a\nb\n"),
+        ("a\rb\r", "a\nb\n"),
+        ("a\nb\n", "a\nb\n"),
+        ("a\r\n\rb", "a\n\nb"),
+    ],
+)
+def test_normalize_newlines_unifies_every_line_ending(raw: str, expected: str) -> None:
+    assert normalize_newlines(raw) == expected


### PR DESCRIPTION
## 背景

Windows 上 drama + reference_video 项目的 `generate_episode_script` 100% 失败，报 `formal artifact input changed while it was selected: drafts/episode_1/script_plan_reference_units.json`；参考视频任务对 `characters/*.png` 也报同一错误。同一项目 `get_workflow_plan` 报 script_plan stale 而 `complete_script_plan_rebuild` 报 not_stale。

## 根因

1. `ProjectArtifactManifestAdapter` 经 `os.open` 的 fd 计算内容摘要时未带 `O_BINARY`。Windows C 运行时缺省文本模式会折叠 CRLF、遇 0x1A 停读，摘要与 `sha256_file` / `visual_file_digest` 的字节摘要永不相等，`resolve_usable_artifact_input_claim` 必然误报。PNG 签名自带 `\r\n\x1a`，所有图片资产同样命中。
2. 修好 1 之后暴露的第二个问题：`plan_episodes` 用 `write_text` 派生的源文在 Windows 上是 CRLF，拆分工具按 `read_text`（LF）冻结 basis，而 `TargetStatePlanner` 按原始字节重算，script_plan 永久 stale。

报告中怀疑的 etag / revision 不等属正常设计，不是 bug。

## 改动

- `lib/artifact_manifest.py`：内容读取（posix / portable 两条路径）与 manifest 读取的 fd 一律附加 `O_BINARY`。
- `lib/artifact_provenance.py` / `lib/artifact_planner.py`：新增 `decode_script_plan_source`，重算依据与拆分工具同一换行口径。
- `lib/text_utils.py` / `lib/episode_ledger.py`：换行归一化抽为 `normalize_newlines` 复用。
- `lib/episode_planner.py`：派生源文按 LF 落盘。
- `lib/artifact_activation.py`：归档导入把信封 `content_digest` 分为 exact / text_mode / mismatch：exact 恢复冻结 claim；text_mode（修复前 Windows 导出的文本模式摘要：CRLF 折叠、0x1A 截断，不可逆，绑不住整份产物）与无信封归档同口径，按当前投影自证补录；mismatch 仍拒绝导入。两份摘要经适配器 `chunk_observer` 在同一次流式读取中算出（`lib/content_digest.TextModeDigest`），大体积媒体不再整体缓冲。
- 测试：二进制描述符标志位（内容 + manifest 读取路径）、图片摘要与 `visual_file_digest` 一致、CRLF 源文 script_plan 保持 CURRENT、文本模式摘要归档（CRLF 折叠 / 0x1A 后字节被换）导入后按投影补录而非恢复归档 claim、`TextModeDigest` 跨块边界、适配器观察者、换行归一化单测。

## 验证

- ruff / basedpyright --warnings / lint-imports / deptry / audit_tests 通过
- 全量后端 pytest 通过（11440 passed，3 skipped）；审查迭代后再跑受影响 44 个测试文件 1415 个测试通过

## 用户侧

升级后直接重试 `generate_episode_script`，无需重做 split / confirm。`action: retry` 提示属通用 internal_error 映射，本 PR 未改。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复 Windows 环境下换行符及特殊字符导致的内容摘要不一致问题。
  - 改善归档导入兼容性，避免合法归档被误判为过期或导入失败。
  - 修复 CRLF、CR 与 LF 换行差异导致的脚本计划状态误判。
  - 确保跨平台写入的派生文件与账本内容保持一致。
  - 优化归档摘要校验，避免内容不完整时错误恢复旧记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

