### PR TITLE
test(text-backends): Gemini 用例断言 genai.Client 构造实参、无用量时 token 保持 None 与降级结果的 provider/model/reason

### DIFF
--- a/tests/unit/lib/text_backends/test_gemini.py
+++ b/tests/unit/lib/text_backends/test_gemini.py
@@ -26,6 +26,8 @@ class TestProperties:
     def test_name(self, mock_genai):
         b = GeminiTextBackend(api_key="k")
         assert b.name == "gemini"
+        # AI Studio 模式：构造时把 api_key 原样交给 genai.Client，未给 base_url 则不带 http_options
+        mock_genai.Client.assert_called_once_with(api_key="k", http_options=None)
 
     def test_default_model(self, mock_genai):
         b = GeminiTextBackend(api_key="k")
@@ -336,6 +338,8 @@ class TestStructuredFallback:
         assert '"genre"' in fb_prompt
         # 校验通过后返回规范化 JSON，下游 model_validate_json 必定成功
         assert _OverviewModel.model_validate_json(result.text) == _OverviewModel(genre="都市", theme="逆袭")
+        assert result.provider == "gemini"
+        assert result.model == backend.model
         assert result.input_tokens == 50
         assert result.output_tokens == 25
 
@@ -348,6 +352,9 @@ class TestStructuredFallback:
         result = await backend.generate(TextGenerationRequest(prompt="p", response_schema=_OverviewModel))
 
         assert _OverviewModel.model_validate_json(result.text).genre == "都市"
+        # 原生与降级两次调用都没有用量时，token 保持 None，不塌成 0
+        assert result.input_tokens is None
+        assert result.output_tokens is None
 
     async def test_fallback_retries_with_error_feedback(self, backend):
         """降级首次输出违反 schema 时带错误反馈重试一次。"""
@@ -380,6 +387,8 @@ class TestStructuredFallback:
         assert gc.call_count == 3
         assert exc_info.value.provider == "gemini"
         assert exc_info.value.model == "gemini-3-flash-preview"
+        # reason 写明降级尝试次数与最后一次校验失败的原因
+        assert exc_info.value.reason == "prompt 注入降级 2 次尝试后输出仍不合规（1 处字段不符（<root>））"
 
     async def test_fallback_logs_raw_model_output(self, backend, caplog):
         """降级触发点以 warning 记录模型原始输出，供事后诊断模型实际吐了什么。"""


### PR DESCRIPTION
`lib/text_backends/gemini.py` 的 12 条 ③（D336 D338 D339 / D370 D372 D389 D390 D394 D395 / D375 D376 / D381）+ 改判 2 条（D364 D365），落在 4 个用例：

- `TestProperties::test_name`：AI Studio 模式以 `api_key="k"`、`http_options=None` 构造 `genai.Client`。
- `TestStructuredFallback::test_fallback_strips_code_fences`：原生与降级调用都无用量时结果 input/output token 保持 None（不塌成 0）。
- `TestStructuredFallback::test_prose_triggers_prompt_fallback_and_succeeds`：降级成功结果 provider=gemini、model 为 backend 的 model。
- `TestStructuredFallback::test_fallback_exhausted_raises_structured_output_exhausted`：终局异常 reason 写明 2 次尝试与最后一次校验原因。

## 验收（runbook 三层，8 模块 2186 mutant 全量复跑一次，本票各 PR 共用）

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 本票改造针对的 mutant | 108（106 + 改判 2） | 108 killed |
| 基线 killed 护栏 | 1414 | 0 回退、0 待复核 |
| 其余基线存活 | 664 | 顺手杀死 92 = 票 1（#2299）已合入的目标，只登记 |
| 等价变异体清单 | 171 | 0 被杀 |

- 硬门：diff 只含测试文件，不触及 `lib/` 与 `server/`。
- 只加强断言，不新增用例、不改输入构造；每条断言只声称判定表 `research/mutmut-batch-2/verdicts.md` 里「加强后的断言检查的是什么」那一句。
- 改判记账见 #2300 决议：D364 / D365 由等价变异体改判 ③（无用量时初值不会被覆盖，token 塌成 0）；D753 维持等价，本票收窄了 `match` 子串。

Part of #2300（Map #2250）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 增强 Gemini 集成测试，覆盖客户端初始化参数校验。
  - 补充结构化输出降级成功、代码栅栏清理及无用量数据处理场景的断言。
  - 增加降级耗尽时错误原因字段的校验，提升相关行为的测试覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->