### PR TITLE
test(image-backends): DashScope/MiniMax 用例断言能力异常携带的 model/names、下载器实参与缺图错误消息

### DIFF
--- a/tests/unit/lib/image_backends/test_dashscope_image_backend.py
+++ b/tests/unit/lib/image_backends/test_dashscope_image_backend.py
@@ -299,6 +299,7 @@ class TestCapabilityGating:
         with pytest.raises(ImageCapabilityError) as ei:
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", image_size="4K"))
         assert ei.value.code == "image_dashscope_4k_t2i_only"
+        assert ei.value.params["model"] == "wan2.7-image"
 
     async def test_all_refs_missing_raises(self, tmp_path: Path):
         from lib.image_backends.dashscope import DashScopeImageBackend
@@ -314,6 +315,7 @@ class TestCapabilityGating:
             )
         # 模型支持 i2i，只是参考图不可读 → 用准确码而非"模型不支持 i2i"
         assert ei.value.code == "image_reference_images_unreadable"
+        assert ei.value.params["model"] == "qwen-image-2.0"
 
     async def test_empty_ref_path_treated_as_missing(self, tmp_path: Path):
         from lib.image_backends.dashscope import DashScopeImageBackend

--- a/tests/unit/lib/image_backends/test_minimax_image_backend.py
+++ b/tests/unit/lib/image_backends/test_minimax_image_backend.py
@@ -120,7 +120,9 @@ class TestTextToImage:
         assert result.provider == PROVIDER_MINIMAX
         assert result.model == "image-01"
         assert result.image_uri == "https://x/out.png"
-        download.assert_called_once()
+        assert result.image_path == tmp_path / "o.png"
+        # 响应里的 URL 与请求的 output_path 原样交给下载器
+        download.assert_called_once_with("https://x/out.png", tmp_path / "o.png")
 
     async def test_default_endpoint_is_domestic(self, tmp_path: Path):
         download = AsyncMock()
@@ -246,6 +248,7 @@ class TestSubjectReference:
                 )
             )
         assert ei.value.code == "image_reference_images_unreadable"
+        assert ei.value.params["model"] == "image-01"
         assert ei.value.params["names"] == "nope.png"
 
     async def test_empty_ref_path_treated_as_missing(self, tmp_path: Path):
@@ -273,6 +276,8 @@ class TestSubjectReference:
         ):
             await b.generate(ImageGenerationRequest(prompt="p", output_path=tmp_path / "o.png", reference_images=[ref]))
         assert ei.value.code == "image_reference_images_unreadable"
+        assert ei.value.params["model"] == "image-01"
+        assert ei.value.params["names"] == "face.png"
 
 
 class TestResponseHandling:
@@ -325,7 +330,7 @@ class TestResponseHandling:
             from lib.image_backends.minimax import MiniMaxImageBackend
 
             b = MiniMaxImageBackend(api_key="sk")
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError, match="缺少 image_urls/image_base64"):
                 await b.generate(ImageGenerationRequest(prompt="x", output_path=tmp_path / "o.png"))
         download.assert_not_called()
 


### PR DESCRIPTION
`lib/image_backends/dashscope.py` 4 条（D675 D676 / D694 D695）+ `lib/image_backends/minimax.py` 15 条（D726 D727 / D732–D735 / D741–D744 D755 D756 / D751 D754 / D764），落在 6 个用例：

- DashScope `test_all_refs_missing_raises` / `test_wan_non_pro_4k_t2i_raises`：能力异常 `params["model"]` 分别为 qwen-image-2.0 / wan2.7-image。
- MiniMax `test_missing_ref_raises_unreadable` / `test_ref_read_oserror_raises_unreadable`：不可读参考图异常 params 携带 model=image-01（后者再加 names=face.png）。
- MiniMax `test_t2i_request_build`：响应里的 URL 与 `request.output_path` 原样交给 `download_image_to_path`；结果 `image_path` 为 `request.output_path`。
- MiniMax `test_empty_data_raises_runtime`：缺图响应的错误消息指明缺少 image_urls/image_base64（`match` 只锁这一段，不锁品牌前缀大小写）。

## 验收（runbook 三层，8 模块 2186 mutant 全量复跑一次，本票各 PR 共用）

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 本票改造针对的 mutant | 108（106 + 改判 2） | 108 killed |
| 基线 killed 护栏 | 1414 | 0 回退、0 待复核 |
| 其余基线存活 | 664 | 顺手杀死 92 = 票 1（#2299）已合入的目标，只登记 |
| 等价变异体清单 | 171 | 0 被杀 |

- 硬门：diff 只含测试文件，不触及 `lib/` 与 `server/`。
- 只加强断言，不新增用例、不改输入构造；每条断言只声称判定表 `research/mutmut-batch-2/verdicts.md` 里「加强后的断言检查的是什么」那一句。
- 改判记账见 #2300 决议：D364 / D365 由等价变异体改判 ③（无用量时初值不会被覆盖，token 塌成 0）；D753 维持等价，本票收窄了 `match` 子串。

Part of #2300（Map #2250）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 增强图像生成相关错误场景的验证，确保错误信息准确包含触发问题的模型名称。
  - 加强图像下载请求测试，校验实际使用的下载地址和输出路径。
  - 完善参考图不可读、响应数据为空等异常场景的错误信息匹配，提升测试覆盖的准确性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->