### PR TITLE
test(video-backends): Gemini 用例断言 types.Image 收到的字节与 mime、拒绝异常的 model 与 resume 重建 operation 的实参

### DIFF
--- a/tests/unit/lib/video_backends/test_gemini_video_resolution.py
+++ b/tests/unit/lib/video_backends/test_gemini_video_resolution.py
@@ -99,6 +99,7 @@ async def test_reference_images_reject_non_8s(tmp_path, seconds):
         await backend.generate(req)
 
     assert exc.value.code == "video_reference_images_duration_unsupported"
+    assert exc.value.params["model"] == "veo-3.1-lite-generate-preview"
     assert exc.value.params["duration"] == seconds
     assert exc.value.params["supported"] == "8s"
     backend._client.aio.models.generate_videos.assert_not_awaited()
@@ -119,6 +120,7 @@ async def test_high_resolution_rejects_non_8s(tmp_path, resolution, seconds):
         await backend.generate(req)
 
     assert exc.value.code == "video_resolution_duration_unsupported"
+    assert exc.value.params["model"] == "veo-3.1-lite-generate-preview"
     assert exc.value.params["resolution"] == resolution.upper()
     assert exc.value.params["duration"] == seconds
     backend._client.aio.models.generate_videos.assert_not_awaited()
@@ -213,6 +215,8 @@ async def test_reference_images_empty_declaration_means_unconstrained(tmp_path, 
     )
     with pytest.raises(RuntimeError):  # 走到 SDK 调用即说明未被约束拦截
         await backend.generate(req)
+
+    backend._client.aio.models.generate_videos.assert_awaited_once()
 
 
 @pytest.mark.parametrize("resolution", ["1080p", "4k"])

--- a/tests/unit/lib/video_backends/test_video_backend_gemini.py
+++ b/tests/unit/lib/video_backends/test_video_backend_gemini.py
@@ -324,14 +324,22 @@ class TestPrepareImageParam:
         img_file.write_bytes(b"\xff\xd8\xff\xe0")  # JPEG magic
 
         result = gemini_backend._prepare_image_param(img_file)
-        assert result is not None
+        # 文件原始字节与按 .jpg 后缀映射的 mime 交给 types.Image
+        assert result is gemini_backend._types.Image.return_value
+        gemini_backend._types.Image.assert_called_once_with(image_bytes=b"\xff\xd8\xff\xe0", mime_type="image/jpeg")
 
     def test_pil_image(self, gemini_backend):
+        from io import BytesIO
+
         from PIL import Image as PILImage
 
         img = PILImage.new("RGB", (10, 10), color="red")
         result = gemini_backend._prepare_image_param(img)
-        assert result is not None
+        # PIL 图像编码为 PNG 字节，mime 为 image/png
+        assert result is gemini_backend._types.Image.return_value
+        image_kwargs = gemini_backend._types.Image.call_args.kwargs
+        assert image_kwargs["mime_type"] == "image/png"
+        assert PILImage.open(BytesIO(image_kwargs["image_bytes"])).format == "PNG"
 
 
 # ── _download_video 测试 ──────────────────────────────────
@@ -418,11 +426,19 @@ class TestGeminiResumeVideo:
         from lib.video_backends.base import ResumeExpiredError
 
         gemini_backend._client.aio.operations.get = AsyncMock(side_effect=RuntimeError("operation not found"))
-        gemini_backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=MagicMock())
+        rebuilt_op = MagicMock()
+        gemini_backend._types.GenerateVideosOperation.model_validate = MagicMock(return_value=rebuilt_op)
 
         request = VideoGenerationRequest(prompt="x", output_path=tmp_path / "out.mp4")
-        with pytest.raises(ResumeExpiredError):
+        with pytest.raises(ResumeExpiredError) as ei:
             await gemini_backend.resume_video("op-not-found", request)
+
+        assert ei.value.provider == "gemini"
+        # 用 job_id 重建未完成的 operation，再以重建对象向远端查询
+        gemini_backend._types.GenerateVideosOperation.model_validate.assert_called_once_with(
+            {"name": "op-not-found", "done": False}
+        )
+        gemini_backend._client.aio.operations.get.assert_awaited_once_with(rebuilt_op)
 
 
 class TestIsGeminiNotFound:


### PR DESCRIPTION
`lib/video_backends/gemini.py` 后半 36 条（D602–D640 共 22 条 / D641 / D642 D643 D649 D650 / D660–D668），落在 6 个用例：

- `TestPrepareImageParam::test_path_reads_file` / `test_pil_image`：`types.Image` 收到文件原始字节与按 .jpg 映射的 image/jpeg；PIL 入参收到 PNG 编码字节与 image/png（原来只断言 `is not None`，而 MagicMock 恒非 None）。
- `test_gemini_video_resolution.py::test_reference_images_empty_declaration_means_unconstrained`：空声明不拦截，`generate_videos` 被 await 一次（原来 `pytest.raises(RuntimeError)` 会被 `VideoCapabilityError` 子类兜住）。
- `test_reference_images_reject_non_8s` / `test_high_resolution_rejects_non_8s`：拒绝异常 params 携带 model=veo-3.1-lite-generate-preview。
- `TestGeminiResumeVideo::test_initial_get_not_found_classified_as_resume_expired`：resume 以 `{name: job_id, done: False}` 调 `GenerateVideosOperation.model_validate`，以其返回值调 `operations.get`；`ResumeExpiredError.provider == "gemini"`。

与同文件前半的 PR 改动区段不重叠，已验证三方合并无冲突，合入顺序无关。

## 验收（runbook 三层，8 模块 2186 mutant 全量复跑一次，本票各 PR 共用）

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 本票改造针对的 mutant | 108（106 + 改判 2） | 108 killed |
| 基线 killed 护栏 | 1414 | 0 回退、0 待复核 |
| 其余基线存活 | 664 | 顺手杀死 92 = 票 1（#2299）已合入的目标，只登记 |
| 等价变异体清单 | 171 | 0 被杀 |

- 硬门：diff 只含测试文件，不触及 `lib/` 与 `server/`。
- 只加强断言，不新增用例、不改输入构造；每条断言只声称判定表 `research/mutmut-batch-2/verdicts.md` 里「加强后的断言检查的是什么」那一句。
- 改判记账见 #2300 决议：D364 / D365 由等价变异体改判 ③（无用量时初值不会被覆盖，token 塌成 0）；D753 维持等价，本票收窄了 `match` 子串。

Part of #2300（Map #2250）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 增强 Gemini 视频生成相关测试，覆盖参考图与高分辨率场景下的模型参数校验。
  - 补充图像输入处理验证，确保文件和 PIL 图像均以正确格式传递。
  - 完善视频续接测试，验证过期任务错误信息及未完成任务的远程状态查询行为。
  - 增加空声明场景验证，确认视频生成调用按预期触发。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->