### PR TITLE
test(sdk-tools): 生成批次工具用例断言注册名与描述非空

### DIFF
--- a/tests/integration/server/agent_runtime/sdk_tools/test_generation_batches.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_generation_batches.py
@@ -41,6 +41,8 @@ async def test_sdk_batch_tools_are_project_bound_and_use_the_durable_queue(db_fa
     ctx = ToolContext("demo", projects.projects_root, projects, queue=queue)
 
     get_tool = get_generation_batch_tool(ctx)
+    assert get_tool.name == "get_generation_batch"
+    assert get_tool.description
     assert isinstance(get_tool.input_schema, dict)
     assert "project" not in get_tool.input_schema["properties"]
     read = await get_tool.handler({"batch_id": batch_id})
@@ -58,7 +60,10 @@ async def test_sdk_batch_tools_are_project_bound_and_use_the_durable_queue(db_fa
     ]
     assert payload["done"] is False
 
-    cancelled = await cancel_generation_batch_tool(ctx).handler({"batch_id": batch_id})
+    cancel_tool = cancel_generation_batch_tool(ctx)
+    assert cancel_tool.name == "cancel_generation_batch"
+    assert cancel_tool.description
+    cancelled = await cancel_tool.handler({"batch_id": batch_id})
     cancellation = json.loads(cancelled["content"][0]["text"])["generation_batch_cancellation"]
     assert cancellation == {
         "cancelled": [enqueued["task_id"]],


### PR DESCRIPTION
第二批池 2（#2298）`server/agent_runtime/sdk_tools/generation_batches.py` 的 5 条 ③（D002–D006），全部落在 `test_sdk_batch_tools_are_project_bound_and_use_the_durable_queue`：get / cancel 两个工具对象的 `.name` 分别为 `get_generation_batch` / `cancel_generation_batch`，`.description` 非空。

验收单独用 `research/mutmut-batch-2/pool2/baseline/` 比对（与池 1 的比对互不干扰），结果见 #2300 决议。

## 验收（runbook 三层，8 模块 2186 mutant 全量复跑一次，本票各 PR 共用）

| 层 | 数量 | 结果 |
| --- | ---: | --- |
| 本票改造针对的 mutant | 108（106 + 改判 2） | 108 killed |
| 基线 killed 护栏 | 1414 | 0 回退、0 待复核 |
| 其余基线存活 | 664 | 顺手杀死 92 = 票 1（#2299）已合入的目标，只登记 |
| 等价变异体清单 | 171 | 0 被杀 |

- 硬门：diff 只含测试文件，不触及 `lib/` 与 `server/`。
- 只加强断言，不新增用例、不改输入构造；每条断言只声称判定表 `research/mutmut-batch-2/verdicts.md` 里「加强后的断言检查的是什么」那一句。
- 改判记账见 #2300 决议：D364 / D365 由等价变异体改判 ③（无用量时初值不会被覆盖，token 塌成 0）；D753 维持等价，本票收窄了 `match` 子串。

Part of #2300（Map #2250）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 增加了对生成批处理工具名称和描述信息的验证。
  - 增加了对取消生成批处理工具名称和描述信息的验证。
  - 调整了取消操作测试的调用方式，以提升测试覆盖的清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->