### PR TITLE
afk stage-1：批量入队逐项 task_id、失败通知带拒因、SSE 前台重连、凭证脱敏、保存按钮复位、草稿版本位

### DIFF
--- a/frontend/src/actions/generation.test.ts
+++ b/frontend/src/actions/generation.test.ts
@@ -213,33 +213,68 @@ describe("单资源入队动作的乐观标记 kind / taskType", () => {
 });
 
 describe("enqueueEpisodeNarration", () => {
-  it("有缺失片段时弹批量提交 toast，不打乐观标记", async () => {
+  it("按映射逐段打标，未入队的段不打标，并弹批量提交 toast", async () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
       task_ids: ["t1", "t2"],
+      task_ids_by_segment: { E1S01: "t1", E1S02: "t2" },
       deduped: false,
       message: "ok",
     });
 
     const res = await enqueueEpisodeNarration("demo", "episode_1.json");
 
+    expect(occupied("demo", "tts", "E1S01")).toBe(true);
+    expect(occupied("demo", "tts", "E1S02")).toBe(true);
+    // 服务端跳过的段（已有旁白 / 无原文）不在映射里，不能被标成生成中
+    expect(occupied("demo", "tts", "E1S03")).toBe(false);
+    expect(markCounts()).toEqual({ resource: 2, scriptFile: 0 });
     expect(useAppStore.getState().toast?.text).toBe(
       i18n.t("dashboard:narration_batch_submitted_toast", { count: 2 }),
     );
-    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
     expect(res).toEqual({ taskIds: ["t1", "t2"], deduped: false });
   });
 
-  it("无缺失片段（task_ids 为空）时弹无缺失提示", async () => {
+  // 每段的标记只等它自己的任务行：等全批落库时，任务列表快照只留最新若干行，
+  // 早的行可能再不出现，那些段会一直显示成生成中。
+  it("每段的标记只等自己的任务行", async () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
-      task_ids: [],
+      task_ids: ["t1", "t2"],
+      task_ids_by_segment: { E1S01: "t1", E1S02: "t2" },
       deduped: false,
       message: "ok",
     });
 
     await enqueueEpisodeNarration("demo", "episode_1.json");
 
+    // 只有 E1S01 的任务行落库：它让位，E1S02 仍占用。
+    useTasksStore.getState().setTasks([
+      {
+        task_id: "t1",
+        project_name: "demo",
+        task_type: "tts",
+        resource_id: "E1S01",
+        status: "completed",
+      },
+    ] as never);
+
+    expect(occupied("demo", "tts", "E1S01")).toBe(false);
+    expect(occupied("demo", "tts", "E1S02")).toBe(true);
+  });
+
+  it("无缺失片段（task_ids 为空）时弹无缺失提示且不留标记", async () => {
+    vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
+      success: true,
+      task_ids: [],
+      task_ids_by_segment: {},
+      deduped: false,
+      message: "ok",
+    });
+
+    await enqueueEpisodeNarration("demo", "episode_1.json");
+
+    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
     expect(useAppStore.getState().toast?.text).toBe(
       i18n.t("dashboard:narration_batch_none_missing_toast"),
     );
@@ -265,11 +300,12 @@ describe("enqueueImageEdit", () => {
 });
 
 describe("enqueueGrid", () => {
-  it("task_ids 非空时按 scriptFile 粒度打标，toast 用后端 message", async () => {
+  it("task_ids 非空时同时打 scriptFile 粒度与逐宫格标记，toast 用后端 message", async () => {
     vi.spyOn(API, "generateGrid").mockResolvedValue({
       success: true,
       grid_ids: ["g1"],
       task_ids: ["t1"],
+      task_ids_by_grid: { g1: "t1" },
       deduped: false,
       message: "已入队 1 个多宫格分镜",
     });
@@ -277,8 +313,38 @@ describe("enqueueGrid", () => {
     const res = await enqueueGrid("demo", 1, "episode_1.json");
 
     expect(scriptFileOccupied("demo", "grid", "episode_1.json")).toBe(true);
+    expect(occupied("demo", "grid", "g1")).toBe(true);
     expect(useAppStore.getState().toast?.text).toBe("已入队 1 个多宫格分镜");
     expect(res).toEqual({ taskIds: ["t1"], deduped: false });
+  });
+
+  // 每张宫格的标记只等它自己的任务行，理由与参考视频批量同：等全批落库会让早的宫格
+  // 因任务快照裁剪而一直显示成生成中。
+  it("每张宫格的标记只等自己的任务行", async () => {
+    vi.spyOn(API, "generateGrid").mockResolvedValue({
+      success: true,
+      grid_ids: ["g1", "g2"],
+      task_ids: ["t1", "t2"],
+      task_ids_by_grid: { g1: "t1", g2: "t2" },
+      deduped: false,
+      message: "已入队 2 个多宫格分镜",
+    });
+
+    await enqueueGrid("demo", 1, "episode_1.json");
+
+    // 只有 g1 的任务行落库：它让位，g2 仍占用。
+    useTasksStore.getState().setTasks([
+      {
+        task_id: "t1",
+        project_name: "demo",
+        task_type: "grid",
+        resource_id: "g1",
+        status: "completed",
+      },
+    ] as never);
+
+    expect(occupied("demo", "grid", "g1")).toBe(false);
+    expect(occupied("demo", "grid", "g2")).toBe(true);
   });
 
   it("task_ids 为空时回滚标记（无任务落库，标记会永久残留）", async () => {
@@ -286,13 +352,14 @@ describe("enqueueGrid", () => {
       success: true,
       grid_ids: [],
       task_ids: [],
+      task_ids_by_grid: {},
       deduped: false,
       message: "无匹配分组",
     });
 
     await enqueueGrid("demo", 1, "episode_1.json", ["S9"]);
 
-    expect(markCounts().scriptFile).toBe(0);
+    expect(markCounts()).toEqual({ resource: 0, scriptFile: 0 });
     expect(scriptFileOccupied("demo", "grid", "episode_1.json")).toBe(false);
   });
 });

--- a/frontend/src/actions/generation.ts
+++ b/frontend/src/actions/generation.ts
@@ -4,7 +4,8 @@
  * 每个动作内部固定封装三件事：
  * 1. 在**请求发出前**于 tasks-store 打乐观占用标记，请求失败即回滚，成功则用后端
  *    返回的 task_id 兑现（见 {@link submit}）——占用态因此从点击那一刻起就成立，
- *    调用方无须自备「请求在途」标记来覆盖网络往返窗口；
+ *    调用方无须自备「请求在途」标记来覆盖网络往返窗口；目标集合由服务端决定的批量
+ *    入口无法预先知道命中哪些资源，改在响应后按映射逐项补打（见 {@link markResourcesByTaskId}）；
  * 2. 调用对应 API 入队端点；
  * 3. 弹提示：后端 deduped=true（同资源任务已在处理中，该调用未新建）时统一
  *    弹 info 提示，否则沿用各操作原有的成功文案。
@@ -101,6 +102,24 @@ function manyTaskIds(res: { task_ids: string[] }): string[] {
   return res.task_ids;
 }
 
+/**
+ * 按后端返回的「资源 id → task_id」映射逐项补打资源粒度标记。
+ *
+ * 用于目标集合由服务端决定的批量入口：请求发出前调用方不知道会命中哪些资源，标记
+ * 因此在响应后补打并立即认领自己那条任务行——每项只等自己的任务落库，未进映射的项
+ * （服务端跳过或未入队成功）一律不打标。
+ */
+function markResourcesByTaskId(
+  projectName: string,
+  resourceKind: ResourceKind,
+  pendingTaskType: string,
+  taskIdsByResource: Record<string, string>,
+): void {
+  for (const [resourceId, taskId] of Object.entries(taskIdsByResource)) {
+    markResource(projectName, resourceKind, resourceId, pendingTaskType).settle([taskId]);
+  }
+}
+
 export async function enqueueStoryboard(
   projectName: string,
   segmentId: string,
@@ -154,8 +173,8 @@ export async function enqueueEpisodeNarration(
   scriptFile: string,
 ): Promise<EnqueueResult> {
   const res = await API.generateEpisodeNarrationAudio(projectName, scriptFile);
-  // 批量响应不含各段 segment_id，无法逐段打乐观标记；批量入口本身没有
-  // 逐段占用消费方，空窗期由 SSE 轮询写回真实任务行兜住。
+  // 入队哪几段由服务端筛选（缺旁白且有原文），请求发出前无从打标，故按响应映射逐段补打。
+  markResourcesByTaskId(projectName, "tts", "tts", res.task_ids_by_segment);
   notifyEnqueued(
     res.deduped,
     res.task_ids.length > 0
@@ -271,6 +290,9 @@ export async function enqueueGrid(
     () => API.generateGrid(projectName, episode, scriptFile, sceneIds),
     manyTaskIds,
   );
+  // grid_id 由服务端现场生成，请求发出前不存在，故按响应映射在响应后逐格补打资源标记；
+  // 往返窗口由上面那个 scriptFile 粒度标记覆盖。
+  markResourcesByTaskId(projectName, "grid", "grid", res.task_ids_by_grid);
   notifyEnqueued(res.deduped, res.message);
   return { taskIds: res.task_ids, deduped: res.deduped };
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1981,7 +1981,14 @@ class API {
   static async generateEpisodeNarrationAudio(
     projectName: string,
     scriptFile: string
-  ): Promise<{ success: boolean; task_ids: string[]; deduped: boolean; message: string }> {
+  ): Promise<{
+    success: boolean;
+    task_ids: string[];
+    /** segment_id → task_id；只含本次真正入队的段，被跳过的段不在其中。 */
+    task_ids_by_segment: Record<string, string>;
+    deduped: boolean;
+    message: string;
+  }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/tts`,
       {
@@ -2975,7 +2982,15 @@ class API {
     episode: number,
     scriptFile: string,
     sceneIds?: string[]
-  ): Promise<{ success: boolean; grid_ids: string[]; task_ids: string[]; deduped: boolean; message: string }> {
+  ): Promise<{
+    success: boolean;
+    grid_ids: string[];
+    task_ids: string[];
+    /** grid_id → task_id；只含本次真正入队的宫格。 */
+    task_ids_by_grid: Record<string, string>;
+    deduped: boolean;
+    message: string;
+  }> {
     return this.request(
       `/projects/${encodeURIComponent(projectName)}/generate/grid/${episode}`,
       { method: "POST", body: JSON.stringify({ script_file: scriptFile, scene_ids: sceneIds }) }

--- a/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
+++ b/frontend/src/components/canvas/StudioCanvasRouter.test.tsx
@@ -1518,6 +1518,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
       task_ids: ["t-1", "t-2"],
+      task_ids_by_segment: { "seg-1": "t-1", "seg-2": "t-2" },
       deduped: false,
       message: "已提交",
     });
@@ -1546,6 +1547,7 @@ describe("StudioCanvasRouter", () => {
     vi.spyOn(API, "generateEpisodeNarrationAudio").mockResolvedValue({
       success: true,
       task_ids: [],
+      task_ids_by_segment: {},
       deduped: false,
       message: "无需补缺",
     });
@@ -1679,6 +1681,7 @@ describe("StudioCanvasRouter", () => {
       success: true,
       grid_ids: ["grid-1"],
       task_ids: ["t-1"],
+      task_ids_by_grid: { "grid-1": "t-1" },
       deduped: false,
       message: "已提交",
     });
@@ -1710,6 +1713,7 @@ describe("StudioCanvasRouter", () => {
       success: true,
       grid_ids: [],
       task_ids: [],
+      task_ids_by_grid: {},
       deduped: false,
       message: "已提交 0 个多宫格分镜生成任务",
     });

--- a/frontend/src/components/pages/ProviderDetail.test.tsx
+++ b/frontend/src/components/pages/ProviderDetail.test.tsx
@@ -202,6 +202,82 @@ describe("ProviderDetail", () => {
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
 
+  it("re-enables the save button on the new provider while an old save is still in flight", async () => {
+    const patch = createDeferred<void>();
+    vi.spyOn(API, "patchProviderConfig").mockReturnValue(patch.promise);
+    vi.spyOn(API, "getProviderConfig").mockImplementation((id) =>
+      Promise.resolve({ ...detailFor(i18n.language), id }),
+    );
+
+    const { rerender } = render(<ProviderDetail providerId="gemini-aistudio" />);
+    await screen.findByText("Gemini AI Studio（中文）");
+    fireEvent.click(screen.getByRole("button", { name: "高级配置" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Max Workers" }), {
+      target: { value: "7" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(screen.getByRole("button", { name: /保存中/ })).toBeDisabled();
+
+    // 切到别的供应商就是新的一次面板停留：上一次保存的进行态属于上一次停留，
+    // 不能让新面板的保存按钮跟着一起禁用。
+    rerender(<ProviderDetail providerId="openai-compatible" />);
+    const workers = await screen.findByRole("spinbutton", { name: "Max Workers" });
+    fireEvent.change(workers, { target: { value: "9" } });
+    expect(screen.getByRole("button", { name: "保存" })).toBeEnabled();
+
+    // 旧保存随后结算：收尾按代次判定，不把新面板重新推回保存中
+    await act(async () => {
+      patch.resolve();
+      await patch.promise;
+    });
+
+    expect(screen.getByRole("button", { name: "保存" })).toBeEnabled();
+    expect(workers).toHaveValue(9);
+  });
+
+  it("keeps the new provider's own save in progress when an older save settles first", async () => {
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+    vi.spyOn(API, "patchProviderConfig")
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    vi.spyOn(API, "getProviderConfig").mockImplementation((id) =>
+      Promise.resolve({ ...detailFor(i18n.language), id }),
+    );
+
+    const { rerender } = render(<ProviderDetail providerId="gemini-aistudio" />);
+    await screen.findByText("Gemini AI Studio（中文）");
+    fireEvent.click(screen.getByRole("button", { name: "高级配置" }));
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Max Workers" }), {
+      target: { value: "7" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    rerender(<ProviderDetail providerId="openai-compatible" />);
+    fireEvent.change(await screen.findByRole("spinbutton", { name: "Max Workers" }), {
+      target: { value: "9" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(screen.getByRole("button", { name: /保存中/ })).toBeDisabled();
+
+    // 旧供应商的 PATCH 后到：它的收尾不能把新面板从自己的保存中态里放出来，
+    // 否则同一份草稿会被重复提交。
+    await act(async () => {
+      first.resolve();
+      await first.promise;
+    });
+    expect(screen.getByRole("button", { name: /保存中/ })).toBeDisabled();
+
+    // 新面板自己的 PATCH 结算后才收尾：草稿清空，保存按钮随之收起。
+    await act(async () => {
+      second.resolve();
+      await second.promise;
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /保存/ })).not.toBeInTheDocument(),
+    );
+  });
+
   it("does not clear the draft when a save from an earlier visit to the same provider settles", async () => {
     const patch = createDeferred<void>();
     vi.spyOn(API, "patchProviderConfig").mockReturnValue(patch.promise);

--- a/frontend/src/components/pages/ProviderDetail.tsx
+++ b/frontend/src/components/pages/ProviderDetail.tsx
@@ -309,6 +309,8 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
       panelGenerationRef.current += 1;
       // providerId 变化或手动重试时重置草稿/详情/错误；语言切换只换详情，保留未保存草稿。
       setDraft({});
+      // 保存的进行态属于上一次面板停留：不复位的话，在途的旧 PATCH 会让新面板的保存按钮一直禁用。
+      setSaving(false);
       applyDetail(null);
       setLoadError(null);
       setSaveError(null);
@@ -368,7 +370,8 @@ export function ProviderDetail({ providerId, onSaved }: Props) {
         // 目录刷新与面板停在谁身上无关：入库的确实是这个供应商。
         onSaved?.();
       }
-      setSaving(false);
+      // 面板已经翻篇的话，进行态由新的那一次停留自己管，这里回写只会把它推回保存中。
+      if (stillOnThisProvider()) setSaving(false);
     }
   }, [draft, providerId, onSaved, applyDetail, startDetailRequest]);
 

--- a/frontend/src/components/task-hud/TaskHud.tsx
+++ b/frontend/src/components/task-hud/TaskHud.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, type RefObject } from "react";
 import { activateOnEnterSpace } from "@/utils/a11y";
 import { voidPromise } from "@/utils/async";
+import { providerReasonOf } from "@/utils/task-target";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Image,
@@ -46,16 +47,6 @@ const FILTER_STATUSES: Record<Exclude<TaskFilter, "all">, readonly TaskItem["sta
   failed: ["failed"],
   done: ["succeeded", "cancelled"],
 };
-
-/**
- * 上游拒因摘要：后端在 `provider_rejected` 的 error_params 里单独回传的上游原文。
- * 它不参与翻译，与走 i18n 模板的 error_message 分开渲染。
- */
-function providerReasonOf(task: TaskItem): string | null {
-  if (task.error_code !== "provider_rejected") return null;
-  const reason = task.error_params?.provider_reason;
-  return typeof reason === "string" && reason.trim() ? reason : null;
-}
 
 function matchesFilter(task: TaskItem, filter: TaskFilter): boolean {
   return filter === "all" || FILTER_STATUSES[filter].includes(task.status);

--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -820,6 +820,7 @@ export default {
   'prop_task_failed': 'Prop "{{id}}" generation failed: {{reason}}',
   'grid_task_failed': 'Multi-grid storyboard generation failed: {{reason}}',
   'image_edit_task_failed': 'Edit for "{{id}}" failed: {{reason}}',
+  'task_failed_provider_reason_suffix': ' (Provider reason: {{reason}})',
   // ========== reference-to-video editor ==========
   'reference_editor_view_aria': 'Editor view',
   'reference_editor_view_script': 'Script',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -800,6 +800,7 @@ export default {
   'prop_task_failed': 'Tạo đạo cụ "{{id}}" thất bại: {{reason}}',
   'grid_task_failed': 'Tạo phân cảnh đa lưới thất bại: {{reason}}',
   'image_edit_task_failed': 'Chỉnh sửa "{{id}}" thất bại: {{reason}}',
+  'task_failed_provider_reason_suffix': ' (Lý do từ nhà cung cấp: {{reason}})',
   // ========== reference-to-video editor ==========
   'reference_editor_view_aria': 'Chế độ xem trình soạn thảo',
   'reference_editor_view_script': 'Kịch bản',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -819,6 +819,7 @@ export default {
   'prop_task_failed': '道具 "{{id}}" 生成失败：{{reason}}',
   'grid_task_failed': '多宫格分镜生成失败：{{reason}}',
   'image_edit_task_failed': '"{{id}}" 编辑失败：{{reason}}',
+  'task_failed_provider_reason_suffix': '（供应商拒因：{{reason}}）',
   // ========== 参考生视频编辑器 ==========
   'reference_editor_view_aria': '编辑器视图',
   'reference_editor_view_script': '文稿',

--- a/frontend/src/utils/sse-stream.test.ts
+++ b/frontend/src/utils/sse-stream.test.ts
@@ -9,7 +9,13 @@ describe("openSseStream", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    Reflect.deleteProperty(document, "visibilityState");
   });
+
+  /** 覆盖 jsdom 的只读 `document.visibilityState`；afterEach 删除自有属性即还原。 */
+  const setVisibility = (state: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", { configurable: true, get: () => state });
+  };
 
   it("connects with the supplied headers and dispatches parsed events", async () => {
     const fake = stubSseFetch();
@@ -135,9 +141,13 @@ describe("openSseStream", () => {
     handle.close();
   });
 
-  it("stops permanently when the server rejects the request", async () => {
+  it("stops permanently when the server rejects the request, releasing the visibility listener", async () => {
     const fake = stubSseFetch(401);
     const onError = vi.fn();
+    // 句柄自行进入终态时调用方通常不再 close()，而 close() 对已关闭的句柄直接返回：
+    // 监听只有在这条路径上就地摘掉，才不会连同整个闭包（onMessage 回调等）常驻 document。
+    const addListener = vi.spyOn(document, "addEventListener");
+    const removeListener = vi.spyOn(document, "removeEventListener");
     const handle = openSseStream({ url: "/api/v1/stream", onMessage: () => {}, onError });
     await flushStream();
 
@@ -146,6 +156,10 @@ describe("openSseStream", () => {
     expect(error.status).toBe(401);
     expect(error.retryable).toBe(false);
     expect(handle.closed).toBe(true);
+
+    const registered = addListener.mock.calls.find(([type]) => type === "visibilitychange");
+    expect(registered).toBeDefined();
+    expect(removeListener).toHaveBeenCalledWith("visibilitychange", registered![1]);
 
     await vi.advanceTimersByTimeAsync(60_000);
     expect(fake.connections).toHaveLength(1);
@@ -184,6 +198,70 @@ describe("openSseStream", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(fake.connections).toHaveLength(1);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reconnects immediately and resets the backoff when the page becomes visible mid-wait", async () => {
+    const fake = stubSseFetch(503);
+    const handle = openSseStream({ url: "/api/v1/stream", onMessage: () => {} });
+    await flushStream();
+    expect(fake.connections).toHaveLength(1);
+
+    // 连续失败把退避推到 30s 上限：1s → 2s → 4s → 8s → 16s → 30s。
+    for (const delay of [1000, 2000, 4000, 8000, 16_000]) {
+      await vi.advanceTimersByTimeAsync(delay);
+      await flushStream();
+    }
+    expect(fake.connections).toHaveLength(6);
+
+    await vi.advanceTimersByTimeAsync(29_000);
+    await flushStream();
+    expect(fake.connections).toHaveLength(6);
+
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushStream();
+    expect(fake.connections).toHaveLength(7);
+
+    // 被抢占的 30s 定时器不再补发一次连接。
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushStream();
+    // 退避归零：这次失败只等首个延迟 1s。
+    expect(fake.connections).toHaveLength(8);
+    handle.close();
+  });
+
+  it("ignores visibilitychange while hidden, while connected, and after close", async () => {
+    const fake = stubSseFetch((index) => (index === 0 ? 200 : 503));
+    const handle = openSseStream({ url: "/api/v1/stream", onMessage: () => {} });
+    await flushStream();
+    expect(fake.connections).toHaveLength(1);
+
+    // 已连接：没有待执行的重连，事件不做任何事。
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushStream();
+    expect(fake.connections).toHaveLength(1);
+
+    fake.latest.end();
+    await flushStream();
+
+    // 退避等待中但页面仍不可见：不抢占定时器。
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushStream();
+    expect(fake.connections).toHaveLength(1);
+
+    // 原定时器照常到点重连。
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushStream();
+    expect(fake.connections).toHaveLength(2);
+
+    handle.close();
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flushStream();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fake.connections).toHaveLength(2);
   });
 
   it("closing from inside a message handler stops parsing and reconnecting", async () => {

--- a/frontend/src/utils/sse-stream.ts
+++ b/frontend/src/utils/sse-stream.ts
@@ -91,6 +91,27 @@ export function openSseStream(options: SseStreamOptions): SseStreamHandle {
     }, delay);
   };
 
+  /**
+   * 后台标签页的长连接常被系统或代理断开，重连在后台反复失败会把退避推到上限。用户切回时
+   * 抢占剩余等待并把退避归零：切回前台是「网络条件已变」的强信号，等待剩下的几十秒只会让
+   * 页面继续停在旧数据上。连接中或已连接（`retryTimer` 为空）时不做任何事。
+   */
+  const handleVisibilityChange = () => {
+    if (closed || retryTimer === null) return;
+    if (document.visibilityState !== "visible") return;
+    clearTimeout(retryTimer);
+    retryTimer = null;
+    attempt = 0;
+    void connect();
+  };
+
+  const visibilityHost = typeof document === "undefined" ? null : document;
+
+  /** 两条终态路径共用：`close()` 与不可重试的失败都必须摘掉监听，否则句柄已死仍挂在 `document` 上。 */
+  const stopWatchingVisibility = () => {
+    visibilityHost?.removeEventListener("visibilitychange", handleVisibilityChange);
+  };
+
   const fail = (error: SseStreamError) => {
     if (closed) return;
     options.onError?.(error);
@@ -98,6 +119,7 @@ export function openSseStream(options: SseStreamOptions): SseStreamHandle {
       scheduleRetry();
     } else {
       closed = true;
+      stopWatchingVisibility();
     }
   };
 
@@ -166,12 +188,14 @@ export function openSseStream(options: SseStreamOptions): SseStreamHandle {
     fail(new SseStreamError("事件流已结束", { retryable: true }));
   };
 
+  visibilityHost?.addEventListener("visibilitychange", handleVisibilityChange);
   void connect();
 
   return {
     close() {
       if (closed) return;
       closed = true;
+      stopWatchingVisibility();
       if (retryTimer !== null) {
         clearTimeout(retryTimer);
         retryTimer = null;

--- a/frontend/src/utils/task-target.test.ts
+++ b/frontend/src/utils/task-target.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TFunction } from "i18next";
+import i18n from "@/i18n";
 import type { ProjectData, TaskItem } from "@/types";
 import { buildTaskFailureTarget, describeTaskFailure } from "@/utils/task-target";
 
@@ -127,6 +128,23 @@ describe("buildTaskFailureTarget", () => {
       ),
     ).toBeNull();
   });
+
+  it("keeps the segment target for a task rejected upstream", () => {
+    // 拒因只进通知文案，不参与 target 解析。
+    const task = makeTask({
+      task_type: "storyboard",
+      resource_id: "E1S01",
+      script_file: "ep1.json",
+      error_code: "provider_rejected",
+      error_params: { provider_reason: "InvalidParameter" },
+    });
+    expect(buildTaskFailureTarget(task, projectData)).toEqual({
+      type: "segment",
+      id: "E1S01",
+      route: "/episodes/1",
+      highlight_style: "flash",
+    });
+  });
 });
 
 describe("describeTaskFailure", () => {
@@ -159,5 +177,106 @@ describe("describeTaskFailure", () => {
         makeTask({ task_type: "image_edit", resource_type: "prop", resource_id: "Sword" }),
       ),
     ).toBe("image_edit_task_failed|Sword|boom");
+  });
+
+  it("appends the provider reason when the task was rejected upstream", () => {
+    const text = describeTaskFailure(
+      t,
+      makeTask({
+        task_type: "storyboard",
+        resource_id: "E1S01",
+        error_code: "provider_rejected",
+        error_params: { provider_reason: "InvalidParameter: prompt violates the content policy" },
+      }),
+    );
+    expect(text).toBe(
+      "storyboard_task_failed|E1S01|boomtask_failed_provider_reason_suffix||"
+        + "InvalidParameter: prompt violates the content policy",
+    );
+  });
+
+  it("renders the provider reason after the per-type text with the real i18n bundle", async () => {
+    await i18n.loadNamespaces("dashboard");
+    const realT = i18n.getFixedT("zh", "dashboard");
+    // error_message 是上游原文，可能带 i18next 占位符字面量；它不参与插值，
+    // 拒因必须仍落在后缀里。
+    const text = describeTaskFailure(
+      realT,
+      makeTask({
+        task_type: "storyboard",
+        resource_id: "E1S01",
+        error_message: "上游返回 {{reason}}",
+        error_code: "provider_rejected",
+        error_params: { provider_reason: "InvalidParameter" },
+      }),
+    );
+    expect(text).toBe('分镜 "E1S01" 生成失败：上游返回 {{reason}}（供应商拒因：InvalidParameter）');
+  });
+
+  it("keeps the plain text when there is no provider reason", () => {
+    // 级联失败等非 provider_rejected 失败没有拒因字段，文案不变。
+    expect(
+      describeTaskFailure(
+        t,
+        makeTask({ task_type: "storyboard", resource_id: "E1S01", error_code: "cascade_blocked_dependency" }),
+      ),
+    ).toBe("storyboard_task_failed|E1S01|boom");
+    expect(
+      describeTaskFailure(
+        t,
+        makeTask({
+          task_type: "storyboard",
+          resource_id: "E1S01",
+          error_code: "provider_rejected",
+          error_params: {},
+        }),
+      ),
+    ).toBe("storyboard_task_failed|E1S01|boom");
+  });
+
+  it("ignores a blank or non-string provider reason", () => {
+    for (const provider_reason of ["   ", 42, null]) {
+      expect(
+        describeTaskFailure(
+          t,
+          makeTask({
+            task_type: "storyboard",
+            resource_id: "E1S01",
+            error_code: "provider_rejected",
+            error_params: { provider_reason },
+          }),
+        ),
+      ).toBe("storyboard_task_failed|E1S01|boom");
+    }
+  });
+
+  it("truncates an over-long provider reason", () => {
+    const text = describeTaskFailure(
+      t,
+      makeTask({
+        task_type: "storyboard",
+        resource_id: "E1S01",
+        error_code: "provider_rejected",
+        error_params: { provider_reason: "x".repeat(400) },
+      }),
+    );
+    expect(text).toBe(
+      `storyboard_task_failed|E1S01|boomtask_failed_provider_reason_suffix||${"x".repeat(120)}\u2026`,
+    );
+  });
+
+  it("truncates on code points so a surrogate pair is never split", () => {
+    const text = describeTaskFailure(
+      t,
+      makeTask({
+        task_type: "storyboard",
+        resource_id: "E1S01",
+        error_code: "provider_rejected",
+        error_params: { provider_reason: "\ud83d\ude80".repeat(200) },
+      }),
+    );
+    expect(text).toBe(
+      `storyboard_task_failed|E1S01|boomtask_failed_provider_reason_suffix||${"\ud83d\ude80".repeat(120)}\u2026`,
+    );
   });
 });

--- a/frontend/src/utils/task-target.ts
+++ b/frontend/src/utils/task-target.ts
@@ -114,11 +114,47 @@ export function buildTaskFailureTarget(
 }
 
 /**
+ * 通知文案里拒因摘要的最大字符数。通知是一行 toast，超出部分截断并省略号收尾，
+ * 完整摘要仍可在任务面板（TaskHud）读到。
+ */
+const PROVIDER_REASON_MAX_LENGTH = 120;
+
+/**
+ * 上游拒因摘要：后端在 `provider_rejected` 的 error_params 里单独回传的上游原文，
+ * 不参与翻译，与走 i18n 模板的 error_message 分开渲染。级联失败等其它失败码没有
+ * 这个字段，返回 null。
+ */
+export function providerReasonOf(task: TaskItem): string | null {
+  if (task.error_code !== "provider_rejected") return null;
+  const reason = task.error_params?.provider_reason;
+  if (typeof reason !== "string") return null;
+  const trimmed = reason.trim();
+  return trimmed || null;
+}
+
+function truncateProviderReason(reason: string): string {
+  // 按码点切分：直接对 UTF-16 code unit 切片会从代理对中间断开，产出孤立代理。
+  const codePoints = [...reason];
+  return codePoints.length > PROVIDER_REASON_MAX_LENGTH
+    ? `${codePoints.slice(0, PROVIDER_REASON_MAX_LENGTH).join("")}…`
+    : reason;
+}
+
+/**
  * 失败任务的通知文案。未知 task_type 返回 null（调用方据此跳过推送）。
+ * 有上游拒因摘要时追加在按 task_type 选出的文案之后。
  */
 export function describeTaskFailure(t: TFunction, task: TaskItem): string | null {
   const reason = task.error_message ?? t("reference_status_failed");
   const config = FAILURE_TEXT_KEYS[task.task_type];
   if (!config) return null;
-  return t(config.key, { [config.idParam]: task.resource_id, reason });
+  const message = t(config.key, { [config.idParam]: task.resource_id, reason });
+  const providerReason = providerReasonOf(task);
+  if (!providerReason) return message;
+  // 拒因后缀单独取模板再拼接，不把已渲染的 message 当插值变量传回 i18next：插值
+  // 对每个 match 走 String.replace，只命中首个同名占位符，message 里若含
+  // `{{reason}}` 这类字面占位符（error_message 是上游原文，可能包含），拒因会落到
+  // 错误位置。
+  const suffix = t("task_failed_provider_reason_suffix", { reason: truncateProviderReason(providerReason) });
+  return `${message}${suffix}`;
 }

--- a/lib/custom_provider/discovery.py
+++ b/lib/custom_provider/discovery.py
@@ -10,6 +10,7 @@ from openai import OpenAI
 
 from lib.config.anthropic_url import derive_anthropic_endpoints
 from lib.custom_provider.endpoints import endpoint_to_media_type, infer_endpoint
+from lib.http_status_errors import raise_for_status_redacted
 from lib.httpx_shared import get_http_client
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ async def _discover_anthropic(base_url: str | None, api_key: str) -> list[dict]:
         },
         timeout=15.0,
     )
-    resp.raise_for_status()
+    raise_for_status_redacted(resp)
     data = resp.json()
     entries = sorted(
         (m for m in data.get("data", []) if m.get("id")),

--- a/lib/draft_quarantine.py
+++ b/lib/draft_quarantine.py
@@ -18,12 +18,20 @@ script_plan 就先取回一份草稿、改完走同一条晋升通道写盘。�
 
 信封形状::
 
-    {"kind": ..., "episode": N, "meta": {...}, "violations": [{"code","label","message"}, ...], "content": {...}}
+    {"kind": ..., "episode": N, "meta": {..., "schema_version": V},
+     "violations": [{"code","label","message"}, ...], "content": {...}}
 
 ``violations`` 是上一轮判定的快照，只供 Agent 阅读定位——晋升时一律按 ``content`` 现值重判，
 不信任草稿里的这份记录。``meta`` 存重判所需、又无法从项目状态重新导出的上下文：script_plan 的源文
 路径（晋升时按整个 ``source/`` 目录重解析会让原文锚的子串判定比产出时更松），以及产出 / 取回
 时正式文件的内容指纹（``base_fingerprint``，晋升前的乐观并发基线）。
+
+``meta`` 另有一个不属于重判上下文的键 ``schema_version``：信封自身的版本位。它由
+``quarantine_envelope`` 统一写入、由 ``read_quarantine`` 解析成 ``QuarantinedDraft.schema_version``
+后从 ``meta`` 里摘掉——消费方读解析结果，不去 ``meta`` 里摸裸键，``meta`` 也就只剩重判上下文
+（``draft_revision`` 的取值范围随之不受版本位影响）。缺失即 v1，口径见
+``resolve_schema_version``。本模块不带迁移框架：版本位只是改 ``meta`` 键语义时可依据的判据，
+没有任何分支按它分流。
 """
 
 from __future__ import annotations
@@ -84,6 +92,12 @@ _QUARANTINE_REPORT_HINTS: dict[str, tuple[str, str]] = {
     ),
 }
 
+#: 本代码写出的隔离草稿信封版本，落在 ``meta.schema_version``。改动任一现有 ``meta`` 键的语义
+#: 时递增它，届时读侧才有据可依地分辨新旧草稿；只加键、不改既有键语义则不必动。
+QUARANTINE_SCHEMA_VERSION = 1
+
+_SCHEMA_VERSION_KEY = "schema_version"
+
 #: 晋升工具名。报告里的处置指引要指名它，写死在这里而非各调用点各写一遍。
 PROMOTE_TOOL_NAME = "promote_draft"
 
@@ -109,18 +123,75 @@ QUARANTINE_KIND_TO_DOC_TYPE: dict[str, str] = {kind: doc_type for doc_type, kind
 
 @dataclass(frozen=True)
 class QuarantinedDraft:
-    """一份读回内存的草稿。``content`` 是待重判的扁平产物，``violations`` 是上一轮的报告快照。"""
+    """一份读回内存的草稿。``content`` 是待重判的扁平产物，``violations`` 是上一轮的报告快照。
+
+    ``schema_version`` 是解析后的信封版本（缺失即 ``1``，口径见 ``resolve_schema_version``），
+    ``meta`` 里不再带这个键：版本位归这一个字段，重判上下文归 ``meta``。
+    """
 
     kind: str
     episode: int
     content: dict[str, Any]
     violations: list[dict[str, Any]]
     meta: dict[str, Any]
+    schema_version: int
     path: Path
 
 
+def resolve_schema_version(meta: dict[str, Any]) -> int:
+    """从落盘信封的 ``meta`` 原值解析出 schema 版本。版本位缺失或不可信时按 ``1`` 读。
+
+    这是「哪一版信封」的唯一判据，读取信封的一方走它，其余消费方走
+    ``QuarantinedDraft.schema_version``；两者都不各自去读 ``meta["schema_version"]``——口径散开后
+    每个调用点都会自己发明一套降级规则。入参是盘上那份 ``meta``，不是 ``QuarantinedDraft.meta``：
+    后者已摘掉版本位，传进来恒得 ``1``。
+
+    口径：
+
+    * **缺失** —— 不带版本位的信封解析为 ``1``；这些草稿的语义就是 v1。
+    * **非整数**（``bool`` / 浮点 / 字符串数字等）与 **小于 1 的整数** —— 同样解析为 ``1``。
+      版本位不可信时唯一确定的事实是「它不是本代码写出来的」，而只存在 v1 一种语义；
+      为此拒读会把一份仍能被 Agent 改好再晋升的草稿变成「无草稿」，代价远大于按最早的语义读。
+    * **大于 ``QUARANTINE_SCHEMA_VERSION`` 的未来版本** —— 原值返回，既不夹取到当前版本也不拒读。
+      本模块不做迁移框架，没有任何分支按这个值分流；提前夹取只会把一份新版草稿伪装成当前版本，
+      而真正需要降级读时，该拒读还是该兼容由那一次语义变更决定，不由此处预判。
+    """
+    version = meta.get(_SCHEMA_VERSION_KEY)
+    if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+        return 1
+    return version
+
+
+def quarantine_envelope(
+    kind: str,
+    episode: int,
+    *,
+    content: dict[str, Any],
+    violations: list[dict[str, Any]],
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """组装可落盘的整份信封，顺带盖上当前的 ``meta.schema_version``。
+
+    落盘信封只由这里构造：版本位写在哪一版、盖在哪个键上只此一处，写侧不必逐个记得补。
+    传入的 ``meta`` 若自带 ``schema_version``（例如从读回的草稿改一改再写回），一律被当前
+    版本覆盖——写出去的这份就是本代码这一版，沿用读到的旧值等于给旧版本贴新语义。
+    """
+    return {
+        "kind": kind,
+        "episode": episode,
+        "meta": {**(meta or {}), _SCHEMA_VERSION_KEY: QUARANTINE_SCHEMA_VERSION},
+        "violations": violations,
+        "content": content,
+    }
+
+
 def draft_revision(draft: QuarantinedDraft) -> str:
-    """Return the canonical optimistic-concurrency token for persisted draft state."""
+    """Return the canonical optimistic-concurrency token for persisted draft state.
+
+    摘要覆盖的字段是 ``quarantine_envelope`` 落盘形状去掉版本位后的那一份：``meta`` 取
+    ``QuarantinedDraft.meta``（不含 ``schema_version``），令牌的取值范围因此与版本位无关。
+    改动落盘形状时这里要一并跟上。
+    """
     return prefixed_canonical_json_digest(
         {
             "kind": draft.kind,
@@ -186,13 +257,13 @@ def write_quarantine(
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_json(
         path,
-        {
-            "kind": kind,
-            "episode": episode,
-            "meta": meta or {},
-            "violations": violation_entries(violations),
-            "content": content,
-        },
+        quarantine_envelope(
+            kind,
+            episode,
+            content=content,
+            violations=violation_entries(violations),
+            meta=meta,
+        ),
     )
     return path
 
@@ -225,12 +296,14 @@ def read_quarantine(project_path: Path, episode: int, kind: str) -> QuarantinedD
     raw_violations = data.get("violations")
     violations = [v for v in raw_violations if isinstance(v, dict)] if isinstance(raw_violations, list) else []
     raw_meta = data.get("meta")
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
     return QuarantinedDraft(
         kind=kind,
         episode=episode,
         content=content,
         violations=violations,
-        meta=raw_meta if isinstance(raw_meta, dict) else {},
+        meta={key: value for key, value in meta.items() if key != _SCHEMA_VERSION_KEY},
+        schema_version=resolve_schema_version(meta),
         path=path,
     )
 
@@ -297,15 +370,18 @@ __all__ = [
     "QUARANTINE_KIND_NARRATION_SCRIPT_PLAN",
     "QUARANTINE_KIND_PROMPT_AUTHORING",
     "QUARANTINE_KIND_SCRIPT_PLAN",
+    "QUARANTINE_SCHEMA_VERSION",
     "QuarantinedDraft",
     "clear_quarantine",
     "draft_payload",
     "draft_revision",
     "quarantine_and_report",
+    "quarantine_envelope",
     "quarantine_exists",
     "quarantine_path",
     "read_quarantine",
     "render_report",
+    "resolve_schema_version",
     "violation_entries",
     "write_quarantine",
 ]

--- a/server/draft_workflow.py
+++ b/server/draft_workflow.py
@@ -29,6 +29,7 @@ from lib.draft_quarantine import (
     draft_payload,
     draft_revision,
     quarantine_and_report,
+    quarantine_envelope,
     quarantine_exists,
     quarantine_path,
     read_quarantine,
@@ -1212,13 +1213,13 @@ class DraftWorkflow:
             before_commit()
         atomic_write_json(
             path,
-            {
-                "kind": draft.kind,
-                "episode": draft.episode,
-                "meta": meta,
-                "violations": draft.violations,
-                "content": content,
-            },
+            quarantine_envelope(
+                draft.kind,
+                draft.episode,
+                content=content,
+                violations=draft.violations,
+                meta=meta,
+            ),
         )
         return self._read(episode, resolved)
 

--- a/server/routers/generate.py
+++ b/server/routers/generate.py
@@ -545,11 +545,20 @@ async def generate_tts_batch(
     project, missing_ids = await asyncio.to_thread(_sync)
 
     if not missing_ids:
-        return {"success": True, "task_ids": [], "deduped": False, "message": _t("tts_batch_none_missing")}
+        return {
+            "success": True,
+            "task_ids": [],
+            "task_ids_by_segment": {},
+            "deduped": False,
+            "message": _t("tts_batch_none_missing"),
+        }
 
     provider_id = await _require_audio_provider_configured(project)
 
     task_ids: list[str] = []
+    # 逐段给出它自己的任务行：调用方的乐观占用标记要各等各的，拿整批清单会让每一段
+    # 都等到全批落库为止；被跳过的段不进映射，调用方据此不给它们打标。
+    task_ids_by_segment: dict[str, str] = {}
     deduped_flags: list[bool] = []
     for seg_id in missing_ids:
         result = await _enqueue_tts_segment(
@@ -560,6 +569,7 @@ async def generate_tts_batch(
             provider_id=provider_id,
         )
         task_ids.append(result["task_id"])
+        task_ids_by_segment[seg_id] = result["task_id"]
         deduped_flags.append(bool(result.get("deduped", False)))
 
     message = _t("tts_batch_submitted", count=len(task_ids)) if task_ids else _t("tts_batch_none_missing")
@@ -567,6 +577,7 @@ async def generate_tts_batch(
     return {
         "success": True,
         "task_ids": task_ids,
+        "task_ids_by_segment": task_ids_by_segment,
         "deduped": bool(task_ids) and all(deduped_flags),
         "message": message,
     }

--- a/server/routers/grids.py
+++ b/server/routers/grids.py
@@ -60,6 +60,9 @@ class GenerateGridResponse(BaseModel):
     success: bool
     grid_ids: list[str]
     task_ids: list[str]
+    # 逐宫格给出它自己的任务行：调用方的乐观占用标记要各等各的，拿整批清单会让每一张
+    # 宫格都等到全批落库为止；未产出宫格的分组不进映射，调用方据此不给它们打标。
+    task_ids_by_grid: dict[str, str]
     # 批量语义：全部入队都命中既有任务（本次一个新任务都没建）才为 True
     deduped: bool
     message: str
@@ -100,7 +103,7 @@ async def generate_grid(
     提交宫格图生成任务到队列，按分段分组，每组生成一张宫格图；场景数超过单张宫格
     格数上限的分组切为多张，末张不足一档时落到更小档并由占位格补齐。
 
-    立即返回 grid_ids 和 task_ids。生成由 GenerationWorker 异步执行。
+    立即返回 grid_ids、task_ids 与两者的逐项映射。生成由 GenerationWorker 异步执行。
     """
     # 广告/短片项目与关闭宫格开关的项目在此一并拒绝：写入边界（create/PATCH 拒 ad 开启
     # grid_storyboard）之外，动作端点再设一道防线，不让 HTTP 直调绕过开关产生计费任务
@@ -128,6 +131,7 @@ async def generate_grid(
 
     grid_ids: list[str] = []
     task_ids: list[str] = []
+    task_ids_by_grid: dict[str, str] = {}
     deduped_flags: list[bool] = []
     queue = get_generation_queue()
     gm = GridManager(project_path)
@@ -198,12 +202,14 @@ async def generate_grid(
             )
             grid_ids.append(grid.id)
             task_ids.append(task["task_id"])
+            task_ids_by_grid[grid.id] = task["task_id"]
             deduped_flags.append(bool(task.get("deduped", False)))
 
     return GenerateGridResponse(
         success=True,
         grid_ids=grid_ids,
         task_ids=task_ids,
+        task_ids_by_grid=task_ids_by_grid,
         deduped=bool(task_ids) and all(deduped_flags),
         message=_t("grid_task_submitted", count=len(grid_ids)),
     )

--- a/server/routers/providers.py
+++ b/server/routers/providers.py
@@ -36,6 +36,7 @@ from lib.db import async_session_factory, get_async_session
 from lib.db.base import dt_to_iso
 from lib.db.repositories.credential_repository import CredentialRepository
 from lib.gemini_shared import VERTEX_SCOPES
+from lib.http_status_errors import raise_for_status_redacted
 from lib.i18n import Locale, Translator, translate_or
 from lib.video_backends.base import VideoAudioMode
 from server.dependencies import get_config_service
@@ -980,7 +981,7 @@ def _check_kling(config: dict[str, str], _t: Callable[..., str]) -> Connectivity
             err = kling_response_error(payload)
             if err is not None:
                 raise RuntimeError(err)
-    resp.raise_for_status()
+    raise_for_status_redacted(resp)
     return ConnectivityCheckResponse(
         success=True,
         available_models=[],

--- a/server/routers/system_config.py
+++ b/server/routers/system_config.py
@@ -35,6 +35,7 @@ from lib.config.repository import mask_secret
 from lib.config.resolver import ConfigResolver
 from lib.config.service import DEFAULT_VIDEO_POLL_TIMEOUT_SECONDS, ConfigService
 from lib.db import get_async_session
+from lib.http_status_errors import raise_for_status_redacted
 from lib.httpx_shared import get_http_client
 from lib.i18n import DEFAULT_LOCALE, Locale, Translator, translate_or
 from server.dependencies import get_config_service
@@ -149,7 +150,7 @@ async def _get_latest_release(
         headers={"Accept": "application/vnd.github+json", "User-Agent": _GITHUB_USER_AGENT},
         timeout=5.0,
     )
-    response.raise_for_status()
+    raise_for_status_redacted(response)
     payload = _build_latest_release_payload(response.json())
 
     _latest_release_cache["payload"] = payload

--- a/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
+++ b/tests/integration/server/agent_runtime/sdk_tools/test_draft_tools.py
@@ -19,6 +19,7 @@ from lib.draft_quarantine import (
     QUARANTINE_KIND_NARRATION_SCRIPT_PLAN,
     QUARANTINE_KIND_PROMPT_AUTHORING,
     QUARANTINE_KIND_SCRIPT_PLAN,
+    QUARANTINE_SCHEMA_VERSION,
     quarantine_path,
     write_quarantine,
 )
@@ -444,6 +445,35 @@ async def test_open_draft_returns_existing_narration_draft(fake_ctx: ToolContext
 
     assert out.get("is_error") is not True
     assert read_nr_quarantine(fake_ctx)["content"]["segments"][0]["novel_text"] == "改到一半的正文"
+
+
+async def test_patch_draft_stamps_the_current_schema_version_on_a_legacy_envelope(fake_ctx: ToolContext) -> None:
+    """patch 是草稿的另一条写入口：它写回的信封同样盖当前版本，不沿用盘上读到的版本位。"""
+    rv_source(fake_ctx)
+    write_rv_script_plan(fake_ctx, [rv_saved_unit("@[张三] 起身")])
+    opened = _draft_result(await open_for_edit(fake_ctx, source="source/episode_1.txt"))
+
+    path = rv_quarantine_path(fake_ctx)
+    envelope = json.loads(path.read_text(encoding="utf-8"))
+    del envelope["meta"]["schema_version"]
+    path.write_text(json.dumps(envelope, ensure_ascii=False), encoding="utf-8")
+
+    content = opened["content"]
+    content["units"][0]["text"] = "@[张三] 走向 @[村口]"
+    patched = await call(
+        patch_draft_tool(fake_ctx),
+        {
+            "episode": 1,
+            "doc_type": "reference_script_plan",
+            "content": content,
+            "base_revision": opened["revision"],
+        },
+    )
+
+    assert patched.get("is_error") is not True, patched
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["meta"]["schema_version"] == QUARANTINE_SCHEMA_VERSION
+    assert saved["meta"]["source"] == "source/episode_1.txt"
 
 
 async def test_patch_draft_supports_multiple_rounds_and_rejects_stale_revision(fake_ctx: ToolContext) -> None:

--- a/tests/unit/lib/custom_provider/test_model_discovery.py
+++ b/tests/unit/lib/custom_provider/test_model_discovery.py
@@ -9,7 +9,10 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+
+from tests.http_capture import capture_http
 
 
 @contextmanager
@@ -485,6 +488,28 @@ class TestDiscoverModelsAnthropic:
         result = await discover_models(discovery_format="anthropic", base_url=None, api_key="k")
         assert [m["model_id"] for m in result] == ["claude-x"]
         assert result[0]["display_name"] == "claude-x"
+
+    async def test_status_error_message_drops_query_and_userinfo_credentials(self):
+        """4xx 抛的是脱敏后的 HTTPStatusError：base_url 里的查询串与权限段凭证都不进异常消息。
+
+        base_url 由用户自填，整条带 api_key query 的 URL 或 https://user:pw@host 形态都会被 httpx
+        原样保留在请求 URL 上；发现失败的异常消息经 discovery_failed 回到自定义供应商表单。
+        """
+        base_url = "https://ant-user:sk-leaked-userinfo@relay.example.com/anthropic?api_key=sk-leaked-query"
+        with capture_http() as http:
+            http.get(host="relay.example.com").respond(status_code=401, text="unauthorized")
+            async with httpx.AsyncClient() as client:
+                with patch("lib.custom_provider.discovery.get_http_client", return_value=client):
+                    from lib.custom_provider.discovery import discover_models
+
+                    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                        await discover_models(discovery_format="anthropic", base_url=base_url, api_key="sk-ant")
+
+        # 泄漏面真实存在：异常保留的请求 URL 两个凭证都带着，消息里都没有
+        assert "sk-leaked-userinfo" in str(exc_info.value.request.url)
+        assert "sk-leaked-query" in str(exc_info.value.request.url)
+        assert str(exc_info.value) == "401 response for https://relay.example.com/anthropic"
+        assert exc_info.value.response.status_code == 401
 
     async def test_unknown_format_raises(self):
         """anthropic 仍是已知 format；未知 format 抛 ValueError 含 anthropic。"""

--- a/tests/unit/lib/test_draft_quarantine.py
+++ b/tests/unit/lib/test_draft_quarantine.py
@@ -18,11 +18,14 @@ from lib.draft_quarantine import (
     QUARANTINE_KIND_NARRATION_SCRIPT_PLAN,
     QUARANTINE_KIND_PROMPT_AUTHORING,
     QUARANTINE_KIND_SCRIPT_PLAN,
+    QUARANTINE_SCHEMA_VERSION,
     clear_quarantine,
+    draft_revision,
     quarantine_exists,
     quarantine_path,
     read_quarantine,
     render_report,
+    resolve_schema_version,
     violation_entries,
     write_quarantine,
 )
@@ -137,6 +140,133 @@ class TestEnvelope:
         clear_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
         clear_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
         assert not quarantine_exists(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+
+
+class TestSchemaVersion:
+    """信封的版本位：写侧固定盖章、读侧缺失即 v1，且不改变任何现有键的语义。"""
+
+    def _envelope_with_meta(self, tmp_path: Path, meta: dict) -> Path:
+        """按给定的 meta 原值写一份草稿信封，绕开写侧的盖章。"""
+        path = quarantine_path(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "kind": QUARANTINE_KIND_SCRIPT_PLAN,
+                    "episode": 1,
+                    "meta": meta,
+                    "violations": [],
+                    "content": {"units": [{"text": "镜头1：门开了"}]},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_written_draft_carries_current_schema_version_on_disk(self, tmp_path: Path):
+        path = write_quarantine(
+            tmp_path,
+            1,
+            QUARANTINE_KIND_SCRIPT_PLAN,
+            content={"units": []},
+            violations=[],
+            meta={"source": "source/episode_1.txt"},
+        )
+        envelope = json.loads(path.read_text(encoding="utf-8"))
+        assert envelope["meta"]["schema_version"] == QUARANTINE_SCHEMA_VERSION
+        assert envelope["meta"]["source"] == "source/episode_1.txt"
+
+    def test_write_stamps_current_version_over_a_stale_one_carried_in_meta(self, tmp_path: Path):
+        """从读回的草稿改一改再写回时，写出去的这份就是本代码这一版；沿用读到的旧值等于给旧版本贴新语义。"""
+        path = write_quarantine(
+            tmp_path,
+            1,
+            QUARANTINE_KIND_SCRIPT_PLAN,
+            content={"units": []},
+            violations=[],
+            meta={"schema_version": 99},
+        )
+        assert json.loads(path.read_text(encoding="utf-8"))["meta"]["schema_version"] == QUARANTINE_SCHEMA_VERSION
+
+    def test_roundtrip_exposes_version_as_field_not_as_meta_key(self, tmp_path: Path):
+        """消费方读解析结果，不去 meta 里摸裸键——版本位不留在 meta 上，meta 只剩重判上下文。"""
+        write_quarantine(
+            tmp_path,
+            1,
+            QUARANTINE_KIND_SCRIPT_PLAN,
+            content={"units": []},
+            violations=[],
+            meta={"source": "source/episode_1.txt"},
+        )
+        draft = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert draft is not None
+        assert draft.schema_version == QUARANTINE_SCHEMA_VERSION
+        assert draft.meta == {"source": "source/episode_1.txt"}
+
+    def test_legacy_envelope_without_version_reads_as_v1_unchanged(self, tmp_path: Path):
+        """不带版本位的信封解析为 v1，其余字段照常读出：它与盖过章的信封走同一条读路。"""
+        self._envelope_with_meta(tmp_path, {"source": "source/episode_1.txt"})
+        draft = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert draft is not None
+        assert draft.schema_version == 1
+        assert draft.meta == {"source": "source/episode_1.txt"}
+        assert draft.content == {"units": [{"text": "镜头1：门开了"}]}
+        assert draft.violations == []
+
+    def test_version_bit_does_not_shift_the_optimistic_concurrency_token(self, tmp_path: Path):
+        """同一份内容盖章前后 revision 相同：版本位若进入令牌，持有未盖章草稿 revision 的 Agent
+        会被判 revision_conflict。"""
+        self._envelope_with_meta(tmp_path, {"source": "source/episode_1.txt"})
+        legacy = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        write_quarantine(
+            tmp_path,
+            1,
+            QUARANTINE_KIND_SCRIPT_PLAN,
+            content={"units": [{"text": "镜头1：门开了"}]},
+            violations=[],
+            meta={"source": "source/episode_1.txt"},
+        )
+        stamped = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert legacy is not None
+        assert stamped is not None
+        assert draft_revision(legacy) == draft_revision(stamped)
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["1", 1.0, True, None, [1], {"v": 1}, 0, -3],
+        ids=["str", "float", "bool", "null", "list", "dict", "zero", "negative"],
+    )
+    def test_unusable_version_reads_as_v1(self, tmp_path: Path, raw: object):
+        """版本位不可信时唯一确定的事实是「它不是本代码写出来的」，而只有 v1 一种语义：
+        为此拒读会把一份仍能被 Agent 改好再晋升的草稿变成「无草稿」。"""
+        self._envelope_with_meta(tmp_path, {"source": "source/episode_1.txt", "schema_version": raw})
+        draft = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert draft is not None
+        assert draft.schema_version == 1
+        assert resolve_schema_version({"schema_version": raw}) == 1
+
+    def test_future_version_is_returned_as_is_and_still_readable(self, tmp_path: Path):
+        """未来版本原值返回、不夹取也不拒读：本模块不做迁移框架，夹取会把新版草稿伪装成当前版本。"""
+        future = QUARANTINE_SCHEMA_VERSION + 7
+        self._envelope_with_meta(tmp_path, {"source": "source/episode_1.txt", "schema_version": future})
+        draft = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert draft is not None
+        assert draft.schema_version == future
+        assert draft.content == {"units": [{"text": "镜头1：门开了"}]}
+
+    def test_missing_meta_object_reads_as_v1_with_empty_context(self, tmp_path: Path):
+        """meta 整个缺失（或被改成非对象）与版本位缺失同口径，不抛错。"""
+        path = quarantine_path(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"kind": QUARANTINE_KIND_SCRIPT_PLAN, "episode": 1, "meta": [], "content": {"units": []}}),
+            encoding="utf-8",
+        )
+        draft = read_quarantine(tmp_path, 1, QUARANTINE_KIND_SCRIPT_PLAN)
+        assert draft is not None
+        assert draft.schema_version == 1
+        assert draft.meta == {}
 
 
 class TestReport:

--- a/tests/unit/server/routers/test_custom_providers_api.py
+++ b/tests/unit/server/routers/test_custom_providers_api.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Generator
 from pathlib import Path
@@ -581,6 +582,34 @@ class TestDiscoverModels:
         assert resp.json()["models"][0]["model_id"] == "gemini-2.0-flash"
         # 确认 discovery_format 透传
         assert mock_discover.call_args.kwargs["discovery_format"] == "google"
+
+    def test_discover_error_text_drops_credentials(self, custom_providers_client: TestClient):
+        """发现失败时回给前端的 discovery_failed 文案不含 base_url 里的查询串与权限段凭证。"""
+        base_url = "https://ant-user:sk-leaked-userinfo@relay.example.com/anthropic?api_key=sk-leaked-query"
+        discovery_client = httpx.AsyncClient()
+        try:
+            with capture_http() as http:
+                route = http.get(host="relay.example.com").respond(status_code=401, text="unauthorized")
+                with patch("lib.custom_provider.discovery.get_http_client", return_value=discovery_client):
+                    resp = custom_providers_client.post(
+                        "/api/v1/custom-providers/discover",
+                        json={
+                            "discovery_format": "anthropic",
+                            "base_url": base_url,
+                            "api_key": "sk-ant",
+                        },
+                    )
+        finally:
+            asyncio.run(discovery_client.aclose())
+
+        # 泄漏面真实存在：出站请求 URL 上带着查询串凭证。权限段口令进异常消息这件事由
+        # test_model_discovery.py 的 test_status_error_message_drops_query_and_userinfo_credentials
+        # 在 exc.request.url 上断言：httpx 出站前会把权限段挪进 Authorization 头。
+        assert "sk-leaked-query" in str(only_request(route).url)
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert "sk-leaked-userinfo" not in detail
+        assert "sk-leaked-query" not in detail
 
     def test_discover_invalid_format(self, custom_providers_client: TestClient):
         """discover_models 抛 UnsupportedDiscoveryFormatError 时返回 400。"""

--- a/tests/unit/server/routers/test_generate_router_tts.py
+++ b/tests/unit/server/routers/test_generate_router_tts.py
@@ -341,6 +341,42 @@ class TestGenerateTtsBatch:
             assert call["task_type"] == "tts"
             assert call["media_type"] == "audio"
 
+    def test_batch_maps_each_missing_segment_to_the_task_it_enqueued(self, tmp_path, monkeypatch):
+        """逐段映射：每个 segment_id 指向它自己那次入队拿到的 task_id。"""
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        # 让 E1S02 也缺旁白，凑出两段入队，映射才有可分辨的对应关系
+        fake_pm.script["segments"][1]["generated_assets"] = {}
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts",
+                json={"script_file": "episode_1.json"},
+            )
+
+        assert res.status_code == 200, res.text
+        body = res.json()
+        enqueued = {call["resource_id"]: f"task-{index}" for index, call in enumerate(fake_queue.calls, start=1)}
+        assert enqueued == {"E1S01": "task-1", "E1S02": "task-2"}
+        assert body["task_ids_by_segment"] == enqueued
+        assert body["task_ids"] == ["task-1", "task-2"]
+
+    def test_batch_skipped_segments_are_absent_from_the_mapping(self, tmp_path, monkeypatch):
+        """跳过的段（已有旁白 / 无原文）不进映射，调用方据此不给它们打标。"""
+        fake_pm = _FakePM(tmp_path / "projects" / "demo")
+        fake_queue = _FakeQueue()
+        client = _client(monkeypatch, fake_pm, fake_queue)
+
+        with client:
+            res = client.post(
+                "/api/v1/projects/demo/generate/tts",
+                json={"script_file": "episode_1.json"},
+            )
+
+        assert res.status_code == 200, res.text
+        assert res.json()["task_ids_by_segment"] == {"E1S01": "task-1"}
+
     def test_metadata_path_without_a_manifest_entry_is_reselected(self, tmp_path, monkeypatch):
         """metadata 里留着旁白路径但清单没有认领 → 算缺失，重新入队。"""
 
@@ -436,6 +472,7 @@ class TestGenerateTtsBatch:
             body = res.json()
             assert body["success"] is True
             assert body["task_ids"] == []
+            assert body["task_ids_by_segment"] == {}
             assert fake_queue.calls == []
 
     def test_audio_provider_not_configured_400(self, tmp_path, monkeypatch):
@@ -468,6 +505,7 @@ class TestGenerateTtsBatch:
             body = res.json()
             assert body["success"] is True
             assert body["task_ids"] == []
+            assert body["task_ids_by_segment"] == {}
             assert fake_queue.calls == []
 
 

--- a/tests/unit/server/routers/test_grids_router.py
+++ b/tests/unit/server/routers/test_grids_router.py
@@ -545,6 +545,56 @@ def test_generate_grid_5_and_6_scenes_use_grid_9(monkeypatch, tmp_path, scene_co
     assert (payloads[0]["rows"], payloads[0]["cols"]) == (3, 3)
 
 
+def test_generate_grid_maps_each_grid_to_the_task_it_enqueued(monkeypatch, tmp_path):
+    """逐宫格映射：每个 grid_id 指向它自己那次入队拿到的 task_id。"""
+
+    async def _gate(_project):
+        return False
+
+    fake_queue = _FakeQueue()
+    client = _client(
+        monkeypatch,
+        # 30 个分段在 9 格封顶下切成多张宫格，映射才有可分辨的对应关系
+        get_project_manager=lambda: _FakePMScenes(tmp_path, 30),
+        get_generation_queue=lambda: fake_queue,
+        resolve_large_grid_allowed=_gate,
+    )
+    with client:
+        resp = client.post(
+            "/api/v1/projects/demo/generate/grid/1",
+            json={"script_file": "episode_1.json"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    enqueued = {call["resource_id"]: f"task-{index}" for index, call in enumerate(fake_queue.calls, start=1)}
+    assert len(enqueued) > 1
+    assert body["task_ids_by_grid"] == enqueued
+    assert body["grid_ids"] == list(enqueued)
+    assert body["task_ids"] == list(enqueued.values())
+
+
+def test_generate_grid_without_matching_groups_maps_nothing(monkeypatch, tmp_path):
+    """scene_ids 过滤掉全部分组时一个任务都没建，映射为空。"""
+    fake_queue = _FakeQueue()
+    client = _client(
+        monkeypatch,
+        get_project_manager=lambda: _FakePMGenerate(tmp_path),
+        get_generation_queue=lambda: fake_queue,
+    )
+    with client:
+        resp = client.post(
+            "/api/v1/projects/demo/generate/grid/1",
+            json={"script_file": "episode_1.json", "scene_ids": ["E9S99"]},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["grid_ids"] == []
+    assert body["task_ids_by_grid"] == {}
+    assert fake_queue.calls == []
+
+
 def test_grid_capability_reports_gate(monkeypatch, tmp_path):
     async def _gate(_project):
         return True

--- a/tests/unit/server/routers/test_providers_api.py
+++ b/tests/unit/server/routers/test_providers_api.py
@@ -23,6 +23,7 @@ from server.dependencies import get_config_service
 from server.routers import providers
 from tests.auth_deps import AUTH_DEPENDENCIES, override_auth
 from tests.factories import make_translator
+from tests.http_capture import capture_http, only_request
 
 # ---------------------------------------------------------------------------
 # 测试应用工厂
@@ -1006,33 +1007,83 @@ class TestTestProviderConnection:
             providers._check_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
     def test_kling_test_fn_raises_http_status_error_when_body_not_json(self):
-        """非 JSON 响应体（如网关错误页）跳过业务错误解析，走 raise_for_status 兜底暴露 HTTP 状态。"""
+        """非 JSON 响应体（如网关错误页）跳过业务错误解析，走状态码兜底暴露 HTTP 状态。"""
+        with capture_http() as http:
+            http.get(host="api-beijing.klingai.com", path="/account/costs").respond(
+                status_code=502, text="<html>bad gateway</html>", headers={"content-type": "text/html"}
+            )
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                providers._check_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
-        class _FailingResponse(self._FakeKlingResponse):
-            def raise_for_status(self) -> None:
-                raise httpx.HTTPStatusError("502 Bad Gateway", request=MagicMock(), response=MagicMock())
-
-        def _fake_get(url, params=None, headers=None, timeout=None):
-            return _FailingResponse({}, content_type="text/html")
-
-        with patch("httpx.get", _fake_get), pytest.raises(httpx.HTTPStatusError, match="502 Bad Gateway"):
-            providers._check_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+        assert exc_info.value.response.status_code == 502
+        assert "502" in str(exc_info.value)
 
     def test_kling_test_fn_falls_back_to_raise_for_status_on_malformed_json(self):
-        """content-type 声称 JSON 但响应体非法/空（如异常网关截断）→ 解析失败不崩溃，走 raise_for_status 兜底。"""
+        """content-type 声称 JSON 但响应体非法/空（如异常网关截断）→ 解析失败不崩溃，走状态码兜底。"""
+        with capture_http() as http:
+            http.get(host="api-beijing.klingai.com", path="/account/costs").respond(
+                status_code=504, text="", headers={"content-type": "application/json"}
+            )
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                providers._check_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
 
-        class _MalformedJsonResponse(self._FakeKlingResponse):
-            def json(self) -> dict:
-                raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        assert exc_info.value.response.status_code == 504
+        assert "504" in str(exc_info.value)
 
-            def raise_for_status(self) -> None:
-                raise httpx.HTTPStatusError("504 Gateway Timeout", request=MagicMock(), response=MagicMock())
+    def test_kling_test_fn_keeps_credentials_out_of_status_error_message(self):
+        """状态码兜底抛的是脱敏后的 HTTPStatusError：base_url 权限段里的口令不进异常消息。
 
-        def _fake_get(url, params=None, headers=None, timeout=None):
-            return _MalformedJsonResponse({})
+        base_url 由用户自填，写成 https://user:pw@host 时 httpx 把口令留在请求 URL 的权限段，
+        裸 raise_for_status 会把整条 URL 写进消息，而这条消息经连接测试端点原样回到设置页。
+        """
+        with capture_http() as http:
+            http.get(host="relay.example.com", path="/account/costs").respond(
+                status_code=401, text="unauthorized", headers={"content-type": "text/plain"}
+            )
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                providers._check_kling(
+                    {"api_key": "sk-kling", "base_url": "https://kl-user:sk-leaked-kling@relay.example.com/v1"},
+                    lambda k, **kw: k,
+                )
 
-        with patch("httpx.get", _fake_get), pytest.raises(httpx.HTTPStatusError, match="504 Gateway Timeout"):
-            providers._check_kling({"api_key": "sk-kling"}, lambda k, **kw: k)
+        # 泄漏面真实存在：异常保留的请求 URL 里带着口令与查询串，消息里两者都没有
+        assert "sk-leaked-kling" in str(exc_info.value.request.url)
+        assert str(exc_info.value) == "401 response for https://relay.example.com/account/costs"
+        assert exc_info.value.response.status_code == 401
+
+    def test_kling_connection_test_via_router_keeps_credentials_out_of_message(self):
+        """端到端：连接测试失败时回给前端的 message 不含 base_url 权限段里的口令。"""
+        cred = ProviderCredential(
+            provider="kling",
+            name="可灵账号",
+            api_key="sk-kling",
+            base_url="https://kl-user:sk-leaked-kling@relay.example.com/v1",
+            is_active=True,
+        )
+        repo = MagicMock(spec=CredentialRepository)
+        repo.get_by_id = AsyncMock(return_value=cred)
+        repo.get_active = AsyncMock(return_value=cred)
+
+        app, _ = _make_session_app()
+        with (
+            patch("server.routers.providers.CredentialRepository", return_value=repo),
+            patch("server.routers.providers.ConfigService", return_value=self._mock_svc()),
+            capture_http() as http,
+        ):
+            route = http.get(host="relay.example.com", path="/account/costs").respond(
+                status_code=401, text="unauthorized", headers={"content-type": "text/plain"}
+            )
+            with TestClient(app) as client:
+                resp = client.post("/api/v1/providers/kling/test")
+
+        # 请求真的发出去了，message 才是走完状态码兜底那条路的产物。口令进异常消息这件事由
+        # test_kling_test_fn_keeps_credentials_out_of_status_error_message 在 exc.request.url
+        # 上断言：httpx 出站前会把权限段挪进 Authorization 头，出站 URL 上看不到它。
+        only_request(route)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert "sk-leaked-kling" not in body["message"]
 
     def test_kling_test_fn_raises_on_inner_data_code_error(self):
         """顶层 code=0 但 data 内嵌业务级 code != 0（如资源包查询失败）→ 同样 RuntimeError。"""

--- a/tests/unit/server/routers/test_system_version_api.py
+++ b/tests/unit/server/routers/test_system_version_api.py
@@ -216,6 +216,24 @@ class TestGetLatestReleaseCache:
         assert route.call_count == 2
         assert second_at > first_at
 
+    async def test_status_error_message_drops_query_credentials(self):
+        """4xx 抛的是脱敏后的 HTTPStatusError：请求 URL 上的查询串不进异常消息。
+
+        用跟随重定向的客户端把失败请求引到带签名查询串的下游地址，构造出「失败的那一条请求
+        URL 带着凭证」：裸 raise_for_status 会把整条 URL 写进消息，端点再把它记进 warning 日志。
+        """
+        leaky = "https://objects.githubusercontent.com/release?api_key=sk-leaked-gh"
+        with capture_http(assert_all_called=True) as http:
+            http.get(_GITHUB_LATEST).respond(status_code=302, headers={"Location": leaky})
+            http.get(url__startswith="https://objects.githubusercontent.com/release").respond(status_code=401)
+            async with httpx.AsyncClient(follow_redirects=True) as client:
+                with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                    await system_config._get_latest_release(http_client=client)
+
+        assert "sk-leaked-gh" in str(exc_info.value.request.url)
+        assert str(exc_info.value) == "401 response for https://objects.githubusercontent.com/release"
+        assert exc_info.value.response.status_code == 401
+
     async def test_http_error_is_not_cached(self):
         """失败响应不写缓存，下一次调用仍然出站重试。"""
         with capture_http(assert_all_called=True) as http:


### PR DESCRIPTION
## 概要

afk-team-workflow 显式 issue 批次（非 Spec 六票），单 stage，每票一个 commit：

- **批量入队逐项交接**：整集配音与宫格批量入队响应新增 `task_ids_by_segment` / `task_ids_by_grid` 映射（原 `task_ids` / `grid_ids` 保留）；前端两条链路在响应后按映射逐项打乐观占用标记、各自认领自己的 task_id 让位，被服务端跳过的项不打标；宫格保留脚本文件粒度的在途标记覆盖往返窗口。
- **任务失败通知带拒因**：供应商拒绝（`provider_rejected`）的失败通知追加脱敏后的拒因摘要（按码点截断，三语后缀模板），跳转到任务面板的 target 不变；`providerReasonOf` 抽到 `utils/task-target.ts` 与任务面板共用。
- **事件流切回前台立即重连**：SSE 客户端监听 `visibilitychange`，页面转可见且处于退避等待时清定时器、退避归零并立即重连；句柄关闭与服务端明确拒绝两条终态都摘除监听；非浏览器环境行为不变。
- **凭证不再回显**：供应商连接测试、检查更新、自定义供应商模型发现三条路径的 4xx 兜底改抛脱敏后的 `HTTPStatusError`（保留 `.response` / `status_code`），异常消息与返回前端的错误文本不含 URL 里的 api_key / 签名参数。
- **供应商详情页保存按钮**：切换供应商时 `saving` 随面板代次立即复位，上一个供应商的在途 PATCH 结算后按代次判定、不回写新面板。
- **隔离草稿版本位**：草稿信封 `meta.schema_version` 由唯一写出口 `quarantine_envelope` 盖章（含 `draft_workflow` patch 路径），读取时缺失或非法视为 v1，未来版本原值返回；版本位不进入 `draft_revision` 乐观并发令牌。

## 验证

每票均经独立 local-reviewer 审查（含变异测试与改回旧实现反证）；前端 `pnpm check`、后端全量闸门与 `audit_tests.py --check` 在各 issue worktree 通过。同机多批次并跑期间登记的时序偶发用例（`test_handle_orphan_fast_path_returns_immediately`、`EndpointsSection.test.tsx` 等）隔离复跑均通过，与本批改动无关。

Closes #1411
Closes #2330
Closes #2304
Closes #2328
Closes #2322
Closes #2329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 旁白与宫格生成现在会按资源分别显示任务状态，未入队资源不会被误标记。
  - 切回前台后，SSE 连接可立即恢复，减少后台等待。
  - 任务失败提示会附带供应商拒绝原因，并支持中英文及越南语。
  - 草稿格式新增版本兼容处理，旧草稿仍可正常读取和保存。

- **问题修复**
  - 修复切换供应商面板时保存状态显示不准确的问题。
  - 外部服务连接失败信息会隐藏 URL 中的敏感凭证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->