### PR TITLE
docs(testing): mutmut runbook 回填选模块规则、已走查模块表、曳光弹步骤，普查脚本进 scripts/

### DIFF
--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -14,6 +14,23 @@ uv sync --group mutation
 
 ## 2. 跑一批
 
+### 2.1 选模块
+
+每批 8 个左右没跑过的模块，从第 8 节「已走查模块」表之外挑；每批开一张 issue 登记模块清单、判定结果与研究分支，合入后把模块补进该表。
+
+- **准入**：`server/routers` 整目录不选；其他目录按文件看，被装饰器跳过的行超过一半的文件不选。mutmut 3.7.0 对带装饰器的函数整棵子树不生成 mutant（仅单个 `@staticmethod` / `@classmethod` 豁免，带装饰器的类整体跳过，不可配置），路由函数与 `@tool` 闭包这类形态跑了也几乎不产出 mutant。跑一次普查列出不合准入的文件：
+
+  ```bash
+  uv run python scripts/decorator_census.py --per-file --min-skip 50
+  ```
+
+  不带参数则按目录汇总跳过行占比，用来看哪些目录整体值得挑。
+
+- **优先级**：按「没跑过、测试多、代码量大」挑，`server/services`、`lib/video_backends`、`lib/custom_provider`、`lib/reference_video` 优先。不找预测候选率或可处置率的规则：替身密度、弱断言用例占比都试过，对结果没有预测力。测试快慢也不是准入条件，超时与并行子进程的问题已在 `tests/conftest.py` 与 `tests/mutmut_plugin.py` 里消除，DB 档集成用例同样跑得干净。
+- **终点**：不设。每批跑完算可处置率（判为 ③ 值得保护的存活 mutant 数 / 存活 mutant 数），连续两批明显下降就停。
+
+### 2.2 跑一轮
+
 1. `git fetch` 后从 `origin/main` 切分支，并核对树里已含上一批合入的 PR。基线若从过期的本地 `main` 切出，上一批改造针对的 mutant 会在本批「复活」，白花一轮复核。
 2. 在 `[tool.mutmut]` 的 `only_mutate` 填本批模块。留空会变异 `source_paths` 全域，一轮数小时。
 3. 跑：
@@ -30,6 +47,8 @@ uv sync --group mutation
 **凡读源码文本而不是 import 模块的用例，都要在 `pytest_add_cli_args` 里按 nodeid `--deselect`，不要整文件 `--ignore`。** `mutants/` 里的源文件同时含所有 mutant 变体（每个字符串字面量都多出 `XXfooXX` / `FOO` 两份），任何扫 `lib/` `server/` 源码字面量再比对登记表的用例都会在 stats 阶段报「未登记」，整轮起不来。`--ignore` 的粒度是文件：同文件里的行为测试会一并消失，它们独家覆盖的 mutant 就记成存活（`test_task_failure_capability.py` 三个扫描用例之外的 100 余个用例就是这种情况）。已排除的是该文件的 `test_capability_codes_registered_no_drift` / `test_no_unscannable_capability_construction_sites` / `test_capability_construction_sites_supply_every_template_param`；新加排除时在 `[tool.mutmut]` 注释里写明它独家能杀什么、为何排除不漏杀（判据同 `test_skill_script_path_guards.py`：排除只多出假存活，不藏假杀死）。
 
 ## 3. 读结果
+
+**先核对每个模块的 mutant 数量级。** 每千行源码约 1000 个 mutant，明显偏少（比如不到十分之一）的模块不是测得好，而是它的函数没被任何用例关联：mutmut 会把这种模块静默归零，终端不报。把它从本批剔掉，不判定；`only_mutate` 里的模块名写错时同样是 0 个 mutant，先核对拼写。
 
 **从 `.meta` 文件算，不读终端汇总。** 每个源模块在 `mutants/` 里有一份 `<模块>.py.meta`，其中 `exit_code_by_key` 是「mutant 名 → pytest exit code」。mutmut 的终端汇总只枚举它认识的几个 exit code，段错误（−11）之类一个计数器都不落，#2257 就漏过两个。
 
@@ -90,6 +109,7 @@ uv run python scripts/mutmut_compare.py \
 
 一批模块的存活 mutant 常拆成几张改造票跨会话合入，它们共用第 2 节保存的同一份基线，各票分别验收：
 
+- **先走曳光弹**：每批改造先挑 2 条，单独走完「改断言 → 全套闸门 → 全量复跑 → 三层验收 → PR 合入」，通过后再批量改其余。曳光弹的两条与后面的批量票共用同一基线，批量票验收时它们落在第三层「基线存活且本次未改造」，被杀只登记。
 - `--reworked` 只填本票的清单；`--equivalent` 填整批的等价变异体清单（每票都要查它零被杀）。
 - 先合入的票已杀死的目标，在后面的票里落在第三层「基线存活且本次未改造」，被杀只登记，不算异常。
 - 每票切分支前 `git fetch` 并核对基线的模块在 `origin/main` 上自基线提交以来零变动：`git diff --stat <基线提交> origin/main -- <模块列表>` 为空。改造 PR 自身不会动这些模块（硬门），但 `main` 上别的提交会。
@@ -115,3 +135,39 @@ uv run python scripts/mutmut_compare.py \
 | 一轮墙钟（8 路并行） | 8 模块 616 个 mutant 约 10 分钟（不含全量 stats 约 5 分钟）；超时归零前是 17:47，墙钟随超时数走 |
 | 超时新进程复核 | 3 到 11 秒 / 个 |
 | 逐条判定 | 约 3 秒 / 个 |
+
+## 8. 已走查模块
+
+选下一批时从表外挑；已跑过的模块不重跑，第二遍没有增量（无覆盖与等价变异体会原样再报一遍）。判定表与基线快照都在各批的研究分支上，不进 `main`。
+
+| 模块 | 批次 | 票号 | 研究分支 |
+| --- | --- | --- | --- |
+| `lib/capability_buckets.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/content_digest.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/episode_paths.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/grid/splitter.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/speech_rate.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/text_metrics.py` | 首批 A 组 | #2257 | `research/mutmut-batch-1`（`baseline/A/`） |
+| `lib/custom_provider/discovery.py` | 首批 B 组 | #2257 | `research/mutmut-batch-1`（`baseline/B/`） |
+| `lib/text_backends/openai.py` | 首批 B 组 | #2257 | `research/mutmut-batch-1`（`baseline/B/`） |
+| `lib/text_backends/instructor_support.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/text_backends/ark.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/text_backends/gemini.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/text_backends/grok.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/video_backends/gemini.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/image_backends/dashscope.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/image_backends/minimax.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `lib/custom_provider/backends.py` | 第二批池 1 | #2297 | `research/mutmut-batch-2` |
+| `server/agent_runtime/sdk_tools/asset_inventory.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/enqueue_assets.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/entry.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/episode_planning.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/generation_batches.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/patch_episode_meta.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/patch_project.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/rename_asset.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/retry_project_migration.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/workflow_plan.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+| `server/agent_runtime/sdk_tools/workflow_status.py` | 第二批池 2 | #2298 | `research/mutmut-batch-2`（`pool2/`） |
+
+第二批池 2 的 11 个模块里 9 个产出 0 个 mutant（`@tool` 闭包整体被跳过）；这类文件按第 2.1 节的准入规则本就不该选，列在表里是为了不再重跑。

--- a/docs/testing/mutmut-runbook.md
+++ b/docs/testing/mutmut-runbook.md
@@ -18,7 +18,7 @@ uv sync --group mutation
 
 每批 8 个左右没跑过的模块，从第 8 节「已走查模块」表之外挑；每批开一张 issue 登记模块清单、判定结果与研究分支，合入后把模块补进该表。
 
-- **准入**：`server/routers` 整目录不选；其他目录按文件看，被装饰器跳过的行超过一半的文件不选。mutmut 3.7.0 对带装饰器的函数整棵子树不生成 mutant（仅单个 `@staticmethod` / `@classmethod` 豁免，带装饰器的类整体跳过，不可配置），路由函数与 `@tool` 闭包这类形态跑了也几乎不产出 mutant。跑一次普查列出不合准入的文件：
+- **准入**：`server/routers` 整目录不选；其他目录按文件看，被装饰器跳过的行占比不低于 50% 的文件不选。mutmut 3.7.0 对带装饰器的函数整棵子树不生成 mutant（仅单个 `@staticmethod` / `@classmethod` 豁免，带装饰器的类整体跳过，不可配置），路由函数与 `@tool` 闭包这类形态跑了也几乎不产出 mutant。跑一次普查列出不合准入的文件：
 
   ```bash
   uv run python scripts/decorator_census.py --per-file --min-skip 50

--- a/scripts/decorator_census.py
+++ b/scripts/decorator_census.py
@@ -114,7 +114,7 @@ def census(root: Path) -> tuple[dict[str, Tally], dict[str, Tally]]:
             continue
         per_file[path.as_posix()] = tally
         per_dir.setdefault(group_key(root, path), Tally()).add(tally)
-    return per_dir, per_file
+    return dict(sorted(per_dir.items())), per_file
 
 
 def render_rows(rows: Iterable[tuple[str, Tally]], label: str) -> list[str]:

--- a/scripts/decorator_census.py
+++ b/scripts/decorator_census.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""统计源码目录里被 mutmut 3.7.0 装饰器规则跳过的函数与函数行占比，供挑选变异测试批次时做准入核对。
+
+mutmut 3.7.0 对带装饰器的 `FunctionDef` / `AsyncFunctionDef` 整棵子树不生成 mutant（仅单个
+`@staticmethod` / `@classmethod` 豁免），带装饰器的 `ClassDef` 整体跳过，嵌套在被跳过节点里的函数一并跳过。
+这是 mutmut 的设计决定，不可配置；跳过行占比过半的文件在 mutmut 下几乎不产出 mutant，不值得进批次。
+
+函数行数按「装饰器首行到函数末行」计；嵌套函数只在外层未被跳过时单独计，外层跳过则整体已计入外层。
+按目录汇总时以 `<根>/<一级子目录>` 为键，直接放在根目录下的文件归 `<根>`。
+
+零第三方依赖。用法见 `--help`，选模块规则见 `docs/testing/mutmut-runbook.md`。
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+EXEMPT_DECORATORS = frozenset({"staticmethod", "classmethod"})
+
+
+@dataclass
+class Tally:
+    """一个文件或目录的统计：函数数、被跳过的函数数、函数行数、被跳过的函数行数。"""
+
+    functions: int = 0
+    skipped_functions: int = 0
+    lines: int = 0
+    skipped_lines: int = 0
+
+    def add(self, other: Tally) -> None:
+        self.functions += other.functions
+        self.skipped_functions += other.skipped_functions
+        self.lines += other.lines
+        self.skipped_lines += other.skipped_lines
+
+    @property
+    def skipped_function_ratio(self) -> float:
+        return self.skipped_functions / self.functions if self.functions else 0.0
+
+    @property
+    def skipped_line_ratio(self) -> float:
+        return self.skipped_lines / self.lines if self.lines else 0.0
+
+
+def is_skipped_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """按 mutmut 规则判断函数自身是否因装饰器被跳过（不含从外层继承的跳过）。"""
+    if not node.decorator_list:
+        return False
+    if len(node.decorator_list) == 1:
+        decorator = node.decorator_list[0]
+        if isinstance(decorator, ast.Name) and decorator.id in EXEMPT_DECORATORS:
+            return False
+    return True
+
+
+def function_span(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    start = min([node.lineno, *(decorator.lineno for decorator in node.decorator_list)])
+    end = node.end_lineno if node.end_lineno is not None else node.lineno
+    return end - start + 1
+
+
+def tally_tree(tree: ast.AST) -> Tally:
+    tally = Tally()
+
+    def visit(node: ast.AST, inherited_skip: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                visit(child, inherited_skip or bool(child.decorator_list))
+            elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                skipped = inherited_skip or is_skipped_function(child)
+                span = function_span(child)
+                tally.functions += 1
+                tally.lines += span
+                if skipped:
+                    tally.skipped_functions += 1
+                    tally.skipped_lines += span
+                else:
+                    visit(child, False)
+            else:
+                visit(child, inherited_skip)
+
+    visit(tree, False)
+    return tally
+
+
+def tally_file(path: Path) -> Tally | None:
+    """解析失败（语法错误）的文件返回 None，不计入统计。"""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return None
+    return tally_tree(tree)
+
+
+def group_key(root: Path, path: Path) -> str:
+    relative = path.relative_to(root)
+    if len(relative.parts) <= 1:
+        return root.as_posix()
+    return (root / relative.parts[0]).as_posix()
+
+
+def census(root: Path) -> tuple[dict[str, Tally], dict[str, Tally]]:
+    """返回 (按目录汇总, 按文件)，两者都以 posix 路径字符串为键、按路径排序。"""
+    per_dir: dict[str, Tally] = {}
+    per_file: dict[str, Tally] = {}
+    for path in sorted(root.rglob("*.py")):
+        tally = tally_file(path)
+        if tally is None:
+            continue
+        per_file[path.as_posix()] = tally
+        per_dir.setdefault(group_key(root, path), Tally()).add(tally)
+    return per_dir, per_file
+
+
+def render_rows(rows: Iterable[tuple[str, Tally]], label: str) -> list[str]:
+    lines = [f"{label:60} {'函数':>6} {'跳过':>6} {'跳过%':>7} {'函数行':>8} {'跳过行':>8} {'跳过行%':>8}"]
+    lines.extend(
+        f"{name:60} {t.functions:6} {t.skipped_functions:6} {t.skipped_function_ratio * 100:6.1f}% "
+        f"{t.lines:8} {t.skipped_lines:8} {t.skipped_line_ratio * 100:7.1f}%"
+        for name, t in rows
+    )
+    return lines
+
+
+def render(root: Path, *, per_file: bool, min_skip: float) -> list[str]:
+    per_dir, per_file_tallies = census(root)
+    lines = [f"== {root.as_posix()}/ =="]
+    if per_file:
+        selected = [(name, t) for name, t in per_file_tallies.items() if t.skipped_line_ratio * 100 >= min_skip]
+        selected.sort(key=lambda item: item[1].skipped_line_ratio, reverse=True)
+        lines.extend(render_rows(selected, "文件"))
+        return lines
+    total = Tally()
+    for tally in per_dir.values():
+        total.add(tally)
+    lines.extend(render_rows(per_dir.items(), "目录"))
+    lines.extend(render_rows([("合计", total)], "")[1:])
+    return lines
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("roots", nargs="*", default=["lib", "server"], help="要统计的源码根目录，默认 lib 与 server")
+    parser.add_argument("--per-file", action="store_true", help="按文件列出并按跳过行占比降序，而不是按目录汇总")
+    parser.add_argument(
+        "--min-skip",
+        type=float,
+        default=0.0,
+        metavar="PCT",
+        help="配合 --per-file：只列出跳过行占比不低于 PCT%% 的文件（准入核对用 50）",
+    )
+    args = parser.parse_args(argv)
+    for raw in args.roots:
+        root = Path(raw)
+        if not root.is_dir():
+            print(f"不是目录：{raw}", file=sys.stderr)
+            return 2
+        print("\n".join(render(root, per_file=args.per_file, min_skip=args.min_skip)))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/decorator_census.py
+++ b/scripts/decorator_census.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import ast
 import sys
+import unicodedata
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -122,10 +123,29 @@ def census(root: Path) -> tuple[dict[str, Tally], dict[str, Tally]]:
     return dict(sorted(per_dir.items())), per_file
 
 
+def display_width(text: str) -> int:
+    """终端显示宽度：东亚宽字符（含中文）占 2 列，其余占 1 列。"""
+    return sum(2 if unicodedata.east_asian_width(char) in "WF" else 1 for char in text)
+
+
+def pad(text: str, width: int, *, align_right: bool = False) -> str:
+    """按显示宽度填充空格，让含中文的表头与合计行和纯 ASCII 路径的行对齐。"""
+    fill = " " * max(width - display_width(text), 0)
+    return fill + text if align_right else text + fill
+
+
 def render_rows(rows: Iterable[tuple[str, Tally]], label: str) -> list[str]:
-    lines = [f"{label:60} {'函数':>6} {'跳过':>6} {'跳过%':>7} {'函数行':>8} {'跳过行':>8} {'跳过行%':>8}"]
+    header_cells = [
+        pad("函数", 6, align_right=True),
+        pad("跳过", 6, align_right=True),
+        pad("跳过%", 7, align_right=True),
+        pad("函数行", 8, align_right=True),
+        pad("跳过行", 8, align_right=True),
+        pad("跳过行%", 8, align_right=True),
+    ]
+    lines = [" ".join([pad(label, 60), *header_cells])]
     lines.extend(
-        f"{name:60} {t.functions:6} {t.skipped_functions:6} {t.skipped_function_ratio * 100:6.1f}% "
+        f"{pad(name, 60)} {t.functions:6} {t.skipped_functions:6} {t.skipped_function_ratio * 100:6.1f}% "
         f"{t.lines:8} {t.skipped_lines:8} {t.skipped_line_ratio * 100:7.1f}%"
         for name, t in rows
     )

--- a/scripts/decorator_census.py
+++ b/scripts/decorator_census.py
@@ -5,7 +5,7 @@ mutmut 3.7.0 对带装饰器的 `FunctionDef` / `AsyncFunctionDef` 整棵子树�
 `@staticmethod` / `@classmethod` 豁免），带装饰器的 `ClassDef` 整体跳过，嵌套在被跳过节点里的函数一并跳过。
 这是 mutmut 的设计决定，不可配置；跳过行占比过半的文件在 mutmut 下几乎不产出 mutant，不值得进批次。
 
-函数行数按「装饰器首行到函数末行」计；嵌套函数只在外层未被跳过时单独计，外层跳过则整体已计入外层。
+函数行数按「装饰器首行到函数末行」的唯一行号计，嵌套函数的行只算一次；嵌套函数只在外层未被跳过时单独计数，外层跳过则整体已计入外层。
 按目录汇总时以 `<根>/<一级子目录>` 为键，直接放在根目录下的文件归 `<根>`。
 
 零第三方依赖。用法见 `--help`，选模块规则见 `docs/testing/mutmut-runbook.md`。
@@ -58,14 +58,17 @@ def is_skipped_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     return True
 
 
-def function_span(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+def function_lines(node: ast.FunctionDef | ast.AsyncFunctionDef) -> range:
+    """函数占用的行号区间，从装饰器首行到函数末行。"""
     start = min([node.lineno, *(decorator.lineno for decorator in node.decorator_list)])
     end = node.end_lineno if node.end_lineno is not None else node.lineno
-    return end - start + 1
+    return range(start, end + 1)
 
 
 def tally_tree(tree: ast.AST) -> Tally:
     tally = Tally()
+    all_lines: set[int] = set()
+    skipped_lines: set[int] = set()
 
     def visit(node: ast.AST, inherited_skip: bool) -> None:
         for child in ast.iter_child_nodes(node):
@@ -73,18 +76,20 @@ def tally_tree(tree: ast.AST) -> Tally:
                 visit(child, inherited_skip or bool(child.decorator_list))
             elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
                 skipped = inherited_skip or is_skipped_function(child)
-                span = function_span(child)
+                lines = function_lines(child)
                 tally.functions += 1
-                tally.lines += span
+                all_lines.update(lines)
                 if skipped:
                     tally.skipped_functions += 1
-                    tally.skipped_lines += span
+                    skipped_lines.update(lines)
                 else:
                     visit(child, False)
             else:
                 visit(child, inherited_skip)
 
     visit(tree, False)
+    tally.lines = len(all_lines)
+    tally.skipped_lines = len(skipped_lines)
     return tally
 
 

--- a/tests/unit/scripts/test_decorator_census.py
+++ b/tests/unit/scripts/test_decorator_census.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.decorator_census import Tally, census, is_skipped_function, main, tally_tree
+from scripts.decorator_census import Tally, census, display_width, is_skipped_function, main, pad, tally_tree
 
 _SOURCE = textwrap.dedent(
     """\
@@ -108,18 +108,31 @@ def test_main_per_file_lists_only_files_at_or_above_min_skip_sorted_by_ratio(
     assert " 60.0%" in out
 
 
+def test_pad_aligns_by_terminal_display_width_so_cjk_labels_line_up_with_ascii_paths() -> None:
+    assert display_width("合计") == 4
+    assert display_width("lib/a.py") == 8
+    assert display_width("café") == 4
+
+    assert pad("合计", 8) == "合计    "
+    assert pad("跳过%", 7, align_right=True) == "  跳过%"
+    assert pad("lib/a.py", 8) == "lib/a.py"
+    assert pad("超出宽度的标签", 4) == "超出宽度的标签"
+
+
 def test_main_prints_directory_summary_with_total_and_rejects_non_directory(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    root = tmp_path / "pkg"
-    (root / "sub").mkdir(parents=True)
-    (root / "sub" / "a.py").write_text("@d\ndef g():\n    return 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    Path("pkg/sub").mkdir(parents=True)
+    Path("pkg/sub/a.py").write_text("@d\ndef g():\n    return 1\n", encoding="utf-8")
 
-    assert main([str(root)]) == 0
+    assert main(["pkg"]) == 0
     out = capsys.readouterr().out
-    assert (root / "sub").as_posix() in out
-    assert "合计" in out
+    assert "pkg/sub" in out
     assert "100.0%" in out
+    table = [line for line in out.splitlines() if line.startswith(("目录", "pkg", "合计"))]
+    assert len(table) == 3
+    assert [display_width(line) for line in table] == [display_width(table[0])] * 3
 
-    assert main([str(tmp_path / "missing")]) == 2
+    assert main(["missing"]) == 2
     assert "不是目录" in capsys.readouterr().err

--- a/tests/unit/scripts/test_decorator_census.py
+++ b/tests/unit/scripts/test_decorator_census.py
@@ -47,10 +47,11 @@ _SOURCE = textwrap.dedent(
 
 
 def test_tally_counts_decorated_functions_decorated_classes_and_nesting_by_mutmut_rules() -> None:
+    """`outer` 里的 `inner` 单独计一个函数，但它的 2 行已在 `outer` 的区间内，行数只算一次。"""
     tally = tally_tree(ast.parse(_SOURCE))
 
-    assert tally == Tally(functions=8, skipped_functions=4, lines=25, skipped_lines=13)
-    assert tally.skipped_line_ratio == pytest.approx(13 / 25)
+    assert tally == Tally(functions=8, skipped_functions=4, lines=23, skipped_lines=13)
+    assert tally.skipped_line_ratio == pytest.approx(13 / 23)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/scripts/test_decorator_census.py
+++ b/tests/unit/scripts/test_decorator_census.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.decorator_census import Tally, census, is_skipped_function, main, tally_tree
+
+_SOURCE = textwrap.dedent(
+    """\
+    def plain():
+        x = 1
+        return x
+
+    @decorate
+    def decorated():
+        return 1
+
+    class Plain:
+        @staticmethod
+        def exempt():
+            return 1
+
+        @property
+        def prop(self):
+            return 1
+
+    @dataclass
+    class Decorated:
+        def method(self):
+            return 1
+
+    def outer():
+        def inner():
+            return 1
+        return inner
+
+    @decorate
+    def outer_skipped():
+        def inner():
+            return 1
+        return inner
+    """
+)
+
+
+def test_tally_counts_decorated_functions_decorated_classes_and_nesting_by_mutmut_rules() -> None:
+    tally = tally_tree(ast.parse(_SOURCE))
+
+    assert tally == Tally(functions=8, skipped_functions=4, lines=25, skipped_lines=13)
+    assert tally.skipped_line_ratio == pytest.approx(13 / 25)
+
+
+@pytest.mark.parametrize(
+    ("decorators", "skipped"),
+    [
+        ("", False),
+        ("@staticmethod\n", False),
+        ("@classmethod\n", False),
+        ("@staticmethod\n@decorate\n", True),
+        ("@functools.cache\n", True),
+        ("@tool(name='x')\n", True),
+    ],
+)
+def test_single_staticmethod_or_classmethod_is_the_only_exempt_decorator(decorators: str, skipped: bool) -> None:
+    node = ast.parse(f"{decorators}def f():\n    return 1\n").body[0]
+    assert isinstance(node, ast.FunctionDef)
+
+    assert is_skipped_function(node) is skipped
+
+
+def test_census_groups_by_first_level_subdirectory_and_skips_unparsable_files(tmp_path: Path) -> None:
+    root = tmp_path / "pkg"
+    (root / "sub").mkdir(parents=True)
+    (root / "top.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (root / "sub" / "a.py").write_text("@d\ndef g():\n    return 1\n", encoding="utf-8")
+    (root / "sub" / "broken.py").write_text("def (:\n", encoding="utf-8")
+
+    per_dir, per_file = census(root)
+
+    assert set(per_file) == {(root / "top.py").as_posix(), (root / "sub" / "a.py").as_posix()}
+    assert per_dir == {
+        root.as_posix(): Tally(functions=1, skipped_functions=0, lines=2, skipped_lines=0),
+        (root / "sub").as_posix(): Tally(functions=1, skipped_functions=1, lines=3, skipped_lines=3),
+    }
+
+
+def test_main_per_file_lists_only_files_at_or_above_min_skip_sorted_by_ratio(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "pkg"
+    root.mkdir()
+    (root / "clean.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (root / "half.py").write_text("def f():\n    return 1\n@d\ndef g():\n    return 1\n", encoding="utf-8")
+    (root / "all.py").write_text("@d\ndef g():\n    return 1\n", encoding="utf-8")
+
+    code = main([str(root), "--per-file", "--min-skip", "50"])
+
+    out = capsys.readouterr().out
+    assert code == 0
+    listed = [line.split()[0] for line in out.splitlines() if line.startswith(str(root))]
+    assert listed == [(root / "all.py").as_posix(), (root / "half.py").as_posix()]
+    assert "100.0%" in out
+    assert " 60.0%" in out
+
+
+def test_main_prints_directory_summary_with_total_and_rejects_non_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "pkg"
+    (root / "sub").mkdir(parents=True)
+    (root / "sub" / "a.py").write_text("@d\ndef g():\n    return 1\n", encoding="utf-8")
+
+    assert main([str(root)]) == 0
+    out = capsys.readouterr().out
+    assert (root / "sub").as_posix() in out
+    assert "合计" in out
+    assert "100.0%" in out
+
+    assert main([str(tmp_path / "missing")]) == 2
+    assert "不是目录" in capsys.readouterr().err

--- a/tests/unit/scripts/test_decorator_census.py
+++ b/tests/unit/scripts/test_decorator_census.py
@@ -80,7 +80,8 @@ def test_census_groups_by_first_level_subdirectory_and_skips_unparsable_files(tm
 
     per_dir, per_file = census(root)
 
-    assert set(per_file) == {(root / "top.py").as_posix(), (root / "sub" / "a.py").as_posix()}
+    assert list(per_file) == [(root / "sub" / "a.py").as_posix(), (root / "top.py").as_posix()]
+    assert list(per_dir) == [root.as_posix(), (root / "sub").as_posix()]
     assert per_dir == {
         root.as_posix(): Tally(functions=1, skipped_functions=0, lines=2, skipped_lines=0),
         (root / "sub").as_posix(): Tally(functions=1, skipped_functions=1, lines=3, skipped_lines=3),


### PR DESCRIPTION
回填 [#2356](https://github.com/ArcReel/ArcReel/issues/2356) 的决议到 `docs/testing/mutmut-runbook.md`，后续批次不开 wayfinder 地图、只按 runbook 走。Closes #2364（Map #2250）。

## 变更

- **§2.1 选模块**：准入（`server/routers` 整目录不选；其他目录按文件看，被装饰器跳过的行过半不选）、优先级（没跑过、测试多、代码量大；`server/services` / `lib/video_backends` / `lib/custom_provider` / `lib/reference_video` 优先，不再找预测规则）、每批 8 个左右、停机判据（连续两批可处置率明显下降就停）。
- **§3 读结果**首步加 mutant 数量级核对：每千行约 1000 个，明显偏少即模块未被用例关联，剔掉不判。
- **§5.1** 加曳光弹步骤：每批改造先挑 2 条走完「改断言 → 全套闸门 → 全量复跑 → 三层验收 → PR」再批量。
- **§8 已走查模块**表（模块 / 批次 / 票号 / 研究分支）：首批 8 个、第二批池 1 的 8 个、池 2 的 11 个。首批的 `lib_grid_splitter.py.meta` 对应当前的 `lib/grid/splitter.py`（`.meta` 文件名把 `/` 压成 `_`）。
- **`scripts/decorator_census.py`**：从 `research/mutmut-batch-2/pool2/` 挪入，加类型注解与 `main(argv)`，新增 `--per-file` / `--min-skip PCT`，准入核对一条命令：`uv run python scripts/decorator_census.py --per-file --min-skip 50`。行数按唯一行号统计，嵌套函数的行不再重复计入分母，因此按目录汇总的数字比 #2356 记录的略高（`lib/` 7.7%、`server/services` 1.9%、`server/agent_runtime` 20.4%、`server/routers` 70.8%），准入结论不变。
- 票面只列两个文件；按仓库 `tests/unit/scripts/` 的约定补了 `test_decorator_census.py`（装饰器规则、目录分组、`--per-file` 过滤与排序、非目录退出码）。

「关联用例快且稳」在 runbook 与地图 Notes 里都没有引用处，无需删除；在优先级条目里写明测试快慢不是准入条件。

review 中已修：准入边界与 `--min-skip 50` 统一为「不低于 50%」；`census` 的目录字典按路径排序返回。

## 验证

- `ruff check` / `ruff format` / `basedpyright --warnings` / `lint-imports` / `deptry` 全过
- `scripts/audit_tests.py --check` 0 违规
- `pytest tests/unit/scripts` 123 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增变异测试装饰器统计工具，可按文件或目录汇总跳过的函数及代码行比例，并支持按比例筛选结果。
  - 增强表格输出对中英文及东亚字符的对齐支持。
  - 增加对非目录路径、语法错误文件及零变异体情况的处理与提示。

- **文档**
  - 完善变异测试运行手册，补充模块准入、优先级、停止规则、结果核验及验收流程。

- **测试**
  - 新增统计工具的单元测试，覆盖装饰器识别、汇总、筛选、排序、对齐和错误处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
