### PR TITLE
fix(agent-runtime): 从 CLI init 消息解析 sdk_session_id，凭证无效时不再误报「SDK 会话创建超时」

### DIFF
--- a/frontend/src/i18n/en/dashboard.ts
+++ b/frontend/src/i18n/en/dashboard.ts
@@ -1787,6 +1787,7 @@ export default {
   'diagnosis_model_required': 'No default model set for this preset. Fill in a default model before testing.',
   'diagnosis_rate_limited': 'Rate limited. Try again later.',
   'diagnosis_network': 'Network unreachable. Check URL and firewall.',
+  'diagnosis_timeout': 'Upstream timed out. The endpoint is reachable but the model did not answer in time; you can save and retry.',
   'diagnosis_unknown': 'Unknown error. See raw response.',
   // ==================== Shot end frame ====================
   'end_frame_title': 'End frame',

--- a/frontend/src/i18n/vi/dashboard.ts
+++ b/frontend/src/i18n/vi/dashboard.ts
@@ -1785,6 +1785,7 @@ export default {
   'diagnosis_model_required': 'Preset này chưa có model mặc định. Hãy điền model mặc định trước khi kiểm tra.',
   'diagnosis_rate_limited': 'Đã vượt giới hạn tốc độ. Thử lại sau.',
   'diagnosis_network': 'Không thể truy cập mạng. Kiểm tra URL và tường lửa.',
+  'diagnosis_timeout': 'Upstream hết thời gian chờ. Endpoint truy cập được nhưng model không trả lời kịp; bạn có thể lưu và thử lại.',
   'diagnosis_unknown': 'Lỗi không xác định. Xem chi tiết bên dưới.',
   // ==================== Khung hình cuối ====================
   'end_frame_title': 'Khung hình cuối',

--- a/frontend/src/i18n/zh/dashboard.ts
+++ b/frontend/src/i18n/zh/dashboard.ts
@@ -1786,6 +1786,7 @@ export default {
   'diagnosis_model_required': '该预设未指定默认模型，请先填写默认模型再测试',
   'diagnosis_rate_limited': '触发限流，稍后重试',
   'diagnosis_network': '网络无法访问，检查 URL 与防火墙',
+  'diagnosis_timeout': '上游响应超时，服务可达但模型在限定时间内未返回；可直接保存后重试',
   'diagnosis_unknown': '未知错误，请查看原始错误信息',
   // ==================== 分镜尾帧 ====================
   'end_frame_title': '尾帧',

--- a/frontend/src/types/agent-credential.ts
+++ b/frontend/src/types/agent-credential.ts
@@ -72,6 +72,7 @@ export type DiagnosisCode =
   | "model_required"
   | "rate_limited"
   | "network"
+  | "timeout"
   | "unknown";
 
 export interface SuggestionAction {

--- a/lib/config/anthropic_probe.py
+++ b/lib/config/anthropic_probe.py
@@ -31,8 +31,10 @@ logger = logging.getLogger(__name__)
 
 _ERR_TRUNCATE = 200
 
-# 超时与其他网络异常同为 status_code=None；error 以此前缀开头即为超时，
-# classify 据此把「服务可达但响应慢」与「网络不通」分开。
+# 超时与其他网络异常同为 status_code=None；error 以此前缀开头即为「服务可达但
+# 响应慢」，classify 据此与「网络不通」分开。只有 ReadTimeout（连接已建立、请求已
+# 发出、等响应超时）能证明服务可达；ConnectTimeout / WriteTimeout / PoolTimeout
+# 不能，与其他网络异常同路径处理。
 _TIMEOUT_ERROR_PREFIX = "timeout: "
 
 # messages 探测上限。带推理的模型（如火山方舟 Agent Plan 的 doubao-seed 系列）
@@ -114,7 +116,7 @@ async def probe_messages(
     started = time.perf_counter()
     try:
         resp = await _post(url=url, headers=headers, payload=payload, timeout_s=timeout_s, http_client=http_client)
-    except httpx.TimeoutException as exc:
+    except httpx.ReadTimeout as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         logger.info("probe_messages timeout url=%s elapsed_ms=%d", url, elapsed)
         return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"{_TIMEOUT_ERROR_PREFIX}{exc!s}")
@@ -214,7 +216,7 @@ async def probe_discovery(
                 timeout_s=timeout_s,
                 http_client=http_client,
             )
-    except httpx.TimeoutException as exc:
+    except httpx.ReadTimeout as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"{_TIMEOUT_ERROR_PREFIX}{exc!s}")
     except httpx.HTTPError as exc:

--- a/lib/config/anthropic_probe.py
+++ b/lib/config/anthropic_probe.py
@@ -31,6 +31,14 @@ logger = logging.getLogger(__name__)
 
 _ERR_TRUNCATE = 200
 
+# 超时与其他网络异常同为 status_code=None；error 以此前缀开头即为超时，
+# classify 据此把「服务可达但响应慢」与「网络不通」分开。
+_TIMEOUT_ERROR_PREFIX = "timeout: "
+
+# messages 探测上限。带推理的模型（如火山方舟 Agent Plan 的 doubao-seed 系列）
+# 首 token 常达 8~10s，上限须留出足够余量，否则正常端点会被误判为网络不通。
+_MESSAGES_PROBE_TIMEOUT_S = 30.0
+
 # 400 错误体里「缺参」措辞紧挨着 model 时 = 模型参数没传（而非模型名不被识别）。
 # 中间允许任意字符以容纳 "missing parameter model" 这类措辞，但限定邻近距离，
 # 避免 body 里另一个参数的缺参提示（如 missing max_tokens）连坐到 model。
@@ -45,6 +53,7 @@ class DiagnosisCode(StrEnum):
     MODEL_REQUIRED = "model_required"
     RATE_LIMITED = "rate_limited"
     NETWORK = "network"
+    TIMEOUT = "timeout"
     UNKNOWN = "unknown"
 
 
@@ -80,7 +89,7 @@ async def probe_messages(
     messages_root: str,
     api_key: str,
     model: str,
-    timeout_s: float = 10.0,
+    timeout_s: float = _MESSAGES_PROBE_TIMEOUT_S,
     http_client: httpx.AsyncClient | None = None,
 ) -> ProbeResult:
     """POST {messages_root}/v1/messages 发最小请求 (max_tokens=1)。
@@ -108,7 +117,7 @@ async def probe_messages(
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         logger.info("probe_messages timeout url=%s elapsed_ms=%d", url, elapsed)
-        return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"timeout: {exc!s}")
+        return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"{_TIMEOUT_ERROR_PREFIX}{exc!s}")
     except httpx.HTTPError as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         logger.info("probe_messages network err url=%s elapsed_ms=%d", url, elapsed)
@@ -168,6 +177,8 @@ def classify_probe_failure(result: ProbeResult) -> DiagnosisCode:
         # 2xx 但 probe 判失败 = 协议不匹配（OpenAI 兼容响应冒充 anthropic）
         return DiagnosisCode.OPENAI_COMPAT_ONLY
     if code is None:
+        if (result.error or "").startswith(_TIMEOUT_ERROR_PREFIX):
+            return DiagnosisCode.TIMEOUT
         return DiagnosisCode.NETWORK
     return DiagnosisCode.UNKNOWN
 
@@ -205,7 +216,7 @@ async def probe_discovery(
             )
     except httpx.TimeoutException as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
-        return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"timeout: {exc!s}")
+        return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=f"{_TIMEOUT_ERROR_PREFIX}{exc!s}")
     except httpx.HTTPError as exc:
         elapsed = int((time.perf_counter() - started) * 1000)
         return ProbeResult(success=False, status_code=None, latency_ms=elapsed, error=_truncate(str(exc)))

--- a/server/agent_runtime/session_manager.py
+++ b/server/agent_runtime/session_manager.py
@@ -60,7 +60,7 @@ from server.sse_channel import IDLE, EvictNonCriticalAndSignal, SseChannel
 
 logger = logging.getLogger(__name__)
 
-from claude_agent_sdk import ClaudeSDKClient, tag_session
+from claude_agent_sdk import ClaudeSDKClient
 from claude_agent_sdk.types import (
     PermissionResultAllow,
     PermissionResultDeny,
@@ -333,7 +333,6 @@ class SessionManager:
         "AskUserQuestion",
     ]
     DEFAULT_SETTING_SOURCES: ClassVar[list[str]] = ["project"]
-    _SDK_ID_TIMEOUT = 60.0
 
     def __init__(
         self,
@@ -343,8 +342,11 @@ class SessionManager:
         in_docker: bool = False,
         sandbox_enabled: bool = True,
         event_log_store: EventLogStore | None = None,
+        sdk_id_timeout: float = 60.0,
     ):
         self.event_log_store = event_log_store or EventLogStore()
+        # 新会话等待 CLI init 上报 sdk_session_id 的上限；超时即判启动失败。
+        self._sdk_id_timeout = sdk_id_timeout
         self.project_root = Path(project_root)
         # Tests construct SessionManager directly without going through
         # AssistantService, so we fall back to the legacy ``project_root/projects``
@@ -719,7 +721,7 @@ class SessionManager:
         try:
             await asyncio.wait(
                 watch_tasks,
-                timeout=self._SDK_ID_TIMEOUT,
+                timeout=self._sdk_id_timeout,
                 return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
@@ -1589,21 +1591,8 @@ class SessionManager:
 
         # Only create DB record for new sessions (no existing meta)
         if not managed.sdk_id_event.is_set():
-            # Run DB create and SDK tag in parallel (tag is independent file I/O)
-            tag_coro = None
-            if tag_session is not None:
-
-                async def _tag() -> None:
-                    try:
-                        await asyncio.to_thread(tag_session, sdk_id, f"project:{managed.project_name}")
-                    except Exception:
-                        logger.warning("tag_session failed for %s", sdk_id, exc_info=True)
-
-                tag_coro = _tag()
-            await asyncio.gather(
-                self.meta_store.create(managed.project_name, sdk_id),
-                *([] if tag_coro is None else [tag_coro]),
-            )
+            # 会话与项目的归属只记在 meta_store。
+            await self.meta_store.create(managed.project_name, sdk_id)
             await self.meta_store.update_status(sdk_id, "running")
             # 新会话首条用户消息先写日志分配身份（seq 0）：本方法在 inbox 任务
             # 内串行执行于任何 assistant 条目定型之前，保证时间线顺序；写入
@@ -1637,10 +1626,20 @@ class SessionManager:
 
     @staticmethod
     def _extract_sdk_session_id(message: Any, msg_dict: dict[str, Any]) -> str | None:
-        """Extract SDK session id from either serialized payload or raw object."""
+        """Extract SDK session id from either serialized payload or raw object.
+
+        CLI 的 system 消息（init / status / api_retry）把 ``session_id`` 放在
+        ``data`` 里而非顶层。首轮 API 请求失败（凭证无效触发 CLI 退避重试）时
+        流里只有这类消息，id 必须能从 init 解析出来，否则新会话只能等超时。
+        """
         sdk_id = msg_dict.get("session_id") or msg_dict.get("sessionId")
         if sdk_id:
             return str(sdk_id)
+        data = msg_dict.get("data")
+        if isinstance(data, dict):
+            nested = data.get("session_id") or data.get("sessionId")
+            if nested:
+                return str(nested)
         raw_sdk_id = getattr(message, "session_id", None) or getattr(message, "sessionId", None)
         if raw_sdk_id:
             return str(raw_sdk_id)

--- a/tests/unit/lib/config/test_anthropic_probe.py
+++ b/tests/unit/lib/config/test_anthropic_probe.py
@@ -144,8 +144,22 @@ def test_classify_probe_failure_429() -> None:
 
 
 def test_classify_probe_failure_network() -> None:
-    p = ProbeResult(success=False, status_code=None, latency_ms=10, error="timeout")
+    p = ProbeResult(success=False, status_code=None, latency_ms=10, error="connection refused")
     assert classify_probe_failure(p) == DiagnosisCode.NETWORK
+
+
+async def test_probe_messages_timeout_classifies_as_timeout(probe_client: httpx.AsyncClient) -> None:
+    with capture_http() as router:
+        router.post("https://api.example.com/v1/messages").mock(side_effect=httpx.ReadTimeout("read timed out"))
+        result = await probe_messages(
+            messages_root="https://api.example.com",
+            api_key="sk",
+            model="x",
+            timeout_s=0.5,
+            http_client=probe_client,
+        )
+
+    assert classify_probe_failure(result) == DiagnosisCode.TIMEOUT
 
 
 def test_classify_probe_failure_openai_compat() -> None:

--- a/tests/unit/lib/config/test_anthropic_probe.py
+++ b/tests/unit/lib/config/test_anthropic_probe.py
@@ -91,9 +91,22 @@ async def test_probe_messages_200_but_not_anthropic_marks_failure(probe_client: 
     assert "non-anthropic" in (result.error or "").lower()
 
 
-async def test_probe_messages_timeout(probe_client: httpx.AsyncClient) -> None:
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (httpx.ReadTimeout("read timed out"), DiagnosisCode.TIMEOUT),
+        (httpx.ConnectTimeout("connect timed out"), DiagnosisCode.NETWORK),
+        (httpx.WriteTimeout("write timed out"), DiagnosisCode.NETWORK),
+        (httpx.PoolTimeout("pool timed out"), DiagnosisCode.NETWORK),
+    ],
+    ids=["read", "connect", "write", "pool"],
+)
+async def test_probe_messages_timeout_only_read_timeout_means_upstream_slow(
+    probe_client: httpx.AsyncClient, exc: httpx.TimeoutException, expected: DiagnosisCode
+) -> None:
+    """只有 ReadTimeout 证明服务可达；其余超时与网络不通同类。"""
     with capture_http() as router:
-        router.post("https://api.example.com/v1/messages").mock(side_effect=httpx.TimeoutException("timeout"))
+        router.post("https://api.example.com/v1/messages").mock(side_effect=exc)
         result = await probe_messages(
             messages_root="https://api.example.com",
             api_key="sk",
@@ -104,7 +117,8 @@ async def test_probe_messages_timeout(probe_client: httpx.AsyncClient) -> None:
 
     assert result.success is False
     assert result.status_code is None
-    assert "timeout" in (result.error or "").lower()
+    assert "timed out" in (result.error or "").lower()
+    assert classify_probe_failure(result) == expected
 
 
 async def test_probe_messages_network_error(probe_client: httpx.AsyncClient) -> None:
@@ -146,20 +160,6 @@ def test_classify_probe_failure_429() -> None:
 def test_classify_probe_failure_network() -> None:
     p = ProbeResult(success=False, status_code=None, latency_ms=10, error="connection refused")
     assert classify_probe_failure(p) == DiagnosisCode.NETWORK
-
-
-async def test_probe_messages_timeout_classifies_as_timeout(probe_client: httpx.AsyncClient) -> None:
-    with capture_http() as router:
-        router.post("https://api.example.com/v1/messages").mock(side_effect=httpx.ReadTimeout("read timed out"))
-        result = await probe_messages(
-            messages_root="https://api.example.com",
-            api_key="sk",
-            model="x",
-            timeout_s=0.5,
-            http_client=probe_client,
-        )
-
-    assert classify_probe_failure(result) == DiagnosisCode.TIMEOUT
 
 
 def test_classify_probe_failure_openai_compat() -> None:
@@ -214,6 +214,27 @@ async def test_probe_discovery_network_error(probe_client: httpx.AsyncClient) ->
     assert result.success is False
     assert result.status_code is None
     assert "dns fail" in (result.error or "").lower()
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (httpx.ReadTimeout("read timed out"), DiagnosisCode.TIMEOUT),
+        (httpx.ConnectTimeout("connect timed out"), DiagnosisCode.NETWORK),
+    ],
+    ids=["read", "connect"],
+)
+async def test_probe_discovery_timeout_follows_messages_probe_rule(
+    probe_client: httpx.AsyncClient, exc: httpx.TimeoutException, expected: DiagnosisCode
+) -> None:
+    with capture_http() as router:
+        router.get("https://api.example.com/v1/models").mock(side_effect=exc)
+        result = await probe_discovery(discovery_root="https://api.example.com", api_key="sk", http_client=probe_client)
+
+    assert result is not None
+    assert result.success is False
+    assert result.status_code is None
+    assert classify_probe_failure(result) == expected
 
 
 async def test_run_test_custom_mode_self_heals_with_anthropic_suffix(probe_client: httpx.AsyncClient) -> None:

--- a/tests/unit/server/agent_runtime/test_event_log_session_flow.py
+++ b/tests/unit/server/agent_runtime/test_event_log_session_flow.py
@@ -202,7 +202,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             user_entry = build_user_entry([{"type": "text", "text": "帮我写分镜"}])
             sdk_id = await manager.send_new_session(
@@ -252,7 +251,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             user_entry = build_user_entry([{"type": "text", "text": "帮我写分镜"}])
             await manager.send_new_session("demo", "帮我写分镜", user_entry=user_entry)
@@ -310,7 +308,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             await manager.send_new_session(
                 "demo",
@@ -361,7 +358,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             await manager.send_message(
                 SDK_ID,
@@ -394,7 +390,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             await manager.send_message(
                 SDK_ID,
@@ -453,7 +448,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             await manager.send_message(
                 SDK_ID,
@@ -503,7 +497,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             await manager.send_message(
                 SDK_ID,
@@ -532,7 +525,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             user_entry = build_user_entry([{"type": "text", "text": "继续"}])
             log_entry = await manager.send_message(
@@ -582,7 +574,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             user_entry = build_user_entry([{"type": "text", "text": "继续"}])
             log_entry = await manager.send_message(SDK_ID, "继续", meta=meta, user_entry=user_entry)
@@ -605,7 +596,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             first = await manager.send_message(
                 SDK_ID,
@@ -654,7 +644,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             with pytest.raises(RuntimeError):
                 await manager.send_message(
@@ -693,7 +682,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
             patch.object(
                 manager.event_log_store,
                 "append_user_entry",
@@ -738,7 +726,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client),
-            patch("server.agent_runtime.session_manager.tag_session", None),
             patch.object(
                 manager.event_log_store,
                 "append_user_entry",
@@ -778,7 +765,6 @@ class TestNewSessionEventLogFlow:
         with (
             patch.object(manager, "_build_options", new=AsyncMock(return_value=fake_options)),
             patch("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: next(clients)),
-            patch("server.agent_runtime.session_manager.tag_session", None),
         ):
             with (
                 patch.object(

--- a/tests/unit/server/agent_runtime/test_session_manager_init_session_id.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_init_session_id.py
@@ -1,0 +1,77 @@
+"""新会话在流里只有 system 消息（init / api_retry）时也要拿到 sdk_session_id。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from claude_agent_sdk.types import SystemMessage
+
+from server.agent_runtime.message_serialization import message_to_dict
+from server.agent_runtime.session_manager import SessionManager
+from server.agent_runtime.session_store import SessionMetaStore
+from tests.fakes import FakeSDKClient
+
+SDK_ID = "sdk-init-only-1"
+
+
+def _init_message() -> dict:
+    return {
+        "type": "system",
+        "subtype": "init",
+        "data": {"type": "system", "subtype": "init", "cwd": "/tmp/demo", "session_id": SDK_ID, "tools": []},
+    }
+
+
+def _api_retry_message(attempt: int) -> dict:
+    return {
+        "type": "system",
+        "subtype": "api_retry",
+        "data": {
+            "type": "system",
+            "subtype": "api_retry",
+            "attempt": attempt,
+            "max_retries": 10,
+            "retry_delay_ms": 500,
+            "error_status": 401,
+            "error": "authentication_failed",
+            "session_id": SDK_ID,
+            "uuid": f"retry-{attempt}",
+        },
+    }
+
+
+def test_system_message_serializes_session_id_under_data() -> None:
+    """真实 SDK 的 SystemMessage 序列化后 session_id 只在 data 里，顶层没有。"""
+    msg = message_to_dict(SystemMessage(subtype="init", data={"subtype": "init", "session_id": SDK_ID}))
+    assert "session_id" not in msg
+    assert msg["data"]["session_id"] == SDK_ID
+
+
+@pytest.mark.asyncio
+async def test_send_new_session_resolves_id_from_init_when_only_system_messages_arrive(
+    tmp_path: Path, meta_store: SessionMetaStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proj_dir = tmp_path / "projects" / "demo"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
+    manager = SessionManager(project_root=tmp_path, meta_store=meta_store, sdk_id_timeout=2.0)
+
+    client = FakeSDKClient(
+        messages=[_init_message(), _api_retry_message(1), _api_retry_message(2)],
+        block_forever=True,
+    )
+
+    async def fake_env():
+        return {"ANTHROPIC_API_KEY": "sk"}
+
+    monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
+    monkeypatch.setattr("server.agent_runtime.session_manager.ClaudeSDKClient", lambda options: client)
+
+    sdk_id = await manager.send_new_session("demo", "你好")
+    try:
+        assert sdk_id == SDK_ID
+        assert manager.sessions[SDK_ID].status == "running"
+        assert (await manager.meta_store.get(SDK_ID)).status == "running"
+    finally:
+        await manager.close_session(sdk_id)

--- a/tests/unit/server/agent_runtime/test_session_manager_user_input.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_user_input.py
@@ -14,7 +14,7 @@ from server.agent_runtime.message_serialization import (
     match_user_echo,
     message_to_dict,
 )
-from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError, ManagedSession
+from server.agent_runtime.session_manager import SDK_AVAILABLE, AgentStartupError, ManagedSession, SessionManager
 from tests.fakes import build_managed_with_actor
 
 
@@ -335,9 +335,10 @@ class TestSessionManagerUserInput:
         assert session_manager.unclaimed_user_echoes == 0
 
     async def test_cleanup_on_error_disconnect_timeout_keeps_startup_failure_out_of_echo_accounting(
-        self, session_manager, meta_store, monkeypatch, caplog, tmp_path
+        self, meta_store, monkeypatch, caplog, tmp_path
     ):
         """会话跑起来后才启动失败时，断开挂起不得把待回放登记误记为未认领。"""
+        session_manager = SessionManager(project_root=tmp_path, meta_store=meta_store, sdk_id_timeout=0.05)
         proj_dir = tmp_path / "projects" / "demo"
         proj_dir.mkdir(parents=True)
         (proj_dir / "project.json").write_text('{"title": "t"}', encoding="utf-8")
@@ -378,7 +379,6 @@ class TestSessionManagerUserInput:
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
         monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
         monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
-        session_manager._sdk_id_timeout = 0.05
         session_manager._session_actor_shutdown_timeout = 0.05
 
         with (

--- a/tests/unit/server/agent_runtime/test_session_manager_user_input.py
+++ b/tests/unit/server/agent_runtime/test_session_manager_user_input.py
@@ -378,7 +378,7 @@ class TestSessionManagerUserInput:
         monkeypatch.setattr("server.agent_runtime.options_assembler.load_provider_env_overrides", fake_env)
         monkeypatch.setattr("server.agent_runtime.session_manager.SessionActor", _FakeActor)
         monkeypatch.setattr(type(session_manager), "_ensure_capacity", AsyncMock(return_value=None))
-        monkeypatch.setattr(type(session_manager), "_SDK_ID_TIMEOUT", 0.05)
+        session_manager._sdk_id_timeout = 0.05
         session_manager._session_actor_shutdown_timeout = 0.05
 
         with (


### PR DESCRIPTION
## Summary

- **误报根因**：`_extract_sdk_session_id` 只读消息顶层 `session_id`，而 CLI 的 system 消息（init / status / api_retry）把它嵌在 `data` 里。正常会话靠后续 stream_event 兜底；凭证无效时 CLI 对 401 指数退避重试约 3 分钟，60s 窗口内只有 system 消息，于是报「SDK 会话创建超时」而非真实的 401。
- **修复**：顶层无 id 时回退读取 `data.session_id`，init 到达即解析。修复后 401 场景 send 在 1s 内返回并建立会话，鉴权失败由 CLI 的 result 落为 turn failure 条目。
- **移除 `tag_session`**：id 提前到 init 时刻后 CLI 尚未落盘，该调用必然 `FileNotFoundError`；仓库内无消费方，归属仅经 meta_store。
- **测试 seam**：`_SDK_ID_TIMEOUT` 类常量改为构造参数 `sdk_id_timeout`；新增回归测试（假客户端只吐 init + api_retry），去掉修复后 2.5s 即以 TimeoutError 变红。
- **连通性探测超时误报**（第二位用户）：火山方舟 Agent Plan 推理模型首 token 常达 8~10s，`probe_messages` 10s 上限超时后归为 `NETWORK`，前端显示「网络无法访问，检查 URL 与防火墙」。上限提到 30s，新增 `DiagnosisCode.TIMEOUT` 与 zh/en/vi 文案。仅 messages 探测改动，discovery（5s）与文本供应商连通性检查（15s）不变。

## Test plan

- [x] `tests/unit/server/agent_runtime/test_session_manager_init_session_id.py` 新增用例：去掉 `data` 回退后 2.5s 变红，修复后通过
- [x] `uv run python -m pytest -n 4 --dist loadfile`：11987 passed, 3 skipped
- [x] `ruff check` / `ruff format` / `basedpyright --warnings` / `lint-imports` / `deptry` / `scripts/audit_tests.py --check` 全部通过
- [x] `(cd frontend && pnpm check)`：2145 passed
- [x] 本地复现回路（aiohttp 假端点返 401 + 真实服务 + bundled CLI）：修复前稳定 61s 504，修复后 200

## 后续（不在本 PR）

- 收到 `api_retry`（401 authentication_failed）时提前向前端透出凭证错误，避免空等约 3 分钟
- 对话侧把 CLI 的 `Not logged in · Please run /login` 映射为「未配置 Agent 凭证」提示
- 既有测试的假 init 消息把 `session_id` 放顶层，与真实 CLI 形状不一致，可统一改为嵌在 `data` 下

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增上游请求超时诊断，可区分网络错误与响应超时。
  - 供应商连通性诊断等待时间延长至 30 秒。
  - 会话启动时可从初始化及重试消息中识别会话 ID，即使首个 API 请求失败。
  - 新增英文、越南文和中文的超时提示翻译。
- **改进**
  - 会话 ID 等待时长支持按需配置，提升会话初始化的灵活性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->