### PR TITLE
fix(prompt): 提示词 YAML 序列化不再按 80 列折行

### DIFF
--- a/lib/prompt_utils.py
+++ b/lib/prompt_utils.py
@@ -23,6 +23,23 @@ AVOID_KEY = "Avoid"
 STORYBOARD_AVOID_ITEMS = "水印、多余文字、Logo"
 VIDEO_AVOID_ITEMS = "BGM、文字字幕、水印"
 
+# 提示词 YAML 的行宽上限。PyYAML 默认 80 列，超宽的纯量会在 ASCII 空格处折成多行——
+# 英文 / 越南语提示词几乎每个值都超 80 列，折行会把原文塞进换行再喂给供应商。取一个任何
+# 提示词都达不到的值，值内容与作者所写逐字一致。
+_PROMPT_YAML_WIDTH = 1_000_000
+
+
+def _dump_prompt_yaml(ordered: Mapping[str, Any]) -> str:
+    """提示词各段共用的 YAML 序列化：键序保持插入序、Unicode 原样、块式布局、不折行。"""
+    return yaml.dump(
+        dict(ordered),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=_PROMPT_YAML_WIDTH,
+    )
+
+
 # 风格值开头的「画风：」前缀（全角/半角冒号）。新版风格模版已去前缀，此处兼容存量 project.json。
 _STYLE_PREFIX_RE = re.compile(r"^画风[：:]\s*")
 
@@ -72,7 +89,7 @@ def image_prompt_to_yaml(image_prompt: dict, project_style: str, *, reference_im
         "ambiance": image_prompt["composition"]["ambiance"],
     }
     ordered[AVOID_KEY] = STORYBOARD_AVOID_ITEMS
-    return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    return _dump_prompt_yaml(ordered)
 
 
 def require_storyboard_scene(image_prompt: Mapping[str, Any]) -> str:
@@ -150,7 +167,7 @@ def video_prompt_to_yaml(video_prompt: dict) -> str:
         ordered["Dialogue"] = dialogue
     ordered[AVOID_KEY] = VIDEO_AVOID_ITEMS
 
-    return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    return _dump_prompt_yaml(ordered)
 
 
 def normalize_video_prompt(prompt: object) -> str:
@@ -257,7 +274,7 @@ def yaml_section(ordered: dict[str, Any]) -> str:
     键名与缩进沿用 ``image_prompt_to_yaml`` / ``video_prompt_to_yaml``：发声声明段、参考图类型
     声明行与 ``Avoid`` 反向约束在结构形态与文本形态下逐字同形，文本形态才能按内容判重。
     """
-    return yaml.dump(ordered, allow_unicode=True, default_flow_style=False, sort_keys=False).rstrip()
+    return _dump_prompt_yaml(ordered).rstrip()
 
 
 def strip_voice_profiles(video_prompt: dict[str, Any]) -> dict[str, Any]:

--- a/lib/reference_image_numbering.py
+++ b/lib/reference_image_numbering.py
@@ -70,10 +70,7 @@ def _describe(slot: ReferenceImageSlot) -> str:
 
 
 def reference_images_declaration(references: Sequence[ReferenceImageSlot]) -> str:
-    """``Reference_Images`` 行的值：按类型分组的编号声明；无参考图时为空串。
-
-    只用全角标点、不含 ASCII 空格：PyYAML 会在超过行宽的空格处折行，声明行不能给它折行点。
-    """
+    """``Reference_Images`` 行的值：按类型分组的编号声明；无参考图时为空串。"""
     groups: dict[str, list[str]] = {}
     for position, slot in enumerate(references):
         groups.setdefault(_describe(slot), []).append(_image_label(position))

--- a/tests/unit/lib/test_prompt_utils.py
+++ b/tests/unit/lib/test_prompt_utils.py
@@ -16,6 +16,7 @@ from lib.prompt_utils import (
     validate_camera_motion,
     validate_shot_type,
     video_prompt_to_yaml,
+    yaml_section,
 )
 
 
@@ -53,6 +54,28 @@ class TestPromptUtils:
         assert parsed["Scene"] == "夜雨中的街道"
         assert parsed["Composition"]["shot_type"] == "Medium Shot"
         assert parsed["Avoid"] == "水印、多余文字、Logo"
+
+    def test_long_values_with_ascii_spaces_stay_on_one_line(self):
+        scene = "A rain-soaked neon street at night, " * 6 + "a lone figure walks under a red umbrella."
+        declaration = "Image 1 is the character reference; " * 3 + "keep the outfit identical."
+        data = {"scene": scene, "composition": {"shot_type": "Medium Shot", "lighting": "warm", "ambiance": "mist"}}
+
+        text = image_prompt_to_yaml(data, "Anime", reference_images=declaration)
+
+        assert f"Scene: {scene}\n" in text
+        assert f"Reference_Images: {declaration}\n" in text
+        assert yaml.safe_load(text)["Scene"] == scene
+
+    def test_video_prompt_long_values_stay_on_one_line(self):
+        action = "The camera slowly pushes in while " * 5 + "the wind lifts the curtain."
+        text = video_prompt_to_yaml({"action": action, "camera_motion": "Push In", "dialogue": []})
+
+        assert f"Action: {action}\n" in text
+
+    def test_yaml_section_long_values_stay_on_one_line(self):
+        line = "Speaker one keeps a low steady voice " * 4 + "throughout the take."
+
+        assert yaml_section({"Voice_Profiles": line}) == f"Voice_Profiles: {line}"
 
     def test_image_prompt_to_yaml_places_reference_images_between_style_and_scene(self):
         data = {"scene": "x", "composition": {"shot_type": "Medium Shot", "lighting": "", "ambiance": ""}}

--- a/tests/unit/lib/test_reference_image_numbering.py
+++ b/tests/unit/lib/test_reference_image_numbering.py
@@ -52,13 +52,6 @@ class TestReferenceImagesDeclaration:
     def test_props_and_extra_images_have_their_own_types(self):
         assert reference_images_declaration([_sheet("prop", "怀表"), _EXTRA]) == "图1为道具参考图；图2为补充参考图。"
 
-    def test_declaration_contains_no_ascii_spaces(self):
-        # PyYAML 会在超过行宽的空格处折行，声明行不能给它折行点。
-        references = [_product("保温杯", "sheet"), _product("保温杯", "original")] + [
-            _sheet("character", f"角色{i}") for i in range(6)
-        ]
-        assert " " not in reference_images_declaration(references)
-
     def test_empty_references_render_nothing(self):
         assert reference_images_declaration([]) == ""
 


### PR DESCRIPTION
## 变更

来源：AFK 批次 `issues-2359-2179-2176` 复盘建议 R1。

PyYAML 默认行宽 80 列，超宽的纯量会在 ASCII 空格处折成多行。中文提示词几乎没有 ASCII 空格所以看不出来，英文 / 越南语项目的 Scene、Action 与参考图声明行却几乎每个值都超宽，折行后的换行随提示词原样发给供应商。

- `lib/prompt_utils.py`：三处 `yaml.dump` 收敛为 `_dump_prompt_yaml` 一个序列化入口，行宽设为任何提示词都达不到的值；键序、Unicode、块式布局参数不变。
- 参考图声明行「不含 ASCII 空格」的约定与对应单测只是为了绕开折行，随本次删除（`lib/reference_image_numbering.py` 文档串、`tests/unit/lib/test_reference_image_numbering.py`）。
- 新增三条单测覆盖 image / video / `yaml_section` 三个入口的长值不折行。

不包含：提示词内容与段落结构不变，预览与实发文本仍逐字相同。

## 验证

- `uv run ruff check . && uv run ruff format . && uv run basedpyright --warnings && uv run lint-imports && uv run deptry lib server alembic scripts tests`：全绿
- `uv run python -m pytest -n 4 --dist loadfile`：12289 passed / 3 skipped
- `uv run python scripts/audit_tests.py --check`：0 处违规
- 未改前端

## 风险与遗留

- 存量项目下一次生成的提示词文本在折行处会与上一次不同；提示词不进 basis 指纹，不触发 stale。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化提示词 YAML 输出格式，较长内容中的英文空格不再导致自动换行，文本可保持单行完整显示。

* **文档**
  * 更新参考图片编号声明的说明，明确其按类型分组编号及无参考图片时的返回结果。

* **测试**
  * 增加对长文本 YAML 输出格式的验证，覆盖图片提示词、视频提示词和语音配置等场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->