### PR TITLE
chore(tests): 定向测试选择含不存在路径时在收集前报错

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 ### 共享设施
 
-- **三角色**：`tests/conftest.py` 只放 fixture 与收集期钩子，禁止被 import（闸门）；`tests/fakes.py` 放替身实现，不含 fixture；`tests/factories.py` 放测试输入构造器（数据与媒体文件 builder）。专题共享模块（如 `tests/auth_deps.py`）允许存在；fakes / factories / 专题模块的公开符号须被 ≥2 个测试文件使用（闸门），仅单个文件使用的移回该文件。
+- **三角色**：`tests/conftest.py` 只放 fixture、收集期钩子与会话启动期的定向选择校验，禁止被 import（闸门）；`tests/fakes.py` 放替身实现，不含 fixture；`tests/factories.py` 放测试输入构造器（数据与媒体文件 builder）。专题共享模块（如 `tests/auth_deps.py`）允许存在；fakes / factories / 专题模块的公开符号须被 ≥2 个测试文件使用（闸门），仅单个文件使用的移回该文件。
 - **局部 conftest**：只为本目录提供 fixture；不得与根 conftest 的 fixture 同名；跨目录共用的 fixture 上提到根 conftest；conftest 之间不互相 import（闸门）。
 - **fixture 覆写与重复**（闸门）：测试文件不得定义与任一 conftest 同名的 fixture——供给同一实体的改为直接消费 conftest 版本，供给不同实体的改一个有区分度的名字；同一实体的 fixture 在 ≥3 个测试文件重复定义时上提 conftest。
 - **DB fixture**：一律派生自 `tests/conftest.py` 唯一的 engine 构造点 `make_test_engine`。`session_factory` / `async_session` 方言感知，`DATABASE_URL` 指向 PostgreSQL 时走真实 PG；`concurrent_session_factory` 同样方言感知，并为 SQLite 提供允许独立连接的 WAL 文件库；`file_session_factory` 恒为文件 SQLite，消费方是标了 `sqlite_only` 的边界用例。四者携带 `uses_db` 标记，构成需要数据库的选择集；PostgreSQL 兼容 job 取其中 `uses_db and not sqlite_only` 的部分，`file_session_factory` 的消费方不在其内。`db_engine` / `db_session` / `db_factory`（内存）与 `file_db_factory`（文件）固定走 SQLite、不带 `uses_db`，供不进该选集的 models 与 repositories 单测使用。唯一登记的例外是 `async_session` 的 PG 分支：它绑定 CI job 已 `alembic upgrade head` 建好的 public schema，隔离原语是外层事务 + SAVEPOINT，与 `make_test_engine` 的 per-test schema + `create_all` 不同，故自建 engine。
@@ -147,7 +147,7 @@ pytest `asyncio_mode = "auto"`，异步用例无需手动标记。
 
 - 入口唯一：本地 `uv run python scripts/audit_tests.py --check`，CI 的独立 `test-lint` 作业跑同一脚本、同一 `--check`（脚本零第三方依赖，该作业只装 Python 不装项目依赖）；输出 `规则号 file:line 修复指引`。
 - 零容忍：违规数恒为 0，无基线、无棘轮、无豁免标注；脚本误报通过修改脚本解决，不为用例添加豁免；新增规则与其存量清零同 PR 上线。
-- 分工：AST 脚本负责代码结构；pytest 收集期只做档位相关校验；运行期不新增检查。前端语义类规则归 eslint，结构类规则由同一脚本扫描 `frontend/src/**/*.test.*`。
+- 分工：AST 脚本负责代码结构；pytest 收集期只做档位相关校验，会话启动期只做定向选择的路径与模块存在性校验（缺失即 `UsageError`，统一 xdist 与 plain 的退出码）；运行期不新增检查。前端语义类规则归 eslint，结构类规则由同一脚本扫描 `frontend/src/**/*.test.*`。
 
 ### 前端测试（vitest）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ DEP002 = [
 # dev 与生产文件，故逐项列出它们正当 import 的测试框架包；其余 dev 依赖仍受本规则守护。
 DEP004 = [
     "pytest",         # 测试框架
+    "_pytest",        # pytest 的内部模块，根 conftest 复用其选择参数解析器
     "pytest_asyncio", # pytest 的 asyncio 插件，测试内直接用 @pytest_asyncio.fixture（本规则按模块名匹配）
     "respx",          # httpx 的测试替身
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,8 +385,13 @@ def _tier_from_path(item: pytest.Item) -> str | None:
 
 
 def _missing_selection_paths(config: pytest.Config) -> list[str]:
-    """命令行位置参数里指向不存在文件或目录的那些（去掉 ``::`` 之后的节点段）。"""
-    base = Path(config.invocation_params.dir)
+    """命令行位置参数里指向不存在文件或目录的那些（去掉 ``::`` 之后的节点段）。
+
+    ``--pyargs`` 下位置参数是模块名而非路径，交由 pytest 自己解析。
+    """
+    if config.getoption("pyargs"):
+        return []
+    base = config.invocation_params.dir
     return [arg for arg in config.args if not (base / arg.split("::", 1)[0]).exists()]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,28 +385,38 @@ def _tier_from_path(item: pytest.Item) -> str | None:
     return head if head in CLASSIFICATION_MARKS else None
 
 
-def _importable_module(name: str) -> bool:
-    """``name`` 能作为已安装模块或包解析。"""
+def _module_not_found(name: str) -> bool:
+    """``name`` 确定解析不到模块。
+
+    ``find_spec`` 解析子模块会导入父包，父包初始化抛出的其他异常不说明模块缺失，
+    一律放行由 pytest 报出真实错误。
+    """
     try:
-        return importlib.util.find_spec(name) is not None
-    except (ImportError, ValueError):
+        return importlib.util.find_spec(name) is None
+    except ModuleNotFoundError:
+        return True
+    except Exception:
         return False
 
 
 def _missing_selection_paths(config: pytest.Config) -> list[str]:
     """命令行位置参数里既不指向已有文件或目录、也解析不到模块的那些。
 
-    比较的是去掉 ``::`` 之后的节点段。``--pyargs`` 下位置参数按模块名解析，解析不到
-    时 pytest 仍会把它当路径，故两条判据都不成立才算缺失。
+    比较的是去掉 ``::`` 之后的节点段；该段为空（``::test_x`` 之类）时选择无效。
+    ``--pyargs`` 下位置参数按模块名解析，解析不到时 pytest 仍会把它当路径，故两条
+    判据都不成立才算缺失。
     """
     base = config.invocation_params.dir
     pyargs = config.getoption("pyargs")
     missing: list[str] = []
     for arg in config.args:
         target = arg.split("::", 1)[0]
+        if not target:
+            missing.append(arg)
+            continue
         if (base / target).exists():
             continue
-        if pyargs and _importable_module(target):
+        if pyargs and not _module_not_found(target):
             continue
         missing.append(arg)
     return missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import atexit
-import importlib.util
 import os
 import shutil
 import sys
@@ -14,6 +13,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+from _pytest.main import resolve_collection_argument
 from sqlalchemy import event, pool, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
@@ -385,53 +385,34 @@ def _tier_from_path(item: pytest.Item) -> str | None:
     return head if head in CLASSIFICATION_MARKS else None
 
 
-def _module_not_found(name: str) -> bool:
-    """``name`` 确定解析不到模块。
+def _validate_selection_args(config: pytest.Config) -> None:
+    """把每个命令行位置参数交给 pytest 自身的解析器，缺失的路径或模块抛 UsageError。
 
-    ``find_spec`` 解析子模块会导入父包，父包初始化抛出的其他异常不说明模块缺失，
-    一律放行由 pytest 报出真实错误。
+    判据完全取自 ``resolve_collection_argument``：路径存在性、``--pyargs`` 的模块解析
+    （含 namespace package 是否按 ``consider_namespace_packages`` 接受）、目录不得带
+    ``::`` 选择段、``[]`` 参数化的位置，都与收集期一致。
     """
-    try:
-        return importlib.util.find_spec(name) is None
-    except ModuleNotFoundError:
-        return True
-    except Exception:
-        return False
-
-
-def _missing_selection_paths(config: pytest.Config) -> list[str]:
-    """命令行位置参数里既不指向已有文件或目录、也解析不到模块的那些。
-
-    比较的是去掉 ``::`` 之后的节点段；该段为空（``::test_x`` 之类）时选择无效。
-    ``--pyargs`` 下位置参数按模块名解析，解析不到时 pytest 仍会把它当路径，故两条
-    判据都不成立才算缺失。
-    """
-    base = config.invocation_params.dir
-    pyargs = config.getoption("pyargs")
-    missing: list[str] = []
-    for arg in config.args:
-        target = arg.split("::", 1)[0]
-        if not target:
-            missing.append(arg)
-            continue
-        if (base / target).exists():
-            continue
-        if pyargs and not _module_not_found(target):
-            continue
-        missing.append(arg)
-    return missing
+    invocation_path = config.invocation_params.dir
+    as_pypath = bool(config.getoption("pyargs"))
+    consider_namespace_packages = bool(config.getini("consider_namespace_packages"))
+    for index, arg in enumerate(config.args):
+        resolve_collection_argument(
+            invocation_path,
+            arg,
+            index,
+            as_pypath=as_pypath,
+            consider_namespace_packages=consider_namespace_packages,
+        )
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    """定向选择里有不存在的路径时直接报用法错误。
+    """定向选择里有不存在的路径或模块时直接报用法错误。
 
-    不带 -n 时 pytest 自己会报「file or directory not found」并以 4 退出；xdist 下
-    controller 只从 worker 汇总结果，缺失路径连同同批的真实文件一起丢掉，只留下
+    不带 -n 时 pytest 自己会在收集期报出同样的 UsageError 并以 4 退出；xdist 下
+    controller 只从 worker 汇总结果，缺失选择连同同批的真实文件一起丢掉，只留下
     「no tests ran」与退出码 5，没有任何错误行。两种模式统一为收集前 fail loud。
     """
-    missing = _missing_selection_paths(session.config)
-    if missing:
-        raise pytest.UsageError("测试选择中的路径不存在: " + ", ".join(missing))
+    _validate_selection_args(session.config)
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,6 +384,24 @@ def _tier_from_path(item: pytest.Item) -> str | None:
     return head if head in CLASSIFICATION_MARKS else None
 
 
+def _missing_selection_paths(config: pytest.Config) -> list[str]:
+    """命令行位置参数里指向不存在文件或目录的那些（去掉 ``::`` 之后的节点段）。"""
+    base = Path(config.invocation_params.dir)
+    return [arg for arg in config.args if not (base / arg.split("::", 1)[0]).exists()]
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """定向选择里有不存在的路径时直接报用法错误。
+
+    不带 -n 时 pytest 自己会报「file or directory not found」并以 4 退出；xdist 下
+    controller 只从 worker 汇总结果，缺失路径连同同批的真实文件一起丢掉，只留下
+    「no tests ran」与退出码 5，没有任何错误行。两种模式统一为收集前 fail loud。
+    """
+    missing = _missing_selection_paths(session.config)
+    if missing:
+        raise pytest.UsageError("测试选择中的路径不存在: " + ", ".join(missing))
+
+
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """按目录注入分类 marker，再按 fixture 来源注入 `uses_db`，最后跑收集期校验。
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import importlib.util
 import os
 import shutil
 import sys
@@ -384,15 +385,31 @@ def _tier_from_path(item: pytest.Item) -> str | None:
     return head if head in CLASSIFICATION_MARKS else None
 
 
-def _missing_selection_paths(config: pytest.Config) -> list[str]:
-    """命令行位置参数里指向不存在文件或目录的那些（去掉 ``::`` 之后的节点段）。
+def _importable_module(name: str) -> bool:
+    """``name`` 能作为已安装模块或包解析。"""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
 
-    ``--pyargs`` 下位置参数是模块名而非路径，交由 pytest 自己解析。
+
+def _missing_selection_paths(config: pytest.Config) -> list[str]:
+    """命令行位置参数里既不指向已有文件或目录、也解析不到模块的那些。
+
+    比较的是去掉 ``::`` 之后的节点段。``--pyargs`` 下位置参数按模块名解析，解析不到
+    时 pytest 仍会把它当路径，故两条判据都不成立才算缺失。
     """
-    if config.getoption("pyargs"):
-        return []
     base = config.invocation_params.dir
-    return [arg for arg in config.args if not (base / arg.split("::", 1)[0]).exists()]
+    pyargs = config.getoption("pyargs")
+    missing: list[str] = []
+    for arg in config.args:
+        target = arg.split("::", 1)[0]
+        if (base / target).exists():
+            continue
+        if pyargs and _importable_module(target):
+            continue
+        missing.append(arg)
+    return missing
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+
+# pytest 收集期解析命令行位置参数、并对缺失项抛 UsageError 的同一入口；
+# 下方 `pytest_sessionstart` 复用它，使会话启动期的校验与收集期同源。
 from _pytest.main import resolve_collection_argument
 from sqlalchemy import event, pool, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine

--- a/tests/integration/test_pytest_selection_guard.py
+++ b/tests/integration/test_pytest_selection_guard.py
@@ -1,0 +1,38 @@
+"""定向测试选择含不存在的路径时，根 conftest 在收集前报用法错误。
+
+不带 -n 时 pytest 自带「file or directory not found」；xdist 下 controller 只汇总 worker
+结果，缺失路径与同批真实文件一起被丢，只剩「no tests ran」与退出码 5。两种模式都要
+以退出码 4 与明确的错误行终止，真实文件也不得被静默跑过。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXISTING = "tests/integration/test_imports.py"
+_MISSING = "tests/integration/does_not_exist_test.py"
+_USAGE_ERROR_EXIT = 4
+
+
+def _run_pytest(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("dist_args", [(), ("-n", "2", "--dist", "loadfile")], ids=["plain", "xdist"])
+def test_missing_selection_path_fails_before_collection(dist_args: tuple[str, ...]):
+    completed = _run_pytest(*dist_args, _EXISTING, _MISSING)
+
+    assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
+    assert _MISSING in completed.stderr
+    assert "passed" not in completed.stdout

--- a/tests/integration/test_pytest_selection_guard.py
+++ b/tests/integration/test_pytest_selection_guard.py
@@ -36,3 +36,11 @@ def test_missing_selection_path_fails_before_collection(dist_args: tuple[str, ..
     assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
     assert _MISSING in completed.stderr
     assert "passed" not in completed.stdout
+
+
+def test_pyargs_module_names_are_not_checked_as_paths():
+    module = ".".join(Path(__file__).relative_to(_REPO_ROOT).with_suffix("").parts)
+
+    completed = _run_pytest("--pyargs", module, "--collect-only")
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/integration/test_pytest_selection_guard.py
+++ b/tests/integration/test_pytest_selection_guard.py
@@ -3,12 +3,13 @@
 不带 -n 时 pytest 自带「file or directory not found」；xdist 下 controller 只汇总 worker
 结果，缺失路径与同批真实文件一起被丢，只剩「no tests ran」与退出码 5。两种模式都要
 以退出码 4 与明确的错误行终止，真实文件也不得被静默跑过。``--pyargs`` 下位置参数按
-模块名判定，存在的模块照常收集，缺失的模块同样在收集前报错；``::`` 之前为空的选择
-（如 ``::test_x``）本身无效，同样报错。
+模块名判定，存在的模块照常收集，缺失的模块、``consider_namespace_packages`` 关闭时的
+namespace package，以及 ``::`` 之前为空的选择（如 ``::test_x``）同样在收集前报错。
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -21,16 +22,18 @@ _MISSING = "tests/integration/does_not_exist_test.py"
 _EXISTING_MODULE = "tests.integration.test_imports"
 _MISSING_MODULE = "tests.integration.does_not_exist_test"
 _NODE_ONLY = "::test_does_not_exist"
+_NAMESPACE_PKG = "arcreel_guard_ns_pkg"
 _USAGE_ERROR_EXIT = 4
 
 
-def _run_pytest(*args: str) -> subprocess.CompletedProcess[str]:
+def _run_pytest(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", *args],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
+        env=None if env is None else {**os.environ, **env},
     )
 
 
@@ -64,4 +67,22 @@ def test_pyargs_missing_module_fails_before_collection(dist_args: tuple[str, ...
 
     assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
     assert _MISSING_MODULE in completed.stderr
+    assert "passed" not in completed.stdout
+
+
+@pytest.mark.parametrize("dist_args", [(), ("-n", "2", "--dist", "loadfile")], ids=["plain", "xdist"])
+def test_pyargs_unusable_namespace_package_fails_before_collection(dist_args: tuple[str, ...], tmp_path: Path):
+    (tmp_path / _NAMESPACE_PKG).mkdir()
+    (tmp_path / _NAMESPACE_PKG / "mod.py").write_text("", encoding="utf-8")
+
+    completed = _run_pytest(
+        *dist_args,
+        "--pyargs",
+        _EXISTING_MODULE,
+        _NAMESPACE_PKG,
+        env={"PYTHONPATH": str(tmp_path)},
+    )
+
+    assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
+    assert _NAMESPACE_PKG in completed.stderr
     assert "passed" not in completed.stdout

--- a/tests/integration/test_pytest_selection_guard.py
+++ b/tests/integration/test_pytest_selection_guard.py
@@ -3,7 +3,8 @@
 不带 -n 时 pytest 自带「file or directory not found」；xdist 下 controller 只汇总 worker
 结果，缺失路径与同批真实文件一起被丢，只剩「no tests ran」与退出码 5。两种模式都要
 以退出码 4 与明确的错误行终止，真实文件也不得被静默跑过。``--pyargs`` 下位置参数按
-模块名判定，存在的模块照常收集，缺失的模块同样在收集前报错。
+模块名判定，存在的模块照常收集，缺失的模块同样在收集前报错；``::`` 之前为空的选择
+（如 ``::test_x``）本身无效，同样报错。
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ _EXISTING = "tests/integration/test_imports.py"
 _MISSING = "tests/integration/does_not_exist_test.py"
 _EXISTING_MODULE = "tests.integration.test_imports"
 _MISSING_MODULE = "tests.integration.does_not_exist_test"
+_NODE_ONLY = "::test_does_not_exist"
 _USAGE_ERROR_EXIT = 4
 
 
@@ -45,6 +47,15 @@ def test_pyargs_existing_module_is_collected():
     completed = _run_pytest("--pyargs", _EXISTING_MODULE, "--collect-only")
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize("dist_args", [(), ("-n", "2", "--dist", "loadfile")], ids=["plain", "xdist"])
+def test_node_only_selector_fails_before_collection(dist_args: tuple[str, ...]):
+    completed = _run_pytest(*dist_args, _EXISTING, _NODE_ONLY)
+
+    assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
+    assert _NODE_ONLY in completed.stderr
+    assert "passed" not in completed.stdout
 
 
 @pytest.mark.parametrize("dist_args", [(), ("-n", "2", "--dist", "loadfile")], ids=["plain", "xdist"])

--- a/tests/integration/test_pytest_selection_guard.py
+++ b/tests/integration/test_pytest_selection_guard.py
@@ -2,7 +2,8 @@
 
 不带 -n 时 pytest 自带「file or directory not found」；xdist 下 controller 只汇总 worker
 结果，缺失路径与同批真实文件一起被丢，只剩「no tests ran」与退出码 5。两种模式都要
-以退出码 4 与明确的错误行终止，真实文件也不得被静默跑过。
+以退出码 4 与明确的错误行终止，真实文件也不得被静默跑过。``--pyargs`` 下位置参数按
+模块名判定，存在的模块照常收集，缺失的模块同样在收集前报错。
 """
 
 from __future__ import annotations
@@ -16,6 +17,8 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXISTING = "tests/integration/test_imports.py"
 _MISSING = "tests/integration/does_not_exist_test.py"
+_EXISTING_MODULE = "tests.integration.test_imports"
+_MISSING_MODULE = "tests.integration.does_not_exist_test"
 _USAGE_ERROR_EXIT = 4
 
 
@@ -38,9 +41,16 @@ def test_missing_selection_path_fails_before_collection(dist_args: tuple[str, ..
     assert "passed" not in completed.stdout
 
 
-def test_pyargs_module_names_are_not_checked_as_paths():
-    module = ".".join(Path(__file__).relative_to(_REPO_ROOT).with_suffix("").parts)
-
-    completed = _run_pytest("--pyargs", module, "--collect-only")
+def test_pyargs_existing_module_is_collected():
+    completed = _run_pytest("--pyargs", _EXISTING_MODULE, "--collect-only")
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize("dist_args", [(), ("-n", "2", "--dist", "loadfile")], ids=["plain", "xdist"])
+def test_pyargs_missing_module_fails_before_collection(dist_args: tuple[str, ...]):
+    completed = _run_pytest(*dist_args, "--pyargs", _EXISTING_MODULE, _MISSING_MODULE)
+
+    assert completed.returncode == _USAGE_ERROR_EXIT, completed.stdout + completed.stderr
+    assert _MISSING_MODULE in completed.stderr
+    assert "passed" not in completed.stdout


### PR DESCRIPTION
## 变更

来源：AFK 批次 `issues-2359-2179-2176` 复盘建议 R5。

不带 `-n` 时 pytest 自带「file or directory not found」并以 4 退出；xdist 下 controller 只汇总 worker 结果，缺失路径连同同批真实文件一起被丢，只剩「no tests ran」与退出码 5，没有任何错误行，手误路径会被当成跑过。

- `tests/conftest.py`：`pytest_sessionstart` 把每个命令行位置参数交给 pytest 自身的 `_pytest.main.resolve_collection_argument` 解析，缺失即由它抛 `UsageError`，两种模式统一以退出码 4 终止。判据与收集期同源：路径存在性、`--pyargs` 模块解析（含按 `consider_namespace_packages` 判定 namespace package）、目录不得带 `::` 选择段、`[]` 参数化位置。不带位置参数（走 `testpaths`）与从子目录调用均不受影响。
- 新增 `tests/integration/test_pytest_selection_guard.py`：子进程分别以 plain 与 `-n 2 --dist loadfile` 运行，覆盖缺失路径、缺失 `--pyargs` 模块、`consider_namespace_packages` 关闭时的 namespace package、`::` 之前为空的选择，断言退出码 4、stderr 含该参数、没有 passed 输出；另有一条断言存在的 `--pyargs` 模块照常收集。
- `CONTRIBUTING.md`：共享设施「三角色」与闸门「分工」两处登记会话启动期的定向选择校验。
- `pyproject.toml`：deptry 的 DEP004 补 `_pytest` 条目。

## 验证

- `uv run ruff check . && uv run ruff format . && uv run basedpyright --warnings && uv run lint-imports && uv run deptry lib server alembic scripts tests`：全绿
- `uv run python -m pytest -n 4 --dist loadfile`：12296 passed / 3 skipped
- `uv run python scripts/audit_tests.py --check`：0 处违规
- 手工核对：`--pyargs tests.integration.test_imports google`（已安装的 namespace package）在修复前 plain 退 4、xdist 退 5 无错误行，修复后两种模式均报 `module or package not found: google`

## 风险与遗留

- `resolve_collection_argument` 是 pytest 私有 API。仓库锁定 `pytest >= 9.0.2`，签名或行为变化会由本 PR 的 plain / xdist 集成用例立刻暴露，不会静默退化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 定向运行测试时，缺失的文件、目录或模块会在测试收集前明确报告用法错误。
  * 普通模式与并行测试模式下的错误处理保持一致。
  * 使用 `--pyargs` 传入可解析模块名时，不会被误判为文件路径。

* **测试**
  * 增加缺失路径及 `--pyargs` 模块名处理的集成测试。

* **文档**
  * 更新测试规范，说明定向选择校验与错误处理行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
